### PR TITLE
[HTML] Doctype scopes

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -54,10 +54,11 @@ contexts:
       push:
         - meta_scope: meta.tag.sgml.html
         - match: ">"
+          scope: punctuation.definition.tag.html
           pop: true
         - match: (?i:DOCTYPE)
           captures:
-            1: entity.name.tag.doctype.html
+            0: entity.name.tag.doctype.html
           push:
             - meta_scope: meta.tag.sgml.doctype.html
             - match: (?=>)


### PR DESCRIPTION
- Adding scope for the pop rule
- Fixing capture number

I guess the convertor has a bug when calculating the capture numbers in case of 
Regex options like `(?i)`
I've not investigated this though. It's just a guess! 

Example: 
```
- match: (?i:DOCTYPE)
```
Shouldn't have a capture index of 1.