### PR TITLE
[Python] Set PYTHONIOENCODING for all platforms

### DIFF
--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -3,10 +3,7 @@
 	"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
 	"selector": "source.python",
 
-	"windows":
-	{
-		"env": {"PYTHONIOENCODING": "utf-8"}
-	},
+	"env": {"PYTHONIOENCODING": "utf-8"},
 
 	"variants":
 	[


### PR DESCRIPTION
According to the docs for `sys.std{in,err,out}`:

>The character encoding is platform-dependent. Under Windows, if the stream is interactive (that is, if its isatty() method returns True), the console codepage is used, otherwise the ANSI code page. Under other platforms, the locale encoding is used (see locale.getpreferredencoding()).

Thus, PYTHONIOENCODING should be set for all platforms.

Iterates on https://github.com/sublimehq/Packages/pull/295.