### PR TITLE
[HTML] Improve completions for empty elements

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -256,14 +256,14 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
         """
         default_list = []
         normal_tags = ([
-            'abbr', 'acronym', 'address', 'applet', 'area', 'article', 'aside',
-            'audio', 'b', 'base', 'basefont', 'bdi', 'bdo', 'big', 'blockquote',
+            'abbr', 'acronym', 'address', 'applet', 'article', 'aside',
+            'audio', 'b', 'basefont', 'bdi', 'bdo', 'big', 'blockquote',
             'body', 'button', 'center', 'canvas', 'caption', 'cdata',
-            'cite', 'col', 'colgroup', 'code', 'content', 'data', 'datalist',
+            'cite', 'colgroup', 'code', 'content', 'data', 'datalist',
             'dir', 'div', 'dd', 'del', 'details', 'dfn', 'dl', 'dt', 'element',
             'em', 'embed', 'fieldset', 'figure', 'figcaption', 'font', 'footer',
             'form', 'frame', 'frameset', 'head', 'header', 'h1', 'h2', 'h3',
-            'h4', 'h5', 'h6', 'i', 'input', 'ins', 'isindex', 'kbd', 'keygen',
+            'h4', 'h5', 'h6', 'i', 'ins', 'isindex', 'kbd', 'keygen',
             'li', 'label', 'legend', 'main', 'map', 'mark', 'meter',
             'nav', 'noframes', 'noscript', 'object', 'ol', 'optgroup',
             'option', 'output', 'p', 'picture', 'pre', 'q', 'rp',
@@ -280,16 +280,24 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
         default_list += ([
             ('a\tTag', 'a href=\"$1\">$0</a>'),
+            ('area\tTag', 'area shape=\"$1\" coords=\"$2\" href=\"$3\">'),
             ('audio\tTag', 'audio src=\"$1\">$0</audio>'),
+            ('base\tTag', 'base href=\"$1\">'),
+            ('br\tTag', 'br>'),
+            ('col\tTag', 'col>'),
+            ('hr\tTag', 'hr>'),
             ('iframe\tTag', 'iframe src=\"$1\">$0</iframe>'),
+            ('input\tTag', 'input type=\"$1\" name=\"$2\">'),
             ('img\tTag', 'img src=\"$1\">'),
             ('link\tTag', 'link rel=\"stylesheet\" type=\"text/css\" href=\"$1\">'),
+            ('meta\tTag', 'meta ${1:charset=\"utf-8\"}>'),
             ('param\tTag', 'param name=\"$1\" value=\"$2\">'),
             ('progress\tTag', 'progress value=\"$1\" max=\"$2\">'),
             ('script\tTag', 'script type=\"${1:text/javascript}\">$0</script>'),
             ('source\tTag', 'source src=\"$1\" type=\"$2\">'),
             ('style\tTag', 'style type=\"${1:text/css}\">$0</style>'),
             ('track\tTag', 'track kind=\"$1\" src=\"$2\">'),
+            ('wbr\tTag', 'wbr>'),
             ('video\tTag', 'video src=\"$1\">$0</video>')
         ])
 


### PR DESCRIPTION
## [HTML] Improve completions for empty elements


Some [empty elements](https://developer.mozilla.org/en-US/docs/Glossary/empty_element) are completing with a closing element.

For example `area` is currently completing to:

```html
<area></area>
```

When it should be completing to:

```html
<area>
```

This will fix completions for: `<area>`, `<col>`, `<base>`, `<meta>`, `<hr>`, `<br>`, `<wbr>`, `<input>`.


`meta`'s completion will render as:

```html
<meta charset="utf-8">
      ^-------------^
       Selected Text
```

Which means a `tab` keypress will jump to after the `>`, completing the example or a `delete` keypress will remove the example and allow for another attribute input. This way it's easier to input something other than just the default.