### PR TITLE
[Python] Improvements on highlighting with focus on keywords

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -31,13 +31,13 @@ contexts:
     - include: classes
     - include: functions
     - include: decorators
+    - include: modifiers
     - include: expressions
 
   expressions:
     - include: comments
     - include: constants
     - include: numbers
-    - include: modifiers
     - include: keywords
     - include: operators
     - include: lambda
@@ -97,10 +97,19 @@ contexts:
       scope: constant.numeric.integer.decimal.python
 
   modifiers:
-    - match: \b(global)\b
-      scope: storage.modifier.global.python
-    - match: \b(nonlocal)\b
-      scope: storage.modifier.nonlocal.python
+    - match: \b(?:(global)|(nonlocal))\b
+      captures:
+        1: storage.modifier.global.python
+        2: storage.modifier.nonlocal.python
+      push:
+        - include: line_continuation
+        - match: $\n?
+          pop: true
+        - match: ','
+          scope: punctuation.separator.storage-list.python
+        - include: name
+        - match: \S+
+          scope: invalid.illegal.name.storage.python
 
   keywords:
     - match: \b(?:(import)|(from))\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -292,9 +292,9 @@ contexts:
         2: keyword.control.flow.yield-from.python
 
   assignments:
-    - match: \+\=|-\=|\*\=|/\=|//\=|%\=|&\=|\|\=|\^\=|>>\=|<<\=|\*\*\=
+    - match: \+=|-=|\*=|/=|//=|%=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
-    - match: \=
+    - match: '='
       scope: keyword.operator.assignment.python
 
   operators:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -37,7 +37,7 @@ contexts:
     - include: modifiers
     - include: assignments
     - match: ;
-      scope: punctuation.separator.statements.python
+      scope: punctuation.terminator.statement.python
     - include: expressions
 
   inline_statements:
@@ -127,7 +127,7 @@ contexts:
     - include: import_alias
     - include: name
     - match: \*
-      scope: keyword.other.import-all.python
+      scope: constant.language.import-all.python
     - match: \S+
       scope: invalid.illegal.name.import.python
 
@@ -139,7 +139,7 @@ contexts:
     # async for ... in ...:
     - match: \b(async +)?(for)\b
       captures:
-        1: keyword.control.flow.async.python
+        1: storage.modifier.async.python
         2: keyword.control.flow.for.python
       push:
         - meta_scope: meta.statement.for.python
@@ -160,7 +160,7 @@ contexts:
     # async with ... as ...:
     - match: \b(async +)?(with)\b
       captures:
-        1: keyword.control.flow.async.python
+        1: storage.modifier.async.python
         2: keyword.control.flow.with.python
       push:
         - meta_scope: meta.statement.with.python
@@ -200,8 +200,7 @@ contexts:
     - match: \b(elif|else|finally|if|try|while)\b
       scope: keyword.control.flow.python
 
-  expressions:
-    # Always include this last!
+  expressions: # Always include this last!
     - include: comments
     - include: constants
     - include: numbers

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1266,13 +1266,13 @@ contexts:
 
   inline_for:
     - match: \b(for)\b
-      scope: keyword.control.flow.for.comprehension.python
+      scope: keyword.control.flow.for.generator.python
       push:
-        - meta_scope: meta.comprehension.python
+        - meta_scope: meta.expression.generator.python
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
           set:
-            - meta_scope: meta.comprehension.python
+            - meta_scope: meta.expression.generator.python
             - include: line_continuation
             - match: '(?=[)\]}])'
               pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -59,6 +59,10 @@ contexts:
         - include: expressions
     - match: \)
       scope: invalid.illegal.stray.brace.round.python
+    - match: \]
+      scope: invalid.illegal.stray.brace.square.python
+    - match: \}
+      scope: invalid.illegal.stray.brace.curly.python
     - include: lists
     - include: dictionaries_and_sets
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -524,7 +524,7 @@ contexts:
             - include: expressions
 
   lambda:
-    - match: \b(lambda)(?=\s+)
+    - match: \b(lambda)(?=\s+|:)
       scope: storage.type.function.inline.python
       push:
         - meta_scope: meta.function.inline.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -338,16 +338,17 @@ contexts:
       scope: keyword.operator.logical.python
 
   classes:
-    - match: '^\s*(class)\s+(?={{identifier}})'
+    - match: '^\s*(class)\b'
       captures:
         1: storage.type.class.python
       push:
         - meta_scope: meta.class.python
+        - include: line_continuation
+        - match: $
+          pop: true
         - match: ':'
           scope: punctuation.section.class.begin.python
           set: maybe-docstrings
-        - match: '(?=^\s*$)'
-          pop: true
         - match: "(?={{identifier}})"
           push:
             - meta_content_scope: entity.name.type.class.python
@@ -357,16 +358,18 @@ contexts:
         - match: '(?=\()'
           set:
             - match: \(
-              scope: meta.class.inheritance.python punctuation.definition.inheritance.begin.python
+              scope: punctuation.definition.inheritance.begin.python
               set:
-                - meta_content_scope: meta.class.inheritance.python
+                - meta_scope: meta.class.inheritance.python
                 - match: \)
                   scope: punctuation.definition.inheritance.end.python
                   set:
+                    - include: line_continuation
+                    - match: $
+                      pop: true
                     - match: ':'
                       scope: meta.class.python punctuation.section.class.begin.python
                       set: maybe-docstrings
-                    - include: comments
                     - match: (?=\S)
                       pop: true
                 - match: ':'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -19,7 +19,7 @@ variables:
   # We support unicode here because Python 3 is the future
   identifier_continue: '[[:alnum:]_]'
   identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
-  path: '({{identifier}}\.)*{{identifier}}'
+  path: '({{identifier}} *\. *)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b
 
 contexts:
@@ -178,7 +178,7 @@ contexts:
                     - meta_scope: entity.other.inherited-class.python
                     - include: identifier-parts
                     - match: '{{identifier}}'
-                    - match: ''
+                    - match: '(?=\S)'
                       pop: true
                 - include: expressions
 
@@ -245,14 +245,14 @@ contexts:
       scope: variable.parameter.python
 
   decorators:
-    - match: '^\s*(?=@\s*{{identifier}}(?:\.{{identifier}})*\s*\()'
+    - match: '^\s*(?=@\s*{{path}}\s*\()'
       comment: a decorator may be a function call which returns a decorator.
       push:
         - meta_scope: meta.function.decorator.python
         - match: \)
           scope: punctuation.definition.arguments.end.python
           pop: true
-        - match: '(?=(@)\s*{{identifier}}(?:\.{{identifier}})*\s*\()'
+        - match: '(?=(@)\s*{{path}}\s*\()'
           captures:
             1: punctuation.definition.decorator.python
           push:
@@ -268,7 +268,7 @@ contexts:
               pop: true
             - include: keyword_arguments
             - include: expressions
-    - match: '^\s*(?=@\s*{{identifier}}(?:\.{{identifier}})*)'
+    - match: '^\s*(?=@\s*{{path}})'
       push:
         - meta_scope: meta.function.decorator.python
         - meta_content_scope: entity.name.function.decorator.python
@@ -283,13 +283,13 @@ contexts:
             - include: dotted_name
 
   item-access:
-    - match: '(?={{identifier}}(?:\.{{identifier}})*\s*\[)'
+    - match: '(?={{path}}\s*\[)'
       push:
         - meta_scope: meta.item-access.python
         - match: \]
           scope: punctuation.definition.arguments.end.python
           pop: true
-        - match: '(?={{identifier}}(?:\.{{identifier}})*\s*\[)'
+        - match: '(?={{path}}\s*\[)'
           push:
             - match: '(?=\s*\[)'
               pop: true
@@ -324,13 +324,13 @@ contexts:
           pop: true
         - include: keyword_arguments
         - include: expressions
-    - match: '(?={{identifier}}(?:\.{{identifier}})*\s*\()'
+    - match: '(?={{path}}\s*\()'
       push:
         - meta_scope: meta.function-call.python
         - match: \)
           scope: punctuation.definition.arguments.end.python
           pop: true
