### PR TITLE
[C/C++] Fix scope for escaped null character (\0)

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -88,7 +88,7 @@ contexts:
         - include: string_escaped_char
 
   string_escaped_char:
-    - match: '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})'
+    - match: '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[0-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})'
       scope: constant.character.escape.c
     - match: \\.
       scope: invalid.illegal.unknown-escape.c


### PR DESCRIPTION
ref: https://github.com/sublimehq/Packages/issues/273