### PR TITLE
[RegExp] Highlight comment punctuation

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -40,6 +40,13 @@ contexts:
     - include: literal
 
   group:
+    - match: \(\?#
+      scope: punctuation.definition.comment.begin.regexp
+      push:
+        - meta_scope: meta.group.regexp comment.block.group.regexp
+        - match: \)
+          scope: punctuation.definition.comment.end.regexp
+          pop: true
     - match: \(
       scope: keyword.control.group.regexp
       push: group-start
@@ -49,13 +56,6 @@ contexts:
     - match: '\?(<[=!]|>|=|:|!)'
       scope: constant.other.assertion.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: '\?#'
-      scope: comment.line.number-sign.regexp
-      set:
-        - meta_content_scope: meta.group.regexp comment.line.number-sign.regexp
-        - match: \)
-          scope: meta.group.regexp keyword.control.group.regexp
-          pop: true
     - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
       captures:
         1: meta.mode-modifier.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -90,8 +90,13 @@
 #       ^ keyword.control.group
 
 (?#foobar)
-#^^^^^^^^^ meta.group.regexp
-#^^^^^^^^ comment.line.number-sign
+#^^^^^^^^^ meta.group comment.block.group
+# <- comment.block.group punctuation.definition.comment.begin
+#^^ punctuation.definition.comment.begin
+#        ^ punctuation.definition.comment.end
+
+( abc (?#foobar) )
+#     ^^^^^^^^^^ meta.group meta.group comment.block.group
 
 a{9}
 #^^^ keyword.operator.quantifier.regexp


### PR DESCRIPTION
As I mentioned in this other PR (https://github.com/sublimehq/Packages/pull/316#issuecomment-215554171), the definiting puntuation of inline-comments `(?#` and `)` were not highlighted as part of the comment.

I also changed the scope name to `comment.block` instead of `comment.line`.