### PR TITLE
[HTML/CSS] Fix custom tag names

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -638,10 +638,10 @@ contexts:
         - meta_scope: meta.selector.css
         - match: "(?=[/@{)])"
           pop: true
-        - match: '\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|content|data|datalist|dd|del|details|dfn|dir|dialog|div|dl|dt|element|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|map|mark|menu|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|rtc|s|samp|script|section|select|shadow|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\b'
-          scope: entity.name.tag.css
         - match: '\b([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)\b'
           scope: entity.name.tag.custom.css
+        - match: '\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|content|data|datalist|dd|del|details|dfn|dir|dialog|div|dl|dt|element|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|map|mark|menu|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|rtc|s|samp|script|section|select|shadow|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\b'
+          scope: entity.name.tag.css
         - match: '(\.)[a-zA-Z0-9_-]+'
           scope: entity.other.attribute-name.class.css
           captures:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -36,8 +36,10 @@
 /*              ^ constant.other.color.hsl-value.css */
 }
 
-html > div > span > custom-tag {}
+html > div > span > custom-tag > div-custom-tag > form-custom-tag {}
 /* ^ entity.name.tag.css */
 /*     ^^^ entity.name.tag.css */
 /*           ^^^^ entity.name.tag.css */
 /*                  ^^^^^^^^^^ entity.name.tag.custom.css */
+/*                               ^^^^^^^^^^^^^^ entity.name.tag.custom.css */
+/*                                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.css */

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -54,6 +54,16 @@ contexts:
               pop: true
         - match: (\s*)(?!--|>)\S(\s*)
           scope: invalid.illegal.bad-comments-or-CDATA.html
+    - match: (</?)([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.custom.html
+      push:
+        - meta_scope: meta.tag.custom.html
+        - match: '>'
+          scope: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
     - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
       captures:
         1: punctuation.definition.tag.begin.html
@@ -161,16 +171,6 @@ contexts:
       push:
         - meta_scope: meta.tag.inline.table.html
         - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
-        - include: tag-stuff
-    - match: (</?)([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.custom.html
-      push:
-        - meta_scope: meta.tag.custom.html
-        - match: '>'
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-stuff

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -51,11 +51,17 @@
         ##                   ^ meta.function-call.js support.function.js
         ## ^^^^^^^^ entity.other.attribute-name
 
-        <article><span><othertag><x-custom-tag></x-custom-tag></othertag></span></article>
+        <article><span><othertag></othertag></span></article>
         ## ^^^^^ entity.name.tag.block.any.html
         ##        ^^^^ entity.name.tag.inline.any.html
         ##              ^^^^^^^^ entity.name.tag.other.html
-        ##                        ^^^^^^^^^^^^ entity.name.tag.custom.html
+
+        <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
+        ##^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##                ^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
 
         <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
         ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html


### PR DESCRIPTION
Turns out I didn’t test the custom tag names well enough in #233 and #236. Custom tags that start with a otherwise known tag are not correctly recognized (e.g. `<form-group>`). I’ve added more tests for these cases, and fixed the syntax definitions to give priority to custom tag names first (otherwise I would have to change every other tag name definition).