### PR TITLE
[IDL] Add support for the Interactive Data Language (IDL)

### DIFF
--- a/IDL/Comments.tmPreferences
+++ b/IDL/Comments.tmPreferences
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.idl</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>; </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/IDL/Completion Rules.tmPreferences
+++ b/IDL/Completion Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>^.*\b(then|end|do|else)$</string>
+		<string>^.*\b(then|do|else|for|while|case|switch|begin|end|function)$</string>
 	</dict>
 </dict>
 </plist>

--- a/IDL/Completion Rules.tmPreferences
+++ b/IDL/Completion Rules.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.idl</string>
+	<key>settings</key>
+	<dict>
+		<key>cancelCompletion</key>
+		<string>^.*\b(then|end|do|else)$</string>
+	</dict>
+</dict>
+</plist>

--- a/IDL/IDL.sublime-syntax
+++ b/IDL/IDL.sublime-syntax
@@ -56,7 +56,7 @@ contexts:
         1: punctuation.definition.comment.idl
     - include: expressions
   expressions:
-    - match: '(?i)((\b0x[0-9a-fA-F]*)|(\b[0-9]+(b|l|ul|u|ll|ull))|(\.[0-9]+|(\b[0-9]+(\.[0-9]*)?))((e|d)-?[0-9]+)?)'
+    - match: '(?i)((\b[0-9]+(b|l|ul|u|ll|ull))|(\.[0-9]+|(\b[0-9]+(\.[0-9]*)?))((e|d)-?[0-9]+)?)'
       scope: constant.numeric.idl
     - match: "(')"
       captures:

--- a/IDL/IDL.sublime-syntax
+++ b/IDL/IDL.sublime-syntax
@@ -239,7 +239,7 @@ contexts:
       push:
         - meta_scope: meta.function-call.procedure.idl
         - include: procedure-call-parameters
-    - match: '(?i){{syspro}}\s*(?:$(?=\n)|(?=\&)|(?=\belse\b))'
+    - match: '(?i){{syspro}}\s*(?:$(?=\n)|(?=\&)|(?=\b{{keyword}}\b))'
       scope: support.function.procedure.idl
     - match: '({{identifier}})\s*(,)'
       captures:

