### PR TITLE
[CSS] Update pseudo elements

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -713,23 +713,60 @@ contexts:
           captures:
             1: punctuation.definition.entity.css
         - match: |-
-            (?x)(:+)
-            (after|before|first-letter|first-line|
-            (-moz-)?selection|
-            (-moz-)(?:placeholder|focus-inner)|(?:(-webkit-|-ms-)input-)?placeholder|
-            (-webkit-)(?:autofill|search-(?:cancel-button|decoration))|
-            (-ms-)(?:browse|check|clear|expand|fill-lower|
-            fill-upper|fill|reveal|thumb|ticks-after|
-            ticks-before|tooltip|track|value))
+            (?x)(:{1,2})
+            (?:after|before|first-letter|first-line|placeholder|selection|
+
+              (-moz-)(?:
+                button-content|color-swatch|
+                focus-(?:inner|outer)|
+                list-(?:bullet|number)|
+                meter-(?:bar|optimum|sub-optimum|sub-sub-optimum)|
+                number-(?:spin-(?:box|down|up))|
+                page(?:-sequence)?|
+                placeholder|progress-bar|
+                range-(?:progress|thumb|track)|
+                scrolled-page-sequence|selection|
+                tree-(?:cell-text|cell|checkbox|column|drop-feedback|image|
+                  indentation|line|progressmeter|row|separator|twisty)
+              )|
+
+              (-ms-)(?:
+                browse|check|clear|expand|fill(?:-lower|-upper)?|
+                input-placeholder|reveal|thumb|ticks-(?:after|before)|tooltip|
+                track|value
+              )|
+
+              (-webkit-)(?:
+                appearance|autofill|calendar-picker-indicator|clear-button|
+                color-swatch(?:-wrapper)?|
+                datetime-edit(?:-(?:ampm-field|day-field|fields-wrapper|
+                  hour-field|millisecond-field|minute-field|month-field|
+                  second-field|text|week-field|year-field))?|
+                details-marker|file-upload-button|
+                (?:inner|outer)-spin-button|
+                input-(?:list-button|placeholder|speech-button)|
+                keygen-select|
+                media-controls(?:-(?:current-time-display|enclosure|
+                  fullscreen-button|mute-button|overlay-enclosure|panel|
+                  play-button|time-remaining-display|timeline|
+                  toggle-closed-captions-button|volume-slider))?|
+                meter-(?:bar|even-less-good-value|inner-element|optimum-value|
+                  suboptimal-value|suboptimum-value)|
+                progress-(?:bar-value|bar|inner-element|value)|
+                resizer|
+                scrollbar(?:-(?:button|corner|thumb|track-piece|track))?|
+                search-(?:cancel-button|decoration|results-button|results-decoration)|
+                slider-(?:container|runnable-track|thumb)|
+                textfield-decoration-container
+              )
+            )
             \b
           scope: entity.other.attribute-name.pseudo-element.css
           captures:
             1: punctuation.definition.entity.css
+            2: support.type.vendor-prefix.css
             3: support.type.vendor-prefix.css
             4: support.type.vendor-prefix.css
-            5: support.type.vendor-prefix.css
-            6: support.type.vendor-prefix.css
-            7: support.type.vendor-prefix.css
         - match: (:)(current|(first|last)-child|(first|last|nth|only)-of-type|backdrop|empty|first|future|left|only-child|past|right|root|scope|target|active|any-link|hover|local-link|link|visited|focus)\b
           scope: entity.other.attribute-name.pseudo-class.css
           captures:


### PR DESCRIPTION
Added support for the following 88 pseudo elements.

There are currently around 300 total pseudo elements but the ones below are:

1. Currently supported
2. In use in some capacity

