### PR TITLE
[HTML] Consistent highlighting of punctuation in attributes

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -190,7 +190,9 @@ contexts:
         - include: entities
   tag-generic-attribute:
     - match: '(?<=[^=])\b([a-zA-Z0-9:-]+)'
-      scope: entity.other.attribute-name.html
+      captures:
+        1: punctuation.separator.key-value.html
+        2: entity.other.attribute-name.html
   tag-id-attribute:
     - match: \b(id)\b\s*(=)
       captures:


### PR DESCRIPTION
Currently, the `=` in id and style attributes gets special treatment by being highlighted. This change will make sure that all attributes are highlighted the same.