### PR TITLE
[Batch] Restrict colon comment matching

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -6,6 +6,8 @@ file_extensions:
   - bat
   - cmd
 scope: source.dosbatch
+variables:
+  colon_comment_start: '(?::[+=,;: ])'
 contexts:
   main:
     - include: comments
@@ -142,12 +144,18 @@ contexts:
         2: entity.name.label.dosbatch
 
   comments:
-    - match: '^\s*(:[+=,;: ])'
-      scope: punctuation.definition.comment.dosbatch
+    - match: '(?:^|(&))\s*(?=({{colon_comment_start}}))'
+      captures:
+        1: keyword.operator.conditional.dosbatch
       push:
-        - meta_scope: comment.line.colon.dosbatch
-        - match: \n
+        - match: '\n'
           pop: true
+        - match: '({{colon_comment_start}})'
+          scope: punctuation.definition.comment.dosbatch
+          push:
+            - meta_scope: comment.line.colon.dosbatch
+            - match: '(?=\n)'
+              pop: true
     # REM command
     # https://technet.microsoft.com/en-us/library/bb490986.aspx
     - match: \b(?i)rem\b

--- a/Batch File/syntax_test_batch_file.bat
+++ b/Batch File/syntax_test_batch_file.bat
@@ -30,13 +30,22 @@ REM
    : Me too!
 :: ^^         punctuation.definition.comment.dosbatch
 
+ECHO : Not a comment
+::   ^^^^^^^^^^^^^^^ - comment
+
+ECHO &:: A comment
+::   ^ keyword.operator.conditional.dosbatch
+::    ^^ punctuation.definition.comment.dosbatch
+::    ^^^^^^^^^^^^ comment.line.colon.dosbatch
+
+  :: an indented comment
+::^^ punctuation.definition.comment.dosbatch
+::^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
+
    ECHO "foo"
 ::      ^       punctuation.definition.string.begin.dosbatch
 ::      ^^^^^   string.quoted.double.dosbatch
 ::          ^   punctuation.definition.string.end.dosbatch
-
-ECHO FOO: %FOO%
-::      ^^^^^^^ - comment
 
    @ECHO OFF
 :: ^ keyword.operator.at.dosbatch


### PR DESCRIPTION
Further improvement for #374. 

Ensures colon comments are only scoped in the proper places:
- When used on a line by itself
- When preceded by the `&` operator <sup><a href="http://stackoverflow.com/questions/11269338/how-can-i-comment-out-a-section-or-add-comments-in-a-batch-file#comment60622945_16839602">1</a></sup> <sup><a href="http://stackoverflow.com/a/12408045">2</a></sup> <sup><a href="http://ss64.com/nt/rem.html">3</a></sup>