### PR TITLE
[Ruby][Rails] Syntax improvements

### DIFF
--- a/Rails/Ruby on Rails.sublime-syntax
+++ b/Rails/Ruby on Rails.sublime-syntax
@@ -87,10 +87,12 @@ contexts:
           pop: true
         - include: 'scope:source.ruby'
         - include: main
-    - match: \b(before_filter|skip_before_filter|skip_after_filter|after_filter|around_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|service|observer|serialize|scaffold|verify|hide_action|append_view_path|prepend_view_path|view_paths)\b
+    - match: '\b(before_(filter|action)|skip_before_(filter|action)|skip_after_(filter|action)|after_(filter|action)|around_(filter|action)|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|observer|serialize|scaffold|verify|hide_action|append_view_path|prepend_view_path|view_paths)(?![?!:])\b'
+      comment: Uses negative lookahead to filter out symbols
       scope: support.function.actionpack.rails
-    - match: \b(named_scope|after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly)\b
+    - match: '\b(named_scope|default_scope|scope|after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|validates|attr_protected|attr_accessible|attr_readonly)(?![?!:])\b'
+      comment: Uses negative lookahead to filter out symbols
       scope: support.function.activerecord.rails
-    - match: \b(alias_method_chain|alias_attribute|delegate|cattr_accessor|mattr_accessor|returning)\b
+    - match: \b(alias_method_chain|alias_attribute|delegate|cattr_accessor|mattr_accessor|class_attribute|returning)\b
       scope: support.function.activesupport.rails
     - include: 'scope:source.ruby'

--- a/Rails/syntax_test_rails.rb
+++ b/Rails/syntax_test_rails.rb
@@ -1,0 +1,17 @@
+# SYNTAX TEST "Packages/Rails/Ruby on Rails.sublime-syntax"
+class ApplicationController < ApplicationController
+  before_filter :find_model
+# ^ support.function.actionpack.rails
+
+  before_action :require_login
+# ^ support.function.actionpack.rails
+
+  class_attribute :subject
+# ^ support.function.activesupport.rails
+
+  def find_model
+    @model = User.find(params[:id]) if params[:id]
+  end
+end
+
+# <- source.ruby.rails

--- a/Rails/syntax_test_rails.rb
+++ b/Rails/syntax_test_rails.rb
@@ -9,6 +9,11 @@ class ApplicationController < ApplicationController
   class_attribute :subject
 # ^ support.function.activesupport.rails
 
+  self.config = { after_filter: 1, after_filter?: 2, after_filter!: 3 }
+  #               ^ constant.other.symbol.ruby.19syntax
+  #                                ^ constant.other.symbol.ruby.19syntax
+  #                                                  ^ constant.other.symbol.ruby.19syntax
+
   def find_model
     @model = User.find(params[:id]) if params[:id]
   end

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1021,10 +1021,16 @@ contexts:
   string_placeholder:
     - match: |-
         (?x)%
