### PR TITLE
Fix Typos and Misspellings

### DIFF
--- a/AppleScript/AppleScript.sublime-syntax
+++ b/AppleScript/AppleScript.sublime-syntax
@@ -715,7 +715,7 @@ contexts:
     - match: \b(XML (attribute|data|element|file)s?)\b
       scope: support.class.system-events.xml.applescript
     - match: \b(print settings|users?|login items?)\b
-      scope: support.class.sytem-events.other.applescript
+      scope: support.class.system-events.other.applescript
   textmate:
     - match: \b(print settings)\b
       scope: support.class.textmate.applescript

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -245,7 +245,7 @@ contexts:
             0: punctuation.definition.method-parameters.end.source.cs
           pop: true
         - match: ","
-          scope: punctuation.definition.seperator.parameter.source.cs
+          scope: punctuation.definition.separator.parameter.source.cs
         - include: code
   attributes:
     - match: '\['

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -33,7 +33,7 @@ contexts:
         - match: "(?i)([_a-z]+[_a-z0-9-]*)"
           scope: support.type.variable-name.css
         - match: (,)
-          scope: punctuation.definition.arbitrary-repitition.css
+          scope: punctuation.definition.arbitrary-repetition.css
         - include: numeric-values
   charset:
     - match: \s*((@)charset\b)\s*
@@ -165,7 +165,7 @@ contexts:
       push:
         - match: '\s*(?:(,)|(?=[{;]))'
           captures:
-            1: punctuation.definition.arbitrary-repitition.css
+            1: punctuation.definition.arbitrary-repetition.css
           pop: true
   keyframes:
     - match: (?=\s*@(?:-webkit-|-moz-|-o-)?keyframes\s*.*?)
@@ -228,7 +228,7 @@ contexts:
       push:
         - match: '\s*(?:(,)|(?=[{;]))'
           captures:
