### PR TITLE
Replaced captures: 0: scope_name with scope: scope_name

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -35,13 +35,11 @@ contexts:
     - match: (?i:\b(Empty|False|Nothing|Null|True)\b)
       scope: constant.language.asp
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.asp
+      scope: punctuation.definition.string.begin.asp
       push:
         - meta_scope: string.quoted.double.asp
         - match: '"(?!")'
-          captures:
-            0: punctuation.definition.string.end.asp
+          scope: punctuation.definition.string.end.asp
           pop: true
         - match: '""'
           scope: constant.character.escape.apostrophe.asp

--- a/ASP/HTML-ASP.sublime-syntax
+++ b/ASP/HTML-ASP.sublime-syntax
@@ -8,13 +8,11 @@ scope: text.html.asp
 contexts:
   main:
     - match: <%=?
-      captures:
-        0: punctuation.section.embedded.begin.asp
+      scope: punctuation.section.embedded.begin.asp
       push:
         - meta_scope: source.asp.embedded.html
         - match: "%>"
-          captures:
-            0: punctuation.section.embedded.end.asp
+          scope: punctuation.section.embedded.end.asp
           pop: true
         - match: (').*?(?=%>)
           scope: comment.line.apostrophe.asp

--- a/ActionScript/ActionScript.sublime-syntax
+++ b/ActionScript/ActionScript.sublime-syntax
@@ -22,37 +22,31 @@ contexts:
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?\b'
       scope: constant.numeric.actionscript.2
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.actionscript.2
+      scope: punctuation.definition.string.begin.actionscript.2
       push:
         - meta_scope: string.quoted.double.actionscript.2
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.actionscript.2
+          scope: punctuation.definition.string.end.actionscript.2
           pop: true
         - match: \\.
           scope: constant.character.escape.actionscript.2
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.actionscript.2
+      scope: punctuation.definition.string.begin.actionscript.2
       push:
         - meta_scope: string.quoted.single.actionscript.2
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.actionscript.2
+          scope: punctuation.definition.string.end.actionscript.2
           pop: true
         - match: \\.
           scope: constant.character.escape.actionscript.2
     - match: \b(BACKSPACE|CAPSLOCK|CONTROL|DELETEKEY|DOWN|END|ENTER|HOME|INSERT|LEFT|LN10|LN2|LOG10E|LOG2E|MAX_VALUE|MIN_VALUE|NEGATIVE_INFINITY|NaN|PGDN|PGUP|PI|POSITIVE_INFINITY|RIGHT|SPACE|SQRT1_2|SQRT2|UP)\b
       scope: support.constant.actionscript.2
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.actionscript.2
+      scope: punctuation.definition.comment.actionscript.2
       push:
         - meta_scope: comment.block.actionscript.2
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.actionscript.2
+          scope: punctuation.definition.comment.actionscript.2
           pop: true
     - match: (//).*$\n?
       scope: comment.line.double-slash.actionscript.2
@@ -74,8 +68,7 @@ contexts:
       push:
         - meta_scope: meta.function.actionscript.2
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.end.actionscript.2
+          scope: punctuation.definition.parameters.end.actionscript.2
           pop: true
         - match: '[^,)\n]+'
           scope: variable.parameter.function.actionscript.2

--- a/AppleScript/AppleScript.sublime-syntax
+++ b/AppleScript/AppleScript.sublime-syntax
@@ -527,24 +527,20 @@ contexts:
       captures:
         1: punctuation.definition.comment.applescript
     - match: \(\*
-      captures:
-        0: punctuation.definition.comment.applescript
+      scope: punctuation.definition.comment.applescript
       push:
         - meta_scope: comment.block.applescript
         - match: \*\)
-          captures:
-            0: punctuation.definition.comment.applescript
+          scope: punctuation.definition.comment.applescript
           pop: true
         - include: comments.nested
   comments.nested:
     - match: \(\*
-      captures:
-        0: punctuation.definition.comment.applescript
+      scope: punctuation.definition.comment.applescript
       push:
         - meta_scope: comment.block.applescript
         - match: \*\)
-          captures:
-            0: punctuation.definition.comment.applescript
+          scope: punctuation.definition.comment.applescript
           pop: true
         - include: comments.nested
   data-structures:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -27,13 +27,11 @@ contexts:
     - match: \s*:\s*:.*$
       scope: comment.line.colons.dosbatch
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.quoted.double.dosbatch
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
     - match: "[|]"
       scope: keyword.operator.pipe.dosbatch

--- a/C#/Build.sublime-syntax
+++ b/C#/Build.sublime-syntax
@@ -8,13 +8,11 @@ scope: source.nant-build
 contexts:
   main:
     - match: <!--
-      captures:
-        0: punctuation.definition.comment.nant
+      scope: punctuation.definition.comment.nant
       push:
         - meta_scope: comment.block.nant
         - match: "-->"
-          captures:
-            0: punctuation.definition.comment.nant
+          scope: punctuation.definition.comment.nant
           pop: true
     - match: "(</?)([-_a-zA-Z0-9:]+)"
       captures:
@@ -30,22 +28,18 @@ contexts:
         - match: " ([a-zA-Z-]+)"
           scope: entity.other.attribute-name.nant
         - match: '"'
-          captures:
-            0: punctuation.definition.string.begin.nant
+          scope: punctuation.definition.string.begin.nant
           push:
             - meta_scope: string.quoted.double.nant
             - match: '"'
-              captures:
-                0: punctuation.definition.string.end.nant
+              scope: punctuation.definition.string.end.nant
               pop: true
         - match: "'"
-          captures:
-            0: punctuation.definition.string.begin.nant
+          scope: punctuation.definition.string.begin.nant
           push:
             - meta_scope: string.quoted.single.nant
             - match: "'"
-              captures:
-                0: punctuation.definition.string.end.nant
+              scope: punctuation.definition.string.end.nant
               pop: true
     - match: "(&)([a-zA-Z]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
       scope: constant.character.entity.nant

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -19,12 +19,10 @@ contexts:
       push:
         - meta_scope: meta.namespace.source.cs
         - match: "}"
-          captures:
-            0: punctuation.section.namespace.end.source.cs
+          scope: punctuation.section.namespace.end.source.cs
           pop: true
         - match: "{"
-          captures:
-            0: punctuation.section.namespace.begin.source.cs
+          scope: punctuation.section.namespace.begin.source.cs
           push:
             - meta_scope: meta.namespace.body.source.cs
             - match: "(?=})"
@@ -33,13 +31,11 @@ contexts:
     - include: code
   block:
     - match: "{"
-      captures:
-        0: punctuation.section.block.begin.source.cs
+      scope: punctuation.section.block.begin.source.cs
       push:
         - meta_scope: meta.block.source.cs
         - match: "}"
-          captures:
-            0: punctuation.section.block.end.source.cs
+          scope: punctuation.section.block.end.source.cs
           pop: true
         - include: code
   builtinTypes:
@@ -50,8 +46,7 @@ contexts:
       push:
         - meta_scope: meta.class.source.cs
         - match: "}"
-          captures:
-            0: punctuation.section.class.end.source.cs
+          scope: punctuation.section.class.end.source.cs
           pop: true
         - include: storage-modifiers
         - include: comments
@@ -68,8 +63,7 @@ contexts:
               captures:
                 1: storage.type.source.cs
         - match: "{"
-          captures:
-            0: punctuation.section.class.begin.source.cs
+          scope: punctuation.section.class.begin.source.cs
           push:
             - meta_scope: meta.class.body.source.cs
             - match: "(?=})"
@@ -88,23 +82,19 @@ contexts:
     - include: builtinTypes
   comments:
     - match: ///
-      captures:
-        0: punctuation.definition.comment.source.cs
+      scope: punctuation.definition.comment.source.cs
       push:
         - meta_scope: comment.block.documentation.source.cs
         - match: $\n?
-          captures:
-            0: punctuation.definition.comment.source.cs
+          scope: punctuation.definition.comment.source.cs
           pop: true
         - include: scope:text.xml
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.source.cs
+      scope: punctuation.definition.comment.source.cs
       push:
         - meta_scope: comment.block.source.cs
         - match: \*/\n?
-          captures:
-            0: punctuation.definition.comment.source.cs
+          scope: punctuation.definition.comment.source.cs
           pop: true
     - match: //
       captures:
@@ -125,24 +115,20 @@ contexts:
       captures:
         0: punctuation.definition.string.begin.source.cs
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.source.cs
+      scope: punctuation.definition.string.begin.source.cs
       push:
         - meta_scope: string.quoted.double.source.cs
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.source.cs
+          scope: punctuation.definition.string.end.source.cs
           pop: true
         - match: \\.
           scope: constant.character.escape.source.cs
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.source.cs
+      scope: punctuation.definition.string.begin.source.cs
       push:
         - meta_scope: string.quoted.single.source.cs
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.source.cs
+          scope: punctuation.definition.string.end.source.cs
           pop: true
         - match: \\.
           scope: constant.character.escape.source.cs
@@ -201,8 +187,7 @@ contexts:
               pop: true
             - include: builtinTypes
         - match: "{"
-          captures:
-            0: punctuation.section.method.begin.source.cs
+          scope: punctuation.section.method.begin.source.cs
           push:
             - meta_scope: meta.method.body.source.cs
             - match: "(?=})"
@@ -212,8 +197,7 @@ contexts:
       push:
         - meta_scope: meta.property.source.cs
         - match: "}"
-          captures:
-            0: punctuation.section.property.end.source.cs
+          scope: punctuation.section.property.end.source.cs
           pop: true
         - include: storage-modifiers
         - match: '([\w.]+)\s*(?={)'
@@ -232,8 +216,7 @@ contexts:
               pop: true
             - include: builtinTypes
         - match: "{"
-          captures:
-            0: punctuation.section.property.begin.source.cs
+          scope: punctuation.section.property.begin.source.cs
           push:
             - meta_scope: meta.method.body.source.cs
             - match: "(?=})"
@@ -247,8 +230,7 @@ contexts:
       push:
         - meta_scope: meta.method-call.source.cs
         - match: \)
-          captures:
-            0: punctuation.definition.method-parameters.end.source.cs
+          scope: punctuation.definition.method-parameters.end.source.cs
           pop: true
         - match: ","
           scope: punctuation.definition.seperator.parameter.source.cs

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -61,8 +61,7 @@ contexts:
       push:
         - meta_scope: meta.function.destructor.c++
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.c
+          scope: punctuation.definition.parameters.c
           pop: true
         - include: $top_level_main
     - match: |-
@@ -78,8 +77,7 @@ contexts:
       push:
         - meta_scope: meta.function.destructor.prototype.c++
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.c
+          scope: punctuation.definition.parameters.c
           pop: true
         - include: $top_level_main
   angle_brackets:
@@ -119,8 +117,7 @@ contexts:
       push:
         - meta_scope: meta.function.constructor.c++
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.c
+          scope: punctuation.definition.parameters.c
           pop: true
         - include: $top_level_main
     - match: |-

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -32,24 +32,20 @@ contexts:
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
       scope: constant.numeric.c
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.c
+      scope: punctuation.definition.string.begin.c
       push:
         - meta_scope: string.quoted.double.c
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.c
+          scope: punctuation.definition.string.end.c
           pop: true
         - include: string_escaped_char
         - include: string_placeholder
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.c
+      scope: punctuation.definition.string.begin.c
       push:
         - meta_scope: string.quoted.single.c
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.c
+          scope: punctuation.definition.string.end.c
           pop: true
         - include: string_escaped_char
     - match: |-
@@ -102,22 +98,18 @@ contexts:
         - match: (?>\\\s*\n)
           scope: punctuation.separator.continuation.c
         - match: '"'
-          captures:
-            0: punctuation.definition.string.begin.c
+          scope: punctuation.definition.string.begin.c
           push:
             - meta_scope: string.quoted.double.include.c
             - match: '"'
-              captures:
-                0: punctuation.definition.string.end.c
+              scope: punctuation.definition.string.end.c
               pop: true
         - match: <
-          captures:
-            0: punctuation.definition.string.begin.c
+          scope: punctuation.definition.string.begin.c
           push:
             - meta_scope: string.quoted.other.lt-gt.include.c
             - match: ">"
-              captures:
-                0: punctuation.definition.string.end.c
+              scope: punctuation.definition.string.end.c
               pop: true
     - include: pragma-mark
     - match: ^\s*#\s*(define|defined|elif|else|if|ifdef|ifndef|line|pragma|undef)\b
@@ -224,13 +216,11 @@ contexts:
       captures:
         1: meta.toc-list.banner.block.c
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.c
+      scope: punctuation.definition.comment.c
       push:
         - meta_scope: comment.block.c
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.c
+          scope: punctuation.definition.comment.c
           pop: true
     - match: \*/.*\n
       scope: invalid.illegal.stray-comment-end.c
@@ -239,8 +229,7 @@ contexts:
       captures:
         1: meta.toc-list.banner.line.c
     - match: //
-      captures:
-        0: punctuation.definition.comment.c
+      scope: punctuation.definition.comment.c
       push:
         - meta_scope: comment.line.double-slash.c++
         - match: $\n?

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -73,8 +73,7 @@ contexts:
         - include: numeric-values
   comment-block:
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.css
+      scope: punctuation.definition.comment.css
       push:
         - meta_scope: comment.block.css
         - match: \*/
@@ -262,8 +261,7 @@ contexts:
     - match: '(?=\{)'
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.property-list.css
+          scope: punctuation.section.property-list.css
           pop: true
         - include: rule-list
   property-values:
@@ -491,8 +489,7 @@ contexts:
           scope: variable.parameter.misc.css
   rule-list:
     - match: '\{'
-      captures:
-        0: punctuation.section.property-list.css
+      scope: punctuation.section.property-list.css
       push:
         - meta_scope: meta.property-list.css
         - match: '(?=\s*\})'
@@ -666,8 +663,7 @@ contexts:
             3: punctuation.section.function.css
           push:
             - match: \)
-              captures:
-                0: punctuation.section.function.css
+              scope: punctuation.section.function.css
               pop: true
             - include: selector
         - match: ((:)nth-(?:(?:last-)?child|(?:last-)?of-type))(\()(\-?(?:\d+n?|n)(?:\+\d+)?|even|odd)(\))
@@ -693,25 +689,21 @@ contexts:
             7: punctuation.definition.string.end.css
   string-double:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.css
+      scope: punctuation.definition.string.begin.css
       push:
         - meta_scope: string.quoted.double.css
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.css
+          scope: punctuation.definition.string.end.css
           pop: true
         - match: \\.
           scope: constant.character.escape.css
   string-single:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.css
