### PR TITLE
[XML] support Unicode, more extensions, minor fixes

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -8,23 +8,30 @@ file_extensions:
   - dtml
   - rss
   - opml
+  - plist
+  - tmLanguage
+  - tmTheme
+  - tmPreferences
+  - sublime-snippet
 first_line_match: '^<\?xml '
 scope: text.xml
 contexts:
   main:
-    - match: '(<\?)\s*([-_a-zA-Z0-9]+)'
+    - match: '(<\?)\s*([-_[:alnum:]]+)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.xml
       push:
         - meta_scope: meta.tag.preprocessor.xml
         - match: (\?>)
+          captures:
+            1: punctuation.definition.tag.end.xml
           pop: true
-        - match: " ([a-zA-Z-]+)"
+        - match: " ([[:alpha:]-]+)"
           scope: entity.other.attribute-name.xml
         - include: doublequotedString
         - include: singlequotedString
-    - match: '(<!)(DOCTYPE)\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)'
+    - match: '(<!)(DOCTYPE)\s+([:[:alpha:]_][:[:alnum:]_.-]*)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: keyword.doctype.xml
@@ -32,6 +39,8 @@ contexts:
       push:
         - meta_scope: meta.tag.sgml.doctype.xml
         - match: \s*(>)
+          captures:
+            1: punctuation.definition.tag.end.xml
           pop: true
         - include: internalSubset
     - match: "<!--"
@@ -41,7 +50,7 @@ contexts:
         - meta_scope: comment.block.xml
         - match: "-->"
           pop: true
-    - match: '(<)((?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+))(?=(\s[^>]*)?></\2>)'
+    - match: '(<)((?:([-_[:alnum:]]+)((:)))?([-_[:alnum:]:]+))(?=(\s[^>]*)?></\2>)'
       captures:
         1: punctuation.definition.tag.begin.xml
         3: entity.name.tag.namespace.xml
@@ -50,7 +59,7 @@ contexts:
         6: entity.name.tag.localname.xml
       push:
         - meta_scope: meta.tag.no-content.xml
-        - match: "(>)(<)(/)(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+)(>)"
+        - match: "(>)(<)(/)(?:([-_[:alnum:]]+)((:)))?([-_[:alnum:]:]+)(>)"
           captures:
             1: punctuation.definition.tag.end.xml
             2: punctuation.definition.tag.begin.xml meta.scope.between-tag-pair.xml
@@ -62,7 +71,7 @@ contexts:
             8: punctuation.definition.tag.end.xml
           pop: true
         - include: tagStuff
-    - match: "(</?)(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+)"
+    - match: "(</?)(?:([-_[:alnum:]]+)((:)))?([-_[:alnum:]:]+)"
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.namespace.xml
@@ -88,7 +97,7 @@ contexts:
             0: punctuation.definition.string.end.xml
           pop: true
   EntityDecl:
-    - match: '(<!)(ENTITY)\s+(%\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\s+(?:SYSTEM|PUBLIC)\s+)?'
+    - match: '(<!)(ENTITY)\s+(%\s+)?([:[:alpha:]_][:[:alnum:]_.-]*)(\s+(?:SYSTEM|PUBLIC)\s+)?'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: keyword.entity.xml
@@ -116,7 +125,7 @@ contexts:
         - include: entity
         - include: bare-ampersand
   entity:
-    - match: "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+    - match: "(&)([:[:alpha:]_][:[:alnum:]_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)"
       scope: constant.character.entity.xml
       captures:
         1: punctuation.definition.constant.xml
@@ -132,7 +141,7 @@ contexts:
         - include: EntityDecl
         - include: parameterEntity
   parameterEntity:
-    - match: "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)"
+    - match: "(%)([:[:alpha:]_][:[:alnum:]_.-]*)(;)"
       scope: constant.character.parameter-entity.xml
       captures:
         1: punctuation.definition.constant.xml
@@ -150,7 +159,7 @@ contexts:
         - include: entity
         - include: bare-ampersand
   tagStuff:
-    - match: " (?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9]+)="
+    - match: " (?:([-_[:alnum:]]+)((:)))?([-_[:alnum:]]+)="
       captures:
         1: entity.other.attribute-name.namespace.xml
         2: entity.other.attribute-name.xml

--- a/XML/syntax_test_XML.xml
+++ b/XML/syntax_test_XML.xml
@@ -1,0 +1,14 @@
+<!-- SYNTAX TEST "Packages/XML/XML.sublime-syntax" -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!--                                ^ punctuation.definition.tag.end.xml -->
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--                                                                                                 ^ punctuation.definition.tag.end.xml -->
+
+<tagname attr="stuff">Contents</tagname>
+<!-- ^ text.xml meta.tag.xml entity.name.tag.localname.xml  -->
+<!--      ^ text.xml meta.tag.xml entity.other.attribute-name.localname.xml -->
+
+<таĝñäᴹə ατţř="șƬűʃ⨍">Contents</таĝñäᴹə>
+<!-- ^ text.xml meta.tag.xml entity.name.tag.localname.xml  -->
+<!--      ^ text.xml meta.tag.xml entity.other.attribute-name.localname.xml -->


### PR DESCRIPTION
Unicode:
* `a-zA-Z` replaced with `[:alpha:]`
* `a-zA-Z0-9` replaced with `[:alnum:]`

New extensions: plist, tmLanguage, tmTheme, tmPreferences, sublime-snippet

Minor fixes:
* closing tag of `<?xml version="1.0" encoding="UTF-8"?>` is now highlighted
* closing tag of `<!DOCTYPE ... >` is now highlighted

Old version:

<img width="834" alt="Old version" src="https://cloud.githubusercontent.com/assets/1776358/12518914/88690c0a-c109-11e5-93be-c73b5c9158b1.png">

New version:

<img width="834" alt="New version" src="https://cloud.githubusercontent.com/assets/1776358/12518925/9203b44a-c109-11e5-8f16-3ddcf5d14e1a.png">
