### PR TITLE
[HTML] Add support for custom tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -124,6 +124,26 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-stuff
+    - match: (</?)([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.custom.html
+      push:
+        - meta_scope: meta.tag.custom.html
+        - match: '>'
+          scope: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - match: (</?)([A-Za-z0-9:_]+-[A-Za-z0-9:_-]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: invalid.illegal.uppercase-custom-tag-name.html
+      push:
+        - meta_scope: meta.tag.custom.html
+        - match: '>'
+          scope: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
     - match: "(</?)([a-zA-Z0-9:]+)"
       captures:
         1: punctuation.definition.tag.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -50,5 +50,15 @@
         <a disabled onclick="setTimeout(function(){}, 100)">Test</a>
         ##                   ^ meta.function-call.js support.function.js
         ## ^^^^^^^^ entity.other.attribute-name
+
+        <article><span><othertag><x-custom-tag></x-custom-tag></othertag></span></article>
+        ## ^^^^^ entity.name.tag.block.any.html
+        ##        ^^^^ entity.name.tag.inline.any.html
+        ##              ^^^^^^^^ entity.name.tag.other.html
+        ##                        ^^^^^^^^^^^^ entity.name.tag.custom.html
+
+        <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
+        ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html
     </body>
+    # ^^^^ entity.name.tag.structure
 </html>


### PR DESCRIPTION
According to the [Custom Elements specification](https://www.w3.org/TR/custom-elements/#concepts), custom element tag names are required to contain a HYPEN-MINUS character.

This pull request adds the ability to match such custom elements properly.

Technically, the specification also requires that the tag names are lower-case, but I guess that would just cause further problems, so it’s easier to just allow dashes in upper- or mixed-case tag names as well.

I hope the weird indentation in the test is not a problem.