### PR TITLE
[PHP] Add support for unicode codepoint escape syntax

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -326,6 +326,8 @@ contexts:
       scope: constant.numeric.octal.php
     - match: '\\x[0-9A-Fa-f]{1,2}'
       scope: constant.numeric.hex.php
+    - match: '\\u\{([0-9A-Fa-f]{2})+\}'
+      scope: constant.numeric.unicodepoint.php
     - match: '\\[nrt\\\$\"]'
       scope: constant.character.escape.php
     - match: '(\{)(?=\$.*?\})'

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -40,3 +40,13 @@ function i(
  * @return
 //   ^ comment.block - keyword.other.phpdoc
  */
+
+$test = "\0 \12 \345g \x0f \u{aa} \u{9999} \u{999}";
+//       ^^ constant.numeric.octal.php
+//          ^^^ constant.numeric.octal.php
+//              ^^^^ constant.numeric.octal.php
+//                  ^ meta.string-contents.quoted.double.php
+//                    ^^^^ constant.numeric.hex.php
+//                         ^^^^^^ constant.numeric.unicodepoint.php
+//                                ^^^^^^^^ constant.numeric.unicodepoint.php
+//                                         ^^^^^^^ meta.string-contents.quoted.double.php


### PR DESCRIPTION
A new unicode codepoint escape syntax was added to PHP 7
http://php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax

Also added tests for some of the other string interpolation features