### PR TITLE
Support for interpreted triple strings in Scala

### DIFF
--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -622,6 +622,66 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>([a-zA-Z$_][a-zA-Z0-9$_]*)"""</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.triple.interpolated.scala</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\$[a-zA-Z$_][a-zA-Z0-9$_]*</string>
+							<key>name</key>
+							<string>variable.parameter</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\$\{</string>
+							<key>end</key>
+							<string>\}</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>variable.parameter</string>
+								</dict>
+							</dict>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>variable.parameter</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>source.scala.embedded</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#nest-curly-and-self</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>end</key>
+					<string>"""(?!")</string>
+					<key>name</key>
+					<string>string.quoted.triple.interpolated.scala</string>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>([a-zA-Z$_][a-zA-Z0-9$_]*)"</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
Fixes highlighting issues with triple interpreted strings in scala, eg:

`val foo = s"""Hello, ${friend}"""`

Prior to this fix ST uses the same rules for triple quotes as it does
for single quotes, which means that multi-lines show an error, and you
can trivially break it by adding another quote into the String:

`val bar = s"""Highlighting will " escape"""`

Currently the highlighting breaks like this:
![screen shot 2015-07-01 at 16 34 42](https://cloud.githubusercontent.com/assets/583851/8459143/2488feda-2013-11e5-97c0-4017b3b22f0f.png)

With this change it looks like this:
![screen shot 2015-07-01 at 16 34 51](https://cloud.githubusercontent.com/assets/583851/8459147/29e84d40-2013-11e5-912e-7259c1a95544.png)
