### PR TITLE
[ShellScript] Reserved Word Kebab Case Highlight Fix

### DIFF
--- a/ShellScript/Shell-Unix-Generic.sublime-syntax
+++ b/ShellScript/Shell-Unix-Generic.sublime-syntax
@@ -111,7 +111,7 @@ contexts:
           pop: true
         - include: main
   function-definition:
-    - match: '\b(function)\s+([^\s\\]+)(?:\s*(\(\)))?'
+    - match: '(?<![-/])\b(function)\s+([^\s\\]+)(?:\s*(\(\)))?'
       captures:
         1: storage.type.function.shell
         2: entity.name.function.shell
@@ -123,7 +123,7 @@ contexts:
             0: punctuation.definition.function.shell
           pop: true
         - include: main
-    - match: '\b([^\s\\=]+)\s*(\(\))'
+    - match: '(?<![-/])\b([^\s\\=]+)\s*(\(\))'
       captures:
         1: entity.name.function.shell
         2: punctuation.definition.arguments.shell
@@ -353,7 +353,7 @@ contexts:
           pop: true
         - include: main
   keyword:
-    - match: \b(?:if|then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return)\b
+    - match: '(?<![-/])\b(?:if|then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return)\b'
       scope: keyword.control.shell
     - match: '(?<![-/])\b(?:export|declare|typeset|local|readonly)\b'
       scope: storage.modifier.shell
@@ -367,58 +367,58 @@ contexts:
     - match: '(?<!\S)-(nt|ot|ef|eq|ne|l[te]|g[te]|[a-hknoprstuwxzOGLSN])'
       scope: keyword.operator.logical.shell
   loop:
-    - match: '\b(for)\s+(?=\({2})'
+    - match: '(?<![-/])\b(for)\s+(?=\({2})'
       captures:
         1: keyword.control.shell
       push:
         - meta_scope: meta.scope.for-loop.shell
-        - match: \b(done)\b
+        - match: '(?<![-/])\b(done)\b'
           captures:
             1: keyword.control.shell
           pop: true
         - include: main
-    - match: '\b(for)\s+((?:[^\s\\]|\\.)+)\b'
+    - match: '(?<![-/])\b(for)\s+((?:[^\s\\]|\\.)+)\b'
       captures:
         1: keyword.control.shell
         2: variable.other.loop.shell
       push:
         - meta_scope: meta.scope.for-in-loop.shell
-        - match: \b(done)\b
+        - match: '(?<![-/])\b(done)\b'
           captures:
             1: keyword.control.shell
           pop: true
         - include: main
-    - match: \b(while|until)\b
+    - match: '(?<![-/])\b(while|until)\b'
       captures:
         1: keyword.control.shell
       push:
         - meta_scope: meta.scope.while-loop.shell
-        - match: \b(done)\b
+        - match: '(?<![-/])\b(done)\b'
           captures:
             1: keyword.control.shell
           pop: true
         - include: main
-    - match: '\b(select)\s+((?:[^\s\\]|\\.)+)\b'
+    - match: '(?<![-/])\b(select)\s+((?:[^\s\\]|\\.)+)\b'
       captures:
         1: keyword.control.shell
         2: variable.other.loop.shell
       push:
         - meta_scope: meta.scope.select-block.shell
-        - match: \b(done)\b
+        - match: '(?<![-/])\b(done)\b'
           captures:
             1: keyword.control.shell
           pop: true
         - include: main
-    - match: \b(case)\b
+    - match: '(?<![-/])\b(case)\b'
       captures:
         1: keyword.control.shell
       push:
         - meta_scope: meta.scope.case-block.shell
-        - match: \b(esac)\b
+        - match: '(?<![-/])\b(esac)\b'
           captures:
             1: keyword.control.shell
           pop: true
-        - match: \b(?:in)\b
+        - match: '(?<![-/])\b(?:in)\b'
           captures:
             1: keyword.control.shell
           push:
@@ -429,12 +429,12 @@ contexts:
             - include: case-clause
             - include: main
         - include: main
-    - match: \b(if)\b
+    - match: '(?<![-/])\b(if)\b'
       captures:
         1: keyword.control.shell
       push:
         - meta_scope: meta.scope.if-block.shell
-        - match: \b(fi)\b
+        - match: '(?<![-/])\b(fi)\b'
           captures:
             1: keyword.control.shell
           pop: true
@@ -470,9 +470,9 @@ contexts:
           pop: true
         - include: main
   pipeline:
-    - match: '\b(clang\+\+|g\+\+)'
+    - match: '(?<![-/])\b(clang\+\+|g\+\+)'
       scope: keyword.other.shell
