### PR TITLE
[C/C++] String escape sequence improvements

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -88,7 +88,7 @@ contexts:
         - include: string_escaped_char
 
   string_escaped_char:
-    - match: '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})'
+    - match: \\(?:\\|[abefnrtv\'"?]|[0-7]{1,3}|x[\da-fA-F]+|u[\da-fA-F]{4}|U[\da-fA-F]{8})
       scope: constant.character.escape.c
     - match: \\.
       scope: invalid.illegal.unknown-escape.c

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -54,12 +54,37 @@ wchar_t str5[] = L"abc";
 /*                ^ punctuation.definition.string.begin */
 /*                 ^ string.quoted.double */
 
-char str6[] = "\"|\n|\r|\0|\x41";
-/*             ^ constant.character.escape */
-/*                ^ constant.character.escape */
-/*                   ^ constant.character.escape */
-/*                      ^ constant.character.escape */
-/*                         ^ constant.character.escape */
+char str6[] = "\a|\b|\e|\f|\n|\r|\t|\v|\'|\"|\?";
+/*             ^^ constant.character.escape */
+/*                ^^ constant.character.escape */
+/*                   ^^ constant.character.escape */
+/*                      ^^ constant.character.escape */
+/*                         ^^ constant.character.escape */
+/*                            ^^ constant.character.escape */
+/*                               ^^ constant.character.escape */
+/*                                  ^^ constant.character.escape */
+/*                                     ^^ constant.character.escape */
+/*                                        ^^ constant.character.escape */
+/*                                           ^^ constant.character.escape */
+
+char str7[] = "\0|\012";
+/*             ^^ constant.character.escape */
+/*                ^^^^ constant.character.escape */
+
+char str8[] = "\x0a|\x41|\xA|\x000065";
+/*             ^^^^ constant.character.escape */
+/*                  ^^^^ constant.character.escape */
+/*                       ^^^ constant.character.escape */
+/*                           ^^^^^^^^ constant.character.escape */
+
+char16_t str9[] = u"\u0063";
+/*                  ^^^^^^ constant.character.escape */
+
+char32_t str10[] = U"\U00000063";
+/*                   ^^^^^^^^^^ constant.character.escape */
+
+char str11[] = "\q";
+/*              ^^ invalid.illegal.unknown-escape */
 
 char rawStr1[] = R"("This is a raw string")";
 /*               ^ storage.type.string */


### PR DESCRIPTION
I made the following changes:
* Fixed issue where some octal escape sequences were highlighted as invalid
* Allowing hexadecimal escape sequences to be more that 2 digits long
* No longer highlighting \p (this is not a valid escape sequence in the C or C++ standards)

I followed the specification found [here](http://en.cppreference.com/w/cpp/language/escape). The only difference is I still highlight \e. This is not part of the C or C++ standards, but is supported by some compilers (I tested with Clang).