--- a/IDL/IDL.sublime-syntax
+++ b/IDL/IDL.sublime-syntax
@@ -1,0 +1,115 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: IDL
+comment: "IDL Syntax: version 0.1"
+file_extensions:
+  - pro
+scope: source.idl
+contexts:
+  main:
+    - include: statements
+    - match: '(?i)\b(pro|function)\b'
+      scope: meta.function.idl
+      captures:
+        1: keyword.control.idl
+      push:
+        - meta_scope: function.definition.idl
+        - match: '(?i)\b(end)$\n?'
+          captures:
+            1: keyword.control.idl
+          pop: true
+        - match: '(?i)\b(pro|function)\b'
+          scope: invalid.illegal.idl
+        - match: '(?i)(?<=function|pro)\s+(\b[a-zA-Z_:]+::)?\b([a-zA-Z_][a-zA-Z_0-9]*)\b'
+          scope: meta.function.idl
+          captures:
+            1: entity.name.function.scope.idl
+            2: entity.name.function.idl
+          push:
+            - meta_scope: function.parameter-list.idl
+            - match: '(?<!\$)\s*$\n?'
+              pop: true
+            - match: '\$'
+              scope: punctuation.line-continuation.idl
+            - match: ','
+              scope: punctuation.separator.idl
+              push:
+                - meta_scope: function.parameter.idl
+                - match: '\$'
+                  scope: punctuation.line-continuation.idl
+                - match: '\b([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*=)'
+                  pop: true
+                  captures:
+                    1: variable.parameter.idl
+                - match: '\b([a-zA-Z_][a-zA-Z_0-9]*)\b(\s*(=)\s*\b([a-zA-Z_][a-zA-Z_0-9]*)\b)?'
+                  pop: true
+                  captures:
+                    1: variable.parameter.keyword.public.idl
+                    3: keyword.operator.assignment.idl
+                    4: variable.parameter.keyword.private.idl
+        - include: statements
+  statements:
+    - match: '(;).*$\n?'
+      scope: comment.line.idl
+      captures:
+        1: punctuation.definition.comment.idl
+    - include: expressions
+  expressions:
+    - match: '(?i)((\b0x[0-9a-fA-F]*)|(\b[0-9]+(b|l|ul|u|ll|ull))|(\.[0-9]+|(\b[0-9]+(\.[0-9]*)?))((e|d)-?[0-9]+)?)'
+      scope: constant.numeric.idl
+    - match: "(')"
+      captures:
+        0: punctuation.definition.string.begin.idl
+      push:
+        - meta_scope: string.quoted.single.idl
+        - match: "(')"
+          captures:
+            0: punctuation.definition.string.end.idl
+          pop: true
+    - match: '(")'
+      captures:
+        0: punctuation.definition.string.begin.idl
+      push:
+        - meta_scope: string.quoted.double.idl
+        - match: '(")'
+          captures:
+            0: punctuation.definition.string.end.idl
+          pop: true
+    - match: (?i)\b(begin|break|do|else|for|if|return|then|repeat|while|end|endif|endelse|endfor|endwhile|return|goto)\b
+      scope: keyword.control.idl
+    - match: '\![a-zA-Z_][a-zA-Z_0-9]*\b'
+      scope: constant.language.idl
+    - match: '(?<![^.]\.|:)\b(self)\b'
+      scope: variable.language.self.idl
+    - match: '(?i)(?<![^.]\.|:)\b(abs|acos|adapt_hist_equal|alog|alog10|amoeba|annotate|app_user_dir|app_user_dir_query|arg_present|array_equal|array_indices|arrow|ascii_template|asin|assoc|atan|axis|bar_plot|beseli|beselj|beselk|besely|beta|bilinear|binary_template|bindgen|binomial|bin_date|blas_axpy|blk_con|box_cursor|breakpoint|broyden|bytarr|byte|byteorder|bytscl|caldat|calendar|call_external|call_function|call_method|call_procedure|catch|cd|ceil|chebyshev|check_math|chisqr_cvf|chisqr_pdf|choldc|cholsol|cindgen|cir_3pnt|close|cluster|cluster_tree|clust_wts|colormap_applicable|color_convert|color_quan|comfit|complex|complexarr|complexround|compute_mesh_normals|cond|congrid|conj|constrained_min|contour|convert_coord|convol|coord2to3|copy_lun|correlate|cos|cosh|cpu|cramer|create_cursor|create_struct|create_view|crossp|crvlength|cti_test|ct_luminance|cursor|curvefit|cvttobm|cv_coord|c_correlate|dblarr|dcindgen|dcomplex|dcomplexarr|define_key|define_msgblk|define_msgblk_from_file|defroi|defsysv|delvar|dendrogram|dendro_plot|deriv|derivsig|determ|device|dfpmin|diag_matrix|dialog_message|dialog_pickfile|dialog_printersetup|dialog_printjob|dialog_read_image|dialog_write_image|digital_filter|dilate|dindgen|dissolve|dist|distance_measure|dlm_load|dlm_register|doc_library|double|draw_roi|efont|eigenql|eigenvec|elmhes|empty|enable_sysrtn|eof|erase|erf|erfc|erfcx|erode|errplot|execute|exit|exp|expand|expand_path|expint|extrac|extract_slice|factorial|fft|filepath|file_basename|file_chmod|file_copy|file_delete|file_dirname|file_expand_path|file_info|file_lines|file_link|file_mkdir|file_move|file_readlink|file_same|file_search|file_test|file_which|findgen|finite|fix|flick|float|floor|flow3|fltarr|flush|format_axis_values|forward_function|free_lun|fstat|fulstr|funct|fv_test|fx_root|fz_roots|f_cvf|f_pdf|gamma|gamma_ct|gauss2dfit|gaussfit|gaussint|gauss_cvf|gauss_pdf|getenv|get_drive_list|get_kbrd|get_lun|get_screen_size|grid3|griddata|grid_input|grid_tps|gs_iter|h5_browser|hanning|hdf_browser|hdf_read|heap_free|heap_gc|help|hilbert|histogram|hist_2d|hist_equal|hls|hough|hqr|hsv|h_eq_ct|h_eq_int|ibeta|icontour|identity|idlitsys_createtool|idl_validname|igamma|iimage|image_cont|image_statistics|imaginary|imap|indgen|intarr|interpol|interpolate|interval_volume|int_2d|int_3d|int_tabulated|invert|ioctl|iplot|ishft|isocontour|isosurface|isurface|itcurrent|itdelete|itgetcurrent|itregister|itreset|itresolve|ivolume|journal|julday|keyword_set|krig2d|kurtosis|kw_test|l64indgen|label_date|label_region|ladfit|laguerre|la_choldc|la_cholmprove|la_cholsol|la_determ|la_eigenproblem|la_eigenql|la_eigenvec|la_elmhes|la_gm_linear_model|la_hqr|la_invert|la_least_squares|la_least_square_equality|la_linear_equation|la_ludc|la_lumprove|la_lusol|la_svd|la_tridc|la_trimprove|la_triql|la_trired|la_trisol|leefilt|legendre|linbcg|lindgen|linfit|linkimage|ll_arc_distance|lmfit|lmgr|lngamma|lnp_test|loadct|locale_get|logical_and|logical_or|logical_true|lon64arr|lonarr|long|long64|lsode|ludc|lumprove|lusol|lu_complex|machar|make_array|make_dll|map_2points|map_continents|map_grid|map_image|map_patch|map_proj_forward|map_proj_image|map_proj_info|map_proj_init|map_proj_inverse|map_set|matrix_multiply|matrix_power|max|md_test|mean|meanabsdev|median|memory|message|min|min_curve_surf|mk_html_help|modifyct|moment|morph_close|morph_distance|morph_gradient|morph_hitormiss|morph_open|morph_thin|morph_tophat|mpeg_close|mpeg_open|mpeg_put|mpeg_save|multi|m_correlate|newton|norm|n_elements|n_params|n_tags|objarr|obj_class|obj_destroy|obj_isa|obj_new|obj_valid|online_help|online_help_pdf_index|on_error|on_ioerror|openr|openu|openw|oplot|oploterr|particle_trace|path_cache|path_sep|pcomp|plot|ploterr|plots|plot_3dbox|plot_field|pnt_line|point_lun|polar_contour|polar_surface|poly|polyfill|polyfillv|polyshade|polywarp|poly_2d|poly_area|poly_fit|popd|powell|primes|print|printd|printf|proceduresandfunctions|product|profile|profiler|profiles|project_vol|psafm|pseudo|ps_show_fonts|ptrarr|ptr_free|ptr_new|ptr_valid|pushd|p_correlate|qgrid3|qhull|qromb|qromo|qsimp|radon|randomn|randomu|ranks|rdpix|read|readf|reads|readu|read_ascii|read_binary|read_bmp|read_dicom|read_gif|read_image|read_interfile|read_jpeg|read_jpeg2000|read_mrsid|read_pict|read_png|read_ppm|read_spr|read_srf|read_sylk|read_tiff|read_wav|read_wave|read_x11_bitmap|read_xwd|real_part|rebin|recall_commands|recon3|reduce_colors|reform|region_grow|register_cursor|regress|replicate|replicate_inplace|resolve_all|resolve_routine|restore|reverse|rk4|roberts|rot|rotate|round|routine_info|rs_test|r_correlate|r_test|save|savgol|scale3|scale3d|scope_level|scope_varfetch|scope_varname|search2d|search3d|setenv|setup_keys|set_plot|set_shading|sfit|shade_surf|shade_surf_irr|shade_volume|shift|shmdebug|shmmap|shmunmap|shmvar|show3|showfont|simplex|sin|sindgen|sinh|size|skewness|skip_lun|slicer3|slide_image|smooth|sobel|socket|sort|spawn|spher_harm|sph_4pnt|sph_scat|spline|spline_p|spl_init|spl_interp|sprsab|sprsax|sprsin|sprstp|sqrt|standardize|stddev|stop|strarr|strcmp|strcompress|streamline|stregex|stretch|string|strjoin|strlen|strlowcase|strmatch|strmessage|strmid|strpos|strput|strsplit|strtrim|struct_assign|struct_hide|strupcase|surface|surfr|svdc|svdfit|svsol|swap_endian|swap_endian_inplace|systime|s_test|t3d|tag_names|tan|tanh|tek_color|temporary|tetra_clip|tetra_surface|tetra_volume|thin|threed|timegen|time_test2|tm_test|total|trace|transpose|triangulate|trigrid|triql|trired|trisol|tri_surf|truncate_lun|ts_coef|ts_diff|ts_fcast|ts_smooth|tv|tvcrs|tvlct|tvrd|tvscl|t_cvf|t_pdf|uindgen|uint|uintarr|ul64indgen|ulindgen|ulon64arr|ulonarr|ulong|ulong64|uniq|unsharp_mask|usersym|value_locate|variance|vector_field|vel|velovect|vert_t3d|voigt|voronoi|voxel_proj|wait|warp_tri|watershed|wdelete|wf_draw|where|window|wmenu|writeu|write_bmp|write_gif|write_image|write_jpeg|write_jpeg2000|write_nrif|write_pict|write_png|write_ppm|write_spr|write_srf|write_sylk|write_tiff|write_wav|write_wave|wset|wshow|wtn|xbm_edit|xdisplayfile|xdxf|xfont|xinteranimate|xloadct|xmanager|xmng_tmpl|xmtool|xobjview|xobjview_rotate|xobjview_write_image|xpalette|xpcolor|xplot3d|xregistered|xroi|xsq_test|xsurface|xvaredit|xvolume|xvolume_rotate|xvolume_write_image|xyouts|zoom|zoom_24)\b(?=[(, ])'
+      scope: support.function.idl
+    - match: (?i)\b(and|or|not|ge|gt|le|lt|eq|neq)\b
+      scope: keyword.operator.idl
+    - match: '->|\.'
+      scope: punctuation.accessor.idl
+    - match: '='
+      scope: keyword.operator.assignment.idl
+    - match: '\+|-|%|##?|\*|\/|\^|~|<|>'
+      scope: keyword.operator.idl
+    - include: brackets
+    - include: procedure-call
+  brackets:
+    - match: \[
+      scope: punctuation.definition.brackets.begin.idl
+      push:
+        - meta_scope: meta.brackets.idl
+        - match: \]
+          scope: punctuation.definition.brackets.end.idl
+          pop: true
+        - include: expressions
+  procedure-call:
+    - match: ','
+      scope: punctuation.separator.idl
+      push:
+        - meta_scope: meta.function-call.idl
+        - match: '(?<!\$)\s*$\n?'
+          pop: true
+        - match: '\$'
+          scope: punctuation.line-continuation.idl
+        - include: expressions

--- a/IDL/IDL.sublime-syntax
+++ b/IDL/IDL.sublime-syntax
@@ -1,99 +1,153 @@
 %YAML 1.2
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
-name: IDL
-comment: "IDL Syntax: version 0.1"
+name: Interactive Data Language
+comment: "IDL Syntax: version 1.0"
 file_extensions:
   - pro
 scope: source.idl
