### PR TITLE
Improvements to Ruby syntax

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -99,7 +99,7 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b(initialize|new|loop|include|extend|raise|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|module_function|public|protected)\b(?![?!])'
+    - match: '\b(initialize|new|loop|include|extend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|module_function|public|protected)\b(?![?!])'
       comment: everything being a method but having a special function is a..
       scope: keyword.other.special-method.ruby
     - match: \b(require|require_relative|gem)\b

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -354,7 +354,7 @@ contexts:
         1: string.regexp.classic.ruby
         2: punctuation.definition.string.ruby
       push:
-        - meta_content_scope: string.regexp.classic.ruby
+        - meta_scope: string.regexp.classic.ruby
         - match: "((/)([eimnosux]*))"
           captures:
             1: punctuation.definition.string.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -739,7 +739,9 @@ contexts:
       captures:
         1: punctuation.separator.variable.ruby
       push:
+        - meta_scope: meta.variable.block.ruby
         - match: (\|)
+          scope: punctuation.separator.variable.ruby
           pop: true
         - match: "[_a-zA-Z][_a-zA-Z0-9]*"
           scope: variable.other.block.ruby


### PR DESCRIPTION
- Added `fail` keyword
- Allow the regex end punctuation to still include the parent `string.regexp` scope
- Make sure the end `|` in block variable gets a scope. Also added a `meta.variable.block.ruby` scope to the whole block variable section