### PR TITLE
[Pascal] Added dpr extension

### DIFF
--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -5,6 +5,7 @@ name: Pascal
 file_extensions:
   - pas
   - p
+  - dpr
 scope: source.pascal
 contexts:
   main:


### PR DESCRIPTION
dpr files are created by Delphi to store the initial unit, same syntax as pas files, so it should be included.