+      scope: punctuation.definition.string.begin.css
       push:
         - meta_scope: string.quoted.single.css
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.css
+          scope: punctuation.definition.string.end.css
           pop: true
         - match: \\.
           scope: constant.character.escape.css

--- a/Clojure/Clojure.sublime-syntax
+++ b/Clojure/Clojure.sublime-syntax
@@ -43,8 +43,7 @@ contexts:
     - include: comment
     - include: metadata
     - match: '\['
-      captures:
-        0: punctuation.definition.vector.begin.clojure
+      scope: punctuation.definition.vector.begin.clojure
       push:
         - meta_scope: meta.structure.binding.vector.clojure
         - match: '(?=\])'
@@ -54,8 +53,7 @@ contexts:
           push:
             - meta_scope: meta.parameters.vector.clojure
             - match: '\]'
-              captures:
-                0: punctuation.definition.vector.end.clojure
+              scope: punctuation.definition.vector.end.clojure
               pop: true
             - include: comment
             - include: metadata
@@ -69,8 +67,7 @@ contexts:
             - include: all
         - include: binding_exp
     - match: '\{'
-      captures:
-        0: punctuation.definition.map.begin.clojure
+      scope: punctuation.definition.map.begin.clojure
       push:
         - meta_scope: meta.structure.binding.map.clojure
         - match: '(?=\])'
@@ -80,8 +77,7 @@ contexts:
           push:
             - meta_scope: meta.function.parameters.map.clojure
             - match: '\}'
-              captures:
-                0: punctuation.definition.map.end.clojure
+              scope: punctuation.definition.map.end.clojure
               pop: true
             - include: comment
             - include: metadata
@@ -159,13 +155,11 @@ contexts:
           pop: true
         - match: '(?<=\[)'
           comment: "TODO: merge with vector"
-          captures:
-            0: punctuation.definition.vector.begin.clojure
+          scope: punctuation.definition.vector.begin.clojure
           push:
             - meta_scope: meta.expression.vector.clojure
             - match: '\]'
-              captures:
-                0: punctuation.definition.vector.end.clojure
+              scope: punctuation.definition.vector.end.clojure
               pop: true
             - include: all
         - include: binding
@@ -176,13 +170,11 @@ contexts:
           pop: true
         - match: '(?<=\{)'
           comment: "TODO: merge with map"
-          captures:
-            0: punctuation.definition.map.begin.clojure
+          scope: punctuation.definition.map.begin.clojure
           push:
             - meta_scope: meta.expression.map.clojure
             - match: "}"
-              captures:
-                0: punctuation.definition.map.end.clojure
+              scope: punctuation.definition.map.end.clojure
               pop: true
             - include: all
         - include: binding
@@ -281,23 +273,19 @@ contexts:
         - include: parameters_body
   function_body_comment:
     - match: '"'
-      captures:
-        0: string.quoted.double.begin.clojure
+      scope: string.quoted.double.begin.clojure
       push:
         - meta_scope: string.docstring.clojure
         - match: '"'
-          captures:
-            0: string.quoted.double.end.clojure
+          scope: string.quoted.double.end.clojure
           pop: true
         - include: string_escape
     - match: '\{'
-      captures:
-        0: comment.punctuation.definition.metadata.begin.clojure
+      scope: comment.punctuation.definition.metadata.begin.clojure
       push:
         - meta_scope: meta.metadata.map.clojure
         - match: '\}'
-          captures:
-            0: comment.punctuation.definition.metadata.end.clojure
+          scope: comment.punctuation.definition.metadata.end.clojure
           pop: true
         - include: metadata_patterns
     - include: function_body
@@ -357,8 +345,7 @@ contexts:
                       pop: true
                     - match: '(?<=\[)'
                       comment: "TODO: merge with vector"
-                      captures:
-                        0: punctuation.definition.vector.begin.clojure
+                      scope: punctuation.definition.vector.begin.clojure
                       push:
                         - meta_scope: meta.expression.vector.clojure
                         - match: '(\])'
@@ -378,13 +365,11 @@ contexts:
                       pop: true
                     - match: '(?<=\{)'
                       comment: "TODO: merge with map"
-                      captures:
-                        0: punctuation.definition.map.begin.clojure
+                      scope: punctuation.definition.map.begin.clojure
                       push:
                         - meta_scope: meta.expression.map.clojure
                         - match: "}"
-                          captures:
-                            0: punctuation.definition.map.end.clojure
+                          scope: punctuation.definition.map.end.clojure
                           pop: true
                         - include: all
                     - include: parameters_body
@@ -432,8 +417,7 @@ contexts:
         - include: keyword
         - include: operator
         - match: '-(?=[a-zA-Z+!\-_?*~#@''`/.$=])'
-          captures:
-            0: keyword.operator.prefix.genclass.clojure
+          scope: keyword.operator.prefix.genclass.clojure
           push:
             - match: '(?![a-zA-Z+!\-_?0-9*~#@''`/.$=])'
               pop: true
@@ -496,8 +480,7 @@ contexts:
             - include: all
         - include: all
     - match: ':(init|main|factory|state|prefix|load-impl-ns|implements|constructors|exposes|impl-ns|exposes-methods|methods)(?![a-zA-Z+!\-_?0-9*~#@''`/.$=])'
-      captures:
-        0: support.other.keyword.genclass.clojure
+      scope: support.other.keyword.genclass.clojure
     - include: all
   gencommon_parameters:
     - include: comment
@@ -626,34 +609,28 @@ contexts:
         - include: function_body_comment
   map:
     - match: "{(?!})"
-      captures:
-        0: punctuation.definition.map.begin.clojure
+      scope: punctuation.definition.map.begin.clojure
       push:
         - meta_scope: meta.expression.map.clojure
         - match: "(?<!{)}"
-          captures:
-            0: punctuation.definition.map.end.clojure
+          scope: punctuation.definition.map.end.clojure
           pop: true
         - include: all
   metadata:
     - match: '#?\^{'
-      captures:
-        0: comment.punctuation.definition.metadata.begin.clojure
+      scope: comment.punctuation.definition.metadata.begin.clojure
       push:
         - meta_scope: punctuation.metadata.map.clojure
         - match: "}"
-          captures:
-            0: comment.punctuation.definition.metadata.end.clojure
+          scope: comment.punctuation.definition.metadata.end.clojure
           pop: true
         - include: metadata_patterns
     - match: '#?\^"'
-      captures:
-        0: comment.punctuation.definition.metadata.begin.clojure
+      scope: comment.punctuation.definition.metadata.begin.clojure
       push:
         - meta_scope: string.metadata.clojure
         - match: '"'
-          captures:
-            0: comment.punctuation.definition.metadata.end.clojure
+          scope: comment.punctuation.definition.metadata.end.clojure
           pop: true
     - match: '(#?\^)([a-zA-Z+!\-_?0-9*/.$=]+)'
       scope: punctuation.metadata.class.clojure
@@ -666,13 +643,11 @@ contexts:
     - match: '(?<=:tag)\s+([a-zA-Z+!\-_?0-9*/.$=]+)'
       scope: storage.type.java.clojure
     - match: (?<=:doc)\s+"
-      captures:
-        0: string.quoted.double.begin.clojure
+      scope: string.quoted.double.begin.clojure
       push:
         - meta_scope: string.docstring.clojure
         - match: '"'
-          captures:
-            0: string.quoted.double.end.clojure
+          scope: string.quoted.double.end.clojure
           pop: true
         - include: string_escape
     - include: all
@@ -756,13 +731,11 @@ contexts:
       scope: constant.other.metadata.read.clojure
   parameters:
     - match: '\['
-      captures:
-        0: punctuation.definition.vector.begin.clojure
+      scope: punctuation.definition.vector.begin.clojure
       push:
         - meta_scope: meta.parameters.vector.clojure
         - match: '\]'
-          captures:
-            0: punctuation.definition.vector.end.clojure
+          scope: punctuation.definition.vector.end.clojure
           pop: true
         - match: \&
           scope: keyword.operator.varargs.clojure
@@ -783,13 +756,11 @@ contexts:
         - include: all
   parameters_function:
     - match: '\['
-      captures:
-        0: punctuation.definition.vector.begin.clojure
+      scope: punctuation.definition.vector.begin.clojure
       push:
         - meta_scope: meta.function.parameters.vector.clojure
         - match: '\]'
-          captures:
-            0: punctuation.definition.vector.end.clojure
+          scope: punctuation.definition.vector.end.clojure
           pop: true
         - match: \&
           scope: keyword.operator.varargs.clojure
@@ -802,13 +773,11 @@ contexts:
         - include: parameters_map
   parameters_map:
     - match: '\{'
-      captures:
-        0: punctuation.definition.map.begin.clojure
+      scope: punctuation.definition.map.begin.clojure
       push:
         - meta_scope: meta.function.parameters.map.clojure
         - match: '\}'
-          captures:
-            0: punctuation.definition.map.end.clojure
+          scope: punctuation.definition.map.end.clojure
           pop: true
         - include: parameters_variable
         - match: '(:as|:or|:keys|:strs|:syms)(?![a-zA-Z+!\-_?0-9*~#@''`/.$=])'
@@ -829,13 +798,11 @@ contexts:
         - include: symbol
   set:
     - match: "#{"
-      captures:
-        0: punctuation.definition.set.begin.clojure
+      scope: punctuation.definition.set.begin.clojure
       push:
         - meta_scope: meta.expression.set.clojure
         - match: "}"
-          captures:
-            0: punctuation.definition.set.end.clojure
+          scope: punctuation.definition.set.end.clojure
           pop: true
         - include: all
   sexpr:
@@ -1052,13 +1019,11 @@ contexts:
                             - include: function_body_comment
   string:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.clojure
+      scope: punctuation.definition.string.begin.clojure
       push:
         - meta_scope: string.quoted.double.clojure
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.clojure
+          scope: punctuation.definition.string.end.clojure
           pop: true
         - include: string_escape
     - match: '\\(u[0-9a-fA-F]{4}|newline|tab|space|backspace|formfeed|return|[^\s])'
@@ -1073,13 +1038,11 @@ contexts:
           pop: true
         - include: symbol
     - match: '#"'
-      captures:
-        0: punctuation.definition.string.begin.clojure
+      scope: punctuation.definition.string.begin.clojure
       push:
         - meta_scope: string.regexp.clojure
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.clojure
+          scope: punctuation.definition.string.end.clojure
           pop: true
         - include: scope:source.regexp
   string_escape:
@@ -1145,12 +1108,10 @@ contexts:
         - include: symbol
   vector:
     - match: '\[(?!\])'
-      captures:
-        0: punctuation.definition.vector.begin.clojure
+      scope: punctuation.definition.vector.begin.clojure
       push:
         - meta_scope: meta.expression.vector.clojure
         - match: '(?<!\[)\]'
-          captures:
-            0: punctuation.definition.vector.end.clojure
+          scope: punctuation.definition.vector.end.clojure
           pop: true
         - include: all

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -115,8 +115,7 @@ contexts:
       push:
         - meta_scope: meta.definition.destructor.d
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.d
+          scope: punctuation.definition.parameters.d
           pop: true
         - include: $top_level_main
     - match: |-
@@ -210,22 +209,18 @@ contexts:
     - include: storage-type-d
   comments:
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.d
+      scope: punctuation.definition.comment.d
       push:
         - meta_scope: comment.block.d
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.d
+          scope: punctuation.definition.comment.d
           pop: true
     - match: /\+
-      captures:
-        0: punctuation.definition.comment.d
+      scope: punctuation.definition.comment.d
       push:
         - meta_scope: comment.block.nested.d
         - match: \+/
