### PR TITLE
Add sbt to the list of supported file extensions

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -4,6 +4,7 @@
 name: Scala
 file_extensions:
   - scala
+  - sbt
 scope: source.scala
 contexts:
   main:


### PR DESCRIPTION
sbt follows a subset of scala syntax now.
So it makes sense to honor scala syntax in sbt files.