### PR TITLE
[TeX] Fix inline Math mode

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -66,7 +66,6 @@ contexts:
         - match: \\\$
           scope: constant.character.escape.tex
         - include: scope:text.tex.math
-        - include: main
     - match: '(\\)[A-Za-z@]+'
       scope: support.function.general.tex
       captures:


### PR DESCRIPTION
This fixes syntax highlighting in the following case:
\lstinline${$ foo \lstinline$}$

In this case the string highlighting would go until the end of the second lstinline, with the change it highlights all as expected.

I'm not sure if anything breaks by this change!
I'm not fluent in the syntax scheme - my document looks fine but I don't use math stuff often.