### PR TITLE
[PHP] Add support for return types

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -525,6 +525,16 @@ contexts:
       push:
         - meta_scope: meta.function.php
         - meta_content_scope: meta.function.arguments.php
+        - match: '(?i)(\)):\s*(array|bool|int|float|string)\s'
+          captures:
+            1: punctuation.definition.parameters.end.php
+            2: storage.type.php
+          pop: true
+        - match: '(?i)(\)):\s*([a-z_][a-z0-9_\\]*)\s*'
+          captures:
+            1: punctuation.definition.parameters.end.php
+            2: support.class.php
+          pop: true
         - match: (\))
           captures:
             1: punctuation.definition.parameters.end.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -40,3 +40,26 @@ function i(
  * @return
 //   ^ comment.block - keyword.other.phpdoc
  */
+
+    function noReturnType(array $param1, int $param2) {}
+//  ^ storage.type.function.php
+//           ^ entity.name.function.php
+//                       ^ punctuation.definition.parameters.begin.php
+//                        ^ meta.function.arguments
+//                              ^ punctuation.definition.variable.php
+//                                       ^ meta.function.arguments
+//                                           ^ punctuation.definition.variable.php
+//                                                  ^ punctuation.definition.parameters.end.php
+    function scalarReturnType($param1): bool {}
+//  ^ storage.type.function.php
+//           ^ entity.name.function.php
+//                           ^ punctuation.definition.parameters.begin.php
+//                                   ^ punctuation.definition.parameters.end.php
+//                                      ^ storage.type.php
+    function classReturnType($param1): stringSpace\Test1 {}
+//  ^ storage.type.function.php
+//           ^ entity.name.function.php
+//                          ^ punctuation.definition.parameters.begin.php
+//                                  ^ punctuation.definition.parameters.end.php
+//                                     ^ support.class.php
+//                                                 ^ support.class.php


### PR DESCRIPTION
At the end of a parameter list PHP 7 now supports a colon to indicate a return type follows (either scalar or a class/interface)
http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration