### PR TITLE
[CSS] Refined function support

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -15,6 +15,21 @@ variables:
   nmchar: '(?:[[-\w]{{nonascii}}]|{{escape}})'
   ident: '-?{{nmstart}}{{nmchar}}*'
 
+  # Types
+  # https://www.w3.org/TR/css3-values/#numeric-types
+  integer: '(?:[-+]?\d+)'
+  number: '[-+]?(?:(?:\d*\.\d+(?:[eE]{{integer}})*)|{{integer}})'
+
+  # Units
+  # https://www.w3.org/TR/css3-values/#lengths
+  font_relative_lengths: '(?i:em|ex|ch|rem)'
+  viewport_percentage_lengths: '(?i:vw|vh|vmin|vmax)'
+  absolute_lengths: '(?i:cm|mm|q|in|pt|pc|px|fr)'
+  angle_units: '(?i:deg|grad|rad|turn)'
+  duration_units: '(?i:s|ms)'
+  frequency_units: '(?i:Hz|kHz)'
+  resolution_units: '(?i:dpi|dpcm|dppx)'
+
   custom_element_chars: |-
     (?x:
         [-_a-z0-9\xB7]
@@ -34,13 +49,26 @@ variables:
       | [\x{00010000}-\x{000EFFFF}]
     )
 
-  rgb_decimal_value: '(?:0*(?:(?:2(?:[0-4][0-9]|5[0-5]))|(?:1?[0-9]{1,2})))'
-
-  color_percentage_range: '(?:100|[0-9]{1,2})%'
-
-  color_alpha_value: '(?:\s*,\s*((?:(?:0?\.[0-9]+)|[0-1])))?'
-
   combinators: '(?:>{1,3}|[~+])'
+
+  # Predefined Counter Styles
+  # https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
+  counter_styles: |-
+    (?xi:
+        arabic-indic | armenian | bengali | cambodian | circle
+      | cjk-decimal | cjk-earthly-branch | cjk-heavenly-stem | decimal-leading-zero
+      | decimal | devanagari | disclosure-closed | disclosure-open | disc
+      | ethiopic-numeric | georgian | gujarati | gurmukhi | hebrew
+      | hiragana-iroha | hiragana | japanese-formal | japanese-informal
+      | kannada | katakana-iroha | katakana | khmer
+      | korean-hangul-formal | korean-hanja-formal | korean-hanja-informal | lao
+      | lower-alpha | lower-armenian | lower-greek | lower-latin | lower-roman
+      | malayalam | mongolian | myanmar | oriya | persian
+      | simp-chinese-formal | simp-chinese-informal
+      | square | tamil | telugu | thai | tibetan
+      | trad-chinese-formal | trad-chinese-informal
+      | upper-alpha | upper-armenian | upper-latin | upper-roman
+    )
 
 contexts:
   main:
@@ -55,24 +83,7 @@ contexts:
     - include: namespace
     - include: page
     - include: property-list
