### PR TITLE
[Regular Expressions] scope invalid quantifiers

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -10,9 +10,17 @@ variables:
   known_char_escape: '\\(?:[tnrfae]|[0-7]{3}|x\{\h{1,7}\}|x\h\h|c\d+)'
   invalid_char_escape: '\\[xcCM]'
   char_escape: '\\.'
+  ranged_quantifier: '\{\d+(,\d*)?\}'
+  lazy_or_possessive: '[?+]?'
+  character_quantifier: '[?*+]'
+  char_class: '\\(?:[wWsSdDhHvVXR]|[pP](?:\{[a-zA-Z_]+\}|(L&|[A-Z][a-z]?)))'
 
 contexts:
   main:
+    - match: ''
+      push: [base-literal, unexpected-quantifier-pop]
+
+  base:
     - include: character-class
     - include: special-escaped-char
     - include: backslashes
@@ -21,30 +29,60 @@ contexts:
     - include: group
     - include: operators
 
+  base-group:
+    - include: base
+    - match: '(?=\))'
+      pop: true
+    - include: literal
+
+  base-literal:
+    - include: base
+    - include: literal
+
   group:
     - match: \(
       scope: keyword.control.group.regexp
-      push:
-        - meta_scope: meta.group.regexp
-        - match: '\?(<[=!]|>|=|:|!)'
-          scope: constant.other.assertion.regexp
-          set: group-body
-        - match: '\?#'
-          scope: meta.group.regexp comment.line.number-sign.regexp
-          set:
-            - meta_content_scope: meta.group.regexp comment.line.number-sign.regexp
-            - match: \)
-              scope: meta.group.regexp keyword.control.group.regexp
-              pop: true
-        - match: ''
-          set: group-body
+      push: group-start
+
+  group-start:
+    - meta_scope: meta.group.regexp
+    - match: '\?(<[=!]|>|=|:|!)'
+      scope: constant.other.assertion.regexp
+      set: [group-body, unexpected-quantifier-pop]
+    - match: '\?#'
+      scope: comment.line.number-sign.regexp
+      set:
+        - meta_content_scope: meta.group.regexp comment.line.number-sign.regexp
+        - match: \)
+          scope: meta.group.regexp keyword.control.group.regexp
+          pop: true
+    - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
+      captures:
+        1: meta.mode-modifier.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '(\?\d+)(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '(\?&\w+)(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '\?<\w+>'
+      scope: keyword.other.named-capture-group.regexp
+      set: [group-body, unexpected-quantifier-pop]
+    - match: ''
+      set: [group-body, unexpected-quantifier-pop]
 
   group-body:
-    - meta_scope: meta.group.regexp
+    - meta_content_scope: meta.group.regexp
     - match: \)
-      scope: keyword.control.group.regexp
+      scope: meta.group.regexp keyword.control.group.regexp
       pop: true
-    - include: main
+    - include: base-group
 
   charset:
     - match: '(\[\^?)]?'
@@ -56,7 +94,7 @@ contexts:
         - match: '\]'
           scope: keyword.control.set.regexp
           pop: true
-        - match: '(?=({{known_char_escape}}|\\.|[^\]])-({{known_char_escape}}|\\.|[^\]]))'
+        - match: '(?=({{known_char_escape}}|{{char_escape}}|[^\]])-({{known_char_escape}}|{{char_escape}}|[^\]]))'
           push:
             - meta_content_scope: constant.other.range.regexp
             - include: special-escaped-char
@@ -84,11 +122,7 @@ contexts:
           scope: keyword.operator.intersection.regexp
 
   character-class:
-    - match: '\\[wWsSdDhHvVXR]'
-      scope: keyword.control.character-class.regexp
-    - match: '\\[pP]\{[a-zA-Z_]+\}'
-      scope: keyword.control.character-class.regexp
-    - match: '\\[pP](L&|[A-Z][a-z]?)'
+    - match: '{{char_class}}'
       scope: keyword.control.character-class.regexp
 
   special-escaped-char:
@@ -104,15 +138,42 @@ contexts:
   backslashes:
     - match: '\\[bBAZzG]|[\^$]'
       scope: keyword.control.anchors.regexp
+      push: unexpected-quantifier-pop
     - match: '\\[QEK]'
       scope: keyword.control.regexp
-    - match: \\([kg]<\w+>|[kg]'\w+')
+      push: unexpected-quantifier-pop
+    - match: \\[kg](<\w+>|'\w+'|\{\w+\}|\d+)
       scope: keyword.other.backref-and-recursion.regexp
     - match: \\[1-9]\d*
       scope: keyword.other.backref-and-recursion.regexp
 
-  operators:
-    - match: '([?*+][?+]?)|\{\d+(,\d*)?\}'
+  quantifiers:
+    - match: '{{ranged_quantifier}}{{lazy_or_possessive}}'
       scope: keyword.operator.quantifier.regexp
