### PR TITLE
adds Swift support

### DIFF
--- a/Swift/Comments.tmPreferences
+++ b/Swift/Comments.tmPreferences
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.swift</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>66529EE0-35DE-11E4-8C21-0800200C9A66</string>
+</dict>
+</plist>

--- a/Swift/README.md
+++ b/Swift/README.md
@@ -1,6 +1,3 @@
 # Swift
 
 Uses the new 'sublime-syntax' format, which is super easy to work with.
-
-Still a work in progress.  I think there's room for improvement in which symbols
-to include, like class and instance `var`/`let`.

--- a/Swift/README.md
+++ b/Swift/README.md
@@ -1,4 +1,4 @@
-# Swift-for-f-ing-sublime
+# Swift
 
 Uses the new 'sublime-syntax' format, which is super easy to work with.
 

--- a/Swift/README.md
+++ b/Swift/README.md
@@ -1,0 +1,6 @@
+# Swift-for-f-ing-sublime
+
+Uses the new 'sublime-syntax' format, which is super easy to work with.
+
+Still a work in progress.  I think there's room for improvement in which symbols
+to include, like class and instance `var`/`let`.

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -1,0 +1,177 @@
+%YAML 1.2
+---
+name: Swift
+file_extensions: [swift]
+scope: source.swift
+prototype:
+  - include: main
+
+contexts:
+  main:
+###################################################### COMMENTS
+    - match: (//+)\s+(MARK:) ?(.*)
+      scope: comment.line
+      captures:
+        1: punctuation.definition.comment
+        2: punctuation.definition.comment
+        3: meta.toc-list
+    - match: (//+).*
+      scope: comment.line
+      captures:
+        1: punctuation.definition.comment
+    - match: (/\*)
+      scope: punctuation.definition.comment
+      push: comment_block
+###################################################### ENUMS
+    - match: (?<=[^\)\w])\.([a-zA-Z]\w*)\(
+      captures:
+       1: constant.language.enum
+      push: enum
+    - match: (?<=[^\)\w])\.[a-zA-Z]\w*
+      scope: constant.language.enum
+###################################################### CONSTANTS
+    - match: \btrue\b
+      scope: constant.language.true
+    - match: \bfalse\b
+      scope: constant.language.false
+    - match: \bnil\b
+      scope: constant.language.nil
+###################################################### KEYWORDS
+    - match: \b(self|super)\b
+      scope: keyword.variable
+    - match: \b_\b
+      scope: constant.language.other
+    - match: \b(import|typealias)\b
+      scope: keyword.other.import
+    - match: \b(count|map|filter)\b
+      scope: support.function
+###################################################### NUMERICS
+    - match: \d+\.\d+
+      scope: constant.numeric.float
+    - match: 0[xX][\da-fA-F]+
+      scope: constant.numeric.hexadecimal
+    - match: 0[oO][0-7]+
+      scope: constant.numeric.octal
+    - match: 0[bB][01]+
+      scope: constant.numeric.binary
+    - match: \d{1,3}(_\d+)*
+      scope: constant.numeric.decimal
+    - match: \d+
+      scope: constant.numeric.decimal
+###################################################### TYPES
+    # class func
+    - match: \b(class)\s+(?=func)
+      scope: meta.function storage.type.function
+    # types that have a parent class
+    - match: \b(enum|class|protocol|extension)\s+((\w+)\s*(:)\s+(\w+))
+      scope: entity.name.type
+      captures:
+        1: keyword.entity
+        2: entity.name.type
+        3: support.class
+        4: keyword.operator
+        5: support.class
+    # types that don't need a parent class
+    - match: \b(enum|class|protocol|extension)\s+(\w+)
+      scope: entity.name.type
+      captures:
+        1: keyword.entity
+        2: entity.name.type support.class
+    # types that *cannot* have a parent class (but DO)
+    - match: '\b(struct)\s+(\w+)\s+(:.*)'
+      scope: entity.name.type
+      captures:
+        1: keyword.entity
+        2: entity.name.type support.class
+        3: invalid
+    # types that *cannot* have a parent class (and do not)
+    - match: \b(struct)\s+(\w+)
+      scope: entity.name.type
+      captures:
+        1: keyword.entity
+        2: entity.name.type support.class
+###################################################### CONTROL
+    - match: \b(if|where|else|for|while|switch)\b
+      scope: keyword.control
+    - match: \b(break|return|case|continue|default)\b
+      scope: keyword.control
+###################################################### VARIABLES
+    - match: \b(var|let)\b
+      captures:
+        1: keyword.other
+###################################################### STRING
+    - match: '"'
+      push: string_double
+###################################################### MODIFIERS
+    - match: \b(weak|lazy|convenience|public|internal|private|final|static|override|required)\b
+      scope: storage.modifier
+    - match: '@\w+'
+      scope: storage.type.decorator
+###################################################### SUPPORT
+    # "system" classes:
+    - match: \b([A-Z]{2})\w+
+      scope: support.class
+    - match: \b(String|Array|Int\d*|Float|Double)\w+
+      scope: support.class
+    # user classes:
+    - match: \b([A-Z])\w*
+      scope: support.class
+###################################################### FUNCTIONS
+    - match: '\b(func)\s+(\w+)\s*\('
+      captures:
+        1: storage.type.function
+        2: entity.name.function variable.function
+      push: function_params
+    - match: '\b(deinit|init)\s*\('
+      captures:
+        1: storage.type.function
+        2: entity.name.function variable.function
+      push: function_params
+    - match: \b(func)\s+(\w+)
+      captures:
+        1: storage.type.function
+        2: entity.name.function variable.function
+    - match: \b(func|deinit|init)\b
+      scope: entity.name.type storage.type.function
+###################################################### VARIABLES
+    - match: '(\w+):'
+      captures:
+        1: variable.parameter
+    - match: \b\w+
+      scope: variable.other
+    - match: '[-+=<>^$#@!~*\\|&?\/.]*'
+      scope: keyword.operator
+    - match: '\('
+      push: paren_expr
+######################################################
+  comment_block:
+    - meta_scope: comment.block
+    - match: \*/
+      pop: true
+  function_params:
+    - include: main
+    - meta_scope: meta.function meta.toc-list
+    - match: '\)'
+      pop: true
+  string_double:
+    - meta_scope: string.quoted.double
+    - match: '\\\('
+      scope: punctuation.section.embedded
+      set: embedded
+    - match: \\.
+      scope: constant.character.escape.c
+    - match: '"'
+      pop: true
+  embedded:
+    - include: main
+    - match: '\)'
+      scope: punctuation.section.embedded
+      set: string_double
+  paren_expr:
+    - include: main
+    - match: '\)'
+      pop: true
+  enum:
+    - include: main
+    - match: '\)'
+      pop: true

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -28,11 +28,11 @@ contexts:
        1: punctuation.definition.preprocessor
        2: meta.preprocessor.c
 ###################################################### ENUMS
-    - match: "(?:[^\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
+    - match: "(?:[^\\?\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
       captures:
        1: constant.language.enum
       push: enum
-    - match: "(?:[^\\)\\w]|^)\\.([a-zA-Z]\\w*)"
+    - match: "(?:[^\\?\\)\\w]|^)\\.([a-zA-Z]\\w*)"
       captures:
        1: constant.language.enum
 ###################################################### CONSTANTS

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -28,11 +28,11 @@ contexts:
        1: punctuation.definition.preprocessor
        2: meta.preprocessor.c
 ###################################################### ENUMS
-    - match: "(?:[^\\?\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
+    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
       captures:
        1: constant.language.enum
       push: enum
-    - match: "(?:[^\\?\\)\\w]|^)\\.([a-zA-Z]\\w*)"
+    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)"
       captures:
        1: constant.language.enum
 ###################################################### CONSTANTS

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -15,13 +15,18 @@ contexts:
         1: punctuation.definition.comment
         2: punctuation.definition.comment
         3: meta.toc-list
