### PR TITLE
[Batch] Fix comments

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -35,17 +35,16 @@ contexts:
       scope: keyword.operator.redirection.dosbatch
 
   comments:
-    - match: '(:[+=,;:])'
+    - match: '(:[+=,;: ])'
       scope: punctuation.definition.comment.dosbatch
       push:
         - meta_scope: comment.line.colon.dosbatch
         - match: \n
           pop: true
-      # REM command
-      # https://technet.microsoft.com/en-us/library/bb490986.aspx
-    - match: \b((?i)rem)\s+
-      captures:
-        1: keyword.command.rem.dosbatch
+    # REM command
+    # https://technet.microsoft.com/en-us/library/bb490986.aspx
+    - match: \b(?i)rem\b
+      scope: keyword.command.rem.dosbatch
       push:
         - meta_content_scope: comment.line.rem.dosbatch
         - match: \n

--- a/Batch File/syntax_test_batch_file.bat
+++ b/Batch File/syntax_test_batch_file.bat
@@ -7,6 +7,10 @@
 ::               ^      invalid.illegal.unexpected-character.dosbatch
 ::                    ^ invalid.illegal.unexpected-character.dosbatch
 
+REM
+   not a comment
+:: ^^^^^^^^^^^^^ - comment.line.rem.dosbatch
+
    :: Me too!
 :: ^^         punctuation.definition.comment.dosbatch
 :: ^^^^^^^^^^ comment.line.colon.dosbatch
@@ -21,6 +25,9 @@
 :: ^^         punctuation.definition.comment.dosbatch
 
    :; Me too!
+:: ^^         punctuation.definition.comment.dosbatch
+
+   : Me too!
 :: ^^         punctuation.definition.comment.dosbatch
 
    ECHO "foo"


### PR DESCRIPTION
Fixes
- runaway scoping when REM is immediately followed by a newline
- Incorrect illegal characters within REM (the [docs](https://technet.microsoft.com/en-us/library/bb490986.aspx) say `(|)` are not allowed but the tests I did say otherwise)
- Allow : and a space to start a line comment