### PR TITLE
[Scala] Keyword highlighting

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -158,7 +158,7 @@ contexts:
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
-    - match: \b(else|if|do|while|for|yield|match|case)\b
+    - match: \b(else|if|do|while|for|yield|match|case|macro)\b
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -164,6 +164,10 @@ contexts:
       scope: keyword.control.exception.scala
     - match: (\?\?\?)              # can't be guarded by \b for some reason (maybe bug?)
       scope: keyword.control.exception.scala
+
+    # catch-all for keywords that we otherwise don't know about
+    - match: \b(forSome|new|extends|with|class|trait|object|def|val|var|import|package)\b
+      scope: keyword.scala
   nest-curly-and-self:
     - match: '\{'
       captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -9,12 +9,12 @@ scope: source.scala
 contexts:
   main:
     - include: storage-modifiers
-    - include: keywords
     - include: declarations
     - include: inheritance
     - include: imports
     - include: comments
     - include: block-comments
+    - include: keywords
     - include: strings
     - include: initialization
     - include: constants
@@ -158,7 +158,7 @@ contexts:
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
-    - match: \b(else|if|do|while|for|yield|match|case|macro)\b
+    - match: \b(else|if|do|while|for|yield|match|case|macro|type)\b
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -162,6 +162,8 @@ contexts:
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala
+    - match: (\?\?\?)              # can't be guarded by \b for some reason (maybe bug?)
+      scope: keyword.control.exception.scala
   nest-curly-and-self:
     - match: '\{'
       captures:

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -156,6 +156,9 @@ object Foo
    else
 // ^^^^ keyword.control.flow.scala
 
+   do
+// ^^ keyword.control.flow.scala
+
    while
 // ^^^^^ keyword.control.flow.scala
 
@@ -171,6 +174,12 @@ object Foo
    case
 // ^^^^ keyword.control.flow.scala
 
+   macro
+// ^^^^^ keyword.control.flow.scala
+
+   type
+// ^^^^ keyword.control.flow.scala
+
    return
 // ^^^^^^ keyword.control.flow.jump.scala
 
@@ -183,8 +192,47 @@ object Foo
    finally
 // ^^^^^^^ keyword.control.exception.scala
 
+   ???
+// ^^^ keyword.control.exception.scala
+
    try
 // ^^^ keyword.control.exception.scala