-        - match: '(?={{identifier}}(?:\.{{identifier}})*\s*\()'
+        - match: '(?={{path}}\s*\()'
           push:
             - match: (?=\s*\()
               pop: true
@@ -409,7 +409,7 @@ contexts:
         - include: expressions
 
   identifier-parts:
-    - match: '{{identifier}}(\.)'
+    - match: '{{identifier}} *(\.)'
       captures:
         1: punctuation.accessor.python
 
@@ -451,31 +451,39 @@ contexts:
   constant_placeholder:
     - match: '(?i:(%(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z%])|(\{([!\[\].:\w ]+)?\}))'
       scope: constant.other.placeholder.python
-  dotted_name:
-    - match: '(?={{identifier}}(?:\.{{identifier}})*)'
+
+  name:
+    - match: '(?={{identifier}})'
       push:
-        - match: '(?![{{identifier_continue}}\.])'
+        - meta_scope: meta.name.python
+        - match: '(?!{{identifier_continue}})'
           pop: true
-        - match: '(\.)(?={{identifier}})'
+        - include: builtin_functions
+        - include: builtin_types
+        - include: builtin_exceptions
+        - include: illegal_names
+        - include: magic_function_names
+        - include: magic_variable_names
+        - include: language_variables
+        - include: generic_names
+
+  dotted_name:
+    - match: '(?={{path}})'
+      push:
+        - meta_scope: meta.name.dotted.python
+        - match: '(?!{{identifier_continue}}| *\.)'
+          pop: true
+        - match: '(\.)(?= *{{identifier}})'
+          scope: punctuation.accessor.python
           push:
-            - match: "(?!{{identifier_continue}})"
+            - match: "(?! *{{identifier_continue}})"
               pop: true
             - include: magic_function_names
             - include: magic_variable_names
             - include: illegal_names
             - include: generic_names
-        - match: '(?={{identifier}})'
-          push:
-            - match: "(?!{{identifier_continue}})"
-              pop: true
-            - include: builtin_functions
-            - include: builtin_types
-            - include: builtin_exceptions
-            - include: illegal_names
-            - include: magic_function_names
-            - include: magic_variable_names
-            - include: language_variables
-            - include: generic_names
+        - include: name
+
   entity_name_class:
     - include: illegal_names
     - include: generic_names

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -511,6 +511,9 @@ contexts:
           scope: punctuation.definition.arguments.end.python
           pop: true
         - include: keyword_arguments
+        - match: ','
+          scope: punctuation.separator.parameters.python
+        - include: inline_for
         - include: expressions
     - match: '(?={{path}}\s*\()'
       push:
@@ -532,6 +535,7 @@ contexts:
             - include: keyword_arguments
             - match: ','
               scope: punctuation.separator.parameters.python
+            - include: inline_for
             - include: expressions
 
   lambda:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -246,6 +246,9 @@ contexts:
       scope: invalid.illegal.stray.brace.curly.python
     - include: lists
     - include: dictionaries_and_sets
+    # For debugging
+    # - match: \S
+    #   scope: invalid.illegal.unmatched
 
   comments:
     - match: "#"

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -362,7 +362,7 @@ contexts:
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\s+(?={{identifier}})'
       captures:
-        1: storage.modifier.python
+        1: storage.modifier.async.python
         2: storage.type.function.python
       push:
         - meta_scope: meta.function.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -534,6 +534,10 @@ contexts:
       captures:
         1: punctuation.separator.continuation.line.python
         2: invalid.illegal.unexpected-text.python
+    # make sure to resume parsing at next line
+      push:
+        - match: (?=.)
+          pop: true
   magic_function_names:
     - match: |-
         (?x)\b(__(?:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -647,17 +647,18 @@ contexts:
     - match: '(?={{path}})'
       push:
         - meta_scope: meta.name.dotted.python
-        - match: '(?!{{identifier_continue}}| *\.)'
-          pop: true
-        - match: '(\.)(?= *{{identifier}})'
-          scope: punctuation.accessor.python
+        - match: ' *(\.) *(?={{identifier}})'
+          captures:
+            1: punctuation.accessor.python
           push:
-            - match: "(?! *{{identifier_continue}})"
+            - match: '(?!{{identifier_continue}})'
               pop: true
             - include: magic_function_names
             - include: magic_variable_names
             - include: illegal_names
             - include: generic_names
+        - match: '(?!{{identifier_continue}})'
+          pop: true
         - include: name
 
   entity_name_class:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -34,6 +34,7 @@ contexts:
     - include: functions
     - include: decorators
     - include: modifiers
+    - include: assignments
     - include: expressions
 
   inline_statements:
@@ -299,17 +300,19 @@ contexts:
         1: keyword.control.flow.yield.python
         2: keyword.control.flow.yield-from.python
 
+  assignments:
+    - match: \+\=|-\=|\*\=|/\=|//\=|%\=|&\=|\|\=|\^\=|>>\=|<<\=|\*\*\=
+      scope: keyword.operator.assignment.augmented.python
+    - match: \=
+      scope: keyword.operator.assignment.python
+
   operators:
     - match: <>
       scope: invalid.deprecated.operator.python
     - match: <\=|>\=|\=\=|<|>|\!\=
       scope: keyword.operator.comparison.python
-    - match: \+\=|-\=|\*\=|/\=|//\=|%\=|&\=|\|\=|\^\=|>>\=|<<\=|\*\*\=
-      scope: keyword.operator.assignment.augmented.python
     - match: \+|\-|\*|\*\*|/|//|%|<<|>>|&|\||\^|~
       scope: keyword.operator.arithmetic.python
-    - match: \=
-      scope: keyword.operator.assignment.python
     - match: \b(and|in|is|not|or)\b
       comment: keyword operators that evaluate to True or False
       scope: keyword.operator.logical.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -15,6 +15,7 @@ file_extensions:
   - Snakefile
 first_line_match: ^#!/.*\bpython\d?\b
 scope: source.python
+
 variables:
   # We support unicode here because Python 3 is the future
   identifier_continue: '[[:alnum:]_]'
@@ -176,7 +177,7 @@ contexts:
                 - match: '(?={{path}})'
                   push:
                     - meta_scope: entity.other.inherited-class.python
-                    - include: identifier-parts
+                    - include: identifier_parts
                     - match: '{{identifier}}'
                     - match: '(?=\S)'
                       pop: true
@@ -204,9 +205,9 @@ contexts:
           set:
             - match: \(
               scope: meta.function.parameters.python punctuation.definition.parameters.begin.python
-              set: function-parameters
+              set: function_parameters
 
-  function-parameters:
+  function_parameters:
     - meta_content_scope: meta.function.parameters.python
     - match: \)
       scope: punctuation.definition.parameters.end.python
@@ -408,7 +409,7 @@ contexts:
           scope: punctuation.separator.key-value.python
         - include: expressions
 
-  identifier-parts:
+  identifier_parts:
     - match: '{{identifier}} *(\.)'
       captures:
         1: punctuation.accessor.python
@@ -441,6 +442,7 @@ contexts:
         	sum|super|type|unichr|vars|zip
         )\b
       scope: support.function.builtin.python
+
   builtin_types:
     - match: |-
         (?x)\b(
@@ -448,6 +450,7 @@ contexts:
         	list|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange
         )\b
       scope: support.type.python
+
   constant_placeholder:
     - match: '(?i:(%(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z%])|(\{([!\[\].:\w ]+)?\}))'
       scope: constant.other.placeholder.python
@@ -487,22 +490,26 @@ contexts:
   entity_name_class:
     - include: illegal_names
     - include: generic_names
+
   entity_name_function:
     - include: magic_function_names
     - include: illegal_names
     - include: generic_names
+
   escaped_char:
     - match: '(\\x\h{2})|(\\[0-7]{3})|(\\[\\"''abfnrtv])'
       captures:
         1: constant.character.escape.hex.python
         2: constant.character.escape.octal.python
         3: constant.character.escape.python
+
   escaped_unicode_char:
     - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[a-zA-Z ]+\})'
       captures:
         1: constant.character.escape.unicode.16-bit-hex.python
         2: constant.character.escape.unicode.32-bit-hex.python
         3: constant.character.escape.unicode.name.python
+
   function_name:
     - include: magic_function_names
     - include: magic_variable_names
@@ -510,11 +517,14 @@ contexts:
     - include: builtin_functions
     - include: builtin_types
     - include: generic_names
+
   generic_names:
     - match: "{{identifier}}"
+
   illegal_names:
     - match: \b(and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield)\b
       scope: invalid.illegal.name.python
+
   keyword_arguments:
     - match: '({{identifier}})\s*(=)(?!=)'
       captures:
@@ -526,9 +536,11 @@ contexts:
             1: punctuation.separator.parameters.python
           pop: true
         - include: expressions
+
   language_variables:
     - match: \b(self|cls)\b
       scope: variable.language.python
+
   line_continuation:
     - match: (\\)(.*)$\n?
       captures:
@@ -538,6 +550,7 @@ contexts:
       push:
         - match: (?=.)
           pop: true
+
   magic_function_names:
     - match: |-
         (?x)\b(__(?:
@@ -553,6 +566,7 @@ contexts:
         )__)\b
       comment: these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
       scope: support.function.magic.python
+
   magic_variable_names:
     - match: \b__(all|bases|class|debug|dict|doc|file|members|metaclass|methods|name|slots|weakref)__\b
       comment: magic variables which a class/module may have.

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1253,15 +1253,6 @@ contexts:
       scope: keyword.control.flow.for.comprehension.python
       push:
         - meta_scope: meta.comprehension.python
-        - match: ','
-          scope: punctuation.separator.target-list.python
-        - match: \(
-          push:
-            - match: ','
-              scope: punctuation.separator.target-list.python
-            - match: \)
-              pop: true
-            - include: name
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
           set:
@@ -1274,7 +1265,7 @@ contexts:
         - match: '(?=[)\]}])'
           scope: invalid.illegal.missing-in.python
           pop: true
-        - include: name
+        - include: target_list
 
   inline_if:
     - match: \b(if)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -524,23 +524,20 @@ contexts:
             - include: expressions
 
   lambda:
-    - match: \b(lambda)(?=\s+|:)
+    - match: \b(lambda)
       scope: storage.type.function.inline.python
       push:
         - meta_scope: meta.function.inline.python
+        - meta_content_scope: meta.function.inline.parameters.python
+        - include: line_continuation_or_pop
         - match: '\:'
           scope: punctuation.section.function.begin.python
           pop: true
-        - match: \s+
-          push:
-            - meta_content_scope: meta.function.inline.parameters.python
-            - match: (?=\:)
-              pop: true
-            - include: keyword_arguments
-            - match: '({{identifier}})\s*(?:(,)|(?=[\n\)\:]))'
-              captures:
-                1: variable.parameter.python
-                2: punctuation.separator.parameters.python
+        - match: ','
+          scope: punctuation.separator.parameters.python
+        - include: keyword_arguments
+        - match: '{{identifier}}'
+          scope: variable.parameter.python
 
   lists:
     - match: '(\[)(\s*(\]))\b'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -28,26 +28,202 @@ contexts:
     - include: statements
 
   statements:
+    - include: inline_statements
+    - include: block_statements
     - include: classes
     - include: functions
     - include: decorators
     - include: modifiers
     - include: expressions
 