+variables:
+  sysfun: '(?i)\b(?:abs|acos|adapt_hist_equal|alog|alog10|amoeba|app_user_dir|app_user_dir_query|arg_present|array_equal|array_indices|ascii_template|asin|assoc|atan|beseli|beselj|beselk|besely|beta|bilinear|bindgen|binomial|bin_date|blk_con|broyden|bytarr|byte|bytscl|call_external|call_function|call_method|ceil|chebyshev|check_math|chisqr_cvf|chisqr_pdf|cholsol|cindgen|cluster|cluster_tree|clust_wts|colormap_applicable|color_quan|comfit|complex|complexarr|complexround|cond|congrid|conj|convert_coord|convol|coord2to3|correlate|cos|cosh|cramer|create_cursor|create_struct|crossp|crvlength|cti_test|ct_luminance|curvefit|cvttobm|cv_coord|c_correlate|dblarr|dcindgen|dcomplex|dcomplexarr|defroi|deriv|derivsig|determ|dialog_message|dialog_pickfile|dialog_printersetup|dialog_printjob|dialog_write_image|digital_filter|dilate|dindgen|dist|distance_measure|double|eigenql|eigenvec|elmhes|eof|erf|erfc|erfcx|erode|execute|exp|expand|expand_path|expint|extrac|extract_slice|factorial|fft|filepath|file_basename|file_dirname|file_expand_path|file_info|file_lines|file_readlink|file_search|file_test|file_which|findgen|finite|fix|float|floor|fltarr|format_axis_values|fstat|fulstr|fv_test|fx_root|fz_roots|f_cvf|f_pdf|gamma|gauss2dfit|gaussfit|gaussint|gauss_cvf|gauss_pdf|getenv|get_kbrd|get_screen_size|grid3|griddata|grid_tps|gs_iter|h5_browser|hdf_read|hilbert|histogram|hist_2d|hist_equal|hough|hqr|ibeta|identity|idlitsys_createtool|idl_validname|igamma|imaginary|indgen|intarr|interpol|interpolate|int_2d|int_3d|int_tabulated|invert|ioctl|ishft|itgetcurrent|julday|keyword_set|krig2d|kurtosis|kw_test|l64indgen|label_date|label_region|ladfit|laguerre|la_cholmprove|la_determ|la_eigenproblem|la_eigenql|la_elmhes|la_gm_linear_model|la_hqr|la_invert|la_least_squares|la_least_square_equality|la_linear_equation|la_lumprove|la_lusol|la_trimprove|la_trisol|leefilt|legendre|linbcg|lindgen|linfit|ll_arc_distance|lmfit|lmgr|lngamma|lnp_test|locale_get|logical_and|logical_or|logical_true|lon64arr|lonarr|long|long64|lsode|lumprove|lusol|lu_complex|machar|make_array|map_2points|map_image|map_patch|map_proj_forward|map_proj_image|map_proj_init|map_proj_inverse|matrix_multiply|matrix_power|max|md_test|mean|meanabsdev|median|memory|min|min_curve_surf|moment|morph_close|morph_distance|morph_gradient|m_correlate|newton|norm|n_elements|n_params|n_tags|objarr|obj_class|obj_isa|obj_new|obj_valid|path_sep|pcomp|pnt_line|polar_surface|poly|polyfillv|polyshade|poly_2d|poly_area|poly_fit|primes|product|profile|ptrarr|ptr_new|ptr_valid|p_correlate|qgrid3|qromb|qromo|qsimp|radon|randomn|randomu|ranks|read_ascii|read_bmp|read_dicom|read_image|read_jpeg2000|read_png|read_spr|read_sylk|read_tiff|read_wav|read_xwd|real_part|rebin|recall_commands|recon3|reform|regress|replicate|reverse|rk4|roberts|rot|rotate|round|routine_info|rs_test|r_correlate|r_test|savgol|scope_varname|search2d|search3d|sfit|shift|shmvar|simplex|sin|sindgen|sinh|size|skewness|smooth|sobel|sort|spawn|spher_harm|sph_scat|spline|spl_init|spl_interp|sprsab|sprsax|sprsin|sprstp|sqrt|standardize|stddev|strarr|strcmp|strcompress|stregex|string|strjoin|strlen|strlowcase|strmatch|strmessage|strmid|strpos|strsplit|strtrim|strupcase|svdfit|svsol|swap_endian|s_test|tag_names|tan|tanh|temporary|thin|tm_test|total|trace|transpose|trigrid|trisol|tri_surf|ts_coef|ts_diff|ts_fcast|ts_smooth|tvrd|t_cvf|t_pdf|uindgen|uint|uintarr|ul64indgen|ulindgen|ulon64arr|ulonarr|ulong|ulong64|uniq|unsharp_mask|value_locate|variance|vert_t3d|voigt|voxel_proj|warp_tri|watershed|where|write_sylk|wtn|xfont|xregistered|xsq_test)\b'
+  syspro: '(?i)\b(?:annotate|arrow|axis|bar_plot|binary_template|blas_axpy|box_cursor|breakpoint|byteorder|caldat|calendar|call_procedure|catch|cd|choldc|cir_3pnt|close|color_convert|compute_mesh_normals|constrained_min|contour|copy_lun|cpu|create_view|cursor|define_key|define_msgblk|define_msgblk_from_file|defsysv|delvar|dendrogram|dendro_plot|device|dfpmin|diag_matrix|dialog_read_image|dissolve|dlm_load|dlm_register|doc_library|draw_roi|efont|empty|enable_sysrtn|erase|errplot|exit|file_chmod|file_copy|file_delete|file_link|file_mkdir|file_move|file_same|flick|flow3|flush|forward_function|free_lun|funct|gamma_ct|get_drive_list|get_lun|grid_input|hanning|hdf_browser|heap_free|heap_gc|help|hls|hsv|h_eq_ct|h_eq_int|icontour|iimage|image_cont|image_statistics|imap|interval_volume|iplot|isocontour|isosurface|isurface|itcurrent|itdelete|itregister|itreset|itresolve|ivolume|journal|la_choldc|la_cholsol|la_eigenvec|la_ludc|la_svd|la_tridc|la_triql|la_trired|linkimage|loadct|ludc|make_dll|map_continents|map_grid|map_proj_info|map_set|message|mk_html_help|modifyct|morph_hitormiss|morph_open|morph_thin|morph_tophat|mpeg_close|mpeg_open|mpeg_put|mpeg_save|multi|obj_destroy|online_help|online_help_pdf_index|on_error|on_ioerror|openr|openu|openw|oplot|oploterr|particle_trace|path_cache|plot|ploterr|plots|plot_3dbox|plot_field|point_lun|polar_contour|polyfill|polywarp|popd|powell|print|printd|printf|profiler|profiles|project_vol|psafm|pseudo|ps_show_fonts|ptr_free|pushd|qhull|rdpix|read|readf|reads|readu|read_binary|read_gif|read_interfile|read_jpeg|read_mrsid|read_pict|read_ppm|read_srf|read_wave|read_x11_bitmap|reduce_colors|region_grow|register_cursor|replicate_inplace|resolve_all|resolve_routine|restore|save|scale3|scale3d|scope_level|scope_varfetch|setenv|setup_keys|set_plot|set_shading|shade_surf|shade_surf_irr|shade_volume|shmdebug|shmmap|shmunmap|show3|showfont|skip_lun|slicer3|slide_image|socket|sph_4pnt|spline_p|stop|streamline|stretch|strput|struct_assign|struct_hide|surface|surfr|svdc|swap_endian_inplace|systime|t3d|tek_color|tetra_clip|tetra_surface|tetra_volume|threed|timegen|time_test2|triangulate|triql|trired|truncate_lun|tv|tvcrs|tvlct|tvscl|usersym|vector_field|vel|velovect|voronoi|wait|wdelete|wf_draw|window|writeu|write_bmp|write_gif|write_image|write_jpeg|write_jpeg2000|write_nrif|write_pict|write_png|write_ppm|write_spr|write_srf|write_tiff|write_wav|write_wave|wset|wshow|xbm_edit|xdisplayfile|xdxf|xinteranimate|xloadct|xmanager|xmng_tmpl|xmtool|xobjview|xobjview_rotate|xobjview_write_image|xpalette|xpcolor|xplot3d|xroi|xsurface|xvaredit|xvolume|xvolume_rotate|xvolume_write_image|xyouts|zoom|zoom_24)\b'
+  identifier: '\b[a-zA-Z_][a-zA-Z_0-9]*\b'
+  number: '(?i)(?:(?:\b[0-9]+(?:b|l|ul|u|ll|ull))|(?:\.[0-9]+|(?:\b[0-9]+(?:\.[0-9]*)?))(?:(?:e|d)(?:(?:\+|-)?[0-9]+)?)?)'
+  keyword: '(?i)\b(?:and|or|not|if|else|while|for|case|begin|end|switch|endif|endelse|endfor|endwhile|endcase|endswitch|return|break|continue|goto|pro|function|compile_opt|then|ge|gt|le|lt|eq|ne)\b'
 contexts:
   main:
     - include: statements
