### PR TITLE
[PHP] Added missing keywords (trait, callable, insteadof, string, int)

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -106,7 +106,7 @@ contexts:
     - include: comments
     - match: |-
         (?x)
-        \s*(array|callable|int|string) # Typehint
+        \s*(array|callable|int|string|bool|float) # Typehint
         \s*(&)?                     # Reference
         \s*((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*) # The variable name
         \s*(=)  # A default value
@@ -131,7 +131,7 @@ contexts:
         - include: numbers
     - match: |-
         (?xi)
-        \s*(array|callable|int|string) # Typehint
+        \s*(array|callable|int|string|bool|float) # Typehint
         \s*(&)?                     # Reference
         \s*((\$+)[a-z_\x{7f}-\x{ff}][a-z0-9_\x{7f}-\x{ff}]*) # The variable name
         (?:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -566,7 +566,7 @@ contexts:
         - match: |-
             (?x)(::)
                                     (?:
-                                        (class[^\w])
+                                        (class)(?:[^\w])
                                         |
                                         ([A-Za-z_][A-Za-z_0-9]*)\s*\(
                                         |

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -106,7 +106,7 @@ contexts:
     - include: comments
     - match: |-
         (?x)
-        \s*(array) # Typehint
+        \s*(array|callable|int|string) # Typehint
         \s*(&)?                     # Reference
         \s*((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*) # The variable name
         \s*(=)  # A default value
@@ -131,7 +131,7 @@ contexts:
         - include: numbers
     - match: |-
         (?xi)
-        \s*(array) # Typehint
+        \s*(array|callable|int|string) # Typehint
         \s*(&)?                     # Reference
         \s*((\$+)[a-z_\x{7f}-\x{ff}][a-z0-9_\x{7f}-\x{ff}]*) # The variable name
         (?:
@@ -376,6 +376,20 @@ contexts:
         - match: (?=;|(?:^\s*$))
           pop: true
         - include: comments
+        - match: |-
+            (?xi)(?:
+              \s*([a-z_](?:[a-z_0-9]+)?)\s*(::)\s*([a-z_](?:[a-z0-9]+)?)\s+(?:(as)\s+([a-z_](?:[a-z0-9]+)?)|(insteadof)\s+([a-z_](?:[a-z0-9]+)?))\s*;
+            )
+          captures:
+            1: support.class.php
+            2: keyword.operator.class.php
+            3: meta.function.php
+            4: support.trait.method.use-as.php
+            5: meta.function.php
+            6: support.trait.method.insteadof.php
+            7: support.class.php
+        - match: '\s*}'
+          pop: true
         - match: '(?i)\s*(?=[a-z_0-9\\])'
           push:
             - match: |-
@@ -391,11 +405,17 @@ contexts:
             - match: '(?i)\s*(?=[\\a-z_0-9])'
               push:
                 - meta_scope: support.other.namespace.use.php
-                - match: '$|(?=[\s,;])'
+                - match: '$|(?=[\s,;])|{'
                   pop: true
                 - match: \\
                   scope: punctuation.separator.inheritance.php
         - match: \s*,\s*
+
+    - match: '(?i)^\s*(trait)\s+([a-z0-9_]+)\s*'
+      captures:
+        1: storage.type.trait.php
+        2: entity.name.type.trait.php
+
     - match: '(?i)^\s*(abstract|final)?\s*(class)\s+([a-z0-9_]+)\s*'
       captures:
         1: storage.modifier.abstract.php
@@ -506,15 +526,15 @@ contexts:
                 3: punctuation.definition.variable.php
     - match: |-
         (?x)\s*
-                                ((?:(?:final|abstract|public|private|protected|static)\s+)*)
-                                (function)
-                                (?:\s+|(\s*&\s*))
-                                (?:
-                                    (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
-                                    |([a-zA-Z0-9_]+)
-                                )
-                                \s*
-                                (\()
+            ((?:(?:final|abstract|public|private|protected|static)\s+)*)
+            (function)
+            (?:\s+|(\s*&\s*))
+            (?:
+                (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
+                |([a-zA-Z0-9_]+)
+            )
+            \s*
+            (\()
       captures:
         1: storage.modifier.php
         2: storage.type.function.php
@@ -546,6 +566,8 @@ contexts:
         - match: |-
             (?x)(::)
                                     (?:
+                                        (class[^\w])
+                                        |
                                         ([A-Za-z_][A-Za-z_0-9]*)\s*\(
                                         |
                                         ((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*)
@@ -554,10 +576,11 @@ contexts:
                                     )?
           captures:
             1: keyword.operator.class.php
-            2: meta.function-call.static.php
-            3: variable.other.class.php
-            4: punctuation.definition.variable.php
-            5: constant.other.class.php
+            2: constant.class.php
+            3: meta.function-call.static.php
+            4: variable.other.class.php
+            5: punctuation.definition.variable.php
+            6: constant.other.class.php
           pop: true
         - match: (self|static|parent)\b
           scope: storage.type.php

--- a/PHP/syntax_test_php5.4,php7.php
+++ b/PHP/syntax_test_php5.4,php7.php
@@ -1,0 +1,35 @@
+// SYNTAX TEST "Packages/PHP/PHP Source.sublime-syntax"
+<?php
+trait A
+// ^ storage.type.trait.php
+{
+
+}
+
+class B
+{
+    use X,
+    Y,
+//  ^ support.other.namespace.use.php
+    Z {
+        X::method1 as another1;
+        //         ^ support.trait.method.use-as.php
+        //            ^ meta.function.php
+        Y::method2 insteadof X;
+        //         ^ support.trait.method.insteadof.php
+        //                   ^ support.class.php
+        X::method2 as another2;
+        //         ^ support.trait.method.use-as.php
+        //            ^ meta.function.php
+    } protected $pro1;
+    // ^ storage.modifier.php
+
+    public function abc(callable $var,          int $var2,          string $var3)
+    //                  ^ storage.type.php
+    //                                          ^ storage.type.php
+    //                                                              ^ storage.type.php
+    {
+        echo B::class;
+        //      ^ constant.class.php
+    }
+}


### PR DESCRIPTION
- Added missing keywords (trait, callable, insteadof)

trait keyword
```
trait Taggable
{
}
```

improve use meta.

Now `as` keywords not being `operator` keyword

Added `insteadof` keyword

```
class Xyz {
    use A, B, C {
        C:method2 insteadof B;
        B::method1 as anotherOne1;
        B::method2 as anotherOne2;
    }
}

```

Added `callable`, `int`, `string` type hint
```
public function abc(callable $var, int $var2, string $var3)
{
   
}
```