### PR TITLE
[Diff] Make scopes consistent

### DIFF
--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -24,28 +24,28 @@ contexts:
       captures:
         1: punctuation.definition.separator.diff
     - match: ^\d+(,\d+)*(a|d|c)\d+(,\d+)*$\n?
-      scope: meta.diff.range.normal
+      scope: meta.range.normal.diff
     - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
-      scope: meta.diff.range.unified
+      scope: meta.range.unified.diff
       captures:
         1: punctuation.definition.range.diff
         2: meta.toc-list.line-number.diff
         3: punctuation.definition.range.diff
     - match: '^(((\-{3}) .+ (\-{4}))|((\*{3}) .+ (\*{4})))$\n?'
-      scope: meta.diff.range.context
+      scope: meta.range.context.diff
       captures:
         3: punctuation.definition.range.diff
         4: punctuation.definition.range.diff
         6: punctuation.definition.range.diff
         7: punctuation.definition.range.diff
     - match: '(^(((-{3}) .+)|((\*{3}) .+))$\n?|^(={4}) .+(?= - ))'
-      scope: meta.diff.header.from-file
+      scope: meta.header.from-file.diff
       captures:
         4: punctuation.definition.from-file.diff
         6: punctuation.definition.from-file.diff
         7: punctuation.definition.from-file.diff
     - match: '(^(\+{3}) .+$\n?| (-) .* (={4})$\n?)'
-      scope: meta.diff.header.to-file
+      scope: meta.header.to-file.diff
       captures:
         2: punctuation.definition.to-file.diff
         3: punctuation.definition.to-file.diff
@@ -65,7 +65,7 @@ contexts:
         3: punctuation.definition.deleted.diff
         6: punctuation.definition.deleted.diff
     - match: ^Index(:) (.+)$\n?
-      scope: meta.diff.index
+      scope: meta.index.diff
       captures:
         1: punctuation.separator.key-value.diff
         2: meta.toc-list.file-name.diff

--- a/Diff/syntax_test_diff.diff
+++ b/Diff/syntax_test_diff.diff
@@ -1,33 +1,33 @@
 # SYNTAX TEST "Packages/Diff/Diff.sublime-syntax"
 
 --- Path to Original File
-#^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.from-file
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.from-file.diff
 # <-                      punctuation.definition.from-file.diff
 #^^                       punctuation.definition.from-file.diff
 
 +++ Path to Modified File
-#^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.to-file
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.to-file.diff
 # <-                      punctuation.definition.to-file.diff
 #^^                       punctuation.definition.to-file.diff
 
 28a211
-#^^^^^ meta.diff.range.normal
+#^^^^^ meta.range.normal.diff
 
 @@ -2,8 +2,11 @@
-#^^^^^^^^^^^^^^^ meta.diff.range.unified
+#^^^^^^^^^^^^^^^ meta.range.unified.diff
 # <-             punctuation.definition.range.diff
 #^               punctuation.definition.range.diff
 #  ^^^^^^^^^^    meta.toc-list.line-number.diff
 #             ^^ punctuation.definition.range.diff
 
 --- Range ----
-#^^^^^^^^^^^^^ meta.diff.range.context
+#^^^^^^^^^^^^^ meta.range.context.diff
 # <-           punctuation.definition.range.diff
 #^^            punctuation.definition.range.diff
 #         ^^^^ punctuation.definition.range.diff
 
 *** Range ****
-#^^^^^^^^^^^^^ meta.diff.range.context
+#^^^^^^^^^^^^^ meta.range.context.diff
 # <-           punctuation.definition.range.diff
 #^^            punctuation.definition.range.diff
 #         ^^^^ punctuation.definition.range.diff
@@ -76,6 +76,6 @@ Plain Text
 # ^^^^^^^^ markup.changed.diff
 
 Index: value
-#^^^^^^^^^^^ meta.diff.index
+#^^^^^^^^^^^ meta.index.diff
 #    ^       punctuation.separator.key-value.diff
 #      ^^^^^ meta.toc-list.file-name.diff


### PR DESCRIPTION
I wasn't sure if placing `.diff` in the middle of scopes was intentional; regardless, it is inconsistent with the other syntaxes.