+  inline_statements:
+    - include: imports
+    - match: \b(raise)\b
+      scope: keyword.control.flow.raise.python
+      push:
+        - meta_scope: meta.statement.raise.python
+        - match: $\n?
+          pop: true
+        - match: \b(from)\b
+          scope: keyword.control.flow.raise.from.python
+          set:
+            - meta_scope: meta.statement.raise.python
+            - include: expressions
+            - match: $\n?
+              pop: true
+        - include: expressions
+    - match: \b(assert)\b
+      scope: keyword.other.assert.python
+      push:
+        - meta_scope: meta.statement.assert.python
+        - include: expressions
+        - match: $\n?
+          pop: true
+    - match: \b(del)\b
+      scope: keyword.other.del.python
+      push:
+        - meta_scope: meta.statement.del.python
+        - include: expressions
+        - match: $\n?
+          pop: true
+    - match: \b(print)\b(?! *($|[,.()\]}]))
+      scope: keyword.other.print.python
+      push:
+        - meta_scope: meta.statement.print.python
+        - include: expressions
+        - match: $\n?
+          pop: true
+    - match: \b(exec)\b(?! *($|[,.()\]}]))
+      scope: keyword.other.exec.python
+      push:
+        - meta_scope: meta.statement.exec.python
+        - include: expressions
+        - match: $\n?
+          pop: true
+    - match: \b(return)\b
+      scope: keyword.control.flow.return.python
+    - match: \b(break|continue|pass)\b
+      scope: keyword.control.flow.python
+
+  imports:
+    - match: \b(import)\b
+      scope: keyword.control.import.python
+      push:
+        - meta_scope: meta.statement.import.python
+        - include: line_continuation
+        - match: $\n?
+          pop: true
+        - include: comments
+        - include: import_alias
+        - include: dotted_name
+        - match: ','
+          scope: punctuation.separator.import-list.python
+    - match: \b(from)\b
+      scope: keyword.control.import.from.python
+      push:
+        - meta_scope: meta.statement.import.python
+          meta_content_scope: meta.import-source.python
+        - include: line_continuation
+        - match: $\n?
+          pop: true
+        - match: \b(import)\b
+          scope: keyword.control.import.python
+          set:
+            - include: line_continuation
+            - match: $\n?
+              pop: true
+            - match: ' *(\()'
+              captures:
+                1: punctuation.definition.begin.import-list
+              set:
+                - meta_scope: meta.statement.import.python
+                - include: comments
+                - match: \)
+                  scope: punctuation.definition.end.import-list
+                  pop: true
+                - include: import_name_list
+            - match: ''
+              set:
+                - meta_scope: meta.statement.import.python
+                - include: line_continuation
+                - match: $\n?
+                  pop: true
+                - include: comments
+                - include: import_name_list
+        - include: dotted_name
+
+  import_name_list:
+    - match: ','
+      scope: punctuation.separator.import-list.python
+    - include: import_alias
+    - include: name
+    - match: \*
+      scope: keyword.other.import-all.python
+    - match: \S+
+      scope: invalid.illegal.name.import.python
+
+  import_alias:
+    - match: \b(as)\b
+      scope: keyword.control.import.as.python
+
+  block_statements:
+    # async for ... in ...:
+    - match: \b(async +)?(for)\b
+      captures:
+        1: keyword.control.flow.async.python
+        2: keyword.control.flow.for.python
+      push:
+        - meta_scope: meta.statement.for.python
+        - match: \b(in)\b
+          scope: keyword.control.flow.for.in.python
+          set:
+            - meta_scope: meta.statement.for.python
+            - include: line_continuation
+            - match: ':'
+              scope: punctuation.definition.block.for.python
+              pop: true
+            - include: expressions
+        - match: ':'
+          scope: invalid.illegal.missing-in.python
+          pop: true
+        - include: target_list
+    # async with ... as ...:
+    - match: \b(async +)?(with)\b
+      captures:
+        1: keyword.control.flow.async.python
+        2: keyword.control.flow.with.python
+      push:
+        - meta_scope: meta.statement.with.python
+        - match: \b(as)\b
+          scope: keyword.control.flow.with.as.python
+          set:
+            - meta_scope: meta.statement.with.python
+            - match: ':'
+              scope: punctuation.definition.block.with.python
+              pop: true
+            - include: name
+        - match: ':'
+          scope: punctuation.definition.block.with.python
+          pop: true
+        - include: expressions
+    # except ... as ...:
+    - match: \b(except)\b
+      scope: keyword.control.flow.except.python
+      push:
+        - meta_scope: meta.statement.except.python
+        - match: ':'
+          scope: punctuation.definition.block.except.python
+          pop: true
+        - match: '\b(as)\b'
+          scope: keyword.control.flow.as.python
+          set:
+            - meta_scope: meta.statement.except.python
+            - include: line_continuation
+            - match: $\n?
+              pop: true
+            - include: name
+            - match: ':'
+              scope: punctuation.definition.block.except.python
+              pop: true
+        - include: target_list
+    - match: \b(elif|else|finally|if|try|while)\b
+      scope: keyword.control.flow.python
+
   expressions:
     - include: comments
     - include: constants
     - include: numbers
-    - include: keywords
+    - include: yields
     - include: operators
     - include: lambda
+    - match: \b(await)\b
+      scope: keyword.other.await.python
+    - include: inline_if
+    - include: strings
     - include: function-calls
     - include: item-access
-    - include: late-keywords
     - include: line_continuation
     - include: language_variables
-    - include: string_quoted_single
-    - include: string_quoted_double
     - include: dotted_name
     - match: \(
       scope: punctuation.definition.group.begin.python
@@ -56,6 +232,7 @@ contexts:
         - match: \)
           scope: punctuation.definition.group.end.python
           pop: true
+        - include: inline_for
         - include: expressions
     - match: \)
       scope: invalid.illegal.stray.brace.round.python
@@ -115,25 +292,11 @@ contexts:
         - match: \S+
           scope: invalid.illegal.name.storage.python
 
-  keywords:
-    - match: \b(?:(import)|(from))\b
+  yields:
+    - match: \b(yield)(?:\s+(from))?\b
       captures:
-        1: keyword.control.import.python
-        2: keyword.control.import.from.python
-    - match: \b(yield)\b(?:\s+(from))?
-      captures:
-        1: keyword.control.flow.python
-        2: keyword.control.flow.python
-    - match: \b(async)\b(?:\s+(for|with)\b)
-      captures:
-        1: keyword.control.flow.python
-        2: keyword.control.flow.python
-    - match: \b(elif|else|except|finally|for|if|try|while|with|break|continue|pass|raise|return|await)\b
-      comment: keywords that delimit flow blocks or alter flow from within a block
-      scope: keyword.control.flow.python
-    - match: \b(as|assert|del|exec|print)\b
-      comment: keywords that haven't fit into other groups (yet).
-      scope: keyword.other.python
+        1: keyword.control.flow.yield.python
+        2: keyword.control.flow.yield-from.python
 
   operators:
     - match: <>
@@ -378,14 +541,6 @@ contexts:
                 1: variable.parameter.python
                 2: punctuation.separator.parameters.python
 
-  late-keywords:
-    - match: \b(def|lambda)\b
-      scope: storage.type.function.python
-    - match: \b(class)\b
-      scope: storage.type.class.python
-    - match: \b(async)\b
-      scope: storage.modifier.python
-
   lists:
     - match: '(\[)(\s*(\]))\b'
       captures:
@@ -401,6 +556,7 @@ contexts:
           pop: true
         - match: ','
           scope: punctuation.separator.list.python
+        - include: inline_for
         - include: expressions
 
   dictionaries_and_sets:
@@ -421,6 +577,7 @@ contexts:
           scope: punctuation.separator.dictionary-or-set.python
         - match: ':'
           scope: punctuation.separator.key-value.python
+        - include: inline_for
         - include: expressions
 
   identifier_parts:
@@ -1090,3 +1247,53 @@ contexts:
   strings:
     - include: string_quoted_double
     - include: string_quoted_single
+
+  inline_for:
+    - match: \b(for)\b
+      scope: keyword.control.flow.for.comprehension.python
+      push:
+        - meta_scope: meta.comprehension.python
+        - match: ','
+          scope: punctuation.separator.target-list.python
+        - match: \(
+          push:
+            - match: ','
+              scope: punctuation.separator.target-list.python
+            - match: \)
+              pop: true
+            - include: name
+        - match: \b(in)\b
+          scope: keyword.control.flow.for.in.python
+          set:
+            - meta_scope: meta.comprehension.python
+            - include: line_continuation
+            - match: '(?=[)\]}])'
+              pop: true
+            - include: inline_if  # not necessary but more explicit
+            - include: expressions
+        - match: '(?=[)\]}])'
+          scope: invalid.illegal.missing-in.python
+          pop: true
+        - include: name
+
+  inline_if:
+    - match: \b(if)\b
+      scope: keyword.control.flow.if.inline.python
+    - match: \b(else)\b
+      scope: keyword.control.flow.else.inline.python
+
+  target_list:
+    - include: line_continuation
+    - match: $\n?
+      pop: true
+    - match: ','
+      scope: punctuation.separator.target-list.python
+    - match: \(
+      push:
+        - include: comments
+        - match: ','
+          scope: punctuation.separator.target-list.python
+        - match: \)
+          pop: true
+        - include: name
+    - include: name

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -48,38 +48,38 @@ contexts:
           scope: keyword.control.flow.raise.from.python
           set:
             - meta_scope: meta.statement.raise.python
-            - include: expressions
             - match: $\n?
               pop: true
+            - include: expressions
         - include: expressions
     - match: \b(assert)\b
       scope: keyword.other.assert.python
       push:
         - meta_scope: meta.statement.assert.python
-        - include: expressions
         - match: $\n?
           pop: true
+        - include: expressions
     - match: \b(del)\b
       scope: keyword.other.del.python
       push:
         - meta_scope: meta.statement.del.python
-        - include: expressions
         - match: $\n?
           pop: true
+        - include: expressions
     - match: \b(print)\b(?! *($|[,.()\]}]))
       scope: keyword.other.print.python
       push:
         - meta_scope: meta.statement.print.python
-        - include: expressions
         - match: $\n?
           pop: true
+        - include: expressions
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
       push:
         - meta_scope: meta.statement.exec.python
-        - include: expressions
         - match: $\n?
           pop: true
+        - include: expressions
     - match: \b(return)\b
       scope: keyword.control.flow.return.python
     - match: \b(break|continue|pass)\b
@@ -210,6 +210,7 @@ contexts:
       scope: keyword.control.flow.python
 
   expressions:
+    # Always include this last!
     - include: comments
     - include: constants
     - include: numbers

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -155,11 +155,16 @@ contexts:
         2: keyword.control.flow.for.python
       push:
         - meta_scope: meta.statement.for.python
+        - include: line_continuation
+        - match: $\n?
+          pop: true
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
           set:
             - meta_scope: meta.statement.for.python
             - include: line_continuation
+            - match: $\n?
+              pop: true
             - match: ':'
               scope: punctuation.definition.block.for.python
               pop: true
@@ -175,10 +180,16 @@ contexts:
         2: keyword.control.flow.with.python
       push:
         - meta_scope: meta.statement.with.python
+        - include: line_continuation
+        - match: $\n?
+          pop: true
         - match: \b(as)\b
           scope: keyword.control.flow.with.as.python
           set:
             - meta_scope: meta.statement.with.python
+            - include: line_continuation
+            - match: $\n?
+              pop: true
             - match: ':'
               scope: punctuation.definition.block.with.python
               pop: true
@@ -192,6 +203,9 @@ contexts:
       scope: keyword.control.flow.except.python
       push:
         - meta_scope: meta.statement.except.python
+        - include: line_continuation
+        - match: $\n?
+          pop: true
         - match: ':'
           scope: punctuation.definition.block.except.python
           pop: true
@@ -202,10 +216,10 @@ contexts:
             - include: line_continuation
             - match: $\n?
               pop: true
