### PR TITLE
[CSS] Use `ident` variable in more places

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -167,8 +167,9 @@ contexts:
         - include: url-function
         - include: media-query-list
 
+  # https://drafts.csswg.org/css-animations/#propdef-animation-name
   keyframe-name:
-    - match: '(?i)\s*[-]?([_\w\-]*)?'
+    - match: '\s*({{ident}})?'
       captures:
         1: entity.other.animation-name.css
       push:
@@ -294,7 +295,7 @@ contexts:
 
 # Namespace At-Rule: https://www.w3.org/TR/css3-namespace/
   namespace:
-    - match: \s*((@)namespace)\s+(\b\S*\b)?
+    - match: '\s*((@)namespace)\s+({{ident}})?'
       captures:
         1: keyword.control.at-rule.namespace.css
         2: punctuation.definition.keyword.css
@@ -518,7 +519,7 @@ contexts:
         - match: "$|(?![-a-z])"
           pop: true
         - include: vendor-prefix
-        - match: '\b(var-)(?i)([_a-z]+[_a-z0-9-]*)'
+        - match: '\b(var-)({{ident}})'
           captures:
             1: keyword.other.custom-property.prefix.css
             2: support.type.custom-property.name.css

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -71,10 +71,12 @@
 /*   ^^^^^^^^^^^^              keyword.control.at-rule.custom-media.css */
 /*                       ^^^^^ support.type.property-name.media.css     */
 
-    @keyframes ellipsis {}
-/*  ^                   punctuation.definition.keyword.css   */
-/*   ^^^^^^^^^          keyword.control.at-rule.keyframe.css */
-/*             ^^^^^^^^ entity.other.animation-name.css      */
+    @keyframes beat, bounce {}
+/*  ^                       punctuation.definition.keyword.css              */
+/*   ^^^^^^^^^              keyword.control.at-rule.keyframe.css            */
+/*             ^^^^         entity.other.animation-name.css                 */
+/*                 ^        punctuation.definition.arbitrary-repetition.css */
+/*                   ^^^^^^ entity.other.animation-name.css                 */
 
 @keyframes test-keyframes-keywords {
     from, to {}


### PR DESCRIPTION
Use the already defined `ident` variable in places where the spec calls for it.