### PR TITLE
[RegExp] Support non-range numeric quantifiers

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
     - include: escaped_char
     - include: charset
     - include: group
-    - match: '([?*+][?+]?)|\{\d*,\d*\}'
+    - match: '([?*+][?+]?)|\{\d*,?\d*\}'
       scope: keyword.operator.quantifier.regexp
 
   group:

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
     - include: escaped_char
     - include: charset
     - include: group
-    - match: '([?*+][?+]?)|\{\d*,?\d*\}'
+    - match: '([?*+][?+]?)|\{\d+(,\d*)?\}'
       scope: keyword.operator.quantifier.regexp
 
   group:

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -94,11 +94,17 @@
 a{9}
 #^^^ keyword.operator.quantifier.regexp
 
-a{,9}
-#^^^^ keyword.operator.quantifier.regexp
-
 a{1,9}
 #^^^^^ keyword.operator.quantifier.regexp
 
 a{9,}
 #^^^^ keyword.operator.quantifier.regexp
+
+a{,9}
+#^^^^ - keyword.operator.quantifier.regexp
+
+a{,}
+#^^^ - keyword.operator.quantifier.regexp
+
+a{}
+#^^ - keyword.operator.quantifier.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -90,3 +90,15 @@
 (?#foobar)
 #^^^^^^^^^ string.regexp.group
 #^^^^^^^^ comment.line.number-sign
+
+a{9}
+#^^^ keyword.operator.quantifier.regexp
+
+a{,9}
+#^^^^ keyword.operator.quantifier.regexp
+
+a{1,9}
+#^^^^^ keyword.operator.quantifier.regexp
+
+a{9,}
+#^^^^ keyword.operator.quantifier.regexp


### PR DESCRIPTION
Allow support for `a{3}` in addition to the existing `a{3,}`, `a{2,3}`, and `a{,3}`. If it is a problem that this makes `a{}` a "valid" regex, let me know, and I'll fix it up.