-            - include: name
             - match: ':'
               scope: punctuation.definition.block.except.python
               pop: true
+            - include: name
         - include: target_list
     - match: \b(elif|else|finally|if|try|while)\b
       scope: keyword.control.flow.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -606,7 +606,7 @@ contexts:
     - match: |-
         (?x)\b(
         	__import__|all|abs|any|apply|ascii|bin|callable|chr|classmethod|cmp|coerce|
-        	compile|delattr|dir|divmod|enumerate|eval|execfile|filter|format|getattr|
+        	compile|delattr|dir|divmod|enumerate|eval|exec|execfile|filter|format|getattr|
         	globals|hasattr|hash|help|hex|id|input|intern|isinstance|issubclass|iter|
         	len|locals|map|max|min|next|oct|open|ord|pow|print|property|range|
         	raw_input|reduce|reload|repr|reversed|round|setattr|sorted|staticmethod|
@@ -693,7 +693,7 @@ contexts:
     - match: "{{identifier}}"
 
   illegal_names:
-    - match: \b(and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield)\b
+    - match: \b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b
       scope: invalid.illegal.name.python
 
   keyword_arguments:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -215,9 +215,9 @@ contexts:
         - meta_content_scope: meta.function.python
         - match: '(?=->)'
           push:
-            - meta_content_scope: meta.function.return-type.python
+            - meta_content_scope: meta.function.annotation.return.python
             - match: ->
-              scope: punctuation.separator.annotation.python
+              scope: punctuation.separator.annotation.return.python
             - match: '(?=:)'
               pop: true
             - include: expressions
@@ -237,8 +237,9 @@ contexts:
           pop: true
         - include: expressions
     - match: ':'
-      scope: punctuation.separator.annotation.python
+      scope: punctuation.separator.annotation.parameter.python
       push:
+        - meta_scope: meta.function.annotation.parameter.python
         - match: '(?=[,)=])'
           pop: true
         - include: expressions

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -215,7 +215,6 @@ contexts:
     - include: function-calls
     - include: item-access
     - include: line_continuation
-    - include: language_variables
     - include: dotted_name
     - match: \(
       scope: punctuation.definition.group.begin.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -3,8 +3,9 @@
 name: Python
 file_extensions:
   - py
-  - rpy
   - pyw
+  - pyi
+  - rpy
   - cpy
   - SConstruct
   - Sconstruct

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -43,13 +43,13 @@ contexts:
       scope: keyword.control.flow.raise.python
       push:
         - meta_scope: meta.statement.raise.python
-        - match: $\n?
+        - match: $
           pop: true
         - match: \b(from)\b
           scope: keyword.control.flow.raise.from.python
           set:
             - meta_scope: meta.statement.raise.python
-            - match: $\n?
+            - match: $
               pop: true
             - include: expressions
         - include: expressions
@@ -57,28 +57,28 @@ contexts:
       scope: keyword.other.assert.python
       push:
         - meta_scope: meta.statement.assert.python
-        - match: $\n?
+        - match: $
           pop: true
         - include: expressions
     - match: \b(del)\b
       scope: keyword.other.del.python
       push:
         - meta_scope: meta.statement.del.python
-        - match: $\n?
+        - match: $
           pop: true
         - include: expressions
     - match: \b(print)\b(?! *($|[,.()\]}]))
       scope: keyword.other.print.python
       push:
         - meta_scope: meta.statement.print.python
-        - match: $\n?
+        - match: $
           pop: true
         - include: expressions
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
       push:
         - meta_scope: meta.statement.exec.python
-        - match: $\n?
+        - match: $
           pop: true
         - include: expressions
     - match: \b(return)\b
@@ -92,7 +92,7 @@ contexts:
       push:
         - meta_scope: meta.statement.import.python
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - include: comments
         - include: import_alias
@@ -105,13 +105,13 @@ contexts:
         - meta_scope: meta.statement.import.python
           meta_content_scope: meta.import-source.python
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - match: \b(import)\b
           scope: keyword.control.import.python
           set:
             - include: line_continuation
-            - match: $\n?
+            - match: $
               pop: true
             - match: ' *(\()'
               captures:
@@ -127,7 +127,7 @@ contexts:
               set:
                 - meta_scope: meta.statement.import.python
                 - include: line_continuation
-                - match: $\n?
+                - match: $
                   pop: true
                 - include: comments
                 - include: import_name_list
@@ -156,14 +156,14 @@ contexts:
       push:
         - meta_scope: meta.statement.for.python
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
           set:
             - meta_scope: meta.statement.for.python
             - include: line_continuation
-            - match: $\n?
+            - match: $
               pop: true
             - match: ':'
               scope: punctuation.definition.block.for.python
@@ -181,14 +181,14 @@ contexts:
       push:
         - meta_scope: meta.statement.with.python
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - match: \b(as)\b
           scope: keyword.control.flow.with.as.python
           set:
             - meta_scope: meta.statement.with.python
             - include: line_continuation
-            - match: $\n?
+            - match: $
               pop: true
             - match: ':'
               scope: punctuation.definition.block.with.python
@@ -204,7 +204,7 @@ contexts:
       push:
         - meta_scope: meta.statement.except.python
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - match: ':'
           scope: punctuation.definition.block.except.python
@@ -214,7 +214,7 @@ contexts:
           set:
             - meta_scope: meta.statement.except.python
             - include: line_continuation
-            - match: $\n?
+            - match: $
               pop: true
             - match: ':'
               scope: punctuation.definition.block.except.python
@@ -305,7 +305,7 @@ contexts:
         2: storage.modifier.nonlocal.python
       push:
         - include: line_continuation
-        - match: $\n?
+        - match: $
           pop: true
         - match: ','
           scope: punctuation.separator.storage-list.python
@@ -474,13 +474,13 @@ contexts:
       push:
         - meta_scope: meta.function.decorator.python
         - meta_content_scope: entity.name.function.decorator.python
-        - match: (?=\s|$\n?|#)
+        - match: (?=\s|$|#)
           pop: true
         - match: '(?=(@)\s*{{identifier}}(\.{{identifier}})*)'
           captures:
             1: punctuation.definition.decorator.python
           push:
-            - match: (?=\s|$\n?|#)
+            - match: (?=\s|$|#)
               pop: true
             - include: dotted_name
 
@@ -732,7 +732,7 @@ contexts:
         1: variable.parameter.python
         2: keyword.operator.assignment.python
       push:
-        - match: '\s*(?:(,)|(?=$\n?|[\)\:]))'
+        - match: '\s*(?:(,)|(?=$|[\)\:]))'
           captures:
             1: punctuation.separator.parameters.python
           pop: true
@@ -1305,7 +1305,7 @@ contexts:
 
   target_list:
     - include: line_continuation
-    - match: $\n?
+    - match: $
       pop: true
     - match: ','
       scope: punctuation.separator.target-list.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -234,6 +234,8 @@ contexts:
         - match: \)
           scope: punctuation.definition.group.end.python
           pop: true
+        - match: ','
+          scope: punctuation.separator.tuple.python
         - include: inline_for
         - include: expressions
     - match: \)
@@ -353,7 +355,7 @@ contexts:
                   scope: invalid.illegal.no-closing-parens.python
                   pop: true
                 - match: ','
-                  scope: punctuation.separator.python
+                  scope: punctuation.separator.inheritance.python
                 - match: '(?={{path}})'
                   push:
                     - meta_scope: entity.other.inherited-class.python
@@ -525,6 +527,8 @@ contexts:
             - match: (?=\))
               pop: true
             - include: keyword_arguments
+            - match: ','
+              scope: punctuation.separator.parameters.python
             - include: expressions
 
   lambda:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -387,17 +387,18 @@ contexts:
                 - include: expressions
 
   functions:
-    - match: '^\s*(?:(async)\s+)?(def)\s+(?={{identifier}})'
+    - match: '^\s*(?:(async)\s+)?(def)\b'
       captures:
         1: storage.modifier.async.python
         2: storage.type.function.python
       push:
         - meta_scope: meta.function.python
+        - include: line_continuation
+        - match: $
+          pop: true
         - match: ':'
           scope: punctuation.section.function.begin.python
           set: maybe-docstrings
-        - match: '^\s*$'
-          pop: true
         - match: "(?={{identifier}})"
           push:
             - meta_content_scope: entity.name.function.python
@@ -423,7 +424,7 @@ contexts:
               scope: punctuation.separator.annotation.return.python
             - match: '(?=:)'
               pop: true
-            - include: expressions
+            - include: expressions # includes line_continuation
         - match: ':'
           scope: punctuation.section.function.begin.python
           set: maybe-docstrings

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1267,6 +1267,7 @@ contexts:
             - match: '(?=[)\]}])'
               pop: true
             - include: inline_if  # not necessary but more explicit
+            - include: inline_for
             - include: expressions
         - match: '(?=[)\]}])'
           scope: invalid.illegal.missing-in.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -524,7 +524,7 @@ contexts:
             - include: expressions
 
   lambda:
-    - match: \b(lambda)(?=\s|:)
+    - match: \b(lambda)(?=\s|:|$)
       scope: storage.type.function.inline.python
       push:
         - meta_scope: meta.function.inline.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -524,7 +524,7 @@ contexts:
             - include: expressions
 
   lambda:
-    - match: \b(lambda)
+    - match: \b(lambda)(?=\s|:)
       scope: storage.type.function.inline.python
       push:
         - meta_scope: meta.function.inline.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -414,6 +414,7 @@ contexts:
         - match: '(?=[,)=])'
           pop: true
         - include: expressions
+    - include: illegal_names
     - match: '{{identifier}}'
       scope: variable.parameter.python
 
@@ -536,6 +537,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.parameters.python
         - include: keyword_arguments
+        - include: illegal_names
         - match: '{{identifier}}'
           scope: variable.parameter.python
 
@@ -696,16 +698,18 @@ contexts:
       scope: invalid.illegal.name.python
 
   keyword_arguments:
-    - match: '({{identifier}})\s*(=)(?!=)'
-      captures:
-        1: variable.parameter.python
-        2: keyword.operator.assignment.python
+    - match: '(?={{identifier}}\s*=(?!=))'
       push:
-        - match: '\s*(?:(,)|(?=$|[\)\:]))'
-          captures:
-            1: punctuation.separator.parameters.python
-          pop: true
-        - include: expressions
+        - include: line_continuation_or_pop
+        - match: '='
+          scope: keyword.operator.assignment.python
+          set:
+            - match: (?=\s*[,):])
+              pop: true
+            - include: expressions
+        - include: illegal_names
+        - match: '{{identifier}}'
+          scope: variable.parameter.python
 
   language_variables:
     - match: \b(self|cls)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -60,7 +60,7 @@ contexts:
     - match: \)
       scope: invalid.illegal.stray.brace.round.python
     - include: lists