-            1: punctuation.definition.arbitrary-repitition.css
+            1: punctuation.definition.arbitrary-repetition.css
           pop: true
         - match: \s*(and)?\s*(\()\s*
           captures:
@@ -449,7 +449,7 @@ contexts:
           pop: true
         - include: numeric-values
         - match: (,)
-          scope: punctuation.definition.arbitrary-repitition.css
+          scope: punctuation.definition.arbitrary-repetition.css
         - match: |-
             \b(?x)(
             at|

--- a/Clojure/Clojure.sublime-syntax
+++ b/Clojure/Clojure.sublime-syntax
@@ -103,7 +103,7 @@ contexts:
     - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
       comment: symbol matching
       push:
-        - meta_scope: meta.structure.binding.symbole.clojure
+        - meta_scope: meta.structure.binding.symbol.clojure
         - match: '(?=\])'
           pop: true
         - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
@@ -203,7 +203,7 @@ contexts:
     - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
       comment: symbol matching
       push:
-        - meta_scope: meta.structure.binding_exp.symbole.clojure
+        - meta_scope: meta.structure.binding_exp.symbol.clojure
         - match: '(?=\])'
           pop: true
         - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
@@ -405,7 +405,7 @@ contexts:
                 - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
                   comment: symbol matching
                   push:
-                    - meta_scope: meta.structure.multi_method_exp.symbole.clojure
+                    - meta_scope: meta.structure.multi_method_exp.symbol.clojure
                     - match: (?=\))
                       pop: true
                     - match: '(?=[a-zA-Z+!\-_?0-9*~#@''`/.$=])'
@@ -1066,9 +1066,9 @@ contexts:
     - match: '(\:{1,2})(?=[a-zA-Z+!\-_?0-9*/.$=])'
       comment: . is OK in symbol ?
       captures:
-        1: keyword.operator.symbole.clojure
+        1: keyword.operator.symbol.clojure
       push:
-        - meta_scope: constant.string.symbole.clojure
+        - meta_scope: constant.string.symbol.clojure
         - match: '(?![a-zA-Z+!\-_?0-9*~#@''`/.$=])'
           pop: true
         - include: symbol

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -185,7 +185,7 @@ contexts:
     - match: |-
         (?x)
                 (func)\s*
-                (?=\(.*,)                                                                        # param list with at leat one comma: (t Type, ...)
+                (?=\(.*,)                                                                        # param list with at least one comma: (t Type, ...)
       scope: keyword.control.go
       push: function_params
   single_param_anonymous_function_begin:

--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -143,7 +143,7 @@ contexts:
         - match: $
           pop: true
         - match: ":"
-          scope: keyword.operator.assert.expression-seperator.groovy
+          scope: keyword.operator.assert.expression-separator.groovy
         - include: groovy-code-minus-map-keys
     - match: \b(throws)\b
       scope: keyword.other.throws.groovy
@@ -172,7 +172,7 @@ contexts:
         - match: $
           pop: true
         - match: ":"
-          scope: keyword.operator.ternary.expression-seperator.groovy
+          scope: keyword.operator.ternary.expression-separator.groovy
         - include: groovy-code-minus-map-keys
     - match: "==~"
       scope: keyword.operator.match.groovy
@@ -194,7 +194,7 @@ contexts:
     - match: (\w+)\s*(:)
       captures:
         1: constant.other.key.groovy
-        2: punctuation.definition.seperator.key-value.groovy
+        2: punctuation.definition.separator.key-value.groovy
   method-call:
     - match: (\w+)(\()
       captures:
@@ -207,7 +207,7 @@ contexts:
             0: punctuation.definition.method-parameters.end.groovy
           pop: true
         - match: ","
-          scope: punctuation.definition.seperator.parameter.groovy
+          scope: punctuation.definition.separator.parameter.groovy
         - include: groovy-code
   method-declaration-remainder:
     - match: \(
@@ -235,7 +235,7 @@ contexts:
           captures:
             1: storage.type.parameter.groovy
         - match: ","
-          scope: punctuation.definition.parameters.seperator.groovy
+          scope: punctuation.definition.parameters.separator.groovy
         - include: comment-block
     - match: (?<=\))\s*(throws)\s
       captures:
@@ -249,7 +249,7 @@ contexts:
         - match: '((?:[a-z]\w*.)*[A-Z]\w*)\s*(?:(,)|$|\{)'
           captures:
             1: storage.type.throwable.groovy
-            2: punctuation.definition.throwables.seperator.groovy
+            2: punctuation.definition.throwables.separator.groovy
   methods:
     - match: |-
         (?x)^\s*
@@ -379,7 +379,7 @@ contexts:
             2: keyword.operator.assignment.groovy
         - include: values
         - match: ","
-          scope: punctuation.definition.seperator.groovy
+          scope: punctuation.definition.separator.groovy
     - match: '@\S+'
       scope: storage.type.annotation.groovy
     - match: \b(def)\b

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
             2: keyword.operator.assignment.java
         - include: code
         - match: ","
-          scope: punctuation.seperator.property.java
+          scope: punctuation.separator.property.java
     - match: '@\w*'
       scope: storage.type.annotation.java
   anonymous-classes-and-new:
@@ -95,7 +95,7 @@ contexts:
         - match: $
           pop: true
         - match: ":"
-          scope: keyword.operator.assert.expression-seperator.java
+          scope: keyword.operator.assert.expression-separator.java
         - include: code
   class:
     - match: '(?=\w?[\w\s]*(?:class|(?:@)?interface|enum)\s+\w+)'

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -715,7 +715,7 @@ contexts:
         1: keyword.operator.assignment.js
     - match: '(?={{identifier}})'
       push:
-        # These matches have to be deplicated to get entity.name.function
+        # These matches have to be duplicated to get entity.name.function
         # on the end of the scope stack since most color schemes require it
         - match: '{{dollar_only_identifier}}'
           scope: variable.other.dollar.only.js punctuation.dollar.js entity.name.function.js
@@ -1096,7 +1096,7 @@ contexts:
     - match: '(?={{identifier}})'
       push:
         # Once we've consumed an identifier, switch to the special context that
-        # property hanldes ambiguous tokens including "/"
+        # property handles ambiguous tokens including "/"
         - match: '(?!{{identifier}})'
           set: after-identifier
         - include: well-known-identifiers

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -411,7 +411,7 @@ contexts:
         		(?:foot)?(?:full)?(?:no)?(?:short)?		# Function Name
         		[cC]ite
         		(?:al)?(?:t|p|author|year(?:par)?|title)?[ANP]*
-        		\*?											# Optional Unabreviated
+        		\*?											# Optional Unabbreviated
         	)
         	(?:(\[)[^\]]*(\]))?								# Optional
         	(?:(\[)[^\]]*(\]))?								#   Arguments

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -196,9 +196,9 @@ contexts:
         					)
         				  | (							# Inline Link
         						\(						# Opening paren
-        							[ \t]*+				# Optional whtiespace
+        							[ \t]*+				# Optional whitespace
         							<?(.*?)>?			# URL
-        							[ \t]*+				# Optional whtiespace
+        							[ \t]*+				# Optional whitespace
         							(					# Optional Title
         								(?<title>['"])
         								(.*?)
@@ -343,9 +343,9 @@ contexts:
         					)
         				  | (							# Inline Link
         						\(						# Opening paren
-        							[ \t]*+				# Optional whtiespace
+        							[ \t]*+				# Optional whitespace
         							<?(.*?)>?			# URL
-        							[ \t]*+				# Optional whtiespace
+        							[ \t]*+				# Optional whitespace
         							(					# Optional Title
         								(?<title>['"])
         								(.*?)

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -101,7 +101,7 @@ contexts:
     - include: matlab_support_toolbox_datafeed
     - include: matlab_support_toolbox_design
     - include: matlab_support_toolbox_excel_link
-    - include: matlab_support_toolbox_filder_design_hdl_coder
+    - include: matlab_support_toolbox_filter_design_hdl_coder
     - include: matlab_support_toolbox_financial_derivatives
     - include: matlab_support_toolbox_financial
     - include: matlab_support_toolbox_fixed_income
@@ -270,10 +270,10 @@ contexts:
     - match: (?<!\.)\b(matlabsub|matlabinit|matlabfcn|MLUseFullDesktop|MLUseCellArray|MLStartDir|MLShowMatlabErrors|MLPutVar|MLPutMatrix|MLOpen|MLMissingDataAsNaN|MLGetVar|MLGetMatrix|MLGetFigure|MLEvalString|MLDeleteMatrix|MLClose|MLAutoStart|MLAppendMatrix)\b
       comment: Matlab excel link toolbox
       scope: support.toolbox.excel-link.matlab
-  matlab_support_toolbox_filder_design_hdl_coder:
+  matlab_support_toolbox_filter_design_hdl_coder:
     - match: (?<!\.)\b(generatetbstimulus|generatetb|generatehdl|fdhdltool)\b
-      comment: Matlab filder design hdl coder toolbox
-      scope: support.toolbox.filder-design-hdl-coder.matlab
+      comment: Matlab filter design hdl coder toolbox
+      scope: support.toolbox.filter-design-hdl-coder.matlab
   matlab_support_toolbox_financial:
     - match: (?<!\.)\b(zero2pyld|zero2fwd|zero2disc|zbtyield|zbtprice|yldtbill|yldmat|ylddisc|yearfrac|yeardays|year|xirr|x2mdate|wrkdydif|willpctr|willad|weights2holdings|weekday|wclose|volroc|vertcat|uplus|uminus|uicalendar|ugarchsim|ugarchpred|ugarchllf|ugarch|typprice|tsmovavg|tsmom|tsaccel|tr2bonds|toweekly|totalreturnprice|tosemi|toquoted|toquarterly|tomonthly|todecimal|today|todaily|toannual|times|time2date|tick2ret|thirtytwo2dec|thirdwednesday|tbl2bond|taxedrr|targetreturn|subsref|subsasgn|stochosc|std|spctkd|sortfts|smoothts|size|sharpe|setfield|selectreturn|second|rsindex|rmfield|ret2tick|resamplets|rdivide|pyld2zero|pvvar|pvtrend|pvfix|prtbill|prmat|prdisc|prcroc|prbyzero|power|posvolidx|portvrisk|portstats|portsim|portrand|portopt|portcons|portalpha|portalloc|pointfig|plus|plot|periodicreturns|peravg|pcpval|pcglims|pcgcomp|pcalims|payuni|payper|payodd|payadv|opprofit|onbalvol|nweekdate|now|nomrr|negvolidx|mvnrstd|mvnrobj|mvnrmle|mvnrfish|mtimes|mrdivide|movavg|months|month|mirr|minute|minus|min|merge|medprice|mean|maxdrawdown|max|macd|m2xdate|lweekdate|lpm|log2|log10|log|llow|length|leadts|lbusdate|lagts|issorted|isfield|isequal|iscompatible|isbusday|irr|inforatio|hour|horzcat|holidays|holdings2weights|hist|highlow|hhigh|getnameidx|getfield|geom2arith|fwd2zero|fvvar|fvfix|fvdisc|ftsuniq|ftstool|ftsinfo|ftsgui|ftsbound|fts2mat|fts2ascii|frontier|frontcon|freqstr|freqnum|frac2cur|fpctkd|fints|filter|fillts|fieldnames|fetch|fbusdate|extfield|exp|ewstats|eomday|eomdate|end|emaxdrawdown|elpm|effrr|ecmnstd|ecmnobj|ecmnmle|ecmninit|ecmnhess|ecmnfish|ecmmvnrstd|ecmmvnrobj|ecmmvnrmle|ecmmvnrfish|ecmlsrobj|ecmlsrmle|discrate|disc2zero|diff|depstln|depsoyd|deprdv|depgendb|depfixdb|dec2thirtytwo|daysdif|daysadd|daysact|days365|days360psa|days360isda|days360e|days360|day|datewrkdy|datevec|datestr|datenum|datemnth|datefind|datedisp|dateaxis|date2time|cur2str|cur2frac|cumsum|createholidays|cpnpersz|cpndaysp|cpndaysn|cpndatepq|cpndatep|cpndatenq|cpndaten|cpncount|cov2corr|corr2cov|convertto|convert2sur|chfield|chartfts|chaikvolat|chaikosc|cftimes|cfport|cfdur|cfdates|cfconv|cfamounts|candle|busdays|busdate|boxcox|bollinger|bolling|bndyield|bndspread|bndprice|bnddury|bnddurp|bndconvy|bndconvp|blsvega|blstheta|blsrho|blsprice|blslambda|blsimpv|blsgamma|blsdelta|blkprice|blkimpv|binprice|beytbill|barh|bar3h|bar3|bar|ascii2fts|arith2geom|annuterm|annurate|amortize|adosc|adline|active2abs|acrudisc|acrubond|accrfrac|abs2active)\b
       comment: Matlab financial toolbox

--- a/OCaml/OCamlyacc.sublime-syntax
+++ b/OCaml/OCamlyacc.sublime-syntax
@@ -106,7 +106,7 @@ contexts:
         - include: comments
   precs:
     - match: '(%)(prec)\s+(([a-z][a-zA-Z0-9_]*)|(([A-Z][a-zA-Z0-9_]*)))'
-      scope: meta.precidence.declaration
+      scope: meta.precedence.declaration
       captures:
         1: keyword.other.decorator.precedence.ocamlyacc
         2: keyword.other.precedence.ocamlyacc

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -759,10 +759,10 @@ contexts:
           scope: constant.character.escape.regex.php
         - include: interpolation
         - match: '(\{)\d+(,\d+)?(\})'
-          scope: string.regexp.arbitrary-repitition.php
+          scope: string.regexp.arbitrary-repetition.php
           captures:
-            1: punctuation.definition.arbitrary-repitition.php
-            3: punctuation.definition.arbitrary-repitition.php
+            1: punctuation.definition.arbitrary-repetition.php
+            3: punctuation.definition.arbitrary-repetition.php
         - match: '\[(?:\^?\])?'
           captures:
             0: punctuation.definition.character-class.php
@@ -786,10 +786,10 @@ contexts:
             0: punctuation.definition.string.end.php
           pop: true
         - match: '(\{)\d+(,\d+)?(\})'
-          scope: string.regexp.arbitrary-repitition.php
+          scope: string.regexp.arbitrary-repetition.php
           captures:
-            1: punctuation.definition.arbitrary-repitition.php
-            3: punctuation.definition.arbitrary-repitition.php
+            1: punctuation.definition.arbitrary-repetition.php
+            3: punctuation.definition.arbitrary-repetition.php
         - match: '(\\){1,2}[.$^\[\]{}]'
           comment: Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)
           scope: constant.character.escape.regex.php

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -169,7 +169,7 @@ contexts:
          ( (?>[a-zA-Z_]\w*(?>\.|::))?                                   # a method name prefix
            (?>[a-zA-Z_]\w*(?>[?!]|=(?!>))?                              # the method name
            |===?|>[>=]?|<=>|<[<=]?|[%&`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) )  # …or an operator method
-         \s*(\()                                                        # the openning parenthesis for arguments
+         \s*(\()                                                        # the opening parenthesis for arguments
       comment: the method pattern comes from the symbol pattern, see there for a explaination
       captures:
         1: keyword.control.def.ruby
@@ -240,7 +240,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
     - match: /=
-      comment: Needs higher precidence than regular expressions.
+      comment: Needs higher precedence than regular expressions.
       scope: keyword.operator.assignment.augmented.ruby
     - match: "'"
       comment: single quoted string (does not allow interpolation)
@@ -356,7 +356,7 @@ contexts:
              | [\s;]unless\s
              | [\s;]when\s
              | [\s;]assert_match\s
-             | [\s;]or\s			# boolean opperators
+             | [\s;]or\s			# boolean operators
              | [\s;]and\s
              | [\s;]not\s
              | [\s.]index\s			# methods
@@ -680,7 +680,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
     - match: '(?><<[-~]("?)((?:[_\w]+_|)CSS)\b\1)'
-      comment: heredoc with embedded css and intented terminator
+      comment: heredoc with embedded css and indented terminator
       captures:
         0: punctuation.definition.string.begin.ruby
       push:
@@ -695,7 +695,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
     - match: '(?><<[-~]("?)((?:[_\w]+_|)(?:JS|JAVASCRIPT))\b\1)'
-      comment: heredoc with embedded javascript and intented terminator
+      comment: heredoc with embedded javascript and indented terminator
       captures:
         0: punctuation.definition.string.begin.ruby
       push:
@@ -710,7 +710,7 @@ contexts:
         - include: interpolated_ruby
         - include: escaped_char
     # - match: '(?><<[-~]("?)((?:[_\w]+_|)(?:SH|SHELL))\b\1)'
-    #   comment: heredoc with embedded shell and intented terminator
+    #   comment: heredoc with embedded shell and indented terminator
     #   captures:
     #     0: punctuation.definition.string.begin.ruby
     #   push:
@@ -725,7 +725,7 @@ contexts:
     #     - include: interpolated_ruby
     #     - include: escaped_char
     - match: '(?><<[-~]("?)((?:[_\w]+_|)RUBY)\b\1)'
-      comment: heredoc with embedded ruby and intented terminator
+      comment: heredoc with embedded ruby and indented terminator
       captures:
         0: punctuation.definition.string.begin.ruby
       push:
@@ -989,10 +989,10 @@ contexts:
     - include: interpolated_ruby
     - include: escaped_char
     - match: '(\{)\d+(,\d+)?(\})'
-      scope: string.regexp.arbitrary-repitition.ruby
+      scope: string.regexp.arbitrary-repetition.ruby
       captures:
-        1: punctuation.definition.arbitrary-repitition.ruby
-        3: punctuation.definition.arbitrary-repitition.ruby
+        1: punctuation.definition.arbitrary-repetition.ruby
+        3: punctuation.definition.arbitrary-repetition.ruby
     - match: '\[(?:\^?\])?'
       captures:
         0: punctuation.definition.character-class.ruby

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -131,7 +131,7 @@ contexts:
     - include: type
 
     # Macro parameters. Ideally we would do this as a with_prototype,
-    # however then we run into indinite recursion
+    # however then we run into infinite recursion
     - match: '\${{identifier}}'
       scope: variable.parameter.rust
 
@@ -789,7 +789,7 @@ contexts:
     - match: '\{\{|\}\}'
       scope: constant.character.escape.rust
     - match: |-
-        (?x)                      # Spec fron http://doc.rust-lang.org/std/fmt/
+        (?x)                      # Spec from http://doc.rust-lang.org/std/fmt/
         \{
           (\d+|{{identifier}})?
           (

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -32,7 +32,7 @@
 #   except for block scalars,
 #   where it is also not verified
 #   (i.e. highlights even if less indentation used than required).
-# - Properties are sometimes incorrectly highlighed
+# - Properties are sometimes incorrectly highlighted
 #   for nested block collections (`- !!seq -`).
 ---
 name: YAML
@@ -298,7 +298,7 @@ contexts:
       scope: punctuation.definition.string.begin.yaml
       push:
         # TODO consider scoping meaningful trailing whitespace for color
-        # schemes with background color definitons.
+        # schemes with background color definitions.
         - meta_scope: string.quoted.double.yaml
           meta_include_prototype: false
         - match: '{{c_ns_esc_char}}'
@@ -413,7 +413,7 @@ contexts:
         - match: :(?=\s|$|{{c_flow_indicator}})
           scope: punctuation.separator.mapping.key-value.yaml
           set: flow-pair-value
-    # Attempt to match plain-in scalars and highlight as "entitiy.name.tag",
+    # Attempt to match plain-in scalars and highlight as "entity.name.tag",
     # if followed by a colon
     - match: |
         (?x)
@@ -502,7 +502,7 @@ contexts:
           scope: invalid.illegal.expected-newline.yaml
           pop: true
         - include: block-node
-    # Attempt to match plain-out scalars and highlight as "entitiy.name.tag",
+    # Attempt to match plain-out scalars and highlight as "entity.name.tag",
     # if followed by a colon
     - match: |
         (?x)


### PR DESCRIPTION
Fixed all the typos and misspellings that I could find.

Some of them affected scopes while others were located within comments.