### PR TITLE
[XML] correctly scope beginning and ending of comments

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -54,10 +54,11 @@ contexts:
           pop: true
         - include: internal-subset
     - match: '<!--'
-      scope: punctuation.definition.comment.xml
+      scope: punctuation.definition.comment.begin.xml
       push:
         - meta_scope: comment.block.xml
         - match: '-->'
+          scope: punctuation.definition.comment.end.xml
           pop: true
     - match: '(</?){{qualified_name}}'
       captures:

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -60,12 +60,13 @@ contexts:
         - match: '-->'
           scope: punctuation.definition.comment.end.xml
           pop: true
-    - match: '(</?){{qualified_name}}'
+    - match: '(</?){{qualified_name}}([^/>\s]*)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.namespace.xml
         3: entity.name.tag.xml punctuation.separator.namespace.xml
         4: entity.name.tag.localname.xml
+        5: invalid.illegal.bad-tag-name.xml
       push:
         - meta_scope: meta.tag.xml
         - match: /?>
@@ -217,7 +218,7 @@ contexts:
         2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
         3: entity.other.attribute-name.localname.xml
         4: punctuation.separator.key-value.xml
-    - match: '(?:\s+|^)([[:digit:].-][[:alnum:]:_.-]*)\s*(=)'
+    - match: '(?:\s+|^)([[:alnum:]:_.-]+)\s*(=)'
       captures:
         1: invalid.illegal.bad-attribute-name.xml
         2: punctuation.separator.key-value.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -217,5 +217,9 @@ contexts:
         2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
         3: entity.other.attribute-name.localname.xml
         4: punctuation.separator.key-value.xml
+    - match: '(?:\s+|^)([[:digit:].-][[:alnum:]:_.-]*)\s*(=)'
+      captures:
+        1: invalid.illegal.bad-attribute-name.xml
+        2: punctuation.separator.key-value.xml
     - include: double-quoted-string
     - include: single-quoted-string

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -185,8 +185,17 @@
      <test
 foo="bar" />
 <!-- <- entity.other.attribute-name.localname -->
-<!-- ^^^ string.quoted.double
-<!--     ^ - string.quoted.double
+<!-- ^^^ string.quoted.double -->
+<!--     ^ - string.quoted.double -->
+
+     <xs:sequence/>
+<!-- ^^^^^^^^^^^^^^ meta.tag -->
+<!--               ^ - meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
+<!--  ^^ entity.name.tag.namespace -->
+<!--    ^ punctuation.separator.namespace -->
+<!--     ^^^^^^^^ entity.name.tag.localname -->
+<!--             ^^ punctuation.definition.tag.end -->
 
 
 <!--
@@ -257,15 +266,20 @@ foo="bar" />
 <!-- ^ invalid.illegal.missing-entity -->
 <!--  ^ - invalid.illegal.missing-entity -->
 
-     <ns::tag ns::attr1="na" ns:2attr="nope"></ns:t:ag>
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+     <ns::tag ns::attr1="na" ns:2attr ="nope"></ns:t:ag>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
 <!-- ^ punctuation.definition.tag.begin -->
-<!--    ^^^^^ - entity.name.tag -->
-<!--          ^^^^^^^^^ - entity.other.attribute-name -->
+<!--  ^^ entity.name.tag -->
+<!--    ^^^^^ invalid.illegal.bad-tag-name - entity.name.tag -->
+<!--          ^^^^^^^^^ invalid.illegal.bad-attribute-name - entity.other.attribute-name -->
+<!--                   ^ punctuation.separator.key-value -->
 <!--                    ^^^^ string.quoted -->
