### PR TITLE
[Ruby] Fix: account for equality with constants

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
         6: punctuation.separator.inheritance.ruby
         7: entity.other.inherited-class.module.third.ruby
         8: punctuation.separator.inheritance.ruby
-    - match: '\b([A-Z]\w*)(?=(,\s*[A-Z]\w*)*\s*=(?!\>))'
+    - match: '\b([A-Z]\w*)(?=(,\s*[A-Z]\w*)*\s*=(?![=\>]))'
       scope: meta.constant.ruby
       comment: constant definition, handles multiple definitions on a single line 'APPLE, ORANGE= 1, 2'
       captures:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -15,6 +15,9 @@ UpperCamelCase = 3
 UPPER_SNAKE_CASE = 4
 # ^^^^^^^^^^^^^^ meta.constant.ruby entity.name.type.constant.ruby
 
+Symbol === :foo
+# ^^^^ variable.other.constant.ruby -meta.constant.ruby
+
 class MyClass
 # ^ meta.class.ruby keyword.control.class.ruby
 #     ^ meta.class.ruby entity.name.type.class.ruby


### PR DESCRIPTION
In `Symbol === x` Symbol is now treated as a constant and not a constant definition.