### PR TITLE
[HTML] Adds scope for class attribute/value

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -196,6 +196,41 @@ contexts:
       captures:
         1: entity.other.attribute-name.html
         2: punctuation.separator.key-value.html
+  tag-class-attribute:
+    - match: \b(class)\b\s*(=)
+      captures:
+        1: entity.other.attribute-name.class.html
+        2: punctuation.separator.key-value.html
+      push:
+        - meta_scope: meta.attribute-with-value.class.html
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.begin.html
+          push:
+            - meta_scope: string.quoted.double.html
+            - meta_content_scope: meta.toc-list.class.html
+            - match: '"'
+              captures:
+                0: punctuation.definition.string.end.html
+              pop: true
+            - include: entities
+        - match: "'"
+          captures:
+            0: punctuation.definition.string.begin.html
+          push:
+            - meta_scope: string.quoted.single.html
+            - meta_content_scope: meta.toc-list.class.html
+            - match: "'"
+              captures:
+                0: punctuation.definition.string.end.html
+              pop: true
+            - include: entities
+        - match: '(?<==)\s*((?:[^\s<>/''"]|/(?!>))+)'
+          scope: string.unquoted.html
+          captures:
+            1: meta.toc-list.class.html
+        - match: ''
+          pop: true
   tag-id-attribute:
     - match: \b(id)\b\s*(=)
       captures:
@@ -324,6 +359,7 @@ contexts:
 
   tag-stuff:
     - include: tag-id-attribute
+    - include: tag-class-attribute
     - include: tag-style-attribute
     - include: tag-event-attribute
     - include: tag-generic-attribute

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -29,5 +29,18 @@
     <body>
         <!-- Comment -->
         ## ^ comment.block.html
+
+        <div id="ElementID"></div>
+        ##    ^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
+        ##       ^ meta.attribute-with-value.id.html meta.toc-list.id.html
+
+        <div class="element-class"></div>
+        ##    ^ meta.attribute-with-value.class.html entity.other.attribute-name.class.html
+        ##          ^ meta.attribute-with-value.class.html meta.toc-list.class.html
+
+        <div style="width: 100%"></div>
+        ##    ^ meta.attribute-with-value.style.html entity.other.attribute-name.style.html
+        ##          ^ source.css meta.property-name.css support.type.property-name.css
+        ##                 ^ meta.property-value.css constant.numeric.css
     </body>
 </html>


### PR DESCRIPTION
In relation to this question/issue https://github.com/sublimehq/Packages/issues/220

Adds scope for class attribute/value. This should help 3rd party plugins add class completions within HTML files.