-<!--                         ^^^^^^^^ - entity.other.attribute-name -->
-<!--                                  ^^^^^^ string.quoted -->
-<!--                                        ^ punctuation.definition.tag.end -->
-<!--                                         ^^ punctuation.definition.tag.begin -->
-<!--                                                  ^ punctuation.definition.tag.end -->
-<!--                                                   ^ - meta.tag -->
+<!--                         ^^^^^^^^ invalid.illegal.bad-attribute-name - entity.other.attribute-name -->
+<!--                                  ^ punctuation.separator.key-value -->
+<!--                                   ^^^^^^ string.quoted -->
+<!--                                         ^ punctuation.definition.tag.end -->
+<!--                                          ^^ punctuation.definition.tag.begin -->
+<!--                                            ^^^^ entity.name.tag -->
+<!--                                                ^^^ invalid.illegal.bad-tag-name - entity.name.tag -->
+<!--                                                   ^ punctuation.definition.tag.end -->
+<!--                                                    ^ - meta.tag -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -30,7 +30,7 @@
 <!--                ^ meta.internalsubset -->
 <!--                 ^^ punctuation.definition.tag.begin -->
 <!--                   ^^^^^^ keyword.entity -->
-<!--                          ^^ variable.entity.xml -->
+<!--                          ^^ variable.entity -->
 <!--                                   ^ punctuation.definition.constant -->
 <!--                                    ^^^^ constant.character.parameter-entity -->
 <!--                                        ^ punctuation.definition.constant -->
@@ -80,20 +80,46 @@
  -->
 
      <!-- A Comment! -->
-     <!-- <- comment.block -->
-<!-- ^ punctuation.definition.comment -->
+<!-- ^^^^ punctuation.definition.comment.begin -->
+<!--     ^ - punctuation.definition.comment.begin -->
+<!-- ^^^^^^^^^^^^^^^^^^^ comment.block -->
+<!--                 ^^^ punctuation.definition.comment.end -->
+<!--                    ^ - comment.block -->
 