-    - match: '(?i)\b(pro|function)\b'
-      scope: meta.function.idl
-      captures:
-        1: keyword.control.idl
-      push:
-        - meta_scope: function.definition.idl
-        - match: '(?i)\b(end)$\n?'
-          captures:
-            1: keyword.control.idl
-          pop: true
-        - match: '(?i)\b(pro|function)\b'
-          scope: invalid.illegal.idl
-        - match: '(?i)(?<=function|pro)\s+(\b[a-zA-Z_:]+::)?\b([a-zA-Z_][a-zA-Z_0-9]*)\b'
-          scope: meta.function.idl
-          captures:
-            1: entity.name.function.scope.idl
-            2: entity.name.function.idl
-          push:
-            - meta_scope: function.parameter-list.idl
-            - match: '(?<!\$)\s*$\n?'
-              pop: true
-            - match: '\$'
-              scope: punctuation.line-continuation.idl
-            - match: ','
-              scope: punctuation.separator.idl
-              push:
-                - meta_scope: function.parameter.idl
-                - match: '\$'
-                  scope: punctuation.line-continuation.idl
-                - match: '\b([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*=)'
-                  pop: true
-                  captures:
-                    1: variable.parameter.idl
-                - match: '\b([a-zA-Z_][a-zA-Z_0-9]*)\b(\s*(=)\s*\b([a-zA-Z_][a-zA-Z_0-9]*)\b)?'
-                  pop: true
-                  captures:
-                    1: variable.parameter.keyword.public.idl
-                    3: keyword.operator.assignment.idl
-                    4: variable.parameter.keyword.private.idl
-        - include: statements
-  statements:
-    - match: '(;).*$\n?'
+    - include: function-definition
+    - match: '(?i)\bend\b'
+      scope: keyword.control.idl
+  comment:
+    - match: '(;).*$'
       scope: comment.line.idl
       captures:
         1: punctuation.definition.comment.idl
-    - include: expressions
-  expressions:
-    - match: '(?i)((\b[0-9]+(b|l|ul|u|ll|ull))|(\.[0-9]+|(\b[0-9]+(\.[0-9]*)?))((e|d)-?[0-9]+)?)'
+  number:
+    - match: '{{number}}'
       scope: constant.numeric.idl
+  string:
     - match: "(')"
-      captures:
-        0: punctuation.definition.string.begin.idl
+      scope: punctuation.definition.string.begin.idl
       push:
         - meta_scope: string.quoted.single.idl
         - match: "(')"
-          captures:
-            0: punctuation.definition.string.end.idl
+          scope: punctuation.definition.string.end.idl
           pop: true
     - match: '(")'
-      captures:
-        0: punctuation.definition.string.begin.idl
+      scope: punctuation.definition.string.begin.idl
       push:
         - meta_scope: string.quoted.double.idl
         - match: '(")'
-          captures:
-            0: punctuation.definition.string.end.idl
+          scope: punctuation.definition.string.end.idl
           pop: true
-    - match: (?i)\b(begin|break|do|else|for|if|return|then|repeat|while|end|endif|endelse|endfor|endwhile|return|goto)\b
-      scope: keyword.control.idl
-    - match: '\![a-zA-Z_][a-zA-Z_0-9]*\b'
+  literal:
+    - include: number
+    - include: string
+  system-variable:
+    - match: '\!{{identifier}}'
       scope: constant.language.idl
-    - match: '(?<![^.]\.|:)\b(self)\b'
+    - match: '\bself\b'
       scope: variable.language.self.idl
