### PR TITLE
[Haskell] Add “newer” classes included on the Haskell Prelude — e.g. Monoid, Foldable…

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -39,7 +39,7 @@ contexts:
           captures:
             1: keyword.other.haskell
           pop: true
-        - match: \b(Monad|Functor|Eq|Ord|Read|Show|Num|(Frac|Ra)tional|Enum|Bounded|Real(Frac|Float)?|Integral|Floating)\b
+        - match: \b(Mon(ad|oid)|Functor|Applicative|(Folda|Traversa)ble|Eq|Ord|Read|Show|Num|(Frac|Ra)tional|Enum|Bounded|Real(Frac|Float)?|Integral|Floating)\b
           scope: support.class.prelude.haskell
         - match: "[A-Z][A-Za-z_']*"
           scope: entity.other.inherited-class.haskell


### PR DESCRIPTION
Newer versions of the Haskell Prelude include [additional typeclasses](http://hackage.haskell.org/package/base-4.8.1.0/docs/Prelude.html) not featured in the package.
This commit adds them.