### PR TITLE
Fix issue #140: Don't match keyword new when used as method reference.

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -46,7 +46,7 @@ contexts:
     - match: '@\w*'
       scope: storage.type.annotation.java
   anonymous-classes-and-new:
-    - match: \bnew\b
+    - match: \b(?<!::)new\b
       captures:
         0: keyword.control.new.java
       push:


### PR DESCRIPTION
ie: In test for anonymous-classes-and-new, ignore 'new' when prefixed with two colons. Fixes problems when using eg: `stream.collect(Collectors.toCollection(ArrayList::new));`