-    - match: '(?i)(?<![^.]\.|:)\b(abs|acos|adapt_hist_equal|alog|alog10|amoeba|annotate|app_user_dir|app_user_dir_query|arg_present|array_equal|array_indices|arrow|ascii_template|asin|assoc|atan|axis|bar_plot|beseli|beselj|beselk|besely|beta|bilinear|binary_template|bindgen|binomial|bin_date|blas_axpy|blk_con|box_cursor|breakpoint|broyden|bytarr|byte|byteorder|bytscl|caldat|calendar|call_external|call_function|call_method|call_procedure|catch|cd|ceil|chebyshev|check_math|chisqr_cvf|chisqr_pdf|choldc|cholsol|cindgen|cir_3pnt|close|cluster|cluster_tree|clust_wts|colormap_applicable|color_convert|color_quan|comfit|complex|complexarr|complexround|compute_mesh_normals|cond|congrid|conj|constrained_min|contour|convert_coord|convol|coord2to3|copy_lun|correlate|cos|cosh|cpu|cramer|create_cursor|create_struct|create_view|crossp|crvlength|cti_test|ct_luminance|cursor|curvefit|cvttobm|cv_coord|c_correlate|dblarr|dcindgen|dcomplex|dcomplexarr|define_key|define_msgblk|define_msgblk_from_file|defroi|defsysv|delvar|dendrogram|dendro_plot|deriv|derivsig|determ|device|dfpmin|diag_matrix|dialog_message|dialog_pickfile|dialog_printersetup|dialog_printjob|dialog_read_image|dialog_write_image|digital_filter|dilate|dindgen|dissolve|dist|distance_measure|dlm_load|dlm_register|doc_library|double|draw_roi|efont|eigenql|eigenvec|elmhes|empty|enable_sysrtn|eof|erase|erf|erfc|erfcx|erode|errplot|execute|exit|exp|expand|expand_path|expint|extrac|extract_slice|factorial|fft|filepath|file_basename|file_chmod|file_copy|file_delete|file_dirname|file_expand_path|file_info|file_lines|file_link|file_mkdir|file_move|file_readlink|file_same|file_search|file_test|file_which|findgen|finite|fix|flick|float|floor|flow3|fltarr|flush|format_axis_values|forward_function|free_lun|fstat|fulstr|funct|fv_test|fx_root|fz_roots|f_cvf|f_pdf|gamma|gamma_ct|gauss2dfit|gaussfit|gaussint|gauss_cvf|gauss_pdf|getenv|get_drive_list|get_kbrd|get_lun|get_screen_size|grid3|griddata|grid_input|grid_tps|gs_iter|h5_browser|hanning|hdf_browser|hdf_read|heap_free|heap_gc|help|hilbert|histogram|hist_2d|hist_equal|hls|hough|hqr|hsv|h_eq_ct|h_eq_int|ibeta|icontour|identity|idlitsys_createtool|idl_validname|igamma|iimage|image_cont|image_statistics|imaginary|imap|indgen|intarr|interpol|interpolate|interval_volume|int_2d|int_3d|int_tabulated|invert|ioctl|iplot|ishft|isocontour|isosurface|isurface|itcurrent|itdelete|itgetcurrent|itregister|itreset|itresolve|ivolume|journal|julday|keyword_set|krig2d|kurtosis|kw_test|l64indgen|label_date|label_region|ladfit|laguerre|la_choldc|la_cholmprove|la_cholsol|la_determ|la_eigenproblem|la_eigenql|la_eigenvec|la_elmhes|la_gm_linear_model|la_hqr|la_invert|la_least_squares|la_least_square_equality|la_linear_equation|la_ludc|la_lumprove|la_lusol|la_svd|la_tridc|la_trimprove|la_triql|la_trired|la_trisol|leefilt|legendre|linbcg|lindgen|linfit|linkimage|ll_arc_distance|lmfit|lmgr|lngamma|lnp_test|loadct|locale_get|logical_and|logical_or|logical_true|lon64arr|lonarr|long|long64|lsode|ludc|lumprove|lusol|lu_complex|machar|make_array|make_dll|map_2points|map_continents|map_grid|map_image|map_patch|map_proj_forward|map_proj_image|map_proj_info|map_proj_init|map_proj_inverse|map_set|matrix_multiply|matrix_power|max|md_test|mean|meanabsdev|median|memory|message|min|min_curve_surf|mk_html_help|modifyct|moment|morph_close|morph_distance|morph_gradient|morph_hitormiss|morph_open|morph_thin|morph_tophat|mpeg_close|mpeg_open|mpeg_put|mpeg_save|multi|m_correlate|newton|norm|n_elements|n_params|n_tags|objarr|obj_class|obj_destroy|obj_isa|obj_new|obj_valid|online_help|online_help_pdf_index|on_error|on_ioerror|openr|openu|openw|oplot|oploterr|particle_trace|path_cache|path_sep|pcomp|plot|ploterr|plots|plot_3dbox|plot_field|pnt_line|point_lun|polar_contour|polar_surface|poly|polyfill|polyfillv|polyshade|polywarp|poly_2d|poly_area|poly_fit|popd|powell|primes|print|printd|printf|proceduresandfunctions|product|profile|profiler|profiles|project_vol|psafm|pseudo|ps_show_fonts|ptrarr|ptr_free|ptr_new|ptr_valid|pushd|p_correlate|qgrid3|qhull|qromb|qromo|qsimp|radon|randomn|randomu|ranks|rdpix|read|readf|reads|readu|read_ascii|read_binary|read_bmp|read_dicom|read_gif|read_image|read_interfile|read_jpeg|read_jpeg2000|read_mrsid|read_pict|read_png|read_ppm|read_spr|read_srf|read_sylk|read_tiff|read_wav|read_wave|read_x11_bitmap|read_xwd|real_part|rebin|recall_commands|recon3|reduce_colors|reform|region_grow|register_cursor|regress|replicate|replicate_inplace|resolve_all|resolve_routine|restore|reverse|rk4|roberts|rot|rotate|round|routine_info|rs_test|r_correlate|r_test|save|savgol|scale3|scale3d|scope_level|scope_varfetch|scope_varname|search2d|search3d|setenv|setup_keys|set_plot|set_shading|sfit|shade_surf|shade_surf_irr|shade_volume|shift|shmdebug|shmmap|shmunmap|shmvar|show3|showfont|simplex|sin|sindgen|sinh|size|skewness|skip_lun|slicer3|slide_image|smooth|sobel|socket|sort|spawn|spher_harm|sph_4pnt|sph_scat|spline|spline_p|spl_init|spl_interp|sprsab|sprsax|sprsin|sprstp|sqrt|standardize|stddev|stop|strarr|strcmp|strcompress|streamline|stregex|stretch|string|strjoin|strlen|strlowcase|strmatch|strmessage|strmid|strpos|strput|strsplit|strtrim|struct_assign|struct_hide|strupcase|surface|surfr|svdc|svdfit|svsol|swap_endian|swap_endian_inplace|systime|s_test|t3d|tag_names|tan|tanh|tek_color|temporary|tetra_clip|tetra_surface|tetra_volume|thin|threed|timegen|time_test2|tm_test|total|trace|transpose|triangulate|trigrid|triql|trired|trisol|tri_surf|truncate_lun|ts_coef|ts_diff|ts_fcast|ts_smooth|tv|tvcrs|tvlct|tvrd|tvscl|t_cvf|t_pdf|uindgen|uint|uintarr|ul64indgen|ulindgen|ulon64arr|ulonarr|ulong|ulong64|uniq|unsharp_mask|usersym|value_locate|variance|vector_field|vel|velovect|vert_t3d|voigt|voronoi|voxel_proj|wait|warp_tri|watershed|wdelete|wf_draw|where|window|wmenu|writeu|write_bmp|write_gif|write_image|write_jpeg|write_jpeg2000|write_nrif|write_pict|write_png|write_ppm|write_spr|write_srf|write_sylk|write_tiff|write_wav|write_wave|wset|wshow|wtn|xbm_edit|xdisplayfile|xdxf|xfont|xinteranimate|xloadct|xmanager|xmng_tmpl|xmtool|xobjview|xobjview_rotate|xobjview_write_image|xpalette|xpcolor|xplot3d|xregistered|xroi|xsq_test|xsurface|xvaredit|xvolume|xvolume_rotate|xvolume_write_image|xyouts|zoom|zoom_24)\b(?=[(, ])'
-      scope: support.function.idl
-    - match: (?i)\b(and|or|not|ge|gt|le|lt|eq|neq)\b
-      scope: keyword.operator.idl
-    - match: '->|\.'
-      scope: punctuation.accessor.idl
-    - match: '='
-      scope: keyword.operator.assignment.idl
-    - match: '\+|-|%|##?|\*|\/|\^|~|<|>'
-      scope: keyword.operator.idl
-    - include: brackets
-    - include: procedure-call
+  if-statement:
+    - match: (?i)\bif\b
+      scope: keyword.control.idl
+      push:
+        - match: '(?i)\bthen\b'
+          scope: keyword.control.idl
+          pop: true
+        - include: expressions
+  for-statement:
+    - match: (?i)\bfor\b
+      scope: keyword.control.idl
+      push:
+        - match: '(?i)\bdo\b'
+          scope: keyword.control.idl
+          pop: true
+        - match: '{{identifier}}\s*(=)'
+          captures:
+            1: keyword.operator.assignment.idl
+        - match: ','
+          scope: punctuation.separator.idl
+        - include: expressions
+  while-statement:
+    - match: (?i)\bwhile\b
+      scope: keyword.control.idl
+      push:
+        - match: '(?i)\bdo\b'
+          scope: keyword.control.idl
+          pop: true
+        - include: expressions
+  case-statement-item:
+    - match: '(?i)\bbegin\b'
+      scope: keyword.control.idl
+      set:
+        - match: '(?i)\bend\b'
+          scope: keyword.control.idl
+          pop: true
+        - include: statements
+    - include: statements
+    - match: '\n'
+      pop: true
+  case-statement-body:
+    - include: statements
+    - match: '(?i)\b(end|endcase|endswitch)\b'
+      scope: keyword.control.idl
+      pop: true
+  case-statement:
+    - match: (?i)\b(case|switch)\b
+      scope: keyword.control.idl
+      push:
+        - meta_scope: meta.case-statement.idl
+        - include: expressions
+        - match: '(?i)\bof\b'
+          scope: keyword.control.idl
+          set:
+            - meta_scope: meta.case-statement.idl
+            - include: case-statement-body
+  return-statement:
+    - match: (?i)\breturn\b
+      scope: keyword.control.idl
+      push:
+          - include: line-continuation
+          - include: expressions
+          - match: ','
+            scope: punctuation.separator.idl
+          - match: '$(?=\n)|({{keyword}})'
+            captures:
+              1: keyword.control.idl
+            pop: true
+          - match: '(;).*$'
+            scope: comment.line.idl
+            captures:
+              1: punctuation.definition.comment.idl
+            pop: true
+  flow-control:
+    - include: if-statement
+    - include: for-statement
+    - include: while-statement
+    - include: case-statement
+    - match: (?i)\belse\b
+      scope: keyword.control.idl
+    - match: (?i)\b(?:break|continue|goto)\b
+      scope: keyword.control.idl
+    - include: return-statement
+  line-continuator:
+      - match: '(\$)'
+        scope: punctuation.line-continuation.idl
+        push:
+          - include: comment
+          - match: '\n'
+            pop: true
+  block:
+    - match: '(?i)\bbegin\b'
+      scope: keyword.control.idl
+      push:
+        - meta_scope: meta.block.idl
+        - match: '(?i)\b(end|endif|endelse|endfor|endwhile)\b'
+          scope: keyword.control.idl
+          pop: true
+        - include: statements
   brackets:
     - match: \[
       scope: punctuation.definition.brackets.begin.idl
@@ -102,14 +156,167 @@ contexts:
         - match: \]
           scope: punctuation.definition.brackets.end.idl
           pop: true
