### PR TITLE
[JavaScript] Fix scoping for arrow functions

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -213,7 +213,7 @@ contexts:
         \s*(async)?
         \s*(?=\([^()]*\)\s*(=>))
       captures:
-        1: entity.name.class.js
+        1: support.class.js
         2: keyword.operator.accessor.js
         3: variable.other.readwrite.js entity.name.function.js
         4: storage.type.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -207,7 +207,7 @@ contexts:
         8: storage.type.function.arrow.js
     - match: |-
         (?x)
-        (\b_?[A-Z][$\w]*)?
+        (\b_?[a-zA-Z_?.$]*)?
         (\.)([_$a-zA-Z][$\w]*)
         \s*=
         \s*(async)?

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -207,7 +207,7 @@ contexts:
         8: storage.type.function.arrow.js
     - match: |-
         (?x)
-        (\b_?[a-zA-Z_?.$]*)?
+        (\b_?[a-zA-Z_.$]*)?
         (\.)([_$a-zA-Z][$\w]*)
         \s*=
         \s*(async)?
@@ -454,7 +454,7 @@ contexts:
         - include: function-declaration-parameters
     - match: |-
         (?x)
-        (\b_?[a-zA-Z_?.$]*)?
+        (\b_?[a-zA-Z_.$]*)?
         (\.)([_$a-zA-Z][$\.\w]*)
         \s*(=)
         \s*(?:(async)\s+)?

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -190,6 +190,14 @@ MyClass.foo = () => {}
 // ^ support.class
 //       ^ entity.name.function
 
+xhr.onload = function() {}
+// <- support.class.js
+//  ^ entity.name.function
+
+xhr.onload = () => {}
+// <- support.class.js
+//  ^ entity.name.function
+
 var simpleArrow = foo => bar
 //   ^ entity.name.function
 //                 ^ variable.parameter.function

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -165,7 +165,7 @@ class MyClass extends TheirClass {
 
     static foo(baz) {
     // ^ storage.type
-    //       ^ entity.name.function  
+    //       ^ entity.name.function
 
     }
 
@@ -183,6 +183,10 @@ class MyClass extends TheirClass {
 }
 
 MyClass.foo = function() {}
+// ^ support.class
+//       ^ entity.name.function
+
+MyClass.foo = () => {}
 // ^ support.class
 //       ^ entity.name.function
 


### PR DESCRIPTION
I noticed in my last pull request I missed a couple of cases related to arrow functions returning different scopes than regular functions. 

I updated the scope and corresponding regex and added tests.

Hope you don't mind sending PRs as little things like this crop up :smile: