### PR TITLE
[JavaScript] Add missing Node.js process objects

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1156,7 +1156,7 @@ contexts:
       scope: support.constant.dom.js
     - match: \b(assert|buffer|child_process|cluster|constants|crypto|dgram|dns|domain|events|fs|http|https|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|tty|url|util|vm|zlib)\b
       scope: support.module.node.js
-    - match: \b(process)(?:(\.)(stdout|stderr|stdin|argv|execPath|execArgv|env|exitCode|version|versions|config|pid|title|arch|platform|mainModule))?\b
+    - match: \b(process)(?:(\.)(arch|argv|config|connected|env|execArgv|execPath|exitCode|mainModule|pid|platform|release|stderr|stdin|stdout|title|version|versions))?\b
       captures:
         1: support.type.object.process.js
         2: punctuation.accessor.js


### PR DESCRIPTION
Adds the missing `connected` and `release` objects from the process Node.js module.
The contents of the capture group were also sorted.

Both objects are supported in the latest Node.js LTS & Stable releases.

- [process.connected - Node 4.4.0 LTS](https://nodejs.org/dist/latest-v4.x/docs/api/process.html#process_process_connected) 
- [process.connected - Node 5.9.0 Stable](https://nodejs.org/dist/latest-v5.x/docs/api/process.html#process_process_connected) 

- [process.release- Node 4.4.0 LTS](https://nodejs.org/dist/latest-v4.x/docs/api/process.html#process_process_release) 
- [process.release- Node 5.9.0 Stable](https://nodejs.org/dist/latest-v5.x/docs/api/process.html#process_process_release) 