### PR TITLE
Create For loop using 'auto' as the iterator type

### DIFF
--- a/C++/Snippets/fora.sublime-snippet
+++ b/C++/Snippets/fora.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+    <content><![CDATA[
+for(auto ${2:i} = ${1}.begin(); ${2:i} != ${1}.end(); ${2:i}++)
+{
+    ${3}
+}
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <tabTrigger>fora</tabTrigger>
+    <!-- Optional: Set a scope to limit where the snippet will trigger -->
+    <scope>source.c, source.objc, source.c++, source.objc++</scope>
+    <description>For loop for containers</description>
+</snippet>


### PR DESCRIPTION
I was stuck in between C++03 and C++11 with MS Visual C++10, so I couldn't use the 'for range' for loop and the forv.sublime-snippets was pointless. I could use 'auto' because it is implemented in VC++10 and gcc4.4 which are the main compilers.