### PR TITLE
[LaTeX] Fix missing captures for end blocks

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -85,6 +85,12 @@ contexts:
         - meta_scope: meta.function.embedded.java.latex
         - meta_content_scope: source.java.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: scope:source.java
     - match: '(?:\s*)((\\)begin)(\{)(lstlisting)(\})(?:(\[).*(\]))?(\s*%\s*(?i:Python)\n?)'
@@ -102,6 +108,12 @@ contexts:
         - meta_scope: meta.function.embedded.python.latex
         - meta_content_scope: source.python.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: scope:source.python
     - match: '(?:\s*)((\\)begin)(\{)(lstlisting)(\})(?:(\[).*(\]))?(\s*%.*\n?)?'
@@ -119,6 +131,12 @@ contexts:
         - meta_scope: meta.function.embedded.generic.latex
         - meta_content_scope: source.generic.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
     - match: '(?:\s*)((\\)begin)(\{)((?:V|v)erbatim|alltt)(\})'
       captures:
@@ -131,6 +149,12 @@ contexts:
         - meta_scope: meta.function.verbatim.latex
         - meta_content_scope: markup.raw.verbatim.latex
         - match: '((\\)end)(\{)(\4)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
     - match: '(?:\s*)((\\)(?:url|href))(\{)([^}]*)(\})'
       scope: meta.function.link.url.latex
@@ -189,6 +213,12 @@ contexts:
                 (\4)        # Previous capture from begin
               (\})                    # Close Bracket
               (?:\s*\n)?        # Match to end of line absent of content
+          captures:
+            1: support.function.end.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: $top_level_main
     - match: |-
@@ -216,6 +246,12 @@ contexts:
                 (\4)        # Previous capture from begin
               (\})                    # Close Bracket
               (?:\s*\n)?        # Match to end of line absent of content
+          captures:
+            1: support.function.end.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - match: \\
           scope: punctuation.definition.table.row.latex
@@ -244,6 +280,12 @@ contexts:
       push:
         - meta_scope: meta.function.environment.list.latex
         - match: '((\\)end)(\{)(\4)(\})(?:\s*\n)?'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: $top_level_main
     - match: '(?:\s*)((\\)begin)(\{)(\w+[*]?)(\})'
@@ -256,6 +298,12 @@ contexts:
       push:
         - meta_scope: meta.function.environment.general.latex
         - match: '((\\)end)(\{)(\4)(\})(?:\s*\n)?'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: $top_level_main
     - match: (\\)(newcommand|renewcommand)\b


### PR DESCRIPTION
This fixes issues #56 and others identical issues with highlighting of end blocks