### PR TITLE
issue 172 - ensure assignment RHS is handled as code

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -223,6 +223,11 @@ contexts:
       scope: keyword.operator.comparison.java
     - match: (=)
       scope: keyword.operator.assignment.java
+      push:
+        - meta_scope: meta.assignment.rhs.java
+        - match: ;
+          pop: true
+        - include: code
     - match: (\-\-|\+\+)
       scope: keyword.operator.increment-decrement.java
     - match: (\-|\+|\*|\/|%)
@@ -234,7 +239,7 @@ contexts:
     - match: ;
       scope: punctuation.terminator.java
   methods:
-    - match: '(?!new)(?=\w.*\s+)(?=[^=]+\()'
+    - match: '(?=\w.*\s+)(?=[^=]+\()'
       push:
         - meta_scope: meta.method.java
         - match: "}|(?=;)"

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -226,6 +226,7 @@ contexts:
       push:
         - meta_scope: meta.assignment.rhs.java
         - match: ;
+          scope: punctuation.terminator.java
           pop: true
         - include: code
     - match: (\-\-|\+\+)

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -5,9 +5,9 @@ public class SyntaxTest {
     private String memberString2 = new String("Hello");
     private String memberString3 = String.valueOf("Hello");
 //                                ^ meta.assignment.rhs.java
+//                                                 ^ string.quoted.double.java
     private int memberLpos = memberString3.indexOf("l");
 //                                                     ^ punctuation.terminator.java
-    private String memberClassPath = System.getProperty("java.class.path");
 
     public static void main(String... args) {
         String[] strings = new String[5];

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -1,6 +1,14 @@
 // SYNTAX TEST "Java.sublime-syntax"
 
 public class SyntaxTest {
+    private String memberString = "Hello";
+    private String memberString2 = new String("Hello");
+    private String memberString3 = String.valueOf("Hello");
+//                                ^ meta.assignment.rhs.java
+    private int memberLpos = memberString3.indexOf("l");
+//                                                     ^ punctuation.terminator.java
+    private String memberClassPath = System.getProperty("java.class.path");
+
     public static void main(String... args) {
         String[] strings = new String[5];
 //                         ^ keyword.control.new.java


### PR DESCRIPTION
Ref: https://github.com/SublimeTextIssues/DefaultPackages/issues/172 which has screenshots etc.

This commit ensures the RHS of an assignment statement is handled as per the code: context, preventing mis-identification of e.g.: method *calls* as if they were method *definitions* when outside of a method.

Also removes a special-case exemption for the keyword `new` as a method name in a method definition, as the new, more conceptually consistent, way should make that unnecessary.