### PR TITLE
Improve JavaScript language grammars

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -332,9 +332,10 @@ contexts:
           captures:
             0: meta.brace.curly.js
           pop: true
-        - match: \b(extends)\b
+        - match: \b(extends)\b ([_$a-zA-Z][$\w]*)?
           captures:
             1: storage.modifier.extends.js
+            2: entity.other.inherited-class.js
           push:
             - meta_scope: meta.class.extends.js
             - match: "(?={)"

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -325,7 +325,7 @@ contexts:
         \s+((?!\b(extends)\b)[_$a-zA-Z][$\w]*)?
       captures:
         1: storage.type.class.js
-        2: entity.name.class.js
+        2: entity.name.type.class.js
       push:
         - meta_scope: meta.class.js
         - match: "}"

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -936,7 +936,7 @@ contexts:
     - match: '\\(x[\da-fA-F]{2}|u[\da-fA-F]{4}|.)'
       scope: constant.character.escape.js
   support:
-    - match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b
+    - match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap|XMLHttpRequest)\b
       scope: support.class.builtin.js
     - match: (?<!\.)\b(clearTimeout|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|setTimeout|super|unescape)\b(?=\()
       scope: support.function.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -950,6 +950,8 @@ contexts:
       scope: keyword.other.jquery.js
     - match: (?<!\.)\b(document|window)\b
       scope: support.type.object.dom.js
+    - match: (?<=\.)(s(hape|ystemId|c(heme|ope|rolling)|ta(ndby|rt)|ize|ummary|pecified|e(ctionRowIndex|lected(Index)?)|rc)|h(space|t(tpEquiv|mlFor)|e(ight|aders)|ref(lang)?)|n(o(Resize|tation(s|Name)|Shade|Href|de(Name|Type|Value)|Wrap)|extSibling|ame)|c(h(ildNodes|Off|ecked|arset)?|ite|o(ntent|o(kie|rds)|de(Base|Type)?|l(s|Span|or)|mpact)|ell(s|Spacing|Padding)|l(ear|assName)|aption)|t(ype|Bodies|itle|Head|ext|a(rget|gName)|Foot)|i(sMap|ndex|d|m(plementation|ages))|o(ptions|wnerDocument|bject)|d(i(sabled|r)|o(c(type|umentElement)|main)|e(clare|f(er|ault(Selected|Checked|Value)))|at(eTime|a))|useMap|p(ublicId|arentNode|r(o(file|mpt)|eviousSibling))|e(n(ctype|tities)|vent|lements)|v(space|ersion|alue(Type)?|Link|Align)|URL|f(irstChild|orm(s)?|ace|rame(Border)?)|width|l(ink(s)?|o(ngDesc|wSrc)|a(stChild|ng|bel))|a(nchors|c(ce(ssKey|pt(Charset)?)|tion)|ttributes|pplets|l(t|ign)|r(chive|eas)|xis|Link|bbr)|r(ow(s|Span|Index)|ules|e(v|ferrer|l|adOnly))|m(ultiple|e(thod|dia)|a(rgin(Height|Width)|xLength))|b(o(dy|rder)|ackground|gColor))\b
+      scope: support.constant.dom.js
     - match: |-
         (?x)
         \b(

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -936,7 +936,7 @@ contexts:
   support:
     - match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b
       scope: support.class.builtin.js
-    - match: (?<!\.)\b(decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|unescape)\b(?=\()
+    - match: (?<!\.)\b(clearTimeout|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|setTimeout|unescape)\b(?=\()
       scope: support.function.js
     - match: \.(shift|sort|splice|unshift|pop|push|reverse)\b(?=\()
       scope: support.function.mutator.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -612,7 +612,7 @@ contexts:
       captures:
         1: storage.type.js
         2: storage.type.accessor.js
-        3: entity.name.accessor.js
+        3: entity.name.function.accessor.js
       push:
         - meta_scope: meta.accessor.js
         - match: (?<=\))

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -938,7 +938,7 @@ contexts:
       scope: support.class.builtin.js
     - match: (?<!\.)\b(clearTimeout|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|setTimeout|unescape)\b(?=\()
       scope: support.function.js
-    - match: \.(shift|sort|splice|unshift|pop|push|reverse)\b(?=\()
+    - match: (?<=\.)(shift|sort|splice|unshift|pop|push|reverse)\b(?=\()
       scope: support.function.mutator.js
     - match: (?<!\.)\b((Eval|Range|Reference|Syntax|Type|URI)?Error)\b
       scope: support.class.error.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -452,11 +452,10 @@ contexts:
         2: keyword.operator.accessor.js
         3: entity.name.function.js
         4: keyword.operator.js
-        5: storage.type.function.js
-        6: storage.type.js
-        7: storage.type.function.js
-        8: keyword.generator.asterisk.js
-        9: entity.name.function.js
+        5: storage.type.js
+        6: storage.type.function.js
+        7: keyword.generator.asterisk.js
+        8: entity.name.function.js
       push:
         - meta_scope: meta.function.static.js
         - match: (?<=\))

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -937,7 +937,7 @@ contexts:
   support:
     - match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b
       scope: support.class.builtin.js
-    - match: (?<!\.)\b(clearTimeout|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|setTimeout|unescape)\b(?=\()
+    - match: (?<!\.)\b(clearTimeout|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|setTimeout|super|unescape)\b(?=\()
       scope: support.function.js
     - match: (?<=\.)(shift|sort|splice|unshift|pop|push|reverse)\b(?=\()
       scope: support.function.mutator.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -944,6 +944,8 @@ contexts:
       scope: support.class.error.js
     - match: (?<!\.)\b(debugger)\b
       scope: keyword.other.js
+    - match: \$(?=(\(|\.))
+      scope: keyword.other.jquery.js
     - match: (?<!\.)\b(document|window)\b
       scope: support.type.object.dom.js
     - match: |-

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -936,9 +936,9 @@ contexts:
   support:
     - match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b
       scope: support.class.builtin.js
-    - match: (?<!\.)\b(decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|unescape)\b
+    - match: (?<!\.)\b(decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|unescape)\b(?=\()
       scope: support.function.js
-    - match: \.(shift|sort|splice|unshift|pop|push|reverse)\b
+    - match: \.(shift|sort|splice|unshift|pop|push|reverse)\b(?=\()
       scope: support.function.mutator.js
     - match: (?<!\.)\b((Eval|Range|Reference|Syntax|Type|URI)?Error)\b
       scope: support.class.error.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -441,20 +441,22 @@ contexts:
         - include: function-declaration-parameters
     - match: |-
         (?x)
-        (\b_?[A-Z][$\w]*)?
-        (\.)([_$a-zA-Z][$\w]*)
-        \s*=
+        (\b_?[a-zA-Z_?.$]*)?
+        (\.)([_$a-zA-Z][$\.\w]*)
+        \s*(=)
         \s*(?:(async)\s+)?
         \s*(function)(?:\s*(\*)|(?=\s|[(]))
         \s*([_$a-zA-Z][$\w]*)?\s*
       captures:
-        1: entity.name.class.js
+        1: support.class.js
         2: keyword.operator.accessor.js
         3: entity.name.function.js
-        4: storage.type.js
+        4: keyword.operator.js
         5: storage.type.function.js
-        6: keyword.generator.asterisk.js
-        7: entity.name.function.js
+        6: storage.type.js
+        7: storage.type.function.js
+        8: keyword.generator.asterisk.js
+        9: entity.name.function.js
       push:
         - meta_scope: meta.function.static.js
         - match: (?<=\))

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -332,7 +332,7 @@ contexts:
           captures:
             0: meta.brace.curly.js
           pop: true
-        - match: \b(extends)\b ([_$a-zA-Z][$\w]*)?
+        - match: \b(extends)\b\s+([_$a-zA-Z][$\w]*)?
           captures:
             1: storage.modifier.extends.js
             2: entity.other.inherited-class.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -597,7 +597,7 @@ contexts:
         1: storage.type.js
         2: storage.type.js
         3: keyword.generator.asterisk.js
-        4: entity.name.method.js
+        4: entity.name.function.method.js
       push:
         - meta_scope: meta.method.js
         - match: (?<=\))

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -334,7 +334,7 @@ contexts:
           pop: true
         - match: \b(extends)\b
           captures:
-            1: storage.type.extends.js
+            1: storage.modifier.extends.js
           push:
             - meta_scope: meta.class.extends.js
             - match: "(?={)"

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -174,7 +174,7 @@ contexts:
       captures:
         1: entity.name.class.js
         2: keyword.operator.accessor.js
-        3: variable.language.prototype.js
+        3: support.constant.prototype.js
         4: keyword.operator.accessor.js
         5: entity.name.function.js
         6: storage.type.js
@@ -197,7 +197,7 @@ contexts:
       captures:
         1: entity.name.class.js
         2: keyword.operator.accessor.js
-        3: variable.language.prototype.js
+        3: support.constant.prototype.js
         4: keyword.operator.accessor.js
         5: entity.name.function.js
         6: storage.type.js
@@ -426,7 +426,7 @@ contexts:
       captures:
         1: entity.name.class.js
         2: keyword.operator.accessor.js
-        3: variable.language.prototype.js
+        3: support.constant.prototype.js
         4: keyword.operator.accessor.js
         5: entity.name.function.js
         6: storage.type.js
@@ -754,13 +754,13 @@ contexts:
       captures:
         1: entity.name.class.js
         2: keyword.operator.accessor.js
-        3: variable.language.prototype.js
+        3: support.constant.prototype.js
     - match: '([_$a-zA-Z][$\w]*)(\.)(prototype)\s*=\s*'
       scope: meta.prototype.declaration.js
       captures:
         1: entity.name.class.js
         2: keyword.operator.accessor.js
-        3: variable.language.prototype.js
+        3: support.constant.prototype.js
   literal-punctuation:
     - match: \;
       scope: punctuation.terminator.statement.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -960,6 +960,8 @@ contexts:
           WRONG_DOCUMENT_ERR|INVALID_CHARACTER_ERR|NO_DATA_ALLOWED_ERR|NO_MODIFICATION_ALLOWED_ERR|NOT_FOUND_ERR|NOT_SUPPORTED_ERR|INUSE_ATTRIBUTE_ERR
         )\b
       scope: support.constant.dom.js
+    - match: \b(s(ub(stringData|mit)|plitText|e(t(NamedItem|Attribute(Node)?)|lect))|has(ChildNodes|Feature)|namedItem|c(l(ick|o(se|neNode))|reate(C(omment|DATASection|aption)|T(Head|extNode|Foot)|DocumentFragment|ProcessingInstruction|E(ntityReference|lement)|Attribute))|tabIndex|i(nsert(Row|Before|Cell|Data)|tem)|open|delete(Row|C(ell|aption)|T(Head|Foot)|Data)|focus|write(ln)?|a(dd|ppend(Child|Data))|re(set|place(Child|Data)|move(NamedItem|Child|Attribute(Node)?)?)|get(NamedItem|Element(sBy(Name|TagName)|ById)|Attribute(Node)?)|blur)\b(?=\()
+      scope: support.function.dom.js
     - match: (?<!\.)\b(console)(?:(\.)(warn|info|log|error|time|timeEnd|assert|count|dir|group|groupCollapsed|groupEnd|profile|profileEnd|table|trace))?\b
       captures:
         1: support.type.object.console.js


### PR DESCRIPTION
This is related to #63 and integrating the Javascript Next grammars in 82b58838389969208d7391fe3ede52e6a78fb851.

The changes in Javascript Next introduced a bunch of regressions from the Javascript grammars in Sublime Text 2 and Sublime Text 3 stable.  The aggressive green function calls were just one of them.

This Pull Request attempts to fix some of the things that were broken. I'm aware there are differences between language grammars and themes, but in this case I think these things should work without needing to modify existing themes.

--

**BEFORE**

![jhcn](https://cloud.githubusercontent.com/assets/259316/9569896/449ff7d2-4f48-11e5-9940-0133e639803b.png)

**AFTER**

![mosj](https://cloud.githubusercontent.com/assets/259316/9569900/4f280c80-4f48-11e5-9db1-ae3f85863d7c.png)

@jskinner @benvie @babel I don't know the proper forum for these changes cause right now there are 3 different people independently maintaining different versions of Javascript Next language grammars. It would probably make sense to standardize one version.