+     <!-- tags and character entities inside me will be ignored <foobar hello="world" /> &amp; <unclosed  -->
+<!-- ^^^^ punctuation.definition.comment.begin -->
+<!--     ^ - punctuation.definition.comment.begin -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - meta.tag - constant.character.entity -->
+<!--                                                                                                      ^^^ punctuation.definition.comment.end -->
+<!--                                                                                                         ^ - comment.block -->
+
+     <!-- <![CDATA[[ignored -->
+<!-- ^^^^ punctuation.definition.comment.begin -->
+<!--     ^ - punctuation.definition.comment.begin -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - string.unquoted.cdata -->
+<!--                        ^^^ punctuation.definition.comment.end -->
+<!--                           ^ - comment.block -->
+
+     <!-- multi
+          line
+          comment -->
+<!-- <- comment.block -->
+<!-- ^^^^^^^^^^^^^^^^ comment.block -->
+<!--              ^^^ punctuation.definition.comment.end -->
+<!--                 ^ - comment.block -->
 
 <!--
   Elements / Tags
  -->
 
      <ns:tagname xmlns:ns="uri">
-<!-- ^ meta.tag -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!--                            ^ - meta.tag -->
 <!-- ^ punctuation.definition.tag.begin -->
 <!--  ^^ entity.name.tag.namespace -->
 <!--    ^ punctuation.separator.namespace -->
 <!--     ^^^^^^^ entity.name.tag.localname -->
+<!--            ^ - entity -->
 <!--             ^^^^^ entity.other.attribute-name.namespace -->
 <!--                  ^ punctuation.separator.namespace -->
 <!--                   ^^ entity.other.attribute-name.localname -->
@@ -102,13 +128,29 @@
 <!--                          ^ punctuation.definition.string.end -->
 <!--                           ^ punctuation.definition.tag.end -->
      text
-<!-- ^ text -->
-    <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
-<!--         ^ string.unquoted.cdata -->
+<!-- ^^^^ text -->
 
-    <таĝñäᴹə ατţř="șƬűʃ⨍">Contents</таĝñäᴹə>
-<!-- ^ meta.tag entity.name.tag.localname  -->
-<!--         ^ meta.tag entity.other.attribute-name.localname -->
+     <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
+<!--                                           ^ - string.unquoted.cdata -->
+
+     <таĝñäᴹə ατţř="șƬűʃ⨍">Contents</таĝñäᴹə>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!--  ^^^^^^^ entity.name.tag.localname -->
+<!--         ^ - entity.name.tag.localname -->
+<!--          ^^^^ entity.other.attribute-name.localname -->
+<!--                       ^^^^^^^^ text -->
+<!--                               ^^ punctuation.definition.tag.begin -->
+<!--                               ^^^^^^^^^^ meta.tag -->
+<!--                                 ^^^^^^^ entity.name.tag.localname -->
+<!--                                        ^ punctuation.definition.tag.end -->
+<!--                                         ^ - meta.tag -->
+
+     <example />
+<!-- ^ punctuation.definition.tag.begin -->
+<!--          ^^ punctuation.definition.tag.end -->
+<!-- ^^^^^^^^^^^ meta.tag -->
+<!--            ^ - meta.tag -->
 
 <!--
   Entities
@@ -116,15 +158,26 @@
 
      &amp;
 <!-- ^ punctuation.definition.constant -->
-<!--  ^^^ -punctuation.definition.constant -->
-<!--     ^ constant.character.entity -->
+<!--  ^^^ - punctuation.definition.constant -->
+<!-- ^^^^^ constant.character.entity -->
+<!--     ^ punctuation.definition.constant -->
+<!--      ^ - constant.character.entity - punctuation.definition.constant -->
+
      &#160;
 <!-- ^ punctuation.definition.constant -->
 <!--  ^^^^ -punctuation.definition.constant -->
-<!--      ^ constant.character.entity -->
-    <!-- &amp; -->
-<!--     ^ -punctuation.definition.constant -->
+<!-- ^^^^^^ constant.character.entity -->
+<!--      ^ punctuation.definition.constant -->
+<!--       ^ - constant.character.entity -->
 
+     <!-- &amp; -->
+<!--      ^ -punctuation.definition.constant -->
+
+     <example attr="&quot;test&quot;" />
+<!--               ^^^^^^^^^^^^^^^^^^ string.quoted.double -->
+<!--                                 ^ - string.quoted.double -->
+<!--                ^^^^^^ constant.character.entity -->
+<!--                          ^^^^^^ constant.character.entity -->
 
 <!--
   Illegals
@@ -132,19 +185,28 @@
 
      &
 <!-- ^ invalid.illegal.bad-ampersand -->
+<!--  ^ - invalid.illegal.bad-ampersand -->
 
      <1tag></-tag>
 <!--  ^^^^ invalid.illegal - entity.name.tag -->
 <!--         ^^^^ invalid.illegal - entity.name.tag -->
+<!--      ^ punctuation.definition.tag.end -->
+<!--       ^ punctuation.definition.tag.begin -->
+<!--             ^ punctuation.definition.tag.end -->
+<!-- ^^^^^^^^^^^^^ meta.tag -->
+<!--              ^ - meta.tag -->
 
      <
 <!-- ^ invalid.illegal.missing-entity -->
+<!--  ^ - invalid.illegal.missing-entity -->
 
      >
 <!-- ^ invalid.illegal.missing-entity -->
+<!--  ^ - invalid.illegal.missing-entity -->
 
      </ns:tagname>
-<!-- ^ meta.tag -->
+<!-- ^^^^^^^^^^^^^ meta.tag -->
+<!--              ^ - meta.tag -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^ entity.name.tag.namespace -->
 <!--     ^ punctuation.separator.namespace -->
@@ -152,10 +214,13 @@
 <!--             ^ punctuation.definition.tag.end -->
 
      <element attr_with.space = "value" />
-<!--                  ^^^ entity.other.attribute-name.localname -->
+<!--          ^^^^^^^^^^^^^^^ entity.other.attribute-name.localname -->
 <!--                          ^ punctuation.separator.key-value -->
 <!--                            ^ punctuation.definition.string.begin -->
 <!--                             ^^^^^ string.quoted -->
+
      <test
-foo="bar" />
+foo='bar' />
 <!-- <- entity.other.attribute-name.localname -->
+<!-- ^^^ string.quoted.single
+<!--     ^ - string.quoted.single

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -166,6 +166,29 @@
 <!--                          ^ punctuation.definition.string.end -->
 <!--                     ^^^^^ constant.character.entity -->
 
+
+     </ns:tagname>
+<!-- ^^^^^^^^^^^^^ meta.tag -->
+<!--              ^ - meta.tag -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^ entity.name.tag.namespace -->
+<!--     ^ punctuation.separator.namespace -->
+<!--      ^^^^^^^ entity.name.tag.localname -->
+<!--             ^ punctuation.definition.tag.end -->
+
+     <element attr_with.space = "value" />
+<!--          ^^^^^^^^^^^^^^^ entity.other.attribute-name.localname -->
+<!--                          ^ punctuation.separator.key-value -->
+<!--                            ^ punctuation.definition.string.begin -->
+<!--                             ^^^^^ string.quoted -->
+
+     <test
+foo="bar" />
+<!-- <- entity.other.attribute-name.localname -->
+<!-- ^^^ string.quoted.double
+<!--     ^ - string.quoted.double
+
+
 <!--
   Entities
  -->
@@ -234,23 +257,15 @@
 <!-- ^ invalid.illegal.missing-entity -->
 <!--  ^ - invalid.illegal.missing-entity -->
 
-     </ns:tagname>
-<!-- ^^^^^^^^^^^^^ meta.tag -->
-<!--              ^ - meta.tag -->
-<!-- ^^ punctuation.definition.tag.begin -->
-<!--   ^^ entity.name.tag.namespace -->
-<!--     ^ punctuation.separator.namespace -->
-<!--      ^^^^^^^ entity.name.tag.localname -->
-<!--             ^ punctuation.definition.tag.end -->
-
-     <element attr_with.space = "value" />
-<!--          ^^^^^^^^^^^^^^^ entity.other.attribute-name.localname -->
-<!--                          ^ punctuation.separator.key-value -->
-<!--                            ^ punctuation.definition.string.begin -->
-<!--                             ^^^^^ string.quoted -->
-
-     <test
-foo="bar" />
-<!-- <- entity.other.attribute-name.localname -->
-<!-- ^^^ string.quoted.double
-<!--     ^ - string.quoted.double
+     <ns::tag ns::attr1="na" ns:2attr="nope"></ns:t:ag>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
+<!--    ^^^^^ - entity.name.tag -->
+<!--          ^^^^^^^^^ - entity.other.attribute-name -->
+<!--                    ^^^^ string.quoted -->
+<!--                         ^^^^^^^^ - entity.other.attribute-name -->
+<!--                                  ^^^^^^ string.quoted -->
+<!--                                        ^ punctuation.definition.tag.end -->
+<!--                                         ^^ punctuation.definition.tag.begin -->
+<!--                                                  ^ punctuation.definition.tag.end -->
+<!--                                                   ^ - meta.tag -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -86,12 +86,13 @@
 <!--                 ^^^ punctuation.definition.comment.end -->
 <!--                    ^ - comment.block -->
 
-     <!-- tags and character entities inside me will be ignored <foobar hello="world" /> &amp; <unclosed  -->
+     <!-- tags and character entities inside me will be ignored <foobar hello="world" /> &amp; <unclosed <!--  -->
 <!-- ^^^^ punctuation.definition.comment.begin -->
 <!--     ^ - punctuation.definition.comment.begin -->
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - meta.tag - constant.character.entity -->
-<!--                                                                                                      ^^^ punctuation.definition.comment.end -->
-<!--                                                                                                         ^ - comment.block -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - meta.tag - constant.character.entity -->
+<!--                                                                                                           ^^^ punctuation.definition.comment.end -->
+<!--                                                                                                              ^ - comment.block -->
+<!--                                                                                                     ^^^^ - punctuation.definition -->
 
      <!-- <![CDATA[[ignored -->
 <!-- ^^^^ punctuation.definition.comment.begin -->
@@ -134,23 +135,36 @@
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
 <!--                                           ^ - string.unquoted.cdata -->
 
-     <таĝñäᴹə ατţř="șƬűʃ⨍">Contents</таĝñäᴹə>
-<!-- ^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+     <таĝñäᴹə ατţř="șƬűʃ⨍" >Contents</таĝñäᴹə>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
 <!--  ^^^^^^^ entity.name.tag.localname -->
 <!--         ^ - entity.name.tag.localname -->
 <!--          ^^^^ entity.other.attribute-name.localname -->
-<!--                       ^^^^^^^^ text -->
-<!--                               ^^ punctuation.definition.tag.begin -->
-<!--                               ^^^^^^^^^^ meta.tag -->
-<!--                                 ^^^^^^^ entity.name.tag.localname -->
-<!--                                        ^ punctuation.definition.tag.end -->
-<!--                                         ^ - meta.tag -->
+<!--              ^ punctuation.separator.key-value - entity.other.attribute-name.localname -->
+<!--               ^^^^^^^ string.quoted -->
+<!--                      ^ - string.quoted - punctuation.definition -->
+<!--                       ^ punctuation.definition.tag.end -->
+<!--                        ^^^^^^^^ text - meta.tag -->
+<!--                                ^^ punctuation.definition.tag.begin -->
+<!--                                ^^^^^^^^^^ meta.tag -->
+<!--                                  ^^^^^^^ entity.name.tag.localname -->
+<!--                                         ^ punctuation.definition.tag.end -->
+<!--                                          ^ - meta.tag -->
 
-     <example />
+     <example ñș:äpos ='&apos;'/>
 <!-- ^ punctuation.definition.tag.begin -->
-<!--          ^^ punctuation.definition.tag.end -->
-<!-- ^^^^^^^^^^^ meta.tag -->
-<!--            ^ - meta.tag -->
+<!--                           ^^ punctuation.definition.tag.end - string -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!--                             ^ - meta.tag -->
+<!--          ^^ entity.other.attribute-name.namespace -->
+<!--            ^ entity.other.attribute-name punctuation.separator.namespace -->
+<!--             ^^^^ entity.other.attribute-name.localname -->
+<!--                  ^ punctuation.separator.key-value -->
+<!--                   ^^^^^^^^ string.quoted.single -->
+<!--                   ^ punctuation.definition.string.begin -->
+<!--                          ^ punctuation.definition.string.end -->
+<!--                     ^^^^^ constant.character.entity -->
 
 <!--
   Entities
@@ -196,6 +210,22 @@
 <!-- ^^^^^^^^^^^^^ meta.tag -->
 <!--              ^ - meta.tag -->
 
+     <1tag attr1="ok" 2attr="nope"></-tag>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
+<!--  ^^^^ invalid.illegal - entity.name.tag -->
+<!--      ^^^^^^^^^^^^ - invalid.illegal - entity.name.tag -->
+<!--       ^^^^^ entity.other.attribute-name.localname -->
+<!--            ^ punctuation.separator.key-value -->
+<!--             ^^^^ string.quoted -->
+<!--                  ^^^^^ invalid.illegal - entity.other.attribute-name.localname -->
+<!--                        ^^^^^ string.quoted -->
+<!--                              ^ punctuation.definition.tag.end -->
+<!--                               ^^ punctuation.definition.tag.begin -->
+<!--                                 ^^^^ invalid.illegal - entity.name.tag -->
+<!--                                     ^ punctuation.definition.tag.end -->
+<!--                                      ^ - meta.tag -->
+
      <
 <!-- ^ invalid.illegal.missing-entity -->
 <!--  ^ - invalid.illegal.missing-entity -->
@@ -220,7 +250,7 @@
 <!--                             ^^^^^ string.quoted -->
 
      <test
-foo='bar' />
+foo="bar" />
 <!-- <- entity.other.attribute-name.localname -->
-<!-- ^^^ string.quoted.single
-<!--     ^ - string.quoted.single
+<!-- ^^^ string.quoted.double
+<!--     ^ - string.quoted.double


### PR DESCRIPTION
Make XML block comment punctuation scope more consistent with other syntaxes (added missing scope for `-->` and appended `.begin` to `<!--`)

Also added more test coverage.