-  cascading-variable:
-    - match: (var)(\()
-      captures:
-        1: support.function.var.css
-        2: punctuation.section.function.css
-      push:
-        - meta_scope: support.type.cascading-variable.css
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: (--)
-          scope: support.constant.custom-property-name.prefix.css
-        - match: "(?i)([_a-z]+[_a-z0-9-]*)"
-          scope: support.type.variable-name.css
-        - match: (,)
-          scope: punctuation.definition.arbitrary-repetition.css
-        - include: numeric-values
+
   charset:
     - match: \s*((@)charset\b)\s*
       captures:
@@ -82,70 +93,29 @@ contexts:
         - meta_scope: meta.at-rule.charset.css
         - include: at-rule-punctuation
         - include: literal-string
+
+  # When including `color-values` and `color-adjuster-functions`, make sure it is
+  # included after the color adjustors to prevent `color-values` from consuming
+  # conflicting function names & color constants such as `red`, `green`, or `blue`.
   color-values:
-      # http://www.w3.org/TR/CSS21/syndata.html#value-def-color
+    - include: color-functions
+      # https://www.w3.org/TR/CSS22/syndata.html#color-units
     - match: \b(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow)\b
       scope: support.constant.color.w3c-standard-color-name.css
       # https://www.w3.org/TR/css3-color/#svg-color
     - match: \b(aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rebeccapurple|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|turquoise|violet|wheat|whitesmoke|yellowgreen)\b
       scope: support.constant.color.w3c-extended-color-keywords.css
-      # https://www.w3.org/TR/css3-color/#currentcolor and https://www.w3.org/TR/css3-color/#transparent-def
+      # Special Color Keywords
+      # https://www.w3.org/TR/css3-color/#currentcolor
+      # https://www.w3.org/TR/css3-color/#transparent-def
     - match: \b((?i)currentColor|transparent)\b
       scope: support.constant.color.w3c-special-color-keyword.css
-    - match: (rgba?)(\()
+      # Hex Color
+    - match: '(#)(\h{3}|\h{6})\b'
+      scope: constant.other.color.rgb-value.css
       captures:
-        1: support.function.misc.css
-        2: punctuation.section.function.css
-      push:
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: |-
-            (?x)
-            ({{rgb_decimal_value}})\s*,\s*  # red,
-            ({{rgb_decimal_value}})\s*,\s*  # green,
-            ({{rgb_decimal_value}})         # blue,
-            (?:{{color_alpha_value}})       # alpha
-          captures:
-            1: constant.other.color.rgb-value.css
-            2: constant.other.color.rgb-value.css
-            3: constant.other.color.rgb-value.css
-            4: constant.other.color.rgb-value.css
-        - match: |-
-            (?x)
-            ({{color_percentage_range}})\s*,\s*  # red,
-            ({{color_percentage_range}})\s*,\s*  # green,
-            ({{color_percentage_range}})         # blue,
-            (?:{{color_alpha_value}})            # alpha
-          captures:
-            1: constant.other.color.rgb-percentage.css
-            2: constant.other.color.rgb-percentage.css
-            3: constant.other.color.rgb-percentage.css
-            4: constant.other.color.rgb-percentage.css
-        - include: numeric-values
-    - match: (hsla?)(\()
-      captures:
-        1: support.function.misc.css
-        2: punctuation.section.function.css
-      push:
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: |-
-            (?x)
-            ((?:-|\+)?
-            (?:\d\.\d+(?:e\-\d+)?|\d+))\s*,\s*   # hue
-            ({{color_percentage_range}})\s*,\s*  # saturation
-            ({{color_percentage_range}})         # lightness
-            (?:{{color_alpha_value}})            # alpha
-          captures:
-            1: constant.other.color.hsl-value.css
-            2: constant.other.color.hsl-value.css
-            3: constant.other.color.hsl-value.css
-            4: constant.other.color.hsl-value.css
-        - include: numeric-values
+        1: punctuation.definition.constant.css
+
   comment-block:
     - match: /\*
       scope: punctuation.definition.comment.css
@@ -154,6 +124,7 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.css
           pop: true
+
   custom-media:
     - match: (?=\s*@custom-media\s*.*?)
       push:
@@ -183,6 +154,7 @@ contexts:
             1: punctuation.section.property-list.css
           pop: true
         - include: rule-list
+
   import:
     - match: \s*((@)import\b)\s*
       captures:
@@ -192,19 +164,9 @@ contexts:
         - meta_scope: meta.at-rule.import.css
         - include: at-rule-punctuation
         - include: literal-string
-        - match: \s*(url)(\()\s*
-          captures:
-            1: support.function.url.css
-            2: punctuation.section.function.css
-          push:
-            - match: \s*(\))\s*
-              captures:
-                1: punctuation.section.function.css
-              pop: true
-            - match: '[^''") \t]+'
-              scope: variable.parameter.url.css
-            - include: literal-string
+        - include: url-function
         - include: media-query-list
+
   keyframe-name:
     - match: '(?i)\s*[-]?([_\w\-]*)?'
       captures:
@@ -214,6 +176,7 @@ contexts:
           captures:
             1: punctuation.definition.arbitrary-repetition.css
           pop: true
+
   # https://drafts.csswg.org/css-animations/#keyframes
   keyframes:
     - match: (?=\s*@(?:-webkit-|-moz-|-o-)?keyframes\s*.*?)
@@ -249,6 +212,7 @@ contexts:
                 2: constant.numeric.css
                 3: keyword.other.unit.css
             - include: main
+
   media:
     - match: (?=\s*@media\s*.*?)
       push:
@@ -273,6 +237,7 @@ contexts:
             - match: '(?=\})'
               pop: true
             - include: main
+
   media-query:
     # Media Types: https://www.w3.org/TR/CSS21/media.html
     - match: (?i)\s*(only|not)?\s*(all|aural|braille|embossed|handheld|print|projection|screen|speech|tty|tv)?
@@ -319,12 +284,14 @@ contexts:
                 2: keyword.operator.arithmetic.css
                 3: constant.numeric.css
             - include: numeric-values
+
   media-query-list:
     - match: '\s*(?=[^{;])'
       push:
         - match: '\s*(?=[{;])'
           pop: true
         - include: media-query
+
 # Namespace At-Rule: https://www.w3.org/TR/css3-namespace/
   namespace:
     - match: \s*((@)namespace)\s+(\b\S*\b)?
@@ -336,6 +303,7 @@ contexts:
         - meta_scope: meta.at-rule.namespace.css
         - include: at-rule-punctuation
         - include: literal-string
+
 # Page At-Rule: https://www.w3.org/TR/CSS2/page.html
   page:
     - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*(?=\{)'
@@ -351,18 +319,7 @@ contexts:
             1: punctuation.section.property-list.css
           pop: true
         - include: rule-list
-  numeric-values:
-    - match: '(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b'
-      scope: constant.other.color.rgb-value.css
-      captures:
-        1: punctuation.definition.constant.css
-    - match: |-
-        (?x)
-            (?:-|\+)?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+))
-            ((?:px|pt|ch|cm|deg|dpi|dpcm|dppx|em|ex|in|grad|fr|mm|ms|pc|rad|rem|s|turn|vh|vw|vmin|vmax|x)\b|%)?
-      scope: constant.numeric.css
-      captures:
-        1: keyword.other.unit.css
+
   property-list:
     - match: '(?=\{)'
       push:
@@ -370,285 +327,180 @@ contexts:
           scope: punctuation.section.property-list.css
           pop: true
         - include: rule-list
-  property-values:
-    - include: vendor-prefix
-    - include: repeat-notation
+
+  property-value-constants:
     - match: |-
-        (?x)\b(
-            absolute|active|add
-          | all(-(petite|small)-caps|-scroll)?
-          | alpha(betic)?
-          | alternate(-reverse)?
-          | always|annotation|antialiased|armenian|at
-          | auto(hiding-scrollbar)?
-          | avoid(-column|-page|-region)?
-          | background(-color|-image|-position|-size)?
-          | backwards|balance|baseline|below|bevel|bicubic|bidi-override|blink
-          | block(-line-height)?
-          | blur
-          | bold(er)?
-          | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
-          | border-(bottom|top)-(left|right)-radius
-          | border-image(-outset|-repeat|-slice|-source|-width)?
-          | border(-bottom|-left|-right|-top|-collapse|-spacing)?
-          | both|bottom
-          | box(-shadow)?
-          | break-(all|word)
-          | brightness
-          | butt(on)?
-          | capitalize
-          | cent(er|ral)
-          | char(acter-variant)?
-          | cjk-ideographic|clip|clone|close-quote
-          | closest-(corner|side)
-          | col-resize|collapse
-          | color(-stop|-burn|-dodge)?
-          | column((-count|-gap|-reverse|-rule(-color|-width)?|-width)|s)?
-          | common-ligatures|condensed|consider-shifts|contain
-          | content(-box|s)?
-          | contextual|contrast|cover
-          | crisp(-e|E)dges
-          | crop
-          | cross(hair)?
-          | da(rken|shed)
-          | decimal(-leading-zero)?
-          | default|dense|diagonal-fractions|difference|disabled
-          | disc(retionary-ligatures)?
-          | disregard-shifts
-          | distribute(-all-lines|-letter|-space)?
-          | dotted|double|drop-shadow
-          | (nwse|nesw|ns|ew|sw|se|nw|ne|w|s|e|n)-resize
-          | ease(-in-out|-in|-out)?
-          | element|ellipsis|embed|end|EndColorStr|evenodd
-          | exclu(de(-ruby)?|sion)
-          | expanded
-          | (extra|semi|ultra)-(condensed|expanded)
-          | farthest-(corner|side)?
-          | fill(-box|-opacity)?
-          | filter|fixed|flat
-          | flex((-basis|-end|-grow|-shrink|-start)|box)?
-          | flip|flood-color
-          | font(-size(-adjust)?|-stretch|-weight)?
-          | forwards
-          | from(-image)?
-          | full-width|geometricPrecision|georgian|glyphs|gradient|grayscale
-          | grid(-height)?
-          | groove|hand|hanging|hard-light|hebrew|height|help|hidden|hide
-          | (hiragana|katakana)(-iroha)?
-          | historical-(forms|ligatures)
-          | horizontal(-tb)?
-          | hue
-          | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
-          | inactive|include-ruby|infinite|inherit|initial
-          | inline(-block|-box|-flex(box)?|-line-height|-table)?
-          | inside
-          | inter(-ideograph|-word|sect)
-          | invert|isolat(e|ion)|italic
-          | jis(04|78|83|90)
-          | justify(-all)?
-          | keep-all
-          | large[r]?
-          | last|left|letter-spacing
-          | light(e[nr]|ing-color)
-          | line(-edge|-height|-through)?
-          | linear(-gradient|RGB)?
-          | lining-nums|list-item|local|loose
-          | lower(-alpha|-greek|-latin|-roman|case)
-          | lr-tb|ltr|lumin(osity|ance)|manual
-          | margin(-bottom|-box|-left|-right|-top)?
-          | marker(-offset|s)?
-          | mathematical
-          | matrix(3d)?
-          | max-(content|height|lines|size|width)
-          | medium|middle
-          | min-(content|height|width)
-          | miter|mixed|move|multiply|newspaper
-          | no-(change|clip|(close|open)-quote|(common|discretionary|historical)-ligatures|contextual|drop|repeat)
-          | none|nonzero|normal|not-allowed|nowrap|oblique
-          | offset(-after|-before|-end|-start)?
-          | oldstyle-nums|opacity|open-quote
-          | optimize(Legibility|Precision|Quality|Speed)
-          | order|ordinal|ornaments
-          | outline(-color|-offset|-width)?
-          | outset|outside|over(line|-edge|lay)
-          | padding(-bottom|-box|-left|-right|-top)?
-          | page|painted|paused
-          | perspective(-origin)?
-          | petite-caps|pixelated|pointer
-          | pre(-line|-wrap)?
-          | preserve-3d
-          | progid:DXImageTransform.Microsoft.(Alpha|Blur|dropshadow|gradient|Shadow)
-          | progress
-          | proportional-(nums|width)
-          | radial-gradient|recto|region|relative
-          | repeat(-[xy])?
-          | repeating-(linear|radial)-gradient
-          | replaced|reset-size|reverse|ridge|right
-          | (rotate|scale|translate)(3d|X|Y|Z)?
-          | round
-          | row(-resize|-reverse)?
-          | rtl|ruby|running|saturat(e|ion)|screen
-          | scroll(-position|bar)?
-          | separate|sepia
-          | shape-(image-threshold|margin|outside)
-          | show
-          | sideways(-lr|-rl)?
-          | simplified
-          | skew[XY]?
-          | slashed-zero|slice
-          | small(-caps|er)?
-          | smooth|snap|solid|soft-light
-          | space(-around|-between)?
-          | span|square|sRGB
-          | stack(ed-fractions)?
-          | start(ColorStr)?
-          | static
-          | step-(end|start)
-          | sticky
-          | stop-(color|opacity)
-          | stretch|strict
-          | stroke(-box|-dash(array|offset)|-miterlimit|-opacity|-width)?
-          | style(set)?
-          | stylistic
-          | sub(grid|pixel-antialiased|tract)?
-          | super|swash
-          | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
-          | tabular-nums|tb-rl
-          | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under)-edge|-shadow|-size(-adjust)?|-top)|field)?
-          | thi(ck|n)
-          | titling-ca(ps|se)
-          | to[p]?
-          | touch|traditional
-          | transform(-origin)?
-          | under(-edge|line)?
-          | unicase|unset
-          | upper(-alpha|-latin|-roman|case)
-          | upright
-          | use-(glyph-orientation|script)
-          | verso
-          | vertical(-align|-ideographic|-lr|-rl|-text)?
-          | view-box
-          | viewport-fill(-opacity)?
-          | visibility
-          | visible(Fill|Painted|Stroke)?
-          | wait|wavy|weight|whitespace|width|word-spacing
-          | wrap(-reverse)?
-          | x{1,2}-(large|small)
-          | z-index|zero
-          | zoom(-in|-out)?
-        )\b
-      scope: support.constant.property-value.css
-      # can be either keywords or functions, therefore slightly more strict matching
-    - match: \b(circle|ellipse|inset)(?!\()\b
+            (?x)\b(
+                absolute|active|add
+              | all(-(petite|small)-caps|-scroll)?
+              | alpha(betic)?
+              | alternate(-reverse)?
+              | always|annotation|antialiased|at
+              | auto(hiding-scrollbar)?
+              | avoid(-column|-page|-region)?
+              | background(-color|-image|-position|-size)?
+              | backwards|balance|baseline|below|bevel|bicubic|bidi-override|blink
+              | block(-line-height)?
+              | blur
+              | bold(er)?
+              | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
+              | border-(bottom|top)-(left|right)-radius
+              | border-image(-outset|-repeat|-slice|-source|-width)?
+              | border(-bottom|-left|-right|-top|-collapse|-spacing)?
+              | both|bottom
+              | box(-shadow)?
+              | break-(all|word)
+              | brightness
+              | butt(on)?
+              | capitalize
+              | cent(er|ral)
+              | char(acter-variant)?
+              | cjk-ideographic|clip|clone|close-quote
+              | closest-(corner|side)
+              | col-resize|collapse
+              | color(-stop|-burn|-dodge)?
+              | column((-count|-gap|-reverse|-rule(-color|-width)?|-width)|s)?
+              | common-ligatures|condensed|consider-shifts|contain
+              | content(-box|s)?
+              | contextual|contrast|cover
+              | crisp(-e|E)dges
+              | crop
+              | cross(hair)?
+              | da(rken|shed)
+              | default|dense|diagonal-fractions|difference|disabled
+              | discretionary-ligatures|disregard-shifts
+              | distribute(-all-lines|-letter|-space)?
+              | dotted|double|drop-shadow
+              | (nwse|nesw|ns|ew|sw|se|nw|ne|w|s|e|n)-resize
+              | ease(-in-out|-in|-out)?
+              | element|ellipsis|embed|end|EndColorStr|evenodd
+              | exclu(de(-ruby)?|sion)
+              | expanded
+              | (extra|semi|ultra)-(condensed|expanded)
+              | farthest-(corner|side)?
+              | fill(-box|-opacity)?
+              | filter|fixed|flat
+              | flex((-basis|-end|-grow|-shrink|-start)|box)?
+              | flip|flood-color
+              | font(-size(-adjust)?|-stretch|-weight)?
+              | forwards
+              | from(-image)?
+              | full-width|geometricPrecision|glyphs|gradient|grayscale
+              | grid(-height)?
+              | groove|hand|hanging|hard-light|height|help|hidden|hide
+              | historical-(forms|ligatures)
+              | horizontal(-tb)?
+              | hue
+              | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
+              | inactive|include-ruby|infinite|inherit|initial
+              | inline(-block|-box|-flex(box)?|-line-height|-table)?
+              | inside
+              | inter(-ideograph|-word|sect)
+              | invert|isolat(e|ion)|italic
+              | jis(04|78|83|90)
+              | justify(-all)?
+              | keep-all
+              | large[r]?
+              | last|left|letter-spacing
+              | light(e[nr]|ing-color)
+              | line(-edge|-height|-through)?
+              | linear(-gradient|RGB)?
+              | lining-nums|list-item|local|loose|lowercase|lr-tb|ltr
+              | lumin(osity|ance)|manual
+              | margin(-bottom|-box|-left|-right|-top)?
+              | marker(-offset|s)?
+              | mathematical
+              | max-(content|height|lines|size|width)
+              | medium|middle
+              | min-(content|height|width)
+              | miter|mixed|move|multiply|newspaper
+              | no-(change|clip|(close|open)-quote|(common|discretionary|historical)-ligatures|contextual|drop|repeat)
+              | none|nonzero|normal|not-allowed|nowrap|oblique
+              | offset(-after|-before|-end|-start)?
+              | oldstyle-nums|opacity|open-quote
+              | optimize(Legibility|Precision|Quality|Speed)
+              | order|ordinal|ornaments
+              | outline(-color|-offset|-width)?
+              | outset|outside|over(line|-edge|lay)
+              | padding(-bottom|-box|-left|-right|-top)?
+              | page|painted|paused
+              | perspective-origin
+              | petite-caps|pixelated|pointer
+              | pre(-line|-wrap)?
+              | preserve-3d
+              | progid:DXImageTransform.Microsoft.(Alpha|Blur|dropshadow|gradient|Shadow)
+              | progress
+              | proportional-(nums|width)
+              | radial-gradient|recto|region|relative
+              | repeat(-[xy])?
+              | repeating-(linear|radial)-gradient
+              | replaced|reset-size|reverse|ridge|right
+              | round
+              | row(-resize|-reverse)?
+              | rtl|ruby|running|saturat(e|ion)|screen
+              | scroll(-position|bar)?
+              | separate|sepia
+              | shape-(image-threshold|margin|outside)
+              | show
+              | sideways(-lr|-rl)?
+              | simplified
+              | slashed-zero|slice
+              | small(-caps|er)?
+              | smooth|snap|solid|soft-light
+              | space(-around|-between)?
+              | span|sRGB
+              | stack(ed-fractions)?
+              | start(ColorStr)?
+              | static
+              | step-(end|start)
+              | sticky
+              | stop-(color|opacity)
+              | stretch|strict
+              | stroke(-box|-dash(array|offset)|-miterlimit|-opacity|-width)?
+              | style(set)?
+              | stylistic
+              | sub(grid|pixel-antialiased|tract)?
+              | super|swash
+              | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
+              | tabular-nums|tb-rl
+              | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under)-edge|-shadow|-size(-adjust)?|-top)|field)?
+              | thi(ck|n)
+              | titling-ca(ps|se)
+              | to[p]?
+              | touch|traditional
+              | transform(-origin)?
+              | under(-edge|line)?
+              | unicase|unset|uppercase|upright
+              | use-(glyph-orientation|script)
+              | verso
+              | vertical(-align|-ideographic|-lr|-rl|-text)?
+              | view-box
+              | viewport-fill(-opacity)?
+              | visibility
+              | visible(Fill|Painted|Stroke)?
+              | wait|wavy|weight|whitespace|width|word-spacing
+              | wrap(-reverse)?
+              | x{1,2}-(large|small)
+              | z-index|zero
+              | zoom(-in|-out)?
+              | ({{counter_styles}})
+            )\b
       scope: support.constant.property-value.css
       # Generic Font Families: https://www.w3.org/TR/CSS2/fonts.html
