### PR TITLE
[Pascal] Fixed one line comments eating keywords from next line

### DIFF
--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -23,32 +23,22 @@ contexts:
         2: entity.name.function.pascal
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
       scope: constant.numeric.pascal
-    - match: '(^[ \t]+)?(?=--)'
+    - match: '(^[ \t]+)?(--)'
       captures:
         1: punctuation.whitespace.comment.leading.pascal
+        2: punctuation.definition.comment.pascal
       push:
-        - match: (?!\G)
+        - meta_scope: comment.line.double-dash.pascal.one
+        - match: \n
           pop: true
-        - match: "--"
-          captures:
-            0: punctuation.definition.comment.pascal
-          push:
-            - meta_scope: comment.line.double-dash.pascal.one
-            - match: '(?=\n)'
-              pop: true
-    - match: '(^[ \t]+)?(?=//)'
+    - match: '(^[ \t]+)?(//)'
       captures:
         1: punctuation.whitespace.comment.leading.pascal
+        2: punctuation.definition.comment.pascal
       push:
-        - match: (?!\G)
+        - meta_scope: comment.line.double-slash.pascal.two
+        - match: \n
           pop: true
-        - match: //
-          captures:
-            0: punctuation.definition.comment.pascal
-          push:
-            - meta_scope: comment.line.double-slash.pascal.two
-            - match: '(?=\n)'
-              pop: true
     - match: \(\*
       captures:
         0: punctuation.definition.comment.pascal

--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -34,7 +34,7 @@ contexts:
             0: punctuation.definition.comment.pascal
           push:
             - meta_scope: comment.line.double-dash.pascal.one
-            - match: \n
+            - match: '(?=\n)'
               pop: true
     - match: '(^[ \t]+)?(?=//)'
       captures:
@@ -47,7 +47,7 @@ contexts:
             0: punctuation.definition.comment.pascal
           push:
             - meta_scope: comment.line.double-slash.pascal.two
-            - match: \n
+            - match: '(?=\n)'
               pop: true
     - match: \(\*
       captures:

--- a/Pascal/syntax_test.pas
+++ b/Pascal/syntax_test.pas
@@ -1,0 +1,17 @@
+// SYNTAX TEST "Packages/Pascal/Pascal.sublime-syntax"
+
+// comment
+procedure foo;
+// ^ meta.function.pascal
+begin
+	// comment
+end;
+// <- keyword.control.pascal
+
+-- comment
+procedure bar;
+// ^ meta.function.pascal
+begin
+	-- comment
+end;
+// <- keyword.control.pascal

--- a/Pascal/syntax_test.pas
+++ b/Pascal/syntax_test.pas
@@ -1,5 +1,15 @@
 // SYNTAX TEST "Packages/Pascal/Pascal.sublime-syntax"
 
+  // double slash comment
+// <- punctuation.whitespace.comment.leading.pascal
+  // <- punctuation.definition.comment.pascal
+  // ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.pascal.two
+
+  -- double dash comment
+// <- punctuation.whitespace.comment.leading.pascal
+  // <- punctuation.definition.comment.pascal
+  // ^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.pascal.one
+
 // comment
 procedure foo;
 // ^ meta.function.pascal


### PR DESCRIPTION
One line comments grab the final `\n` which is apparently needed for matching a `\b` if there's a keyword right on the next line (with no trailing space). This is visually annoying and breaks jumping to symbols for functions/procedures that have a comment right before them.