### PR TITLE
[PHP] Use clear_scopes to implement proper HTML nesting inside of PHP blocks

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -13,12 +13,6 @@ contexts:
   main:
     - include: statements
 
-  embedded:
-    - meta_content_scope: meta.embedded.block.php source.php
-    - match: '(?=\?>)'
-      pop: true
-    - include: statements
-
   statements:
     - include: class
     - include: use-statement
@@ -78,6 +72,44 @@ contexts:
     - match: \}
       scope: punctuation.definition.block.end.php
     - include: expressions
+
+  block:
+    - match: '\}'
+      scope: punctuation.definition.block.end.php
+      pop: true
+    - match: '\{'
+      scope: punctuation.definition.block.begin.php
+      push: block
+    - include: embedded-html
+    - include: statements
+
+  embedded-html:
+    - match: '\?>'
+      scope: meta.embedded.block.php punctuation.section.embedded.end.php
+      push:
+        - meta_scope: embedding.php text.html.basic
+        - clear_scopes: true
+        - match: '<\?(?i:php)?'
+          scope: meta.embedded.block.php punctuation.section.embedded.begin.php
+          pop: true
+        - match: ''
+          with_prototype:
+            - include: single-line-php-tag
+            - match: '(?=<\?(?i:php)?)'
+              pop: true
+          push:
+            - include: scope:text.html.basic
+
+  single-line-php-tag:
+    - match: '(<\?=|<\?(?i:php)?(?=.*\?>))'
+      scope: punctuation.section.embedded.begin.php
+      push:
+        - meta_scope: meta.embedded.line.nested.php
+        - meta_content_scope: source.php
+        - match: \?>
+          scope: punctuation.section.embedded.end.php
+          pop: true
+        - include: statements
 
   expressions:
     - include: comments
@@ -358,12 +390,12 @@ contexts:
         1: storage.modifier.abstract.php
         2: storage.type.class.php
         3: entity.name.class.php
-      set: class-definition
+      push: class-definition
 
   class-definition:
-    - meta_scope: meta.embedded.block.php source.php meta.class.php
+    - meta_scope: meta.class.php
     - match: "(?=;)"
-      set: embedded
+      pop: true
     - match: '\{'
       scope: meta.block.php punctuation.definition.block.php
       set: class-body
@@ -408,11 +440,11 @@ contexts:
           pop: true
 
   class-body:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php
+    - meta_content_scope: meta.class.php meta.block.php
     - include: comments
     - match: '\}'
-      scope: punctuation.definition.block.php
-      set: embedded
+      scope: meta.class.php meta.block.php punctuation.definition.block.php
+      pop: true
     - match: (?i)\b(use)\b\s*
       captures:
         1: keyword.other.use.php
@@ -421,11 +453,11 @@ contexts:
         - match: (?=;|(?:^\s*$))
           pop: true
         - match: '\{'
-          scope: meta.block.php punctuation.definition.block.php
+          scope: punctuation.definition.block.php
           set:
-            - meta_content_scope: meta.use.php meta.block.php
+            - meta_scope: meta.use.php meta.block.php
             - match: '}'
-              scope: meta.use.php meta.block.php punctuation.definition.block.php
+              scope: punctuation.definition.block.php
               pop: true
             - include: comments
             - match: \b(as)\b
@@ -456,13 +488,12 @@ contexts:
               pop: true
         - match: ','
           scope: punctuation.separator.php
-    - include: method
     - include: statements
 
   function:
     - match: (?i)(?=(?:\b(?:final|abstract|public|private|protected|static)\s+)*\bfunction\b\s*(&\s*)?{{identifier_start}})
-      set:
-        - meta_content_scope: meta.embedded.block.php source.php meta.function.php
+      push:
+        - meta_content_scope: meta.function.php
         - include: comments
         - match: '(?i)\b(final|abstract|public|private|protected|static)\b'
           scope: storage.modifier.php
