### PR TITLE
Refinement for Batch.

### DIFF
--- a/Batch File/Batch File.sublime-settings
+++ b/Batch File/Batch File.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // Determines what character(s) are used to terminate each line in new files.
+    // Valid values are 'system' (whatever the OS uses), 'windows' (CRLF) and
+    // 'unix' (LF only).
+    "default_line_ending": "windows"
+}

--- a/Batch File/Batch File.tmLanguage
+++ b/Batch File/Batch File.tmLanguage
@@ -10,7 +10,7 @@
                 <key>name</key>
                 <string>keyword.command.dosbatch</string>
                 <key>match</key>
-                <string>\b(?i)(?:append|assoc|at|attrib|break|cacls|cd|chcp|chdir|chkdsk|chkntfs|cls|cmd|color|comp|compact|convert|copy|date|del|dir|diskcomp|diskcopy|doskey|echo|endlocal|erase|fc|find|findstr|format|ftype|graftabl|help|keyb|label|md|mkdir|mode|more|move|path|pause|popd|print|prompt|pushd|rd|recover|rem|ren|rename|replace|restore|rmdir|set|setlocal|shift|sort|start|subst|time|title|tree|type|ver|verify|vol|xcopy)\b</string>
+                <string>\b(?i)(?:append|assoc|at|attrib|break|cacls|cd|chcp|chdir|chkdsk|chkntfs|cls|cmd|color|comp|compact|convert|copy|date|del|dir|diskcomp|diskcopy|doskey|echo|endlocal|erase|fc|find|findstr|format|ftype|graftabl|help|keyb|label|md|mkdir|mode|more|move|path|pause|popd|print|prompt|pushd|rd|recover|ren|rename|replace|restore|rmdir|set|setlocal|shift|sort|start|subst|time|title|tree|type|ver|verify|vol|xcopy)\b</string>
             </dict>
             <dict>
                 <key>name</key>

--- a/Batch File/Batch File.tmLanguage
+++ b/Batch File/Batch File.tmLanguage
@@ -106,6 +106,7 @@
         <key>fileTypes</key>
         <array>
             <string>bat</string>
+            <string>cmd</string>
         </array>
     </dict>
 </plist>


### PR DESCRIPTION
In short,

1. Add `cmd` into file extensions.
1. A batch file only works under Windows so we use `\r\n` as the default line ending.
1. It's usual to use `REM` as a comment in a batch file.
![img1](https://cloud.githubusercontent.com/assets/6594915/8209308/e1457402-153e-11e5-8f83-fcd24aeb6d20.png)

Three forum threads are referenced.
http://www.sublimetext.com/forum/viewtopic.php?f=2&p=52597
http://www.sublimetext.com/forum/viewtopic.php?f=3&t=12139
http://www.sublimetext.com/forum/viewtopic.php?f=2&t=13935