### PR TITLE
Detect functions in Shell scripts correctly

### DIFF
--- a/ShellScript/Shell-Unix-Generic.sublime-syntax
+++ b/ShellScript/Shell-Unix-Generic.sublime-syntax
@@ -20,7 +20,6 @@ scope: source.shell
 contexts:
   main:
     - include: comment
-    - include: pipeline
     - include: list
     - include: compound-command
     - include: loop
@@ -33,6 +32,7 @@ contexts:
     - include: redirection
     - include: pathname
     - include: keyword
+    - include: pipeline
     - include: support
   comment:
     - match: '(?<!\S)(#)(?!\{).*$\n?'


### PR DESCRIPTION
The following functions are not correctly highlighted, and do not appear in Goto Symbol, before this change (and in the current version of Sublime, Build 3111):

```
function x() {
}
function y {
}
```

The problem is that `function` gets caught as a keyword in the pipeline context, which makes it impossible for the function-definition context to catch the cases that begin with `function`.