@@ -477,39 +508,12 @@ contexts:
         # Lookahead is used here to prevent doubling up of meta.function and meta.function.parameters
         - match: (?=\()
           set:
-            - meta_content_scope: meta.embedded.block.php source.php
             - match: \(
               scope: meta.function.parameters.php meta.group.php punctuation.definition.group.begin.php
               set: function-parameters
         # Exit on unexpected content
         - match: (?=\S)
-          set: embedded
-
-  method:
-    - match: (?i)(?=(?:\b(?:final|abstract|public|private|protected|static)\s+)*\bfunction\b\s*(&\s*)?{{identifier_start}})
-      set:
-        - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php
-        - include: comments
-        - match: '(?i)\b(final|abstract|public|private|protected|static)\b'
-          scope: storage.modifier.php
-        - match: (?i)\bfunction\b
-          scope: storage.type.function.php
-        - match: '&'
-          scope: storage.modifier.reference.php
-        - match: '(__(?:callStatic|call|construct|destruct|get|set|isset|unset|toString|clone|set_state|sleep|wakeup|autoload|invoke|debugInfo))'
-          scope: entity.name.function.php support.function.magic.php
-        - match: '{{identifier}}'
-          scope: entity.name.function.php
-        # Lookahead is used here to prevent doubling up of meta.function and meta.function.parameters
-        - match: (?=\()
-          set:
-            - meta_content_scope: meta.embedded.block.php source.php
-            - match: \(
-              scope: meta.function.parameters.php meta.group.php punctuation.definition.group.begin.php
-              set: method-parameters
-        # Exit on unexpected content
-        - match: (?=\S)
-          set: class-body
+          pop: true
 
   closure:
     - match: (?i)\b(function)\s*(&)?\s*(?=\()
@@ -517,19 +521,17 @@ contexts:
       captures:
         1: storage.type.function.php
         2: storage.modifier.reference.php
-      set:
-        - meta_content_scope: meta.embedded.block.php source.php
+      push:
         - match: \(
           scope: meta.function.parameters.php meta.group.php punctuation.definition.group.begin.php
           set: function-parameters
 
   function-parameters:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.parameters.php meta.group.php
+    - meta_content_scope: meta.function.parameters.php meta.group.php
     - match: '\)'
       scope: punctuation.definition.group.end.php
       set:
-        - meta_content_scope: meta.embedded.block.php source.php meta.function.php
-        - include: comments
+        - meta_content_scope: meta.function.php
         - match: '\b(use)\b\s*(\()'
           scope: meta.function.closure.use.php
           captures:
@@ -543,43 +545,7 @@ contexts:
           set: function-body
         # Exit on unexpected content
         - match: (?=\S)
-          set: embedded
-    - include: comments
-    - match: \b(array|callable|int|string|bool|float)\b
-      scope: storage.type.php
-    # Class name type hint
-    - match: '{{identifier}}'
-      scope: support.class.php
-    - match: '&'
-      scope: storage.modifier.reference.php
-    - match: (\$+){{identifier}}
-      scope: variable.parameter.php
-      captures:
-        1: punctuation.definition.variable.php
-    - match: ','
-      scope: punctuation.separator.php
-    - match: '='
-      scope: keyword.operator.assignment.php
-      push:
-        - match: '(?=,|\))'
           pop: true
-        - include: expressions
-
-  method-parameters:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.parameters.php meta.group.php
-    - match: '\)'
-      scope: punctuation.definition.group.end.php
-      set:
-        - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php
-        - include: comments
-        - match: '(?=:)'
-          set: method-return-type
-        - match: \{
-          scope: meta.block.php punctuation.definition.block.begin.php
-          set: method-body
-        # Exit on unexpected content
-        - match: (?=\S)
-          set: class-body
     - include: comments
     - match: \b(array|callable|int|string|bool|float)\b
       scope: storage.type.php
@@ -602,12 +568,12 @@ contexts:
         - include: expressions
 
   function-use:
-      - meta_content_scope: meta.embedded.block.php source.php meta.function.closure.use.php
+      - meta_content_scope: meta.function.closure.use.php
       - include: comments
       - match: '\)'
         scope: punctuation.definition.group.end.php
         set:
-          - meta_content_scope: meta.embedded.block.php source.php meta.function.php
+          - meta_content_scope: meta.function.php
           - match: '(?=:)'
             set: function-return-type
           - match: \{
@@ -615,7 +581,7 @@ contexts:
             set: function-body
           # Exit on unexpected content
           - match: (?=\S)
-            set: embedded
+            pop: true
       - match: '&'
         scope: storage.modifier.reference.php
       - match: '(\$+){{identifier}}'
@@ -626,9 +592,9 @@ contexts:
         scope: punctuation.separator.php
 
   function-return-type:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.return-type.php
+    - meta_content_scope: meta.function.return-type.php
     - match: '(?=;)'
-      set: embedded
+      pop: true
     - match: \{
       scope: meta.block.php punctuation.definition.block.begin.php
       set: function-body
@@ -644,71 +610,17 @@ contexts:
         2: support.class.php
     # Exit on unexpected content
     - match: (?=\S)
-      set: embedded
-
-  method-return-type:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.return-type.php
-    - match: '(?=;)'
-      set: class-body
-    - match: \{
-      scope: meta.block.php punctuation.definition.block.begin.php
-      set: method-body
-    - match: ':'
-      scope: punctuation.separator.php
-    - match: \b(array|bool|int|float|string)\b
-      scope: storage.type.php
-    - include: class-builtin
-    - include: identifier-parts
-    - match: '(\\)?({{identifier}})(?!\\)'
-      captures:
-        1: punctuation.separator.namespace.php
-        2: support.class.php
-    # Exit on unexpected content
-    - match: (?=\S)
-      set: class-body
+      pop: true
 
   function-body:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
+    - meta_content_scope: meta.function.php meta.block.php
     - match: \}
-      scope: punctuation.definition.block.end.php
-      set: embedded
+      scope: meta.function.php meta.block.php punctuation.definition.block.end.php
+      pop: true
+    - include: embedded-html
     - match: '\{'
       scope: punctuation.definition.block.begin.php
-      set: function-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-body
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  method-body:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: \}
-      scope: punctuation.definition.block.end.php
-      set: class-body
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: method-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-body
-          set:
-            - include: scope:text.html.basic
+      push: block
     - include: statements
 
   class-name:
@@ -929,7 +841,7 @@ contexts:
       captures:
         1: keyword.other.new.php
         2: storage.type.class.php
-      set: class-definition
+      push: class-definition
     - match: (?i)(new)\s+
       captures:
         1: keyword.other.new.php
@@ -1457,283 +1369,3 @@ contexts:
             2: constant.other.php
         - match: ''
           pop: true
-
-  # These context handle literal PHP output inside of functions, classes and
-  # methods. There isn't a good way to arbitrary switch between the two, but
-  # maintain different scope stacks to allow snippets and completions to work
-  # as expected, so we do some gymnastics to do the right thing for a reasonable
-  # number of levels of nesting. Most modern PHP that uses the advanced
-  # constructs where this won't be 100% correct also aren't going to be
-  # switching to literal HTML output inside of methods, so this should be
-  # generally "good enough".
-
-  single-line-php-tag:
-    - match: '(<\?=|<\?(?i:php)?(?=.*\?>))'
-      scope: punctuation.section.embedded.begin.php
-      push:
-        - meta_scope: meta.embedded.line.nested.php
-        - meta_content_scope: source.php
-        - match: \?>
-          scope: punctuation.section.embedded.end.php
-          pop: true
-        - include: 'scope:source.php'
-
-  function-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: function-body
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: function-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  function-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: function-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: function-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  function-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: function-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: function-block-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  function-block-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: function-block-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: function-block-block-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-block-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  function-block-block-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: function-block-block-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      push: function-block-block-block-block-block-nested
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: function-block-block-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  # After five levels of nesting, we give up on trying to maintain the scope
-  # of literal output HTML, which may lead to background color being off, or
-  # snippets and completions triggering for PHP instead of HTML
-  function-block-block-block-block-block-nested:
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      pop: true
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      push: function-block-block-block-block-block-nested
-    - match: '\?>'
-      scope: punctuation.section.embedded.end.php
-      with_prototype:
-        - include: single-line-php-tag
-        - match: '<\?(?i:php)?'
-          scope: punctuation.section.embedded.begin.php
-          pop: true
-      push: scope:text.html.basic
-    - include: statements
-
-  method-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: method-body
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: method-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  method-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: method-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: method-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  method-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: method-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: method-block-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  method-block-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: method-block-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      set: method-block-block-block-block-block
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-block-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  method-block-block-block-block-block:
-    - meta_content_scope: meta.embedded.block.php source.php meta.class.php meta.block.php meta.function.php meta.block.php
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      set: method-block-block-block-block
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      push: method-block-block-block-block-block-nested
-    # We set using a lookahead so the close tag doesn't get the source.php scope
-    - match: '(?=\?>)'
-      set:
-        - match: '\?>'
-          scope: meta.embedded.block.php punctuation.section.embedded.end.php
-          with_prototype:
-            - include: single-line-php-tag
-            - match: '<\?(?i:php)?'
-              scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-              set: method-block-block-block-block-block
-          set:
-            - include: scope:text.html.basic
-    - include: statements
-
-  # After five levels of nesting, we give up on trying to maintain the scope
-  # of literal output HTML, which may lead to background color being off, or
-  # snippets and completions triggering for PHP instead of HTML
-  method-block-block-block-block-block-nested:
-    - match: '\}'
-      scope: punctuation.definition.block.end.php
-      pop: true
-    - match: '\{'
-      scope: punctuation.definition.block.begin.php
-      push: method-block-block-block-block-block-nested
-    - match: '\?>'
-      scope: punctuation.section.embedded.end.php
-      with_prototype:
-        - include: single-line-php-tag
-        - match: '<\?(?i:php)?'
-          scope: punctuation.section.embedded.begin.php
-          pop: true
-      push: scope:text.html.basic
-    - include: statements

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -17,7 +17,16 @@ contexts:
     - match: ''
       push: 'scope:text.html.basic'
       with_prototype:
-        - match: '(<\?=|<\?(?i:php)?(?=.*\?>))'
+        - match: '<\?(?i:php|=)?(?![^?]*\?>)'
+          scope: punctuation.section.embedded.begin.php
+          push:
+            - meta_scope: meta.embedded.block.php
+            - meta_content_scope: source.php
+            - match: \?>
+              scope: punctuation.section.embedded.end.php
+              pop: true
+            - include: 'scope:source.php'
+        - match: <\?(?i:php|=)?
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.line.php
@@ -26,11 +35,3 @@ contexts:
               scope: punctuation.section.embedded.end.php
               pop: true
             - include: 'scope:source.php'
-        - match: <\?(?i:php)?
-          scope: meta.embedded.block.php punctuation.section.embedded.begin.php
-          push:
-            - match: \?>
-              scope: meta.embedded.block.php punctuation.section.embedded.end.php
-              pop: true
-            - match: ''
-              push: 'scope:source.php#embedded'

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -711,8 +711,10 @@ class OutputsHtml {
 
         <div class="acf-gallery-side-info acf-cf<?php if () { echo ' class-name'; } ?>" id="myid"></div>
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.php
 //           ^^^^^ meta.attribute-with-value
 //                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.line.nested.php
+//                                                                                    ^^^^^^^^^^^^^^^^^^ - source.php
 //                                              ^^^^^ punctuation.section.embedded.begin - source.php
 //                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.php
 //                                                                                  ^^ punctuation.section.embedded.end - source.php
@@ -748,6 +750,22 @@ function embedHtml() {
     }
 //  ^ meta.function meta.block punctuation.definition.block.end
 
+    $myClass = new class {
+        function foo() {
+            ?>
+            <div></div>
+//          ^^^^^^^^^^^ meta.tag - source.php
+            <?
+        }
+    }
+
+    $myClosure = function() use ($var) {
+        ?>
+        <div></div>
+//      ^^^^^^^^^^^ meta.tag - source.php
+        <?
+    }
+
     try {
         if (1) {
             if (1) {
@@ -758,8 +776,10 @@ function embedHtml() {
 
                     <div class="acf-gallery-side-info acf-cf<?php if () { echo ' class-name'; } ?>" id="myid"></div>
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.php
 //                       ^^^^^ meta.attribute-with-value
 //                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.line.nested.php
+//                                                                                                ^^^^^^^^^^^^^^^^^^ - source.php
 //                                                          ^^^^^ punctuation.section.embedded.begin
 //                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.php
 //                                                                                              ^^ punctuation.section.embedded.end
@@ -771,18 +791,12 @@ function embedHtml() {
 //                  ^^^^^ punctuation.section.embedded.begin
 //                       ^ source.php
                 } finally {
-                    // This tests maxing out the standard handling of block
-                    // nesting in a function. As we can see, the HTML is still
-                    // highlighted properly, but the background doesn't lose
-                    // the highlighting of being inside of source.* scope.
-                    // Additionally, snippets and completions will trigger for
-                    // PHP inside of this scope, and HTML will not trigger.
                     if (1) {
                         if (1) {
                             ?>
 //                          ^^ punctuation.section.embedded.end
                             <div>
-//                          ^^^^^ meta.tag
+//                          ^^^^^ meta.tag - source.php
                             </div>
                             <?
 //                          ^^ punctuation.section.embedded.begin


### PR DESCRIPTION
This effectively reverts cd7f8c24ef8c785fc9ff01c1c157beadb35278d8, and will be merged right before we ship 3115 since it uses new functionality.

It has the side effect of also allowing literal HTML output inside of anonymous class methods and closures.