### PR TITLE
[SQL] Add WITH as a sql keyword

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -79,7 +79,7 @@ contexts:
       scope: constant.numeric.sql
     - match: (?i:\b(true|false)\b)
       scope: constant.boolean.sql
-    - match: (?i:\b(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|from|set|where|group\sby|or|like|between|and|case|when|then|else|end|union(\s+all)?|having|order\sby|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)
+    - match: (?i:\b(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|from|set|where|group\sby|or|like|between|and|with|case|when|then|else|end|union(\s+all)?|having|order\sby|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)
       scope: keyword.other.DML.sql
     - match: (?i:\b(on|((is\s+)?not\s+)?null)\b)
       scope: keyword.other.DDL.create.II.sql


### PR DESCRIPTION
Hi SublimeHQ! I'm aware that this is a little deficient with respect to pull request guidelines, but I didn't see a sql syntax test to start from. I defer to greater experts than myself on SQL or Sublime as to whether I've done this right, but my goal was to highlight the word "with" as a keyword, and that appears to be working locally over here.