### PR TITLE
Add missing captures to pop patterns

### DIFF
--- a/ActionScript/ActionScript.sublime-syntax
+++ b/ActionScript/ActionScript.sublime-syntax
@@ -51,6 +51,8 @@ contexts:
       push:
         - meta_scope: comment.block.actionscript.2
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.actionscript.2
           pop: true
     - match: (//).*$\n?
       scope: comment.line.double-slash.actionscript.2

--- a/AppleScript/AppleScript.sublime-syntax
+++ b/AppleScript/AppleScript.sublime-syntax
@@ -34,11 +34,11 @@ contexts:
         - include: main
     - match: |-
         ^(?x)
-          \s*(to|on)\s+           # "on" or "to"
-          (\w+)             # function name
-          (\()              # opening paren
-            ((?:[\s,:\{\}]*(?:\w+)?)*)  # parameters
-          (\))              # closing paren
+        	\s*(to|on)\s+ 					# "on" or "to"
+        	(\w+)							# function name
+        	(\()							# opening paren
+        		((?:[\s,:\{\}]*(?:\w+)?)*)	# parameters
+        	(\))							# closing paren
       comment: |
         This is not a very well-designed rule.  For now,
                                 we can leave it like this though, as it sorta works.
@@ -57,13 +57,13 @@ contexts:
         - include: main
     - match: |-
         ^(?x)
-          \s*(to|on)\s+           # "on" or "to"
-          (\w+)             # function name
-          (?:\s+
-            (of|in)\s+          # "of" or "in"
-            (\w+)           # direct parameter
-          )?
-          (?=\s+(above|against|apart\s+from|around|aside\s+from|at|below|beneath|beside|between|by|for|from|instead\s+of|into|on|onto|out\s+of|over|thru|under)\b)
+        	\s*(to|on)\s+ 					# "on" or "to"
+        	(\w+)							# function name
+        	(?:\s+
+        		(of|in)\s+					# "of" or "in"
+        		(\w+)						# direct parameter
+        	)?
+        	(?=\s+(above|against|apart\s+from|around|aside\s+from|at|below|beneath|beside|between|by|for|from|instead\s+of|into|on|onto|out\s+of|over|thru|under)\b)
       comment: "TODO: match `given` parameters"
       captures:
         1: keyword.control.function.applescript
@@ -83,9 +83,9 @@ contexts:
         - include: main
     - match: |-
         ^(?x)
-          \s*(to|on)\s+           # "on" or "to"
-          (\w+)             # function name
-          (?=\s*(--.*?)?$)        # nothing else
+        	\s*(to|on)\s+ 					# "on" or "to"
+        	(\w+)							# function name
+        	(?=\s*(--.*?)?$)				# nothing else
       captures:
         1: keyword.control.function.applescript
         2: entity.name.function.handler.applescript
@@ -340,6 +340,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application.textmate.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: textmate
         - include: standard-suite
@@ -351,6 +353,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application.finder.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: finder
         - include: standard-suite
@@ -362,6 +366,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application.system-events.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: system-events
         - include: standard-suite
@@ -373,6 +379,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application.itunes.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: itunes
         - include: standard-suite
@@ -384,6 +392,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application-process.generic.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: standard-suite
         - include: main
@@ -394,6 +404,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.application.generic.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: standard-suite
         - include: main
@@ -404,6 +416,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.generic.applescript
         - match: ^\s*(end(?:\s+tell)?)(?=\s*(--.*?)?$)
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: main
     - match: ^\s*(tell)\s+(?=.*\bto\b)
@@ -413,6 +427,8 @@ contexts:
       push:
         - meta_scope: meta.block.tell.generic.applescript
         - match: (?<!¬)$
+          captures:
+            1: keyword.control.tell.applescript
           pop: true
         - include: main
   built-in:
@@ -447,17 +463,17 @@ contexts:
       scope: keyword.operator.comparison.applescript
     - match: |-
         (?ix)\b
-          (and|or|div|mod|as|not
-          |(a\s+)?(ref(\s+to)?|reference\s+to)
-          |equal(s|\s+to)|contains?|comes\s+(after|before)|(start|begin|end)s?\s+with
-          )
+        	(and|or|div|mod|as|not
+        	|(a\s+)?(ref(\s+to)?|reference\s+to)
+        	|equal(s|\s+to)|contains?|comes\s+(after|before)|(start|begin|end)s?\s+with
+        	)
         \b
       scope: keyword.operator.word.applescript
     - match: |-
         (?ix)\b
-          (is(n't|\s+not)?(\s+(equal(\s+to)?|(less|greater)\s+than(\s+or\s+equal(\s+to)?)?|in|contained\s+by))?
-          |does(n't|\s+not)\s+(equal|come\s+(before|after)|contain)
-          )
+        	(is(n't|\s+not)?(\s+(equal(\s+to)?|(less|greater)\s+than(\s+or\s+equal(\s+to)?)?|in|contained\s+by))?
+        	|does(n't|\s+not)\s+(equal|come\s+(before|after)|contain)
+        	)
         \b
       comment: In double quotes so we can use a single quote in the keywords.
       scope: keyword.operator.word.applescript
@@ -491,12 +507,12 @@ contexts:
       scope: support.class.built-in.applescript
     - match: |-
         (?ix)\b
-          ( (cubic\s+(centi)?|square\s+(kilo)?|centi|kilo)met(er|re)s
-          | square\s+(yards|feet|miles)|cubic\s+(yards|feet|inches)|miles|inches
-          | lit(re|er)s|gallons|quarts
-          | (kilo)?grams|ounces|pounds
-          | degrees\s+(Celsius|Fahrenheit|Kelvin)
-          )
+        	(	(cubic\s+(centi)?|square\s+(kilo)?|centi|kilo)met(er|re)s
+        	|	square\s+(yards|feet|miles)|cubic\s+(yards|feet|inches)|miles|inches
+        	|	lit(re|er)s|gallons|quarts
+        	|	(kilo)?grams|ounces|pounds
+        	|	degrees\s+(Celsius|Fahrenheit|Kelvin)
+        	)
         \b
       scope: support.class.built-in.unit.applescript
     - match: \b(?i:seconds|minutes|hours|days)\b
@@ -516,6 +532,8 @@ contexts:
       push:
         - meta_scope: comment.block.applescript
         - match: \*\)
+          captures:
+            0: punctuation.definition.comment.applescript
           pop: true
         - include: comments.nested
   comments.nested:
@@ -525,6 +543,8 @@ contexts:
       push:
         - meta_scope: comment.block.applescript
         - match: \*\)
+          captures:
+            0: punctuation.definition.comment.applescript
           pop: true
         - include: comments.nested
   data-structures:
@@ -535,6 +555,8 @@ contexts:
       push:
         - meta_scope: meta.array.applescript
         - match: '(\})'
+          captures:
+            1: punctuation.section.array.applescript
           pop: true
         - match: '(\w+|((\|)[^|\n]*(\|)))\s*(:)'
           captures:
@@ -554,6 +576,8 @@ contexts:
       push:
         - meta_scope: string.quoted.double.application-name.applescript
         - match: (")
+          captures:
+            1: punctuation.definition.string.applescript
           pop: true
         - match: \\.
           scope: constant.character.escape.applescript
@@ -563,6 +587,8 @@ contexts:
       push:
         - meta_scope: string.quoted.double.applescript
         - match: (")
+          captures:
+            1: punctuation.definition.string.applescript
           pop: true
         - match: \\.
           scope: constant.character.escape.applescript

--- a/C#/Build.sublime-syntax
+++ b/C#/Build.sublime-syntax
@@ -13,6 +13,8 @@ contexts:
       push:
         - meta_scope: comment.block.nant
         - match: "-->"
+          captures:
+            0: punctuation.definition.comment.nant
           pop: true
     - match: "(</?)([-_a-zA-Z0-9:]+)"
       captures:
@@ -21,6 +23,9 @@ contexts:
       push:
         - meta_scope: meta.tag.nant
         - match: (/?>)
+          captures:
+            1: punctuation.definition.tag.nant
+            2: entity.name.tag.nant
           pop: true
         - match: " ([a-zA-Z-]+)"
           scope: entity.other.attribute-name.nant

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -93,6 +93,8 @@ contexts:
       push:
         - meta_scope: comment.block.documentation.source.cs
         - match: $\n?
+          captures:
+            0: punctuation.definition.comment.source.cs
           pop: true
         - include: scope:text.xml
     - match: /\*
@@ -101,6 +103,8 @@ contexts:
       push:
         - meta_scope: comment.block.source.cs
         - match: \*/\n?
+          captures:
+            0: punctuation.definition.comment.source.cs
           pop: true
     - match: //
       captures:
@@ -108,6 +112,8 @@ contexts:
       push:
         - meta_scope: comment.line.double-slash.source.cs
         - match: $\n?
+          captures:
+            1: punctuation.definition.comment.source.cs
           pop: true
   constants:
     - match: \b(true|false|null|this|base)\b
@@ -216,6 +222,8 @@ contexts:
           push:
             - meta_scope: meta.method.identifier.source.cs
             - match: "(?={)"
+              captures:
+                1: entity.name.function.source.cs
               pop: true
         - match: '(?=\w.*\s+[\w.]+\s*\{)'
           push:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -85,6 +85,8 @@ contexts:
       push:
         - meta_scope: meta.preprocessor.diagnostic.c
         - match: $
+          captures:
+            1: keyword.control.import.error.c
           pop: true
         - match: (?>\\\s*\n)
           scope: punctuation.separator.continuation.c
@@ -94,6 +96,8 @@ contexts:
       push:
         - meta_scope: meta.preprocessor.c.include
         - match: (?=(?://|/\*))|$
+          captures:
+            1: keyword.control.import.include.c
           pop: true
         - match: (?>\\\s*\n)
           scope: punctuation.separator.continuation.c
@@ -122,6 +126,8 @@ contexts:
       push:
         - meta_scope: meta.preprocessor.c
         - match: (?=(?://|/\*))|$
+          captures:
+            1: keyword.control.import.c
           pop: true
         - match: (?>\\\s*\n)
           scope: punctuation.separator.continuation.c
@@ -223,6 +229,8 @@ contexts:
       push:
         - meta_scope: comment.block.c
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.c
           pop: true
     - match: \*/.*\n
       scope: invalid.illegal.stray-comment-end.c
@@ -269,6 +277,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b)
           captures:
@@ -276,6 +288,9 @@ contexts:
             2: keyword.control.import.else.c
           push:
             - match: (?=^\s*#\s*endif\b.*$)
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: $top_level_main
         - match: ""
@@ -293,6 +308,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b)
           captures:
@@ -300,6 +319,9 @@ contexts:
             2: keyword.control.import.else.c
           push:
             - match: (?=^\s*#\s*endif\b.*$)
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: block_innards
         - match: ""
@@ -317,6 +339,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b).*
           captures:
@@ -325,6 +351,9 @@ contexts:
           push:
             - meta_content_scope: comment.block.preprocessor.else-branch
             - match: (?=^\s*#\s*endif\b.*$)
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: disabled
             - include: pragma-mark
@@ -341,6 +370,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b).*
           captures:
@@ -349,6 +382,9 @@ contexts:
           push:
             - meta_content_scope: comment.block.preprocessor.else-branch.in-block
             - match: (?=^\s*#\s*endif\b.*$)
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: disabled
             - include: pragma-mark
@@ -364,6 +400,9 @@ contexts:
         2: keyword.control.import.c
       push:
         - match: ^\s*(#\s*(endif)\b).*$
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.c
           pop: true
         - include: $top_level_main
   preprocessor-rule-other-block:
@@ -373,6 +412,9 @@ contexts:
         2: keyword.control.import.c
       push:
         - match: ^\s*(#\s*(endif)\b).*$
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.c
           pop: true
         - include: block_innards
   sizeof:

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -54,6 +54,8 @@ contexts:
           push:
             - meta_scope: meta.definition.class.extends.d
             - match: "(?={)"
+              captures:
+                1: storage.modifier.d
               pop: true
             - include: all-types
     - match: |-
@@ -77,6 +79,8 @@ contexts:
           push:
             - meta_scope: meta.definition.class.extends.d
             - match: "(?={)"
+              captures:
+                1: storage.modifier.d
               pop: true
             - include: all-types
     - match: |-
@@ -91,6 +95,9 @@ contexts:
       push:
         - meta_scope: meta.definition.constructor.d
         - match: "(?={)"
+          captures:
+            1: storage.modifier.d
+            3: entity.name.function.constructor.d
           pop: true
         - include: $top_level_main
     - match: |-
@@ -208,6 +215,8 @@ contexts:
       push:
         - meta_scope: comment.block.d
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.d
           pop: true
     - match: /\+
       captures:
@@ -215,6 +224,8 @@ contexts:
       push:
         - meta_scope: comment.block.nested.d
         - match: \+/
+          captures:
+            0: punctuation.definition.comment.d
           pop: true
     - match: (//).*$\n?
       scope: comment.line.double-slash.d
@@ -238,6 +249,8 @@ contexts:
       push:
         - meta_scope: meta.definition.throws.d
         - match: "(?={)"
+          captures:
+            1: keyword.other.class-fns.d
           pop: true
         - include: all-types
   storage-type-d:

--- a/Erlang/HTML (Erlang).sublime-syntax
+++ b/Erlang/HTML (Erlang).sublime-syntax
@@ -13,6 +13,8 @@ contexts:
       push:
         - meta_scope: source.erlang.embedded.html
         - match: </erl>
+          captures:
+            0: punctuation.section.embedded.erlang
           pop: true
         - include: scope:source.erlang
     - include: scope:text.html.basic

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -62,6 +62,8 @@ contexts:
       push:
         - meta_scope: comment.block.go
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.go
           pop: true
     - match: \*/.*\n
       scope: invalid.illegal.stray-commend-end.go

--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -41,4 +41,6 @@ contexts:
       push:
         - meta_scope: comment.block.dot
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.dot
           pop: true

--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -49,6 +49,13 @@ contexts:
       push:
         - meta_scope: meta.definition.class.groovy
         - match: $
+          captures:
+            1: storage.modifier.access-control.groovy
+            2: storage.modifier.static.groovy
+            3: storage.modifier.final.groovy
+            4: storage.modifier.other.groovy
+            5: storage.type.class.groovy
+            6: entity.name.type.class.groovy
           pop: true
         - match: '(extends)\s+([a-zA-Z0-9_\.]+(?:<(?:[a-zA-Z0-9_, ])+>)?)\s*'
           scope: meta.definition.class.inherited.classes.groovy
@@ -73,6 +80,8 @@ contexts:
       push:
         - meta_scope: comment.block.groovy
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.groovy
           pop: true
   comments:
     - match: /\*\*/
@@ -148,7 +157,7 @@ contexts:
       scope: keyword.operator.range.groovy
     - match: \->
       scope: keyword.operator.arrow.groovy
-    - match: <<
+    - match: "<<"
       scope: keyword.operator.leftshift.groovy
     - match: (?<=\S)\.(?=\S)
       scope: keyword.operator.navigation.groovy
@@ -233,6 +242,8 @@ contexts:
       push:
         - meta_scope: meta.definition.method.throwables.groovy
         - match: '(?=$|\{)'
+          captures:
+            1: storage.modifier.throws.groovy
           pop: true
         - match: '((?:[a-z]\w*.)*[A-Z]\w*)\s*(?:(,)|$|\{)'
           captures:
@@ -322,6 +333,8 @@ contexts:
         0: punctuation.section.scope.groovy
       push:
         - match: '\}'
+          captures:
+            0: punctuation.section.scope.groovy
           pop: true
         - include: nest_curly
   numbers:
@@ -392,6 +405,8 @@ contexts:
           push:
             - meta_scope: source.groovy.embedded.source
             - match: '\}'
+              captures:
+                0: punctuation.section.embedded.groovy
               pop: true
             - include: nest_curly
   string-quoted-single:

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -193,6 +193,8 @@ contexts:
         - meta_scope: comment.block.haskell
         - include: block_comment
         - match: '-\}'
+          captures:
+            0: punctuation.definition.comment.haskell
           pop: true
   comments:
     - match: (--).*$\n?

--- a/Haskell/Literate Haskell.sublime-syntax
+++ b/Haskell/Literate Haskell.sublime-syntax
@@ -17,6 +17,11 @@ contexts:
         - meta_scope: meta.function.embedded.haskell.latex
         - meta_content_scope: source.haskell.embedded.latex
         - match: '^((\\)end)({)code(})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: punctuation.definition.arguments.end.latex
           pop: true
         - include: scope:source.haskell
     - include: scope:text.tex.latex

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -13,6 +13,8 @@ contexts:
       push:
         - meta_scope: comment.block.jsp
         - match: "--%>"
+          captures:
+            0: punctuation.definition.comment.jsp
           pop: true
     - match: <%@
       captures:
@@ -20,6 +22,8 @@ contexts:
       push:
         - meta_scope: meta.directive.jsp
         - match: "%>"
+          captures:
+            0: punctuation.section.directive.jsp
           pop: true
         - match: \w+
           captures:
@@ -80,6 +84,9 @@ contexts:
                 2: punctuation.section.embedded.jsp
               push:
                 - match: "(<jsp:scriptlet>|<jsp:expression>|<jsp:declaration>)|(<%[!=]?)"
+                  captures:
+                    1: meta.tag.block.jsp
+                    2: punctuation.section.embedded.jsp
                   pop: true
                 - include: scope:text.html.jsp
             - include: scope:source.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -174,6 +174,8 @@ contexts:
       push:
         - meta_scope: comment.block.java
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.java
           pop: true
     - match: \s*((//).*$\n?)
       captures:

--- a/Java/JavaProperties.sublime-syntax
+++ b/Java/JavaProperties.sublime-syntax
@@ -17,6 +17,8 @@ contexts:
       push:
         - meta_scope: comment.block.java-props
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.java-props
           pop: true
     - match: "^([^:=]+)([:=])(.*)$"
       comment: Not compliant with the properties file spec, but this works for me, and I'm the one who counts around here.

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -41,20 +41,20 @@ contexts:
         - include: main
     - match: |-
         (?x)
-        (                         # Capture 1
-          (\\)                      # Marker
-          (?:
-            (?:sub){0,2}section             # Functions
-            | (?:sub)?paragraph
-            | chapter|part|addpart
-            | addchap|addsec|minisec
-          )
-          (?:\*)?                     # Optional Unnumbered
+        (													# Capture 1
+        	(\\)											# Marker
+        	(?:
+        		(?:sub){0,2}section							# Functions
+        	  | (?:sub)?paragraph
+        	  | chapter|part|addpart
+        	  | addchap|addsec|minisec
+        	)
+        	(?:\*)?											# Optional Unnumbered
         )
         (?:
-          (\[)([^\[]*?)(\])               # Optional Title
+        	(\[)([^\[]*?)(\])								# Optional Title
         )??
-        (\{)                        # Opening Bracket
+        (\{)												# Opening Bracket
       comment: this works OK with all kinds of crazy stuff as long as section is one line
       captures:
         1: support.function.section.latex
@@ -85,6 +85,15 @@ contexts:
         - meta_scope: meta.function.embedded.java.latex
         - meta_content_scope: source.java.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
+            6: punctuation.definition.arguments.optional.begin.latex
+            7: punctuation.definition.arguments.optional.end.latex
+            8: comment.line.percentage.latex
           pop: true
         - include: scope:source.java
     - match: '(?:\s*)((\\)begin)(\{)(lstlisting)(\})(?:(\[).*(\]))?(\s*%\s*(?i:Python)\n?)'
@@ -102,6 +111,15 @@ contexts:
         - meta_scope: meta.function.embedded.python.latex
         - meta_content_scope: source.python.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
+            6: punctuation.definition.arguments.optional.begin.latex
+            7: punctuation.definition.arguments.optional.end.latex
+            8: comment.line.percentage.latex
           pop: true
         - include: scope:source.python
     - match: '(?:\s*)((\\)begin)(\{)(lstlisting)(\})(?:(\[).*(\]))?(\s*%.*\n?)?'
@@ -119,6 +137,15 @@ contexts:
         - meta_scope: meta.function.embedded.generic.latex
         - meta_content_scope: source.generic.embedded
         - match: '((\\)end)(\{)(lstlisting)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
+            6: punctuation.definition.arguments.optional.begin.latex
+            7: punctuation.definition.arguments.optional.end.latex
+            8: comment.line.percentage.latex
           pop: true
     - match: '(?:\s*)((\\)begin)(\{)((?:V|v)erbatim|alltt)(\})'
       captures:
@@ -131,6 +158,12 @@ contexts:
         - meta_scope: meta.function.verbatim.latex
         - meta_content_scope: markup.raw.verbatim.latex
         - match: '((\\)end)(\{)(\4)(\})'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
     - match: '(?:\s*)((\\)(?:url|href))(\{)([^}]*)(\})'
       scope: meta.function.link.url.latex
@@ -159,19 +192,19 @@ contexts:
         5: punctuation.definition.arguments.end.latex
     - match: |-
         (?x)
-          (?:\s*)                   # Optional whitespace
-          ((\\)begin)                 # Marker - Function
-          (\{)                    # Open Bracket
-            (
-              (?:
-                align|equation|eqnarray     # Argument
-                | multline|aligned|alignat
-                | split|gather|gathered
-              )
-              (?:\*)?               # Optional Unnumbered
-            )
-          (\})                    # Close Bracket
-          (\s*\n)?        # Match to end of line absent of content
+        	(?:\s*)										# Optional whitespace
+        	((\\)begin)									# Marker - Function
+        	(\{)										# Open Bracket
+        		(
+        			(?:
+        				align|equation|eqnarray			# Argument
+        			  | multline|aligned|alignat
+        			  | split|gather|gathered
+        			)
+        			(?:\*)?								# Optional Unnumbered
+        		)
+        	(\})										# Close Bracket
+        	(\s*\n)?				# Match to end of line absent of content
       captures:
         1: support.function.be.latex
         2: punctuation.definition.function.latex
@@ -183,22 +216,28 @@ contexts:
         - meta_content_scope: string.other.math.block.environment.latex
         - match: |-
             (?x)
-              (?:\s*)                   # Optional whitespace
-              ((\\)end)                 # Marker - Function
-              (\{)                    # Open Bracket
-                (\4)        # Previous capture from begin
-              (\})                    # Close Bracket
-              (?:\s*\n)?        # Match to end of line absent of content
+            	(?:\s*)										# Optional whitespace
+            	((\\)end)									# Marker - Function
+            	(\{)										# Open Bracket
+            		(\4)				# Previous capture from begin
+            	(\})										# Close Bracket
+            	(?:\s*\n)?				# Match to end of line absent of content
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - include: $top_level_main
     - match: |-
         (?x)
-          (?:\s*)                   # Optional whitespace
-          ((\\)begin)                 # Marker - Function
-          (\{)                    # Open Bracket
-            (array|tabular[xy*]?)
-          (\})                    # Close Bracket
-          (\s*\n)?        # Match to end of line absent of content
+        	(?:\s*)										# Optional whitespace
+        	((\\)begin)									# Marker - Function
+        	(\{)										# Open Bracket
+        		(array|tabular[xy*]?)
+        	(\})										# Close Bracket
+        	(\s*\n)?				# Match to end of line absent of content
       captures:
         1: support.function.be.latex
         2: punctuation.definition.function.latex
@@ -210,12 +249,18 @@ contexts:
         - meta_content_scope: meta.data.environment.tabular.latex
         - match: |-
             (?x)
-              (?:\s*)                   # Optional whitespace
-              ((\\)end)                 # Marker - Function
-              (\{)                    # Open Bracket
-                (\4)        # Previous capture from begin
-              (\})                    # Close Bracket
-              (?:\s*\n)?        # Match to end of line absent of content
+            	(?:\s*)										# Optional whitespace
+            	((\\)end)									# Marker - Function
+            	(\{)										# Open Bracket
+            		(\4)				# Previous capture from begin
+            	(\})										# Close Bracket
+            	(?:\s*\n)?				# Match to end of line absent of content
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.end.latex
           pop: true
         - match: \\
           scope: punctuation.definition.table.row.latex
@@ -244,6 +289,12 @@ contexts:
       push:
         - meta_scope: meta.function.environment.list.latex
         - match: '((\\)end)(\{)(\4)(\})(?:\s*\n)?'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.latex
           pop: true
         - include: $top_level_main
     - match: '(?:\s*)((\\)begin)(\{)(\w+[*]?)(\})'
@@ -256,6 +307,12 @@ contexts:
       push:
         - meta_scope: meta.function.environment.general.latex
         - match: '((\\)end)(\{)(\4)(\})(?:\s*\n)?'
+          captures:
+            1: support.function.be.latex
+            2: punctuation.definition.function.latex
+            3: punctuation.definition.arguments.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.arguments.latex
           pop: true
         - include: $top_level_main
     - match: (\\)(newcommand|renewcommand)\b
@@ -349,16 +406,16 @@ contexts:
         1: punctuation.definition.keyword.latex
     - match: |-
         (?x)
-          (
-            (\\)                    # Marker
-            (?:foot)?(?:full)?(?:no)?(?:short)?   # Function Name
-            [cC]ite
-            (?:al)?(?:t|p|author|year(?:par)?|title)?[ANP]*
-            \*?                     # Optional Unabreviated
-          )
-          (?:(\[)[^\]]*(\]))?               # Optional
-          (?:(\[)[^\]]*(\]))?               #   Arguments
-          (\{)                      # Opening Bracket
+        	(
+        		(\\)										# Marker
+        		(?:foot)?(?:full)?(?:no)?(?:short)?		# Function Name
+        		[cC]ite
+        		(?:al)?(?:t|p|author|year(?:par)?|title)?[ANP]*
+        		\*?											# Optional Unabreviated
+        	)
+        	(?:(\[)[^\]]*(\]))?								# Optional
+        	(?:(\[)[^\]]*(\]))?								#   Arguments
+        	(\{)											# Opening Bracket
       captures:
         1: keyword.control.cite.latex
         2: punctuation.definition.keyword.latex

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -12,10 +12,10 @@ contexts:
   main:
     - match: |-
         (?x)^
-        (?= [ ]{,3}>.
-        | ([ ]{4}|\t)(?!$)
-        | [#]{1,6}\s*+
-        | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+        (?=	[ ]{,3}>.
+        |	([ ]{4}|\t)(?!$)
+        |	[#]{1,6}\s*+
+        |	[ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
         )
       comment: |
         We could also use an empty end match and set
@@ -25,10 +25,10 @@ contexts:
         - meta_scope: meta.block-level.markdown
         - match: |-
             (?x)^
-            (?! [ ]{,3}>.
-            | ([ ]{4}|\t)
-            | [#]{1,6}\s*+
-            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            (?!	[ ]{,3}>.
+            |	([ ]{4}|\t)
+            |	[#]{1,6}\s*+
+            |	[ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             )
           pop: true
         - include: block_quote
@@ -41,6 +41,8 @@ contexts:
       push:
         - meta_scope: markup.list.unnumbered.markdown
         - match: ^(?=\S)
+          captures:
+            1: punctuation.definition.list_item.markdown
           pop: true
         - include: list-paragraph
     - match: '^[ ]{0,3}[0-9]+(\.)(?=\s)'
@@ -49,6 +51,8 @@ contexts:
       push:
         - meta_scope: markup.list.numbered.markdown
         - match: ^(?=\S)
+          captures:
+            1: punctuation.definition.list_item.markdown
           pop: true
         - include: list-paragraph
     - match: '^(?=<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\b)(?!.*?</\1>)'
@@ -67,17 +71,17 @@ contexts:
         - include: scope:text.html.basic
     - match: |-
         (?x:
-          \s*           # Leading whitespace
-          (\[)(.+?)(\])(:)    # Reference name
-          [ \t]*          # Optional whitespace
-          (<?)(\S+?)(>?)      # The url
-          [ \t]*          # Optional whitespace
-          (?:
-              ((\().+?(\)))   # Match title in quotes…
-            | ((").+?("))   # or in parens.
-          )?            # Title is optional
-          \s*           # Optional whitespace
-          $
+        	\s*						# Leading whitespace
+        	(\[)(.+?)(\])(:)		# Reference name
+        	[ \t]*					# Optional whitespace
+        	(<?)(\S+?)(>?)			# The url
+        	[ \t]*					# Optional whitespace
+        	(?:
+        		  ((\().+?(\)))		# Match title in quotes…
+        		| ((").+?("))		# or in parens.
+        	)?						# Title is optional
+        	\s*						# Optional whitespace
+        	$
         )
       scope: meta.link.reference.def.markdown
       captures:
@@ -127,14 +131,14 @@ contexts:
         - meta_scope: markup.quote.markdown
         - match: |-
             (?x)^
-            (?= \s*$
-            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
-            | [ ]{,3}>.
+            (?=	\s*$
+            |	[ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            |	[ ]{,3}>.
             )
           pop: true
         - match: |-
             (?x)\G
-            (?= [ ]{,3}>.
+            (?=	[ ]{,3}>.
             )
           push:
             - match: ^
@@ -142,9 +146,9 @@ contexts:
             - include: block_quote
         - match: |-
             (?x)\G
-            (?= ([ ]{4}|\t)
-            | [#]{1,6}\s*+
-            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            (?=	([ ]{4}|\t)
+            |	[#]{1,6}\s*+
+            |	[ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             )
           push:
             - include: block_raw
@@ -154,11 +158,11 @@ contexts:
               pop: true
         - match: |-
             (?x)\G
-            (?! $
-            | [ ]{,3}>.
-            | ([ ]{4}|\t)
-            | [#]{1,6}\s*+
-            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            (?!	$
+            |	[ ]{,3}>.
+            |	([ ]{4}|\t)
+            |	[#]{1,6}\s*+
+            |	[ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             )
           push:
             - match: $|(?<=\n)
@@ -170,50 +174,52 @@ contexts:
   bold:
     - match: |-
         (?x)
-          (\*\*|__)(?=\S)               # Open
-          (?=
-            (
-                <[^>]*+>              # HTML tags
-              | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
-                                # Raw
-              | \\[\\`*_{}\[\]()#.!+\->]?+      # Escapes
-              | \[
-              (
-                      (?<square>          # Named group
-                    [^\[\]\\]       # Match most chars
-                        | \\.           # Escaped chars
-                        | \[ \g<square>*+ \]    # Nested brackets
-                      )*+
-                \]
-                (
-                  (             # Reference Link
-                    [ ]?          # Optional space
-                    \[[^\]]*+\]       # Ref name
-                  )
-                  | (             # Inline Link
-                    \(            # Opening paren
-                      [ \t]*+       # Optional whtiespace
-                      <?(.*?)>?     # URL
-                      [ \t]*+       # Optional whtiespace
-                      (         # Optional Title
-                        (?<title>['"])
-                        (.*?)
-                        \k<title>
-                      )?
-                    \)
-                  )
-                )
-              )
-              | (?!(?<=\S)\1).            # Everything besides
-                                # style closer
-            )++
-            (?<=\S)\1               # Close
-          )
+        	(\*\*|__)(?=\S)								# Open
+        	(?=
+        		(
+        		    <[^>]*+>							# HTML tags
+        		  | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
+        												# Raw
+        		  | \\[\\`*_{}\[\]()#.!+\->]?+			# Escapes
+        		  | \[
+        			(
+        			        (?<square>					# Named group
+        						[^\[\]\\]				# Match most chars
+        			          | \\.						# Escaped chars
+        			          | \[ \g<square>*+ \]		# Nested brackets
+        			        )*+
+        				\]
+        				(
+        					(							# Reference Link
+        						[ ]?					# Optional space
+        						\[[^\]]*+\]				# Ref name
+        					)
+        				  | (							# Inline Link
+        						\(						# Opening paren
+        							[ \t]*+				# Optional whtiespace
+        							<?(.*?)>?			# URL
+        							[ \t]*+				# Optional whtiespace
+        							(					# Optional Title
+        								(?<title>['"])
+        								(.*?)
+        								\k<title>
+        							)?
+        						\)
+        					)
+        				)
+        			)
+        		  | (?!(?<=\S)\1).						# Everything besides
+        												# style closer
+        		)++
+        		(?<=\S)\1								# Close
+        	)
       captures:
         1: punctuation.definition.bold.markdown
       push:
         - meta_scope: markup.bold.markdown
         - match: (?<=\S)(\1)
+          captures:
+            1: punctuation.definition.bold.markdown
           pop: true
         - match: "(?=<[^>]*?>)"
           push:
@@ -249,25 +255,27 @@ contexts:
         - meta_scope: markup.heading.markdown
         - meta_content_scope: entity.name.section.markdown
         - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
           pop: true
         - include: inline
   image-inline:
     - match: |-
         (?x:
-                \!              # Images start with !
-                (\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
-                              # Match the link text.
-                ([ ])?            # Space not allowed
-                (\()            # Opening paren for url
-                  (<?)(\S+?)(>?)      # The url
-                  [ \t]*          # Optional whitespace
-                  (?:
-                      ((\().+?(\)))   # Match title in parens…
-                    | ((").+?("))   # or in quotes.
-                  )?            # Title is optional
-                  \s*           # Optional whitespace
-                (\))
-               )
+        				\!							# Images start with !
+        				(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
+        											# Match the link text.
+        				([ ])?						# Space not allowed
+        				(\()						# Opening paren for url
+        					(<?)(\S+?)(>?)			# The url
+        					[ \t]*					# Optional whitespace
+        					(?:
+        						  ((\().+?(\)))		# Match title in parens…
+        						| ((").+?("))		# or in quotes.
+        					)?						# Title is optional
+        					\s*						# Optional whitespace
+        				(\))
+        			 )
       scope: meta.image.inline.markdown
       captures:
         1: punctuation.definition.string.begin.markdown
@@ -313,51 +321,53 @@ contexts:
   italic:
     - match: |-
         (?x)
-          (\*|_)(?=\S)                # Open
-          (?=
-            (
-                <[^>]*+>              # HTML tags
-              | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
-                                # Raw
-              | \\[\\`*_{}\[\]()#.!+\->]?+      # Escapes
-              | \[
-              (
-                      (?<square>          # Named group
-                    [^\[\]\\]       # Match most chars
-                        | \\.           # Escaped chars
-                        | \[ \g<square>*+ \]    # Nested brackets
-                      )*+
-                \]
-                (
-                  (             # Reference Link
-                    [ ]?          # Optional space
-                    \[[^\]]*+\]       # Ref name
-                  )
-                  | (             # Inline Link
-                    \(            # Opening paren
-                      [ \t]*+       # Optional whtiespace
-                      <?(.*?)>?     # URL
-                      [ \t]*+       # Optional whtiespace
-                      (         # Optional Title
-                        (?<title>['"])
-                        (.*?)
-                        \k<title>
-                      )?
-                    \)
-                  )
-                )
-              )
-              | \1\1                # Must be bold closer
-              | (?!(?<=\S)\1).            # Everything besides
-                                # style closer
-            )++
-            (?<=\S)\1               # Close
-          )
+        	(\*|_)(?=\S)								# Open
+        	(?=
+        		(
+        		    <[^>]*+>							# HTML tags
+        		  | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
+        												# Raw
+        		  | \\[\\`*_{}\[\]()#.!+\->]?+			# Escapes
+        		  | \[
+        			(
+        			        (?<square>					# Named group
+        						[^\[\]\\]				# Match most chars
+        			          | \\.						# Escaped chars
+        			          | \[ \g<square>*+ \]		# Nested brackets
+        			        )*+
+        				\]
+        				(
+        					(							# Reference Link
+        						[ ]?					# Optional space
+        						\[[^\]]*+\]				# Ref name
+        					)
+        				  | (							# Inline Link
+        						\(						# Opening paren
+        							[ \t]*+				# Optional whtiespace
+        							<?(.*?)>?			# URL
+        							[ \t]*+				# Optional whtiespace
+        							(					# Optional Title
+        								(?<title>['"])
+        								(.*?)
+        								\k<title>
+        							)?
+        						\)
+        					)
+        				)
+        			)
+        		  | \1\1								# Must be bold closer
+        		  | (?!(?<=\S)\1).						# Everything besides
+        												# style closer
+        		)++
+        		(?<=\S)\1								# Close
+        	)
       captures:
         1: punctuation.definition.italic.markdown
       push:
         - meta_scope: markup.italic.markdown
         - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+          captures:
+            1: punctuation.definition.italic.markdown
           pop: true
         - match: "(?=<[^>]*?>)"
           push:
@@ -396,19 +406,19 @@ contexts:
   link-inline:
     - match: |-
         (?x:
-                (\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
-                              # Match the link text.
-                ([ ])?            # Space not allowed
-                (\()            # Opening paren for url
-                  (<?)(.*?)(>?)     # The url
-                  [ \t]*          # Optional whitespace
-                  (?:
-                      ((\().+?(\)))   # Match title in parens…
-                    | ((").+?("))   # or in quotes.
-                  )?            # Title is optional
-                  \s*           # Optional whitespace
-                (\))
-               )
+        				(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
+        											# Match the link text.
+        				([ ])?						# Space not allowed
+        				(\()						# Opening paren for url
+        					(<?)(.*?)(>?)			# The url
+        					[ \t]*					# Optional whitespace
+        					(?:
+        						  ((\().+?(\)))		# Match title in parens…
+        						| ((").+?("))		# or in quotes.
+        					)?						# Title is optional
+        					\s*						# Optional whitespace
+        				(\))
+        			 )
       scope: meta.link.inline.markdown
       captures:
         1: punctuation.definition.string.begin.markdown

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -69,6 +69,8 @@ contexts:
       push:
         - meta_scope: comment.block.percentage.matlab
         - match: '%\}\s*\n'
+          captures:
+            1: punctuation.definition.comment.matlab
           pop: true
     - match: (%).*$\n?
       scope: comment.line.percentage.matlab

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -21,6 +21,14 @@ contexts:
         - meta_scope: meta.interface-or-protocol.objc
         - meta_content_scope: meta.scope.interface.objc
         - match: ((@)end)\b
+          captures:
+            1: storage.type.objc
+            2: punctuation.definition.storage.type.objc
+            4: entity.name.type.objc
+            6: punctuation.definition.entity.other.inherited-class.objc
+            7: entity.other.inherited-class.objc
+            8: meta.divider.objc
+            9: meta.inherited-class.objc
           pop: true
         - include: interface_innards
     - match: '((@)(implementation))\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*([A-Za-z][A-Za-z0-9]*))?'
@@ -33,6 +41,11 @@ contexts:
         - meta_scope: meta.implementation.objc
         - meta_content_scope: meta.scope.implementation.objc
         - match: ((@)end)\b
+          captures:
+            1: storage.type.objc
+            2: punctuation.definition.storage.type.objc
+            4: entity.name.type.objc
+            5: entity.other.inherited-class.objc
           pop: true
         - include: implementation_innards
     - match: '@"'
@@ -141,6 +154,8 @@ contexts:
       push:
         - meta_scope: comment.block.objc
         - match: \*/
+          captures:
+            0: punctuation.definition.comment.objc
           pop: true
     - match: //
       captures:
@@ -231,7 +246,7 @@ contexts:
     - match: |-
         (?x) (?: (?= \s )  (?:(?<=else|new|return) | (?<!\w)) (\s+))?
         (\b
-          (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate)\s*\()(?:(?!NS)[A-Za-z_][A-Za-z0-9_]*+\b | :: )++                  # actual name
+        	(?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate)\s*\()(?:(?!NS)[A-Za-z_][A-Za-z0-9_]*+\b | :: )++                  # actual name
         )
          \s*(\()
       scope: meta.function-call.c
@@ -276,6 +291,9 @@ contexts:
           push:
             - meta_scope: meta.return-type.objc
             - match: (\))\s*(\w+\b)
+              captures:
+                1: punctuation.definition.type.objc
+                2: entity.name.function.objc
               pop: true
             - include: protocol_list
             - include: protocol_type_qualifier
@@ -321,6 +339,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b.*?(?:(?=(?://|/\*))|$))
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b)
           captures:
@@ -328,6 +350,9 @@ contexts:
             2: keyword.control.import.else.c
           push:
             - match: (?=^\s*#\s*endif\b.*?(?:(?=(?://|/\*))|$))
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: interface_innards
         - match: ""
@@ -345,6 +370,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b.*?(?:(?=(?://|/\*))|$))
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b)
           captures:
@@ -352,6 +381,9 @@ contexts:
             2: keyword.control.import.else.c
           push:
             - match: (?=^\s*#\s*endif\b.*?(?:(?=(?://|/\*))|$))
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: interface_innards
         - match: ""
@@ -369,6 +401,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b.*?(?:(?=(?://|/\*))|$))
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b).*
           captures:
@@ -377,6 +413,9 @@ contexts:
           push:
             - meta_content_scope: comment.block.preprocessor.else-branch.c
             - match: (?=^\s*#\s*endif\b.*?(?:(?=(?://|/\*))|$))
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: disabled
             - include: pragma-mark
@@ -393,6 +432,10 @@ contexts:
         3: constant.numeric.preprocessor.c
       push:
         - match: ^\s*(#\s*(endif)\b.*?(?:(?=(?://|/\*))|$))
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.if.c
+            3: constant.numeric.preprocessor.c
           pop: true
         - match: ^\s*(#\s*(else)\b).*
           captures:
@@ -401,6 +444,9 @@ contexts:
           push:
             - meta_content_scope: comment.block.preprocessor.else-branch.c
             - match: (?=^\s*#\s*endif\b.*?(?:(?=(?://|/\*))|$))
+              captures:
+                1: meta.preprocessor.c
+                2: keyword.control.import.else.c
               pop: true
             - include: disabled
             - include: pragma-mark
@@ -416,6 +462,9 @@ contexts:
         2: keyword.control.import.c
       push:
         - match: ^\s*(#\s*(endif)\b).*?(?:(?=(?://|/\*))|$)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.c
           pop: true
         - include: implementation_innards
   preprocessor-rule-other-interface:
@@ -425,6 +474,9 @@ contexts:
         2: keyword.control.import.c
       push:
         - match: ^\s*(#\s*(endif)\b).*?(?:(?=(?://|/\*))|$)
+          captures:
+            1: meta.preprocessor.c
+            2: keyword.control.import.c
           pop: true
         - include: interface_innards
   properties:

--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -54,6 +54,8 @@ contexts:
       push:
         - meta_scope: comment.block.pascal.one
         - match: \*\)
+          captures:
+            0: punctuation.definition.comment.pascal
           pop: true
     - match: '\{'
       captures:
@@ -61,6 +63,8 @@ contexts:
       push:
         - meta_scope: comment.block.pascal.two
         - match: '\}'
+          captures:
+            0: punctuation.definition.comment.pascal
           pop: true
     - match: '"'
       comment: Double quoted strings are an extension and (generally) support C-style escape sequences.

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -20,6 +20,8 @@ contexts:
       push:
         - meta_scope: comment.block.documentation.perl
         - match: ^=cut
+          captures:
+            0: punctuation.definition.comment.perl
           pop: true
     - include: variable
     - match: '\b(?=qr\s*[^\s\w])'
@@ -32,6 +34,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.nested_braces.perl
             - match: '\}'
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -43,6 +48,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.nested_brackets.perl
             - match: '\]'
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -54,6 +62,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.nested_ltgt.perl
             - match: ">"
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -65,6 +76,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.nested_parens.perl
             - match: \)
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -76,6 +90,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.single-quote.perl
             - match: \'
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
         - match: '(qr)\s*([^\s\w\''\{\[\(\<])'
@@ -85,6 +102,9 @@ contexts:
           push:
             - meta_scope: string.regexp.compile.simple-delimiter.perl
             - match: \2
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - match: '\$(?=[^\s\w\''\{\[\(\<])'
               comment: This is to prevent thinks like qr/foo$/ to treat $/ as a variable
@@ -108,6 +128,9 @@ contexts:
           push:
             - meta_scope: string.regexp.nested_braces.perl
             - match: '\}'
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: nested_braces
@@ -118,6 +141,9 @@ contexts:
           push:
             - meta_scope: string.regexp.nested_brackets.perl
             - match: '\]'
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: nested_brackets
@@ -128,6 +154,9 @@ contexts:
           push:
             - meta_scope: string.regexp.nested_ltgt.perl
             - match: ">"
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: nested_ltgt
@@ -138,6 +167,9 @@ contexts:
           push:
             - meta_scope: string.regexp.nested_parens.perl
             - match: \)
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
             - include: nested_parens
@@ -147,6 +179,8 @@ contexts:
           push:
             - meta_scope: string.regexp.format.nested_braces.perl
             - match: '\}'
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -157,16 +191,20 @@ contexts:
           push:
             - meta_scope: string.regexp.format.nested_brackets.perl
             - match: '\]'
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
             - include: nested_brackets_interpolated
-        - match: <
+        - match: "<"
           captures:
             0: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.nested_ltgt.perl
             - match: ">"
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -177,6 +215,8 @@ contexts:
           push:
             - meta_scope: string.regexp.format.nested_parens.perl
             - match: \)
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -187,6 +227,8 @@ contexts:
           push:
             - meta_scope: string.regexp.format.single_quote.perl
             - match: "'"
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - match: '\\[''\\]'
               scope: constant.character.escape.perl
@@ -196,6 +238,8 @@ contexts:
           push:
             - meta_scope: string.regexp.format.simple_delimiter.perl
             - match: \1
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -222,6 +266,9 @@ contexts:
           push:
             - meta_scope: string.regexp.replaceXXX.simple_delimiter.perl
             - match: (?=\2)
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
         - match: "'"
@@ -230,6 +277,8 @@ contexts:
           push:
             - meta_scope: string.regexp.replaceXXX.format.single_quote.perl
             - match: "'"
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - match: '\\[''\\]'
               scope: constant.character.escape.perl.perl
@@ -239,6 +288,8 @@ contexts:
           push:
             - meta_scope: string.regexp.replaceXXX.format.simple_delimiter.perl
             - match: \1
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -258,6 +309,9 @@ contexts:
           push:
             - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
             - match: (?=\2)
+              captures:
+                0: punctuation.definition.string.perl
+                1: support.function.perl
               pop: true
             - include: escaped_char
         - match: "'"
@@ -266,6 +320,8 @@ contexts:
           push:
             - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
             - match: '''(?=[egimos]*x[egimos]*)\b'
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
         - match: (.)
@@ -274,6 +330,8 @@ contexts:
           push:
             - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
             - match: '\1(?=[egimos]*x[egimos]*)\b'
+              captures:
+                0: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -406,6 +464,10 @@ contexts:
       push:
         - meta_content_scope: text.html.embedded.perl
         - match: (^HTML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -418,6 +480,10 @@ contexts:
       push:
         - meta_content_scope: text.xml.embedded.perl
         - match: (^XML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -430,6 +496,10 @@ contexts:
       push:
         - meta_content_scope: text.css.embedded.perl
         - match: (^CSS$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -442,6 +512,10 @@ contexts:
       push:
         - meta_content_scope: text.js.embedded.perl
         - match: (^JAVASCRIPT$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -454,6 +528,10 @@ contexts:
       push:
         - meta_content_scope: source.sql.embedded.perl
         - match: (^SQL$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -466,6 +544,10 @@ contexts:
       push:
         - meta_content_scope: text.postscript.embedded.perl
         - match: (^POSTSCRIPT$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -478,6 +560,10 @@ contexts:
       push:
         - meta_content_scope: string.unquoted.heredoc.doublequote.perl
         - match: (^\3$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.doublequote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -489,6 +575,10 @@ contexts:
       push:
         - meta_content_scope: text.html.embedded.perl
         - match: (^HTML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:text.html.basic
     - match: ((<<) *'XML').*\n?
@@ -499,6 +589,10 @@ contexts:
       push:
         - meta_content_scope: text.xml.embedded.perl
         - match: (^XML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:text.xml
     - match: ((<<) *'CSS').*\n?
@@ -509,6 +603,10 @@ contexts:
       push:
         - meta_content_scope: text.css.embedded.perl
         - match: (^CSS$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:source.css
     - match: ((<<) *'JAVASCRIPT').*\n?
@@ -519,6 +617,10 @@ contexts:
       push:
         - meta_content_scope: text.js.embedded.perl
         - match: (^JAVASCRIPT$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:source.js
     - match: ((<<) *'SQL').*\n?
@@ -529,6 +631,10 @@ contexts:
       push:
         - meta_content_scope: source.sql.embedded.perl
         - match: (^SQL$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:source.sql
     - match: ((<<) *'POSTSCRIPT').*\n?
@@ -539,6 +645,10 @@ contexts:
       push:
         - meta_content_scope: source.postscript.embedded.perl
         - match: (^POSTSCRIPT)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: scope:source.postscript
     - match: '((<<) *''([^'']*)'').*\n?'
@@ -549,6 +659,10 @@ contexts:
       push:
         - meta_content_scope: string.unquoted.heredoc.quote.perl
         - match: (^\3$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.quote.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
     - match: '((<<) *`([^`]*)`).*\n?'
       captures:
@@ -558,6 +672,10 @@ contexts:
       push:
         - meta_content_scope: string.unquoted.heredoc.backtick.perl
         - match: (^\3$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.backtick.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -569,6 +687,10 @@ contexts:
       push:
         - meta_content_scope: text.html.embedded.perl
         - match: (^HTML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -581,6 +703,10 @@ contexts:
       push:
         - meta_content_scope: text.xml.embedded.perl
         - match: (^XML$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -593,6 +719,10 @@ contexts:
       push:
         - meta_content_scope: source.sql.embedded.perl
         - match: (^SQL$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -605,6 +735,10 @@ contexts:
       push:
         - meta_content_scope: source.postscript.embedded.perl
         - match: (^POSTSCRIPT)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -617,6 +751,10 @@ contexts:
       push:
         - meta_content_scope: string.unquoted.heredoc.perl
         - match: (^\3$)
+          captures:
+            0: punctuation.definition.string.perl
+            1: string.unquoted.heredoc.perl
+            2: punctuation.definition.heredoc.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -875,6 +1013,8 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: '\}'
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: escaped_char
         - include: nested_braces
@@ -884,6 +1024,8 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: '\}'
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: escaped_char
         - include: variable
@@ -894,6 +1036,8 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: '\]'
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: escaped_char
         - include: nested_brackets
@@ -903,24 +1047,30 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: '\]'
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: escaped_char
         - include: variable
         - include: nested_brackets_interpolated
   nested_ltgt:
-    - match: <
+    - match: "<"
       captures:
         1: punctuation.section.scope.perl
       push:
         - match: ">"
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: nested_ltgt
   nested_ltgt_interpolated:
-    - match: <
+    - match: "<"
       captures:
         1: punctuation.section.scope.perl
       push:
         - match: ">"
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: variable
         - include: nested_ltgt_interpolated
@@ -930,6 +1080,8 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: \)
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - include: escaped_char
         - include: nested_parens
@@ -939,6 +1091,8 @@ contexts:
         1: punctuation.section.scope.perl
       push:
         - match: \)
+          captures:
+            1: punctuation.section.scope.perl
           pop: true
         - match: '\$(?=[^\s\w\''\{\[\(\<])'
           comment: This is to prevent thinks like qr/foo$/ to treat $/ as a variable

--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -24,6 +24,10 @@ contexts:
         4: punctuation.separator.key-value.restructuredtext
       push:
         - match: '^(?!\1[ \t])'
+          captures:
+            2: meta.directive.restructuredtext
+            3: punctuation.definition.directive.restructuredtext
+            4: punctuation.separator.key-value.restructuredtext
           pop: true
         - include: scope:text.html.basic
     - match: '(\.\.)\s[A-z][A-z0-9-_]+(::)\s*$'
@@ -40,6 +44,9 @@ contexts:
       push:
         - meta_scope: meta.raw.block.restructuredtext
         - match: '^(?=\1[^\s]+)'
+          captures:
+            2: markup.raw.restructuredtext
+            3: punctuation.definition.raw.restructuredtext
           pop: true
         - match: .+
           scope: markup.raw.restructuredtext
@@ -154,6 +161,8 @@ contexts:
       push:
         - meta_scope: markup.raw.restructuredtext
         - match: "``"
+          captures:
+            0: punctuation.definition.raw.restructuredtext
           pop: true
     - match: "(`)[^`]+(`)(?!_)"
       comment: intepreted text

--- a/ShellScript/Shell-Unix-Generic.sublime-syntax
+++ b/ShellScript/Shell-Unix-Generic.sublime-syntax
@@ -50,6 +50,8 @@ contexts:
           push:
             - meta_scope: meta.scope.case-pattern.shell
             - match: \)
+              captures:
+                0: punctuation.definition.case-pattern.shell
               pop: true
             - match: \|
               scope: punctuation.separator.pipe-sign.shell
@@ -70,6 +72,8 @@ contexts:
       push:
         - meta_scope: meta.scope.logical-expression.shell
         - match: '(\]{2})'
+          captures:
+            1: punctuation.definition.logical-expression.shell
           pop: true
         - include: logical-expression
         - include: main
@@ -89,6 +93,8 @@ contexts:
       push:
         - meta_scope: meta.scope.subshell.shell
         - match: (\))
+          captures:
+            1: punctuation.definition.subshell.shell
           pop: true
         - include: main
     - match: '(?<=\s|^)(\{)(?=\s|$)'
@@ -97,6 +103,8 @@ contexts:
       push:
         - meta_scope: meta.scope.group.shell
         - match: '(?<=^|;)\s*(\})'
+          captures:
+            1: punctuation.definition.group.shell
           pop: true
         - include: main
   function-definition:
@@ -362,6 +370,8 @@ contexts:
       push:
         - meta_scope: meta.scope.for-loop.shell
         - match: \b(done)\b
+          captures:
+            1: keyword.control.shell
           pop: true
         - include: main
     - match: '\b(for)\s+((?:[^\s\\]|\\.)+)\b'
@@ -381,6 +391,8 @@ contexts:
       push:
         - meta_scope: meta.scope.while-loop.shell
         - match: \b(done)\b
+          captures:
+            1: keyword.control.shell
           pop: true
         - include: main
     - match: '\b(select)\s+((?:[^\s\\]|\\.)+)\b'
@@ -400,6 +412,8 @@ contexts:
       push:
         - meta_scope: meta.scope.case-block.shell
         - match: \b(esac)\b
+          captures:
+            1: keyword.control.shell
           pop: true
         - match: \b(?:in)\b
           captures:
@@ -539,6 +553,8 @@ contexts:
       push:
         - meta_scope: variable.other.bracket.shell
         - match: '\}'
+          captures:
+            0: punctuation.definition.variable.shell
           pop: true
         - match: '!|:[-=?]?|\*|@|#{1,2}|%{1,2}|/'
           scope: keyword.operator.expansion.shell

--- a/Textile/Textile.sublime-syntax
+++ b/Textile/Textile.sublime-syntax
@@ -16,6 +16,10 @@ contexts:
       push:
         - meta_scope: markup.heading.textile
         - match: ^$
+          captures:
+            1: entity.name.tag.heading.textile
+            3: entity.name.type.textile
+            4: entity.name.tag.heading.textile
           pop: true
         - include: inline
         - include: scope:text.html.basic
@@ -27,6 +31,10 @@ contexts:
       push:
         - meta_scope: markup.quote.textile
         - match: ^$
+          captures:
+            1: entity.name.tag.blockquote.textile
+            3: entity.name.type.textile
+            4: entity.name.tag.blockquote.textile
           pop: true
         - include: inline
         - include: scope:text.html.basic
@@ -38,6 +46,10 @@ contexts:
       push:
         - meta_scope: markup.other.footnote.textile
         - match: ^$
+          captures:
+            1: entity.name.tag.footnote.textile
+            3: entity.name.type.textile
+            4: entity.name.tag.footnote.textile
           pop: true
         - include: inline
         - include: scope:text.html.basic
@@ -49,6 +61,10 @@ contexts:
       push:
         - meta_scope: markup.other.table.textile
         - match: ^$
+          captures:
+            1: entity.name.tag.footnote.textile
+            3: entity.name.type.textile
+            4: entity.name.tag.footnote.textile
           pop: true
         - include: inline
         - include: scope:text.html.basic
@@ -80,24 +96,24 @@ contexts:
         1: entity.name.type.textile
     - match: |-
         (?x)
-              "               # Start name, etc
-                (?:             # Attributes
-                  # I swear, this is how the language is defined,
-                  # couldnt make it up if I tried.
-                  (?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
-                    # Class, Style, Lang
-                  | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
-                    # Style, Lang, Class
-                  | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
-                    # Lang, Style, Class
-                )?
-                ([^"]+?)          # Link name
-                \s?             # Optional whitespace
-                (?:\(([^)]+?)\))?
-              ":                # End name
-              (\w[-\w_]*)           # Linkref
-              (?=[^\w\/;]*?(<|\s|$))      # Catch closing punctuation
-                              #  and end of meta.link
+        			"								# Start name, etc
+        				(?:							# Attributes
+        					# I swear, this is how the language is defined,
+        					# couldnt make it up if I tried.
+        					(?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
+        						# Class, Style, Lang
+        				  | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
+        						# Style, Lang, Class
+        				  | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
+        						# Lang, Style, Class
+        				)?
+        				([^"]+?)					# Link name
+        				\s?							# Optional whitespace
+        				(?:\(([^)]+?)\))?
+        			":								# End name
+        			(\w[-\w_]*)						# Linkref
+        			(?=[^\w\/;]*?(<|\s|$))			# Catch closing punctuation
+        											#  and end of meta.link
       scope: meta.link.reference.textile
       captures:
         1: string.other.link.title.textile
@@ -105,24 +121,24 @@ contexts:
         3: constant.other.reference.link.textile
     - match: |-
         (?x)
-              "               # Start name, etc
-                (?:             # Attributes
-                  # I swear, this is how the language is defined,
-                  # couldnt make it up if I tried.
-                  (?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
-                    # Class, Style, Lang
-                  | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
-                    # Style, Lang, Class
-                  | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
-                    # Lang, Style, Class
-                )?
-                ([^"]+?)          # Link name
-                \s?             # Optional whitespace
-                (?:\(([^)]+?)\))?
-              ":                # End Name
-              (\S*?(?:\w|\/|;))       # URL
-              (?=[^\w\/;]*?(<|\s|$))      # Catch closing punctuation
-                              #  and end of meta.link
+        			"								# Start name, etc
+        				(?:							# Attributes
+        					# I swear, this is how the language is defined,
+        					# couldnt make it up if I tried.
+        					(?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
+        						# Class, Style, Lang
+        				  | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
+        						# Style, Lang, Class
+        				  | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
+        						# Lang, Style, Class
+        				)?
+        				([^"]+?)					# Link name
+        				\s?							# Optional whitespace
+        				(?:\(([^)]+?)\))?
+        			":								# End Name
+        			(\S*?(?:\w|\/|;))				# URL
+        			(?=[^\w\/;]*?(<|\s|$))			# Catch closing punctuation
+        											#  and end of meta.link
       scope: meta.link.inline.textile
       captures:
         1: string.other.link.title.textile
@@ -130,28 +146,28 @@ contexts:
         3: markup.underline.link.textile
     - match: |-
         (?x)
-              \!                    # Open image
-              (\<|\=|\>)?               # Optional alignment
-              (?:                   # Attributes
-                # I swear, this is how the language is defined,
-                # couldnt make it up if I tried.
-                (?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
-                  # Class, Style, Lang
-                | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
-                  # Style, Lang, Class
-                | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
-                  # Lang, Style, Class
-              )?
-              (?:\.[ ])?                      # Optional
-              ([^\s(!]+?)                   # Image URL
-              \s?                           # Optional space
-              (?:\(((?:[^\(\)]|\([^\)]+\))+?)\))?     # Optional title
-              \!                    # Close image
-              (?:
-                :
-                (\S*?(?:\w|\/|;))         # URL
-                (?=[^\w\/;]*?(<|\s|$))        # Catch closing punctuation
-              )?
+        			\!										# Open image
+        			(\<|\=|\>)?								# Optional alignment
+        			(?:										# Attributes
+        				# I swear, this is how the language is defined,
+        				# couldnt make it up if I tried.
+        				(?:\([^)]+\))?(?:\{[^}]+\})?(?:\[[^\]]+\])?
+        					# Class, Style, Lang
+        			  | (?:\{[^}]+\})?(?:\[[^\]]+\])?(?:\([^)]+\))?
+        					# Style, Lang, Class
+        			  | (?:\[[^\]]+\])?(?:\{[^}]+\})?(?:\([^)]+\))?
+        					# Lang, Style, Class
+        			)?
+        			(?:\.[ ])?            					# Optional
+        			([^\s(!]+?)         					# Image URL
+        			\s?                						# Optional space
+        			(?:\(((?:[^\(\)]|\([^\)]+\))+?)\))?   	# Optional title
+        			\!										# Close image
+        			(?:
+        				:
+        				(\S*?(?:\w|\/|;))					# URL
+        				(?=[^\w\/;]*?(<|\s|$))				# Catch closing punctuation
+        			)?
       scope: meta.image.inline.textile
       captures:
         2: markup.underline.link.image.textile


### PR DESCRIPTION
As explained in #56, the converter did not consider copying the "captures" dict to the pop pattern that is pushed onto the stack. I altered the conversion script (and made it suitable for command-line use because there were a few flaws with it). For convenience, it's now possible to pass entire directories.

Fixes #56, closes #57.

---

Changes to `Default/convert_syntax.py`:
```diff
--- C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Packages\Default\convert_syntax.py   Tue Jun  2 11:04:30 2015
+++ C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Packages\Default\convert_syntax.py   Mon Jul  6 00:16:43 2015
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import plistlib
 import os
 import sys
@@ -9,6 +11,7 @@
 
 def needs_yaml_quoting(s):
     return (s == "" or s[0] in "\"'%-:?@`&*!,#|>0123456789="
+        or s.startswith("<<")
         or s in ["true", "false", "null"]
         or "# " in s or ": " in s
         or "[" in s or "]" in s or "{" in s or "}" in s
@@ -213,8 +216,9 @@
             end_entry = {}
             end_entry["match"] = format_regex(p["end"])
             end_entry["pop"] = True
-            if "endCaptures" in p:
-                captures = format_captures(p["endCaptures"])
+            if "endCaptures" in p or "captures" in p:
+                captures = format_captures(
+                    p.get("endCaptures", p.get("captures")))
                 if "0" in captures:
                     end_entry["scope"] = captures["0"]
                     del captures["0"]
@@ -294,8 +298,12 @@
                 # ctx.append({"include-syntax": key})
                 ctx.append({"include": format_external_syntax(key)})
 
-        else:
-            raise Exception("unknown pattern type: ")
+        elif list(p.keys()) == ["comment"]:
+            comment = format_comment(p["comment"])
+            if comment:
+                ctx.append({"comment": comment})
+        else:
+            raise Exception("unknown pattern type: %s" % p.keys())
 
     return ctx
 
@@ -394,7 +402,7 @@
             data = to_yaml(convert(syn))
 
             # to_yaml will leave some trailing whitespace, remove it
-            data = "\n".join([l.rstrip() for l in data.splitlines()]) + "\n"
+            data = "\n".join(l.rstrip() for l in data.splitlines()) + "\n"
 
             v = self.window.new_file()
             v.set_name(os.path.basename(base) + ".sublime-syntax")
@@ -432,9 +440,12 @@
     import fnmatch
 
     class sublime:
-        def find_resources(pattern):
+        base_path = "."
+
+        @classmethod
+        def find_resources(cls, pattern):
             paths = []
-            for root, dirs, files in os.walk('.'):
+            for root, dirs, files in os.walk(cls.base_path):
                 for fname in files:
                     if fnmatch.fnmatch(fname, pattern):
                         path = os.path.join(root, fname)
@@ -445,23 +456,41 @@
                         paths.append(path)
             return paths
 
+        @staticmethod
         def load_resource(fname):
             with open(fname, "r", encoding="utf-8") as f:
                 return f.read()
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
+    args = sys.argv[1:]
+
+    if not args:
         print("usage: convert_syntax.py files")
-    else:
-        for fname in sys.argv[1:]:
-            o = convert(fname)
-
+        print("       convert_syntax.py folder")
+    else:
+        filenames = []
+        for path in args:
+            if os.path.isdir(path):
+                sublime.base_path = path
+                filenames.extend(sublime.find_resources("*.tmLanguage"))
+            else:
+                filenames.append(path)
+
+        for fname in filenames:
+            outfile = os.path.splitext(fname)[0] + ".sublime-syntax"
+            if os.path.exists(outfile):
+                print("file already exists: " + outfile)
+                continue
+
+            data = convert(fname)
+            text = to_yaml(data)
             # verify that to_yaml produces valid yaml for this object
             if yaml:
-                assert(o == yaml.load(to_yaml(o)))
-
-            with open(os.path.splitext(fname)[0] + ".sublime-syntax", "w",
-                encoding="utf-8") as f:
-                data = to_yaml(convert(sys.argv[1]))
-                data = "\n".join([l.rstrip() for l in data.splitlines()]) + "\n"
-                f.write(data)
+                assert(data == yaml.load(text))
+
+            with open(outfile, "w", encoding="utf-8") as f:
+                # to_yaml will leave some trailing whitespace, remove it
+                text = "\n".join(l.rstrip() for l in text.splitlines()) + "\n"
+                f.write(text)
+
+            print("converted " + outfile)
```

The `<<` check was needed for Groovy.tmLanguage, because a `<<` designates the "merge" type: http://yaml.org/type/merge.html

Clojure.tmLanguage was using a lot of "patterns" that only consisted of a comment key, so I made the script recognize these and copy them over.