### PR TITLE
[Python] fix \ chars in strings being always treated as line cont

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -733,6 +733,11 @@ contexts:
     - match: $|(?=;|#)
       pop: true
 
+  line_continuation_inside_string:
+    - match: (\\)$\n?
+      captures:
+        1: punctuation.separator.continuation.line.python
+
   magic_function_names:
     - match: |-
         (?x)\b(__(?:
@@ -1000,7 +1005,7 @@ contexts:
         - include: escaped_unicode_char
         - include: escaped_char
         - include: constant_placeholder
-        - include: line_continuation
+        - include: line_continuation_inside_string
     # Single-line string, bytes
     - match: '([bB])(")'
       captures:
@@ -1241,7 +1246,7 @@ contexts:
         - include: escaped_unicode_char
         - include: escaped_char
         - include: constant_placeholder
-        - include: line_continuation
+        - include: line_continuation_inside_string
     # Single-line string, bytes
     - match: '([bB])('')'
       captures:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -845,5 +845,9 @@ world'
 #     ^ - string.quoted.single.block.python
 #    ^ punctuation.definition.string.end.python
 
+x = 'hello\s world'
+#         ^^ - punctuation.separator.continuation.line.python
+#          ^^^^^^^^ - invalid.illegal.unexpected-text.python
+
 # <- - meta
 # this test is to ensure we're not matching anything here anymore


### PR DESCRIPTION
in a non-raw string, having something after the ``\`` that isn't a recognized escape sequence was causing the entire rest of the line to be marked as illegal. i.e. `\s`
this fixes that.