### PR TITLE
[Scala] Misc improvements and additions

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -157,7 +157,7 @@ contexts:
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
-    - match: \b(else|if|do|while|for|yield|match|case)\b
+    - match: \b(else|if|do|while|for|yield|match|case|macro)\b
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -19,8 +19,8 @@ contexts:
     - include: constants
     - include: char-literal
     - include: scala-symbol
-    - include: empty-parentheses
     - include: parameter-list
+    - include: empty-parentheses
     - include: qualifiedClassName
     - include: xml-literal
   block-comments:
@@ -175,10 +175,16 @@ contexts:
         - include: nest-curly-and-self
     - include: main
   parameter-list:
-    - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*([A-Za-z0-9][\w|_|?|\.]*)?,?'
-      captures:
-        1: variable.parameter
-        2: entity.name.class
+    - match: '\('
+      push:
+        - match: '\)'
+          pop: true
+        - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
+          captures:
+            1: variable.parameter
+            2: entity.name.class
+        - include: main
+        - include: parameter-list
   qualifiedClassName:
     - match: '(\b([A-Z][\w]*))'
       captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -161,6 +161,8 @@ contexts:
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala
+    - match: (\?\?\?)              # can't be guarded by \b for some reason (maybe bug?)
+      scope: keyword.control.exception.scala
   nest-curly-and-self:
     - match: '\{'
       captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -84,7 +84,7 @@ contexts:
     - match: |-
         (?x)
         \b(def)\s+
-        (([a-zA-Z$_][a-zA-Z0-9$_]*(_[^a-zA-Z0-9\s]+)?)|`.*`|[^\w\[\(\:\_\s]+)
+        (_*([a-zA-Z$][a-zA-Z0-9$]*|[^a-zA-Z0-9$`\s\(\)\[\]\{\};\.]+)(_+([a-zA-Z$][a-zA-Z0-9$]*|[^a-zA-Z0-9$`\s\(\)\[\]\{\};\._]+)?)*|`[^`]+`|[^\w\[\(\:\_\s]+)
       captures:
         1: keyword.declaration.scala
         2: entity.name.function.declaration


### PR DESCRIPTION
- `macro` is (sort of) a keyword
- `???` isn't a keyword, but everyone treats it as if it is, so I think the highlighting is valid (note: implementing this unveiled a bug in Sublime's `\b` support, detailed in a comment)
- Parameter list pre-`:` highlighting (e.g. `foo: Int`) no longer applies at arbitrary points in the file.  Instead, parentheses are detected as a sub-mode, allowing the special highlighting to take place.  This means that the phrase `a :: b` is now *correctly* highlighted (except inside of parentheses, unfortunately; work in progress!)
  + Also, I removed the special override on the right-hand side of the `:`, so the `Int` in `foo: Int` highlights uniformly with how `Int` highlights in normal text (i.e. as a special primitive type)
- `def` identifier syntax now more closely matches the Scala specification (I still haven't fixed `val` or extraction).  This allows `def +(x: Int)` to highlight correctly.

Also, the YAML format is infinitely easier to edit than the old plist version.