### PR TITLE
[Haskell] Add UnicodeSyntax symbols for type definitions

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -161,7 +161,7 @@ contexts:
         4: constant.character.escape.hexadecimal.haskell
         5: constant.character.escape.control.haskell
         6: punctuation.definition.string.end.haskell
-    - match: '^\s*([a-z_][a-zA-Z0-9_'']*|\([|!%$+\-.,=</>]+\))\s*(::)'
+    - match: '^\s*([a-z_][a-zA-Z0-9_'']*|\([|!%$+\-.,=</>]+\))\s*(::|∷)'
       captures:
         1: entity.name.function.haskell
         2: keyword.other.double-colon.haskell
@@ -235,9 +235,9 @@ contexts:
           scope: keyword.other.preprocessor.haskell
   type_signature:
     - include: pragma
-    - match: "->"
+    - match: "(->|→)"
       scope: keyword.other.arrow.haskell
-    - match: "=>"
+    - match: "(=>|⇒)"
       scope: keyword.other.big-arrow.haskell
     - match: '\b[a-z][a-zA-Z0-9_'']*\b'
       scope: variable.other.generic-type.haskell


### PR DESCRIPTION
The GHC Haskell compiler [allows the use of unicode symbols](https://downloads.haskell.org/~ghc/7.2.1/docs/html/users_guide/syntax-extns.html) for some keywords when the UnicodeSyntax extension is enabled.

This commit adds support for the following symbols:
* `→` for `->`
* `⇒` for `=>`
* `∷` for `::`

The other characters demand deeper changes on the syntax definition but could be added. The symbols above comprise everything needed for type declarations, though.