### PR TITLE
[Ruby] giving symbols a higher precedence than ruby keywords

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -80,6 +80,11 @@ contexts:
     - match: (?<!\.)\belse(\s)+if\b
       comment: else if is a common mistake carried over from other languages. it works if you put in a second end, but it’s never what you want.
       scope: invalid.deprecated.ruby
+    - match: '(?>[a-zA-Z_]\w*(?>[?!])?)(:)(?!:)'
+      comment: symbols
+      scope: constant.other.symbol.ruby.19syntax
+      captures:
+        1: punctuation.definition.constant.ruby
     - match: '(?<!\.)\b(BEGIN|begin|case|class|else|elsif|END|end|ensure|for|if|in|module|rescue|then|unless|until|when|while)\b(?![?!])'
       comment: everything being a reserved word, not a value and needing a 'end' is a..
       scope: keyword.control.ruby
@@ -562,11 +567,6 @@ contexts:
     - match: '(?<!:)(:)(?>[a-zA-Z_]\w*(?>[?!]|=(?![>=]))?|===?|>[>=]?|<[<=]?|<=>|[%&`/\|]|\*\*?|=?~|[-+]@?|\[\]=?|@@?[a-zA-Z_]\w*)'
       comment: symbols
       scope: constant.other.symbol.ruby
-      captures:
-        1: punctuation.definition.constant.ruby
-    - match: '(?>[a-zA-Z_]\w*(?>[?!])?)(:)(?!:)'
-      comment: symbols
-      scope: constant.other.symbol.ruby.19syntax
       captures:
         1: punctuation.definition.constant.ruby
     - match: ^=begin


### PR DESCRIPTION
So that we have have reserved keywords as symbol names like
{
  begin: 'begin'
  end:   'end'
}

fixes #53