-            [#0\- +']*                                  # flags
-            (\[\d+\])?                                  # field (argument #)
-            [,;:_]?                                     # separator character (AltiVec)
-            ((-?\d+)|(\[\d+\])?\*)?                     # minimum field width
-            (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
-            [diouxXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]     # conversion type
+            ([#0\- +\*]|(\d+\$))*                       # flags
+            (-?\d+)?                                    # minimum field width
+            (\.(\d+)?)?                                 # precision
+            [diouxXDOUeEfFgGaAcCsSpnvtTbByYhHmMzZ%]     # conversion type
       scope: constant.other.placeholder.ruby
+      comment: |
+        %[flags][width][.precision]type
+
+        A format sequence consists of a percent sign, followed by optional
+        flags, width, and precision indicators, then terminated with a field
+        type character.
+
+        Also this is used for time format in strftime.

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -116,7 +116,7 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b(initialize|new|loop|include|extend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|module_function|public|protected)\b(?![?!])'
+    - match: '\b(initialize|new|loop|include|extend|prepend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|module_function|public|protected|private)\b(?![?!])'
       comment: everything being a method but having a special function is a..
       scope: keyword.other.special-method.ruby
     - match: \b(require|require_relative|gem)\b

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1028,5 +1028,3 @@ contexts:
             (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
             [diouxXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]     # conversion type
       scope: constant.other.placeholder.ruby
-    - match: "%"
-      scope: invalid.illegal.placeholder.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -107,6 +107,8 @@ contexts:
     - match: (?<!\.)\b(and|not|or)\b
       comment: as above, just doesn't need a 'end' and does a logic operation
       scope: keyword.operator.logical.ruby
+    - match: '^!+|(?<=[ \t])!+|&&|\|\||\^'
+      scope: keyword.operator.logical.ruby
     - match: '(?<!\.)\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\b(?![?!])|\bdefined\?|\bblock_given\?'
       comment: just as above but being not a logical operation
       scope: keyword.control.pseudo-method.ruby
@@ -767,14 +769,14 @@ contexts:
           scope: variable.other.block.ruby
         - match: ","
           scope: punctuation.separator.variable.ruby
+        - match: \*|&
+          scope: keyword.operator.arithmetic.ruby
     - match: "=>"
       scope: punctuation.separator.key-value
     - match: '<<=|%=|&=|\*=|\*\*=|\+=|\-=|\^=|\|{1,2}=|<<'
       scope: keyword.operator.assignment.augmented.ruby
     - match: '<=>|<(?!<|=)|>(?!<|=|>)|<=|>=|===|==|=~|!=|!~|(?<=[ \t])\?'
       scope: keyword.operator.comparison.ruby
-    - match: '(?<=[ \t])!+|\bnot\b|&&|\band\b|\|\||\bor\b|\^'
-      scope: keyword.operator.logical.ruby
     - match: (%|&|\*\*|\*|\+|\-|/)
       scope: keyword.operator.arithmetic.ruby
     - match: "="

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -440,7 +440,7 @@ contexts:
             0: punctuation.definition.string.end.ruby
           pop: true
         - include: regex_sub
-    - match: '%[QWSR]?\('
+    - match: '%[QWI]?\('
       comment: literal capable of interpolation ()
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -453,7 +453,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_parens_i
-    - match: '%[QWSR]?\['
+    - match: '%[QWI]?\['
       comment: "literal capable of interpolation []"
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -466,7 +466,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_brackets_i
-    - match: '%[QWSR]?\<'
+    - match: '%[QWI]?\<'
       comment: literal capable of interpolation <>
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -479,7 +479,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_ltgt_i
-    - match: '%[QWSR]?\{'
+    - match: '%[QWI]?\{'
       comment: "literal capable of interpolation -- {}"
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -492,7 +492,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
         - include: nest_curly_i
-    - match: '%[QWSR]([^\w])'
+    - match: '%[QWI]([^\w])'
       comment: literal capable of interpolation -- wildcard
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -516,7 +516,7 @@ contexts:
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
-    - match: '%[qws]\('
+    - match: '%[qwsi]\('
       comment: literal incapable of interpolation -- ()
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -529,7 +529,7 @@ contexts:
         - match: \\\)|\\\\
           scope: constant.character.escape.ruby
         - include: nest_parens
-    - match: '%[qws]\<'
+    - match: '%[qwsi]\<'
       comment: literal incapable of interpolation -- <>
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -542,7 +542,7 @@ contexts:
         - match: \\\>|\\\\
           scope: constant.character.escape.ruby
         - include: nest_ltgt
-    - match: '%[qws]\['
+    - match: '%[qwsi]\['
       comment: "literal incapable of interpolation -- []"
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -555,7 +555,7 @@ contexts:
         - match: '\\\]|\\\\'
           scope: constant.character.escape.ruby
         - include: nest_brackets
-    - match: '%[qws]\{'
+    - match: '%[qwsi]\{'
       comment: "literal incapable of interpolation -- {}"
       captures:
         0: punctuation.definition.string.begin.ruby
@@ -568,7 +568,7 @@ contexts:
         - match: '\\\}|\\\\'
           scope: constant.character.escape.ruby
         - include: nest_curly
-    - match: '%[qws]([^\w])'
+    - match: '%[qwsi]([^\w])'
       comment: literal incapable of interpolation -- wildcard
       captures:
         0: punctuation.definition.string.begin.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -87,6 +87,11 @@ contexts:
         6: punctuation.separator.inheritance.ruby
         7: entity.other.inherited-class.module.third.ruby
         8: punctuation.separator.inheritance.ruby
+    - match: '([A-Z]\w*)(?=(,\s*[A-Z]\w*)*\s*=(?!\>))'
+      scope: meta.constant.ruby
+      comment: constant definition, handles multiple definitions on a single line 'APPLE, ORANGE= 1, 2'
+      captures:
+        1: entity.name.type.constant.ruby
     - match: (?<!\.)\belse(\s)+if\b
       comment: else if is a common mistake carried over from other languages. it works if you put in a second end, but it’s never what you want.
       scope: invalid.deprecated.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -249,6 +249,7 @@ contexts:
           pop: true
         - match: \\'|\\\\
           scope: constant.character.escape.ruby
+        - include: string_placeholder
     - match: '"'
       comment: double quoted string (allows for interpolation)
       captures:
@@ -261,6 +262,7 @@ contexts:
           pop: true
         - include: interpolated_ruby
         - include: escaped_char
+        - include: string_placeholder
     - match: "`"
       comment: execute string (allows for interpolation)
       captures:
@@ -1011,3 +1013,15 @@ contexts:
       scope: comment.line.number-sign.ruby
       captures:
         1: punctuation.definition.comment.ruby
+  string_placeholder:
+    - match: |-
+        (?x)%
+            [#0\- +']*                                  # flags
+            (\[\d+\])?                                  # field (argument #)
+            [,;:_]?                                     # separator character (AltiVec)
+            ((-?\d+)|(\[\d+\])?\*)?                     # minimum field width
+            (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
+            [diouxXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]     # conversion type
+      scope: constant.other.placeholder.ruby
+    - match: "%"
+      scope: invalid.illegal.placeholder.ruby

--- a/Ruby/Snippets/def_initialize.sublime-snippet
+++ b/Ruby/Snippets/def_initialize.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+def initialize(${1:options})
+	@${1/,\s*/, @/g} = $1
+end
+]]>
+	</content>
+	<tabTrigger>defi</tabTrigger>
+	<scope>source.ruby</scope>
+	<description>def initialize ..</description>
+</snippet>

--- a/Ruby/Snippets/service_object.sublime-snippet
+++ b/Ruby/Snippets/service_object.sublime-snippet
@@ -1,0 +1,19 @@
+<snippet>
+<content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+	def self.call(*args)
+		new(*args).call
+	end
+
+	def initialize(${2:options})
+		@${2/,\s*/, @/g} = $2
+	end
+
+	def call
+		$0
+	end
+end]]>
+</content>
+	<tabTrigger>cla</tabTrigger>
+	<scope>source.ruby</scope>
+	<description>Service Object skeleton</description>
+</snippet>

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -21,6 +21,13 @@ class MyClass
 #          ^^^ punctuation.definition.string.begin.ruby
 #             ^^^^^ string.quoted.other.literal.lower.ruby
 
+  A, B, C = :a, :b, :c
+# ^ meta.constant.ruby entity.name.type.constant.ruby
+#  ^ punctuation.separator.object.ruby
+#    ^ meta.constant.ruby entity.name.type.constant.ruby
+#     ^ punctuation.separator.object.ruby
+#       ^ meta.constant.ruby entity.name.type.constant.ruby
+
   %I[#{ENV['APP_NAME']} apple orange]
 # ^^^ punctuation.definition.string.begin.ruby
 #      ^ meta.environment-variable.ruby variable.other.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -50,6 +50,17 @@ class MyClass
                 # ^^ string.quoted.double.ruby constant.other.placeholder.ruby
     str = 'number %d' % 11
                 # ^^ string.quoted.single.ruby constant.other.placeholder.ruby
+    str = 'number %08d' % 11
+                # ^^^^ string.quoted.single.ruby constant.other.placeholder.ruby
+    str = 'number %.2f' % 11
+                # ^^^^ string.quoted.single.ruby constant.other.placeholder.ruby
+    str = 'number %-8.2d' % 11
+                # ^^^^^^ string.quoted.single.ruby constant.other.placeholder.ruby
+    str = '%2$02d' % [212.00, 3]
+         # ^^^^^^ string.quoted.single.ruby constant.other.placeholder.ruby
+    str = sprintf("%1$*2$s %2$d", "hello", -8)
+    #              ^^^^^^^ string.quoted.double.ruby constant.other.placeholder.ruby
+    #                      ^^^^ string.quoted.double.ruby constant.other.placeholder.ruby
   end
 
 end

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1,8 +1,50 @@
 # SYNTAX TEST "Packages/Ruby/Ruby.sublime-syntax"
-
 puts 'test'
 
 puts <<~EOF
   Indented string!
 EOF
 # ^ string.unquoted.heredoc
+
+class MyClass
+# ^ meta.class.ruby keyword.control.class.ruby
+#     ^ meta.class.ruby entity.name.type.class.ruby
+
+  prepend Module.new
+# ^ keyword.other.special-method.ruby
+#         ^ support.class.ruby
+#                 ^ keyword.other.special-method.ruby
+
+  FIELDS = %i[a b c]
+# ^ meta.constant.ruby entity.name.type.constant.ruby
+#        ^ keyword.operator.assignment.ruby
+#          ^^^ punctuation.definition.string.begin.ruby
+#             ^^^^^ string.quoted.other.literal.lower.ruby
+
+  %I[#{ENV['APP_NAME']} apple orange]
+# ^^^ punctuation.definition.string.begin.ruby
+#      ^ meta.environment-variable.ruby variable.other.constant.ruby
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.literal.upper.ruby
+
+  def name
+# ^ keyword.control.def.ruby
+#     ^^^^ meta.function.method.without-arguments.ruby entity.name.function.ruby
+    [self.class.name, @name].map do |*args|
+    # ^ variable.language.ruby
+    #                 ^ variable.other.readwrite.instance.ruby punctuation.definition.variable.ruby
+    #                  ^^^^ variable.other.readwrite.instance.ruby
+    #                                ^ keyword.operator.arithmetic.ruby
+    #                                  ^ meta.variable.block.ruby
+    end
+  end
+
+  def my_method
+    str = "number %d" %  11
+                # ^^ string.quoted.double.ruby constant.other.placeholder.ruby
+    str = 'number %d' % 11
+                # ^^ string.quoted.single.ruby constant.other.placeholder.ruby
+  end
+
+end
+
+# <- source.ruby


### PR DESCRIPTION
## Rails

* Add support for some Rails 4 special methods (e.g. `before_action`)
* Fix highlighting when special methods are used as symbols

## Ruby

* Add pattern for constant definitions, apply `entity.name.type` so Go To Definition finds it
* Fix logical operators highlighting: `and`, `or`, `not` could be methods and in that case should not be highlighted.
* Add `prepend` as a special method. It is very similar to `include`.
* Add support for `%I` and `%i`: symbol arrays
* Remove `%S` and `%R` as they are not valid percent expressions
* Block variables can have modifiers (`*` and `&`), recognize these with the same scope as in methods.
* Add support for string formatting literals. E.g. `%s` or `%f`. Code copied for the Go syntax definition.
