### PR TITLE
[Ruby] Do not match camelCase as a constant

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
         6: punctuation.separator.inheritance.ruby
         7: entity.other.inherited-class.module.third.ruby
         8: punctuation.separator.inheritance.ruby
-    - match: '([A-Z]\w*)(?=(,\s*[A-Z]\w*)*\s*=(?!\>))'
+    - match: '\b([A-Z]\w*)(?=(,\s*[A-Z]\w*)*\s*=(?!\>))'
       scope: meta.constant.ruby
       comment: constant definition, handles multiple definitions on a single line 'APPLE, ORANGE= 1, 2'
       captures:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -6,6 +6,15 @@ puts <<~EOF
 EOF
 # ^ string.unquoted.heredoc
 
+lower_snake_case = 1
+# ^^^^^^^^^^^^^^ -meta.constant.ruby -entity.name.type.constant.ruby
+lowerCamelCase = 2
+# ^^^^^^^^^^^^ -meta.constant.ruby -entity.name.type.constant.ruby
+UpperCamelCase = 3
+# ^^^^^^^^^^^^ meta.constant.ruby entity.name.type.constant.ruby
+UPPER_SNAKE_CASE = 4
+# ^^^^^^^^^^^^^^ meta.constant.ruby entity.name.type.constant.ruby
+
 class MyClass
 # ^ meta.class.ruby keyword.control.class.ruby
 #     ^ meta.class.ruby entity.name.type.class.ruby


### PR DESCRIPTION
Previously, the uppercase portion of a camelCase variable was matched as
a constant. Adding a simple `\b` to the match rule should fix this.

Before

<img width="1069" alt="b" src="https://cloud.githubusercontent.com/assets/6496454/14591315/e8fff954-04dc-11e6-8257-08dd1078c678.png">

After

<img width="1077" alt="a" src="https://cloud.githubusercontent.com/assets/6496454/14591318/edab1df8-04dc-11e6-8343-90d0b15aba97.png">
