### PR TITLE
Fixes regex parse fail of bracket array syntax.

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -110,7 +110,7 @@ contexts:
         \s*(&)?                     # Reference
         \s*((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*) # The variable name
         \s*(=)  # A default value
-        \s*(array)\s*(\()
+        \s*(?:(array)\s*(\()|\[)
       captures:
         1: storage.type.php
         2: storage.modifier.reference.php
@@ -122,7 +122,7 @@ contexts:
       push:
         - meta_scope: meta.function.argument.array.php
         - meta_content_scope: meta.array.php
-        - match: \)
+        - match: [\)\]]
           captures:
             0: punctuation.definition.array.end.php
           pop: true


### PR DESCRIPTION
The language file for PHP doesn't seem to support the "new" bracket syntax for arrays introduced on PHP 5.4 (http://php.net/manual/en/migration54.new-features.php).

Fortunately, the colouring still mostly works anyway; except when a function argument is typehinted.

This regex change appears to be successful in fixing it on my tests.

##### Before
![Before](http://i.imgur.com/sDcLkkv.png)

##### After
![After](http://i.imgur.com/JxmIIm4.png)

Note that I've tried the changes on the tm version; not the sublime one, but the regexes are the same.