### PR TITLE
[Rust] Kleene star operator is optional

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -523,7 +523,7 @@ contexts:
         1: keyword.operator.rust
         2: punctuation.definition.group.begin.rust
       push:
-        - match: '(\)).([*+])'
+        - match: '(\))[^*+]?([*+])'
           capture:
             1: punctuation.definition.group.end.rust
             2: keyword.operator.rust

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -782,15 +782,33 @@ macro_rules! alternate_group (
 
 macro_rules! kleene_star {
     ($($arg:tt)+) => (
+//   ^ source.rust meta.macro.rust meta.block.rust meta.group.rust keyword.operator.rust
+//    ^ source.rust meta.macro.rust meta.block.rust meta.group.rust punctuation.definition.group.begin.rust
+//     ^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust variable.other.rust
+//         ^^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust
+//              ^ source.rust meta.macro.rust meta.block.rust meta.group.rust punctuation.definition.group.end.rust
+//                ^ source.rust meta.macro.rust meta.block.rust keyword.operator.rust
         println!($($arg));
     ),
     ($($arg:tt)*) => (
+//     ^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust variable.other.rust
+//         ^^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust
+//              ^ source.rust meta.macro.rust meta.block.rust meta.group.rust punctuation.definition.group.end.rust
+//                ^ source.rust meta.macro.rust meta.block.rust keyword.operator.rust
         println!($($arg)*);
     ),
     ($($arg:tt);+) => (
+//     ^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust variable.other.rust
+//         ^^^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust
+//               ^ source.rust meta.macro.rust meta.block.rust meta.group.rust punctuation.definition.group.end.rust
+//                 ^ source.rust meta.macro.rust meta.block.rust keyword.operator.rust
         println!($($arg));
     ),
     ($($arg:tt),*) => (
+//     ^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust variable.other.rust
+//         ^^^^^^ source.rust meta.macro.rust meta.block.rust meta.group.rust
+//               ^ source.rust meta.macro.rust meta.block.rust meta.group.rust punctuation.definition.group.end.rust
+//                 ^ source.rust meta.macro.rust meta.block.rust keyword.operator.rust
         println!($($arg)*);
     )
 }

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -779,3 +779,18 @@ macro_rules! alternate_group (
         println!("Test {}!", $a)
     )
 )
+
+macro_rules! kleene_star {
+    ($($arg:tt)+) => (
+        println!($($arg));
+    ),
+    ($($arg:tt)*) => (
+        println!($($arg)*);
+    ),
+    ($($arg:tt);+) => (
+        println!($($arg));
+    ),
+    ($($arg:tt),*) => (
+        println!($($arg)*);
+    )
+}


### PR DESCRIPTION
https://doc.rust-lang.org/reference.html#macros states
> The Kleene star operator consists of $ and parentheses, optionally followed by a separator token, followed by * or +. 

so the operator should not be required and should be optionally anything except * or +