### PR TITLE
[Groovy] Support comment toggling

### DIFF
--- a/Groovy/Comments.tmPreferences
+++ b/Groovy/Comments.tmPreferences
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.groovy</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>FBA964F9-EA31-44D1-A5FD-AE8AB3FF8954</string>
+</dict>
+</plist>


### PR DESCRIPTION
Sublime Text has had a long-standing issue where comments in Groovy
code cannot be toggled with Ctrl+/. The workaround has been to copy
the comments preferences from the Java package and change the
source.java to source.groovy.

One source for the fix:
http://stackoverflow.com/questions/24567263/how-to-enable-groovy-comments-in-sublimetext-3-on-a-mac