### PR TITLE
[Python] Fix string block scope starting with ws

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -561,7 +561,7 @@ contexts:
     - match: '([uU]?r)(""")'
       captures:
         1: storage.type.string.python
-        2: string.quoted.double.block.python punctuation.definition.string.begin.python
+        2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
@@ -593,7 +593,7 @@ contexts:
     - match: '([uU]?)(""")'
       captures:
         1: storage.type.string.python
-        2: string.quoted.double.block.python punctuation.definition.string.begin.python
+        2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
@@ -721,7 +721,7 @@ contexts:
     - match: '([uU]?r)('''''')'
       captures:
         1: storage.type.string.python
-        2: string.quoted.single.block.python punctuation.definition.string.begin.python
+        2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
@@ -753,7 +753,7 @@ contexts:
     - match: '([uU]?)('''''')'
       captures:
         1: storage.type.string.python
-        2: string.quoted.single.block.python punctuation.definition.string.begin.python
+        2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -563,6 +563,7 @@ contexts:
         1: storage.type.string.python
         2: string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
+        - meta_scope: string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: string.quoted.double.block.python
@@ -594,6 +595,7 @@ contexts:
         1: storage.type.string.python
         2: string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
+        - meta_scope: string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: string.quoted.double.block.python
@@ -721,6 +723,7 @@ contexts:
         1: storage.type.string.python
         2: string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
+        - meta_scope: string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: string.quoted.single.block.python
@@ -752,6 +755,7 @@ contexts:
         1: storage.type.string.python
         2: string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
+        - meta_scope: string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: string.quoted.single.block.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -114,7 +114,7 @@ string = """
 """
 
 string = """
-#        ^^^ string.quoted.double.block
+#        ^^^ string.quoted.double.block - string string
 """
 
 string = r"""

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -103,6 +103,16 @@ regex = R"\b ([fobar]*){1}(?:a|b)?"
 bad_string = 'SELECT * FROM users
 #                                ^ invalid.illegal.unclosed-string
 
+string = '''
+
+# <- string.quoted.single.block
+'''
+
+string = """
+
+# <- string.quoted.double.block
+"""
+
 string = """
 #        ^^^ string.quoted.double.block
 """
@@ -135,6 +145,7 @@ query = \
 
 query = \
     r"""
+
     SELECT
         (
         SELECT CASE field
@@ -165,4 +176,3 @@ sql = 'SELECT * FROM foo -- bar baz'
 #       ^ source.sql
 #                            ^ source.sql comment.line.double-dash
 #                                  ^ punctuation.definition.string.end.python - source.sql
-


### PR DESCRIPTION
All whitespace until the first non-whitespace character was not
correctly scoped and will be visible for color schemes with a background
color for strings.

Fixes what I mentioned [here](https://github.com/sublimehq/Packages/commit/76c4d5fcf31956c41d061b4daaef60c1ad4b67a3#commitcomment-16871122).