### PR TITLE
[Scala] Symbolic method name support

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -85,7 +85,7 @@ contexts:
     - match: |-
         (?x)
         \b(def)\s+
-        (([a-zA-Z$_][a-zA-Z0-9$_]*(_[^a-zA-Z0-9\s]+)?)|`.*`|[^\w\[\(\:\_\s]+)
+        (_*([a-zA-Z$][a-zA-Z0-9$]*|[^a-zA-Z0-9$`\s\(\)\[\]\{\};\.]+)(_+([a-zA-Z$][a-zA-Z0-9$]*|[^a-zA-Z0-9$`\s\(\)\[\]\{\};\._]+)?)*|`[^`]+`|[^\w\[\(\:\_\s]+)
       captures:
         1: keyword.declaration.scala
         2: entity.name.function.declaration

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -20,6 +20,30 @@ def foo(a: Int, b: Bar): Baz = 42
 //                       ^^^ entity.name.class
 //                             ^^ constant.numeric.scala
 
+   def +(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^ entity.name.function.declaration
+
+   def `this is a test`(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^^^^^^^^^^^^^^^^ entity.name.function.declaration
+
+   def ::(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^^ entity.name.function.declaration
+
+   def foo_+(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^^^^^ entity.name.function.declaration
+
+   def foo42_+(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^^^^^^^ entity.name.function.declaration
+
+   def foo42_+_abc(a: Int)
+// ^^^ keyword.declaration.scala
+//     ^^^^^^^^^^^ entity.name.function.declaration
+
 val foo: Unit
 //^ keyword.declaration.stable.scala
 //  ^^^ entity.name.val.declaration

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1,0 +1,224 @@
+// SYNTAX TEST "Packages/Scala/Scala.sublime-syntax"
+// <- source.scala comment.line.double-slash.scala
+
+package fubar
+// ^^^^ keyword.other.scoping
+//      ^^^^^ entity.name.package.scala
+
+import fubar.{Unit, Foo}
+// ^^^ keyword.other.import
+// <- meta.import.scala
+//     ^^^^^ variable.package.scala
+//            ^^^^ variable.import.scala
+
+def foo(a: Int, b: Bar): Baz = 42
+//^ keyword.declaration.scala
+//  ^^^ entity.name.function.declaration
+//      ^ variable.parameter
+//         ^^^ entity.name.class
+//                 ^^^ entity.name.class
+//                       ^^^ entity.name.class
+//                             ^^ constant.numeric.scala
+
+val foo: Unit
+//^ keyword.declaration.stable.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+var foo: Unit
+//^ keyword.declaration.volatile.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+class Foo[A](a: Bar) extends Baz with Bin
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+//        ^ entity.name.class
+//           ^ variable.parameter
+//              ^^^ entity.name.class
+//                   ^^^^^^^ keyword.declaration.scala
+//                           ^^^ entity.other.inherited-class.scala
+//                               ^^^^ keyword.declaration.scala
+//                                    ^^^ entity.other.inherited-class.scala
+
+trait Foo
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+
+object Foo
+// ^^^ keyword.declaration.scala
+//     ^^^ entity.name.class
+
+   42
+// ^^ constant.numeric.scala
+
+   42D
+// ^^^ constant.numeric.scala
+
+   42d
+// ^^^ constant.numeric.scala
+
+   42F
+// ^^^ constant.numeric.scala
+
+   42f
+// ^^^ constant.numeric.scala
+
+   42L
+// ^^^ constant.numeric.scala
+
+   42l
+// ^^^ constant.numeric.scala
+
+   true
+// ^^^^ constant.language.scala
+
+   false
+// ^^^^^ constant.language.scala
+
+   null
+// ^^^^ constant.language.scala
+
+   Nil
+// ^^^ constant.language.scala
+
+   None
+// ^^^^ constant.language.scala
+
+   this
+// ^^^^ variable.language.scala
+
+   super
+// ^^^^^ variable.language.scala
+
+   "testing"
+// ^^^^^^^^^ string.quoted.double.scala
+
+   """testing"""
+// ^^^^^^^^^^^^^ string.quoted.triple.scala
+
+   s"testing $a ${42}"
+// ^^^^^^^^^ string.quoted.interpolated.scala
+//           ^^ variable.parameter
+//              ^^ variable.parameter
+//                ^^ constant.numeric.scala
+//                  ^ variable.parameter
+
+   s"""testing $a ${42}"""
+// ^^^^^^^^^^^ string.quoted.triple.interpolated.scala
+//             ^^ variable.parameter
+//                ^^ variable.parameter
+//                  ^^ constant.numeric.scala
+//                    ^ variable.parameter
+//                     ^^^ string.quoted.triple.interpolated.scala
+
+   Unit
+// ^^^^ storage.type.primitive.scala
+
+   Byte
+// ^^^^ storage.type.primitive.scala
+
+   Short
+// ^^^^^ storage.type.primitive.scala
+
+   Int
+// ^^^ storage.type.primitive.scala
+
+   Long
+// ^^^^ storage.type.primitive.scala
+
+   Float
+// ^^^^^ storage.type.primitive.scala
+
+   Double
+// ^^^^^^ storage.type.primitive.scala
+
+   Boolean
+// ^^^^^^^ storage.type.primitive.scala
+
+   String
+// ^^^^^^ entity.name.class
+
+   // this is a comment
+// ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
+
+/*
+// <- comment.block.scala
+*/
+
+/**
+// <- comment.block.documentation.scala
+*/
+
+   if
+// ^^ keyword.control.flow.scala
+
+   else
+// ^^^^ keyword.control.flow.scala
+
+   while
+// ^^^^^ keyword.control.flow.scala
+
+   for
+// ^^^ keyword.control.flow.scala
+
+   yield
+// ^^^^^ keyword.control.flow.scala
+
+   match
+// ^^^^^ keyword.control.flow.scala
+
+   case
+// ^^^^ keyword.control.flow.scala
+
+   return
+// ^^^^^^ keyword.control.flow.jump.scala
+
+   throw
+// ^^^^^ keyword.control.flow.jump.scala
+
+   catch
+// ^^^^^ keyword.control.exception.scala
+
+   finally
+// ^^^^^^^ keyword.control.exception.scala
+
+   try
+// ^^^ keyword.control.exception.scala
+
+   private
+// ^^^^^^^ storage.modifier.access
+
+   protected
+// ^^^^^^^^^ storage.modifier.access
+
+   abstract
+// ^^^^^^^^ storage.modifier.other
+
+   final
+// ^^^^^ storage.modifier.other
+
+   lazy
+// ^^^^ storage.modifier.other
+
+   sealed
+// ^^^^^^ storage.modifier.other
+
+   implicit
+// ^^^^^^^^ storage.modifier.other
+
+   override
+// ^^^^^^^^ storage.modifier.other
+
+   ({ type λ[α] = Foo[α] })#λ
+// ^^^^^^^^^^^^^^ comment.block.scala
+//                ^^^ entity.name.class
+//                    ^ comment.block.empty.scala
+//                       ^^^^ comment.block.scala
+
+   ({ type λ[α, β] = Foo[α, β] })#λ
+// ^^^^^^^^^^^^^^^^^ comment.block.scala
+//                   ^^^ entity.name.class
+//                       ^ comment.block.empty.scala
+//                          ^ comment.block.empty.scala
+//                             ^^^^ comment.block.scala


### PR DESCRIPTION
Fixes syntax highlighting for symbolic methods (e.g. `def +`) and methods with backticks.