### PR TITLE
Whitespace Fix for CSS Comments initiated with `Ctrl+/` in ST3 Build 3103

### DIFF
--- a/CSS/Comments.tmPreferences
+++ b/CSS/Comments.tmPreferences
@@ -14,13 +14,13 @@
 				<key>name</key>
 				<string>TM_COMMENT_START</string>
 				<key>value</key>
-				<string>/*</string>
+				<string>/* </string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END</string>
 				<key>value</key>
-				<string>*/</string>
+				<string> */</string>
 			</dict>
 			<dict>
 				<key>name</key>


### PR DESCRIPTION
CSS Comments previously displayed as `/*Comment Here*/` and now display as `/* Comment Here */`

Modified Comments.tmPreferences in CSS Package.
**17**: Changed `<string>/*</string>` to `<string>/* </string>`
**23**: Change `<string>*/</string>` to `<string> */</string>`