### PR TITLE
[Diff] Fix Changed & Deleted Punctuation

### DIFF
--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -58,12 +58,12 @@ contexts:
     - match: ^(!).*$\n?
       scope: markup.changed.diff
       captures:
-        1: punctuation.definition.inserted.diff
+        1: punctuation.definition.changed.diff
     - match: ^(((<)( .*)?)|((-).*))$\n?
       scope: markup.deleted.diff
       captures:
-        3: punctuation.definition.inserted.diff
-        6: punctuation.definition.inserted.diff
+        3: punctuation.definition.deleted.diff
+        6: punctuation.definition.deleted.diff
     - match: ^Index(:) (.+)$\n?
       scope: meta.diff.index
       captures:

--- a/Diff/syntax_test_diff.diff
+++ b/Diff/syntax_test_diff.diff
@@ -1,0 +1,85 @@
+# SYNTAX TEST "Packages/Diff/Diff.sublime-syntax"
+
+--- Path to Original File
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.from-file
+# <-                      punctuation.definition.from-file.diff
+#^^                       punctuation.definition.from-file.diff
+
++++ Path to Modified File
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.to-file
+# <-                      punctuation.definition.to-file.diff
+#^^                       punctuation.definition.to-file.diff
+
+28a211
+#^^^^^ meta.diff.range.normal
+
+@@ -2,8 +2,11 @@
+#^^^^^^^^^^^^^^^ meta.diff.range.unified
+# <-             punctuation.definition.range.diff
+#^               punctuation.definition.range.diff
+#  ^^^^^^^^^^    meta.toc-list.line-number.diff
+#             ^^ punctuation.definition.range.diff
+
+--- Range ----
+#^^^^^^^^^^^^^ meta.diff.range.context
+# <-           punctuation.definition.range.diff
+#^^            punctuation.definition.range.diff
+#         ^^^^ punctuation.definition.range.diff
+
+*** Range ****
+#^^^^^^^^^^^^^ meta.diff.range.context
+# <-           punctuation.definition.range.diff
+#^^            punctuation.definition.range.diff
+#         ^^^^ punctuation.definition.range.diff
+
+***************
+#^^^^^^^^^^^^^^ meta.separator.diff
+#^^^^^^^^^^^^^^ punctuation.definition.separator.diff
+
+****************
+#^^^^^^^^^^^^^^^ -meta.separator.diff
+#^^^^^^^^^^^^^^^ -punctuation.definition.separator.diff
+
+===================================================================
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.separator.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ punctuation.definition.separator.diff
+
+====================================================================
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -meta.separator.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -punctuation.definition.separator.diff
+
+---
+#^^ meta.separator.diff
+#^^ punctuation.definition.separator.diff
+
+----
+#^^^ -meta.separator.diff
+#^^^ -punctuation.definition.separator.diff
+
+Plain Text
+#^^^^^^^^^ source.diff
+
++ Addition
+# <-       punctuation.definition.inserted.diff
+# ^^^^^^^^ markup.inserted.diff
+
+> Addition
+# <-       punctuation.definition.inserted.diff
+# ^^^^^^^^ markup.inserted.diff
+
+- Deletion
+# <-       punctuation.definition.deleted.diff
+# ^^^^^^^^ markup.deleted.diff
+
+< Deletion
+# <-       punctuation.definition.deleted.diff
+# ^^^^^^^^ markup.deleted.diff
+
+! Modified
+# <-       punctuation.definition.changed.diff
+# ^^^^^^^^ markup.changed.diff
+
+Index: value
+#^^^^^^^^^^^ meta.diff.index
+#    ^       punctuation.separator.key-value.diff
+#      ^^^^^ meta.toc-list.file-name.diff


### PR DESCRIPTION
The previous Diff syntax was scoping `changed` & `deleted` punctuation as `inserted`. These changes fix these issues and adds tests.