### PR TITLE
Ruby file extensions

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -52,9 +52,17 @@ file_extensions:
   - gemspec
   - irbrc
   - capfile
+  - prawn
+  - Cheffile
   - Gemfile
+  - Guardfile
   - Vagrantfile
   - config.ru
+  - Appraisals
+  - Rantfile
+  - Brewfile
+  - Berksfile
+  - Thorfile
 first_line_match: ^#!/.*\bruby
 scope: source.ruby
 contexts:


### PR DESCRIPTION
Rubyists like their DSLs

see https://github.com/textmate/ruby.tmbundle/blob/master/Syntaxes/Ruby.plist#L40

Yes, View > Syntax > Open all with current extension as... works, but IMO these are common enough to include.

note: prawn is used as *.pdf.prawn