### PR TITLE
[Scala] Avoid highlighting colon prefixes as parameters

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -138,7 +138,7 @@ contexts:
           pop: true
         - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
           captures:
-            1: entity.name.variable variable.parameter
+            1: entity.name.parameter variable.parameter
         - include: main
     - match: '(?=[:\{=\n])'
       pop: true
@@ -169,7 +169,7 @@ contexts:
           pop: true
         - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
           captures:
-            1: entity.name.variable variable.parameter
+            1: entity.name.parameter variable.parameter
         - include: main
     - match: '(?=([\{\n]|extends))'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -20,8 +20,8 @@ contexts:
     - include: constants
     - include: char-literal
     - include: scala-symbol
-    - include: empty-parentheses
     - include: parameter-list
+    - include: empty-parentheses
     - include: qualifiedClassName
     - include: xml-literal
   block-comments:
@@ -174,10 +174,16 @@ contexts:
         - include: nest-curly-and-self
     - include: main
   parameter-list:
-    - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*([A-Za-z0-9][\w|_|?|\.]*)?,?'
-      captures:
-        1: variable.parameter
-        2: entity.name.class
+    - match: '\('
+      push:
+        - match: '\)'
+          pop: true
+        - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
+          captures:
+            1: variable.parameter
+            2: entity.name.class
+        - include: main
+        - include: parameter-list
   qualifiedClassName:
     - match: '(\b([A-Z][\w]*))'
       captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -20,7 +20,6 @@ contexts:
     - include: constants
     - include: char-literal
     - include: scala-symbol
-    - include: parameter-list
     - include: empty-parentheses
     - include: qualifiedClassName
     - include: xml-literal
@@ -89,11 +88,13 @@ contexts:
       captures:
         1: keyword.declaration.scala
         2: entity.name.function.declaration
+      push: function-type-parameter-list
     - match: '(case)?\b(class|trait|object)\s+([^\s\{\(\[]+)'
       captures:
         1: keyword.declaration.scala
         2: keyword.declaration.scala
         3: entity.name.class.declaration
+      push: class-type-parameter-list
     - match: '\b(type)\s+(([a-zA-Z$_][a-zA-Z0-9$_]*(_[^a-zA-Z0-9\s]+)?)|`.*`)'
       captures:
         1: keyword.declaration.scala
@@ -112,6 +113,66 @@ contexts:
       captures:
         1: keyword.other.scoping.scala
         2: entity.name.package.scala
+  function-type-parameter-list:
+    - match: '(?=\()'
+      set: function-parameter-list
+    - match: '\['
+      push: function-tparams-brackets
+    - match: '(?=[:\{=\n])'
+      pop: true
+  function-tparams-brackets:
+    - match: '\['
+      push: function-tparams-brackets
+    - match: '\]'
+      pop: true
+    - include: main
+  function-parameter-list:
+    - match: '\('
+      push:
+        - match: '\('
+          push:
+            - match: '\)'
+              pop: true
+            - include: main
+        - match: '\)'
+          pop: true
+        - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
+          captures:
+            1: entity.name.variable variable.parameter
+        - include: main
+    - match: '(?=[:\{=\n])'
+      pop: true
+  class-type-parameter-list:
+    - match: '\b(private|protected)\b'
+      scope: storage.modifier.access
+    - match: '(?=\()'
+      set: class-parameter-list
+    - match: '\['
+      push: class-tparams-brackets
+    - match: '(?=([\{\n]|extends))'
+      pop: true
+  class-tparams-brackets:
+    - match: '\['
+      push: class-tparams-brackets
+    - match: '\]'
+      pop: true
+    - include: main
+  class-parameter-list:
+    - match: '\('
+      push:
+        - match: '\('
+          push:
+            - match: '\)'
+              pop: true
+            - include: main
+        - match: '\)'
+          pop: true
+        - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
+          captures:
+            1: entity.name.variable variable.parameter
+        - include: main
+    - match: '(?=([\{\n]|extends))'
+      pop: true
   empty-parentheses:
     - match: \(\)
       scope: meta.parentheses.scala
@@ -173,17 +234,6 @@ contexts:
           pop: true
         - include: nest-curly-and-self
     - include: main
