### PR TITLE
Scala fixes and features

### DIFF
--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -492,7 +492,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(new)\s+([^\s\{\(\[]+)</string>
+			<string>\b(new)\s+([^\s\{\(\}\)\[]+)</string>
 		</dict>
 		<key>keywords</key>
 		<dict>

--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -593,7 +593,7 @@
 					<key>begin</key>
 					<string>"""</string>
 					<key>end</key>
-					<string>"""</string>
+					<string>"""(?!")</string>
 					<key>name</key>
 					<string>string.quoted.triple.scala</string>
 				</dict>

--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -198,7 +198,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(this|super|self)\b</string>
+					<string>\b(this|super)\b</string>
 					<key>name</key>
 					<string>variable.language.scala</string>
 				</dict>

--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -620,6 +620,78 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>begin</key>
+					<string>([a-zA-Z$_][a-zA-Z0-9$_]*)"</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.interpolated.scala</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\n</string>
+							<key>name</key>
+							<string>invalid.string.newline</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\.</string>
+							<key>name</key>
+							<string>constant.character.escape.scala</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\$[a-zA-Z$_][a-zA-Z0-9$_]*</string>
+							<key>name</key>
+							<string>variable.parameter</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\$\{</string>
+							<key>end</key>
+							<string>\}</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>variable.parameter</string>
+								</dict>
+							</dict>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>variable.parameter</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>source.scala.embedded</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#nest-curly-and-self</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>end</key>
+					<string>"</string>
+					<key>name</key>
+					<string>string.quoted.interpolated.scala</string>
+				</dict>
 			</array>
 		</dict>
 		<key>xml-attribute</key>
@@ -642,6 +714,37 @@
 					</dict>
 					<key>match</key>
 					<string>(\w+)=("[^"]*")</string>
+				</dict>
+			</array>
+		</dict>
+		<key>nest-curly-and-self</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\{</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.scope.scala</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#nest-curly-and-self</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>

--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -561,7 +561,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.symbol</string>
+					<string>constant.other.symbol</string>
 				</dict>
 			</dict>
 			<key>match</key>

--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -215,6 +215,41 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>begin</key>
+					<string>\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*=</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>comment.block.scala</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>[αβ]</string>
+							<key>name</key>
+							<string>comment.block.empty.scala</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
+					<key>end</key>
+					<string>\}\)#λ</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>comment.block.scala</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This PR adds an assortment of fixes for the Scala mode (including one performance bug fix!).  I've been running with this mode as my primary mode for Scala across several non-trivial codebases for quite some time now, and it works much better than the original.  The exact features are split out into individual commits, so if you don't want one (or more), we can rebase some things away.  I do recommend taking the whole package though.

- `self` isn't a keyword in Scala, though `super` and `this` are
- Type lambdas (e.g. `({ type λ[α] = EitherT[Task, Throwable, α] })#λ`) are a very common pattern in highly abstracted Scala.  I added a bit of syntax highlighting which parses out the boilerplate and highlights it as a comment, while highlighting the rest as a type definition.  This makes things [FAR more readable](http://imgur.com/aPmRzZa.png).  It only works for lambdas of up to arity-2 and only using greek letters (conventional).
- The performance bug was in the `new` regex, which was overly greedy and could sometimes consume the entire file before backtracking.
- Symbols now highlight the same way that they do in Ruby, which means that they highlight *at all* on Monokai
- Triple quoted strings with extra closing quotes (which are valid) now highlight correctly.  For example: `"""phooey"""".length` now highlights as you would expect.
- String interpolation was introduced in Scala 2.10.  I've added support for [highlighting](http://imgur.com/BmVMI4F.png) in the same style as Ruby interpolated strings, though the regexes are a bit more complicated.  Technically, it is possible to implement interpolation macros in Scala which will *not* highlight using this code, but they would be highly unconventional and I've never seen one.  My regex covers all practical known cases.