### PR TITLE
[Rails] Stop HTML (Rails) from initially matching everything

### DIFF
--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -8,26 +8,26 @@ file_extensions:
 scope: text.html.ruby
 contexts:
   main:
-    - match: ''
-      push: 'scope:text.html.basic'
-      with_prototype:
-        - match: "<%+#"
+    - match: "<%+#"
+      captures:
+        0: punctuation.definition.comment.erb
+      push:
+        - meta_scope: comment.block.erb
+        - match: "%>"
+          pop: true
+    - include: scope:text.html.basic
+
+    - match: "<%+(?!>)[-=]?"
+      captures:
+        0: punctuation.section.embedded.ruby
+      push:
+        - meta_scope: source.ruby.rails.embedded.html
+        - match: "-?%>"
+          scope: punctuation.section.embedded.ruby
+          pop: true
+        - match: (#).*?(?=-?%>)
+          scope: comment.line.number-sign.ruby
           captures:
-            0: punctuation.definition.comment.erb
-          push:
-            - meta_scope: comment.block.erb
-            - match: "%>"
-              pop: true
-        - match: "<%+(?!>)[-=]?"
-          captures:
-            0: punctuation.section.embedded.ruby
-          push:
-            - meta_scope: source.ruby.rails.embedded.html
-            - match: "-?%>"
-              scope: punctuation.section.embedded.ruby
-              pop: true
-            - match: (#).*?(?=-?%>)
-              scope: comment.line.number-sign.ruby
-              captures:
-                1: punctuation.definition.comment.ruby
-            - include: "Ruby on Rails.sublime-syntax"
+            1: punctuation.definition.comment.ruby
+        - include: "Ruby on Rails.sublime-syntax"
+    - include: scope:text.html.basic

--- a/Rails/syntax_test_html_rails.html.erb
+++ b/Rails/syntax_test_html_rails.html.erb
@@ -1,0 +1,19 @@
+# SYNTAX TEST "Packages/Rails/HTML (Rails).sublime-syntax"
+
+<p>Normal HTML</p>
+#  ^ text.html.ruby
+
+<%# ruby comment %>
+# ^ comment.block.erb
+
+<% if true # comment inside embedded %>
+#  ^ source.ruby.rails.embedded.html
+#          ^ punctuation.definition.comment.ruby
+  
+  <p>Normal HTML</p>
+#    ^ text.html.ruby
+<% end %>
+#  ^ keyword.control.ruby
+
+<% if false -%><p>inline erb</p><% end -%>
+#           ^ punctuation.section.embedded.ruby


### PR DESCRIPTION
While working on supporting HTML (Rails) highlighting in the Markdown Extended package, I noticed I couldn't end the markdown code block once I include the `text.html.ruby` syntax. This looked to be because of the initial `match: ''`.

Normally, this isn't a problem when opening a `.html.erb` file, but it was when trying to apply the syntax highlighting to a section of the file as the Markdown Extended package does.

This change should more closely follow the patterns in the HTML (Erlang), HTML (Tcl), and HTML (ASP) syntax definitions as well.