+
+   forSome
+// ^^^^^^^ keyword.scala
+
+   new
+// ^^^ keyword.scala
+
+   extends
+// ^^^^^^^ keyword.scala
+
+   with
+// ^^^^ keyword.scala
+
+   class
+// ^^^^^ keyword.scala
+
+   trait
+// ^^^^^ keyword.scala
+
+   object
+// ^^^^^^ keyword.scala
+
+   def
+// ^^^ keyword.scala
+
+   val
+// ^^^ keyword.declaration.stable.scala
+
+   var
+// ^^^ keyword.declaration.volatile.scala
+
+   import
+// ^^^^^^ keyword.other.import.scala
+
+   package
+// ^^^^^^^ keyword.scala
 
    private
 // ^^^^^^^ storage.modifier.access

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1,0 +1,224 @@
+// SYNTAX TEST "Packages/Scala/Scala.sublime-syntax"
+// <- source.scala comment.line.double-slash.scala
+
+package fubar
+// ^^^^ keyword.other.scoping
+//      ^^^^^ entity.name.package.scala
+
+import fubar.{Unit, Foo}
+// ^^^ keyword.other.import
+// <- meta.import.scala
+//     ^^^^^ variable.package.scala
+//            ^^^^ variable.import.scala
+
+def foo(a: Int, b: Bar): Baz = 42
+//^ keyword.declaration.scala
+//  ^^^ entity.name.function.declaration
+//      ^ variable.parameter
+//         ^^^ entity.name.class
+//                 ^^^ entity.name.class
+//                       ^^^ entity.name.class
+//                             ^^ constant.numeric.scala
+
+val foo: Unit
+//^ keyword.declaration.stable.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+var foo: Unit
+//^ keyword.declaration.volatile.scala
+//  ^^^ entity.name.val.declaration
+//       ^^^^ storage.type.primitive.scala
+
+class Foo[A](a: Bar) extends Baz with Bin
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+//        ^ entity.name.class
+//           ^ variable.parameter
+//              ^^^ entity.name.class
+//                   ^^^^^^^ keyword.declaration.scala
+//                           ^^^ entity.other.inherited-class.scala
+//                               ^^^^ keyword.declaration.scala
+//                                    ^^^ entity.other.inherited-class.scala
+
+trait Foo
+// ^^ keyword.declaration.scala
+//    ^^^ entity.name.class
+
+object Foo
+// ^^^ keyword.declaration.scala
+//     ^^^ entity.name.class
+
+   42
+// ^^ constant.numeric.scala
+
+   42D
+// ^^^ constant.numeric.scala
+
+   42d
+// ^^^ constant.numeric.scala
+
+   42F
+// ^^^ constant.numeric.scala
+
+   42f
+// ^^^ constant.numeric.scala
+
+   42L
+// ^^^ constant.numeric.scala
+
+   42l
+// ^^^ constant.numeric.scala
+
+   true
+// ^^^^ constant.language.scala
+
+   false
+// ^^^^^ constant.language.scala
+
+   null
+// ^^^^ constant.language.scala
+
+   Nil
+// ^^^ constant.language.scala
+
+   None
+// ^^^^ constant.language.scala
+
+   this
+// ^^^^ variable.language.scala
+
+   super
+// ^^^^^ variable.language.scala
+
+   "testing"
+// ^^^^^^^^^ string.quoted.double.scala
+
+   """testing"""
+// ^^^^^^^^^^^^^ string.quoted.triple.scala
+
+   s"testing $a ${42}"
+// ^^^^^^^^^ string.quoted.interpolated.scala
+//           ^^ variable.parameter
+//              ^^ variable.parameter
+//                ^^ constant.numeric.scala
+//                  ^ variable.parameter
+
+   s"""testing $a ${42}"""
+// ^^^^^^^^^^^ string.quoted.triple.interpolated.scala
+//             ^^ variable.parameter
+//                ^^ variable.parameter
+//                  ^^ constant.numeric.scala
+//                    ^ variable.parameter
+//                     ^^^ string.quoted.triple.interpolated.scala
+
+   Unit
+// ^^^^ storage.type.primitive.scala
+
+   Byte
+// ^^^^ storage.type.primitive.scala
+
+   Short
+// ^^^^^ storage.type.primitive.scala
+
+   Int
+// ^^^ storage.type.primitive.scala
+
+   Long
+// ^^^^ storage.type.primitive.scala
+
+   Float
+// ^^^^^ storage.type.primitive.scala
+
+   Double
+// ^^^^^^ storage.type.primitive.scala
+
+   Boolean
+// ^^^^^^^ storage.type.primitive.scala
+
+   String
+// ^^^^^^ entity.name.class
+
+   // this is a comment
+// ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
+
+/*
+// <- comment.block.scala
+*/
+
+/**
+// <- comment.block.documentation.scala
+*/
+
+   if
+// ^^ keyword.control.flow.scala
+
+   else
+// ^^^^ keyword.control.flow.scala
+
+   while
+// ^^^^^ keyword.control.flow.scala
+
+   for
+// ^^^ keyword.control.flow.scala
+
+   yield
+// ^^^^^ keyword.control.flow.scala
+
+   match
+// ^^^^^ keyword.control.flow.scala
+
+   case
+// ^^^^ keyword.control.flow.scala
+
+   return
+// ^^^^^^ keyword.control.flow.jump.scala
+
+   throw
+// ^^^^^ keyword.control.flow.jump.scala
+
+   catch
+// ^^^^^ keyword.control.exception.scala
+
+   finally
+// ^^^^^^^ keyword.control.exception.scala
+
+   try
+// ^^^ keyword.control.exception.scala
+
+   private
+// ^^^^^^^ storage.modifier.access
+
+   protected
+// ^^^^^^^^^ storage.modifier.access
+
+   abstract
+// ^^^^^^^^ storage.modifier.other
+
+   final
+// ^^^^^ storage.modifier.other
+
+   lazy
+// ^^^^ storage.modifier.other
+
+   sealed
+// ^^^^^^ storage.modifier.other
+
+   implicit
+// ^^^^^^^^ storage.modifier.other
+
+   override
+// ^^^^^^^^ storage.modifier.other
+
+   ({ type λ[α] = Foo[α] })#λ
+// ^^^^^^^^^^^^^^ comment.block.scala
+//                ^^^ entity.name.class
+//                    ^ comment.block.empty.scala
+//                       ^^^^ comment.block.scala
+
+   ({ type λ[α, β] = Foo[α, β] })#λ
+// ^^^^^^^^^^^^^^^^^ comment.block.scala
+//                   ^^^ entity.name.class
+//                       ^ comment.block.empty.scala
+//                          ^ comment.block.empty.scala
+//                             ^^^^ comment.block.scala


### PR DESCRIPTION
The Scala mode does this weird thing where it only highlights certain keywords in context (e.g. `class` is only highlighted in `class Foo`, not when by itself).  This is deceptive since these keywords aren't valid identifiers.  This PR adds fallback highlighting support for those keywords.

Also adds support for highlighting `macro` and `???`, the latter of which isn't actually a keyword, but most people treat it as if it is.