### PR TITLE
[XML] assign scope to attribute equals sign and support attributes beginning on a new line

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -210,7 +210,7 @@ contexts:
         - include: entity
         - include: should-be-entity
   tag-stuff:
-    - match: '\s+{{qualified_name}}\s*(=)'
+    - match: '(?:\s+|^){{qualified_name}}\s*(=)'
       captures:
         1: entity.other.attribute-name.namespace.xml
         2: entity.other.attribute-name.xml punctuation.separator.namespace.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -210,10 +210,11 @@ contexts:
         - include: entity
         - include: should-be-entity
   tag-stuff:
-    - match: '\s+{{qualified_name}}\s*='
+    - match: '\s+{{qualified_name}}\s*(=)'
       captures:
         1: entity.other.attribute-name.namespace.xml
         2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
         3: entity.other.attribute-name.localname.xml
+        4: punctuation.separator.key-value.xml
     - include: double-quoted-string
     - include: single-quoted-string

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -156,3 +156,6 @@
 <!--                          ^ punctuation.separator.key-value -->
 <!--                            ^ punctuation.definition.string.begin -->
 <!--                             ^^^^^ string.quoted -->
+     <test
+foo="bar" />
+<!-- <- entity.other.attribute-name.localname -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -153,5 +153,6 @@
 
      <element attr_with.space = "value" />
 <!--                  ^^^ entity.other.attribute-name.localname -->
+<!--                          ^ punctuation.separator.key-value -->
 <!--                            ^ punctuation.definition.string.begin -->
 <!--                             ^^^^^ string.quoted -->


### PR DESCRIPTION
for consistency with the HTML syntax

fixes #309