-          captures:
-            0: punctuation.definition.comment.d
+          scope: punctuation.definition.comment.d
           pop: true
     - match: (//).*$\n?
       scope: comment.line.double-slash.d
@@ -263,13 +258,11 @@ contexts:
       scope: invalid.illegal.unknown-escape.d
   strings:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.d
+      scope: punctuation.definition.string.begin.d
       push:
         - meta_scope: string.quoted.double.d
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.d
+          scope: punctuation.definition.string.end.d
           pop: true
         - include: string_escaped_char
     - match: (r)(")
@@ -285,8 +278,7 @@ contexts:
           pop: true
         - include: regular_expressions
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.d
+      scope: punctuation.definition.string.begin.d
       push:
         - meta_scope: string.quoted.double.raw.backtick.d
         - match: ((?<=`)(`)|`)
@@ -295,13 +287,11 @@ contexts:
             2: meta.empty-string.double.d
           pop: true
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.d
+      scope: punctuation.definition.string.begin.d
       push:
         - meta_scope: string.quoted.single.d
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.d
+          scope: punctuation.definition.string.end.d
           pop: true
         - include: string_escaped_char
   support-type-built-ins-classes-d:

--- a/Erlang/HTML (Erlang).sublime-syntax
+++ b/Erlang/HTML (Erlang).sublime-syntax
@@ -8,13 +8,11 @@ scope: text.html.erlang.yaws
 contexts:
   main:
     - match: <erl>
-      captures:
-        0: punctuation.section.embedded.erlang
+      scope: punctuation.section.embedded.erlang
       push:
         - meta_scope: source.erlang.embedded.html
         - match: </erl>
-          captures:
-            0: punctuation.section.embedded.erlang
+          scope: punctuation.section.embedded.erlang
           pop: true
         - include: scope:source.erlang
     - include: scope:text.html.basic

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -21,13 +21,11 @@ contexts:
         - match: (?=(?://|/\*))|$
           pop: true
         - match: '"'
-          captures:
-            0: punctuation.definition.string.begin.go
+          scope: punctuation.definition.string.begin.go
           push:
             - meta_scope: string.quoted.double.import.go
             - match: '"'
-              captures:
-                0: punctuation.definition.string.end.go
+              scope: punctuation.definition.string.end.go
               pop: true
     - include: block
     - include: root_parens
@@ -57,13 +55,11 @@ contexts:
       captures:
         1: meta.toc-list.banner.block.go
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.go
+      scope: punctuation.definition.comment.go
       push:
         - meta_scope: comment.block.go
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.go
+          scope: punctuation.definition.comment.go
           pop: true
     - match: \*/.*\n
       scope: invalid.illegal.stray-commend-end.go
@@ -72,8 +68,7 @@ contexts:
       captures:
         1: meta.toc-list.banner.line.go
     - match: //
-      captures:
-        0: punctuation.definition.comment.go
+      scope: punctuation.definition.comment.go
       push:
         - meta_scope: comment.line.double-slash.go
         - match: $\n?
@@ -219,32 +214,26 @@ contexts:
       scope: invalid.illegal.placeholder.go
   strings:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.go
+      scope: punctuation.definition.string.begin.go
       push:
         - meta_scope: string.quoted.double.go
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.go
+          scope: punctuation.definition.string.end.go
           pop: true
         - include: string_placeholder
         - include: string_escaped_char
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.go
+      scope: punctuation.definition.string.begin.go
       push:
         - meta_scope: string.quoted.single.go
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.go
+          scope: punctuation.definition.string.end.go
           pop: true
         - include: string_escaped_char
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.go
+      scope: punctuation.definition.string.begin.go
       push:
         - meta_scope: string.quoted.raw.go
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.go
+          scope: punctuation.definition.string.end.go
           pop: true

--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -17,13 +17,11 @@ contexts:
     - match: \b(bgcolor|center|clusterrank|color|comment|compound|concentrate|fillcolor|fontname|fontpath|fontsize|label|labeljust|labelloc|layers|margin|mclimit|nodesep|nslimit|nslimit1|ordering|orientation|page|pagedir|quantum|rank|rankdir|ranksep|ratio|remincross|rotate|samplepoints|searchsize|size|style|URL)\b
       scope: support.constant.attribute.graph.dot
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.dot
+      scope: punctuation.definition.string.begin.dot
       push:
         - meta_scope: string.quoted.double.dot
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.dot
+          scope: punctuation.definition.string.end.dot
           pop: true
         - match: \\.
           scope: constant.character.escape.dot
@@ -36,11 +34,9 @@ contexts:
       captures:
         1: punctuation.definition.comment.dot
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.dot
+      scope: punctuation.definition.comment.dot
       push:
         - meta_scope: comment.block.dot
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.dot
+          scope: punctuation.definition.comment.dot
           pop: true

--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -75,13 +75,11 @@ contexts:
                 2: punctuation.definition.implemented.interfaces.separator.groovy
   comment-block:
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.groovy
+      scope: punctuation.definition.comment.groovy
       push:
         - meta_scope: comment.block.groovy
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.groovy
+          scope: punctuation.definition.comment.groovy
           pop: true
   comments:
     - match: /\*\*/
@@ -123,13 +121,11 @@ contexts:
     - match: \b(return|break|continue|default|do|while|for|switch|if|else)\b
       scope: keyword.control.groovy
     - match: \bcase\b
-      captures:
-        0: keyword.control.groovy
+      scope: keyword.control.groovy
       push:
         - meta_scope: meta.case.groovy
         - match: ":"
-          captures:
-            0: punctuation.definition.case-terminator.groovy
+          scope: punctuation.definition.case-terminator.groovy
           pop: true
         - include: groovy-code-minus-map-keys
     - match: \b(new)\b
@@ -164,8 +160,7 @@ contexts:
     - match: (?<=\S)\?\.(?=\S)
       scope: keyword.operator.safe-navigation.groovy
     - match: \?
-      captures:
-        0: keyword.operator.ternary.groovy
+      scope: keyword.operator.ternary.groovy
       push:
         - meta_scope: meta.evaluation.ternary.groovy
         - match: $
@@ -202,21 +197,18 @@ contexts:
       push:
         - meta_scope: meta.method-call.groovy
         - match: \)
-          captures:
-            0: punctuation.definition.method-parameters.end.groovy
+          scope: punctuation.definition.method-parameters.end.groovy
           pop: true
         - match: ","
           scope: punctuation.definition.seperator.parameter.groovy
         - include: groovy-code
   method-declaration-remainder:
     - match: \(
-      captures:
-        0: punctuation.definition.parameters.begin.groovy
+      scope: punctuation.definition.parameters.begin.groovy
       push:
         - meta_content_scope: meta.definition.method.parameters.groovy
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.end.groovy
+          scope: punctuation.definition.parameters.end.groovy
           pop: true
         - match: |-
             (?x)\s*
@@ -329,12 +321,10 @@ contexts:
         - include: method-declaration-remainder
   nest_curly:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.groovy
+      scope: punctuation.section.scope.groovy
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.groovy
+          scope: punctuation.section.scope.groovy
           pop: true
         - include: nest_curly
   numbers:
@@ -342,13 +332,11 @@ contexts:
       scope: constant.numeric.groovy
   regexp:
     - match: "/(?=[^/]+/)"
-      captures:
-        0: punctuation.definition.string.regexp.begin.groovy
+      scope: punctuation.definition.string.regexp.begin.groovy
       push:
         - meta_scope: string.regexp.groovy
         - match: /
-          captures:
-            0: punctuation.definition.string.regexp.end.groovy
+          scope: punctuation.definition.string.regexp.end.groovy
           pop: true
         - match: \\.
           scope: constant.character.escape.groovy
@@ -387,37 +375,31 @@ contexts:
       scope: storage.type.primitive.groovy
   string-quoted-double:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.groovy
+      scope: punctuation.definition.string.begin.groovy
       push:
         - meta_scope: string.quoted.double.groovy
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.groovy
+          scope: punctuation.definition.string.end.groovy
           pop: true
         - match: \\.
           scope: constant.character.escape.groovy
         - match: \$\w+
           scope: variable.other.interpolated.groovy
         - match: '\$\{'
-          captures:
-            0: punctuation.section.embedded.groovy
+          scope: punctuation.section.embedded.groovy
           push:
             - meta_scope: source.groovy.embedded.source
             - match: '\}'
-              captures:
-                0: punctuation.section.embedded.groovy
+              scope: punctuation.section.embedded.groovy
               pop: true
             - include: nest_curly
   string-quoted-single:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.groovy
+      scope: punctuation.definition.string.begin.groovy
       push:
         - meta_scope: string.quoted.single.groovy
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.groovy
+          scope: punctuation.definition.string.end.groovy
           pop: true
         - match: \\.
           scope: constant.character.escape.groovy
@@ -427,13 +409,11 @@ contexts:
     - include: regexp
   structures:
     - match: '\['
-      captures:
-        0: punctuation.definition.structure.begin.groovy
+      scope: punctuation.definition.structure.begin.groovy
       push:
         - meta_scope: meta.structure.groovy
         - match: '\]'
-          captures:
-            0: punctuation.definition.structure.end.groovy
+          scope: punctuation.definition.structure.end.groovy
           pop: true
         - include: groovy-code
         - match: ","

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -40,8 +40,7 @@ contexts:
         - include: string-double-quoted
         - include: string-single-quoted
     - match: <!--
-      captures:
-        0: punctuation.definition.comment.html
+      scope: punctuation.definition.comment.html
       push:
         - meta_scope: comment.block.html
         - match: '--\s*>'
@@ -49,16 +48,14 @@ contexts:
         - match: "--"
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
-      captures:
-        0: punctuation.definition.tag.html
+      scope: punctuation.definition.tag.html
       push:
         - meta_scope: meta.tag.sgml.html
         - match: ">"
           scope: punctuation.definition.tag.html
           pop: true
         - match: (?i:DOCTYPE)
-          captures:
-            0: entity.name.tag.doctype.html
+          scope: entity.name.tag.doctype.html
           push:
             - meta_scope: meta.tag.sgml.doctype.html
             - match: (?=>)
@@ -169,24 +166,20 @@ contexts:
       scope: invalid.illegal.bad-ampersand.html
   string-double-quoted:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.html
+      scope: punctuation.definition.string.begin.html
       push:
         - meta_scope: string.quoted.double.html
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.html
+          scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
   string-single-quoted:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.html
+      scope: punctuation.definition.string.begin.html
       push:
         - meta_scope: string.quoted.single.html
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.html
+          scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
   tag-generic-attribute:
@@ -202,25 +195,21 @@ contexts:
       push:
         - meta_scope: meta.attribute-with-value.id.html
         - match: '"'
-          captures:
-            0: punctuation.definition.string.begin.html
+          scope: punctuation.definition.string.begin.html
           push:
             - meta_scope: string.quoted.double.html
             - meta_content_scope: meta.toc-list.id.html
             - match: '"'
-              captures:
-                0: punctuation.definition.string.end.html
+              scope: punctuation.definition.string.end.html
               pop: true
             - include: entities
         - match: "'"
-          captures:
-            0: punctuation.definition.string.begin.html
+          scope: punctuation.definition.string.begin.html
           push:
             - meta_scope: string.quoted.single.html
             - meta_content_scope: meta.toc-list.id.html
             - match: "'"
-              captures:
-                0: punctuation.definition.string.end.html
+              scope: punctuation.definition.string.end.html
               pop: true
             - include: entities
         - match: '(?<==)\s*((?:[^\s<>/''"]|/(?!>))+)'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -94,13 +94,11 @@ contexts:
         1: punctuation.definition.preprocessor.c
     - include: pragma
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.haskell
+      scope: punctuation.definition.string.begin.haskell
       push:
         - meta_scope: string.quoted.double.haskell
         - match: $|"
-          captures:
-            0: punctuation.definition.string.end.haskell
+          scope: punctuation.definition.string.end.haskell
           pop: true
         - match: '\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\"''\&])'
           scope: constant.character.escape.haskell
@@ -110,8 +108,7 @@ contexts:
           scope: constant.character.escape.control.haskell
     - match: '\[(?:|e|d|t|p)\|'
       comment: Points out splices in ast quotes
-      captures:
-        0: keyword.other.quasibracket.haskell
+      scope: keyword.other.quasibracket.haskell
       push:
         - meta_scope: meta.other.quasiquote.haskell
         - match: '(.*)(\|\])'
@@ -129,8 +126,7 @@ contexts:
       comment: Highlight the beginning of a splice.
       scope: keyword.other.splice.haskell
     - match: '\[[a-zA-Z0-9_'']*\|'
-      captures:
-        0: keyword.other.quasibracket.haskell
+      scope: keyword.other.quasibracket.haskell
       push:
         - meta_scope: meta.other.quasiquote.haskell
         - match: '(.*)(\|\])'
@@ -187,14 +183,12 @@ contexts:
       scope: punctuation.separator.comma.haskell
   block_comment:
     - match: '\{-(?!#)'
-      captures:
-        0: punctuation.definition.comment.haskell
+      scope: punctuation.definition.comment.haskell
       push:
         - meta_scope: comment.block.haskell
         - include: block_comment
         - match: '-\}'
-          captures:
-            0: punctuation.definition.comment.haskell
+          scope: punctuation.definition.comment.haskell
           pop: true
   comments:
     - match: (--).*$\n?

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -8,26 +8,21 @@ scope: text.html.jsp
 contexts:
   main:
     - match: <%--
-      captures:
-        0: punctuation.definition.comment.jsp
+      scope: punctuation.definition.comment.jsp
       push:
         - meta_scope: comment.block.jsp
         - match: "--%>"
-          captures:
-            0: punctuation.definition.comment.jsp
+          scope: punctuation.definition.comment.jsp
           pop: true
     - match: <%@
-      captures:
-        0: punctuation.section.directive.jsp
+      scope: punctuation.section.directive.jsp
       push:
         - meta_scope: meta.directive.jsp
         - match: "%>"
-          captures:
-            0: punctuation.section.directive.jsp
+          scope: punctuation.section.directive.jsp
           pop: true
         - match: \w+
-          captures:
-            0: keyword.other.directive.jsp
+          scope: keyword.other.directive.jsp
           push:
             - match: (?=%>)
               pop: true
@@ -36,24 +31,20 @@ contexts:
             - match: "="
               scope: keyword.operator.assignment.jsp
             - match: '"'
-              captures:
-                0: punctuation.definition.string.begin.jsp
+              scope: punctuation.definition.string.begin.jsp
               push:
                 - meta_scope: string.quoted.double.jsp
                 - match: '"'
-                  captures:
-                    0: punctuation.definition.string.end.jsp
+                  scope: punctuation.definition.string.end.jsp
                   pop: true
                 - match: \\.
                   scope: constant.character.escape.jsp
             - match: "'"
-              captures:
-                0: punctuation.definition.string.begin.jsp
+              scope: punctuation.definition.string.begin.jsp
               push:
                 - meta_scope: string.quoted.single.jsp
                 - match: "'"
-                  captures:
-                    0: punctuation.definition.string.end.jsp
+                  scope: punctuation.definition.string.end.jsp
                   pop: true
                 - match: \\.
                   scope: constant.character.escape.jsp

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -47,8 +47,7 @@ contexts:
       scope: storage.type.annotation.java
   anonymous-classes-and-new:
     - match: \bnew\b
-      captures:
-        0: keyword.control.new.java
+      scope: keyword.control.new.java
       push:
         - match: '(?<=\)|\])(?!\s*{)|(?<=})|(?=;)'
           pop: true
@@ -102,8 +101,7 @@ contexts:
       push:
         - meta_scope: meta.class.java
         - match: "}"
-          captures:
-            0: punctuation.section.class.end.java
+          scope: punctuation.section.class.end.java
           pop: true
         - include: storage-modifiers
         - include: comments
@@ -113,8 +111,7 @@ contexts:
             1: storage.modifier.java
             2: entity.name.type.class.java
         - match: extends
-          captures:
-            0: storage.modifier.extends.java
+          scope: storage.modifier.extends.java
           push:
             - meta_scope: meta.definition.class.inherited.classes.java
             - match: "(?={|implements)"
@@ -169,13 +166,11 @@ contexts:
     - include: comments-inline
   comments-inline:
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.java
+      scope: punctuation.definition.comment.java
       push:
         - meta_scope: comment.block.java
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.java
+          scope: punctuation.definition.comment.java
           pop: true
     - match: \s*((//).*$\n?)
       captures:
@@ -198,8 +193,7 @@ contexts:
         - match: "(?=;|})"
           pop: true
         - match: \w+
-          captures:
-            0: constant.other.enum.java
+          scope: constant.other.enum.java
           push:
             - meta_scope: meta.enum.java
             - match: "(?=,|;|})"
@@ -331,31 +325,26 @@ contexts:
         1: storage.modifier.java
   strings:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.java
+      scope: punctuation.definition.string.begin.java
       push:
         - meta_scope: string.quoted.double.java
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.java
+          scope: punctuation.definition.string.end.java
           pop: true
         - match: \\.
           scope: constant.character.escape.java
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.java
+      scope: punctuation.definition.string.begin.java
       push:
         - meta_scope: string.quoted.single.java
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.java
+          scope: punctuation.definition.string.end.java
           pop: true
         - match: \\.
           scope: constant.character.escape.java
   throws:
     - match: throws
-      captures:
-        0: storage.modifier.java
+      scope: storage.modifier.java
       push:
         - meta_scope: meta.throwables.java
         - match: "(?={|;)"

--- a/Java/JavaDoc.sublime-syntax
+++ b/Java/JavaDoc.sublime-syntax
@@ -12,8 +12,7 @@ contexts:
       push:
         - meta_scope: comment.block.documentation.javadoc
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.javadoc
+          scope: punctuation.definition.comment.javadoc
           pop: true
         - include: invalid
         - match: \*\s*(?=\w)
@@ -163,8 +162,7 @@ contexts:
         - meta_scope: meta.directive.code.javadoc
         - meta_content_scope: markup.raw.code.javadoc
         - match: '\}'
-          captures:
-            0: punctuation.definition.directive.end.javadoc
+          scope: punctuation.definition.directive.end.javadoc
           pop: true
     - match: '(\{)((\@)literal)'
       captures:
@@ -175,8 +173,7 @@ contexts:
         - meta_scope: meta.directive.literal.javadoc
         - meta_content_scope: markup.raw.literal.javadoc
         - match: '\}'
-          captures:
-            0: punctuation.definition.directive.end.javadoc
+          scope: punctuation.definition.directive.end.javadoc
           pop: true
     - match: '(\{)((\@)docRoot)(\})'
       scope: meta.directive.docRoot.javadoc

--- a/Java/JavaProperties.sublime-syntax
+++ b/Java/JavaProperties.sublime-syntax
@@ -12,13 +12,11 @@ contexts:
       captures:
         1: punctuation.definition.comment.java-props
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.java-props
+      scope: punctuation.definition.comment.java-props
       push:
         - meta_scope: comment.block.java-props
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.java-props
+          scope: punctuation.definition.comment.java-props
           pop: true
     - match: "^([^:=]+)([:=])(.*)$"
       comment: Not compliant with the properties file spec, but this works for me, and I'm the one who counts around here.

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -17,13 +17,11 @@ contexts:
     - include: value
   array:
     - match: '\['
-      captures:
-        0: punctuation.definition.array.begin.json
+      scope: punctuation.definition.array.begin.json
       push:
         - meta_scope: meta.structure.array.json
         - match: '\]'
-          captures:
-            0: punctuation.definition.array.end.json
+          scope: punctuation.definition.array.end.json
           pop: true
         - include: value
         - match: ","
@@ -32,15 +30,13 @@ contexts:
           scope: invalid.illegal.expected-array-separator.json
   comments:
     - match: /\*\*
-      captures:
-        0: punctuation.definition.comment.json
+      scope: punctuation.definition.comment.json
       push:
         - meta_scope: comment.block.documentation.json
         - match: \*/
           pop: true
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.json
+      scope: punctuation.definition.comment.json
       push:
         - meta_scope: comment.block.json
         - match: \*/
@@ -79,19 +75,16 @@ contexts:
   object:
     - match: '\{'
       comment: a JSON object
-      captures:
-        0: punctuation.definition.dictionary.begin.json
+      scope: punctuation.definition.dictionary.begin.json
       push:
         - meta_scope: meta.structure.dictionary.json
         - match: '\}'
-          captures:
-            0: punctuation.definition.dictionary.end.json
+          scope: punctuation.definition.dictionary.end.json
           pop: true
         - include: string
         - include: comments
         - match: ":"
-          captures:
-            0: punctuation.separator.dictionary.key-value.json
+          scope: punctuation.separator.dictionary.key-value.json
           push:
             - meta_scope: meta.structure.dictionary.value.json
             - match: '(,)|(?=\})'
@@ -105,13 +98,11 @@ contexts:
           scope: invalid.illegal.expected-dictionary-separator.json
   string:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.json
+      scope: punctuation.definition.string.begin.json
       push:
         - meta_scope: string.quoted.double.json
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.json
+          scope: punctuation.definition.string.end.json
           pop: true
         - match: |-
             (?x:                # turn on extended mode

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -18,22 +18,18 @@ contexts:
   comments:
     - include: special-comments-conditional-compilation
     - match: /\*\*(?!/)
-      captures:
-        0: punctuation.definition.comment.js
+      scope: punctuation.definition.comment.js
       push:
         - meta_scope: comment.block.documentation.js
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.js
+          scope: punctuation.definition.comment.js
           pop: true
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.js
+      scope: punctuation.definition.comment.js
       push:
         - meta_scope: comment.block.js
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.js
+          scope: punctuation.definition.comment.js
           pop: true
     - match: (<!--|-->)
       scope: comment.block.html.js
@@ -58,13 +54,11 @@ contexts:
     - include: literal-punctuation
   curly-brackets:
     - match: '\{'
-      captures:
-        0: meta.brace.curly.js
+      scope: meta.brace.curly.js
       push:
         - meta_scope: meta.group.braces.curly
         - match: '\}'
-          captures:
-            0: meta.brace.curly.js
+          scope: meta.brace.curly.js
           pop: true
         - include: main
   expression:
@@ -90,12 +84,10 @@ contexts:
     - include: literal-variable
   function-declaration-parameters:
     - match: \(
-      captures:
-        0: punctuation.definition.parameters.begin.js
+      scope: punctuation.definition.parameters.begin.js
       push:
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.end.js
+          scope: punctuation.definition.parameters.end.js
           pop: true
         - match: (?<!\.)\.\.\.
           scope: keyword.operator.spread.js
@@ -104,8 +96,7 @@ contexts:
         - match: ","
           scope: punctuation.separator.parameter.function.js
         - match: "="
-          captures:
-            0: keyword.operator.assignment.js
+          scope: keyword.operator.assignment.js
           push:
             - meta_scope: meta.parameter.optional.js
             - match: "(?=[,)])"
@@ -329,8 +320,7 @@ contexts:
       push:
         - meta_scope: meta.class.js
         - match: "}"
-          captures:
-            0: meta.brace.curly.js
+          scope: meta.brace.curly.js
           pop: true
         - match: \b(extends)\b
           captures:
@@ -341,8 +331,7 @@ contexts:
               pop: true
             - include: expression
         - match: "{"
-          captures:
-            0: meta.brace.curly.js
+          scope: meta.brace.curly.js
           push:
             - match: "(?=})"
               pop: true
@@ -368,12 +357,10 @@ contexts:
       push:
         - meta_scope: meta.for.js
         - match: \)
-          captures:
-            0: meta.brace.round.js
+          scope: meta.brace.round.js
           pop: true
         - match: \(
-          captures:
-            0: meta.brace.round.js
+          scope: meta.brace.round.js
           push:
             - match: (?=\))
               pop: true
@@ -550,8 +537,7 @@ contexts:
         )\s*:)
       push:
         - match: ":"
-          captures:
-            0: punctuation.separator.key-value.js
+          scope: punctuation.separator.key-value.js
           pop: true
         - include: literal-string
     - match: '(?<!\.|\?|\?\s)([_$a-zA-Z][$\w]*)\s*(:)'
@@ -774,18 +760,15 @@ contexts:
       push:
         - meta_scope: string.quasi.js
         - match: "`"
-          captures:
-            0: punctuation.definition.quasi.end.js
+          scope: punctuation.definition.quasi.end.js
           pop: true
         - include: string-content
         - match: '\${'
-          captures:
-            0: punctuation.quasi.element.begin.js
+          scope: punctuation.quasi.element.begin.js
           push:
             - meta_scope: entity.quasi.element.js
             - match: "}"
-              captures:
-                0: punctuation.quasi.element.end.js
+              scope: punctuation.quasi.element.end.js
               pop: true
             - include: expression
   literal-regexp:
@@ -810,8 +793,7 @@ contexts:
         - include: scope:source.regexp.js
   literal-string:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.js
+      scope: punctuation.definition.string.begin.js
       push:
         - meta_scope: string.quoted.single.js
         - match: (')|(\n)
@@ -821,8 +803,7 @@ contexts:
           pop: true
         - include: string-content
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.js
+      scope: punctuation.definition.string.begin.js
       push:
         - meta_scope: string.quoted.double.js
         - match: (")|(\n)
@@ -838,13 +819,11 @@ contexts:
       push:
         - meta_scope: meta.switch.js
         - match: '\}'
-          captures:
-            0: meta.brace.curly.js
+          scope: meta.brace.curly.js
           pop: true
         - include: round-brackets
         - match: '\{'
-          captures:
-            0: meta.brace.curly.js
+          scope: meta.brace.curly.js
           push:
             - match: "(?=})"
               pop: true
@@ -884,21 +863,18 @@ contexts:
       scope: variable.other.readwrite.js
   round-brackets:
     - match: \(
-      captures:
-        0: meta.brace.round.js
+      scope: meta.brace.round.js
       push:
         - meta_scope: meta.group.braces.round
         - match: \)
-          captures:
-            0: meta.brace.round.js
+          scope: meta.brace.round.js
           pop: true
         - include: expression
     - match: \)
       scope: invalid.illegal.stray.brace.round.js
   special-comments-conditional-compilation:
     - match: /\*(?=@)
-      captures:
-        0: punctuation.definition.comment.js
+      scope: punctuation.definition.comment.js
       push:
         - meta_scope: comment.block.conditional.js
         - match: \*/
@@ -919,13 +895,11 @@ contexts:
         1: punctuation.definition.variable.js
   square-brackets:
     - match: '\['
-      captures:
-        0: meta.brace.square.js
+      scope: meta.brace.square.js
       push:
         - meta_scope: meta.group.braces.square
         - match: '\]'
-          captures:
-            0: meta.brace.square.js
+          scope: meta.brace.square.js
           pop: true
         - include: expression
   string-content:

--- a/LaTeX/Bibtex.sublime-syntax
+++ b/LaTeX/Bibtex.sublime-syntax
@@ -12,8 +12,7 @@ scope: text.bibtex
 contexts:
   main:
     - match: "@Comment"
-      captures:
-        0: punctuation.definition.comment.bibtex
+      scope: punctuation.definition.comment.bibtex
       push:
         - meta_scope: comment.line.at-sign.bibtex
         - match: $\n?
@@ -27,8 +26,7 @@ contexts:
       push:
         - meta_scope: meta.string-constant.braces.bibtex
         - match: '\}'
-          captures:
-            0: punctuation.section.string-constant.end.bibtex
+          scope: punctuation.section.string-constant.end.bibtex
           pop: true
         - include: string_content
     - match: '((@)String)\s*(\()\s*([a-zA-Z]*)'
@@ -40,8 +38,7 @@ contexts:
       push:
         - meta_scope: meta.string-constant.parenthesis.bibtex
         - match: \)
-          captures:
-            0: punctuation.section.string-constant.end.bibtex
+          scope: punctuation.section.string-constant.end.bibtex
           pop: true
         - include: string_content
     - match: '((@)[a-zA-Z]+)\s*(\{)\s*([^\s,]*)'
@@ -53,8 +50,7 @@ contexts:
       push:
         - meta_scope: meta.entry.braces.bibtex
         - match: '\}'
-          captures:
-            0: punctuation.section.entry.end.bibtex
+          scope: punctuation.section.entry.end.bibtex
           pop: true
         - match: '([a-zA-Z]+)\s*(\=)'
           captures:
@@ -75,8 +71,7 @@ contexts:
       push:
         - meta_scope: meta.entry.parenthesis.bibtex
         - match: \)
-          captures:
-            0: punctuation.section.entry.end.bibtex
+          scope: punctuation.section.entry.end.bibtex
           pop: true
         - match: '([a-zA-Z]+)\s*(\=)'
           captures:
@@ -98,33 +93,27 @@ contexts:
       scope: constant.numeric.bibtex
   nested_braces:
     - match: '\{'
-      captures:
-        0: punctuation.definition.group.begin.bibtex
+      scope: punctuation.definition.group.begin.bibtex
       push:
         - match: '\}'
-          captures:
-            0: punctuation.definition.group.end.bibtex
+          scope: punctuation.definition.group.end.bibtex
           pop: true
         - include: nested_braces
   string_content:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.bibtex
+      scope: punctuation.definition.string.begin.bibtex
       push:
         - meta_scope: string.quoted.double.bibtex
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.bibtex
+          scope: punctuation.definition.string.end.bibtex
           pop: true
         - include: nested_braces
     - match: '\{'
-      captures:
-        0: punctuation.definition.string.begin.bibtex
+      scope: punctuation.definition.string.begin.bibtex
       push:
         - meta_scope: string.quoted.other.braces.bibtex
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.bibtex
+          scope: punctuation.definition.string.end.bibtex
           pop: true
         - match: "@"
           scope: invalid.illegal.at-sign.bibtex

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -36,13 +36,11 @@ contexts:
         - match: '[0-9]+\-\-[0-9]+'
           scope: variable.parameter.hyphenation.latex2
     - match: (<)
-      captures:
-        0: punctuation.definition.string.begin.log.latex
+      scope: punctuation.definition.string.begin.log.latex
       push:
         - meta_scope: string.unquoted.other.filename.log.latex
         - match: (>)
-          captures:
-            0: punctuation.definition.string.end.log.latex
+          scope: punctuation.definition.string.end.log.latex
           pop: true
         - match: (.*/.*\.pdf)
           scope: support.function.with-arg.latex

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -22,8 +22,7 @@ contexts:
         - meta_scope: meta.preamble.latex
         - meta_content_scope: support.class.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.end.latex
+          scope: punctuation.definition.arguments.end.latex
           pop: true
         - include: main
     - match: '((\\)(?:include|input))(\{)'
@@ -35,8 +34,7 @@ contexts:
         - meta_scope: meta.include.latex
         - meta_content_scope: support.class.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.end.latex
+          scope: punctuation.definition.arguments.end.latex
           pop: true
         - include: main
     - match: |-
@@ -67,8 +65,7 @@ contexts:
         - meta_scope: meta.function.section.latex
         - meta_content_scope: entity.name.section.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.end.latex
+          scope: punctuation.definition.arguments.end.latex
           pop: true
         - include: main
     - match: '(?:\s*)((\\)begin)(\{)(lstlisting)(\})(?:(\[).*(\]))?(\s*%\s*(?i:Java)\n?)'
@@ -327,8 +324,7 @@ contexts:
       push:
         - meta_content_scope: meta.paragraph.margin.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.marginpar.end.latex
+          scope: punctuation.definition.marginpar.end.latex
           pop: true
         - include: $top_level_main
     - match: '((\\)footnote)(\{)'
@@ -339,8 +335,7 @@ contexts:
       push:
         - meta_content_scope: meta.footnote.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.footnote.end.latex
+          scope: punctuation.definition.footnote.end.latex
           pop: true
         - include: $top_level_main
     - match: '((\\)emph)(\{)'
@@ -352,8 +347,7 @@ contexts:
         - meta_scope: meta.function.emph.latex
         - meta_content_scope: markup.italic.emph.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.emph.end.latex
+          scope: punctuation.definition.emph.end.latex
           pop: true
         - include: $top_level_main
     - match: '((\\)textit)(\{)'
@@ -369,8 +363,7 @@ contexts:
         - meta_scope: meta.function.textit.latex
         - meta_content_scope: markup.italic.textit.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.textit.end.latex
+          scope: punctuation.definition.textit.end.latex
           pop: true
         - include: $top_level_main
     - match: '((\\)textbf)(\{)'
@@ -382,8 +375,7 @@ contexts:
         - meta_scope: meta.function.textbf.latex
         - meta_content_scope: markup.bold.textbf.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.textbf.end.latex
+          scope: punctuation.definition.textbf.end.latex
           pop: true
         - include: $top_level_main
     - match: '((\\)texttt)(\{)'
@@ -395,8 +387,7 @@ contexts:
         - meta_scope: meta.function.texttt.latex
         - meta_content_scope: markup.raw.texttt.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.texttt.end.latex
+          scope: punctuation.definition.texttt.end.latex
           pop: true
         - include: $top_level_main
     - match: (\\)item\b
@@ -427,8 +418,7 @@ contexts:
       push:
         - meta_scope: meta.citation.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.latex
+          scope: punctuation.definition.arguments.latex
           pop: true
         - match: '[\w:.]+'
           scope: constant.other.reference.citation.latex
@@ -440,8 +430,7 @@ contexts:
       push:
         - meta_scope: meta.reference.label.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.begin.latex
+          scope: punctuation.definition.arguments.begin.latex
           pop: true
         - match: '[a-zA-Z0-9\.,:/*!^_-]'
           scope: constant.other.reference.label.latex
@@ -453,8 +442,7 @@ contexts:
       push:
         - meta_scope: meta.definition.label.latex
         - match: '\}'
-          captures:
-            0: punctuation.definition.arguments.end.latex
+          scope: punctuation.definition.arguments.end.latex
           pop: true
         - match: '[a-zA-Z0-9\.,:/*!^_-]'
           scope: variable.parameter.definition.label.latex
@@ -482,63 +470,51 @@ contexts:
         4: markup.raw.verb.latex
         5: punctuation.definition.verb.latex
     - match: '"`'
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.quoted.double.european.latex
         - match: '"'''
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: "``"
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.quoted.double.latex
         - match: '''''|"'
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: '">'
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.quoted.double.guillemot.latex
         - match: '"<'
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: '"<'
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.quoted.double.guillemot.latex
         - match: '">'
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: \\\(
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.other.math.latex
         - match: \\\)
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: '\\\['
-      captures:
-        0: punctuation.definition.string.begin.latex
+      scope: punctuation.definition.string.begin.latex
       push:
         - meta_scope: string.other.math.latex
         - match: '\\\]'
-          captures:
-            0: punctuation.definition.string.end.latex
+          scope: punctuation.definition.string.end.latex
           pop: true
         - include: $top_level_main
     - match: (?<!\S)'.*?'

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -30,38 +30,32 @@ contexts:
       captures:
         1: punctuation.definition.comment.tex
     - match: '\{'
-      captures:
-        0: punctuation.section.group.tex
+      scope: punctuation.section.group.tex
       push:
         - meta_scope: meta.group.braces.tex
         - match: '\}'
-          captures:
-            0: punctuation.section.group.tex
+          scope: punctuation.section.group.tex
           pop: true
         - include: $top_level_main
     - match: '[\[\]]'
       scope: punctuation.definition.brackets.tex
     - match: \$\$
-      captures:
-        0: punctuation.definition.string.begin.tex
+      scope: punctuation.definition.string.begin.tex
       push:
         - meta_scope: string.other.math.block.tex
         - match: \$\$
-          captures:
-            0: punctuation.definition.string.end.tex
+          scope: punctuation.definition.string.end.tex
           pop: true
         - include: scope:text.tex.math
         - include: main
     - match: \\\\
       scope: constant.character.newline.tex
     - match: \$
-      captures:
-        0: punctuation.definition.string.begin.tex
+      scope: punctuation.definition.string.begin.tex
       push:
         - meta_scope: string.other.math.tex
         - match: \$
-          captures:
-            0: punctuation.definition.string.end.tex
+          scope: punctuation.definition.string.end.tex
           pop: true
         - match: \\\$
           scope: constant.character.escape.tex

--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -40,13 +40,11 @@ contexts:
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
       scope: constant.numeric.lisp
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.lisp
+      scope: punctuation.definition.string.begin.lisp
       push:
         - meta_scope: string.quoted.double.lisp
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.lisp
+          scope: punctuation.definition.string.end.lisp
           pop: true
         - match: \\.
           scope: constant.character.escape.lisp

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -20,13 +20,11 @@ contexts:
     - match: '(?<![\d.])\b0[xX][a-fA-F\d\.]+([pP][\-\+]?\d+)?|\b\d+(\.\d+)?([eE]-?\d+)?|\.\d+([eE]-?\d+)?'
       scope: constant.numeric.lua
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.lua
+      scope: punctuation.definition.string.begin.lua
       push:
         - meta_scope: string.quoted.single.lua
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.lua
+          scope: punctuation.definition.string.end.lua
           pop: true
         - match: '\\([abfnrtv\\"'']|\r?\n|\n\r?|\d\d?\d?)'
           scope: constant.character.escape.lua
@@ -35,13 +33,11 @@ contexts:
         - match: '\\u\{[0-9a-fA-F]{,7}\}'
           scope: constant.character.escape.lua
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.lua
+      scope: punctuation.definition.string.begin.lua
       push:
         - meta_scope: string.quoted.double.lua
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.lua
+          scope: punctuation.definition.string.end.lua
           pop: true
         - match: '\\([abfnrtv\\"'']|\r?\n|\n\r?|\d\d?\d?)'
           scope: constant.character.escape.lua
@@ -50,22 +46,18 @@ contexts:
         - match: '\\u\{[0-9a-fA-F]{,7}\}'
           scope: constant.character.escape.lua
     - match: '(?<!--)\[(=*)\['
-      captures:
-        0: punctuation.definition.string.begin.lua
+      scope: punctuation.definition.string.begin.lua
       push:
         - meta_scope: string.quoted.other.multiline.lua
         - match: '\]\1\]'
-          captures:
-            0: punctuation.definition.string.end.lua
+          scope: punctuation.definition.string.end.lua
           pop: true
     - match: '--\[(=*)\['
-      captures:
-        0: punctuation.definition.comment.lua
+      scope: punctuation.definition.comment.lua
       push:
         - meta_scope: comment.block.lua
         - match: '\]\1\]'
-          captures:
-            0: punctuation.definition.comment.lua
+          scope: punctuation.definition.comment.lua
           pop: true
     - match: '(--)(?!\[\[).*$\n?'
       scope: comment.line.double-dash.lua

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -98,8 +98,7 @@ contexts:
         - match: (?<!\\)\\$\n
           scope: punctuation.separator.continuation.makefile
     - match: '\#'
-      captures:
-        0: punctuation.definition.comment.makefile
+      scope: punctuation.definition.comment.makefile
       push:
         - meta_scope: comment.line.number-sign.makefile
         - match: $\n

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -26,8 +26,7 @@ contexts:
         - meta_scope: meta.function.with-arguments.matlab
         - meta_content_scope: variable.parameter.input.function.matlab
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.matlab
+          scope: punctuation.definition.parameters.matlab
           pop: true
     - match: |-
         (?x)
@@ -143,13 +142,11 @@ contexts:
     - include: operators
   brackets:
     - match: '\['
-      captures:
-        0: meta.brackets.matlab
+      scope: meta.brackets.matlab
       push:
         - meta_content_scope: meta.brackets.matlab
         - match: '\]'
-          captures:
-            0: meta.brackets.matlab
+          scope: meta.brackets.matlab
           pop: true
         - include: allofem
   constants_override:
@@ -158,13 +155,11 @@ contexts:
       scope: meta.inappropriate.matlab
   curlybrackets:
     - match: '\{'
-      captures:
-        0: meta.brackets.curly.matlab
+      scope: meta.brackets.curly.matlab
       push:
         - meta_content_scope: meta.brackets.curly.matlab
         - match: '\}'
-          captures:
-            0: meta.brackets.curly.matlab
+          scope: meta.brackets.curly.matlab
           pop: true
         - include: allofem
         - include: end_in_parens
@@ -392,13 +387,11 @@ contexts:
       scope: keyword.operator.symbols.matlab
   parens:
     - match: \(
-      captures:
-        0: meta.parens.matlab
+      scope: meta.parens.matlab
       push:
         - meta_content_scope: meta.parens.matlab
         - match: \)
-          captures:
-            0: meta.parens.matlab
+          scope: meta.parens.matlab
           pop: true
         - include: allofem
         - include: end_in_parens
@@ -408,13 +401,11 @@ contexts:
       scope: constant.character.escape.matlab
   string:
     - match: '((?<=(\[|\(|\{|=|\s|;|:|,))|^)'''
-      captures:
-        0: punctuation.definition.string.begin.matlab
+      scope: punctuation.definition.string.begin.matlab
       push:
         - meta_scope: string.quoted.single.matlab
         - match: '''(?=(\]|\)|\}|=|~|<|>|&|\||-|\+|\*|\.|\^|\||\s|;|:|,))'
-          captures:
-            0: punctuation.definition.string.end.matlab
+          scope: punctuation.definition.string.end.matlab
           pop: true
         - include: escaped_quote
         - include: unescaped_quote

--- a/OCaml/OCamlyacc.sublime-syntax
+++ b/OCaml/OCamlyacc.sublime-syntax
@@ -119,8 +119,7 @@ contexts:
       scope: entity.name.type.token.reference.ocamlyacc
   rule-patterns:
     - match: ((?<!\||:)(\||:)(?!\||:))
-      captures:
-        0: punctuation.separator.rule.ocamlyacc
+      scope: punctuation.separator.rule.ocamlyacc
       push:
         - meta_scope: meta.rule-match.ocaml
         - match: \s*(?=\||;)
@@ -131,13 +130,11 @@ contexts:
         - include: comments
   rules:
     - match: "[a-z][a-zA-Z_]*"
-      captures:
-        0: entity.name.function.non-terminal.ocamlyacc
+      scope: entity.name.function.non-terminal.ocamlyacc
       push:
         - meta_scope: meta.non-terminal.ocamlyacc
         - match: ;
-          captures:
-            0: punctuation.separator.rule.ocamlyacc
+          scope: punctuation.separator.rule.ocamlyacc
           pop: true
         - include: rule-patterns
   semantic-actions:
@@ -153,12 +150,10 @@ contexts:
         - include: scope:source.ocaml
   symbol-types:
     - match: <
-      captures:
-        0: punctuation.definition.type-declaration.begin.ocamlyacc
+      scope: punctuation.definition.type-declaration.begin.ocamlyacc
       push:
         - meta_scope: meta.token.type-declaration.ocamlyacc
         - match: ">"
-          captures:
-            0: punctuation.definition.type-declaration.end.ocamlyacc
+          scope: punctuation.definition.type-declaration.end.ocamlyacc
           pop: true
         - include: scope:source.ocaml

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -49,13 +49,11 @@ contexts:
           pop: true
         - include: implementation_innards
     - match: '@"'
-      captures:
-        0: punctuation.definition.string.begin.objc
+      scope: punctuation.definition.string.begin.objc
       push:
         - meta_scope: string.quoted.double.objc
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.objc
+          scope: punctuation.definition.string.end.objc
           pop: true
         - match: '\\(\\|[abefnrtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-zA-Z0-9]+)'
           scope: constant.character.escape.objc
@@ -149,17 +147,14 @@ contexts:
     - include: bracketed_content
   comment:
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.objc
+      scope: punctuation.definition.comment.objc
       push:
         - meta_scope: comment.block.objc
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.objc
+          scope: punctuation.definition.comment.objc
           pop: true
     - match: //
-      captures:
-        0: punctuation.definition.comment.objc
+      scope: punctuation.definition.comment.objc
       push:
         - meta_scope: comment.line.double-slash.c++
         - match: $\n?
@@ -168,13 +163,11 @@ contexts:
           scope: punctuation.separator.continuation.c++
   bracketed_content:
     - match: '\['
-      captures:
-        0: punctuation.section.scope.begin.objc
+      scope: punctuation.section.scope.begin.objc
       push:
         - meta_scope: meta.bracketed.objc
         - match: '\]'
-          captures:
-            0: punctuation.section.scope.end.objc
+          scope: punctuation.section.scope.end.objc
           pop: true
         - match: (?=predicateWithFormat:)(?<=NSPredicate )(predicateWithFormat:)
           captures:
@@ -193,13 +186,11 @@ contexts:
               captures:
                 1: punctuation.separator.arguments.objc
             - match: '@"'
-              captures:
-                0: punctuation.definition.string.begin.objc
+              scope: punctuation.definition.string.begin.objc
               push:
                 - meta_scope: string.quoted.double.objc
                 - match: '"'
-                  captures:
-                    0: punctuation.definition.string.end.objc
+                  scope: punctuation.definition.string.end.objc
                   pop: true
                 - match: \b(AND|OR|NOT|IN)\b
                   scope: keyword.operator.logical.predicate.cocoa

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -34,23 +34,19 @@ contexts:
         This now only highlights a docblock if the first line contains only /**
                                         - this is to stop highlighting everything as invalid when people do comment banners with /******** ...
                                         - Now matches /**#@+ too - used for docblock templates: http://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.docblocktemplate
-      captures:
-        0: punctuation.definition.comment.php
+      scope: punctuation.definition.comment.php
       push:
         - meta_scope: comment.block.documentation.phpdoc.php
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.php
+          scope: punctuation.definition.comment.php
           pop: true
         - include: php_doc
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.php
+      scope: punctuation.definition.comment.php
       push:
         - meta_scope: comment.block.php
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.php
+          scope: punctuation.definition.comment.php
           pop: true
     - match: (//).*?($\n?|(?=\?>))
       scope: comment.line.double-slash.php
@@ -123,8 +119,7 @@ contexts:
         - meta_scope: meta.function.argument.array.php
         - meta_content_scope: meta.array.php
         - match: \)
-          captures:
-            0: punctuation.definition.array.end.php
+          scope: punctuation.definition.array.end.php
           pop: true
         - include: comments
         - include: strings
@@ -578,8 +573,7 @@ contexts:
       push:
         - meta_scope: meta.array.php
         - match: \)
-          captures:
-            0: punctuation.definition.array.end.php
+          scope: punctuation.definition.array.end.php
           pop: true
         - include: language
     - match: (?i)\s*\(\s*(array|real|double|float|int(eger)?|bool(ean)?|string|object|binary|unset)\s*\)
@@ -636,12 +630,10 @@ contexts:
         1: entity.name.goto-label.php
     - include: string-backtick
     - match: '\['
-      captures:
-        0: punctuation.section.array.begin.php
+      scope: punctuation.section.array.begin.php
       push:
         - match: '\]'
-          captures:
-            0: punctuation.section.array.end.php
+          scope: punctuation.section.array.end.php
           pop: true
         - include: language
     - include: constants
@@ -701,8 +693,7 @@ contexts:
       push:
         - meta_scope: meta.array.php
         - match: \)
-          captures:
-            0: punctuation.definition.array.end.php
+          scope: punctuation.definition.array.end.php
           pop: true
         - include: parameter-default-types
     - include: instantiation
@@ -742,13 +733,11 @@ contexts:
         1: keyword.other.phpdoc.php
   regex-double-quoted:
     - match: '(?x)"/ (?= (\\.|[^"/])++/[imsxeADSUXu]*" )'
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.regexp.double-quoted.php
         - match: '(/)([imsxeADSUXu]*)(")'
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: '(\\){1,2}[.$^\[\]{}]'
           comment: Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)
@@ -760,26 +749,22 @@ contexts:
             1: punctuation.definition.arbitrary-repitition.php
             3: punctuation.definition.arbitrary-repitition.php
         - match: '\[(?:\^?\])?'
-          captures:
-            0: punctuation.definition.character-class.php
+          scope: punctuation.definition.character-class.php
           push:
             - meta_scope: string.regexp.character-class.php
             - match: '\]'
-              captures:
-                0: punctuation.definition.character-class.php
+              scope: punctuation.definition.character-class.php
               pop: true
             - include: interpolation
         - match: "[$^+*]"
           scope: keyword.operator.regexp.php
   regex-single-quoted:
     - match: '(?x)''/ (?= (\\.|[^''/])++/[imsxeADSUXu]*'' )'
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.regexp.single-quoted.php
         - match: "(/)([imsxeADSUXu]*)(')"
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: '(\{)\d+(,\d+)?(\})'
           scope: string.regexp.arbitrary-repitition.php
@@ -793,13 +778,11 @@ contexts:
           comment: Escaped from the PHP string – there can also be 2 backslashes (since 1 will escape the first)
           scope: constant.character.escape.php
         - match: '\[(?:\^?\])?'
-          captures:
-            0: punctuation.definition.character-class.php
+          scope: punctuation.definition.character-class.php
           push:
             - meta_scope: string.regexp.character-class.php
             - match: '\]'
-              captures:
-                0: punctuation.definition.character-class.php
+              scope: punctuation.definition.character-class.php
               pop: true
             - match: '\\[\\''\[\]]'
               scope: constant.character.escape.php
@@ -807,14 +790,12 @@ contexts:
           scope: keyword.operator.regexp.php
   sql-string-double-quoted:
     - match: '"\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b)'
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.quoted.double.sql.php
         - meta_content_scope: source.sql.embedded.php
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: '#(\\"|[^"])*(?="|$\n?)'
           scope: comment.line.number-sign.sql
@@ -848,14 +829,12 @@ contexts:
         - include: scope:source.sql
   sql-string-single-quoted:
     - match: '''\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b)'
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.quoted.single.sql.php
         - meta_content_scope: source.sql.embedded.php
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: '#(\\''|[^''])*(?=''|$\n?)'
           scope: comment.line.number-sign.sql
@@ -876,13 +855,11 @@ contexts:
         - include: scope:source.sql
   string-backtick:
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.interpolated.php
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: \\.
           scope: constant.character.escape.php
@@ -890,26 +867,22 @@ contexts:
   string-double-quoted:
     - match: '"'
       comment: This contentName is just to allow the usage of “select scope” to select the string contents first, then the string with quotes
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.quoted.double.php
         - meta_content_scope: meta.string-contents.quoted.double.php
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - include: interpolation
   string-single-quoted:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.php
+      scope: punctuation.definition.string.begin.php
       push:
         - meta_scope: string.quoted.single.php
         - meta_content_scope: meta.string-contents.quoted.single.php
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.php
+          scope: punctuation.definition.string.end.php
           pop: true
         - match: '\\[\\'']'
           scope: constant.character.escape.php

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -17,8 +17,7 @@ contexts:
       push: 'scope:text.html.basic'
       with_prototype:
         - match: '<\?(?i:php|=)?(?![^?]*\?>)'
-          captures:
-            0: punctuation.section.embedded.begin.php
+          scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.block.php
             - meta_content_scope: source.php
@@ -29,8 +28,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
         - match: <\?(?i:php|=)?
-          captures:
-            0: punctuation.section.embedded.begin.php
+          scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.line.php
             - meta_content_scope: source.php

--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -29,8 +29,7 @@ contexts:
         - match: (?!\G)
           pop: true
         - match: "--"
-          captures:
-            0: punctuation.definition.comment.pascal
+          scope: punctuation.definition.comment.pascal
           push:
             - meta_scope: comment.line.double-dash.pascal.one
             - match: \n
@@ -42,50 +41,41 @@ contexts:
         - match: (?!\G)
           pop: true
         - match: //
-          captures:
-            0: punctuation.definition.comment.pascal
+          scope: punctuation.definition.comment.pascal
           push:
             - meta_scope: comment.line.double-slash.pascal.two
             - match: \n
               pop: true
     - match: \(\*
-      captures:
-        0: punctuation.definition.comment.pascal
+      scope: punctuation.definition.comment.pascal
       push:
         - meta_scope: comment.block.pascal.one
         - match: \*\)
-          captures:
-            0: punctuation.definition.comment.pascal
+          scope: punctuation.definition.comment.pascal
           pop: true
     - match: '\{'
-      captures:
-        0: punctuation.definition.comment.pascal
+      scope: punctuation.definition.comment.pascal
       push:
         - meta_scope: comment.block.pascal.two
         - match: '\}'
-          captures:
-            0: punctuation.definition.comment.pascal
+          scope: punctuation.definition.comment.pascal
           pop: true
     - match: '"'
       comment: Double quoted strings are an extension and (generally) support C-style escape sequences.
-      captures:
-        0: punctuation.definition.string.begin.pascal
+      scope: punctuation.definition.string.begin.pascal
       push:
         - meta_scope: string.quoted.double.pascal
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.pascal
+          scope: punctuation.definition.string.end.pascal
           pop: true
         - match: \\.
           scope: constant.character.escape.pascal
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.pascal
+      scope: punctuation.definition.string.begin.pascal
       push:
         - meta_scope: string.quoted.single.pascal
         - match: "''"
           scope: constant.character.escape.apostrophe.pascal
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.pascal
+          scope: punctuation.definition.string.end.pascal
           pop: true

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -15,13 +15,11 @@ contexts:
   main:
     - include: line_comment
     - match: ^=
-      captures:
-        0: punctuation.definition.comment.perl
+      scope: punctuation.definition.comment.perl
       push:
         - meta_scope: comment.block.documentation.perl
         - match: ^=cut
-          captures:
-            0: punctuation.definition.comment.perl
+          scope: punctuation.definition.comment.perl
           pop: true
     - include: variable
     - match: '\b(?=qr\s*[^\s\w])'
@@ -174,72 +172,60 @@ contexts:
             - include: escaped_char
             - include: nested_parens
         - match: '\{'
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.nested_braces.perl
             - match: '\}'
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
             - include: nested_braces_interpolated
         - match: '\['
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.nested_brackets.perl
             - match: '\]'
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
             - include: nested_brackets_interpolated
         - match: "<"
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.nested_ltgt.perl
             - match: ">"
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
             - include: nested_ltgt_interpolated
         - match: \(
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.nested_parens.perl
             - match: \)
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
             - include: nested_parens_interpolated
         - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.single_quote.perl
             - match: "'"
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - match: '\\[''\\]'
               scope: constant.character.escape.perl
         - match: '([^\s\w\[({<;])'
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.format.simple_delimiter.perl
             - match: \1
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -272,24 +258,20 @@ contexts:
               pop: true
             - include: escaped_char
         - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.replaceXXX.format.single_quote.perl
             - match: "'"
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - match: '\\[''\\]'
               scope: constant.character.escape.perl.perl
         - match: '([^\s\w\[({<])'
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.replaceXXX.format.simple_delimiter.perl
             - match: \1
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -315,23 +297,19 @@ contexts:
               pop: true
             - include: escaped_char
         - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
             - match: '''(?=[egimos]*x[egimos]*)\b'
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
         - match: (.)
-          captures:
-            0: punctuation.definition.string.perl
+          scope: punctuation.definition.string.perl
           push:
             - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
             - match: '\1(?=[egimos]*x[egimos]*)\b'
-              captures:
-                0: punctuation.definition.string.perl
+              scope: punctuation.definition.string.perl
               pop: true
             - include: escaped_char
             - include: variable
@@ -345,8 +323,7 @@ contexts:
         1: punctuation.definition.string.perl
         5: punctuation.definition.string.perl
     - match: (?<!\\)(\~\s*\/)
-      captures:
-        0: punctuation.definition.string.perl
+      scope: punctuation.definition.string.perl
       push:
         - meta_scope: string.regexp.find.extended.perl
         - match: '\/([cgimos]*x[cgimos]*)\b'
@@ -390,49 +367,41 @@ contexts:
         2: punctuation.definition.string.perl
         5: punctuation.definition.string.perl
     - match: \b(m)\s*(?<!\\)\(
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.regexp.find-m-paren.perl
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_parens_interpolated
         - include: variable
     - match: '\b(m)\s*(?<!\\)\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.regexp.find-m-brace.perl
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_braces_interpolated
         - include: variable
     - match: '\b(m)\s*(?<!\\)\['
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.regexp.find-m-bracket.perl
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_brackets_interpolated
         - include: variable
     - match: \b(m)\s*(?<!\\)\<
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.regexp.find-m-ltgt.perl
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_ltgt_interpolated
@@ -759,228 +728,188 @@ contexts:
         - include: escaped_char
         - include: variable
     - match: '\bqq\s*([^\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.qq.perl
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: variable
     - match: '\bqx\s*([^''\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx.perl
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: variable
     - match: \bqx\s*'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx.single-quote.perl
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.double.perl
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: variable
     - match: '\bqw?\s*([^\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.q.perl
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.single.perl
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - match: '\\[''\\]'
           scope: constant.character.escape.perl
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.perl
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: variable
     - match: \bqq\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.qq-paren.perl
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_parens_interpolated
         - include: variable
     - match: '\bqq\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.qq-brace.perl
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_braces_interpolated
         - include: variable
     - match: '\bqq\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.qq-bracket.perl
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_brackets_interpolated
         - include: variable
     - match: \bqq\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.qq-ltgt.perl
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_ltgt_interpolated
         - include: variable
     - match: \bqx\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx-paren.perl
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_parens_interpolated
         - include: variable
     - match: '\bqx\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx-brace.perl
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_braces_interpolated
         - include: variable
     - match: '\bqx\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx-bracket.perl
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_brackets_interpolated
         - include: variable
     - match: \bqx\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.interpolated.qx-ltgt.perl
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_ltgt_interpolated
         - include: variable
     - match: \bqw?\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.q-paren.perl
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_parens
     - match: '\bqw?\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.q-brace.perl
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_braces
     - match: '\bqw?\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.q-bracket.perl
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_brackets
     - match: \bqw?\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.quoted.other.q-ltgt.perl
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
         - include: escaped_char
         - include: nested_ltgt
     - match: ^__\w+__
-      captures:
-        0: punctuation.definition.string.begin.perl
+      scope: punctuation.definition.string.begin.perl
       push:
         - meta_scope: string.unquoted.program-block.perl
         - match: $
-          captures:
-            0: punctuation.definition.string.end.perl
+          scope: punctuation.definition.string.end.perl
           pop: true
     - match: '\b(format)\s+([A-Za-z]+)\s*='
       captures:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -19,8 +19,7 @@ variables:
 contexts:
   main:
     - match: "#"
-      captures:
-        0: punctuation.definition.comment.python
+      scope: punctuation.definition.comment.python
       push:
         - meta_scope: comment.line.number-sign.python
         - match: \n
@@ -50,7 +49,7 @@ contexts:
         1: storage.modifier.global.python
     - match: \b(nonlocal)\b
       captures:
-        1: storage.modifier.nonlocal.python        
+        1: storage.modifier.nonlocal.python
     - match: \b(?:(import)|(from))\b
       captures:
         1: keyword.control.import.python
@@ -546,8 +545,7 @@ contexts:
         -
           - meta_scope: string.quoted.double.block.raw-regex.python
           - match: '"""'
-            captures:
-              0: punctuation.definition.string.end.python
+            scope: punctuation.definition.string.end.python
             pop: true
         - "Regular Expressions (Python).sublime-syntax"
       with_prototype:
@@ -583,8 +581,7 @@ contexts:
       push:
         - meta_scope: string.quoted.double.block.raw.python
         - match: '"""'
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_unicode_char
@@ -596,8 +593,7 @@ contexts:
       push:
         - meta_scope: string.quoted.double.block.python
         - match: '"""'
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_unicode_char
@@ -636,8 +632,7 @@ contexts:
       push:
         - meta_scope: string.quoted.double.block.sql.python
         - match: '"""'
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_char
@@ -661,8 +656,7 @@ contexts:
       push:
         - meta_scope: string.quoted.double.block.python
         - match: '"""'
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_char
@@ -688,8 +682,7 @@ contexts:
         -
           - meta_scope: string.quoted.single.block.raw-regex.python
           - match: "'''"
-            captures:
-              0: punctuation.definition.string.end.python
+            scope: punctuation.definition.string.end.python
             pop: true
         - "Regular Expressions (Python).sublime-syntax"
       with_prototype:
@@ -725,8 +718,7 @@ contexts:
       push:
         - meta_scope: string.quoted.single.block.raw.python
         - match: "'''"
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_unicode_char
@@ -738,8 +730,7 @@ contexts:
       push:
         - meta_scope: string.quoted.single.block.python
         - match: "'''"
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_unicode_char
@@ -778,8 +769,7 @@ contexts:
       push:
         - meta_scope: string.quoted.single.block.python
         - match: "'''"
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_char
@@ -803,8 +793,7 @@ contexts:
       push:
         - meta_scope: string.quoted.single.block.python
         - match: "'''"
-          captures:
-            0: punctuation.definition.string.end.python
+          scope: punctuation.definition.string.end.python
           pop: true
         - include: constant_placeholder
         - include: escaped_char

--- a/R/R Console.sublime-syntax
+++ b/R/R Console.sublime-syntax
@@ -7,8 +7,7 @@ scope: source.r-console
 contexts:
   main:
     - match: "^> "
-      captures:
-        0: punctuation.section.embedded.r-console
+      scope: punctuation.section.embedded.r-console
       push:
         - meta_scope: source.r.embedded.r-console
         - match: \n|\z

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -36,24 +36,20 @@ contexts:
     - match: (\.\.\.|\$|:|\~)
       scope: keyword.other.r
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.r
+      scope: punctuation.definition.string.begin.r
       push:
         - meta_scope: string.quoted.double.r
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.r
+          scope: punctuation.definition.string.end.r
           pop: true
         - match: \\.
           scope: constant.character.escape.r
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.r
+      scope: punctuation.definition.string.begin.r
       push:
         - meta_scope: string.quoted.single.r
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.r
+          scope: punctuation.definition.string.end.r
           pop: true
         - match: \\.
           scope: constant.character.escape.r

--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -12,15 +12,13 @@ contexts:
       push: 'scope:text.html.basic'
       with_prototype:
         - match: "<%+#"
-          captures:
-            0: punctuation.definition.comment.erb
+          scope: punctuation.definition.comment.erb
           push:
             - meta_scope: comment.block.erb
             - match: "%>"
               pop: true
         - match: "<%+(?!>)[-=]?"
-          captures:
-            0: punctuation.section.embedded.ruby
+          scope: punctuation.section.embedded.ruby
           push:
             - meta_scope: source.ruby.rails.embedded.html
             - match: "-?%>"

--- a/Rails/JavaScript (Rails).sublime-syntax
+++ b/Rails/JavaScript (Rails).sublime-syntax
@@ -7,15 +7,13 @@ scope: source.js.rails
 contexts:
   main:
     - match: "<%+#"
-      captures:
-        0: punctuation.definition.comment.erb
+      scope: punctuation.definition.comment.erb
       push:
         - meta_scope: comment.block.erb
         - match: "%>"
           pop: true
     - match: "<%+(?!>)[-=]?"
-      captures:
-        0: punctuation.section.embedded.ruby
+      scope: punctuation.section.embedded.ruby
       push:
         - meta_scope: source.ruby.rails.erb
         - match: "-?%>"

--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -156,13 +156,11 @@ contexts:
         4: punctuation.definition.constant.restructuredtext
     - match: "``"
       comment: inline literal
-      captures:
-        0: punctuation.definition.raw.restructuredtext
+      scope: punctuation.definition.raw.restructuredtext
       push:
         - meta_scope: markup.raw.restructuredtext
         - match: "``"
-          captures:
-            0: punctuation.definition.raw.restructuredtext
+          scope: punctuation.definition.raw.restructuredtext
           pop: true
     - match: "(`)[^`]+(`)(?!_)"
       comment: intepreted text

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -164,8 +164,7 @@ contexts:
         - meta_scope: meta.function.method.with-arguments.ruby
         - meta_content_scope: variable.parameter.function.ruby
         - match: \)