+        - match: ','
+          scope: punctuation.separator.idl
         - include: expressions
-  procedure-call:
+  parens:
+    - match: \(
+      scope: punctuation.definition.group.begin.idl
+      push:
+        - meta_scope: meta.group.idl
+        - include: expressions
+        - match: \)
+          scope: punctuation.definition.group.end.idl
+          pop: true
+  structure:
+    - match: '{'
+      scope: punctuation.definition.brackets.begin.idl
+      push:
+        - meta_scope: meta.structure-definition.idl
+        - match: '}'
+          scope: punctuation.definition.brackets.end.idl
+          pop: true
+        - match: ','
+          scope: punctuation.separator.idl
+        - match: '({{identifier}})\s*(:)'
+          captures:
+            1: variable.parameter.idl
+            2: punctuation.separator.idl
+        - include: expressions
+  function-call-parameters:
+    - match: '\)'
+      scope: punctuation.definition.group.end.idl
+      pop: true
     - match: ','
       scope: punctuation.separator.idl
+    - match: '({{identifier}})\s*(=)'
+      captures:
+        1: variable.parameter.idl
+        2: keyword.operator.assignment.idl
+    - match: '/{{identifier}}'
+      scope: variable.parameter.keyword.idl
+    - include: expressions
+  function-call:
+    - match: '({{sysfun}})\s*(\()'
+      captures:
+        1: support.function.idl
+        2: punctuation.definition.group.begin.idl
+      push:
+        - meta_scope: meta.function-call
+        - include: function-call-parameters
+    - match: '(?i)(?!{{keyword}})({{identifier}})\s*(\()'
+      captures:
+        1: variable.function.idl
+        2: punctuation.definition.group.begin.idl
       push:
         - meta_scope: meta.function-call.idl
-        - match: '(?<!\$)\s*$\n?'
+        - include: function-call-parameters
+  procedure-call-parameters:
+    - match: '(&)|$(?=\n)|({{keyword}})'
+      captures:
+        1: keyword.operator.idl
+        2: keyword.control.idl
+      pop: true
+    - match: '(;).*$'
+      scope: comment.line.idl
+      captures:
+        1: punctuation.definition.comment.idl
+      pop: true
+    - match: ','
+      scope: punctuation.separator.idl
+    - match: '({{identifier}})\s*(=)'
+      captures:
+        1: variable.parameter.idl
+        2: keyword.operator.assignment.idl
+    - match: '/{{identifier}}'
+      scope: variable.parameter.keyword.idl
+    - include: expressions
+  procedure-call:
+    - match: '({{syspro}})\s*(,)'
+      captures:
+        1: support.function.procedure.idl
+        2: punctuation.separator.idl
+      push:
+        - meta_scope: meta.function-call.procedure.idl
+        - include: procedure-call-parameters
+    - match: '(?i){{syspro}}\s*(?:$(?=\n)|(?=\&)|(?=\belse\b))'
+      scope: support.function.procedure.idl
+    - match: '({{identifier}})\s*(,)'
+      captures:
+        1: variable.function.procedure.idl
+        2: punctuation.separator.idl
+      push:
+        - meta_scope: meta.function-call.procedure.idl
+        - include: procedure-call-parameters
+  operators:
+    - match: '%|#{1,2}|\*|\/|\^|~|<|>|\+|\-|\|\||\&\&|\?'
+      scope: keyword.operator.idl
+    - match: '='
+      scope: keyword.operator.assignment.idl
+    - match: '(?i)\b(eq|ne|gt|ge|lt|le|and|not|xor|or)\b'
+      scope: keyword.operator.idl
+    - match: ':'
+      scope: keyword.operator.idl
+  incr-operators:
+    - match: '\+\+|\-\-'
+      scope: keyword.operator.idl
+  member-access:
+    - match: '\->|\.(?![0-9])'
+      scope: punctuation.accessor.idl
+  function-definition:
+    - match: (?i)\b(pro|function)\s+\b([a-zA-Z_:0-9]+::)?({{identifier}})\b
+      captures:
+        1: keyword.control.idl
+        2: entity.name.function.scope.idl
+        3: entity.name.function.idl
+      push:
+        - meta_scope: function.definition.idl
+        - match: ','
+          scope: punctuation.separator.idl
+        - match: '({{identifier}})\s*(=)\s*({{identifier}})'
+          captures:
+            1: variable.parameter.keyword.public.idl
+            2: keyword.operator.assignment.idl
+            3: variable.parameter.keyword.private.idl
+        - match: '{{identifier}}'
+          scope: variable.parameter.idl
+        - include: line-continuator
+        - match: '$(?=\n)'
+          set:
+            - meta_scope: function-definition.body.idl
+            - include: statements
+            - match: '(?i)\bend\b'
+              scope: keyword.control.idl
+              pop: true
+  compile-opt:
+    - match : '(?i)\bcompile_opt\b'
+      scope: keyword.control.idl
+      push:
+        - include: line-continuator
+        - match: '{{identifier}}'
+          scope: meta.compiler-option
+        - match: ','
+          scope: punctuation.separator.idl
+        - match: '$(?=\n)'
           pop: true
-        - match: '\$'
-          scope: punctuation.line-continuation.idl
-        - include: expressions
+  expressions:
+    - include: literal
+    - include: system-variable
+    - include: function-call
+    - include: member-access
+    - include: operators
+    - include: incr-operators
+    - include: brackets
+    - include: parens
+    - include: structure
+    - include: line-continuator
+  statements:
+    - include: comment
+    - include: line-continuator
+    - include: compile-opt
+    - include: flow-control
+    - include: block
+    - include: procedure-call
+    - match: '&'
+      scope: keyword.operator.idl
+    - include: expressions

--- a/IDL/Indent.tmPreferences
+++ b/IDL/Indent.tmPreferences
@@ -8,9 +8,11 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>(?i)^\s*(end|endfor|endwhile|endif|endelse)\s*$</string>
+		<string>(?i)^\s*(else|end|endi|endif|endf|endfo|endfor|ende|endel|endels|endelse|endwhile|endcase|endswitch)\b.*$</string>
 		<key>increaseIndentPattern</key>
-		<string>(?i)^\s*(pro|function|(begin\b((?!end).)))*$</string>
+		<string>(?i)(^.*\b(begin|of)\s*$)|(^\s*(function|pro)\b.*$)</string>
+		<key>bracketIndentNextLinePattern</key>
+		<string>^.*\$\s*$</string>
 	</dict>
 </dict>
 </plist>

