### PR TITLE
Add .gradle files to the list of Groovy extensions

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -5,6 +5,7 @@ name: Groovy
 file_extensions:
   - groovy
   - gvy
+  - gradle
 scope: source.groovy
 contexts:
   main:


### PR DESCRIPTION
Gradle [1] is a build system that uses Groovy as its DSL.

[1] http://gradle.org/