### PR TITLE
[XML] Add missing scopes for captures

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -19,6 +19,8 @@ contexts:
       push:
         - meta_scope: meta.tag.preprocessor.xml
         - match: (\?>)
+          captures:
+            1: punctuation.definition.tag.end.xml
           pop: true
         - match: " ([a-zA-Z-]+)"
           scope: entity.other.attribute-name.xml
@@ -32,6 +34,8 @@ contexts:
       push:
         - meta_scope: meta.tag.sgml.doctype.xml
         - match: \s*(>)
+          captures:
+            1: punctuation.definition.tag.end.xml
           pop: true
         - include: internalSubset
     - match: "<!--"
@@ -97,6 +101,8 @@ contexts:
         5: keyword.entitytype.xml
       push:
         - match: (>)
+          captures:
+            1: punctuation.definition.tag.end.xml
           pop: true
         - include: doublequotedString
         - include: singlequotedString

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -1,0 +1,102 @@
+<!-- SYNTAX TEST "Packages/Packages/XML/XML.sublime-syntax" -->
+
+
+<!--
+  XML Declaration
+ -->
+
+     <?xml
+     <!-- <- meta.tag.preprocessor -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^ entity.name.tag -->
+     version="1.0"
+<!-- ^^^^^^^ entity.other.attribute-name -->
+<!--         ^ punctuation.definition.string.begin -->
+<!--         ^^^^^ string.quoted -->
+<!--             ^ punctuation.definition.string.end -->
+     ?>
+<!-- ^^ punctuation.definition.tag.end -->
+
+
+<!--
+  DOCTYPE Declaration
+ -->
+
+     <!DOCTYPE root [<!ENTITY br "\n"> %name;]>
+     <!-- <- meta.tag.sgml.doctype -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^^^^^ keyword.doctype -->
+<!--           ^^^^ variable.documentroot -->
+<!--                ^ meta.internalsubset -->
+<!--                 ^^ punctuation.definition.tag.begin -->
+<!--                   ^^^^^^ keyword.entity -->
+<!--                          ^^ variable.entity.xml -->
+<!--                                   ^ punctuation.definition.constant -->
+<!--                                    ^^^^ constant.character.parameter-entity -->
+<!--                                        ^ punctuation.definition.constant -->
+<!--                                          ^ punctuation.definition.tag.end -->
+
+
+<!--
+  Comments
+ -->
+
+     <!-- A Comment! -->
+     <!-- <- comment.block -->
+<!-- ^ punctuation.definition.comment -->
+
+
+<!--
+  Elements / Tags
+ -->
+
+     <ns:tagname xmlns:ns="uri">
+<!-- ^ meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
+<!--  ^^ entity.name.tag.namespace -->
+<!--    ^ punctuation.separator.namespace -->
+<!--     ^^^^^^^ entity.name.tag.localname -->
+<!--             ^^^^^ entity.other.attribute-name.namespace -->
+<!--                  ^ punctuation.separator.namespace -->
+<!--                   ^^ entity.other.attribute-name.localname -->
+<!--                      ^ punctuation.definition.string.begin -->
+<!--                      ^^^^^ string.quoted -->
+<!--                          ^ punctuation.definition.string.end -->
+<!--                           ^ punctuation.definition.tag.end -->
+     text
+<!-- ^ text -->
+    <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
+<!--         ^ string.unquoted.cdata -->
+
+
+<!--
+  Entities
+ -->
+
+     &amp;
+<!-- ^ punctuation.definition.constant -->
+<!--  ^^^ -punctuation.definition.constant -->
+<!--     ^ constant.character.entity -->
+     &#160;
+<!-- ^ punctuation.definition.constant -->
+<!--  ^^^^ -punctuation.definition.constant -->
+<!--      ^ constant.character.entity -->
+    <!-- &amp; -->
+<!--     ^ -punctuation.definition.constant -->
+
+
+<!--
+  Illegals
+ -->
+
+     &
+<!-- ^ invalid.illegal.bad-ampersand -->
+
+
+     </ns:tagname>
+<!-- ^ meta.tag -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^ entity.name.tag.namespace -->
+<!--     ^ punctuation.separator.namespace -->
+<!--      ^^^^^^^ entity.name.tag.localname -->
+<!--             ^ punctuation.definition.tag.end -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -1,4 +1,4 @@
-<!-- SYNTAX TEST "Packages/Packages/XML/XML.sublime-syntax" -->
+<!-- SYNTAX TEST "Packages/XML/XML.sublime-syntax" -->
 
 
 <!--


### PR DESCRIPTION
Previously, the XML syntax was capturing tag ends for XML Declaration, DOCTYPE, and Entity Declaration but not applying any scopes to them. This patch corrects these occurrences by applying a `punctuation.definition.tag.end` scope before the contexts are popped.