### PR TITLE
[CSS] Improve pseudo class & element matching

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -312,7 +312,7 @@ contexts:
         1: keyword.control.at-rule.page.css
         2: punctuation.definition.keyword.css
         3: punctuation.definition.entity.css
-        4: entity.other.attribute-name.pseudo-class.css
+        4: entity.other.pseudo-class.css
       push:
         - meta_scope: meta.at-rule.page.css
         - match: '\s*(\})'
@@ -655,18 +655,6 @@ contexts:
           scope: punctuation.separator.combinator.css
         - match: '({{combinators}}){2,}'
           scope: invalid.illegal.combinator.css
-        - match: (:)((active|valid)-drop-target)\b
-          scope: entity.other.attribute-name.pseudo-class.drag-and-drop.css
-          captures:
-            1: punctuation.definition.entity.css
-        - match: (:)(checked|enabled|default|disabled|indeterminate|invalid|in-range|optional|out-of-range|placeholder-shown|required|read-only|read-write|user-error|valid)\b
-          scope: entity.other.attribute-name.pseudo-class.ui-state.css
-          captures:
-            1: punctuation.definition.entity.css
-        - match: (:)((nth-(last-)?)?column)\b
-          scope: entity.other.attribute-name.pseudo-class.grid-structural.css
-          captures:
-            1: punctuation.definition.entity.css
         - match: |-
             (?x)(:{1,2})
             (?:after|before|first-letter|first-line|placeholder|selection|
@@ -722,25 +710,7 @@ contexts:
             2: support.type.vendor-prefix.css
             3: support.type.vendor-prefix.css
             4: support.type.vendor-prefix.css
-        - match: (:)(current|(first|last)-child|(first|last|nth|only)-of-type|backdrop|empty|first|future|left|only-child|past|right|root|scope|target|active|any-link|hover|local-link|link|visited|focus)\b
-          scope: entity.other.attribute-name.pseudo-class.css
-          captures:
-            1: punctuation.definition.entity.css
-        - match: ((:)dir|lang|matches|not|nth-(?:last-)?match)(\()
-          captures:
-            1: entity.other.attribute-name.pseudo-class.css
-            2: punctuation.definition.entity.css
-            3: punctuation.definition.group.begin.css
-          push:
-            - include: function-notation-terminator
-            - include: selector
-        - match: ((:)nth-(?:(?:last-)?child|(?:last-)?of-type))(\()(\-?(?:\d+n?|n)(?:\+\d+)?|even|odd)(\))
-          captures:
-            1: entity.other.attribute-name.pseudo-class.css
-            2: punctuation.definition.entity.css
-            3: punctuation.section.function.css
-            4: constant.numeric.css
-            5: punctuation.section.function.css
+        - include: pseudo-classes # pseudo-classes must be included after pseudo-elements
         # Attribute Selectors
         # https://drafts.csswg.org/selectors-4/#attribute-selectors
         - match: '\['
@@ -765,6 +735,90 @@ contexts:
             - match: '\]'
               scope: punctuation.definition.entity.css
               pop: true
+
+  # Pseudo Classes
+  # https://drafts.csswg.org/selectors-4/#pseudo-classes
+  pseudo-classes:
+      # Functional Pseudo Classes
+      # https://drafts.csswg.org/selectors-4/#functional-pseudo-class
+
+      # Functional Pseudo Classes with a single unquoted string
+    - match: '(:)(dir|lang)(?=\()'
+      scope: entity.other.pseudo-class.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: unquoted-string
+
+      # Functional Pseudo Classes with selector list
+    - match: '(:)(matches|not|has)(?=\()'
+      scope: entity.other.pseudo-class.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - include: selector
+
+      # Special :drop() pseudo-class
+    - match: '(:)(drop)(?=\()'
+      scope: entity.other.pseudo-class.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: \b(active|valid|invalid)\b
+            scope: keyword.other.pseudo-class.css
+
+      # Functional Pseudo Classes with `An+B` param
+      # An+B Notation: https://drafts.csswg.org/css-syntax/#anb
+      # nth-last-child(), nth-child(), nth-last-of-type(), nth-of-type()
+    - match: '(:)(nth-last-child|nth-child|nth-last-of-type|nth-of-type)(?=\()'
+      scope: entity.other.pseudo-class.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-notation-terminator
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+          - meta_scope: meta.group.css
+          - match: '(?=\))'
+            pop: true
+          - match: \b(even|odd)\b
+            scope: keyword.other.pseudo-class.css
+          - match: '(?:[-+]?(?:\d+)?(n)(\s*[-+]\s*\d+)?|[-+]?\s*\d+)'
+            scope: constant.numeric.css
+            captures:
+              1: keyword.other.unit.css
+
+      # Regular Pseudo Classes
+    - match: '(:)({{ident}})'
+      scope: entity.other.pseudo-class.css
+      captures:
+        1: punctuation.definition.entity.css
 
   builtin-functions:
     - include: attr-function

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -655,61 +655,7 @@ contexts:
           scope: punctuation.separator.combinator.css
         - match: '({{combinators}}){2,}'
           scope: invalid.illegal.combinator.css
-        - match: |-
-            (?x)(:{1,2})
-            (?:after|before|first-letter|first-line|placeholder|selection|
-
-              (-moz-)(?:
-                button-content|color-swatch|
-                focus-(?:inner|outer)|
-                list-(?:bullet|number)|
-                meter-(?:bar|optimum|sub-optimum|sub-sub-optimum)|
-                number-(?:spin-(?:box|down|up))|
-                page(?:-sequence)?|
-                placeholder|progress-bar|
-                range-(?:progress|thumb|track)|
-                scrolled-page-sequence|selection|
-                tree-(?:cell-text|cell|checkbox|column|drop-feedback|image|
-                  indentation|line|progressmeter|row|separator|twisty)
-              )|
-
-              (-ms-)(?:
-                browse|check|clear|expand|fill(?:-lower|-upper)?|
-                input-placeholder|reveal|thumb|ticks-(?:after|before)|tooltip|
-                track|value
-              )|
-
-              (-webkit-)(?:
-                appearance|autofill|calendar-picker-indicator|clear-button|
-                color-swatch(?:-wrapper)?|
-                datetime-edit(?:-(?:ampm-field|day-field|fields-wrapper|
-                  hour-field|millisecond-field|minute-field|month-field|
-                  second-field|text|week-field|year-field))?|
-                details-marker|file-upload-button|
-                (?:inner|outer)-spin-button|
-                input-(?:list-button|placeholder|speech-button)|
-                keygen-select|
-                media-controls(?:-(?:current-time-display|enclosure|
-                  fullscreen-button|mute-button|overlay-enclosure|panel|
-                  play-button|time-remaining-display|timeline|
-                  toggle-closed-captions-button|volume-slider))?|
-                meter-(?:bar|even-less-good-value|inner-element|optimum-value|
-                  suboptimal-value|suboptimum-value)|
-                progress-(?:bar-value|bar|inner-element|value)|
-                resizer|
-                scrollbar(?:-(?:button|corner|thumb|track-piece|track))?|
-                search-(?:cancel-button|decoration|results-button|results-decoration)|
-                slider-(?:container|runnable-track|thumb)|
-                textfield-decoration-container
-              )
-            )
-            \b
-          scope: entity.other.attribute-name.pseudo-element.css
-          captures:
-            1: punctuation.definition.entity.css
-            2: support.type.vendor-prefix.css
-            3: support.type.vendor-prefix.css
-            4: support.type.vendor-prefix.css
+        - include: pseudo-elements
         - include: pseudo-classes # pseudo-classes must be included after pseudo-elements
         # Attribute Selectors
         # https://drafts.csswg.org/selectors-4/#attribute-selectors
@@ -735,6 +681,20 @@ contexts:
             - match: '\]'
               scope: punctuation.definition.entity.css
               pop: true
+
+  # Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-elements:
+    - match: |-
+        (?x:
+            (:{1,2})(?:before|after|first-line|first-letter) # CSS1 & CSS2 require : or ::
+          | (::)(-(?:moz|ms|webkit)-)?(?:{{ident}}) # CSS3 requires ::
+        )\b
+      scope: entity.other.pseudo-element.css
+      captures:
+        1: punctuation.definition.entity.css
+        2: punctuation.definition.entity.css
+        3: support.type.vendor-prefix.css
 
   # Pseudo Classes
   # https://drafts.csswg.org/selectors-4/#pseudo-classes

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -163,9 +163,34 @@
 /*          ^^^^^^^^^^ keyword.other.important.css */
 }
 
-.test-pseudo-classes:nth-child(2n):hover {}
-/*                   ^^^^^^^^^           entity.other.attribute-name.pseudo-class.css */
-/*                                 ^^^^^ entity.other.attribute-name.pseudo-class.css */
+/* Test Functional Pseudo Class Meta Scopes */
+.test:nth-child(even) {}
+/*   ^^^^^^^^^^^^^^^^ meta.function-call.css                 */
+/*             ^^^^^^ meta.group.css                         */
+/*             ^      punctuation.definition.group.begin.css */
+/*                  ^ punctuation.definition.group.end.css   */
+
+.test-pseudo-classes:nth-child(2):hover {}
+/*                   ^^^^^^^^^          entity.other.pseudo-class.css     */
+/*                             ^        constant.numeric.css              */
+/*                               ^      punctuation.definition.entity.css */
+/*                                ^^^^^ entity.other.pseudo-class.css     */
+
+.test-pseudo-class-numerics:nth-last-of-type(-n+3) {}
+/*                         ^^^^^^^^^^^^^^^^^      entity.other.pseudo-class.css */
+/*                                           ^^^^ constant.numeric.css          */
+
+.test-pseudo-class-keywords:nth-of-type(odd) {}
+/*                         ^^^^^^^^^^^^     entity.other.pseudo-class.css  */
+/*                                      ^^^ keyword.other.pseudo-class.css */
+
+.test-pseudo-class-strings:dir(ltr) {}
+/*                        ^^^^     entity.other.pseudo-class.css */
+/*                             ^^^ string.unquoted.css           */
+
+.test-pseudo-class-tag:not(*) {}
+/*                    ^^^^   entity.other.pseudo-class.css */
+/*                         ^ entity.name.tag.wildcard.css  */
 
 .test-pseudo-elements::before {}
 /*                     ^^^^^^ entity.other.attribute-name.pseudo-element.css */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -193,10 +193,16 @@
 /*                         ^ entity.name.tag.wildcard.css  */
 
 .test-pseudo-elements::before {}
-/*                     ^^^^^^ entity.other.attribute-name.pseudo-element.css */
+/*                   ^^       punctuation.definition.entity.css */
+/*                   ^^^^^^^^ entity.other.pseudo-element.css   */
 
 .test-pseudo-elements:after {}
-/*                    ^^^^^ entity.other.attribute-name.pseudo-element.css */
+/*                   ^      punctuation.definition.entity.css */
+/*                   ^^^^^^ entity.other.pseudo-element.css   */
+
+.test-pseudo-elements::-webkit-slider-runnable-track
+/*                   ^^ punctuation.definition.entity.css                            */
+/*                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.pseudo-element.css */
 
 .test-unicode { top: "\2764 \273e"; }
 /*                    ^^^^^       constant.character.escape.css */


### PR DESCRIPTION
1. pseudo classes & elements are now scoped as `entity.other.pseudo-{class/element}.css` instead of `entity.other.attribute-name.pseudo-{class/element}.css`

2. Functional pseudo-classes are handled uniquely while all others are handled generally. It is no longer necessary to list all pseudo classes in order to match them

I left the functional pseudo-class names scoped as `entity.other.pseudo-class.css` to maintain consistency with other pseudo-classes. They could however be scoped as `support.function.pseudo-class.css` to maintain consistency with other functions.