-    - match: '\b(7za|alias|apropos|apt-get|aptitude|ar|aspell|autoconf|awk|base64|basename|bash|bc|bg|bind|brew|builtin|bzip2|cal|cat|cc|cd|cfdisk|chgrp|chkconfig|chmod|chown|chroot|cksum|clang|clear|cmake|cmp|comm|command|cp|cron|crontab|crontab|csh|lua|csplit|cut|date|dc|dd|ddrescue|declare|depmod|df|diff3?|dig|dir|dircolors|dirname|dirs|dmesg|du|egrep|eject|enable|env|thtool|eval|exec|exit|expand|expect|export|expr|fdformat|fdisk|fg|fgrep|file|find|fmt|fold|format|free|fsck|ftp|function|fuser|gawk|gcc|getopts|git|grep|groupadd|groupdel|groupmd|groups|gzip|hash|head|help|hg|history|hostname|iconv|id|ifconfig|ifdown|ifup|import|insmod|install|jar|java|jobs|join|kill|killall|kmod|less|let|link|llvm|ln|local|locate|logname|loout|look|lpc|lpr|lprint|lprintd|lprintq|lprm|ls|lsod|lsof|mail|make|man|md5sum|mkdir|mkfifo|mkisofs|mknod|mmv|modinfo|modprobe|more|most|mount|mtools|mtr|mutt|mv|mysql|netstat|nice|nl|nohup|notify-se|nslookup|nstat|op|open|openssl|paswd|paste|pathchk|perl|php|ping|pkill|popd|pr|printcap|printenv|printf|ps|pushd|pv|pwd|py|python[\d.]*|quota|quotachec|quotactl|ram|rar|rcp|read|readarray|readonly|reboot|remsync|renae|renice|return|rev|rm|rmdir|rmmod|rsync|ruby|scp|screen|sdiff|sed|select|seq|set|sftp|sh|shift|shopt|shutdown|sleep|slocate|sort|source|split|sqlite3?|ssh|stat|strace|su|sudo|sum|susend|svn|sync|tail|tar|tcsh|tee|test|time|timeout|times|top|touch|tput|tr|tracerout|trap|true|tsort|tty|type|ulimit|umask|umount|unalias|uname|unexpand|uniq|units|unrar|unset|unshar|unil|updatedb|uptime|useradd|userdel|usermod|users|uudecode|uuencode|vmstat|wait|watch|wc|wget|whatis|whereis|which|while|who|whoami|write|xargs|xdg-open|xz|yum|zip|zsh)\b'
+    - match: '(?<![-/])\b(7za|alias|apropos|apt-get|aptitude|ar|aspell|autoconf|awk|base64|basename|bash|bc|bg|bind|brew|builtin|bzip2|cal|cat|cc|cd|cfdisk|chgrp|chkconfig|chmod|chown|chroot|cksum|clang|clear|cmake|cmp|comm|command|cp|cron|crontab|crontab|csh|lua|csplit|cut|date|dc|dd|ddrescue|declare|depmod|df|diff3?|dig|dir|dircolors|dirname|dirs|dmesg|du|egrep|eject|enable|env|thtool|eval|exec|exit|expand|expect|export|expr|fdformat|fdisk|fg|fgrep|file|find|fmt|fold|format|free|fsck|ftp|function|fuser|gawk|gcc|getopts|git|grep|groupadd|groupdel|groupmd|groups|gzip|hash|head|help|hg|history|hostname|iconv|id|ifconfig|ifdown|ifup|import|insmod|install|jar|java|jobs|join|kill|killall|kmod|less|let|link|llvm|ln|local|locate|logname|loout|look|lpc|lpr|lprint|lprintd|lprintq|lprm|ls|lsod|lsof|mail|make|man|md5sum|mkdir|mkfifo|mkisofs|mknod|mmv|modinfo|modprobe|more|most|mount|mtools|mtr|mutt|mv|mysql|netstat|nice|nl|nohup|notify-se|nslookup|nstat|op|open|openssl|paswd|paste|pathchk|perl|php|ping|pkill|popd|pr|printcap|printenv|printf|ps|pushd|pv|pwd|py|python[\d.]*|quota|quotachec|quotactl|ram|rar|rcp|read|readarray|readonly|reboot|remsync|renae|renice|return|rev|rm|rmdir|rmmod|rsync|ruby|scp|screen|sdiff|sed|select|seq|set|sftp|sh|shift|shopt|shutdown|sleep|slocate|sort|source|split|sqlite3?|ssh|stat|strace|su|sudo|sum|susend|svn|sync|tail|tar|tcsh|tee|test|time|timeout|times|top|touch|tput|tr|tracerout|trap|true|tsort|tty|type|ulimit|umask|umount|unalias|uname|unexpand|uniq|units|unrar|unset|unshar|unil|updatedb|uptime|useradd|userdel|usermod|users|uudecode|uuencode|vmstat|wait|watch|wc|wget|whatis|whereis|which|while|who|whoami|write|xargs|xdg-open|xz|yum|zip|zsh)\b'
       scope: keyword.other.shell
     - match: "[|!]"
       scope: keyword.operator.pipe.shell


### PR DESCRIPTION
Previously the ShellScript highlighting behaved oddly when you used "reserved" words in a non-string token, e.g. function name, while using a "-" as the delimiter aka kebab case. For some reserved words like "while", it simply highlighted the word differently than its sibling and in other cases, like "for", it completely broke highlighting for the rest of the file.

Previous:
<img width="547" alt="screen shot 2016-02-11 at 12 12 58 am" src="https://cloud.githubusercontent.com/assets/860313/12969831/4cb4bba0-d054-11e5-8491-d384f44a2f66.png">

Current:
<img width="544" alt="screen shot 2016-02-11 at 1 18 26 am" src="https://cloud.githubusercontent.com/assets/860313/12970488/68421e18-d05d-11e5-8501-b3434ce17870.png">
