### PR TITLE
Fix for issue #118. class-body-keywords context for subset of keyword matches outside methods.

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -143,6 +143,7 @@ contexts:
     - include: methods
     - include: annotations
     - include: storage-modifiers
+    - include: class-body-keywords
     - include: code
   code:
     - include: comments
@@ -223,12 +224,6 @@ contexts:
       scope: keyword.operator.comparison.java
     - match: (=)
       scope: keyword.operator.assignment.java
-      push:
-        - meta_scope: meta.assignment.rhs.java
-        - match: ;
-          scope: punctuation.terminator.java
-          pop: true
-        - include: code
     - match: (\-\-|\+\+)
       scope: keyword.operator.increment-decrement.java
     - match: (\-|\+|\*|\/|%)
@@ -237,6 +232,17 @@ contexts:
       scope: keyword.operator.logical.java
     - match: (?<=\S)\.(?=\S)
       scope: keyword.operator.dereference.java
+    - match: ;
+      scope: punctuation.terminator.java
+  class-body-keywords:
+    - match: (=)
+      scope: keyword.operator.assignment.java
+      push:
+        - meta_scope: meta.assignment.rhs.java
+        - match: ;
+          scope: punctuation.terminator.java
+          pop: true
+        - include: code
     - match: ;
       scope: punctuation.terminator.java
   methods:

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -140,10 +140,10 @@ contexts:
     - include: comments
     - include: class
     - include: enums
+    - include: class-body-keywords
     - include: methods
     - include: annotations
     - include: storage-modifiers
-    - include: class-body-keywords
     - include: code
   code:
     - include: comments
@@ -235,6 +235,8 @@ contexts:
     - match: ;
       scope: punctuation.terminator.java
   class-body-keywords:
+    - match: \b(default)\b
+      scope: keyword.control.java
     - match: (=)
       scope: keyword.operator.assignment.java
       push:

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -235,8 +235,6 @@ contexts:
     - match: ;
       scope: punctuation.terminator.java
   class-body-keywords:
-    - match: \b(default)\b
-      scope: keyword.control.java
     - match: (=)
       scope: keyword.operator.assignment.java
       push:
@@ -340,7 +338,7 @@ contexts:
     - match: \b(?:void|boolean|byte|char|short|int|float|long|double)\b
       scope: storage.type.primitive.java
   storage-modifiers:
-    - match: \b(public|private|protected|static|final|native|synchronized|strictfp|abstract|threadsafe|transient)\b
+    - match: \b(public|private|protected|static|final|native|synchronized|strictfp|abstract|threadsafe|transient|default)\b
       captures:
         1: storage.modifier.java
   strings:

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -16,6 +16,13 @@ public class SyntaxTest {
             .collect(Collectors.toCollection(ArrayList::new)));
 //                                                      ^ meta.method.body.java - keyword.control.new.java
         anotherMethod();
+        try (Stream<String> lines = Files.lines(path)) {
+//                                                   ^ meta.method.body.java - meta.assignment.rhs.java
+            lines.forEach(System.out::println);
+        }
+        try (for int i = 0; i < 10; i+= 2) {
+            System.out.println(i);
+        }
     }
 
     private static void printList(List<String> args) {


### PR DESCRIPTION
Fix for issue #118: Restrict the use of the `meta.assignment.rhs.java` scope to the `class-body:` context, by having a separate `class-body-keywords:` context containing a restricted set of keyword matches for use in class-body only (as opposed to generally in code). Then the assignment operator in *there* can have the `meta.assignment.rhs.java` scope and the assignment operator in `keywords:` can revert to what it was before.

Currently `class-body-keywords:` only contains matches for the assignment operator and the semicolon terminator as none of the other matched keywords should appear outside of methods *except* in an assignment RHS.