--- a/IDL/Indent.tmPreferences
+++ b/IDL/Indent.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Indent</string>
+	<key>scope</key>
+	<string>source.idl</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>(?i)^\s*(end|endfor|endwhile|endif|endelse)\s*$</string>
+		<key>increaseIndentPattern</key>
+		<string>(?i)^\s*(pro|function|(begin\b((?!end).)))*$</string>
+	</dict>
+</dict>
+</plist>

--- a/IDL/syntax_test_idl.pro
+++ b/IDL/syntax_test_idl.pro
@@ -28,14 +28,12 @@
 ;                                 ^ constant.numeric
 ;                                    ^ constant.numeric
 
-0xff 0x00 1b .5 1. .5e2 1.e2
+1b .5 1. .5e2 1.e2
 ; <- constant.numeric
-;    ^ constant.numeric
-;         ^ constant.numeric
-;            ^ constant.numeric
-;               ^ constant.numeric
-;                  ^ constant.numeric
-;                       ^ constant.numeric
+;  ^ constant.numeric
+;     ^ constant.numeric
+;        ^ constant.numeric
+;             ^ constant.numeric
 
 function foo::bar, p0, p1_pub=p1_priv
 ;        ^ entity.name.function.scope
@@ -76,12 +74,14 @@ FUNCTION foo::bar, p0, p1_pub=p1_priv, $
 ;                      ^ variable.parameter.keyword.public
 ;                             ^ variable.parameter.keyword.private
 
+; !WIP!
     print, x, y+2, z[5], format='(F12.5)', format = 'test'
 ;   ^ support.function
 ;        ^ meta.function-call
 ;                        ^ variable.parameter
 ;                                          ^ variable.parameter
 
+; !WIP!
     print, x, y+2, z[5], $
         format='(F12.5)'
 ;       ^ meta.function-call

--- a/IDL/syntax_test_idl.pro
+++ b/IDL/syntax_test_idl.pro
@@ -1,0 +1,89 @@
+; SYNTAX TEST "Packages/IDL/IDL.sublime-syntax"
+; foo
+; ^ source.idl comment.line
+; <- punctuation.definition.comment
+
+"Hello, World! ; not a comment"
+; <- punctuation.definition.string.begin
+;^ string.quoted.double
+;                ^ string.quoted.double - comment.line
+;                             ^ punctuation.definition.string.end
+
+'Hello, World! ; not a comment'
+; <- punctuation.definition.string.begin
+;^ string.quoted.single
+;                ^ string.quoted.single - comment.line
+;                             ^ punctuation.definition.string.end
+
+1 10 1.0 1e2 10E20 1e-2 1d2 1L 1l 1u 0
+; <- constant.numeric
+; ^ constant.numeric
+;    ^ constant.numeric
+;        ^ constant.numeric
+;            ^ constant.numeric
+;                  ^ constant.numeric
+;                       ^ constant.numeric
+;                           ^ constant.numeric
+;                              ^ constant.numeric
+;                                 ^ constant.numeric
+;                                    ^ constant.numeric
+
+0xff 0x00 1b .5 1. .5e2 1.e2
+; <- constant.numeric
+;    ^ constant.numeric
+;         ^ constant.numeric
+;            ^ constant.numeric
+;               ^ constant.numeric
+;                  ^ constant.numeric
+;                       ^ constant.numeric
+
+function foo::bar, p0, p1_pub=p1_priv
+;        ^ entity.name.function.scope
+;             ^ entity.name.function
+;                  ^ function.parameter-list
+;                  ^ variable.parameter - variable.parameter.keyword
+;                      ^ variable.parameter.keyword.public
+;                             ^ variable.parameter.keyword.private
+
+    function foo::bar
+;   ^ invalid.illegal
+
+    p0->bar.foobar = 1
+;     ^ punctuation.accessor
+;          ^ punctuation.accessor
+;                  ^ keyword.operator.assignment
+
+    if n_elements(p0) eq 0 then begin
+;   ^ keyword.control
+;      ^ support.function
+;                     ^ keyword.operator
+;                          ^ keyword.control
+;                               ^ keyword.control
+        p0 = p1_priv[0] + self.babar + !xyz2
+;                   ^ punctuation.definition.brackets.begin
+;                    ^ meta.brackets
+;                     ^ punctuation.definition.brackets.end
+;                         ^ variable.language.self
+;                                      ^ constant.language
+    endif
+;   ^ keyword.control
+end
+
+FUNCTION foo::bar, p0, p1_pub=p1_priv, $
+                   p2, p3_pub=p3_priv
+;                  ^ function.parameter-list
+;                  ^ variable.parameter - variable.parameter.keyword
+;                      ^ variable.parameter.keyword.public
+;                             ^ variable.parameter.keyword.private
+
+    print, x, y+2, z[5], format='(F12.5)', format = 'test'
+;   ^ support.function
+;        ^ meta.function-call
+;                        ^ variable.parameter
+;                                          ^ variable.parameter
+
+    print, x, y+2, z[5], $
+        format='(F12.5)'
+;       ^ meta.function-call
+;       ^ variable.parameter
+END

--- a/IDL/syntax_test_idl.pro
+++ b/IDL/syntax_test_idl.pro
@@ -3,48 +3,216 @@
 ; ^ source.idl comment.line
 ; <- punctuation.definition.comment
 
-"Hello, World! ; not a comment"
-; <- punctuation.definition.string.begin
-;^ string.quoted.double
-;                ^ string.quoted.double - comment.line
-;                             ^ punctuation.definition.string.end
+a = "Hello, World! ; not a comment"
+; ^ keyword.operator
+;   ^ punctuation.definition.string.begin
+;   ^ string.quoted.double
+;                  ^ string.quoted.double - comment.line
+;                                 ^ punctuation.definition.string.end
 
+a = $
 'Hello, World! ; not a comment'
 ; <- punctuation.definition.string.begin
-;^ string.quoted.single
-;                ^ string.quoted.single - comment.line
+; <- string.quoted.single
+;              ^ string.quoted.single - comment.line
 ;                             ^ punctuation.definition.string.end
 
-1 10 1.0 1e2 10E20 1e-2 1d2 1L 1l 1u 0
-; <- constant.numeric
-; ^ constant.numeric
+b = [1,10,1.0,1e2,10E20,1e-2,1d2,1L,1l,1u,0]
 ;    ^ constant.numeric
-;        ^ constant.numeric
-;            ^ constant.numeric
-;                  ^ constant.numeric
-;                       ^ constant.numeric
-;                           ^ constant.numeric
-;                              ^ constant.numeric
-;                                 ^ constant.numeric
-;                                    ^ constant.numeric
-
-1b .5 1. .5e2 1.e2
-; <- constant.numeric
-;  ^ constant.numeric
-;     ^ constant.numeric
-;        ^ constant.numeric
+;      ^ constant.numeric
+;         ^ constant.numeric
 ;             ^ constant.numeric
