### PR TITLE
Show D functions in the symbol list

### DIFF
--- a/D/Symbol List-Method-Constructor.tmPreferences
+++ b/D/Symbol List-Method-Constructor.tmPreferences
@@ -9,7 +9,7 @@
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
-		<integer>0</integer>
+		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
       s/^\s*([^\)]+)/ $1/;  # pad</string>


### PR DESCRIPTION
Why was this disabled to begin with?