### PR TITLE
Synchronized isn't a keyword in scala

### DIFF
--- a/Scala/Scala.tmLanguage
+++ b/Scala/Scala.tmLanguage
@@ -579,7 +579,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(synchronized|@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b</string>
+					<string>\b(@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b</string>
 					<key>name</key>
 					<string>storage.modifier.other</string>
 				</dict>


### PR DESCRIPTION
I almost never use it, but `synchronized` really isn't a keyword in Scala.  It's a method on `AnyRef`.