### PR TITLE
[JavaScript] Added function label entities

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -355,7 +355,7 @@ contexts:
                 1: storage.type.js
                 2: storage.type.accessor.js
                 3: keyword.generator.asterisk.js
-                4: entity.name.function.method.js
+                4: entity.name.function.method.js entity.name.function.label.js
               push:
                 - meta_scope: meta.method.js
                 - match: (?<=\))
@@ -402,7 +402,7 @@ contexts:
         1: storage.type.js
         2: storage.type.function.js
         3: keyword.generator.asterisk.js
-        4: entity.name.function.js
+        4: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.function.js
         - match: (?<=\))
@@ -420,7 +420,7 @@ contexts:
         2: storage.type.js
         3: storage.type.function.js
         4: keyword.generator.asterisk.js
-        5: entity.name.function.js
+        5: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.function.js
         - match: (?<=\))
@@ -444,7 +444,7 @@ contexts:
         6: storage.type.js
         7: storage.type.function.js
         8: keyword.generator.asterisk.js
-        9: entity.name.function.js
+        9: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.prototype.function.js
         - match: (?<=\))
@@ -466,7 +466,7 @@ contexts:
         5: storage.type.js
         6: storage.type.function.js
         7: keyword.generator.asterisk.js
-        8: entity.name.function.js
+        8: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.function.static.js
         - match: (?<=\))
@@ -509,7 +509,7 @@ contexts:
         3: storage.type.js
         4: storage.type.function.js
         5: keyword.generator.asterisk.js
-        6: entity.name.function.js
+        6: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.function.json.js
         - match: (?<=\))
@@ -538,7 +538,7 @@ contexts:
         10: storage.type.js
         11: storage.type.function.js
         12: keyword.generator.asterisk.js
-        13: entity.name.function.js
+        13: entity.name.function.js entity.name.function.label.js
       push:
         - meta_scope: meta.function.json.js
         - match: (?<=\))
@@ -608,7 +608,7 @@ contexts:
         1: storage.type.js
         2: storage.type.js
         3: keyword.generator.asterisk.js
-        4: entity.name.function.method.js
+        4: entity.name.function.method.js entity.name.function.label.js
       push:
         - meta_scope: meta.method.js
         - match: (?<=\))

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -5,6 +5,7 @@ import TheirClass from "./mypath";
 function foo() {
 // ^ storage.type.function
 //        ^ entity.name.function
+//        ^ entity.name.function.label.js
 }
 
 var bar = function() {
@@ -49,15 +50,19 @@ var obj = {
     'key5': true
     // <- string.quoted.single
     //    ^ punctuation.separator.key-value - string
+    key6: function qux () {}
+    //             ^ entity.name.function.label.js
 
     static foo(bar) {
     // ^ storage.type
     //      ^entity.name.function
+    //      ^entity.name.function.label.js
     }
 
     *baz(){
     // <- keyword.generator.asterisk
     // ^ entity.name.function
+    // ^ entity.name.function.label.js
     }
 }
 
@@ -123,7 +128,7 @@ class MyClass extends TheirClass {
     static foo(baz) {
     // ^ storage.type
     //       ^ entity.name.function  
-
+    //       ^ entity.name.function.label.js
     }
 
     qux()
@@ -137,6 +142,7 @@ class MyClass extends TheirClass {
 
     baz() { return null }
     // <- entity.name.function
+    // <- entity.name.function.label.js
 }
 
 MyClass.foo = function() {}


### PR DESCRIPTION
As discussed in #154, added `entity.name.function.label.js` to clearly mark which part of function expression or declaration is a proper function name. Now functions have both `entity.name.function.js` (or `entity.name.function.method.js`) and `entity.name.function.label.js`, so this change is backwards compatible.