```
::-moz-button-content
::-moz-color-swatch
::-moz-focus-outer
::-moz-list-bullet
::-moz-list-number
::-moz-meter-bar
::-moz-meter-optimum
::-moz-meter-sub-optimum
::-moz-meter-sub-sub-optimum
::-moz-number-spin-box
::-moz-number-spin-down
::-moz-number-spin-up
::-moz-page
::-moz-page-sequence
::-moz-progress-bar
::-moz-range-progress
::-moz-range-thumb
::-moz-range-track
::-moz-scrolled-page-sequence
::-moz-tree-cell
::-moz-tree-cell-text
::-moz-tree-checkbox
::-moz-tree-column
::-moz-tree-drop-feedback
::-moz-tree-image
::-moz-tree-indentation
::-moz-tree-line
::-moz-tree-progressmeter
::-moz-tree-row
::-moz-tree-separator
::-moz-tree-twisty
::-webkit-appearance
::-webkit-calendar-picker-indicator
::-webkit-clear-button
::-webkit-color-swatch
::-webkit-color-swatch-wrapper
::-webkit-datetime-edit
::-webkit-datetime-edit-day-field
::-webkit-datetime-edit-fields-wrapper
::-webkit-datetime-edit-hour-field
::-webkit-datetime-edit-millisecond-field
::-webkit-datetime-edit-minute-field
::-webkit-datetime-edit-month-field
::-webkit-datetime-edit-second-field
::-webkit-datetime-edit-week-field
::-webkit-datetime-edit-year-field
::-webkit-details-marker
::-webkit-file-upload-button
::-webkit-inner-spin-button
::-webkit-input-list-button
::-webkit-input-speech-button
::-webkit-keygen-select
::-webkit-media-controls
::-webkit-media-controls-current-time-display
::-webkit-media-controls-enclosure
::-webkit-media-controls-fullscreen-button
::-webkit-media-controls-mute-button
::-webkit-media-controls-overlay-enclosure
::-webkit-media-controls-panel
::-webkit-media-controls-play-button
::-webkit-media-controls-time-remaining-display
::-webkit-media-controls-timeline
::-webkit-media-controls-toggle-closed-captions-button
::-webkit-media-controls-volume-slider
::-webkit-meter-bar
::-webkit-meter-even-less-good-value
::-webkit-meter-inner-element
::-webkit-meter-optimum-value
::-webkit-meter-suboptimal-value
::-webkit-meter-suboptimum-value
::-webkit-outer-spin-button
::-webkit-progress-bar
::-webkit-progress-bar-value
::-webkit-progress-inner-element
::-webkit-progress-value
::-webkit-resizer
::-webkit-scrollbar
::-webkit-scrollbar-button
::-webkit-scrollbar-corner
::-webkit-scrollbar-thumb
::-webkit-scrollbar-track
::-webkit-scrollbar-track-piece
::-webkit-search-results-button
::-webkit-search-results-decoration
::-webkit-slider-container
::-webkit-slider-runnable-track
::-webkit-slider-thumb
::-webkit-textfield-decoration-container
```

### Performance Tests

```
// 35K Lines // 745133 Chars // 745,472 bytes
```

----

#### Before:
```
Syntax "Packages/CSS.sublime-syntax" took an average of 378.7ms over 10 runs
Syntax "Packages/CSS.sublime-syntax" took an average of 382.6ms over 10 runs
Syntax "Packages/CSS.sublime-syntax" took an average of 397.3ms over 10 runs
Syntax "Packages/CSS.sublime-syntax" took an average of 385.6ms over 10 runs
Syntax "Packages/CSS.sublime-syntax" took an average of 398.7ms over 10 runs
```

**Average:** `388.58ms`

----

#### After:
```
Syntax "Packages/CSS (Modified).sublime-syntax" took an average of 377.0ms over 10 runs
Syntax "Packages/CSS (Modified).sublime-syntax" took an average of 367.8ms over 10 runs
Syntax "Packages/CSS (Modified).sublime-syntax" took an average of 382.6ms over 10 runs
Syntax "Packages/CSS (Modified).sublime-syntax" took an average of 373.8ms over 10 runs
Syntax "Packages/CSS (Modified).sublime-syntax" took an average of 388.5ms over 10 runs
```

**Average:** `377.94ms`
