### PR TITLE
[C++] Ignore indention of multi-line block comments

### DIFF
--- a/C++/Indentation Rules.tmPreferences
+++ b/C++/Indentation Rules.tmPreferences
@@ -27,7 +27,7 @@
 		</string>
 
 		<key>unIndentedLinePattern</key>
-		<string>^\s*((/\*|.*\*/|//|#|template\b.*?&gt;(?!\(.*\))|@protocol|@interface(?!.*\{)|@implementation|@end).*)?$</string>
+		<string>^\s*((/\*|\*|.*\*/|//|#|template\b.*?&gt;(?!\(.*\))|@protocol|@interface(?!.*\{)|@implementation|@end).*)?$</string>
 
 		<key>indentSquareBrackets</key>
 		<true/>


### PR DESCRIPTION
Lines matching ^\s+\*.*$ in multi-line block comments previously triggered a
matching indention on lines following it (even if e.g. preprocessor statements
were in between).

For example:

```
 /*
  * Copyright ...
  */
  ^--- this line is indented by one space
 #include <stdlib.h>
  ^--- this line too
```

Fixes #417.