### PR TITLE
Fix scope mismatch between Ruby syntax and Haml

### DIFF
--- a/Rails/Ruby Haml.sublime-syntax
+++ b/Rails/Ruby Haml.sublime-syntax
@@ -72,7 +72,7 @@ contexts:
         - match: '((do|\{)( \|[^|]+\|)?)$|$|^(?!.*\|\s*$)'
           captures:
             1: source.ruby.embedded.html
-            2: keyword.control.ruby.start-block
+            2: keyword.control.start-block.ruby
           pop: true
         - match: "#.*$"
           comment: Hack to let ruby comments work in this context properly


### PR DESCRIPTION
I found this while investigating all the scopes in the repo where order mattered and this was the only one. Turns out it is a mistake and this should match the one in the Ruby syntax file.

So fun fact: in all the default syntaxes order of the scope doesn't matter when checking equality. Not sure if this is true for all prefixes yet though.

@wbond 