### PR TITLE
Improve some Javascript snippets

### DIFF
--- a/JavaScript/for-()-{}-(faster).sublime-snippet
+++ b/JavaScript/for-()-{}-(faster).sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[for (var ${20:i} = ${1:Things}.length - 1; ${20:i} >= 0; ${20:i}--) {
 	${100:${1:Things}[${20:i}]}$0
-};]]></content>
+}]]></content>
     <tabTrigger>for</tabTrigger>
     <scope>source.js</scope>
     <description>for (…) {…} (Improved Native For-Loop)</description>

--- a/JavaScript/for-()-{}.sublime-snippet
+++ b/JavaScript/for-()-{}.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[for (var ${20:i} = 0; ${20:i} < ${1:Things}.length; ${20:i}++) {
 	${100:${1:Things}[${20:i}]}$0
-};]]></content>
+}]]></content>
     <tabTrigger>for</tabTrigger>
     <scope>source.js</scope>
     <description>for (…) {…}</description>

--- a/JavaScript/function-(fun).sublime-snippet
+++ b/JavaScript/function-(fun).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[function ${1:function_name} (${2:argument}) {
+    <content><![CDATA[function ${1:function_name}(${2:argument}) {
 	${0:// body...}
 }]]></content>
     <tabTrigger>fun</tabTrigger>

--- a/JavaScript/function.sublime-snippet
+++ b/JavaScript/function.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[function($1) {${0:$TM_SELECTED_TEXT}};]]></content>
+    <content><![CDATA[function($1) {${0:$TM_SELECTED_TEXT}}]]></content>
     <tabTrigger>f</tabTrigger>
     <scope>source.js</scope>
     <description>Anonymous Function</description>

--- a/JavaScript/if-___-else.sublime-snippet
+++ b/JavaScript/if-___-else.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}} else{};]]></content>
+    <content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}} else {}]]></content>
     <tabTrigger>ife</tabTrigger>
     <scope>source.js</scope>
     <description>if … else</description>

--- a/JavaScript/if.sublime-snippet
+++ b/JavaScript/if.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}};]]></content>
+    <content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}}]]></content>
     <tabTrigger>if</tabTrigger>
     <scope>source.js</scope>
     <description>if</description>


### PR DESCRIPTION
- Remove unnecessary semicolons for `for`, `if` & `function()` snippets
- Also ensure consistent code style

This PR should be used instead of #34 