### PR TITLE
[CSS] Added percentage types to more functions

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -395,7 +395,7 @@ contexts:
               | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
               | inactive|include-ruby|infinite|inherit|initial
               | inline(-block|-box|-flex(box)?|-line-height|-table)?
-              | inside
+              | inset|inside
               | inter(-ideograph|-word|sect)
               | invert|isolat(e|ion)|italic
               | jis(04|78|83|90)
@@ -923,6 +923,7 @@ contexts:
           - match: '(?=\))'
             pop: true
           - include: comma-delimiter
+          - include: percentage-type
           - include: length-type
           - include: number-type
 
@@ -939,6 +940,7 @@ contexts:
           - meta_scope: meta.group.css
           - match: '(?=\))'
             pop: true
+          - include: percentage-type
           - include: length-type
           - include: number-type
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -385,15 +385,19 @@
 /*                 ^   punctuation.separator.css      */
 /*                   ^ constant.numeric.css           */
 
-    top: translate3d(1, 2px);
-/*       ^^^^^^^^^^^        support.function.transform.css */
-/*                   ^      constant.numeric.css           */
-/*                    ^     punctuation.separator.css      */
-/*                      ^^^ constant.numeric.css           */
+    top: translate3d(1, 2px, 3%);
+/*       ^^^^^^^^^^^            support.function.transform.css */
+/*                   ^          constant.numeric.css           */
+/*                    ^         punctuation.separator.css      */
+/*                      ^^^     constant.numeric.css           */
+/*                           ^^ constant.numeric.css           */
 
     top: translateY(2px);
 /*       ^^^^^^^^^^     support.function.transform.css */
 /*                  ^^^ constant.numeric.css           */
+
+    top: translateX(1%);
+/*                  ^^ constant.numeric.css */
 
     top: skewY(1deg);
 /*       ^^^^^      support.function.transform.css */


### PR DESCRIPTION
Browsers support `percentage` values in some functions even though the spec doesn't call for it. I added support for these instances.

I also added the `inset` property value