### PR TITLE
[Python] Fix encoding issues on Windows

### DIFF
--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -3,6 +3,11 @@
 	"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
 	"selector": "source.python",
 
+    "windows":
+    {
+        "env": {"PYTHONIOENCODING": "utf-8"}
+    },
+
 	"variants":
 	[
 		{


### PR DESCRIPTION
ST would try to read output as utf-8, but Python (by default) uses the
system's OEM encoding, which can differ greatly (cp850 for Western
Europe). Telling the Python runner to always use utf-8 for output makes
this work fine.

Test code to run with this build system:
```
print(u"\uFFFD")
```

Fixes https://github.com/SublimeTextIssues/Core/issues/926 (which also has some other relevant/related information).

---

I would also like to change the command on Windows to use the `py` executable that gets installed in the Windows folder, but it's not installed with Python 2 automatically unfortunately and wouldn't work then. Maybe we could a the Python 2-compatible cmd (using `python`) as a variant?