-    - match: (\b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)\b)
+    - match: \b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)\b
       scope: support.constant.font-name.css
+
+  property-values:
+    - include: vendor-prefix
+    - include: builtin-functions
     - include: unicode-range
     - include: numeric-values
     - include: color-values
+    - include: property-value-constants
     - include: literal-string
-    - match: (rect)(\()
-      captures:
-        1: support.function.misc.css
-        2: punctuation.section.function.css
-      push:
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - include: numeric-values
-    - include: cascading-variable
-    - match: (cubic-bezier|steps)(\()
-      captures:
-        1: support.function.timing-function.css
-        2: punctuation.section.function.css
-      push:
-        - meta_scope: support.type.function.easing.css
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: (,)+
-          scope: punctuation.section.function.css
-        - include: numeric-values
-        - match: (end|start)+
-          scope: support.keyword.timing-direction.css
-    - match: (circle|ellipse|inset|polygon)(\()
-      captures:
-        1: support.function.shape.css
-        2: punctuation.section.function.css
-      push:
-        - meta_scope: support.type.shape.definition.css
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - include: numeric-values
-        - match: (,)
-          scope: punctuation.definition.arbitrary-repetition.css
-        - match: |-
-            \b(?x)(
-            at|
-            bottom|
-            center|closest-side|
-            evenodd|
-            farthest-side|
-            left|
-            nonzero|
-            right|round|
-            top)\b
-          scope: support.constant.property-value.css
-    - match: (calc)(\()
-      captures:
-        1: support.function.calc.css
-        2: punctuation.section.function.css
-      push:
-        - meta_scope: support.type.expression.calc.css
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: "[()]"
-          scope: punctuation.section.function.css
-        - include: cascading-variable
-        - include: numeric-values
-        - match: "[-/*+]"
-          scope: punctuation.operator.function.css
-    - match: (attr|counter|counters|cross-fade|format|image-set|image|local|minmax|url)(\()
-      captures:
-        1: support.function.misc.css
-        2: punctuation.section.function.css
-      push:
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: (?:min|max)-content
-          scope: support.constant.property-value.css
-        - include: literal-string
-        - include: numeric-values
-        - include: color-values
-        - match: '[^''") \t]+'
-          scope: variable.parameter.misc.css
     - match: \!\s*important
       scope: keyword.other.important.css
-  repeat-notation:
-    - match: (repeat)(\()
-      captures:
-        1: support.function.misc.css
-        2: punctuation.section.function.css
-      push:
-        - match: (\))
-          captures:
-            1: punctuation.section.function.css
-          pop: true
-        - match: (?:min|max)-content
-          scope: support.constant.property-value.css
-        - include: literal-string
-        - include: numeric-values
-        - match: '[^''") \t]+'
-          scope: variable.parameter.misc.css
+
   rule-list:
     - match: '\{'
       scope: punctuation.section.property-list.css
@@ -657,6 +509,7 @@ contexts:
         - match: '(?=\s*\})'
           pop: true
         - include: rule-list-body
+
   rule-list-body:
     - include: comment-block
     - match: "(?=[-a-z])"
@@ -673,14 +526,7 @@ contexts:
             - meta_scope: invalid.deprecated.custom-property.css
             - match: \b
               pop: true
-        - match: "(?i)(--)([_a-z]+[_a-z0-9-]*)"
-          captures:
-            1: keyword.other.custom-property.prefix.css
-            2: support.type.custom-property.name.css
-          push:
-            - meta_scope: support.type.custom-property.css
-            - match: \b
-              pop: true
+        - include: custom-property-name
         - match: |-
             \b(?x)(
                 align(-content|-items|-self)?
@@ -777,6 +623,7 @@ contexts:
             1: punctuation.terminator.rule.css
           pop: true
         - include: property-values
+
   selector:
     - match: '\s*(?=[:.*#a-zA-Z\[])'
       push:
@@ -882,11 +729,9 @@ contexts:
           captures:
             1: entity.other.attribute-name.pseudo-class.css
             2: punctuation.definition.entity.css
-            3: punctuation.section.function.css
+            3: punctuation.definition.group.begin.css
           push:
-            - match: \)
-              scope: punctuation.section.function.css
-              pop: true
+            - include: function-notation-terminator
             - include: selector
         - match: ((:)nth-(?:(?:last-)?child|(?:last-)?of-type))(\()(\-?(?:\d+n?|n)(?:\+\d+)?|even|odd)(\))
           captures:
@@ -901,12 +746,8 @@ contexts:
           scope: punctuation.definition.entity.css
           push:
             - meta_scope: meta.attribute-selector.css
-            - match: '(?:(-?[_a-z][_a-z0-9-]*)|(\*))?([|])(?!=)'
-              captures:
-                1: entity.other.namespace-prefix.css
-                2: entity.name.namespace.wildcard.css
-                3: punctuation.separator.namespace.css
-            - match: '[^\\ =<>`~*|^$\]\[]+'
+            - include: qualified-name
+            - match: '({{ident}})'
               scope: entity.other.attribute-name.css
             - match: '\s*([~*|^$]?=)\s*'
               captures:
@@ -923,6 +764,888 @@ contexts:
             - match: '\]'
               scope: punctuation.definition.entity.css
               pop: true
+
+  builtin-functions:
+    - include: attr-function
+    - include: calc-function
+    - include: cross-fade-function
+    - include: filter-functions
+    - include: gradient-functions
+    - include: image-function
+    - include: image-set-function
+    - include: minmax-function
+    - include: url-function
+    - include: var-function
+    - include: color-adjuster-functions
+
+      # filter()
+      # https://drafts.fxtf.org/filters/#funcdef-filter
+    - match: '\b(filter)(?=\()'
+      scope: support.function.filter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: image-type
+          - include: literal-string
+          - include: filter-functions
+
+      # counter()
+      # https://drafts.csswg.org/css-lists-3/#funcdef-counter
+    - match: '\b(counter)(?=\()'
+      scope: support.function.counter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '({{ident}})'
+            scope: entity.other.counter-name.css string.unquoted.css
+          - match: '(?=,)'
+            push:
+              - match: '(?=\))'
+                pop: true
+              - include: comma-delimiter
+              - match: '\b({{counter_styles}}|none)\b'
+                scope: support.constant.property-value.counter-style.css
+
+      # counters()
+      # https://drafts.csswg.org/css-lists-3/#funcdef-counters
+    - match: '\b(counters)(?=\()'
+      scope: support.function.counter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '({{ident}})'
+            scope: entity.other.counter-name.css string.unquoted.css
+          - match: '(?=,)'
+            push:
+              - match: '(?=\))'
+                pop: true
+              - include: comma-delimiter
+              - include: literal-string
+              - match: '\b({{counter_styles}}|none)\b'
+                scope: support.constant.property-value.counter-style.css
+
+      # format()
+      # https://drafts.csswg.org/css-fonts-3/#descdef-src
+      # format() is also mentioned in `issue 2` at https://drafts.csswg.org/css-images-3/#issues-index
+      # but does not seem to be implemented in any manner
+    - match: '\b(format)(?=\()'
+      scope: support.function.font-face.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: literal-string
+
+      # local()
+      # https://drafts.csswg.org/css-fonts-3/#descdef-src
+    - match: '\b(local)(?=\()'
+      scope: support.function.font-face.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: unquoted-string
+
+      # Transform Functions
+      # https://www.w3.org/TR/css-transforms-1/#transform-functions
+
+      # transform functions with comma separated <number> types
+      # matrix(), scale(), matrix3d(), scale3d()
+    - match: '\b(matrix3d|scale3d|matrix|scale)(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: number-type
+
+      # transform functions with comma separated <number> or <length> types
+      # translate(), translate3d()
+    - match: '\b(translate(3d)?)(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: length-type
+          - include: number-type
+
+      # transform functions with a single <number> or <length> type
+      # translateX(), translateY()
+    - match: '\b(translate[XY])(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: length-type
+          - include: number-type
+
+      # transform functions with a single <angle> type
+      # rotate(), skewX(), skewY(), rotateX(), rotateY(), rotateZ()
+    - match: '\b(rotate[XYZ]?|skew[XY])(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: angle-type
+
+      # transform functions with comma separated <angle> types
+      # skew()
+    - match: '\b(skew)(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: angle-type
+
+      # transform functions with a single <length> type
+      # translateZ(), perspective()
+    - match: '\b(translateZ|perspective)(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: length-type
+
+      # transform functions with a comma separated <number> or <angle> types
+      # rotate3d()
+    - match: '\b(rotate3d)(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: angle-type
+          - include: number-type
+
+      # transform functions with a single <number> type
+      # scaleX(), scaleY(), scaleZ()
+    - match: '\b(scale[XYZ])(?=\()'
+      scope: support.function.transform.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: number-type
+
+      # Timing Functions
+      # https://www.w3.org/TR/web-animations-1/#timing-functions
+
+      # cubic-bezier()
+      # https://www.w3.org/TR/web-animations-1/#cubic-bzier-timing-function
+    - match: '\b(cubic-bezier)(?=\()'
+      scope: support.function.timing.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: number-type
+
+      # steps()
+      # https://www.w3.org/TR/web-animations-1/#step-timing-function
+    - match: '\b(steps)(?=\()'
+      scope: support.function.timing.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: integer-type
+          - match: (end|middle|start)
+            scope: support.keyword.timing-direction.css
+
+      # Shape Functions
+      # https://www.w3.org/TR/css-shapes-1/#typedef-basic-shape
+
+      # rect() - Deprecated
+      # https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect
+    - match: '\b(rect)(?=\()'
+      scope: support.function.shape.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: \bauto\b
+            scope: support.constant.property-value.css
+          - include: length-type
+
+      # inset()
+      # https://www.w3.org/TR/css-shapes-1/#funcdef-inset
+    - match: '\b(inset)(?=\()'
+      scope: support.function.shape.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '\bround\b'
+            scope: keyword.other.css
+          - include: length-type
+          - include: percentage-type
+
+      # circle()
+      # https://www.w3.org/TR/css-shapes-1/#funcdef-circle
+      # ellipse()
+      # https://www.w3.org/TR/css-shapes-1/#funcdef-ellipse
+    - match: '\b(circle|ellipse)(?=\()'
+      scope: support.function.shape.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '\bat\b'
+            scope: keyword.other.css
+          - match: '\b(top|right|bottom|left|center|closest-side|farthest-side)\b'
+            scope: support.constant.property-value.css
+          - include: length-type
+          - include: percentage-type
+
+      # polygon()
+      # https://www.w3.org/TR/css-shapes-1/#funcdef-polygon
+    - match: '\b(polygon)(?=\()'
+      scope: support.function.shape.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '\b(nonzero|evenodd)\b'
+            scope: support.constant.property-value.css
+          - include: length-type
+          - include: percentage-type
+
+      # toggle()
+      # https://www.w3.org/TR/css3-values/#toggle-notation
+    - match: '\b(toggle)(?=\()'
+      scope: support.function.toggle.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: vendor-prefix
+          - include: property-value-constants
+          - include: numeric-values
+          - include: color-values
+          - include: literal-string
+
+      # repeat()
+      # https://drafts.csswg.org/css-grid/#funcdef-repeat
+    - match: '\b(repeat)(?=\()'
+      scope: support.function.grid.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: length-type
+          - include: percentage-type
+          - include: minmax-function
+          - include: integer-type
+          - match: \b(auto-fill|auto-fit)\b
+            scope: support.keyword.repetitions.css
+          - match: \b(max-content|min-content|auto)\b
+            scope: support.constant.property-value.css
+
+  # var()
+  # https://drafts.csswg.org/css-variables/#funcdef-var
+  var-function:
+    - match: '\b(var)(?=\()'
+      scope: support.function.var.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: custom-property-name
+
+  # Filter Functions
+  # https://drafts.fxtf.org/filters/#typedef-filter-function
+  filter-functions:
+      # blur()
+      # https://drafts.fxtf.org/filters/#funcdef-filter-blur
+    - match: '\b(blur)(?=\()'
+      scope: support.function.filter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: length-type
+
+      # brightness(), contrast(), grayscale(), invert(), opacity(), saturate(), sepia()
+      # https://drafts.fxtf.org/filters/#funcdef-filter-brightness
+    - match: '\b(brightness|contrast|grayscale|invert|opacity|saturate|sepia)(?=\()'
+      scope: support.function.filter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: percentage-type
+          - include: number-type
+
+      # drop-shadow()
+      # https://drafts.fxtf.org/filters/#funcdef-filter-drop-shadow
+    - match: '\b(drop-shadow)(?=\()'
+      scope: support.function.filter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: length-type
+          - include: color-values
+
+      # hue-rotate()
+      # https://drafts.fxtf.org/filters/#funcdef-filter-hue-rotate
+    - match: '\b(hue-rotate)(?=\()'
+      scope: support.function.filter.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: angle-type
+
+  # calc()
+  # https://www.w3.org/TR/css3-values/#funcdef-calc
+  calc-function:
+    - match: '\b(calc)(?=\()'
+      scope: support.function.calc.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: calc-function
+          - include: var-function
+          - include: numeric-values
+          - include: attr-function
+          - match: "[-/*+]"
+            scope: keyword.operator.css
+
+  # attr()
+  # https://www.w3.org/TR/css3-values/#funcdef-attr
+  attr-function:
+    - match: '\b(attr)(?=\()'
+      scope: support.function.attr.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: qualified-name
+          - include: literal-string
+          - match: '({{ident}})'
+            scope: entity.other.attribute-name.css
+            push:
+            - match: |-
+                (?x)\b(
+                    {{font_relative_lengths}}
+                  | {{viewport_percentage_lengths}}
+                  | {{absolute_lengths}}
+                  | {{angle_units}}
+                  | {{duration_units}}
+                  | {{frequency_units}}
+                  | {{resolution_units}}
+                )\b
+              scope: keyword.other.unit.css
+            - match: '(?=\))'
+              pop: true
+            - include: comma-delimiter
+            - include: property-value-constants
+            - include: numeric-values
+            - include: color-values
+
+  # url()
+  # https://drafts.csswg.org/css-images-3/#url-notation
+  url-function:
+    - match: '\b(url)(?=\()'
+      scope: support.function.url.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: literal-string
+          - include: unquoted-string
+
+  # image()
+  # https://drafts.csswg.org/css-images-3/#funcdef-image
+  image-function:
+    - match: '\b(image)(?=\()'
+      scope: support.function.image.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: image-type
+          - include: literal-string
+          - include: color-values
+          - include: comma-delimiter
+          - include: unquoted-string
+
+  # image-set()
+  # https://drafts.csswg.org/css-images-3/#funcdef-image-set
+  image-set-function:
+    - match: '\b(image-set)(?=\()'
+      scope: support.function.image.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: literal-string
+          - include: color-values
+          - include: comma-delimiter
+          - include: resolution-type
+          - include: image-type
+          - match: '[0-9]+(x)'
+            scope: constant.numeric.css
+            captures:
+              1: keyword.other.unit.css
+          - include: unquoted-string
+
+  # Gradient Functions
+  # https://drafts.csswg.org/css-images-3/#gradients
+  gradient-functions:
+      # linear-gradient()
+      # https://drafts.csswg.org/css-images-3/#linear-gradients
+      # repeating-linear-gradient()
+      # https://drafts.csswg.org/css-images-3/#funcdef-repeating-linear-gradient
+    - match: '\b((?:repeating-)?linear-gradient)(?=\()'
+      scope: support.function.gradient.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: angle-type
+          - include: comma-delimiter
+          - include: color-values
+          - include: percentage-type
+          - include: length-type
+          - match: '\bto\b'
+            scope: keyword.other.css
+          - match: \b(top|right|bottom|left)\b
+            scope: support.constant.property-value.css
+
+      # radial-gradient()
+      # https://drafts.csswg.org/css-images-3/#radial-gradients
+      # repeating-radial-gradient()
+      # https://drafts.csswg.org/css-images-3/#funcdef-repeating-radial-gradient
+    - match: '\b((?:repeating-)?radial-gradient)(?=\()'
+      scope: support.function.gradient.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: color-values
+          - include: percentage-type
+          - include: length-type
+          - match: '\b(at|circle|ellipse)\b'
+            scope: keyword.other.css
+          - match: |-
+              (?x)\b(
+                  left
+                | center
+                | right
+                | top
+                | bottom
+                | closest-corner
+                | closest-side
+                | farthest-corner
+                | farthest-side
+              )\b
+            scope: support.constant.property-value.css
+
+  # cross-fade()
+  # https://drafts.csswg.org/css-images-3/#cross-fade-function
+  cross-fade-function:
+    - match: '\b(cross-fade)(?=\()'
+      scope: support.function.image.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: percentage-type
+          - include: color-values
+          - include: image-type
+          - include: literal-string
+          - include: unquoted-string
+
+  # minmax()
+  # https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax
+  minmax-function:
+    - match: '\b(minmax)(?=\()'
+      scope: support.function.grid.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: length-type
+          - match: \b(max-content|min-content)\b
+            scope: support.constant.property-value.css
+
+  # Color Functions
+  # https://drafts.csswg.org/css-color
+  color-functions:
+      # rgb(), rgba()
+      # https://drafts.csswg.org/css-color/#rgb-functions
+    - match: '\b(rgba?)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: percentage-type
+          - include: number-type
+
+      # hsl(), hsla()
+      # https://drafts.csswg.org/css-color/#the-hsl-notation
+      # hwb() - Not yet implemented by browsers
+      # https://drafts.csswg.org/css-color/#funcdef-hwb
+    - match: '\b(hsla?|hwb)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: angle-type
+          - include: percentage-type
+          - include: number-type
+
+      # gray() - Not yet implemented by browsers
+      # https://drafts.csswg.org/css-color/#funcdef-gray
+    - match: '\b(gray)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: percentage-type
+          - include: number-type
+
+      # device-cmyk() - Not yet implemented by browsers
+      # https://drafts.csswg.org/css-color/#funcdef-device-cmyk
+    - match: '\b(device-cmyk)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: color-adjuster-functions # must be included before `color-values`
+          - include: color-values
+          - include: percentage-type
+          - include: number-type
+
+      # color-mod() - Not yet implemented by browsers
+      # https://drafts.csswg.org/css-color/#funcdef-color-mod
+    - match: '\b(color)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: comma-delimiter
+          - include: color-adjuster-functions # must be included before `color-values`
+          - include: color-values
+          - include: angle-type
+          - include: number-type
+
+  # Color Adjuster Functions - Not yet implemented by browsers
+  # https://drafts.csswg.org/css-color/#typedef-color-adjuster
+  color-adjuster-functions:
+      # red(), green(), blue(), alpha() - Not yet implemented by browsers
+    - match: '\b(red|green|blue|alpha|a)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: color-adjuster-operators
+          - include: percentage-type
+          - include: number-type
+
+      # hue() - Not yet implemented by browsers
+    - match: '\b(hue|h)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: color-adjuster-operators
+          - include: angle-type
+
+      # saturation(), lightness(), whiteness(), blackness() - Not yet implemented by browsers
+    - match: '\b(saturation|lightness|whiteness|blackness|[slwb])(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: color-adjuster-operators
+          - include: percentage-type
+
+      # tint(), shade(), contrast() - Not yet implemented by browsers
+      # contrast() interferes with the contrast() filter function;
+      # therefore, it is not yet implemented here
+    - match: '\b(tint|shade)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: percentage-type
+
+      # blend(), blenda() - Not yet implemented by browsers
+    - match: '\b(blenda|blend)(?=\()'
+      scope: support.function.color.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: '\b(rgb|hsl|hwb)\b'
+            scope: keyword.other.color-space.css
+          - include: color-values
+          - include: percentage-type
+
   unicode-range:
     - match: |-
         (?xi)
@@ -934,14 +1657,52 @@ contexts:
         1: support.constant.unicode-range.prefix.css
         2: constant.codepoint-range.css
         3: punctuation.section.range.css
+
+  # Qualified Name
+  # https://drafts.csswg.org/css-namespaces-3/#css-qnames
+  qualified-name:
+    - match: '(?:({{ident}})|(\*))?([|])(?!=)'
+      captures:
+        1: entity.other.namespace-prefix.css
+        2: entity.name.namespace.wildcard.css
+        3: punctuation.separator.namespace.css
+
+  # Custom Properties
+  # https://drafts.csswg.org/css-variables/#typedef-custom-property-name
+  custom-property-name:
+    - match: '(--)({{ident}})'
+      scope: support.type.custom-property.css
+      captures:
+        1: punctuation.definition.custom-property.css
+        2: support.type.custom-property.name.css
+
+  color-adjuster-operators:
+    - match: '[\-\+*](?=\s+)'
+      scope: keyword.operator.css
+
+  comma-delimiter:
+    - match: '\s*(,)\s*'
+      captures:
+        1: punctuation.separator.css
+
   vendor-prefix:
     - match: "-(?:webkit|moz|ms|o)-"
       scope: support.type.vendor-prefix.css
+
+  function-notation-terminator:
+    - match: '\)'
+      scope: meta.group.css punctuation.definition.group.end.css
+      pop: true
+
   at-rule-punctuation:
     - match: \;
       scope: punctuation.terminator.rule.css
     - match: (?=;|$)
       pop: true
+
+  unquoted-string:
+    - match: '[^\s''"]'
+      scope: string.unquoted.css
 
   literal-string:
     - match: "'"
@@ -970,3 +1731,70 @@ contexts:
       scope: constant.character.escape.newline.css
     - match: '\\(\h{1,6}|.)'
       scope: constant.character.escape.css
+
+  # https://www.w3.org/TR/css3-values/#numeric-types
+  numeric-values:
+    - include: dimensions
+    - include: percentage-type
+    - include: number-type
+
+  integer-type:
+    - match: '{{integer}}'
+      scope: constant.numeric.css
+
+  # Make sure `number-type` is included after any other numeric values
+  # as `number-type` will consume all numeric values.
+  number-type:
+    - match: '{{number}}'
+      scope: constant.numeric.css
+
+  percentage-type:
+    - match: '{{number}}(%)'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  dimensions:
+    - include: angle-type
+    - include: frequency-type
+    - include: length-type
+    - include: resolution-type
+    - include: time-type
+
+  length-type:
+    - match: '{{number}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})\b'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  time-type:
+    - match: '{{number}}({{duration_units}})\b'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  frequency-type:
+    - match: '{{number}}({{frequency_units}})\b'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  resolution-type:
+    - match: '{{number}}({{resolution_units}})\b'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  angle-type:
+    - match: '{{number}}({{angle_units}})\b'
+      scope: constant.numeric.css
+      captures:
+        1: keyword.other.unit.css
+
+  # https://drafts.csswg.org/css-images-3/#typedef-image
+  image-type:
+    - include: cross-fade-function
+    - include: gradient-functions
+    - include: image-function
+    - include: image-set-function
+    - include: url-function

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -23,7 +23,11 @@
 /*          ^ punctuation.terminator.rule.css      */
 
     top: cubic-bezier(0.2, 0, 0.13, 2);
-/*                       ^ punctuation.section.function.css */
+/*                       ^ punctuation.separator.css*/
+
+    top: url("image");
+/*          ^         punctuation.definition.group.begin.css */
+/*                  ^ punctuation.definition.group.end.css */
 }
 /* < punctuation.section.property-list.css */
 
@@ -87,7 +91,7 @@
 /*        ^^^^^^^ constant.numeric.css */
 
     0%, to {}
-/*  ^^     constant.numeric.css */
+/*  ^^     constant.numeric.css          */
 /*      ^^ keyword.keyframe-selector.css */
 }
 
@@ -96,17 +100,18 @@
 /*   ^^^^^^^^^ keyword.control.at-rule.font-face.css */
 
 .test-var { --test-var: arial; }
-/*          ^^^^^^^^^^ support.type.custom-property.css         */
-/*          ^^         keyword.other.custom-property.prefix.css */
-/*            ^^^^^^^^ support.type.custom-property.name.css    */
+/*          ^^^^^^^^^^ support.type.custom-property.css       */
+/*          ^^         punctuation.definition.custom-property */
+/*            ^^^^^^^^ support.type.custom-property.name.css  */
 
-.test-var { font: var(--a-b); }
-/*                ^^^        support.function.var.css                         */
-/*                   ^       punctuation.section.function.css                 */
-/*                   ^^^^^^^ support.type.cascading-variable.css              */
-/*                    ^^     support.constant.custom-property-name.prefix.css */
-/*                      ^^^  support.type.variable-name.css                   */
-/*                         ^ punctuation.section.function.css                 */
+.test-types {
+    top: 20;
+/*       ^^ constant.numeric.css */
+    top: +.95e-20;
+/*       ^^^^^^^^ constant.numeric.css */
+    top: -1.5e+93%;
+/*       ^^^^^^^^^ constant.numeric.css */
+}
 
 .test-units {
     top: 1px;
@@ -129,31 +134,24 @@
 /*                         ^^^ meta.property-value.css */
 }
 
-.test-functions {
-    background-image: url("image");
-/*                    ^^^          support.function.misc.css        */
-/*                       ^         punctuation.section.function.css */
-/*                               ^ punctuation.section.function.css */
-}
-
 .test-operators {
     top: calc(1px + 1px);
-    /*            ^ punctuation.operator.function */
+    /*            ^ keyword.operator.css */
     top: calc(1px - 1px);
-    /*            ^ punctuation.operator.function */
+    /*            ^ keyword.operator.css */
     top: calc(1px / 1px);
-    /*            ^ punctuation.operator.function */
+    /*            ^ keyword.operator.css */
     top: calc(1px * 1px);
-    /*            ^ punctuation.operator.function */
+    /*            ^ keyword.operator.css */
 
     top: calc(1px+1px);
-    /*           ^ -punctuation.operator.function */
+    /*           ^ -keyword.operator.css */
     top: calc(1px-1px);
-    /*           ^ -punctuation.operator.function */
+    /*           ^ -keyword.operator.css */
     top: calc(1px/1px);
-    /*           ^ punctuation.operator.function */
+    /*           ^ keyword.operator.css */
     top: calc(1px*1px);
-    /*           ^ punctuation.operator.function */
+    /*           ^ keyword.operator.css */
 }
 
 .test-important {
@@ -174,7 +172,7 @@
 /*                    ^^^^^ entity.other.attribute-name.pseudo-element.css */
 
 .test-unicode { top: "\2764 \273e"; }
-/*                    ^^^^^ constant.character.escape.css */
+/*                    ^^^^^       constant.character.escape.css */
 /*                          ^^^^^ constant.character.escape.css */
 
 .test-unicode-range {
@@ -215,7 +213,7 @@
 /*                                                                     ^^ keyword.operator.attribute-selector.css */
 
 .test-attribute-selectors-whitespace[a = ""] {}
-/*                                   ^ entity.other.attribute-name.css */
+/*                                   ^   entity.other.attribute-name.css         */
 /*                                     ^ keyword.operator.attribute-selector.css */
 
 .test-attribute-selectors-flags[a="" i] {}
@@ -267,50 +265,366 @@
 
     color: #137;
 /*         ^ constant.other.color.rgb-value.css */
+}
 
-    color: rgb(255, 99, 99);
-/*         ^^^             support.function.misc.css          */
-/*             ^^^         constant.other.color.rgb-value.css */
-/*                ^        meta.property-value.css            */
-/*                  ^^     constant.other.color.rgb-value.css */
-/*                    ^    meta.property-value.css            */
-/*                      ^^ constant.other.color.rgb-value.css */
+.test-function-meta {
+    top: filter(param1, 20px);
+/*       ^^^^^^^^^^^^^^^^^^^^ meta.function-call.css */
+/*             ^^^^^^^^^^^^^^ meta.group.css         */
+}
 
-    color: rgba(255, 99, 99, 0.25);
-/*         ^^^^                   support.function.misc.css          */
-/*              ^^^               constant.other.color.rgb-value.css */
-/*                 ^              meta.property-value.css            */
-/*                   ^^           constant.other.color.rgb-value.css */
-/*                     ^          meta.property-value.css            */
-/*                       ^^       constant.other.color.rgb-value.css */
-/*                         ^      meta.property-value.css            */
-/*                           ^^^^ constant.other.color.rgb-value.css */
+.test-color-functions {
+    top: rgb(1, 4.5%);
+/*       ^^^         support.function.color.css */
+/*           ^       constant.numeric.css       */
+/*            ^      punctuation.separator.css  */
+/*              ^^^^ constant.numeric.css       */
 
-    color: rgb(255, 255, 255);
-/*             ^^^           constant.other.color.rgb-value.css */
-/*                  ^^^      constant.other.color.rgb-value.css */
-/*                       ^^^ constant.other.color.rgb-value.css */
+    top: rgba();
+/*       ^^^^ support.function.color.css */
 
-    color: rgba(66%, 66%, 66%, 0.22);
-/*         ^ support.function.misc.css */
-/*              ^ constant.other.color.rgb-percentage.css */
+    top: hsl(1deg, 4.5%);
+/*       ^^^            support.function.color.css */
+/*           ^^^^       constant.numeric.css       */
+/*               ^      punctuation.separator.css  */
+/*                 ^^^^ constant.numeric.css       */
 
-    color: hsl(3.4e-2, 0%, 100%);
-/*         ^ support.function.misc.css */
-/*             ^ constant.other.color.hsl-value.css */
+    top: hsla();
+/*       ^^^^ support.function.color.css */
 
-    color: hsla(120, 50%, 50%, .77);
-/*         ^ support.function.misc.css */
-/*              ^ constant.other.color.hsl-value.css */
+    top: hwb();
+/*       ^^^ support.function.color.css */
 
-    color: hsla(120, 50%, 50%, .77);
-/*              ^^^                constant.other.color.hsl-value.css */
-/*                 ^               meta.property-value.css            */
-/*                   ^^^           constant.other.color.hsl-value.css */
-/*                      ^          meta.property-value.css            */
-/*                        ^^^      constant.other.color.hsl-value.css */
-/*                           ^     meta.property-value.css            */
-/*                             ^^^ constant.other.color.hsl-value.css */
+
+    top: gray(1, 4.5%);
+/*       ^^^^         support.function.color.css */
+/*            ^       constant.numeric.css       */
+/*             ^      punctuation.separator.css  */
+/*               ^^^^ constant.numeric.css       */
+
+    top: device-cmyk(0.5, 1%, red());
+/*       ^^^^^^^^^^^              support.function.color.css */
+/*                   ^^^          constant.numeric.css       */
+/*                      ^         punctuation.separator.css  */
+/*                        ^^      constant.numeric.css       */
+/*                            ^^^ support.function.color.css */
+
+    top: color(w() s());
+/*       ^^^^^       support.function.color.css */
+/*             ^     support.function.color.css */
+/*                 ^ support.function.color.css */
+
+    top: alpha(- 1.5%);
+/*       ^^^^^        support.function.color.css */
+/*             ^      keyword.operator.css       */
+/*               ^^^^ constant.numeric.css       */
+
+    top: h(+ 1.5deg);
+/*       ^          support.function.color.css */
+/*         ^        keyword.operator.css       */
+/*           ^^^^^^ constant.numeric.css       */
+
+    top: w(* 1.5%);
+/*       ^        support.function.color.css */
+/*         ^      keyword.operator.css       */
+/*           ^^^^ constant.numeric.css       */
+
+    top: shade(1.5%);
+/*       ^^^^^      support.function.color.css */
+/*             ^^^^ constant.numeric.css       */
+
+    top: blenda(red 50% hsl);
+/*       ^^^^^^             support.function.color.css                         */
+/*              ^^^         support.constant.color.w3c-standard-color-name.css */
+/*                  ^^^     constant.numeric.css                               */
+/*                      ^^^ keyword.other.color-space.css                      */
+}
+
+.test-transform-functions {
+    top: rotate3d(-1, 2deg);
+/*       ^^^^^^^^          support.function.transform.css */
+/*                ^^       constant.numeric.css           */
+/*                    ^^^^ constant.numeric.css           */
+
+    top: matrix3d(1, 0);
+/*       ^^^^^^^^      support.function.transform.css */
+/*                ^    constant.numeric.css           */
+/*                 ^   punctuation.separator.css      */
+/*                   ^ constant.numeric.css           */
+
+    top: translate3d(1, 2px);
+/*       ^^^^^^^^^^^        support.function.transform.css */
+/*                   ^      constant.numeric.css           */
+/*                    ^     punctuation.separator.css      */
+/*                      ^^^ constant.numeric.css           */
+
+    top: translateY(2px);
+/*       ^^^^^^^^^^     support.function.transform.css */
+/*                  ^^^ constant.numeric.css           */
+
+    top: skewY(1deg);
+/*       ^^^^^      support.function.transform.css */
+/*             ^^^^ constant.numeric.css           */
+
+    top: skew(1deg, 2turn);
+/*       ^^^^             support.function.transform.css */
+/*            ^^^^        constant.numeric.css           */
+/*                ^       punctuation.separator.css      */
+/*                  ^^^^^ constant.numeric.css           */
+
+    top: perspective(17px);
+/*       ^^^^^^^^^^^      support.function.transform.css */
+/*                   ^^^^ constant.numeric.css           */
+
+    top: scaleY(2);
+/*       ^^^^^^   support.function.transform.css */
+/*              ^ constant.numeric.css           */
+
+    top: skewY(1rad) rotate(1turn);
+/*                   ^^^^^^       support.function.transform.css */
+/*                          ^^^^^ constant.numeric.css           */
+}
+
+.test-timing-functions {
+    top: cubic-bezier(0.42, 0, 0.58, 1);
+/*       ^^^^^^^^^^^^      support.function.timing.css */
+/*                    ^^^^ constant.numeric.css        */
+
+    top: steps(020, start);
+/*       ^^^^^          support.function.timing.css            */
+/*             ^^^      constant.numeric.css                   */
+/*                  ^^^^^ support.keyword.timing-direction.css */
+
+    top: steps(1, end);
+/*                ^^^ support.keyword.timing-direction.css */
+
+    top: steps(1, middle);
+/*                ^^^^^^ support.keyword.timing-direction.css */
+}
+
+.test-shape-functions {
+    top: circle(at top 5.5e20em);
+/*       ^^^^^^                 support.function.shape.css          */
+/*              ^^              keyword.other.css                   */
+/*                 ^^^          support.constant.property-value.css */
+/*                     ^^^^^^^^ constant.numeric.css                */
+
+    top: ellipse(at 0%);
+/*       ^^^^^^^       support.function.shape.css */
+/*               ^^    keyword.other.css          */
+/*                  ^^ constant.numeric.css       */
+
+    top: ellipse(closest-side);
+/*               ^^^^^^^^^^^^ support.constant.property-value.css */
+
+    top: inset(1.1px round 50%);
+/*       ^^^^^             support.function.shape.css */
+/*             ^^^^^       constant.numeric.css       */
+/*                   ^^^^^ keyword.other.css          */
+
+    top: rect(auto);
+/*       ^^^^      support.function.shape.css          */
+/*            ^^^^ support.constant.property-value.css */
+
+    top: rect(1px);
+/*            ^^^ constant.numeric.css */
+}
+
+.test-calc-function {
+    top: calc(1.1px + 2rad);
+/*       ^^^^              support.function.calc.css */
+/*            ^^^^^        constant.numeric.css      */
+/*                    ^^^^ constant.numeric.css      */
+
+    top: calc(attr(start, 1) - 1);
+    /*        ^^^^ support.function.attr.css */
+
+    top: calc(calc() * calc());
+/*       ^^^^               support.function.calc.css         */
+/*            ^^^^          support.function.calc.css         */
+/*                   ^      keyword.operator.css */
+/*                     ^^^^ support.function.calc.css         */
+}
+
+.test-toggle-function {
+    top: toggle(5px red preserve-3d);
+/*       ^^^^^^                     support.function.toggle.css                        */
+/*              ^^^                 constant.numeric.css                               */
+/*                  ^^^             support.constant.color.w3c-standard-color-name.css */
+/*                      ^^^^^^^^^^^ support.constant.property-value.css                */
+}
+
+.test-attr-function {
+    top: attr(*|c);
+/*       ^^^^      support.function.attr.css           */
+/*            ^    entity.name.namespace.wildcard.css  */
+/*             ^   punctuation.separator.namespace.css */
+/*              ^  entity.other.attribute-name.css     */
+
+    top: attr(n|size);
+/*            ^      entity.other.namespace-prefix.css */
+/*              ^^^^ entity.other.attribute-name.css   */
+
+    top: attr(size px, auto);
+/*            ^^^^          entity.other.attribute-name.css     */
+/*                 ^^       keyword.other.unit.css              */
+/*                   ^      punctuation.separator.css           */
+/*                     ^^^^ support.constant.property-value.css */
+
+    top: attr(preserve-3d);
+/*            ^^^^^^^^^^^ entity.other.attribute-name.css */
+}
+
+.test-url-function {
+    top: url("a");
+/*       ^^^     support.function.url.css */
+/*           ^^^ string.quoted.double.css */
+
+    top: url(a);
+/*           ^ string.unquoted.css */
+}
+
+.test-image-functions {
+    top: image("a");
+/*       ^^^^^     support.function.image.css */
+/*             ^^^ string.quoted.double.css   */
+
+    top: image(a);
+/*             ^ string.unquoted.css */
+
+    top: image("a", rgb(0, 0, 0));
+/*                ^       punctuation.separator.css */
+/*                      ^ constant.numeric.css      */
+
+    top: image-set("a" 1x, a 4dpi);
+/*                 ^^^            string.quoted.double.css  */
+/*                     ^^         constant.numeric.css      */
+/*                      ^         keyword.other.unit.css    */
+/*                       ^        punctuation.separator.css */
+/*                         ^      string.unquoted.css       */
+/*                           ^^^^ constant.numeric.css      */
+
+    top: cross-fade(50% "a", b);
+/*       ^^^^^^^^^^            support.function.image.css */
+/*                  ^^^        constant.numeric.css       */
+/*                      ^^^    string.quoted.double.css   */
+/*                         ^   punctuation.separator.css  */
+/*                           ^ string.unquoted.css        */
+}
+
+.test-gradient-functions {
+    top: linear-gradient();
+/*       ^^^^^^^^^^^^^^^ support.function.gradient.css */
+
+    top: linear-gradient(45deg, white);
+/*                       ^^^^^        constant.numeric.css                               */
+/*                            ^       punctuation.separator.css                          */
+/*                              ^^^^^ support.constant.color.w3c-standard-color-name.css */
+
+    top: linear-gradient(to top left);
+/*                       ^^          keyword.other.css                   */
+/*                          ^^^      support.constant.property-value.css */
+/*                              ^^^^ support.constant.property-value.css */
+
+    top: linear-gradient(0%, 100%);
+/*                       ^^       constant.numeric.css */
+/*                           ^^^^ constant.numeric.css */
+
+    top: repeating-linear-gradient();
+/*       ^^^^^^^^^^^^^^^^^^^^^^^^^ support.function.gradient.css */
+
+    top: radial-gradient();
+/*       ^^^^^^^^^^^^^^^ support.function.gradient.css */
+
+    top: radial-gradient(circle at top left);
+/*                       ^^^^^^             keyword.other.css                   */
+/*                              ^^          keyword.other.css                   */
+/*                                 ^^^      support.constant.property-value.css */
+/*                                     ^^^^ support.constant.property-value.css */
+
+    top: radial-gradient(red, blue);
+/*                       ^^^  support.constant.color.w3c-standard-color-name.css */
+/*                          ^ punctuation.separator.css                          */
+
+    top: repeating-radial-gradient();
+/*       ^^^^^^^^^^^^^^^^^^^^^^^^^ support.function.gradient.css */
+}
+
+.test-counter-functions {
+    top: counter(name, decimal-leading-zero);
+/*       ^^^^^^^                            support.function.counter.css                      */
+/*               ^^^^                       string.unquoted.css                               */
+/*                   ^                      punctuation.separator.css                         */
+/*                     ^^^^^^^^^^^^^^^^^^^^ support.constant.property-value.counter-style.css */
+
+    top: counters(name, "str", none);
+/*       ^^^^^^^^                   support.function.counter.css                      */
+/*                ^^^^              string.unquoted.css                               */
+/*                    ^             punctuation.separator.css                         */
+/*                      ^^^^^       string.quoted.double.css                          */
+/*                           ^      punctuation.separator.css                         */
+/*                             ^^^^ support.constant.property-value.counter-style.css */
+}
+
+.test-grid-functions {
+    top: repeat(20);
+/*       ^^^^^^    support.function.grid.css */
+/*              ^^ constant.numeric.css      */
+
+    top: repeat(auto-fit, 2fr minmax() 5%);
+/*              ^^^^^^^^                  support.keyword.repetitions.css */
+/*                      ^                 punctuation.separator.css       */
+/*                        ^^^             constant.numeric.css            */
+/*                            ^^^^^^      support.function.grid.css       */
+/*                                     ^^ constant.numeric.css            */
+
+    top: minmax(min-content, 1fr);
+/*       ^^^^^^                  support.function.grid.css           */
+/*              ^^^^^^^^^^^      support.constant.property-value.css */
+/*                         ^     punctuation.separator.css           */
+/*                           ^^^ constant.numeric.css                */
+}
+
+.test-filter-functions {
+    top: filter(url(), blur());
+/*       ^^^^^^             support.function.filter.css */
+/*              ^^^         support.function.url.css    */
+/*                     ^^^^ support.function.filter.css */
+
+    top: blur(1px);
+/*       ^^^^     support.function.filter.css */
+
+    top: sepia(1% 1);
+/*       ^^^^^      support.function.filter.css */
+/*             ^^   constant.numeric.css        */
+/*                ^ constant.numeric.css        */
+
+    top: drop-shadow(1px rgb());
+/*       ^^^^^^^^^^^         support.function.filter.css */
+/*                   ^^^     constant.numeric.css        */
+/*                       ^^^ support.function.color.css  */
+
+    top: hue-rotate(1turn);
+/*       ^^^^^^^^^^       support.function.filter.css */
+/*                  ^^^^^ constant.numeric.css        */
+}
+
+/* Test Font Functions: format() & local() */
+@font-face {
+  src: format("embedded-opentype");
+/*     ^^^^^^                     support.function.font-face.css */
+/*            ^^^^^^^^^^^^^^^^^^^ string.quoted.double.css       */
+
+  src: local(Gentium-Bold);
+/*     ^^^^^              support.function.font-face.css */
+/*           ^^^^^^^^^^^^ string.unquoted.css            */
+}
+
+.test-var-function {
+    top: var(--name);
+/*       ^^^         support.function.var.css                   */
+/*           ^^      punctuation.definition.custom-property.css */
+/*             ^^^^  support.type.custom-property.name.css      */
 }
 
 .test-custom-tags > div > span + cust·m-tÀg > div-cøstom-tag ~ form-Çust😀m-tag.classname:last-child:hover {}


### PR DESCRIPTION
Not all functions were previously supported and those that were implemented were supporting keywords or values that are not compatible as an argument for that function.

For example:

1. the `cubic-bezier()` timing function was matching the keywords `end` & `start` which are only supported by the `steps()` timing function

2. `url()` was matching the property values `min-content` & `max-content` which are only supported by the `repeat()` and `minmax()` functions

---------

This PR changes some existing implementations:

1. **color functions** - `rgb(), rgba(), hsl(), hsla()`

 color function arguments no longer have specific scopes. *ie*: `constant.other.color.hsl-value.css` is now just `constant.numeric.css`. This seems more fitting as the arguments themselves are just numeric values.

2. **hex colors** were moved out of `numeric-values` and into `color-values`

3. **numeric-values** are now implemented in a modular fashion.

 This was necessary to allow for functions to `include` only the types of arguments they need.

--------

Things that need improvement / feedback:

1. Is the approach of including only needed types an improvement over the previous implementation?

 Ideally, all not-allowed arguments for each individual function would be scoped as `invalid` but such an implementation would require extensive work and a lot of duplicate/similar constructs.

 With the changes in this PR, the not-allowed arguments are simply not specifically scoped.

2. Grouping functions by the types of arguments *-VS-* providing a unique scope/meta_scope for each function

 *ie*: `translateX()` & `translateY()` are grouped because they both take a single `<number>` or `<length>` type  argument. This prevents each individual function from having unique scopes/meta_scopes like some of the other functions have, such as `hue-rotate()` which has its name scoped as `support.function.filter.hue-rotate.css` and pushes a `meta_scope` of `support.type.function.filter.css` because it belongs to the `filter` category of functions.

3. Inconsistent function scopes & meta_scopes

4. There are some scopes that are commented with a `TODO` tag that require feedback

--------

This PR adds support for the following functions:

```css
{
any-property: toggle();
background: linear-gradient();
background: radial-gradient();
background: repeating-linear-gradient();
background: repeating-radial-gradient();
color: alpha();
color: blackness();
color: blend();
color: blenda();
color: blue();
color: color-mod();
color: device-cmyk();
color: gray();
color: green();
color: hue();
color: hwb();
color: lightness();
color: red();
color: saturation();
color: shade();
color: tint();
color: whiteness();
filter: blur();
filter: brightness();
filter: contrast();
filter: drop-shadow();
filter: filter();
filter: grayscale();
filter: hue-rotate();
filter: invert();
filter: opacity();
filter: saturate();
filter: sepia();
transform: matrix();
transform: matrix3d();
transform: perspective();
transform: rotate();
transform: rotate3d();
transform: rotateX();
transform: rotateY();
transform: rotateZ();
transform: scale();
transform: scale3d();
transform: scaleX();
transform: scaleY();
transform: scaleZ();
transform: skew();
transform: skewX();
transform: skewY();
transform: translate();
transform: translate3d();
transform: translateX();
transform: translateY();
transform: translateZ();
}
```


----------------------
#### Performance:

`// 35K lines ; 1,427,552 chars ; 1.36MB`

Before:
```
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 214.7ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 212.6ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 212.7ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 212.5ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 213.7ms over 10 runs
```

**Average: 213.24ms**

--------------------

After:
```
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 221.1ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 221.4ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 219.8ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 220.1ms over 10 runs
Syntax "Packages/CSS/CSS.sublime-syntax" took an average of 220.1ms over 10 runs
```
**Average: 220.5ms**