### PR TITLE
[YAML] Fix end of block detection

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -18,8 +18,12 @@ contexts:
         5: punctuation.separator.key-value.yaml
       push:
         - meta_scope: string.unquoted.block.yaml
-        - match: ^(?!^\1)|^(?=\1(-|\w+\s*:)|#)
-          pop: true
+        # Match first non-empty string to extract the indentation level
+        - match: ^(\s+)
+          set:
+          - meta_scope: string.unquoted.block.yaml
+          - match: ^(?!^\1|$)|^(?=\1(-|\w+\s*:)|#)
+            pop: true
 
     # Keyword literals
     - match: \b(true|false|null)\s*(?=$|,|\}|\])

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -24,7 +24,7 @@ contexts:
           set:
           - meta_scope: string.unquoted.block.yaml
           - include: comment
-          - match: ^(?!^\1|$)|^(?=\1(-|\w+\s*:)|#)
+          - match: ^(?!^\1|$)
             pop: true
 
     # Keyword literals

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -19,9 +19,11 @@ contexts:
       push:
         - meta_scope: string.unquoted.block.yaml
         # Match first non-empty string to extract the indentation level
+        - include: comment
         - match: ^(\s+)
           set:
           - meta_scope: string.unquoted.block.yaml
+          - include: comment
           - match: ^(?!^\1|$)|^(?=\1(-|\w+\s*:)|#)
             pop: true
 
@@ -81,13 +83,15 @@ contexts:
         1: entity.name.tag.yaml
         2: keyword.operator.merge-key.yaml
         3: punctuation.definition.keyword.yaml
-    - match: '(?<=^| )(#).*$'
-      scope: comment.line.number-sign.yaml
-      captures:
-        1: punctuation.definition.comment.yaml
+    - include: comment
     - match: (#).*?(?=%>)
     - match: "-"
       scope: keyword.operator.symbol
 
     - match: '[^''"%\-:?@`&*!,#|>\s\[\]{}](?:[^\[\]{}:#,]|:[^ ]|(?<! )#)*'
       scope: string.unquoted.yaml
+  comment:
+    - match: '(?<=^| )(#).*$'
+      scope: comment.line.number-sign.yaml
+      captures:
+        1: punctuation.definition.comment.yaml

--- a/YAML/syntax_test_yaml.yaml
+++ b/YAML/syntax_test_yaml.yaml
@@ -25,7 +25,7 @@ str6: >
 
 not_a_number: 3hello
 #             ^ -constant.numeric
-also_not_a_number: 3 hello 
+also_not_a_number: 3 hello
 #                  ^ -constant.numeric
 still_not_a_number: hello3
 #                        ^ -constant.numeric
@@ -59,5 +59,22 @@ constants:
 #   ^ constant.yaml
 
 key:with:colon: yes, I know
-# ^ meta.tag.yaml 
-#          ^ meta.tag.yaml 
+# ^ meta.tag.yaml
+#          ^ meta.tag.yaml
+
+  - unquoted_block: |-
+# ^ punctuation.definition.entry.yaml
+    Start of the block
+#   ^ string.unquoted.block.yaml
+      indent higher is still in the block
+#     ^ string.unquoted.block.yaml
+      # This is a comment
+#     ^ comment
+    Still in block
+#   ^ string.unquoted.block.yaml
+
+  - unquoted_block2: |-
+    Start of the block
+    Still in block
+    - new_entry: value
+#     ^ entity.name.tag.yaml

--- a/YAML/syntax_test_yaml.yaml
+++ b/YAML/syntax_test_yaml.yaml
@@ -76,5 +76,5 @@ key:with:colon: yes, I know
   - unquoted_block2: |-
     Start of the block
     Still in block
-    - new_entry: value
-#     ^ entity.name.tag.yaml
+    - also: in the block
+#   ^ string.unquoted.block.yaml


### PR DESCRIPTION
Use first non-empty line to extract indentation level
Empty line inside a block do not pop out of the block