-          captures:
-            0: punctuation.definition.parameters.ruby
+          scope: punctuation.definition.parameters.ruby
           pop: true
         - include: main
     - match: |-
@@ -203,24 +202,20 @@ contexts:
     - match: '\b(0[xX]\h(?>_?\h)*|\d(?>_?\d)*(\.(?![^[:space:][:digit:]])(?>_?\d)*)?([eE][-+]?\d(?>_?\d)*)?|0[bB][01]+)\b'
       scope: constant.numeric.ruby
     - match: ":'"
-      captures:
-        0: punctuation.definition.constant.ruby
+      scope: punctuation.definition.constant.ruby
       push:
         - meta_scope: constant.other.symbol.single-quoted.ruby
         - match: "'"
-          captures:
-            0: punctuation.definition.constant.ruby
+          scope: punctuation.definition.constant.ruby
           pop: true
         - match: '\\[''\\]'
           scope: constant.character.escape.ruby
     - match: ':"'
-      captures:
-        0: punctuation.definition.constant.ruby
+      scope: punctuation.definition.constant.ruby
       push:
         - meta_scope: constant.other.symbol.double-quoted.ruby
         - match: '"'
-          captures:
-            0: punctuation.definition.constant.ruby
+          scope: punctuation.definition.constant.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
@@ -229,101 +224,85 @@ contexts:
       scope: keyword.operator.assignment.augmented.ruby
     - match: "'"
       comment: single quoted string (does not allow interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.single.ruby
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: \\'|\\\\
           scope: constant.character.escape.ruby
     - match: '"'
       comment: double quoted string (allows for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.double.ruby
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
     - match: "`"
       comment: execute string (allows for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
     - match: '%x\{'
       comment: execute string (allow for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_curly_i
     - match: '%x\['
       comment: execute string (allow for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_brackets_i
     - match: '%x\<'
       comment: execute string (allow for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_ltgt_i
     - match: '%x\('
       comment: execute string (allow for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_parens_i
     - match: '%x([^\w])'
       comment: execute string (allow for interpolation)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.interpolated.ruby
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
@@ -375,200 +354,168 @@ contexts:
         - include: regex_sub
     - match: '%r\{'
       comment: regular expressions (literal)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.regexp.mod-r.ruby
         - match: '\}[eimnosux]*'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
         - include: nest_curly_r
     - match: '%r\['
       comment: regular expressions (literal)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.regexp.mod-r.ruby
         - match: '\][eimnosux]*'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
         - include: nest_brackets_r
     - match: '%r\('
       comment: regular expressions (literal)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.regexp.mod-r.ruby
         - match: '\)[eimnosux]*'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
         - include: nest_parens_r
     - match: '%r\<'
       comment: regular expressions (literal)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.regexp.mod-r.ruby
         - match: '\>[eimnosux]*'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
         - include: nest_ltgt_r
     - match: '%r([^\w])'
       comment: regular expressions (literal)
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.regexp.mod-r.ruby
         - match: '\1[eimnosux]*'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
     - match: '%[QWSR]?\('
       comment: literal capable of interpolation ()
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.upper.ruby
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_parens_i
     - match: '%[QWSR]?\['
       comment: "literal capable of interpolation []"
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.upper.ruby
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_brackets_i
     - match: '%[QWSR]?\<'
       comment: literal capable of interpolation <>
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.upper.ruby
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_ltgt_i
     - match: '%[QWSR]?\{'
       comment: "literal capable of interpolation -- {}"
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.double.ruby.mod
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_curly_i
     - match: '%[QWSR]([^\w])'
       comment: literal capable of interpolation -- wildcard
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.upper.ruby
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
     - match: '%([^\w\s=])'
       comment: literal capable of interpolation -- wildcard
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.other.ruby
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
     - match: '%[qws]\('
       comment: literal incapable of interpolation -- ()
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.lower.ruby
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: \\\)|\\\\
           scope: constant.character.escape.ruby
         - include: nest_parens
     - match: '%[qws]\<'
       comment: literal incapable of interpolation -- <>
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.lower.ruby
         - match: \>
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: \\\>|\\\\
           scope: constant.character.escape.ruby
         - include: nest_ltgt
     - match: '%[qws]\['
       comment: "literal incapable of interpolation -- []"
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.lower.ruby
         - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: '\\\]|\\\\'
           scope: constant.character.escape.ruby
         - include: nest_brackets
     - match: '%[qws]\{'
       comment: "literal incapable of interpolation -- {}"
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.lower.ruby
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: '\\\}|\\\\'
           scope: constant.character.escape.ruby
         - include: nest_curly
     - match: '%[qws]([^\w])'
       comment: literal incapable of interpolation -- wildcard
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.quoted.other.literal.lower.ruby
         - match: \1
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - match: \\.
           comment: Cant be named because its not neccesarily an escape.
@@ -579,13 +526,11 @@ contexts:
         1: punctuation.definition.constant.ruby
     - match: ^=begin
       comment: multiline comments
-      captures:
-        0: punctuation.definition.comment.ruby
+      scope: punctuation.definition.comment.ruby
       push:
         - meta_scope: comment.block.documentation.ruby
         - match: ^=end
-          captures:
-            0: punctuation.definition.comment.ruby
+          scope: punctuation.definition.comment.ruby
           pop: true
     - match: '(?:^[ \t]+)?(#).*$\n?'
       scope: comment.line.number-sign.ruby
@@ -618,13 +563,11 @@ contexts:
       scope: constant.numeric.ruby
     - match: ^__END__\n
       comment: __END__ marker
-      captures:
-        0: string.unquoted.program-block.ruby
+      scope: string.unquoted.program-block.ruby
       push:
         - meta_content_scope: text.plain
         - match: (?=not)impossible
-          captures:
-            0: string.unquoted.program-block.ruby
+          scope: string.unquoted.program-block.ruby
           pop: true
         - match: (?=<?xml|<(?i:html\b)|!DOCTYPE (?i:html\b))
           push:
@@ -634,14 +577,12 @@ contexts:
             - include: scope:text.html.basic
     - match: '(?><<-("?)((?:[_\w]+_|)HTML)\b\1)'
       comment: heredoc with embedded HTML and indented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.embedded.html.ruby
         - meta_content_scope: text.html.embedded.ruby
         - match: \s*\2$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: scope:text.html.basic
@@ -649,14 +590,12 @@ contexts:
         - include: escaped_char
     - match: '(?><<-("?)((?:[_\w]+_|)SQL)\b\1)'
       comment: heredoc with embedded SQL and indented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.embedded.sql.ruby
         - meta_content_scope: text.sql.embedded.ruby
         - match: \s*\2$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: scope:source.sql
@@ -664,14 +603,12 @@ contexts:
         - include: escaped_char
     - match: '(?><<-("?)((?:[_\w]+_|)CSS)\b\1)'
       comment: heredoc with embedded css and intented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.embedded.css.ruby
         - meta_content_scope: text.css.embedded.ruby
         - match: \s*\2$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: 'scope:source.css'
@@ -679,14 +616,12 @@ contexts:
         - include: escaped_char
     - match: '(?><<-("?)((?:[_\w]+_|)(?:JS|JAVASCRIPT))\b\1)'
       comment: heredoc with embedded javascript and intented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.embedded.js.ruby
         - meta_content_scope: text.js.embedded.ruby
         - match: \s*\2$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: 'scope:source.js'
@@ -709,40 +644,34 @@ contexts:
     #     - include: escaped_char
     - match: '(?><<-("?)((?:[_\w]+_|)RUBY)\b\1)'
       comment: heredoc with embedded ruby and intented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.embedded.ruby.ruby
         - meta_content_scope: text.ruby.embedded.ruby
         - match: \s*\2$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: main
         - include: interpolated_ruby
         - include: escaped_char
     - match: (?>\=\s*<<(\w+))
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.heredoc.ruby
         - match: ^\1$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: interpolated_ruby
         - include: escaped_char
     - match: (?><<-(\w+))
       comment: heredoc with indented terminator
-      captures:
-        0: punctuation.definition.string.begin.ruby
+      scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: string.unquoted.heredoc.ruby
         - match: \s*\1$
-          captures:
-            0: punctuation.definition.string.end.ruby
+          scope: punctuation.definition.string.end.ruby
           pop: true
         - include: heredoc
         - include: interpolated_ruby
@@ -803,13 +732,11 @@ contexts:
         0: punctuation.section.embedded.ruby
         1: source.ruby.embedded.source.empty
     - match: '#\{'
-      captures:
-        0: punctuation.section.embedded.ruby
+      scope: punctuation.section.embedded.ruby
       push:
         - meta_scope: source.ruby.embedded.source
         - match: '\}'
-          captures:
-            0: punctuation.section.embedded.ruby
+          scope: punctuation.section.embedded.ruby
           pop: true
         - include: nest_curly_and_self
         - include: main
@@ -827,144 +754,118 @@ contexts:
         1: punctuation.definition.variable.ruby
   nest_brackets:
     - match: '\['
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\]'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: nest_brackets
   nest_brackets_i:
     - match: '\['
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\]'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_brackets_i
   nest_brackets_r:
     - match: '\['
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\]'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: regex_sub
         - include: nest_brackets_r
   nest_curly:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: nest_curly
   nest_curly_and_self:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: nest_curly_and_self
     - include: main
   nest_curly_i:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_curly_i
   nest_curly_r:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: regex_sub
         - include: nest_curly_r
   nest_ltgt:
     - match: \<
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \>
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: nest_ltgt
   nest_ltgt_i:
     - match: \<
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \>
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_ltgt_i
   nest_ltgt_r:
     - match: \<
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \>
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: regex_sub
         - include: nest_ltgt_r
   nest_parens:
     - match: \(
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \)
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: nest_parens
   nest_parens_i:
     - match: \(
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \)
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_parens_i
   nest_parens_r:
     - match: \(
-      captures:
-        0: punctuation.section.scope.ruby
+      scope: punctuation.section.scope.ruby
       push:
         - match: \)
-          captures:
-            0: punctuation.section.scope.ruby
+          scope: punctuation.section.scope.ruby
           pop: true
         - include: regex_sub
         - include: nest_parens_r
@@ -977,23 +878,19 @@ contexts:
         1: punctuation.definition.arbitrary-repitition.ruby
         3: punctuation.definition.arbitrary-repitition.ruby
     - match: '\[(?:\^?\])?'
-      captures:
-        0: punctuation.definition.character-class.ruby
+      scope: punctuation.definition.character-class.ruby
       push:
         - meta_scope: string.regexp.character-class.ruby
         - match: '\]'
-          captures:
-            0: punctuation.definition.character-class.ruby
+          scope: punctuation.definition.character-class.ruby
           pop: true
         - include: escaped_char
     - match: \(
-      captures:
-        0: punctuation.definition.group.ruby
+      scope: punctuation.definition.group.ruby
       push:
         - meta_scope: string.regexp.group.ruby
         - match: \)
-          captures:
-            0: punctuation.definition.group.ruby
+          scope: punctuation.definition.group.ruby
           pop: true
         - include: regex_sub
     - match: '(?<=^|\s)(#)\s[[a-zA-Z0-9,. \t?!-][^\x{00}-\x{7F}]]*$'

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -125,48 +125,41 @@ contexts:
         2: punctuation.section.scope.end.sql
   comments:
     - match: "--"
-      captures:
-        0: punctuation.definition.comment.sql
+      scope: punctuation.definition.comment.sql
       push:
         - meta_scope: comment.line.double-dash.sql
         - match: \n
           pop: true
     - match: "#"
-      captures:
-        0: punctuation.definition.comment.sql
+      scope: punctuation.definition.comment.sql
       push:
         - meta_scope: comment.line.number-sign.sql
         - match: \n
           pop: true
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.sql
+      scope: punctuation.definition.comment.sql
       push:
         - meta_scope: comment.block.c
         - match: \*/
           pop: true
   regexps:
     - match: /(?=\S.*/)
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.regexp.sql
         - match: /
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_interpolation
         - match: \\/
           scope: constant.character.escape.slash.sql
     - match: '%r\{'
       comment: We should probably handle nested bracket pairs!?! -- Allan
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.regexp.modr.sql
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_interpolation
   string_escape:
@@ -180,42 +173,34 @@ contexts:
         3: punctuation.definition.string.end.sql
   strings:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.quoted.single.sql
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_escape
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.quoted.other.backtick.sql
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_escape
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.quoted.double.sql
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_interpolation
     - match: '%\{'
-      captures:
-        0: punctuation.definition.string.begin.sql
+      scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.other.quoted.brackets.sql
         - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.sql
+          scope: punctuation.definition.string.end.sql
           pop: true
         - include: string_interpolation

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -48,13 +48,11 @@ contexts:
       captures:
         0: punctuation.definition.comment.scala
     - match: (^\s*)?/\*\*
-      captures:
-        0: punctuation.definition.comment.scala
+      scope: punctuation.definition.comment.scala
       push:
         - meta_scope: comment.block.documentation.scala
         - match: \*/(\s*\n)?
-          captures:
-            0: punctuation.definition.comment.scala
+          scope: punctuation.definition.comment.scala
           pop: true
         - match: (@\w+\s)
           scope: keyword.other.documentation.scaladoc.scala
@@ -71,12 +69,10 @@ contexts:
       scope: storage.type.primitive.scala
   declarations:
     - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
-      captures:
-        0: comment.block.scala
+      scope: comment.block.scala
       push:
         - match: '\}\)#λ'
-          captures:
-            0: comment.block.scala
+          scope: comment.block.scala
           pop: true
         - match: "[αβ]"
           scope: comment.block.empty.scala
@@ -163,12 +159,10 @@ contexts:
       scope: keyword.control.exception.scala
   nest-curly-and-self:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.scala
+      scope: punctuation.section.scope.scala
       push:
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.scala
+          scope: punctuation.section.scope.scala
           pop: true
         - include: nest-curly-and-self
     - include: main
@@ -215,13 +209,11 @@ contexts:
         - match: '\$[a-zA-Z$_][a-zA-Z0-9$_]*'
           scope: variable.parameter
         - match: '\$\{'
-          captures:
-            0: variable.parameter
+          scope: variable.parameter
           push:
             - meta_scope: source.scala.embedded
             - match: '\}'
-              captures:
-                0: variable.parameter
+              scope: variable.parameter
               pop: true
             - include: nest-curly-and-self
             - include: main
@@ -239,13 +231,11 @@ contexts:
         - match: '\$[a-zA-Z$_][a-zA-Z0-9$_]*'
           scope: variable.parameter
         - match: '\$\{'
-          captures:
-            0: variable.parameter
+          scope: variable.parameter
           push:
             - meta_scope: source.scala.embedded
             - match: '\}'
-              captures:
-                0: variable.parameter
+              scope: variable.parameter
               pop: true
             - include: nest-curly-and-self
             - include: main

--- a/ShellScript/Shell-Unix-Generic.sublime-syntax
+++ b/ShellScript/Shell-Unix-Generic.sublime-syntax
@@ -41,17 +41,14 @@ contexts:
       push:
         - meta_scope: meta.scope.case-clause.shell
         - match: ;;
-          captures:
-            0: punctuation.terminator.case-clause.shell
+          scope: punctuation.terminator.case-clause.shell
           pop: true
         - match: (\(|(?=\S))
-          captures:
-            0: punctuation.definition.case-pattern.shell
+          scope: punctuation.definition.case-pattern.shell
           push:
             - meta_scope: meta.scope.case-pattern.shell
             - match: \)
-              captures:
-                0: punctuation.definition.case-pattern.shell
+              scope: punctuation.definition.case-pattern.shell
               pop: true
             - match: \|
               scope: punctuation.separator.pipe-sign.shell
@@ -78,13 +75,11 @@ contexts:
         - include: logical-expression
         - include: main
     - match: '(\({2})'
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.other.math.shell
         - match: '(\){2})'
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - include: math
     - match: (\()
@@ -116,8 +111,7 @@ contexts:
       push:
         - meta_scope: meta.function.shell
         - match: ;|&|$
-          captures:
-            0: punctuation.definition.function.shell
+          scope: punctuation.definition.function.shell
           pop: true
         - include: main
     - match: '\b([^\s\\=]+)\s*(\(\))'
@@ -127,8 +121,7 @@ contexts:
       push:
         - meta_scope: meta.function.shell
         - match: ;|&|$
-          captures:
-            0: punctuation.definition.function.shell
+          scope: punctuation.definition.function.shell
           pop: true
         - include: main
   heredoc:
@@ -318,35 +311,29 @@ contexts:
         2: string.unquoted.herestring.shell
   interpolation:
     - match: '\$\({2}'
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.other.math.shell
         - match: '\){2}'
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - include: math
     - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.interpolated.backtick.shell
         - match: "`"
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - match: '\\[`\\$]'
           scope: constant.character.escape.shell
         - include: main
     - match: \$\(
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.interpolated.dollar.shell
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - include: main
   keyword:
@@ -475,13 +462,11 @@ contexts:
       scope: keyword.operator.pipe.shell
   redirection:
     - match: '[><]\('
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.interpolated.process-substitution.shell
         - match: \)
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - include: main
     - match: '&>|\d*>&\d*|\d*(>>|>|<)|\d*<&|\d*<>'
@@ -491,35 +476,29 @@ contexts:
     - match: \\.
       scope: constant.character.escape.shell
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.quoted.single.shell
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
     - match: \$?"
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.quoted.double.shell
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - match: '\\[\$`"\\\n]'
           scope: constant.character.escape.shell
         - include: variable
         - include: interpolation
     - match: \$'
-      captures:
-        0: punctuation.definition.string.begin.shell
+      scope: punctuation.definition.string.begin.shell
       push:
         - meta_scope: string.quoted.single.dollar.shell
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.shell
+          scope: punctuation.definition.string.end.shell
           pop: true
         - match: \\(a|b|e|f|n|r|t|v|\\|')
           scope: constant.character.escape.ansi-c.shell
@@ -548,13 +527,11 @@ contexts:
       captures:
         1: punctuation.definition.variable.shell
     - match: '\$\{'
-      captures:
-        0: punctuation.definition.variable.shell
+      scope: punctuation.definition.variable.shell
       push:
         - meta_scope: variable.other.bracket.shell
         - match: '\}'
-          captures:
-            0: punctuation.definition.variable.shell
+          scope: punctuation.definition.variable.shell
           pop: true
         - match: '!|:[-=?]?|\*|@|#{1,2}|%{1,2}|/'
           scope: keyword.operator.expansion.shell

--- a/TCL/HTML (Tcl).sublime-syntax
+++ b/TCL/HTML (Tcl).sublime-syntax
@@ -8,13 +8,11 @@ scope: text.html.tcl
 contexts:
   main:
     - match: <%
-      captures:
-        0: punctuation.section.embedded.begin.tcl
+      scope: punctuation.section.embedded.begin.tcl
       push:
         - meta_scope: source.tcl.embedded.html
         - match: "%>"
-          captures:
-            0: punctuation.section.embedded.end.tcl
+          scope: punctuation.section.embedded.end.tcl
           pop: true
         - match: (env|ns_adp_argc|ns_adp_argv|ns_adp_bind_args|ns_adp_break|ns_adp_debug|ns_adp_dir|ns_adp_dump|ns_adp_eval|ns_adp_exception|ns_adp_include|ns_adp_parse|ns_adp_puts|ns_adp_registertag|ns_adp_return|ns_adp_stream|ns_adp_tell|ns_adp_trunc|ns_atclose|ns_atexit|ns_atshutdown|ns_atsignal|ns_cache_flush|ns_cache_names|ns_cache_size|ns_cache_stats|ns_checkurl|ns_chmod|ns_cond|ns_config|ns_configsection|ns_configsections|ns_conn|ns_conncptofp|ns_connsendfp|ns_cp|ns_cpfp|ns_critsec|ns_crypt|ns_db|ns_dbconfigpath|ns_dberror|ns_dbformvalue|ns_dbformvalueput|ns_dbquotename|ns_dbquotevalue|ns_deleterow|ns_eval|ns_event|ns_ext|ns_findrowbyid|ns_fmttime|ns_ftruncate|ns_getcsv|ns_getform|ns_get_multipart_formdata|ns_geturl|ns_gifsize|ns_gmtime|ns_guesstype|ns_hostbyaddr|ns_hrefs|ns_httpget|ns_httpopen|ns_httptime|ns_info|ns_insertrow|ns_jpegsize|ns_kill|ns_library|ns_link|ns_localsqltimestamp|ns_localtime|ns_log|ns_logroll|ns_markfordelete|ns_mkdir|ns_mktemp|ns_modulepath|ns_mutex|ns_normalizepath|ns_param|ns_parseheader|ns_parsehttptime|ns_parsequery|ns_passwordcheck|ns_perm|ns_permpasswd|ns_pooldescription|ns_puts|ns_queryexists|ns_queryget|ns_querygetall|ns_quotehtml|ns_rand|ns_register_adptag|ns_register_filter|ns_register_proc|ns_register_trace|ns_rename|ns_requestauthorize|ns_respond|ns_return|ns_returnredirect|ns_rmdir|ns_rollfile|ns_rwlock|ns_schedule_daily|ns_schedule_proc|ns_schedule_weekly|ns_section|ns_sema|ns_sendmail|ns_server|ns_set|ns_setexpires|ns_set_precision|ns_share|ns_shutdown|ns_sleep|ns_sockaccept|ns_sockblocking|ns_sockcallback|ns_sockcheck|ns_socketpair|ns_socklistencallback|ns_socknonblocking|ns_socknread|ns_sockopen|ns_sockselect|ns_striphtml|ns_symlink|ns_thread|ns_time|ns_tmpnam|ns_truncate|ns_unlink|ns_unschedule_proc|ns_url2file|ns_urldecode|ns_urlencode|ns_uudecode|ns_uuencode|ns_write|ns_writecontent|ns_writefp|nsv_incr)\b
           scope: keyword.other.tcl.aolserver

--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -50,13 +50,11 @@ contexts:
     - include: escape
     - include: variable
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.tcl
+      scope: punctuation.definition.string.begin.tcl
       push:
         - meta_scope: string.quoted.double.tcl
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.tcl
+          scope: punctuation.definition.string.end.tcl
           pop: true
         - include: escape
         - include: variable
@@ -84,13 +82,11 @@ contexts:
         - include: inner-braces
   embedded:
     - match: '\['
-      captures:
-        0: punctuation.section.embedded.begin.tcl
+      scope: punctuation.section.embedded.begin.tcl
       push:
         - meta_scope: source.tcl.embedded
         - match: '\]'
-          captures:
-            0: punctuation.section.embedded.end.tcl
+          scope: punctuation.section.embedded.end.tcl
           pop: true
         - include: scope:source.tcl
   escape:

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -35,8 +35,7 @@ contexts:
           pop: true
         - include: internalSubset
     - match: "<!--"
-      captures:
-        0: punctuation.definition.comment.xml
+      scope: punctuation.definition.comment.xml
       push:
         - meta_scope: comment.block.xml
         - match: "-->"
@@ -79,13 +78,11 @@ contexts:
     - include: entity
     - include: bare-ampersand
     - match: '<!\[CDATA\['
-      captures:
-        0: punctuation.definition.string.begin.xml
+      scope: punctuation.definition.string.begin.xml
       push:
         - meta_scope: string.unquoted.cdata.xml
         - match: "]]>"
-          captures:
-            0: punctuation.definition.string.end.xml
+          scope: punctuation.definition.string.end.xml
           pop: true
   EntityDecl:
     - match: '(<!)(ENTITY)\s+(%\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\s+(?:SYSTEM|PUBLIC)\s+)?'
@@ -105,13 +102,11 @@ contexts:
       scope: invalid.illegal.bad-ampersand.xml
   doublequotedString:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.xml
+      scope: punctuation.definition.string.begin.xml
       push:
         - meta_scope: string.quoted.double.xml
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.xml
+          scope: punctuation.definition.string.end.xml
           pop: true
         - include: entity
         - include: bare-ampersand
@@ -139,13 +134,11 @@ contexts:
         3: punctuation.definition.constant.xml
   singlequotedString:
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.xml
+      scope: punctuation.definition.string.begin.xml
       push:
         - meta_scope: string.quoted.single.xml
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.xml
+          scope: punctuation.definition.string.end.xml
           pop: true
         - include: entity
         - include: bare-ampersand

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -56,26 +56,22 @@ contexts:
       captures:
         1: punctuation.definition.variable.yaml
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.yaml
+      scope: punctuation.definition.string.begin.yaml
       push:
         - meta_scope: string.quoted.double.yaml
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.yaml
+          scope: punctuation.definition.string.end.yaml
           pop: true
         - match: \\.
           scope: constant.character.escape.yaml
     - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.yaml
+      scope: punctuation.definition.string.begin.yaml
       push:
         - meta_scope: string.quoted.single.yaml
         - match: "''"
           scope: constant.character.escape.yaml
         - match: "'"
-          captures:
-            0: punctuation.definition.string.end.yaml
+          scope: punctuation.definition.string.end.yaml
           pop: true
     - match: '(\<\<): ((\*).*)$'
       scope: keyword.operator.merge-key.yaml


### PR DESCRIPTION
Saves over 600 lines of code and simplifies syntax files. 
Here are the three find and replace steps I took:

1. Replace captures with only 0 key that also has scope definition.
we shouldn't replace these ones. so I temporarily replace 0: with X:
Find: `(scope: )(.+)(\n\s+captures:\n\s+)(0:)(.+)(\n)(?!\s+\d)`
Replace: `\1\2\3X:\5\6`

2. Replace captures: 0: scope_name with scope: scope_name
Find: `captures:\n\s+0:(.+)\n(?!\s+\d)`
Replace: `scope:\1\n`

3. Bring back the X: scopes
Find: `(scope: )(.+)(\n\s+captures:\n\s+)(X:)(.+)(\n)(?!\s+\d)`
Replace: `\1\2\30:\5\6`