### PR TITLE
[Batch File] Add NOT to IF. Fix == never matched.

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -128,7 +128,7 @@ contexts:
   operators:
     - match: '@(?=\S)'
       scope: keyword.operator.at.dosbatch
-    - match: \b(?i:EQU|NEQ|LSS|LEQ|GTR|GEQ|==)\b
+    - match: \b(?i:EQU|NEQ|LSS|LEQ|GTR|GEQ)\b|==
       scope: keyword.operator.comparison.dosbatch
     - match: '&&?|\|\|'
       scope: keyword.operator.conditional.dosbatch

--- a/Batch File/syntax_test_batch_file.bat
+++ b/Batch File/syntax_test_batch_file.bat
@@ -78,8 +78,18 @@ ECHO &:: A comment
 :: ^^         keyword.control.conditional.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
 
-   FOR %%G IN (a,b) DO (md %%G)
+   IF NOT foo EQU bar
+:: ^^             keyword.control.conditional.dosbatch
+::    ^^^         keyword.operator.logical.dosbatch
+::            ^^^ keyword.operator.comparison.dosbatch
+
+   IF foo == bar
+:: ^^         keyword.control.conditional.dosbatch
+::        ^^  keyword.operator.comparison.dosbatch
+
+   FOR %%G IN (0,9) DO (md %%G)
 :: ^^^                 keyword.control.repeat.dosbatch
+::             ^       constant.numeric.dosbatch
 
    FIND "a" |
 ::          ^ keyword.operator.pipe.dosbatch
@@ -186,9 +196,11 @@ ECHO %t:foo=!bar:~0,-4!%
 
 ECHO Not% a variable
 ::      ^^^^^^^^^^^^ - variable.other.readwrite.dosbatch
+::   ^^^             - keyword.operator.logical.dosbatch
 
 ECHO Not! a variable
 ::      ^^^^^^^^^^^^ - variable.other.readwrite.dosbatch
+::   ^^^             - keyword.operator.logical.dosbatch
 
 :: Numerics
 SET /A r = 010 + 0x20 - 24


### PR DESCRIPTION
- `IF` statements get an optional `NOT`.
    + Tests to ensure that `ECHO foo not` doesn't match.
- Fix and add test for `==` not working as a comparator.
- Add minor test to ensure that future updates to `FOR` (which needs some love) do not clobber highlighting of its `IN` clause.