+;                 ^ constant.numeric
+;                       ^ constant.numeric
+;                            ^ constant.numeric
+;                                ^ constant.numeric
+;                                   ^ constant.numeric
+;                                      ^ constant.numeric
+;                                         ^ constant.numeric
+
+b = [1b,.5,1.,.5e2,1.e+21,1d]
+;   ^ punctuation.definition.brackets.begin
+;    ^ constant.numeric
+;       ^ constant.numeric
+;          ^ constant.numeric
+;             ^ constant.numeric
+;                  ^ constant.numeric
+;                         ^ constant.numeric
+;                           ^ punctuation.definition.brackets.end
+
+a = b & c = d
+; ^ keyword.operator
+;         ^ keyword.operator
+
+a = b.foo->bar
+; ^ keyword.operator
+;    ^ punctuation.accessor
+;        ^ punctuation.accessor
+
+a = b+c & a = b-c & a = b*c & a = b/c
+;    ^ keyword.operator
+;              ^ keyword.operator
+;                        ^ keyword.operator
+;                                  ^ keyword.operator
+
+a = b%c & a = b#c & a = a##c & a++ & a--
+;    ^ keyword.operator
+;              ^ keyword.operator
+;                        ^ keyword.operator
+;                               ^ keyword.operator
+;                                     ^ keyword.operator
+
+a = b ? c : d
+;     ^ keyword.operator
+;         ^ keyword.operator
+
+b.foo->bar = a
+;^ punctuation.accessor
+;    ^ punctuation.accessor
+;          ^ keyword.operator
+
+a = foo(b, bar(c, d, bar=2, /test))
+;   ^ meta.function-call
+;                  ^ meta.function-call meta.function-call
+;                    ^ variable.parameter
+;                           ^ variable.parameter.keyword
+
+a = foo($ ; test comment
+;   ^ meta.function-call
+;         ^ comment.line
+    b+2, $
+    bar($
+        c,$
+        d,$
+;       ^ meta.function-call meta.function-call
+        bar=2,$
+;       ^ variable.parameter
+        /test$
+;       ^ variable.parameter.keyword
+    )$
+)
+
+b = sqrt(2)
+;   ^ meta.function-call support.function
+
+dostuff, a, b, width=2, /silent
+; <- meta.function-call.procedure
+;           ^ meta.function-call.procedure
+;              ^ variable.parameter
+;                       ^ variable.parameter.keyword
+
+dostuff, $
+    a, $
+    b+2, $
+    width=2, $
+    /silent
+;   ^ variable.parameter.keyword
+
+print, x, y, z, format='(3F5.1)'
+; <- support.function.procedure
+
+print, x & print, z
+; <- support.function
+;          ^ support.function
+
+print & print
+; <- support.function
+;       ^ support.function
+
+print, x ; print the value of x
+; <- support.function
+;        ^ comment.line
+
+if i eq 0 then print else print, i
+;              ^ support.function
+;                    ^ keyword.control
+;                         ^ support.function
+
+if a eq 1 or e xor p then b = d
+; <- keyword.control
+;    ^ keyword.operator
+;         ^ keyword.operator
+;              ^ keyword.operator
+;                    ^ keyword.control
+;                           ^ keyword.operator
+
+IF b ne 2 and a lt b THEN begin
+; <- keyword.control
+;    ^ keyword.operator
+;         ^ keyword.operator
+;               ^ keyword.operator
+;                    ^ keyword.control
+;                         ^ meta.block
+    a = c
+;     ^ keyword.operator
+endif else begin
+;     ^ keyword.control
+;          ^ meta.block
+    c = a
+;     ^ keyword.operator
+endelse
+
+for i=0, 15 do begin
+; <- keyword.control
+;           ^ keyword.control
+;              ^ meta.block
+    a += 1
+;     ^ keyword.operator
+    break
+;   ^ keyword.control
+endfor
+
+while a ne b do begin
+; <- keyword.control
+;            ^ keyword.control
+;               ^ meta.block
+    b /= c
+;     ^ keyword.operator
+    continue
+;   ^ keyword.control
+endwhile
+
+for $
+    i=0, $
+    15 do $
+;      ^ keyword.control
+;         ^ punctuation.line-continuation
+    begin
+    c += v
+end
+
+case b of
+; <- meta.case-statement keyword.control
+;      ^ keyword.control
+    '2': a=1
+;   ^ meta.case-statement string.quoted.single
+;         ^ keyword.operator
+    '3': begin
+;   ^ meta.case-statement string.quoted.single
+;        ^ keyword.control
+        c=3
+;        ^ keyword.operator
+    end
+;   ^ keyword.control
+    1: d=4
+;   ^ meta.case-statement constant.numeric
+;       ^ keyword.operator
+    1 && 2: d=5
+;   ^ meta.case-statement constant.numeric
+;     ^ meta.case-statement keyword.operator
+;            ^ keyword.operator
+    else: print, e
+;   ^ meta.case-statement keyword.control
+;         ^ meta.function-call.procedure
+endcase
+; <- keyword.control
 
 function foo::bar, p0, p1_pub=p1_priv
 ;        ^ entity.name.function.scope
 ;             ^ entity.name.function
-;                  ^ function.parameter-list
 ;                  ^ variable.parameter - variable.parameter.keyword
 ;                      ^ variable.parameter.keyword.public
 ;                             ^ variable.parameter.keyword.private
-
-    function foo::bar
-;   ^ invalid.illegal
 
     p0->bar.foobar = 1
 ;     ^ punctuation.accessor
@@ -65,25 +233,36 @@ function foo::bar, p0, p1_pub=p1_priv
 ;                                      ^ constant.language
     endif
 ;   ^ keyword.control
+
+    return, bla
+;   ^ keyword.control
 end
 
-FUNCTION foo::bar, p0, p1_pub=p1_priv, $
-                   p2, p3_pub=p3_priv
-;                  ^ function.parameter-list
-;                  ^ variable.parameter - variable.parameter.keyword
-;                      ^ variable.parameter.keyword.public
-;                             ^ variable.parameter.keyword.private
+FUNCTION bar, p0, p1_pub=p1_priv, $
+              p2, p3_pub=p3_priv
+;             ^ variable.parameter - variable.parameter.keyword
+;                 ^ variable.parameter.keyword.public
+;                        ^ variable.parameter.keyword.private
 
-; !WIP!
     print, x, y+2, z[5], format='(F12.5)', format = 'test'
 ;   ^ support.function
 ;        ^ meta.function-call
 ;                        ^ variable.parameter
 ;                                          ^ variable.parameter
 
-; !WIP!
     print, x, y+2, z[5], $
         format='(F12.5)'
 ;       ^ meta.function-call
 ;       ^ variable.parameter
+
+    if x eq 1 then return, 1 else return, 0
+;   ^ keyword.control
+;             ^ keyword.control
+;                  ^ keyword.control
+;                            ^ keyword.control
+;                                 ^ keyword.control
+
+    RETURN, bla ; return the value of bla
+;   ^ keyword.control
+;               ^ comment.line
 END


### PR DESCRIPTION
**Not ready for merge.** 
I've created the pull request to gather your comments, and also to check if this is a wanted feature.

IDL is an old language that is (unfortunately) still widely used in data science, including astronomy, astrophysics and earth science.
More info on Wikipedia: https://en.wikipedia.org/wiki/IDL_%28programming_language%29

There is a unofficial package that offers support for this language in Sublime, however it is based on the older .tmLanguage syntax, and it does not properly highlights all the scopes and variable types. I've therefore started a rewrite from scratch (using the Lua .sublime-syntax file as a skeleton).

I will report back when the parser reaches my expectations. In the mean time, I think I might need help understanding the "Indent" file. It should be easy to support 90% of the cases, since IDL exclusively uses keywords for flow control, i.e:
```IDL
; Multi instruction construct
if b eq 1 then begin
    a = 2
endif ; or just 'end'

; Single instruction construct
if b eq 1 then a = 2
```

However this can become messy very quickly, since IDL allows any instruction to be split into multiple lines by inserting the '$' character essentially anywhere:
```IDL
; Single instruction construct split into multiple lines
if b eq 1 then $
    a = 2
if b eq 1 $
    then a = 2
if $
    b eq 1 $
    then $
    a = 2
```

This issue (plus the fact that multiple instructions can be combined on the same line with the "&" character) also make writing the parser quite difficult. Is there a standard and easy way to handle this? 