### PR TITLE
[RegEx] Anchor highlighting bug fix

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -9,7 +9,7 @@ contexts:
   main:
     - match: \|
       scope: keyword.operator.regexp
-    - match: '\\[bBAZzG^$]'
+    - match: '\\[bBAZzG]|[\^$]'
       scope: keyword.control.anchors.regexp
     - include: character_class
     - include: escaped_char


### PR DESCRIPTION
Fixing a bug where the ^ and $ anchors were incorrectly highlighted only when preceded with a backslash