### PR TITLE
modified: HTML/html_completions.py#L296

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -293,7 +293,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
             ('meta\tTag', 'meta ${1:charset=\"utf-8\"}>'),
             ('param\tTag', 'param name=\"$1\" value=\"$2\">'),
             ('progress\tTag', 'progress value=\"$1\" max=\"$2\">'),
-            ('script\tTag', 'script type=\"${1:text/javascript}\">$0</script>'),
+            ('script\tTag', 'script>$1</script>'),
             ('source\tTag', 'source src=\"$1\" type=\"$2\">'),
             ('style\tTag', 'style type=\"${1:text/css}\">$0</style>'),
             ('track\tTag', 'track kind=\"$1\" src=\"$2\">'),


### PR DESCRIPTION
Removed the default "text/javascript" type from `<script>` tag in HTML/html_completions.py file.
As JavaScript is the default scripting Language in HTML.