-    - match: (//+).*
+    - match: (//+).*(\n|$)
       scope: comment.line
       captures:
         1: punctuation.definition.comment
     - match: (/\*)
       scope: punctuation.definition.comment
       push: comment_block
+###################################################### PRECOMPILED
+    - match: ^\s*(#)(\w+)(.*)$
+      captures:
+       1: punctuation.definition.preprocessor
+       2: meta.preprocessor.c
 ###################################################### ENUMS
     - match: (?<=[^\)\w])\.([a-zA-Z]\w*)\(
       captures:
@@ -36,15 +41,6 @@ contexts:
       scope: constant.language.false
     - match: \bnil\b
       scope: constant.language.nil
-###################################################### KEYWORDS
-    - match: \b(self|super)\b
-      scope: keyword.variable
-    - match: \b_\b
-      scope: constant.language.other
-    - match: \b(import|typealias)\b
-      scope: keyword.other.import
-    - match: \b(count|map|filter)\b
-      scope: support.function
 ###################################################### NUMERICS
     - match: \d+\.\d+
       scope: constant.numeric.float
@@ -90,20 +86,29 @@ contexts:
       captures:
         1: keyword.entity
         2: entity.name.type support.class
+###################################################### KEYWORDS
+    - match: \b(self|super)\b
+      scope: keyword.variable
+    - match: \b_\b
+      scope: constant.language.other
+    - match: \b(import)\b
+      scope: keyword.other.import
 ###################################################### CONTROL
-    - match: \b(if|where|else|for|while|switch)\b
+    - match: \b(if|where|else|for|while|switch|do|defer)\b
       scope: keyword.control
-    - match: \b(break|return|case|continue|default)\b
+    - match: \b(break|fallthrough|guard|try|catch|throws|return|case|continue|default)\b
+      scope: keyword.control
+    - match: '#(available)\b'
       scope: keyword.control
 ###################################################### VARIABLES
-    - match: \b(var|let)\b
+    - match: \b(var|let|typealias|unowned)\b
       captures:
-        1: keyword.other
+        1: keyword.variable
 ###################################################### STRING
     - match: '"'
       push: string_double
 ###################################################### MODIFIERS
-    - match: \b(weak|lazy|convenience|public|internal|private|final|static|override|required)\b
+    - match: \b(weak|lazy|convenience|public|internal|private|final|static|override|required|prefix|postfix|infix)\b
       scope: storage.modifier
     - match: '@\w+'
       scope: storage.type.decorator
@@ -117,7 +122,7 @@ contexts:
     - match: \b([A-Z])\w*
       scope: support.class
 ###################################################### FUNCTIONS
-    - match: '\b(func)\s+(\w+)\s*\('
+    - match: '\b(func|operator)\s+(\w+)\s*\('
       captures:
         1: storage.type.function
         2: entity.name.function variable.function

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -10,13 +10,13 @@ contexts:
   main:
 ###################################################### COMMENTS
     - match: (//+)\s+(MARK:) ?(.*)
-      scope: comment.line
+      scope: comment.line.double-slash
       captures:
         1: punctuation.definition.comment
         2: punctuation.definition.comment
         3: meta.toc-list
     - match: (//+).*(\n|$)
-      scope: comment.line
+      scope: comment.line.double-slash
       captures:
         1: punctuation.definition.comment
     - match: (/\*)
@@ -27,6 +27,9 @@ contexts:
       captures:
        1: punctuation.definition.preprocessor
        2: meta.preprocessor.c
+###################################################### STRING
+    - match: '"'
+      push: string_double
 ###################################################### ENUMS
     - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
       captures:
@@ -56,24 +59,30 @@ contexts:
     - match: \d+
       scope: constant.numeric.decimal
 ###################################################### TYPES
+    # optional func
+    - match: \b(optional)\s+(?=func)
+      scope: meta.function storage.type.function
     # class func
     - match: \b(class)\s+(?=func)
       scope: meta.function storage.type.function
     # types that have a parent class
-    - match: \b(enum|class|protocol|extension)\s+((\w+)\s*(:)\s+(\w+))
-      scope: entity.name.type
+    - match: \b((enum|class|protocol|extension)\s+((\w+)\s*(:)\s*(\w+(?:\s*,\s*\w+)*)))\s*([{])
       captures:
-        1: keyword.entity
-        2: entity.name.type
-        3: support.class
-        4: keyword.operator
-        5: support.class
+        1: entity.name.type
+        2: keyword.entity
+        4: support.class
+        5: keyword.operator
+        6: support.class
+        7: punctuation.definition.block
+      push: type_body
     # types that don't need a parent class
-    - match: \b(enum|class|protocol|extension)\s+(\w+)
-      scope: entity.name.type
+    - match: \b((enum|class|protocol|extension)\s+(\w+))\s*([{])
       captures:
-        1: keyword.entity
-        2: entity.name.type support.class
+        1: entity.name.type
+        2: keyword.entity
+        3: support.class
+        4: punctuation.definition.block
+      push: type_body
     # types that *cannot* have a parent class (but DO)
     - match: '\b(struct)\s+(\w+)\s+(:.*)'
       scope: entity.name.type
@@ -87,6 +96,10 @@ contexts:
       captures:
         1: keyword.entity
         2: entity.name.type support.class
+    - match: \b(enum|class|protocol|extension|struct)\s+(\w+)
+      captures:
+        1: keyword.entity
+        2: support.class
 ###################################################### KEYWORDS
     - match: \b(self|super)\b
       scope: keyword.variable
@@ -95,19 +108,30 @@ contexts:
     - match: \b(import)\b
       scope: keyword.other.import
 ###################################################### CONTROL
-    - match: \b(if|where|else|for|while|switch|do|defer)\b
+    - match: \b(if|where|else|for|while|switch|do|defer|in)\b
       scope: keyword.control
     - match: \b(break|fallthrough|guard|try|catch|throws|return|case|continue|default)\b
       scope: keyword.control
     - match: '#(available)\b'
       scope: keyword.control
 ###################################################### VARIABLES
-    - match: \b(var|let|typealias|unowned)\b
+    - match: '\b(var|let)\s+(\w+):'
       captures:
         1: keyword.variable
-###################################################### STRING
-    - match: '"'
-      push: string_double
+        2: variable.other
+        # 3: support.class
+      push: variable_type
+    - match: '\b(var|let)\s+\('
+      captures:
+        1: keyword.variable
+      push: tuple_body
+    - match: \b(var|let)\s+(\w+)
+      captures:
+        1: keyword.variable
+        2: variable.other
+    - match: \b(typealias|associatedtype|unowned)\b
+      captures:
+        1: keyword.variable
 ###################################################### MODIFIERS
     - match: \b(weak|lazy|convenience|public|internal|private|final|static|override|required|prefix|postfix|infix)\b
       scope: storage.modifier
@@ -139,32 +163,72 @@ contexts:
         2: entity.name.function variable.function
     - match: \b(func|deinit|init)\b
       scope: entity.name.type storage.type.function
+###################################################### CLOSURES
+    - match: '{'
+      push: closure_body
 ###################################################### VARIABLES
-    - match: '(\w+):'
-      captures:
-        1: variable.parameter
-    - match: \b\w+
+    - match: __\w+__
+      scope: variable.other invalid.deprecated
+    - match: \b(\w+\?)
+      scope: variable.other.optional
+    - match: \b(\w+)
       scope: variable.other
+    - match: (\$)(\d+)
+      scope: invalid
+    - match: '[?:]{2,}'
+      scope: keyword.operator
+    - match: '[?:]'
+      scope: keyword.operator.ternary
     - match: '[-+=<>^$#@!~*\\|&?\/.]*'
       scope: keyword.operator
     - match: '\('
       push: paren_expr
 ######################################################
+  type_body:
+    - meta_scope: meta.class
+    - match: \b((var|let)\s+(\w+)\s*(?:(:)\s*(\w+))?)
+      captures:
+        1: meta.toc-list
+        2: keyword.variable
+    - include: main
+    - match: '}'
+      scope: punctuation.definition.block
+      pop: true
   comment_block:
     - meta_scope: comment.block
+    - match: (/\*)
+      scope: punctuation.definition.comment
+      push: comment_block
     - match: \*/
+      scope: punctuation.definition.comment
       pop: true
   function_params:
-    - include: main
     - meta_scope: meta.function meta.toc-list
+    - match: '(\w+): (\w+)'
+      captures:
+        1: variable.parameter
+        2: support.class
+    - match: \w+
+      scope: invalid
+    - match: '\)\s*\{'
+      push: function_body
     - match: '\)'
+      pop: true
+    - match: '\}'
+      pop: true
+  function_body:
+    - meta_scope: meta.function
+    - include: main
+    - match: '(?=\})'
       pop: true
   string_double:
     - meta_scope: string.quoted.double
+    - match: '\\u[{][a-zA-Z\d]+[}]'
+      scope: constant.character.escape.unicode
     - match: '\\\('
       scope: punctuation.section.embedded
       set: embedded
-    - match: \\.
+    - match: \\[0tnr"'\\]
       scope: constant.character.escape.c
     - match: '"'
       pop: true
@@ -180,4 +244,39 @@ contexts:
   enum:
     - include: main
     - match: '\)'
+      pop: true
+  tuple_body:
+    - meta_scope: support.tuple
+    - match: '(\w+)\s*:\s*(\w+)'
+      captures:
+        1: variable.other
+        2: support.class
+    - match: \w+
+      scope: variable.other
+    - match: ','
+    - match: '\)'
+      pop: true
+  closure_body:
+    - meta_scope: meta.closure
+    - match: (\$)(\d+)
+      scope: variable.placeholder
+    - include: main
+    - match: '}'
+      pop: true
+  optional_type:
+    - match: '[.]'
+      scope: keyword.operator
+    - match: \w+
+      scope: support.class
+    - match: '>'
+      pop: true
+  variable_type:
+    - match: '<'
+      push: optional_type
+    - match: \W
+      scope: invalid
+    - match: '[.]'
+      push: variable_type
+    - match: \w+
+      scope: support.class
       pop: true

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -8,36 +8,21 @@ prototype:
 
 contexts:
   main:
-###################################################### COMMENTS
-    - match: (//+)\s+(MARK:) ?(.*)
-      scope: comment.line.double-slash
-      captures:
-        1: punctuation.definition.comment
-        2: punctuation.definition.comment
-        3: meta.toc-list
-    - match: (//+).*(\n|$)
-      scope: comment.line.double-slash
-      captures:
-        1: punctuation.definition.comment
-    - match: (/\*)
-      scope: punctuation.definition.comment
-      push: comment_block
-###################################################### PRECOMPILED
-    - match: ^\s*(#)(\w+)(.*)$
-      captures:
-       1: punctuation.definition.preprocessor
-       2: meta.preprocessor.c
+    - include: comments
 ###################################################### STRING
     - match: '"'
+      scope: punctuation.definition.string.begin
       push: string_double
 ###################################################### ENUMS
-    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
-      captures:
-       1: constant.language.enum
-      push: enum
-    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)"
-      captures:
-       1: constant.language.enum
+    - match: '\.([A-Z]\w*)'
+      scope: constant.language.enum
+###################################################### GROUPS
+    - match: '\('
+      scope: punctuation.definition.group.begin
+      push: paren_expr
+    - match: '\['
+      scope: punctuation.definition.array.begin
+      push: array_expr
 ###################################################### CONSTANTS
     - match: \btrue\b
       scope: constant.language.true
@@ -50,11 +35,17 @@ contexts:
       scope: constant.numeric.float
     - match: 0[xX][\da-fA-F]+
       scope: constant.numeric.hexadecimal
+    - match: 0[xX][\d\w]+
+      scope: invalid
     - match: 0[oO][0-7]+
       scope: constant.numeric.octal
+    - match: 0[oO]\d+
+      scope: invalid
     - match: 0[bB][01]+
       scope: constant.numeric.binary
-    - match: \d{1,3}(_\d+)*
+    - match: 0[bB]\d+
+      scope: invalid
+    - match: \d{1,}(_\d+)*
       scope: constant.numeric.decimal
     - match: \d+
       scope: constant.numeric.decimal
@@ -66,40 +57,21 @@ contexts:
     - match: \b(class)\s+(?=func)
       scope: meta.function storage.type.function
     # types that have a parent class
-    - match: \b((enum|class|protocol|extension)\s+((\w+)\s*(:)\s*(\w+(?:\s*,\s*\w+)*)))\s*([{])
-      captures:
-        1: entity.name.type
-        2: keyword.entity
-        4: support.class
-        5: keyword.operator
-        6: support.class
-        7: punctuation.definition.block
-      push: type_body
-    # types that don't need a parent class
-    - match: \b((enum|class|protocol|extension)\s+(\w+))\s*([{])
-      captures:
-        1: entity.name.type
-        2: keyword.entity
-        3: support.class
-        4: punctuation.definition.block
-      push: type_body
-    # types that *cannot* have a parent class (but DO)
-    - match: '\b(struct)\s+(\w+)\s+(:.*)'
-      scope: entity.name.type
-      captures:
-        1: keyword.entity
-        2: entity.name.type support.class
-        3: invalid
-    # types that *cannot* have a parent class (and do not)
-    - match: \b(struct)\s+(\w+)
-      scope: entity.name.type
-      captures:
-        1: keyword.entity
-        2: entity.name.type support.class
-    - match: \b(enum|class|protocol|extension|struct)\s+(\w+)
-      captures:
-        1: keyword.entity
-        2: support.class
+    - match: \benum\b
+      scope: storage.type.enum
+      push: storage_type
+    - match: \bclass\b
+      scope: storage.type.class
+      push: storage_type
+    - match: \bprotocol\b
+      scope: storage.type.protocol
+      push: storage_type
+    - match: \bextension\b
+      scope: storage.type.extension
+      push: storage_type
+    - match: \b(struct)\b
+      scope: storage.type.struct
+      push: storage_type
 ###################################################### KEYWORDS
     - match: \b(self|super)\b
       scope: keyword.variable
@@ -108,18 +80,24 @@ contexts:
     - match: \b(import)\b
       scope: keyword.other.import
 ###################################################### CONTROL
-    - match: \b(if|where|else|for|while|switch|do|defer|in)\b
+    - match: \b(if|guard|try|catch|while|for|switch)\b
       scope: keyword.control
-    - match: \b(break|fallthrough|guard|try|catch|throws|return|case|continue|default)\b
+      push: conditional_body
+    - match: where
+      scope: invalid
+    - match: \b(else|do|defer)\b
+      scope: keyword.control
+      push: control_body
+    - match: \b(break|fallthrough|throws|return|case|continue|default|in)\b
       scope: keyword.control
     - match: '#(available)\b'
       scope: keyword.control
 ###################################################### VARIABLES
-    - match: '\b(var|let)\s+(\w+):'
+    - match: '\b(var|let)\s+(\w+)\s*(:)'
       captures:
         1: keyword.variable
         2: variable.other
-        # 3: support.class
+        3: keyword.operator.type
       push: variable_type
     - match: '\b(var|let)\s+\('
       captures:
@@ -139,23 +117,36 @@ contexts:
       scope: storage.type.decorator
 ###################################################### SUPPORT
     # "system" classes:
-    - match: \b([A-Z]{2})\w+
+    - match: '\b([A-Z]{2}\w+)(\.)(?=\w)'
+      captures:
+        1: support.class
+        2: keyword.operator
+    - match: '\b[A-Z]{2}\w+'
       scope: support.class
-    - match: \b(String|Array|Int\d*|Float|Double)\w+
+    - match: '\b(String|Array|Int\d*|Float|Double)(\.)(?=\w)'
+      captures:
+        1: support.class
+        2: keyword.operator
+    - match: '\b(String|Array|Int\d*|Float|Double)\b'
       scope: support.class
     # user classes:
+    - match: '\b([A-Z]\w+)(\.)(?=\w)'
+      captures:
+        1: support.class
+        2: keyword.operator
     - match: \b([A-Z])\w*
       scope: support.class
 ###################################################### FUNCTIONS
-    - match: '\b(func|operator)\s+(\w+)\s*\('
+    - match: '\b(func|operator)\s+(\w+)\s*(\()'
       captures:
         1: storage.type.function
         2: entity.name.function variable.function
+        3: punctuation.definition.args.begin
       push: function_params
-    - match: '\b(deinit|init)\s*\('
+    - match: '\b(deinit|init)\s*(\()'
       captures:
-        1: storage.type.function
-        2: entity.name.function variable.function
+        1: storage.type.function keyword.other
+        2: punctuation.definition.args.begin
       push: function_params
     - match: \b(func)\s+(\w+)
       captures:
@@ -166,34 +157,61 @@ contexts:
 ###################################################### CLOSURES
     - match: '{'
       push: closure_body
-###################################################### VARIABLES
-    - match: __\w+__
+###################################################### MACROS
+    - match: __(FILE|LINE|FUNCTION|COLUMN|DSO_HANDLE)__
       scope: variable.other invalid.deprecated
+    - match: '#(file|line|function|column|dso_handle)'
+      scope: constant.language
+###################################################### PRECOMPILED
+    - match: ^\s*(#)(\w+)(.*)$
+      captures:
+       1: punctuation.definition.preprocessor
+       2: meta.preprocessor.c
+###################################################### VARIABLES
     - match: \b(\w+\?)
       scope: variable.other.optional
+    - match: \b(\w+\!)
+      scope: variable.other.force-unwrap
     - match: \b(\w+)
       scope: variable.other
     - match: (\$)(\d+)
       scope: invalid
-    - match: '[?:]{2,}'
+###################################################### OPERATORS
+    - match: '[?]{3,}'
+      scope: keyword.operator
+    - match: '[?]{2}'
+      scope: keyword.operator.nil-coalesce
+    - match: '[:]{2,}'
       scope: keyword.operator
     - match: '[?:]'
       scope: keyword.operator.ternary
-    - match: '[-+=<>^$#@!~*\\|&?\/.]*'
+    - match: '[-+=<>^$#@!~*\\|&?\/]+[.][-+=<>^$#@!~*\\|&?\/.]*'
+      scope: invalid keyword.operator
+    - match: '[-+=<>^$#@!~*\\|&?\/]+'
       scope: keyword.operator
-    - match: '\('
-      push: paren_expr
-######################################################
-  type_body:
-    - meta_scope: meta.class
-    - match: \b((var|let)\s+(\w+)\s*(?:(:)\s*(\w+))?)
+    - match: '[.][-+=<>^$#@!~*\\|&?\/.]+'
+      scope: keyword.operator
+    - match: '[.]'
+      scope: keyword.operator.accessor
+      push: accessor_operator
+    - match: '[\]}\)]'
+      scope: invalid
+###################################################### COMMENTS
+  comments:
+    - match: (//+)\s+(MARK:) ?(.*)
+      scope: comment.line.double-slash
       captures:
-        1: meta.toc-list
-        2: keyword.variable
-    - include: main
-    - match: '}'
-      scope: punctuation.definition.block
-      pop: true
+        1: punctuation.definition.comment
+        2: punctuation.definition.comment
+        3: meta.toc-list
+    - match: (//+).*(\n|$)
+      scope: comment.line.double-slash
+      captures:
+        1: punctuation.definition.comment
+    - match: (/\*)
+      scope: punctuation.definition.comment
+      push: comment_block
+######################################################
   comment_block:
     - meta_scope: comment.block
     - match: (/\*)
@@ -204,23 +222,26 @@ contexts:
       pop: true
   function_params:
     - meta_scope: meta.function meta.toc-list
-    - match: '(\w+): (\w+)'
+    - match: '(\w+)\s*:'
       captures:
         1: variable.parameter
-        2: support.class
+      push: variable_type
     - match: \w+
       scope: invalid
-    - match: '\)\s*\{'
-      push: function_body
+    - match: '(\))\s*(\{)'
+      captures:
+        - punctuation.definition.function.begin
+      set: function_body
     - match: '\)'
       pop: true
     - match: '\}'
       pop: true
   function_body:
     - meta_scope: meta.function
-    - include: main
-    - match: '(?=\})'
+    - match: '}'
+      scope: punctuation.definition.function.end
       pop: true
+    - include: main
   string_double:
     - meta_scope: string.quoted.double
     - match: '\\u[{][a-zA-Z\d]+[}]'
@@ -231,26 +252,81 @@ contexts:
     - match: \\[0tnr"'\\]
       scope: constant.character.escape.c
     - match: '"'
+      scope: punctuation.definition.string.end
       pop: true
   embedded:
-    - include: main
     - match: '\)'
       scope: punctuation.section.embedded
       set: string_double
-  paren_expr:
     - include: main
-    - match: '\)'
+  dictionary_value:
+    - meta_scope: meta.dictionary-value
+    - match: ','
+      scope: keyword.operator.comma
       pop: true
-  enum:
+    - match: '(?=])'
+      pop: true
     - include: main
-    - match: '\)'
-      pop: true
-  tuple_body:
-    - meta_scope: support.tuple
-    - match: '(\w+)\s*:\s*(\w+)'
+  array_expr:
+    - meta_scope: meta.array-or-dictionary
+    - match: '(")(\w+)(")\s*(:)'
+      captures:
+        1: string.quoted.double punctuation.definition.string.begin
+        2: string.quoted.double
+        3: string.quoted.double punctuation.definition.string.end
+        4: keyword.operator.dictionary-key
+      push: dictionary_value
+    - match: '(\w+)\s*(:)'
       captures:
         1: variable.other
-        2: support.class
+        2: keyword.operator.dictionary-key
+      push: dictionary_value
+    - match: '\]'
+      scope: punctuation.definition.array.end
+      pop: true
+    - include: main
+  paren_expr:
+    - meta_scope: meta.group
+    - match: '\)'
+      scope: punctuation.definition.group.end
+      pop: true
+    - include: main
+  storage_type:
+    - match: (\w+)\s*(:)
+      captures:
+        1: entity.name.type
+        2: keyword.operator.type
+      push: class_type
+    - match: '{'
+      scope: punctuation.definition.block.begin meta.class
+      set: storage_body
+    - match: (\w+)
+      scope: entity.name.type
+      set: storage_body_start
+    - include: comments
+  storage_body_start:
+    - include: comments
+    - match: '\{'
+      scope: punctuation.definition.block.begin meta.class
+      set: storage_body
+    - match: '.'
+      scope: invalid
+  storage_body:
+    - meta_scope: meta.class
+    - match: \b((var|let)\s+(\w+)\s*(?:(:)\s*(\w+))?)
+      captures:
+        1: meta.toc-list
+        2: keyword.variable
+    - match: '}'
+      scope: punctuation.definition.block.end
+      pop: true
+    - include: main
+  tuple_body:
+    - meta_scope: support.tuple
+    - match: '(\w+)\s*:'
+      captures:
+        1: variable.other
+      push: variable_type
     - match: \w+
       scope: variable.other
     - match: ','
@@ -260,23 +336,80 @@ contexts:
     - meta_scope: meta.closure
     - match: (\$)(\d+)
       scope: variable.placeholder
-    - include: main
     - match: '}'
       pop: true
-  optional_type:
+    - include: main
+  generic_type:
     - match: '[.]'
       scope: keyword.operator
     - match: \w+
       scope: support.class
     - match: '>'
       pop: true
-  variable_type:
-    - match: '<'
-      push: optional_type
-    - match: \W
-      scope: invalid
-    - match: '[.]'
-      push: variable_type
+  class_type:
     - match: \w+
       scope: support.class
+      set: class_type_valid
+    - match: \W
+      scope: invalid
+  class_type_valid:
+    - match: \w+
+      scope: support.class
+    - match: '[.,]'
+      scope: keyword.operator
+    - match: '(?=[{])'
       pop: true
+    - match: \W
+      scope: invalid
+    - match: '$'
+      pop: true
+  variable_type:
+    - match: \w+
+      scope: support.class
+      set: variable_type_valid
+    - match: '<'
+      push: generic_type
+    - match: \W
+      scope: invalid
+  variable_type_valid:
+    - match: \w+
+      scope: support.class
+    - match: '<'
+      push: generic_type
+    - match: '[.]'
+      scope: keyword.operator
+    - match: '(?=[=,)\]}])'
+      pop: true
+    - match: \W
+      scope: invalid
+    - match: '$'
+      pop: true
+  accessor_operator:
+    - match: '\.'
+      scope: invalid
+    - match: '\w+\?'
+      scope: variable.other.optional
+      pop: true
+    - match: '\w+\!'
+      scope: variable.other.force-unwrap
+      pop: true
+    - match: '\w+'
+      scope: variable.other
+      pop: true
+  conditional_body:
+    - meta_scope: testing
+    - match: '\{'
+      scope: punctuation.definition.control.begin
+    - match: 'where'
+      scope: keyword.control
+    - match: '}'
+      scope: punctuation.definition.control.end
+      pop: true
+    - include: main
+  control_body:
+    - match: '\{'
+      scope: punctuation.definition.control.begin
+    - match: '}'
+      scope: punctuation.definition.control.end
+      pop: true
+    - include: main

--- a/Swift/Swift.sublime-syntax
+++ b/Swift/Swift.sublime-syntax
@@ -28,12 +28,13 @@ contexts:
        1: punctuation.definition.preprocessor
        2: meta.preprocessor.c
 ###################################################### ENUMS
-    - match: (?<=[^\)\w])\.([a-zA-Z]\w*)\(
+    - match: "(?:[^\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
       captures:
        1: constant.language.enum
       push: enum
-    - match: (?<=[^\)\w])\.[a-zA-Z]\w*
-      scope: constant.language.enum
+    - match: "(?:[^\\)\\w]|^)\\.([a-zA-Z]\\w*)"
+      captures:
+       1: constant.language.enum
 ###################################################### CONSTANTS
     - match: \btrue\b
       scope: constant.language.true

--- a/Swift/syntax_test.swift
+++ b/Swift/syntax_test.swift
@@ -53,30 +53,39 @@ nil
 // <- constant.numeric
 // <- constant.numeric.decimal
 1_000_000
+// <- constant.numeric.decimal
 //^^^^^^^ constant.numeric.decimal
 0xDEADBEEF
 // <- constant.numeric.hexadecimal
 //^^^^^^^^ constant.numeric.hexadecimal
 0xGGGGG
-//^^^^^ -constant.numeric.hexadecimal
+//^^^^^ invalid - constant.numeric.hexadecimal
 0o12345670
 // <- constant.numeric.octal
 //^^^^^^^^ constant.numeric.octal
 0o8888
-//^^^^ -constant.numeric.octal
+//^^^^ invalid - constant.numeric.octal
 0b01010110101
 // <- constant.numeric.binary
 //^^^^^^^^^^^ constant.numeric.binary
 0b22222
-//^^^^^ -constant.numeric.binary
+//^^^^^ invalid - constant.numeric.binary
 
-var foo: int.foo
+foo! + bar!.baz
+//^^ variable.other.force-unwrap
+//     ^^^^ variable.other.force-unwrap
+
+var foo: = 0
+//       ^ invalid
+
+var foo: int.foo = bar
 // <- keyword.variable
 //  ^^^ variable.other
 //       ^^^ support.class
+//          ^ keyword.operator
 //           ^^^ support.class
-var foo: = 0
-//       ^ invalid
+var foo: int.foo = bar
+//               ^ -invalid
 
 let foo = 0
 // <- keyword.variable
@@ -85,6 +94,7 @@ let foo = 0
 foo + (a?.bar ?? 0)
 //^ variable.other
 //     ^^ variable.other.optional
+//            ^^ keyword.operator.nil-coalesce
 
 let (a: Int, b) = (1, 2)
 //  ^^^^^^^^^^^ support.tuple
@@ -94,11 +104,9 @@ let (a: Int, b) = (1, 2)
 
 __FILE__
 // ^^^^^ invalid.deprecated
-
-if { /**/ }
-// <- keyword.control
-where { /**/ }
-// <- keyword.control
+#file
+// <- constant.language
+// ^^ constant.language
 
 #if FOO
 // <- punctuation.definition.preprocessor
@@ -106,7 +114,7 @@ where { /**/ }
 #endif
 //^^^ meta.preprocessor.c
 
-if a || b
+if a || b {}
 // <- keyword
 //   ^^ keyword.operator
 
@@ -135,24 +143,29 @@ UIColor
 // <- support.class
 
 enum Foo { case Value }
-// <- keyword.entity
-//   ^ support.class
-//   ^ entity.name.type
+// <- storage.type
+// <- storage.type.enum
+//   ^^^ entity.name.type
 enum Foo : String { case Value }
 //                ^ punctuation.definition.block
 //                             ^ punctuation.definition.block
-//                  ^^^^^^^^^^ meta.class
+//                ^^^^^^^^^^^^^^ meta.class
 class Foo:String{ let var }
-// <- keyword.entity
-//    ^ support.class
-//    ^ entity.name.type
-//        ^ support.class
+// <- storage.type
+// <- storage.type.class
+//    ^^^ entity.name.type
+//        ^^^^^^ support.class
+class Foo:String{ let var }
+//              ^^^^^^^^^^^ meta.class
 //              ^ punctuation.definition.block
 //                        ^ punctuation.definition.block
-//                ^^^^^^^ meta.class
 class Foo:String,Proto{ let var }
-// <- keyword.entity
-//               ^ support.class
+// <- storage.type
+// <- storage.type.class
+//       ^ keyword.operator.type
+//        ^^^^^^ support.class
+//              ^ keyword.operator
+//               ^^^^^ support.class
 
 enum Foo : String {
   case Value
@@ -161,16 +174,27 @@ enum Foo : String {
 
 if foo {}
 // <- keyword.control
+if { /**/ }
+// ^ punctuation.definition.control.begin
+//        ^ punctuation.definition.control.end
 else {}
 // <- keyword.control
-for {}
+guard {}
+// <- keyword.control
+try {}
+// <- keyword.control
+catch {}
+// <- keyword.control
+for i in 0..0 {}
 // <- keyword.control
 while true {}
 // <- keyword.control
-//    ^^^^ constant
 switch foo { case .Bar: }
 // <- keyword.control
 //           ^^^^ keyword.control
+where
+// <- invalid
+
 break
 // <- keyword.control
 return
@@ -185,45 +209,55 @@ continue
 default
 // <- keyword.control
 
+a .+. b
+//^^^ keyword.operator
+a +.. b
+//^^^ invalid keyword.operator
+
 enum Foo {}
-// <- keyword.entity
-//   ^^^ support.class
+// <- storage.type.enum
+//   ^^^ entity.name.type
 //       ^^ punctuation.definition.block
 //       ^^ meta.class
 enum Foo : Bar {}
-// <- keyword.entity
-//   ^^^ support.class
+// <- storage.type.enum
+//   ^^^ entity.name.type
 //         ^^^ support.class
-struct Foo
-// <- keyword.entity
-//     ^^^ support.class
-struct Foo : Bar
-//         ^ invalid
-//           ^ invalid
+
+struct Foo invalid {}
+// <- storage.type.struct
+//     ^^^ entity.name.type
+//         ^^^^^^^ invalid
+//                 ^^ meta.class
+
 class Foo {}
-// <- keyword.entity
-//    ^^^ support.class
+// <- storage.type.class
+//    ^^^ entity.name.type
 class Foo : Bar {}
-// <- keyword.entity
-//    ^^^ support.class
+// <- storage.type.class
+//    ^^^ entity.name.type
 //        ^ keyword.operator
 //          ^^^ support.class
 protocol Foo {}
-// <- keyword.entity
-//       ^^^ support.class
+// <- storage.type.protocol
+//       ^^^ entity.name.type
 //           ^^ punctuation.definition.block
 //           ^^ meta.class
 protocol Foo : Bar {}
-// <- keyword.entity
-//       ^^^ support.class
+// <- storage.type.protocol
+//       ^^^ entity.name.type
 //           ^ keyword.operator
 //             ^^^ support.class
 extension Foo {}
-// <- keyword.entity
-//        ^^^ support.class
-extension Foo: Bar
-// <- keyword.entity
-//        ^ support.class
+// <- storage.type.extension
+//        ^^^ entity.name.type
+extension Foo
+//        ^^^ entity.name.type
+{}
+// <- meta.class
+extension Foo: Bar {}
+// <- storage.type.extension
+//        ^^^ entity.name.type
 //           ^ keyword.operator
 //             ^^^ support.class
 
@@ -286,26 +320,44 @@ func foo(a, b: String) {
 //     ^ -string
 //                     ^ -punctuation.section
 
-a = (.Foo(.bar))
-//    ^ constant.language.enum
-//         ^ constant.language.enum
+".Foo"
+// <- string.quoted punctuation.definition.string.begin
+// ^ string.quoted
+//   ^ punctuation.definition.string.end
 
-.Foo+.Bar
- // <- constant.language.enum
-//  ^ -constant.language.enum
-//    ^ constant.language.enum
+a = (.Foo(bar))
+//    ^^^ constant.language.enum
+//  ^^^^^^^^^^^ meta.group
+//         ^^^ - constant.language.enum
+//  ^ punctuation.definition.group.begin
+//            ^ punctuation.definition.group.end
 
-a.Foo + a?.bar()
+.Foo .Bar
+// <- - meta.group
+// <- constant.language.enum
+//    ^^^ constant.language.enum
+
+Module.Type.Other
+// <- support.class
+//    ^ keyword.operator
+//     ^^^^ support.class
+//         ^ keyword.operator
+//          ^^^^^ support.class
+Module.Type + a?.bar()
 // <- -constant.language.enum
-//^ -constant.language.enum
+//     ^ -constant.language.enum
 //         ^ -constant.language.enum
 
-".Foo"
-// <- string.quoted
-// ^ string.quoted
-
 [1, 2, 3]
-["a": 1,"b": 2,"c": 3]
+// <- meta.array-or-dictionary
+[ "a": true, "b": 2, "c": 3 ]
+// <- meta.array-or-dictionary
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.array-or-dictionary
+// <- punctuation.definition.array.begin
+//                          ^ punctuation.definition.array.end
+[ "a": true ? a : b, "b": 2, "c": 3 ]
+//   ^ keyword.operator.dictionary-key
+//              ^ keyword.operator.ternary
 
 let foo = $0
 //        ^^ invalid

--- a/Swift/syntax_test.swift
+++ b/Swift/syntax_test.swift
@@ -61,6 +61,11 @@ if { /**/ }
 where { /**/ }
 /// <- keyword.control
 
+#if FOO
+/// <- punctuation.definition.preprocessor
+#endif
+/// ^ meta.preprocessor.c
+
 if a || b
 /// <- keyword
 ///  ^ keyword.operator

--- a/Swift/syntax_test.swift
+++ b/Swift/syntax_test.swift
@@ -1,200 +1,214 @@
-/// SYNTAX TEST "Packages/Swift-for-f-ing-sublime/Swift.sublime-syntax"
+//  SYNTAX TEST "Packages/Swift-for-f-ing-sublime/Swift.sublime-syntax"
 
 // comment
-/// ^ comment.line
-/// <- punctuation.definition.comment
+//  ^ comment.line
+// <- punctuation.definition.comment
 
 // MARK: testing!
-/// ^ comment.line
-/// ^ punctuation.definition.comment
-///      ^ meta.toc-list
+//  ^ comment.line
+//  ^ punctuation.definition.comment
+//       ^ meta.toc-list
 
 
 /* comment */
-/// ^comment.block
+//  ^comment.block
 /* 000 */
-/// ^comment.block
-/// ^ comment - constant
+//  ^comment.block
+//  ^ comment - constant
 000 /* "string" */
-/// <- -comment
-///     ^comment.block
-///     ^-string
+// <- -comment
+//      ^comment.block
+//      ^-string
 
 true
-/// <- constant.language
-/// <- constant.language.true
+// <- constant.language
+// <- constant.language.true
 false
-/// <- constant.language
-/// <- constant.language.false
+// <- constant.language
+// <- constant.language.false
 nil
-/// <- constant.language
-/// <- constant.language.nil
+// <- constant.language
+// <- constant.language.nil
 
 1.1  100.001
-/// <- constant.numeric
-/// <- constant.numeric.float
-///  ^ constant.numeric
-/// ^ source.swift
+// <- constant.numeric
+// <- constant.numeric.float
+//   ^ constant.numeric
+//  ^ source.swift
 100
-/// <- constant.numeric
-/// <- constant.numeric.decimal
+// <- constant.numeric
+// <- constant.numeric.decimal
 1_000_000
-///  ^ constant.numeric.decimal
+//   ^ constant.numeric.decimal
 0xDEADBEEF
-/// <- constant.numeric.hexadecimal
-/// ^ constant.numeric.hexadecimal
+// <- constant.numeric.hexadecimal
+//  ^ constant.numeric.hexadecimal
 0xGGGGG
-/// ^ -constant.numeric.hexadecimal
+//  ^ -constant.numeric.hexadecimal
 0o12345670
-/// <- constant.numeric.octal
-/// ^ constant.numeric.octal
+// <- constant.numeric.octal
+//  ^ constant.numeric.octal
 0o8888
-/// ^ -constant.numeric.octal
+//  ^ -constant.numeric.octal
 0b01010110101
-/// <- constant.numeric.binary
-/// ^ constant.numeric.binary
+// <- constant.numeric.binary
+//  ^ constant.numeric.binary
 0b22222
-/// ^ -constant.numeric.binary
+//  ^ -constant.numeric.binary
 
 if { /**/ }
-/// <- keyword.control
+// <- keyword.control
 where { /**/ }
-/// <- keyword.control
+// <- keyword.control
 
 #if FOO
-/// <- punctuation.definition.preprocessor
+// <- punctuation.definition.preprocessor
 #endif
-/// ^ meta.preprocessor.c
+//  ^ meta.preprocessor.c
 
 if a || b
-/// <- keyword
-///  ^ keyword.operator
+// <- keyword
+//   ^ keyword.operator
 
 public func foo
-/// <- storage.modifier
-///    ^ storage.type
-///    ^ storage.type.function
-///         ^ variable
-///         ^ entity.name.function
+// <- storage.modifier
+//     ^ storage.type
+//     ^ storage.type.function
+//          ^ variable
+//          ^ entity.name.function
 
 self
-/// <- keyword.variable
+// <- keyword.variable
 super
-/// <- keyword.variable
+// <- keyword.variable
 
 Color
-/// <- support.class
+// <- support.class
 UIColor
-/// <- support.class
+// <- support.class
 
 enum Foo { case Value }
-/// <- keyword.entity
-///  ^ support.class
-///  ^ entity.name.type
+// <- keyword.entity
+//   ^ support.class
+//   ^ entity.name.type
 enum Foo : String { case Value }
-/// <- keyword.entity
-///  ^ support.class
-///  ^ entity.name.type
-///        ^ support.class
+// <- keyword.entity
+//   ^ support.class
+//   ^ entity.name.type
+//         ^ support.class
 
 enum Foo : String {
   case Value
-/// ^ keyword.control
+//  ^ keyword.control
 }
 
 if foo {}
-/// <- keyword.control
+// <- keyword.control
 else {}
-/// <- keyword.control
+// <- keyword.control
 for {}
-/// <- keyword.control
+// <- keyword.control
 while true {}
-/// <- keyword.control
-///   ^ constant
+// <- keyword.control
+//    ^ constant
 switch foo { case .Bar: }
-/// <- keyword.control
-///          ^ keyword.control
+// <- keyword.control
+//           ^ keyword.control
 break
-/// <- keyword.control
+// <- keyword.control
 return
-/// <- keyword.control
+// <- keyword.control
 case 0..0
-/// <- keyword.control
-///  ^ constant.numeric
-///   ^ keyword.operator
-///     ^ constant.numeric
+// <- keyword.control
+//   ^ constant.numeric
+//    ^ keyword.operator
+//      ^ constant.numeric
 continue
-/// <- keyword.control
+// <- keyword.control
 default
-/// <- keyword.control
+// <- keyword.control
 
 enum Foo
-/// <- keyword.entity
-///  ^ support.class
+// <- keyword.entity
+//   ^ support.class
 enum Foo : Bar {}
-/// <- keyword.entity
-///  ^ support.class
-///        ^ support.class
+// <- keyword.entity
+//   ^ support.class
+//         ^ support.class
 struct Foo
-/// <- keyword.entity
-///    ^ support.class
+// <- keyword.entity
+//     ^ support.class
 struct Foo : Bar
-///        ^ invalid
-///          ^ invalid
+//         ^ invalid
+//           ^ invalid
 class Foo
-/// <- keyword.entity
-///   ^ support.class
+// <- keyword.entity
+//    ^ support.class
 class Foo : Bar {}
-/// <- keyword.entity
-///   ^ support.class
-///         ^ support.class
+// <- keyword.entity
+//    ^ support.class
+//          ^ support.class
 protocol Foo
-/// <- keyword.entity
-///      ^ support.class
+// <- keyword.entity
+//       ^ support.class
 protocol Foo : Bar {}
-/// <- keyword.entity
-///      ^ support.class
-///            ^ support.class
+// <- keyword.entity
+//       ^ support.class
+//             ^ support.class
 extension Foo
-/// <- keyword.entity
-///       ^ support.class
+// <- keyword.entity
+//        ^ support.class
 extension Foo : Bar
-/// <- keyword.entity
-///       ^ support.class
-///           ^ keyword.operator
-///             ^ support.class
+// <- keyword.entity
+//        ^ support.class
+//            ^ keyword.operator
+//              ^ support.class
 
 func foo()
-///  ^ variable.function
+//   ^ variable.function
 class func foo()
-///  <- meta.function
-///  <- storage.type.function
-///   ^ storage.type.function
+//   <- meta.function
+//   <- storage.type.function
+//    ^ storage.type.function
 
 func foo() { foo }
-///  ^ variable.function
-///      ^ meta.function
+//   ^ variable.function
+//       ^ meta.function
 
 
 func foo(a, b: String) { foo }
-///  ^ variable.function
-///      ^ meta.function
-///         ^ variable.parameter
+//   ^ variable.function
+//       ^ meta.function
+//          ^ variable.parameter
 
 "foo"
-/// <- string
-/// <- string.quoted
+// <- string
+// <- string.quoted
 
 "foo\"" foo
-/// <- string
-/// ^ constant.character.escape
-///  ^ constant.character.escape
-///   ^ string
-///     ^ -string
+// <- string
+//  ^ constant.character.escape
+//   ^ constant.character.escape
+//    ^ string
+//      ^ -string
 
 "foo \(bar + (foo * bar))"
-/// <- string
-///  ^ punctuation.section
-///                     ^ punctuation.section
-///    ^ -string
-///                    ^ -punctuation.section
+// <- string
+//   ^ punctuation.section
+//                      ^ punctuation.section
+//     ^ -string
+//                     ^ -punctuation.section
+
+a = (.Foo(.bahr))
+//    ^ constant.language.enum
+//         ^ constant.language.enum
+
+.Foo+.Bar
+ // <- constant.language.enum
+//  ^ -constant.language.enum
+//    ^ constant.language.enum
+
+a.Foo + a.bar()
+// <- -constant.language.enum
+//^ -constant.language.enum
+//        ^ -constant.language.enum

--- a/Swift/syntax_test.swift
+++ b/Swift/syntax_test.swift
@@ -1,24 +1,39 @@
 //  SYNTAX TEST "Packages/Swift-for-f-ing-sublime/Swift.sublime-syntax"
 
 // comment
-//  ^ comment.line
+// ^^^^^^^ comment.line
 // <- punctuation.definition.comment
 
 // MARK: testing!
-//  ^ comment.line
-//  ^ punctuation.definition.comment
-//       ^ meta.toc-list
+// ^^^^^^^^^^^^^^ comment.line
+// ^^^^^ punctuation.definition.comment
+//       ^^^^^^^^ meta.toc-list
 
 
 /* comment */
-//  ^comment.block
+// ^^^^^^^^^^ comment.block
+a  /* aa */ a
+// ^^ punctuation.definition.comment
+//    ^^ -punctuation.definition.comment
+//       ^^ punctuation.definition.comment
+//          ^ -punctuation.definition.comment
+
 /* 000 */
-//  ^comment.block
-//  ^ comment - constant
+//^^^^^^^ comment.block
+// ^^^ -constant
 000 /* "string" */
 // <- -comment
-//      ^comment.block
-//      ^-string
+//  ^^^^^^^^^^^^^^ comment.block
+//     ^^^^^^^^ -string
+
+a  /* /* */ */ + b
+//<- -comment.block
+// ^^^^^^^^^^^ comment.block
+// ^^ punctuation.definition.comment
+//    ^^ punctuation.definition.comment
+//       ^^ punctuation.definition.comment
+//          ^^ punctuation.definition.comment
+//             ^^^ -comment.block
 
 true
 // <- constant.language
@@ -33,28 +48,52 @@ nil
 1.1  100.001
 // <- constant.numeric
 // <- constant.numeric.float
-//   ^ constant.numeric
-//  ^ source.swift
+//   ^^^^^^^ constant.numeric
 100
 // <- constant.numeric
 // <- constant.numeric.decimal
 1_000_000
-//   ^ constant.numeric.decimal
+//^^^^^^^ constant.numeric.decimal
 0xDEADBEEF
 // <- constant.numeric.hexadecimal
-//  ^ constant.numeric.hexadecimal
+//^^^^^^^^ constant.numeric.hexadecimal
 0xGGGGG
-//  ^ -constant.numeric.hexadecimal
+//^^^^^ -constant.numeric.hexadecimal
 0o12345670
 // <- constant.numeric.octal
-//  ^ constant.numeric.octal
+//^^^^^^^^ constant.numeric.octal
 0o8888
-//  ^ -constant.numeric.octal
+//^^^^ -constant.numeric.octal
 0b01010110101
 // <- constant.numeric.binary
-//  ^ constant.numeric.binary
+//^^^^^^^^^^^ constant.numeric.binary
 0b22222
-//  ^ -constant.numeric.binary
+//^^^^^ -constant.numeric.binary
+
+var foo: int.foo
+// <- keyword.variable
+//  ^^^ variable.other
+//       ^^^ support.class
+//           ^^^ support.class
+var foo: = 0
+//       ^ invalid
+
+let foo = 0
+// <- keyword.variable
+//  ^^^ variable.other
+
+foo + (a?.bar ?? 0)
+//^ variable.other
+//     ^^ variable.other.optional
+
+let (a: Int, b) = (1, 2)
+//  ^^^^^^^^^^^ support.tuple
+//   ^ variable.other
+//      ^^^ support.class
+//           ^ variable.other
+
+__FILE__
+// ^^^^^ invalid.deprecated
 
 if { /**/ }
 // <- keyword.control
@@ -63,12 +102,20 @@ where { /**/ }
 
 #if FOO
 // <- punctuation.definition.preprocessor
+//  ^^^ source.swift
 #endif
-//  ^ meta.preprocessor.c
+//^^^ meta.preprocessor.c
 
 if a || b
 // <- keyword
-//   ^ keyword.operator
+//   ^^ keyword.operator
+
+true ? 1 : 2
+//   ^ keyword.operator.ternary
+//       ^ keyword.operator.ternary
+true ?? 1 :: 2
+//   ^^ -keyword.operator.ternary
+//        ^^ -keyword.operator.ternary
 
 public func foo
 // <- storage.modifier
@@ -92,10 +139,20 @@ enum Foo { case Value }
 //   ^ support.class
 //   ^ entity.name.type
 enum Foo : String { case Value }
+//                ^ punctuation.definition.block
+//                             ^ punctuation.definition.block
+//                  ^^^^^^^^^^ meta.class
+class Foo:String{ let var }
 // <- keyword.entity
-//   ^ support.class
-//   ^ entity.name.type
-//         ^ support.class
+//    ^ support.class
+//    ^ entity.name.type
+//        ^ support.class
+//              ^ punctuation.definition.block
+//                        ^ punctuation.definition.block
+//                ^^^^^^^ meta.class
+class Foo:String,Proto{ let var }
+// <- keyword.entity
+//               ^ support.class
 
 enum Foo : String {
   case Value
@@ -110,10 +167,10 @@ for {}
 // <- keyword.control
 while true {}
 // <- keyword.control
-//    ^ constant
+//    ^^^^ constant
 switch foo { case .Bar: }
 // <- keyword.control
-//           ^ keyword.control
+//           ^^^^ keyword.control
 break
 // <- keyword.control
 return
@@ -121,76 +178,106 @@ return
 case 0..0
 // <- keyword.control
 //   ^ constant.numeric
-//    ^ keyword.operator
+//    ^^ keyword.operator
 //      ^ constant.numeric
 continue
 // <- keyword.control
 default
 // <- keyword.control
 
-enum Foo
+enum Foo {}
 // <- keyword.entity
-//   ^ support.class
+//   ^^^ support.class
+//       ^^ punctuation.definition.block
+//       ^^ meta.class
 enum Foo : Bar {}
 // <- keyword.entity
-//   ^ support.class
-//         ^ support.class
+//   ^^^ support.class
+//         ^^^ support.class
 struct Foo
 // <- keyword.entity
-//     ^ support.class
+//     ^^^ support.class
 struct Foo : Bar
 //         ^ invalid
 //           ^ invalid
-class Foo
+class Foo {}
 // <- keyword.entity
-//    ^ support.class
+//    ^^^ support.class
 class Foo : Bar {}
 // <- keyword.entity
-//    ^ support.class
-//          ^ support.class
-protocol Foo
+//    ^^^ support.class
+//        ^ keyword.operator
+//          ^^^ support.class
+protocol Foo {}
 // <- keyword.entity
-//       ^ support.class
+//       ^^^ support.class
+//           ^^ punctuation.definition.block
+//           ^^ meta.class
 protocol Foo : Bar {}
 // <- keyword.entity
-//       ^ support.class
-//             ^ support.class
-extension Foo
+//       ^^^ support.class
+//           ^ keyword.operator
+//             ^^^ support.class
+extension Foo {}
+// <- keyword.entity
+//        ^^^ support.class
+extension Foo: Bar
 // <- keyword.entity
 //        ^ support.class
-extension Foo : Bar
-// <- keyword.entity
-//        ^ support.class
-//            ^ keyword.operator
-//              ^ support.class
+//           ^ keyword.operator
+//             ^^^ support.class
+
+protocol Bla {
+    func foo()
+//  ^^^^^^^^ meta.function
+//  ^^^^ storage.type.function
+    optional func foo()
+//  ^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^ storage.type.function
+}
 
 func foo()
-//   ^ variable.function
-class func foo()
+//   <- meta.function
+func foo() {}
+//   <- meta.function
+//   ^^^ variable.function
+//         ^^ meta.function
+class func foo() {}
 //   <- meta.function
 //   <- storage.type.function
 //    ^ storage.type.function
 
 func foo() { foo }
-//   ^ variable.function
-//       ^ meta.function
+//   ^^^ variable.function
+//         ^^^^^^^ meta.function
 
-
-func foo(a, b: String) { foo }
+func foo(a, b: String) {
 //   ^ variable.function
-//       ^ meta.function
+//       ^ invalid
 //          ^ variable.parameter
+//             ^^^^^^ support.class
+//                     ^ meta.function
+    let foo = bar
+//  ^^^^^^^^^^^^^ meta.function
+}
 
 "foo"
 // <- string
 // <- string.quoted
 
-"foo\"" foo
+"foo\"\e" foo
 // <- string
-//  ^ constant.character.escape
-//   ^ constant.character.escape
-//    ^ string
-//      ^ -string
+//  ^^ constant.character.escape
+//    ^^ -constant.character.escape
+//      ^ string
+//        ^ -string
+
+"\u{24}"
+ //<- constant.character.escape.unicode
+//^^^^^ constant.character.escape.unicode
+"\u{1F496}"
+ //<- constant.character.escape.unicode
+//^^^^^^^^ constant.character.escape.unicode
 
 "foo \(bar + (foo * bar))"
 // <- string
@@ -199,7 +286,7 @@ func foo(a, b: String) { foo }
 //     ^ -string
 //                     ^ -punctuation.section
 
-a = (.Foo(.bahr))
+a = (.Foo(.bar))
 //    ^ constant.language.enum
 //         ^ constant.language.enum
 
@@ -208,7 +295,20 @@ a = (.Foo(.bahr))
 //  ^ -constant.language.enum
 //    ^ constant.language.enum
 
-a.Foo + a.bar()
+a.Foo + a?.bar()
 // <- -constant.language.enum
 //^ -constant.language.enum
-//        ^ -constant.language.enum
+//         ^ -constant.language.enum
+
+".Foo"
+// <- string.quoted
+// ^ string.quoted
+
+[1, 2, 3]
+["a": 1,"b": 2,"c": 3]
+
+let foo = $0
+//        ^^ invalid
+let block = { (a) in $0 }
+//          ^^^^^^^^^^^^^ meta.closure
+//                   ^^ variable.placeholder

--- a/Swift/syntax_test.swift
+++ b/Swift/syntax_test.swift
@@ -1,0 +1,195 @@
+/// SYNTAX TEST "Packages/Swift-for-f-ing-sublime/Swift.sublime-syntax"
+
+// comment
+/// ^ comment.line
+/// <- punctuation.definition.comment
+
+// MARK: testing!
+/// ^ comment.line
+/// ^ punctuation.definition.comment
+///      ^ meta.toc-list
+
+
+/* comment */
+/// ^comment.block
+/* 000 */
+/// ^comment.block
+/// ^ comment - constant
+000 /* "string" */
+/// <- -comment
+///     ^comment.block
+///     ^-string
+
+true
+/// <- constant.language
+/// <- constant.language.true
+false
+/// <- constant.language
+/// <- constant.language.false
+nil
+/// <- constant.language
+/// <- constant.language.nil
+
+1.1  100.001
+/// <- constant.numeric
+/// <- constant.numeric.float
+///  ^ constant.numeric
+/// ^ source.swift
+100
+/// <- constant.numeric
+/// <- constant.numeric.decimal
+1_000_000
+///  ^ constant.numeric.decimal
+0xDEADBEEF
+/// <- constant.numeric.hexadecimal
+/// ^ constant.numeric.hexadecimal
+0xGGGGG
+/// ^ -constant.numeric.hexadecimal
+0o12345670
+/// <- constant.numeric.octal
+/// ^ constant.numeric.octal
+0o8888
+/// ^ -constant.numeric.octal
+0b01010110101
+/// <- constant.numeric.binary
+/// ^ constant.numeric.binary
+0b22222
+/// ^ -constant.numeric.binary
+
+if { /**/ }
+/// <- keyword.control
+where { /**/ }
+/// <- keyword.control
+
+if a || b
+/// <- keyword
+///  ^ keyword.operator
+
+public func foo
+/// <- storage.modifier
+///    ^ storage.type
+///    ^ storage.type.function
+///         ^ variable
+///         ^ entity.name.function
+
+self
+/// <- keyword.variable
+super
+/// <- keyword.variable
+
+Color
+/// <- support.class
+UIColor
+/// <- support.class
+
+enum Foo { case Value }
+/// <- keyword.entity
+///  ^ support.class
+///  ^ entity.name.type
+enum Foo : String { case Value }
+/// <- keyword.entity
+///  ^ support.class
+///  ^ entity.name.type
+///        ^ support.class
+
+enum Foo : String {
+  case Value
+/// ^ keyword.control
+}
+
+if foo {}
+/// <- keyword.control
+else {}
+/// <- keyword.control
+for {}
+/// <- keyword.control
+while true {}
+/// <- keyword.control
+///   ^ constant
+switch foo { case .Bar: }
+/// <- keyword.control
+///          ^ keyword.control
+break
+/// <- keyword.control
+return
+/// <- keyword.control
+case 0..0
+/// <- keyword.control
+///  ^ constant.numeric
+///   ^ keyword.operator
+///     ^ constant.numeric
+continue
+/// <- keyword.control
+default
+/// <- keyword.control
+
+enum Foo
+/// <- keyword.entity
+///  ^ support.class
+enum Foo : Bar {}
+/// <- keyword.entity
+///  ^ support.class
+///        ^ support.class
+struct Foo
+/// <- keyword.entity
+///    ^ support.class
+struct Foo : Bar
+///        ^ invalid
+///          ^ invalid
+class Foo
+/// <- keyword.entity
+///   ^ support.class
+class Foo : Bar {}
+/// <- keyword.entity
+///   ^ support.class
+///         ^ support.class
+protocol Foo
+/// <- keyword.entity
+///      ^ support.class
+protocol Foo : Bar {}
+/// <- keyword.entity
+///      ^ support.class
+///            ^ support.class
+extension Foo
+/// <- keyword.entity
+///       ^ support.class
+extension Foo : Bar
+/// <- keyword.entity
+///       ^ support.class
+///           ^ keyword.operator
+///             ^ support.class
+
+func foo()
+///  ^ variable.function
+class func foo()
+///  <- meta.function
+///  <- storage.type.function
+///   ^ storage.type.function
+
+func foo() { foo }
+///  ^ variable.function
+///      ^ meta.function
+
+
+func foo(a, b: String) { foo }
+///  ^ variable.function
+///      ^ meta.function
+///         ^ variable.parameter
+
+"foo"
+/// <- string
+/// <- string.quoted
+
+"foo\"" foo
+/// <- string
+/// ^ constant.character.escape
+///  ^ constant.character.escape
+///   ^ string
+///     ^ -string
+
+"foo \(bar + (foo * bar))"
+/// <- string
+///  ^ punctuation.section
+///                     ^ punctuation.section
+///    ^ -string
+///                    ^ -punctuation.section


### PR DESCRIPTION
This is based on my "Swift for **ing Sublime package" (named so because I was frustrated with other packages).  This uses the new .sublime-syntax format, which I've been loving.  Some notable features:

Good support for "Go to symbol", including matching the `// MARK:` that Swift uses as a "goto label" feature.  Also supported are the long method names that swift uses. 

Notably missing from the "Go to symbol" feature is the ability to go to `var foo` in a class or struct body.  Especially useful if the `var foo` is a computed property (e.g. `var foo: String { return ... }`)
