### PR TITLE
[JavaScript] Update class name scope

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -675,7 +675,7 @@ contexts:
             - match: '(?=\S)'
               pop: true
         - match: '{{identifier}}'
-          scope: entity.name.type.class.js
+          scope: entity.name.class.js
         - include: comments
 
   class-body:

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -371,7 +371,7 @@ try {
 
 class MyClass extends TheirClass {
 // <- storage.type.class
-//    ^^^^^^^ entity.name.type.class
+//    ^^^^^^^ entity.name.class
 //                               ^ meta.block
     constructor(el)
 //  ^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous


### PR DESCRIPTION
changed class name scope from `entity.name.type.class.js` to `entity.name.class.js` as per https://github.com/sublimehq/Packages/issues/445