-    - include: dictionaries
+    - include: dictionaries_and_sets
 
   comments:
     - match: "#"
@@ -390,7 +390,7 @@ contexts:
           scope: punctuation.separator.list.python
         - include: expressions
 
-  dictionaries:
+  dictionaries_and_sets:
     - match: '(\{)(\s*(\}))'
       scope: meta.structure.dictionary.python
       captures:
@@ -398,14 +398,14 @@ contexts:
         2: meta.empty-dictionary.python
         3: punctuation.definition.dictionary.end.python
     - match: \{
-      scope: punctuation.definition.dictionary.begin.python
+      scope: punctuation.definition.dictionary-or-set.begin.python
       push:
-        - meta_scope: meta.structure.dictionary.python
+        - meta_scope: meta.structure.dictionary-or-set.python
         - match: \}
-          scope: punctuation.definition.dictionary.end.python
+          scope: punctuation.definition.dictionary-or-set.end.python
           pop: true
         - match: ','
-          scope: punctuation.separator.dictionary.python
+          scope: punctuation.separator.dictionary-or-set.python
         - match: ':'
           scope: punctuation.separator.key-value.python
         - include: expressions

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -117,9 +117,6 @@ contexts:
     - match: \b(elif|else|except|finally|for|if|try|while|with|break|continue|pass|raise|return|await)\b
       comment: keywords that delimit flow blocks or alter flow from within a block
       scope: keyword.control.flow.python
-    - match: \b(and|in|is|not|or)\b
-      comment: keyword operators that evaluate to True or False
-      scope: keyword.operator.logical.python
     - match: \b(as|assert|del|exec|print)\b
       comment: keywords that haven't fit into other groups (yet).
       scope: keyword.other.python
@@ -135,6 +132,9 @@ contexts:
       scope: keyword.operator.arithmetic.python
     - match: \=
       scope: keyword.operator.assignment.python
+    - match: \b(and|in|is|not|or)\b
+      comment: keyword operators that evaluate to True or False
+      scope: keyword.operator.logical.python
 
   classes:
     - match: '^\s*(class)\s+(?={{identifier}})'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -36,6 +36,8 @@ contexts:
     - include: decorators
     - include: modifiers
     - include: assignments
+    - match: ;
+      scope: punctuation.separator.statements.python
     - include: expressions
 
   inline_statements:
@@ -44,14 +46,12 @@ contexts:
       scope: keyword.control.flow.raise.python
       push:
         - meta_scope: meta.statement.raise.python
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: \b(from)\b
           scope: keyword.control.flow.raise.from.python
           set:
             - meta_scope: meta.statement.raise.python
-            - match: $
-              pop: true
+            - include: line_continuation_or_pop
             - include: expressions
         - include: expressions
     - match: \b(assert)\b
@@ -65,22 +65,19 @@ contexts:
       scope: keyword.other.del.python
       push:
         - meta_scope: meta.statement.del.python
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - include: expressions
     - match: \b(print)\b(?! *($|[,.()\]}]))
       scope: keyword.other.print.python
       push:
         - meta_scope: meta.statement.print.python
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - include: expressions
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
       push:
         - meta_scope: meta.statement.exec.python
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - include: expressions
     - match: \b(return)\b
       scope: keyword.control.flow.return.python
@@ -92,10 +89,7 @@ contexts:
       scope: keyword.control.import.python
       push:
         - meta_scope: meta.statement.import.python
-        - include: line_continuation
-        - match: $
-          pop: true
-        - include: comments
+        - include: line_continuation_or_pop
         - include: import_alias
         - include: dotted_name
         - match: ','
@@ -105,15 +99,11 @@ contexts:
       push:
         - meta_scope: meta.statement.import.python
           meta_content_scope: meta.import-source.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: \b(import)\b
           scope: keyword.control.import.python
           set:
-            - include: line_continuation
-            - match: $
-              pop: true
+            - include: line_continuation_or_pop
             - match: ' *(\()'
               captures:
                 1: punctuation.definition.begin.import-list
@@ -127,10 +117,7 @@ contexts:
             - match: ''
               set:
                 - meta_scope: meta.statement.import.python
-                - include: line_continuation
-                - match: $
-                  pop: true
-                - include: comments
+                - include: line_continuation_or_pop
                 - include: import_name_list
         - include: dotted_name
 
@@ -156,16 +143,12 @@ contexts:
         2: keyword.control.flow.for.python
       push:
         - meta_scope: meta.statement.for.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
           set:
             - meta_scope: meta.statement.for.python
-            - include: line_continuation
-            - match: $
-              pop: true
+            - include: line_continuation_or_pop
             - match: ':'
               scope: punctuation.definition.block.for.python
               pop: true
@@ -181,16 +164,12 @@ contexts:
         2: keyword.control.flow.with.python
       push:
         - meta_scope: meta.statement.with.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: \b(as)\b
           scope: keyword.control.flow.with.as.python
           set:
             - meta_scope: meta.statement.with.python
-            - include: line_continuation
-            - match: $
-              pop: true
+            - include: line_continuation_or_pop
             - match: ':'
               scope: punctuation.definition.block.with.python
               pop: true
@@ -204,9 +183,7 @@ contexts:
       scope: keyword.control.flow.except.python
       push:
         - meta_scope: meta.statement.except.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: ':'
           scope: punctuation.definition.block.except.python
           pop: true
@@ -214,9 +191,7 @@ contexts:
           scope: keyword.control.flow.as.python
           set:
             - meta_scope: meta.statement.except.python
-            - include: line_continuation
-            - match: $
-              pop: true
+            - include: line_continuation_or_pop
             - match: ':'
               scope: punctuation.definition.block.except.python
               pop: true
@@ -305,9 +280,7 @@ contexts:
         1: storage.modifier.global.python
         2: storage.modifier.nonlocal.python
       push:
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: ','
           scope: punctuation.separator.storage-list.python
         - include: name
@@ -343,9 +316,7 @@ contexts:
         1: storage.type.class.python
       push:
         - meta_scope: meta.class.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: ':'
           scope: punctuation.section.class.begin.python
           set: maybe-docstrings
@@ -364,9 +335,7 @@ contexts:
                 - match: \)
                   scope: punctuation.definition.inheritance.end.python
                   set:
-                    - include: line_continuation
-                    - match: $
-                      pop: true
+                    - include: line_continuation_or_pop
                     - match: ':'
                       scope: meta.class.python punctuation.section.class.begin.python
                       set: maybe-docstrings
@@ -393,9 +362,7 @@ contexts:
         2: storage.type.function.python
       push:
         - meta_scope: meta.function.python
-        - include: line_continuation
-        - match: $
-          pop: true
+        - include: line_continuation_or_pop
         - match: ':'
           scope: punctuation.section.function.begin.python
           set: maybe-docstrings
@@ -756,6 +723,11 @@ contexts:
       push:
         - match: (?=.)
           pop: true
