### PR TITLE
[JavaScript] get and set must be followed by a method name to be an accessor

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -940,7 +940,7 @@ contexts:
         - include: comments
 
   method-declaration:
-    - match: \b(get|set)\b\s*
+    - match: \b(get|set)\b(?!\s*\()\s*
       scope: meta.function.declaration.js
       captures:
         1: storage.type.accessor.js

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -345,6 +345,23 @@ class MyClass extends TheirClass {
     baz() { return null }
 //  ^^^^^ meta.function.declaration - meta.function.anonymous
     // <- entity.name.function
+
+    get() { return "foobar"; }
+//  ^^^^^ meta.function.declaration.js
+//  ^^^ entity.name.function.js - storage.type.accessor
+
+    set (value) { return value; }
+//  ^^^^^^^^^^^ meta.function.declaration.js
+//       ^^^^^ variable.parameter.function.js
+//  ^^^ entity.name.function.js - storage.type.accessor
+
+    set  abc(value1, value2) { return value1 + value2; }
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.js
+//  ^^^ storage.type.accessor - entity.name.function.js
+//       ^^^ entity.name.function.js
+//           ^^^^^^ variable.parameter.function.js
+//                 ^ punctuation.separator.parameter.function.js
+//                   ^^^^^^ variable.parameter.function.js
 }
 // <- meta.block
 


### PR DESCRIPTION
...otherwise they are just normal method names. fixes #404