-  parameter-list:
-    - match: '\('
-      push:
-        - match: '\)'
-          pop: true
-        - match: '([a-zA-Z$_][a-zA-Z0-9$_]*)\s*:\s*'
-          captures:
-            1: variable.parameter
-            2: entity.name.class
-        - include: main
-        - include: parameter-list
   qualifiedClassName:
     - match: '(\b([A-Z][\w]*))'
       captures:

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -44,6 +44,14 @@ def foo(a: Int, b: Bar): Baz = 42
 // ^^^ keyword.declaration.scala
 //     ^^^^^^^^^^^ entity.name.function.declaration
 
+   def foo[A]
+// ^^^ keyword.declaration.scala
+//     ^^^ entity.name.function.declaration
+//         ^ entity.name.class
+
+   def foo(implicit bar: Int): Unit
+//         ^^^^^^^^ storage.modifier.other
+
 val foo: Unit
 //^ keyword.declaration.stable.scala
 //  ^^^ entity.name.val.declaration
@@ -64,6 +72,12 @@ class Foo[A](a: Bar) extends Baz with Bin
 //                           ^^^ entity.other.inherited-class.scala
 //                               ^^^^ keyword.declaration.scala
 //                                    ^^^ entity.other.inherited-class.scala
+
+   class Foo private[this] (a: Int)(b: String)
+//           ^^^^^^^ storage.modifier.access
+//                   ^^^^ variable.language.scala
+//                          ^ variable.parameter
+//                                  ^ variable.parameter
 
 trait Foo
 // ^^ keyword.declaration.scala
@@ -251,6 +265,14 @@ object Foo
 // ^^^^^^^^^ source.scala
 //           ^^^ constant.language.scala
 
+  (a :: b :: Nil)
+// ^^^^^^^^^ source.scala
+//           ^^^ constant.language.scala
+
    a: Int
 // ^^ source.scala
+//    ^^^ storage.type.primitive.scala
+
+  (a: Int)
+// ^ source.scala
 //    ^^^ storage.type.primitive.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -15,7 +15,7 @@ def foo(a: Int, b: Bar): Baz = 42
 //^ keyword.declaration.scala
 //  ^^^ entity.name.function.declaration
 //      ^ variable.parameter
-//         ^^^ entity.name.class
+//         ^^^ storage.type.primitive.scala
 //                 ^^^ entity.name.class
 //                       ^^^ entity.name.class
 //                             ^^ constant.numeric.scala
@@ -222,3 +222,11 @@ object Foo
 //                       ^ comment.block.empty.scala
 //                          ^ comment.block.empty.scala
 //                             ^^^^ comment.block.scala