+
+  line_continuation_or_pop:
+    - include: line_continuation
+    - match: $|(?=;|#)
+      pop: true
 
   magic_function_names:
     - match: |-
@@ -1292,7 +1264,6 @@ contexts:
           scope: keyword.control.flow.for.in.python
           set:
             - meta_scope: meta.expression.generator.python
-            - include: line_continuation
             - match: '(?=[)\]}])'
               pop: true
             - include: inline_if  # not necessary but more explicit
@@ -1309,9 +1280,7 @@ contexts:
       scope: keyword.control.flow.else.inline.python
 
   target_list:
-    - include: line_continuation
-    - match: $
-      pop: true
+    - include: line_continuation_or_pop
     - match: ','
       scope: punctuation.separator.target-list.python
     - match: \(

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -409,6 +409,7 @@ contexts:
     - match: '='
       scope: keyword.operator.assignment.python
       push:
+        - meta_scope: meta.function.default-value.python
         - match: '(?=[,)])'
           pop: true
         - include: expressions

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -80,6 +80,14 @@ def my_func(param1, # Multi-line function definition
 #                          ^ punctuation.definition.block.for
         pass
 
+    for \
+        a \
+        in \
+        b:
+#       ^^ meta.statement.for
+
+    for
+#   ^^^ keyword.control.flow.for
     b = c in d
 #         ^^ keyword.operator.logical
 
@@ -96,6 +104,14 @@ def my_func(param1, # Multi-line function definition
         await something()
 #       ^^^^^ keyword.other.await
 
+    with \
+        open() \
+        as \
+        x:
+#       ^^ meta.statement.with
+
+    with
+#   ^^^^ keyword.control.flow.with
     yield from
 #   ^^^^^ keyword.control.flow.yield
 #         ^^^^ keyword.control.flow.yield-from
@@ -345,7 +361,8 @@ except (KeyError, NameError) as e:
 #                 ^^^^^^^^^ support.type.exception
 #                            ^^ keyword.control.flow.as
 #                                ^ punctuation.definition.block
-except StopIteration \
+except \
+    StopIteration \
     as \
     err:
 #   ^^^^ meta.statement.except
@@ -354,9 +371,11 @@ except StopIteration
     as
 #   ^^ invalid.illegal.name - meta.statement.except
 
+except
+#^^^^^ keyword.control.flow.except
+
 raise
 #^^^^ meta.statement.raise keyword.control.flow.raise
-
 raise Ellipsis
 #^^^^^^^^^^^^^ meta.statement.raise
 #^^^^ keyword.control.flow.raise

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -188,6 +188,13 @@ myset = {"key", True, key2, [-1], {}}
 #                               ^ punctuation.separator.dictionary-or-set
 #                                 ^^ meta.structure.dictionary
 
+)
+# <- invalid.illegal.stray.brace.round
+]
+# <- invalid.illegal.stray.brace.square
+}
+# <- invalid.illegal.stray.brace.curly
+
 ###############################
 # Strings and embedded syntaxes
 ###############################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -11,6 +11,8 @@ from os import path, chdir # comment
 #                  ^ punctuation.separator.import-list
 #                    ^^^^^ meta.name
 #                          ^ comment
+from collections.abc import Iterable
+#                    ^^^^^^ keyword.control.import
 from \
     os \
     import \
@@ -40,13 +42,15 @@ from a import (b as c)
 import re; re.compile(r'')
 #        ^^^^^^^^^^^^^^^^^ - meta.statement.import
 #        ^ punctuation.separator.statements
+
 name
 #^^^ meta.name
-#
 name1 . name2
 #^^^^^^^^^^^^ meta.name.dotted
 #     ^ punctuation.accessor
 #^^^^ meta.name.dotted meta.name
+name .2name
+#     ^ - meta.name
 
 class
 #^^^^ storage.type.class

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -51,6 +51,11 @@ name1 . name2
 #^^^^ meta.name.dotted meta.name
 name .2name
 #     ^ - meta.name
+self.int
+#^^^^^^^ meta.name.dotted
+#^^^ variable.language
+#   ^ punctuation.accessor
+#    ^^^ - support.type
 
 class
 #^^^^ storage.type.class

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1,10 +1,40 @@
 # SYNTAX TEST "Packages/Python/Python.sublime-syntax"
 
-import sys
+import sys # comment
 #^^^^^ keyword.control.import
+#          ^ comment
+from os import path, chdir # comment
+#^^^ keyword.control.import.from
+#       ^^^^^^ keyword.control.import
+#              ^^^^ meta.name
+#                  ^ punctuation.separator.import-list
+#                    ^^^^^ meta.name
+#                          ^ comment
+from \
+    os \
+    import \
+    path
+#   ^^^^ meta.statement.import
+from sys import (version, # comment
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.import
+#               ^ punctuation.definition.begin.import-list
+#                         ^ comment
+                 version_info, . ) # comment
+#                ^^^^^^^^^^^^^ meta.statement.import
+#                              ^ invalid.illegal.name.import
+#                                ^ punctuation.definition.end.import-list
+#                                  ^ comment
 import path from os
-#^^^^^ keyword.control.import
-#           ^^^^ keyword.control.import.from
+#           ^^^^ invalid.illegal.name
+from .sub import *
+#                ^ keyword.other.import-all.python
+import a as b
+#        ^^ keyword.control.import.as.python
+from a import b as c, d as e
+#               ^^ keyword.control.import.as.python
+#                       ^^ keyword.control.import.as.python
+from a import (b as c)
+#                ^^ keyword.control.import.as.python
 
 name
 #^^^ meta.name
@@ -13,6 +43,16 @@ name1 . name2
 #^^^^^^^^^^^^ meta.name.dotted
 #     ^ punctuation.accessor
 #^^^^ meta.name.dotted meta.name
+
+class
+#^^^^ invalid.illegal.name
+def
+#^^ invalid.illegal.name
+
+# Currently, async and await are still recognized as valid identifiers unless in an "async" block
+async
+#^^^^ - invalid.illegal.name
+#
 
 def abc():
     global from, for, variable, .
@@ -31,15 +71,50 @@ def my_func(param1, # Multi-line function definition
     print('Hi!')
 
     async for i in myfunc():
-#   ^ keyword.control.flow
-#         ^ keyword.control.flow
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.for
+#   ^^^^^ keyword.control.flow.async
+#         ^^^ keyword.control.flow.for
+#               ^^ keyword.control.flow.for.in
+#                          ^ punctuation.definition.block.for
         pass
 
-    async with context_manager():
-#   ^ keyword.control.flow
-#         ^ keyword.control.flow
-        pass
+    for i:
+#        ^ invalid.illegal.missing-in
 
+    a for b in c: # TODO make this invalid (for not at beginning of line)
+
+    async with context_manager() as c:
+#   ^^^^^ keyword.control.flow.async
+#         ^^^^ keyword.control.flow.with
+#                                ^^ keyword.control.flow.with.as
+#                                    ^ punctuation.definition.block.with
+        await something()
+#       ^^^^^ keyword.other.await
+
+    yield from
+#   ^^^^^ keyword.control.flow.yield
+#         ^^^^ keyword.control.flow.yield-from
+
+    yield fromsomething
+#         ^^^^ - keyword
+
+    print (file=None)
+#   ^^^^^ - keyword
+    print . __class__
+#   ^^^^^ - keyword
+    print "keyword"
+#   ^^^^^^^^^^^^^^^ meta.statement.print
+#   ^^^^^ keyword
+    print __init__
+#   ^^^^^ keyword
+#
+    exec 123
+#   ^^^^^^^^ meta.statement.exec
+    callback(print , print
+#            ^^^^^ - keyword
+#                    ^^^^^ - keyword
+             , print)
+#              ^^^^^ - keyword
 
 def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
@@ -187,6 +262,73 @@ myset = {"key", True, key2, [-1], {}}
 #                             ^ constant.numeric
 #                               ^ punctuation.separator.dictionary-or-set
 #                                 ^^ meta.structure.dictionary
+
+generator = (i for i in range(100))
+#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+#              ^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#              ^^^ keyword.control.flow.for.comprehension
+#                  ^ meta.name
+#                    ^^ keyword.control.flow.for.in
+list_ = [i for i in range(100)]
+#       ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
+#          ^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#          ^^^ keyword.control.flow.for.comprehension
+#                ^^ keyword.control.flow.for.in
+set_ = {i for i in range(100)}
+#      ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+#         ^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#         ^^^ keyword.control.flow.for.comprehension
+#               ^^ keyword.control.flow.for.in
+dict_ = {i: i for i in range(100)}
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+#             ^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#             ^^^ keyword.control.flow.for.comprehension
+#                   ^^ keyword.control.flow.for.in
+list_ = [i for i in range(100) if i > 0 else -1]
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#                              ^^ keyword.control.flow.if.inline
+#                                       ^^^^ keyword.control.flow.else.inline
+
+a if b else c
+# ^^ keyword.control.flow
+#      ^^^^ keyword.control.flow
+
+except Exception:
+#^^^^^^^^^^^^^^^^ meta.statement.except
+#^^^^^ keyword.control.flow.except
+#      ^^^^^^^^^ support.type.exception
+#               ^ punctuation.definition.block
+except (KeyError, NameError) as e:
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.except
+#^^^^^ keyword.control.flow.except
+#       ^^^^^^^^ support.type.exception
+#               ^ punctuation.separator.target-list
+#                 ^^^^^^^^^ support.type.exception
+#                            ^^ keyword.control.flow.as
+#                                ^ punctuation.definition.block
+except StopIteration \
+    as \
+    err:
+#   ^^^^ meta.statement.except
+
+except StopIteration
+    as
+#   ^^ invalid.illegal.name - meta.statement.except
+
+raise
+#^^^^ meta.statement.raise keyword.control.flow.raise
+
+raise Ellipsis
+#^^^^^^^^^^^^^ meta.statement.raise
+#^^^^ keyword.control.flow.raise
+#     ^^^^^^^^ constant.language
+raise KeyError() from z
+#^^^^^^^^^^^^^^^^^^^^^^ meta.statement.raise
+#^^^^ keyword.control.flow.raise
+#     ^^^^^^^^ support.type.exception
+#                ^^^^ keyword.control.flow.raise.from
+#                     ^ meta.name
 
 )
 # <- invalid.illegal.stray.brace.round

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -14,6 +14,14 @@ name1 . name2
 #     ^ punctuation.accessor
 #^^^^ meta.name.dotted meta.name
 
+def abc():
+    global from, for, variable, .
+#   ^^^^^^ storage.modifier.global
+#          ^^^^ invalid.illegal.name
+#                ^^^ invalid.illegal.name
+#                     ^^^^^^^^ meta.name
+#                               ^ invalid.illegal.name.storage
+
 def my_func(param1, # Multi-line function definition
 #                   ^ comment.line.number-sign
     # This is defaulted

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -171,7 +171,7 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 #                                                                                                ^ punctuation.definition.parameters.end
 #                                                                                                  ^^ punctuation.separator.annotation
 #                                                                                                     ^^^ support.type
-#                                                                                                        ^ punctuation.section.function
+#                                                                                                        ^ punctuation.section.function.begin
     pass
 
 
@@ -185,7 +185,9 @@ async def coroutine(param1):
 
 
 class MyClass():
-
+#^^^^^^^^^^^^^^^ meta.class
+#            ^^ meta.class.inheritance
+#              ^ punctuation.section.class.begin
     def my_func(self, param1, # Multi-line function definition
 #                             ^ comment.line.number-sign
         # This is defaulted

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -100,9 +100,9 @@ def my_func(param1, # Multi-line function definition
 #         ^^^^ - keyword
 
     print (file=None)
-#   ^^^^^ - keyword
+#   ^^^^^ support.function.builtin - keyword
     print . __class__
-#   ^^^^^ - keyword
+#   ^^^^^ support.function.builtin - keyword
     print "keyword"
 #   ^^^^^^^^^^^^^^^ meta.statement.print
 #   ^^^^^ keyword
@@ -111,6 +111,9 @@ def my_func(param1, # Multi-line function definition
 #
     exec 123
 #   ^^^^^^^^ meta.statement.exec
+#   ^^^^ keyword
+    exec ("print('ok')")
+#   ^^^^ support.function.builtin - keyword
     callback(print , print
 #            ^^^^^ - keyword
 #                    ^^^^^ - keyword

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -174,6 +174,8 @@ def _():
 #        ^^^^ invalid.illegal.name
 #            ^ keyword.operator.assignment
 #             ^^^^ string
+    lambda
+#   ^^^^^^ storage.type.function.inline
 
 
 ##################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1,4 +1,5 @@
 # SYNTAX TEST "Packages/Python/Python.sublime-syntax"
+# <- source.python comment.line.number-sign punctuation.definition.comment
 
 import sys # comment
 #^^^^^ keyword.control.import
@@ -671,3 +672,9 @@ rB'''This is a \n (test|with), %s no unicode \UDEAD'''
 #                              ^^ - constant
 #                                            ^^ constant.character.escape.backslash.regexp
 #                                              ^^^^ - constant
+
+
+
+
+# <- - meta
+# this test is to ensure we're not matching anything here anymore

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -291,28 +291,28 @@ myset = {"key", True, key2, [-1], {}}
 
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
-#              ^^^^^^^^^^^^^^^^^^^ meta.comprehension
-#              ^^^ keyword.control.flow.for.comprehension
+#              ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#              ^^^ keyword.control.flow.for.generator
 #                  ^ meta.name
 #                    ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
-#          ^^^^^^^^^^^^^^^^^^^ meta.comprehension
-#          ^^^ keyword.control.flow.for.comprehension
+#          ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#          ^^^ keyword.control.flow.for.generator
 #                ^^ keyword.control.flow.for.in
 set_ = {i for i in range(100)}
 #      ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
-#         ^^^^^^^^^^^^^^^^^^^ meta.comprehension
-#         ^^^ keyword.control.flow.for.comprehension
+#         ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#         ^^^ keyword.control.flow.for.generator
 #               ^^ keyword.control.flow.for.in
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
-#             ^^^^^^^^^^^^^^^^^^^ meta.comprehension
-#             ^^^ keyword.control.flow.for.comprehension
+#             ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#             ^^^ keyword.control.flow.for.generator
 #                   ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.comprehension
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.expression.generator
 #                              ^^ keyword.control.flow.if.inline
 #                                       ^^^^ keyword.control.flow.else.inline
 
@@ -322,10 +322,10 @@ list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #                                                 ^^ keyword.operator.logical
 
 list(i for i in generator)
-#      ^^^^^^^^^^^^^^^^^^ meta.comprehension
+#      ^^^^^^^^^^^^^^^^^^ meta.expression.generator
 list((i for i in generator), 123)
-#       ^^^^^^^^^^^^^^^^^^ meta.comprehension
-#                         ^^^^^^^ - meta.comprehension
+#       ^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#                         ^^^^^^^ - meta.expression.generator
 #                          ^ punctuation.separator.parameters
 
 a if b else c

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -321,6 +321,13 @@ list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #                              ^^ keyword.control.flow.for.in
 #                                                 ^^ keyword.operator.logical
 
+list(i for i in generator)
+#      ^^^^^^^^^^^^^^^^^^ meta.comprehension
+list((i for i in generator), 123)
+#       ^^^^^^^^^^^^^^^^^^ meta.comprehension
+#                         ^^^^^^^ - meta.comprehension
+#                          ^ punctuation.separator.parameters
+
 a if b else c
 # ^^ keyword.control.flow
 #      ^^^^ keyword.control.flow

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -162,9 +162,18 @@ def _():
         a, \
         b=2: pass
 #       ^^^^ meta.function.inline
+#        ^ keyword.operator.assignment
 #          ^ punctuation.section.function.begin
 #            ^^^^ keyword
 
+    lambda as, in=2: pass
+#          ^^ invalid.illegal.name
+#              ^^ invalid.illegal.name
+    call(from='no')
+#   ^^^^^^^^^^^^^^^ meta.function-call
+#        ^^^^ invalid.illegal.name
+#            ^ keyword.operator.assignment
+#             ^^^^ string
 
 
 ##################
@@ -218,6 +227,10 @@ def my_func(param1, # Multi-line function definition
 #              ^ punctuation.definition.parameters.end
     print('Hi!')
 
+
+def func(from='me'):
+#        ^^^^ invalid.illegal.name
+    pass
 
 def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -48,7 +48,7 @@ name1 . name2
 class
 #^^^^ storage.type.class
 def
-#^^ invalid.illegal.name
+#^^ storage.type.function
 
 # Currently, async and await are still recognized as valid identifiers unless in an "async" block
 async

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -46,7 +46,7 @@ name1 . name2
 #^^^^ meta.name.dotted meta.name
 
 class
-#^^^^ invalid.illegal.name
+#^^^^ storage.type.class
 def
 #^^ invalid.illegal.name
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -6,6 +6,14 @@ import path from os
 #^^^^^ keyword.control.import
 #           ^^^^ keyword.control.import.from
 
+name
+#^^^ meta.name
+#
+name1 . name2
+#^^^^^^^^^^^^ meta.name.dotted
+#     ^ punctuation.accessor
+#^^^^ meta.name.dotted meta.name
+
 def my_func(param1, # Multi-line function definition
 #                   ^ comment.line.number-sign
     # This is defaulted
@@ -96,9 +104,9 @@ class MyClass(Inherited,
 #     ^^^^^^^ entity.name.type.class
 #             ^^^^^^^^^ entity.other.inherited-class
 #                      ^ punctuation.separator
-              module.Inherited2):
-#             ^^^^^^^^^^^^^^^^^ entity.other.inherited-class
-#                   ^ punctuation.accessor
+              module . Inherited2):
+#             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
+#                    ^ punctuation.accessor
     """
     This is a test of docstrings
     """

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -150,11 +150,12 @@ mydict = {}
 
 key2 = "my_key"
 mydict = {"key": True, key2: (1, 2, [-1, -2])}
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
 #         ^^^^^ string.quoted.double
 #              ^ punctuation.separator.key-value
 #                ^^^^ constant.language
-#                    ^ punctuation.separator.dictionary
+#                    ^ punctuation.separator.dictionary-or-set
+#                      ^^^^ meta.name.dotted
 #                          ^ punctuation.separator.key-value
 #                            ^^^^^^^^^^^^^^^^ meta.group
 #                            ^ punctuation.definition.group.begin
@@ -163,8 +164,21 @@ mydict = {"key": True, key2: (1, 2, [-1, -2])}
 #                                   ^^^^^^^ meta.structure.list
 #                                      ^ punctuation.separator.list
 #                                           ^ punctuation.definition.group.end
-#        ^ punctuation.definition.dictionary.begin
-#                                            ^ punctuation.definition.dictionary.end
+#        ^ punctuation.definition.dictionary-or-set.begin
+#                                            ^ punctuation.definition.dictionary-or-set.end
+
+myset = {"key", True, key2, [-1], {}}
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+#        ^^^^^ string.quoted.double
+#             ^ punctuation.separator.dictionary-or-set
+#               ^^^^ constant.language
+#                   ^ punctuation.separator.dictionary-or-set
+#                     ^^^^ meta.name.dotted
+#                         ^ punctuation.separator.dictionary-or-set
+#                           ^^^^ meta.structure.list
+#                             ^ constant.numeric
+#                               ^ punctuation.separator.dictionary-or-set
+#                                 ^^ meta.structure.dictionary
 
 ###############################
 # Strings and embedded syntaxes

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -37,6 +37,9 @@ from a import b as c, d as e
 from a import (b as c)
 #                ^^ keyword.control.import.as.python
 
+import re; re.compile(r'')
+#        ^^^^^^^^^^^^^^^^^ - meta.statement.import
+#        ^ punctuation.separator.statements
 name
 #^^^ meta.name
 #

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -358,6 +358,14 @@ list((i for i in generator), 123)
 #                         ^^^^^^^ - meta.expression.generator
 #                          ^ punctuation.separator.parameters
 
+_ = [m
+     for cls in self.__class__.mro()
+#    ^^^ keyword.control.flow.for.generator
+#            ^^ keyword.control.flow.for.in
+     for m in cls.__dict__]
+#    ^^^ keyword.control.flow.for.generator
+#          ^^ keyword.control.flow.for.in
+
 a if b else c
 # ^^ keyword.control.flow
 #      ^^^^ keyword.control.flow

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -147,6 +147,7 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 #                                                                    ^^^^^^ variable.parameter
 #                                                                          ^ punctuation.separator.annotation
 #                                                                            ^^^^^^^^ string.quoted.double
+#                                                                                     ^^^^^^^^^^^ meta.function.default-value
 #                                                                                     ^ keyword.operator.assignment
 #                                                                                       ^^^^^^^^^ string.quoted.double
 #                                                                                                ^ punctuation.definition.parameters.end

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -147,11 +147,23 @@ def _():
 #       ^^^^^^^ meta.function.inline
 #       ^^^^^^ storage.type.function.inline
 #             ^ punctuation.section.function.begin
-    _(lambda x: y)
+#               ^^^^ keyword
+
+    _(lambda x, y: 10)
 #     ^^^^^^^^^ meta.function.inline
 #     ^^^^^^ storage.type.function.inline
-#            ^ meta.function.inline.parameters
+#           ^^^^^ meta.function.inline.parameters
 #            ^ variable.parameter
+#             ^ punctuation.separator.parameters
+#               ^ variable.parameter
+#                  ^^ constant.numeric
+
+    lambda \
+        a, \
+        b=2: pass
+#       ^^^^ meta.function.inline
+#          ^ punctuation.section.function.begin
+#            ^^^^ keyword
 
 
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -214,6 +214,10 @@ class Unterminated(Inherited:
 # Lists and dicts
 ##################
 
+not_a_tuple = (a = 2, b += 3)
+#                ^ - keyword
+#                        ^ - keyword
+
 mylist = []
 #        ^^ meta.structure.list.python
 #        ^ punctuation.definition.list.begin

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -34,7 +34,7 @@ from sys import (version, # comment
 import path from os
 #           ^^^^ invalid.illegal.name
 from .sub import *
-#                ^ keyword.other.import-all.python
+#                ^ constant.language.import-all.python
 import a as b
 #        ^^ keyword.control.import.as.python
 from a import b as c, d as e
@@ -45,7 +45,7 @@ from a import (b as c)
 
 import re; re.compile(r'')
 #        ^^^^^^^^^^^^^^^^^ - meta.statement.import
-#        ^ punctuation.separator.statements
+#        ^ punctuation.terminator.statement
 
 ##################
 # Identifiers
@@ -94,7 +94,7 @@ def _():
 
     async for i in myfunc():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.for
-#   ^^^^^ keyword.control.flow.async
+#   ^^^^^ storage.modifier.async
 #         ^^^ keyword.control.flow.for
 #               ^^ keyword.control.flow.for.in
 #                          ^ punctuation.definition.block.for
@@ -118,7 +118,7 @@ def _():
 #       ^^ meta.statement.with
 
     async with context_manager() as c:
-#   ^^^^^ keyword.control.flow.async
+#   ^^^^^ storage.modifier.async
 #         ^^^^ keyword.control.flow.with
 #                                ^^ keyword.control.flow.with.as
 #                                    ^ punctuation.definition.block.with

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -64,6 +64,7 @@ def abc():
 #                               ^ invalid.illegal.name.storage
 
 def my_func(param1, # Multi-line function definition
+#                 ^ punctuation.separator.parameters
 #                   ^ comment.line.number-sign
     # This is defaulted
 #   ^ comment.line.number-sign
@@ -119,6 +120,7 @@ def my_func(param1, # Multi-line function definition
 #   ^^^^ support.function.builtin - keyword
     callback(print , print
 #            ^^^^^ - keyword
+#                  ^ punctuation.separator.parameters
 #                    ^^^^^ - keyword
              , print)
 #              ^^^^^ - keyword
@@ -195,10 +197,11 @@ class UnicødeIdentifier():
 class MyClass(Inherited,
 #     ^^^^^^^ entity.name.type.class
 #             ^^^^^^^^^ entity.other.inherited-class
-#                      ^ punctuation.separator
-              module . Inherited2):
+#                      ^ punctuation.separator.inheritance
+              module . Inherited2, metaclass=ABCMeta):
 #             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
-#                    ^ punctuation.accessor
+#                                ^ punctuation.separator.inheritance
+#                                  TODO
     """
     This is a test of docstrings
     """
@@ -214,6 +217,17 @@ class Unterminated(Inherited:
 # Lists and dicts
 ##################
 
+mytuple = ("this", 'is', 4, tuple)
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+#         ^ punctuation.definition.group.begin
+#          ^^^^^^ string.quoted.double
+#                ^ punctuation.separator.tuple
+#                  ^^^^ string.quoted.single
+#                      ^ punctuation.separator.tuple
+#                        ^ constant.numeric
+#                         ^ punctuation.separator.tuple
+#                           ^^^^^ support.type
+#                                ^ punctuation.definition.group.end
 not_a_tuple = (a = 2, b += 3)
 #                ^ - keyword
 #                        ^ - keyword

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1,6 +1,10 @@
 # SYNTAX TEST "Packages/Python/Python.sublime-syntax"
 # <- source.python comment.line.number-sign punctuation.definition.comment
 
+##################
+# Imports
+##################
+
 import sys # comment
 #^^^^^ keyword.control.import
 #          ^ comment
@@ -43,6 +47,10 @@ import re; re.compile(r'')
 #        ^^^^^^^^^^^^^^^^^ - meta.statement.import
 #        ^ punctuation.separator.statements
 
+##################
+# Identifiers
+##################
+
 name
 #^^^ meta.name
 name1 . name2
@@ -67,22 +75,22 @@ async
 #^^^^ - invalid.illegal.name
 #
 
-def abc():
-    global from, for, variable, .
-#   ^^^^^^ storage.modifier.global
-#          ^^^^ invalid.illegal.name
-#                ^^^ invalid.illegal.name
-#                     ^^^^^^^^ meta.name
-#                               ^ invalid.illegal.name.storage
 
-def my_func(param1, # Multi-line function definition
-#                 ^ punctuation.separator.parameters
-#                   ^ comment.line.number-sign
-    # This is defaulted
-#   ^ comment.line.number-sign
-    param2='#1'):
-#              ^ punctuation.definition.parameters.end
-    print('Hi!')
+
+##################
+# Block statements
+##################
+def _():
+    for
+#   ^^^ keyword.control.flow.for
+    b = c in d
+#         ^^ keyword.operator.logical
+
+    for \
+        a \
+        in \
+        b:
+#       ^^ meta.statement.for
 
     async for i in myfunc():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.for
@@ -92,21 +100,22 @@ def my_func(param1, # Multi-line function definition
 #                          ^ punctuation.definition.block.for
         pass
 
-    for \
-        a \
-        in \
-        b:
-#       ^^ meta.statement.for
-
-    for
-#   ^^^ keyword.control.flow.for
-    b = c in d
-#         ^^ keyword.operator.logical
-
     for i:
 #        ^ invalid.illegal.missing-in
 
-    a for b in c: # TODO make this invalid (for not at beginning of line)
+    a for b in c:  # TODO make this invalid (for not at beginning of line)
+
+
+    with
+#   ^^^^ keyword.control.flow.with
+    something as nothing:
+#             ^^ invalid.illegal.name
+
+    with \
+        open() \
+        as \
+        x:
+#       ^^ meta.statement.with
 
     async with context_manager() as c:
 #   ^^^^^ keyword.control.flow.async
@@ -116,14 +125,13 @@ def my_func(param1, # Multi-line function definition
         await something()
 #       ^^^^^ keyword.other.await
 
-    with \
-        open() \
-        as \
-        x:
-#       ^^ meta.statement.with
 
-    with
-#   ^^^^ keyword.control.flow.with
+
+##################
+# Expressions
+##################
+
+def _():
     yield from
 #   ^^^^^ keyword.control.flow.yield
 #         ^^^^ keyword.control.flow.yield-from
@@ -131,6 +139,17 @@ def my_func(param1, # Multi-line function definition
     yield fromsomething
 #         ^^^^ - keyword
 
+    a if b else c
+#     ^^ keyword.control.flow
+#          ^^^^ keyword.control.flow
+
+
+
+##################
+# print & exec
+##################
+
+def _():
     print (file=None)
 #   ^^^^^ support.function.builtin - keyword
     print . __class__
@@ -152,6 +171,31 @@ def my_func(param1, # Multi-line function definition
 #                    ^^^^^ - keyword
              , print)
 #              ^^^^^ - keyword
+
+
+
+##################
+# Function definitions
+##################
+
+def abc():
+    global from, for, variable, .
+#   ^^^^^^ storage.modifier.global
+#          ^^^^ invalid.illegal.name
+#                ^^^ invalid.illegal.name
+#                     ^^^^^^^^ meta.name
+#                               ^ invalid.illegal.name.storage
+
+
+def my_func(param1, # Multi-line function definition
+#                 ^ punctuation.separator.parameters
+#                   ^ comment.line.number-sign
+    # This is defaulted
+#   ^ comment.line.number-sign
+    param2='#1'):
+#              ^ punctuation.definition.parameters.end
+    print('Hi!')
+
 
 def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
@@ -196,6 +240,11 @@ async def coroutine(param1):
    pass
 
 
+
+##################
+# Class definitions
+##################
+
 class MyClass():
 #^^^^^^^^^^^^^^^ meta.class
 #            ^^ meta.class.inheritance
@@ -238,13 +287,14 @@ class MyClass(Inherited,
 #   ^ comment.block
     pass
 
+
 class Unterminated(Inherited:
 #                           ^ invalid.illegal
 
 
 
 ##################
-# Lists and dicts
+# Collection literals and generators
 ##################
 
 mytuple = ("this", 'is', 4, tuple)
@@ -366,9 +416,11 @@ _ = [m
 #    ^^^ keyword.control.flow.for.generator
 #          ^^ keyword.control.flow.for.in
 
-a if b else c
-# ^^ keyword.control.flow
-#      ^^^^ keyword.control.flow
+
+
+##################
+# Exception handling
+##################
 
 except Exception:
 #^^^^^^^^^^^^^^^^ meta.statement.except
@@ -409,12 +461,21 @@ raise KeyError() from z
 #                ^^^^ keyword.control.flow.raise.from
 #                     ^ meta.name
 
+
+
+##################
+# Stray braces
+##################
+
 )
 # <- invalid.illegal.stray.brace.round
 ]
 # <- invalid.illegal.stray.brace.square
 }
 # <- invalid.illegal.stray.brace.curly
+
+
+
 
 ###############################
 # Strings and embedded syntaxes

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -36,9 +36,10 @@ def my_func(param1, # Multi-line function definition
 def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
-#                                                                                                  ^^^^^^ meta.function.return-type
+#                                                                                                  ^^^^^^ meta.function.annotation.return
 #                   ^ - meta.function meta.function.parameters
 #                    ^^^^^^ variable.parameter
+#                          ^^^^^ meta.function.annotation.parameter
 #                          ^ punctuation.separator.annotation
 #                            ^^^ support.type
 #                               ^ punctuation.separator.parameters
@@ -68,7 +69,7 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                  ^^^^^^^^ meta.function.parameters
-# <- storage.modifier
+# <- storage.modifier.async
 #     ^ storage.type
 #         ^ entity.name.function
    pass

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -143,6 +143,16 @@ def _():
 #     ^^ keyword.control.flow
 #          ^^^^ keyword.control.flow
 
+    c = lambda: pass
+#       ^^^^^^^ meta.function.inline
+#       ^^^^^^ storage.type.function.inline
+#             ^ punctuation.section.function.begin
+    _(lambda x: y)
+#     ^^^^^^^^^ meta.function.inline
+#     ^^^^^^ storage.type.function.inline
+#            ^ meta.function.inline.parameters
+#            ^ variable.parameter
+
 
 
 ##################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -79,6 +79,9 @@ def my_func(param1, # Multi-line function definition
 #                          ^ punctuation.definition.block.for
         pass
 
+    b = c in d
+#         ^^ keyword.operator.logical
+
     for i:
 #        ^ invalid.illegal.missing-in
 
@@ -293,6 +296,11 @@ list_ = [i for i in range(100) if i > 0 else -1]
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.comprehension
 #                              ^^ keyword.control.flow.if.inline
 #                                       ^^^^ keyword.control.flow.else.inline
+
+list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
+#           ^^ keyword.operator.logical
+#                              ^^ keyword.control.flow.for.in
+#                                                 ^^ keyword.operator.logical
 
 a if b else c
 # ^^ keyword.control.flow


### PR DESCRIPTION
I finally ~~found the time~~ made some time to work on this. There is still things left to be done, but especially keyword matching is greatly improved now for keywords that only occur in conjunction with other keywords (in statements, e.g. `for ... in ...:`). Additionally, list comprehensions are more properly matched and only where applicale and highlighting of `print` and `exec` is smarter.

While I was working on it, I also 

- allowed dots in dotted_names to be surrounded by spaces,
- made set literals have an appearance
- unified context formatting (underscores and separated with empty lines)
- added scopes for annotations, default values and all commas
- made assignments in expressions illegal, as well as storage modifiers
- made semicolons get matched
- more...?

---

**Performance tests** (with `Lib/_pydecimal.py` (6300 lines) as bundled in Python 3.5)

Before: ~105ms
After: ~105ms

---

What remains to be done is to make statements only match at the beginning of a line so that `for` or `def` may not appear in the middle of a line. There are a couple ways of doing this (I assume you know enough about this now thanks to the JavaScript rewrite), but this will be left up for later since it's another medium-scale change to scope management.

Item-access and function calls also need to be revisited, not only because they still contain look-behinds but also because of how inaccurate they are. While function calls in general are alright, item access sometimes gets confused with list literals.

Also, decorators are clearly lacking at this moment. They should be parsed like an inline-keyword (in that they allow expressions to follow but do not span more than one line unless explicitly continued or wrapped in a group). They should also not be scoped as `entity.name.function.decorator` imo.
I have a [change for this ready in a branch](https://github.com/FichteForks/Packages/commit/cd5628519bf67abab43a292a898ae6a38b279770) but it really takes some getting used to considering how long it has been "wrong". I will not be including this change in this PR and open a new one once this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sublimehq/packages/386)
<!-- Reviewable:end -->
