### PR TITLE
[JavaScript] Removes jsx extension from list

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -5,7 +5,6 @@ name: JavaScript
 file_extensions:
   - js
   - htc
-  - jsx
 first_line_match: ^#!/.*\b(node|js)$\n?
 scope: source.js
 contexts:


### PR DESCRIPTION
jsx isn't part of core JS and not supported in this syntax file