+
+   a :: b :: Nil
+// ^^^^^^^^^ source.scala
+//           ^^^ constant.language.scala
+
+   a: Int
+// ^^ source.scala
+//    ^^^ storage.type.primitive.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1,0 +1,224 @@
+// SYNTAX TEST "Packages/Scala/Scala.sublime-syntax"
+// <- source.scala comment.line.double-slash.scala
+
+package fubar
+// ^^^^ keyword.other.scoping
+//      ^^^^^ entity.name.package.scala
+
+import fubar.{Unit, Foo}
+// ^^^ keyword.other.import
+// <- meta.import.scala
+//     ^^^^^ variable.package.scala
+//            ^^^^ variable.import.scala
+
+def foo(a: Int, b: Bar): Baz = 42
+//^ keyword.declaration.scala
+//  ^^^ entity.name.function.declaration
+//      ^ variable.parameter
+//         ^^^ entity.name.class
+//                 ^^^ entity.name.class
+//                       ^^^ entity.name.class
+//                             ^^ constant.numeric.scala
+
+val foo: Unit
+//^ keyword.declaration.stable.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+var foo: Unit
+//^ keyword.declaration.volatile.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+class Foo[A](a: Bar) extends Baz with Bin
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+//        ^ entity.name.class
+//           ^ variable.parameter
+//              ^^^ entity.name.class
+//                   ^^^^^^^ keyword.declaration.scala
+//                           ^^^ entity.other.inherited-class.scala
+//                               ^^^^ keyword.declaration.scala
+//                                    ^^^ entity.other.inherited-class.scala
+
+trait Foo
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+
+object Foo
+// ^^^ keyword.declaration.scala
+//     ^^^ entity.name.class
+
+   42
+// ^^ constant.numeric.scala
+
+   42D
+// ^^^ constant.numeric.scala
+
+   42d
+// ^^^ constant.numeric.scala
+
+   42F
+// ^^^ constant.numeric.scala
+
+   42f
+// ^^^ constant.numeric.scala
+
+   42L
+// ^^^ constant.numeric.scala
+
+   42l
+// ^^^ constant.numeric.scala
+
+   true
+// ^^^^ constant.language.scala
+
+   false
+// ^^^^^ constant.language.scala
+
+   null
+// ^^^^ constant.language.scala
+
+   Nil
+// ^^^ constant.language.scala
+
+   None
+// ^^^^ constant.language.scala
+
+   this
+// ^^^^ variable.language.scala
+
+   super
+// ^^^^^ variable.language.scala
+
+   "testing"
+// ^^^^^^^^^ string.quoted.double.scala
+
+   """testing"""
+// ^^^^^^^^^^^^^ string.quoted.triple.scala
+
+   s"testing $a ${42}"
+// ^^^^^^^^^ string.quoted.interpolated.scala
+//           ^^ variable.parameter
+//              ^^ variable.parameter
+//                ^^ constant.numeric.scala
+//                  ^ variable.parameter
+
+   s"""testing $a ${42}"""
+// ^^^^^^^^^^^ string.quoted.triple.interpolated.scala
+//             ^^ variable.parameter
+//                ^^ variable.parameter
+//                  ^^ constant.numeric.scala
+//                    ^ variable.parameter
+//                     ^^^ string.quoted.triple.interpolated.scala
+
+   Unit
+// ^^^^ storage.type.primitive.scala
+
+   Byte
+// ^^^^ storage.type.primitive.scala
+
+   Short
+// ^^^^^ storage.type.primitive.scala
+
+   Int
+// ^^^ storage.type.primitive.scala
+
+   Long
+// ^^^^ storage.type.primitive.scala
+
+   Float
+// ^^^^^ storage.type.primitive.scala
+
+   Double
+// ^^^^^^ storage.type.primitive.scala
+
+   Boolean
+// ^^^^^^^ storage.type.primitive.scala
+
+   String
+// ^^^^^^ entity.name.class
+
+   // this is a comment
+// ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
+
+/*
+// <- comment.block.scala
+*/
+
+/**
+// <- comment.block.documentation.scala
+*/
+
+   if
+// ^^ keyword.control.flow.scala
+
+   else
+// ^^^^ keyword.control.flow.scala
+
+   while
+// ^^^^^ keyword.control.flow.scala
+
+   for
+// ^^^ keyword.control.flow.scala
+
+   yield
+// ^^^^^ keyword.control.flow.scala
+
+   match
+// ^^^^^ keyword.control.flow.scala
+
+   case
+// ^^^^ keyword.control.flow.scala
+
+   return
+// ^^^^^^ keyword.control.flow.jump.scala
+
+   throw
+// ^^^^^ keyword.control.flow.jump.scala
+
+   catch
+// ^^^^^ keyword.control.exception.scala
+
+   finally
+// ^^^^^^^ keyword.control.exception.scala
+
+   try
+// ^^^ keyword.control.exception.scala
+
+   private
+// ^^^^^^^ storage.modifier.access
+
+   protected
+// ^^^^^^^^^ storage.modifier.access
+
+   abstract
+// ^^^^^^^^ storage.modifier.other
+
+   final
+// ^^^^^ storage.modifier.other
+
+   lazy
+// ^^^^ storage.modifier.other
+
+   sealed
+// ^^^^^^ storage.modifier.other
+
+   implicit
+// ^^^^^^^^ storage.modifier.other
+
+   override
+// ^^^^^^^^ storage.modifier.other
+
+   ({ type λ[α] = Foo[α] })#λ
+// ^^^^^^^^^^^^^^ comment.block.scala
+//                ^^^ entity.name.class
+//                    ^ comment.block.empty.scala
+//                       ^^^^ comment.block.scala
+
+   ({ type λ[α, β] = Foo[α, β] })#λ
+// ^^^^^^^^^^^^^^^^^ comment.block.scala
+//                   ^^^ entity.name.class
+//                       ^ comment.block.empty.scala
+//                          ^ comment.block.empty.scala
+//                             ^^^^ comment.block.scala


### PR DESCRIPTION
…mostly.

This is still a bit of a work in progress, but it's still a significant improvement over what is there *now*.  The semantic here is to look for enclosing parentheses.  So still a few false positives, but far fewer than before.