+      push: unexpected-quantifier-pop
+    - match: '{{character_quantifier}}{{lazy_or_possessive}}'
+      scope: keyword.operator.quantifier.regexp
+      push: unexpected-quantifier-pop
+
+  unexpected-quantifier:
+    - match: '{{ranged_quantifier}}{{lazy_or_possessive}}'
+      scope: invalid.illegal.unexpected-quantifier.regexp
+    - match: '{{character_quantifier}}{{lazy_or_possessive}}'
+      scope: invalid.illegal.unexpected-quantifier.regexp
+
+  unexpected-quantifier-pop:
+    - include: unexpected-quantifier
+    - match: ''
+      pop: true
+
+  operators:
     - match: \|
       scope: keyword.operator.regexp
+      push: unexpected-quantifier-pop
+
+  literal:
+    - include: quantifiers
+    - match: '\.'
+      scope: keyword.other.any.regexp # https://github.com/sublimehq/Packages/issues/314
+    - match: .
+      scope: meta.literal.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -152,6 +152,7 @@ hello++
 # ^^ keyword.operator.quantifier.regexp
 
 (?=.++\.??\|{2,3}|{2})
+#^^ constant.other.assertion.regexp
 #  ^ keyword.other.any.regexp - meta.literal.regexp
 #   ^^ keyword.operator.quantifier.regexp
 #     ^^ constant.character.escape.regexp
@@ -193,3 +194,22 @@ hello++
 (?<named_group>test)
 #^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
 #              ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
+
+(?![a-z]+?)
+#^^ meta.group.regexp constant.other.assertion.regexp - meta.group.regexp meta.group.regexp
+#  ^ keyword.control.set.regexp
+#      ^ keyword.control.set.regexp
+#   ^^^ constant.other.range.regexp
+#       ^^ keyword.operator.quantifier.regexp
+
+(?![abc].\g1(?m)$)[\g1]
+#^^ constant.other.assertion.regexp
+#  ^ keyword.control.set.regexp
+#      ^ keyword.control.set.regexp
+#   ^^^ - meta.literal.regexp
+#       ^ keyword.other.any.regexp
+#        ^^^ keyword.other.backref-and-recursion.regexp
+#               ^ keyword.control.anchors.regexp
+#            ^^ meta.group.regexp meta.group.regexp meta.mode-modifier.regexp
+#                  ^^ constant.character.escape.regexp
+#                  ^^^ - keyword.other.backref-and-recursion.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -110,3 +110,86 @@ a{,}
 
 a{}
 #^^ - keyword.operator.quantifier.regexp
+
+|{1,2}
+#^^^^^ invalid.illegal.unexpected-quantifier.regexp
+
+hello**
+#     ^ invalid.illegal.unexpected-quantifier.regexp
+#<- meta.literal.regexp
+#^^^^ meta.literal.regexp
+
+hello++
+#    ^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}?)
+#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}+)
+#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}?+)
+#      ^ invalid.illegal.unexpected-quantifier.regexp
+
+[\w{1}+]
+#  ^^^^ - invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+(?x)
+#^^ meta.mode-modifier.regexp
+
+(?-ix)
+#^^^^ meta.mode-modifier.regexp
+
+(?sm-ixxs)
+#^^^^^^^^ meta.mode-modifier.regexp
+
+(?abc)
+#^ invalid.illegal.unexpected-quantifier.regexp - meta.mode-modifier.regexp
+# ^^^ meta.literal.regexp - meta.mode-modifier.regexp
+
+ .*?
+#^ keyword.other.any.regexp - meta.literal.regexp
+# ^^ keyword.operator.quantifier.regexp
+
+(?=.++\.??\|{2,3}|{2})
+#  ^ keyword.other.any.regexp - meta.literal.regexp
+#   ^^ keyword.operator.quantifier.regexp
+#     ^^ constant.character.escape.regexp
+#       ^^ keyword.operator.quantifier.regexp
+#         ^^ constant.character.escape.regexp
+#           ^^^^^ keyword.operator.quantifier.regexp
+#                 ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+\G{2}
+# ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+ \g{1}
+#^^^^^ keyword.other.backref-and-recursion.regexp - keyword.operator.quantifier.regexp
+
+ \g1
+#^^^ keyword.other.backref-and-recursion.regexp
+
+ \g{named_group}
+#^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+
+ \g'named_group'
+#^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+
+ \g<named_group>
+#^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+
+(?1)
+#^^ keyword.other.backref-and-recursion.regexp
+
+(1)
+#^ meta.literal.regexp - keyword.other.backref-and-recursion.regexp
+
+(?&named_group)
+#^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+
+(?={2})
+#  ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+(?<named_group>test)
+#^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
+#              ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp


### PR DESCRIPTION
I thought I would share my solution for issue #315.

It is not perfect in my opinion, because it's not DRY, so I would be interested to see if anyone has a better solution :) EDIT: this has since been corrected :+1: 

Other improvements:
- it scopes literal characters as `meta.literal.regexp`
- it also scopes the `.` character as `keyword.other.any.regexp` as per #314 
- correctly scope mode modifiers i.e. `(?x)` or `(?-i)` as `meta.mode-modifier.regexp`

(if you don't like any of the scope names, we can change them)

Regular expressions don't tend to get that big, but I did a performance measurement anyway on a 400 byte file:
- Before my changes:

  > Syntax "Packages/Regular Expressions/RegExp.sublime-syntax" took an average of 0.1ms over 10 runs
- After my changes:

  > Syntax "Packages/Regular Expressions/RegExp.sublime-syntax" took an average of 0.2ms over 10 runs
