### PR TITLE
Update Default.sublime-keymap

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -24,4 +24,11 @@
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
 		]
 	}
+	{ "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{ $0 }"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|$)", "match_all": true }
+		]
+	}
 ]


### PR DESCRIPTION
// auto pair curly brackets
// current build does not space correctly, this fixes
// other consideration. after entering selector colon corect spacing added and ; but ; retype results ;; rather than st2 ignore and move past ;|