### PR TITLE
[Scala] Pattern match highlighting for case, val and for

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -433,6 +433,10 @@ contexts:
         - meta_scope: source.scala
         - match: '`'
           pop: true
+    - match: '\b[a-z][a-zA-Z0-9_]*\.'
+      scope: source.scala
+    - match: '\.[a-z][a-zA-Z0-9_]*\b'
+      scope: source.scala
     - match: '\b[a-z][a-zA-Z0-9_]*\b'
       scope: entity.name.parameter variable.parameter
     - match: '\b[A-Z][a-zA-Z0-9_]*'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -272,7 +272,7 @@ contexts:
           pop: true
         - include: for-parens-body
   for-braces-body:
-    - match: '^(?=([^<←=\{]|<[^\-])+(<-|←|=[\s\b]))'
+    - match: '^(?=([^<←=\{\}]|<[^\-])+(<-|←|=[\s\b]))'
       push:
         - match: '^\s*(val)\s+'
           scope: keyword.declaration.stable.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -36,6 +36,8 @@ contexts:
     - include: char-literal
     - include: scala-symbol
     - include: empty-parentheses
+    - include: braces
+    - include: parameter-list
     - include: qualifiedClassName
     - include: xml-literal
     - include: late-keywords
@@ -140,6 +142,17 @@ contexts:
           captures:
             1: keyword.control.flow.scala
         - include: pattern-match
+  braces:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: main
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: main
   function-type-parameter-list:
     - match: '(?=\()'
       set: function-parameter-list

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -134,7 +134,7 @@ contexts:
             - match: '\)'
               pop: true
             - include: pattern-match
-        - match: '=>'
+        - match: '=>|⇒'
           pop: true
         - include: pattern-match
   function-type-parameter-list:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -119,6 +119,18 @@ contexts:
       captures:
         1: keyword.other.scoping.scala
         2: entity.name.package.scala
+    - match: '\b(case)\b'
+      captures:
+        0: keyword.declaration.scala
+      push:
+        - match: '\('
+          push:
+            - match: '\)'
+              pop: true
+            - include: pattern-match
+        - match: '=>'
+          pop: true
+        - include: pattern-match
   function-type-parameter-list:
     - match: '(?=\()'
       set: function-parameter-list
@@ -225,7 +237,7 @@ contexts:
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
-    - match: \b(else|if|do|while|for|yield|match|case)\b
+    - match: \b(else|if|do|while|for|yield|match)\b
       scope: keyword.control.flow.scala
     - match: \b(catch|finally|try)\b
       scope: keyword.control.exception.scala
@@ -332,3 +344,23 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
+  pattern-match:
+    - include: comments
+    - include: block-comments
+    - include: constants
+    - include: char-literal
+    - include: scala-symbol
+    - include: strings
+    - include: xml-literal
+    - match: '`'
+      push:
+        - meta_scope: source.scala
+        - match: '`'
+          pop: true
+    - match: '\b[a-z][a-zA-Z0-9_]*\b'
+      scope: entity.name.parameter variable.parameter
+    - match: '\b[A-Z][a-zA-Z0-9_]*'
+      captures:
+        0: entity.name.class
+    - match: '@|_'
+      scope: keyword

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -25,6 +25,7 @@ contexts:
     - include: storage-modifiers
     - include: declarations
     - include: inheritance
+    - include: for-comprehension
     - include: keywords
     - include: imports
     - include: comments
@@ -242,6 +243,40 @@ contexts:
       captures:
         1: keyword.scala
         2: entity.name.class.scala
+  for-comprehension:
+    - match: '\b(for)\s*\{'
+      captures:
+        1: keyword.control.flow.scala
+      push:
+        - match: '\}'
+          pop: true
+        - include: for-body
+    - match: '\b(for)\s*\('
+      captures:
+        1: keyword.control.flow.scala
+      push:
+        - match: '\)'
+          pop: true
+        - include: for-body
+  for-body:
+    - match: '^(?=([^<←=]|<[^\-])+(<-|←|=))'
+      push:
+        - match: '^\s*(val)\s+'
+          scope: keyword.declaration.stable.scala
+        - match: <-|←|=
+          pop: true
+        - include: pattern-match
+    - match: '\{'
+      push:
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\('
+      push:
+        - match: '\)'
+          pop: true
+        - include: main
+    - include: main
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -272,7 +272,7 @@ contexts:
           pop: true
         - include: for-parens-body
   for-braces-body:
-    - match: '^(?=([^<←=]|<[^\-])+(<-|←|=))'
+    - match: '^(?=([^<←=\{]|<[^\-])+(<-|←|=[\s\b]))'
       push:
         - match: '^\s*(val)\s+'
           scope: keyword.declaration.stable.scala
@@ -438,5 +438,10 @@ contexts:
     - match: '\b[A-Z][a-zA-Z0-9_]*'
       captures:
         0: entity.name.class
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: main
     - match: '@|_'
       scope: keyword

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -250,15 +250,15 @@ contexts:
       push:
         - match: '\}'
           pop: true
-        - include: for-body
+        - include: for-braces-body
     - match: '\b(for)\s*\('
       captures:
         1: keyword.control.flow.scala
       push:
         - match: '\)'
           pop: true
-        - include: for-body
-  for-body:
+        - include: for-parens-body
+  for-braces-body:
     - match: '^(?=([^<←=]|<[^\-])+(<-|←|=))'
       push:
         - match: '^\s*(val)\s+'
@@ -277,6 +277,25 @@ contexts:
           pop: true
         - include: main
     - include: main
+  for-parens-body:
+    - match: '<-|←|='
+      push:
+        - match: ;
+          pop: true
+        - match: '\{'
+          push:
+            - match: '\}'
+              pop: true
+            - include: main
+        - match: '\('
+          push:
+            - match: '\)'
+              pop: true
+            - include: main
+        - include: main
+    - match: '\b(val)\b'
+      scope: keyword.declaration.stable.scala
+    - include: pattern-match
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -23,9 +23,9 @@ variables:
 contexts:
   main:
     - include: storage-modifiers
-    - include: keywords
     - include: declarations
     - include: inheritance
+    - include: keywords
     - include: imports
     - include: comments
     - include: block-comments
@@ -95,7 +95,7 @@ contexts:
         1: keyword.declaration.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
-    - match: '(case)?\b(class|trait|object)\s+([^\s\{\(\[]+)'
+    - match: '\b(case\s+)?(class|trait|object)\s+([^\s\{\(\[]+)'
       captures:
         1: keyword.declaration.scala
         2: keyword.declaration.scala
@@ -355,6 +355,7 @@ contexts:
   pattern-match:
     - include: comments
     - include: block-comments
+    - include: keywords
     - include: constants
     - include: char-literal
     - include: scala-symbol

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -134,8 +134,10 @@ contexts:
             - match: '\)'
               pop: true
             - include: pattern-match
-        - match: '=>|⇒'
+        - match: '=>|⇒|\b(if)\b'
           pop: true
+          captures:
+            1: keyword.control.flow.scala
         - include: pattern-match
   function-type-parameter-list:
     - match: '(?=\()'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -105,11 +105,17 @@ contexts:
       captures:
         1: keyword.declaration.scala
         2: entity.name.type.scala
-    - match: '\b(?:(val)|(var))\s+(([a-zA-Z$_][a-zA-Z0-9$_]*(_[^a-zA-Z0-9\s]+)?)|`.*`)?'
+    - match: '\b(?:(var))\s+(([a-zA-Z$_][a-zA-Z0-9$_]*(_[^a-zA-Z0-9\s]+)?)|`.*`)?'
+      captures:
+        1: keyword.declaration.volatile.scala
+        2: entity.name.var.declaration variable.parameter
+    - match: '\b(val)\b'
       captures:
         1: keyword.declaration.stable.scala
-        2: keyword.declaration.volatile.scala
-        3: entity.name.val.scala
+      push:
+        - match: '=|\n'
+          pop: true
+        - include: pattern-match
     - match: '\b(package object)\s+([^\s\{\(\[]+)'
       captures:
         1: keyword.declaration.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -98,7 +98,7 @@ contexts:
         1: keyword.declaration.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
-    - match: '\b(case\s+)?(class|trait|object)\s+([^\s\{\(\[]+)'
+    - match: '\b(case\s+)?(class|trait|object)(?:\s+([^\s\{\(\[]+))?'
       captures:
         1: keyword.declaration.scala
         2: keyword.declaration.scala

--- a/Scala/Symbols.tmPreferences
+++ b/Scala/Symbols.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>entity.name.function.declaration, entity.name.class.declaration, entity.name.val.declaration, entity.name.type.declaration</string>
+	<string>entity.name.function.declaration, entity.name.class.declaration, entity.name.val.declaration, entity.name.type.declaration, entity.name.parameter</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -347,7 +347,7 @@ object Foo
    case abc @ `abc` =>
 //      ^^^ entity.name variable.parameter
 //          ^ keyword
-//            ^^^^^ source.scala
+//            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
 //                               ^ keyword
@@ -387,27 +387,27 @@ object Foo
 //      ^^^ constant.language.scala
 
    case _ ⇒ _
-//          ^ source.scala
+//          ^ - keyword
 
    case _ if stuff =>
 //        ^^ keyword.control.flow.scala
-//           ^^^^^ source.scala
+//           ^^^^^ - variable.parameter
 
    val abc @ `abc`
 // ^^^ keyword.declaration.stable.scala
 //     ^^^ entity.name variable.parameter
 //         ^ keyword
-//           ^^^^^ source.scala
+//           ^^^^^ - variable.parameter
 
    _
-// ^ source.scala
+// ^ - keyword
 
    val ble @ `abc` = _
 // ^^^ keyword.declaration.stable.scala
 //     ^^^ entity.name variable.parameter
 //         ^ keyword
-//           ^^^^^ source.scala
-//                   ^ source.scala
+//           ^^^^^ - variable.parameter
+//                   ^ - keyword
 
    case object Thingy extends Other
 // ^^^^ keyword.declaration.scala
@@ -436,56 +436,56 @@ object Foo
 
      a <- _
 //   ^ entity.name.parameter variable.parameter
-//        ^ source.scala
+//        ^ - keyword
 
      a ← _
 //   ^ entity.name.parameter variable.parameter
-//       ^ source.scala
+//       ^ - variable.parameter
 
      (b, c @ _) <- _
 //    ^ entity.name.parameter variable.parameter
 //       ^ entity.name.parameter variable.parameter
 //         ^ keyword
 //           ^ keyword
-//                 ^ source.scala
+//                 ^ - keyword
        _
-//     ^ source.scala
+//     ^ - variable.parameter
 
      testing = _
 //   ^^^^^^^ entity.name.parameter variable.parameter
-//             ^ source.scala
+//             ^ - keyword
 
      testing = {
 //   ^^^^^^^ entity.name.parameter variable.parameter
        testing = false
-//     ^^^^^^^ source.scala
+//     ^^^^^^^ - variable.parameter
      }
 
      testing = (
 //   ^^^^^^^ entity.name.parameter variable.parameter
        testing = false
-//     ^^^^^^^ source.scala
+//     ^^^^^^^ - variable.parameter
      )
 
      val testing = 42
 //   ^^^ keyword.declaration.stable.scala
 //       ^^^^^^^ entity.name.parameter variable.parameter
    } _
-//   ^ source.scala
+//   ^ - variable.parameter
 
    for (a <- _; (b, c @ _) ← _; val abc = _) _
 // ^^^ keyword.control.flow.scala
 //      ^ entity.name.parameter variable.parameter
-//           ^ source.scala
+//           ^ - keyword
 //               ^ entity.name.parameter variable.parameter
 //                  ^ entity.name.parameter variable.parameter
 //                    ^ keyword
 //                      ^ keyword
-//                           ^ source.scala
+//                           ^ - keyword
 //                              ^^^ keyword.declaration.stable.scala
 //                                  ^^^ entity.name.parameter variable.parameter
-//                                        ^ source.scala
-//                                           ^ source.scala
+//                                        ^ - keyword
+//                                           ^ - keyword
 
    for {
      sss <- { {} }
@@ -493,3 +493,18 @@ object Foo
      qqq <- stuff
 //   ^^^ entity.name.parameter variable.parameter
    }
+
+   for {
+     back <- Traverse[Option]
+//   ^^^^ entity.name.parameter variable.parameter
+//           ^^^^^^^^ entity.name.class
+//                    ^^^^^^ entity.name.class
+       .traverse[Free, Stuff](res) { r =>
+//      ^^^^^^^^ - variable.parameter
+//                            ^^^ - variable.parameter
+//                                   ^ - variable.parameter
+   }
+
+
+  val baseSettings: Seq[Def.Setting[_]] = _
+//                                  ^ - keyword

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -486,3 +486,10 @@ object Foo
 //                                  ^^^ entity.name.parameter variable.parameter
 //                                        ^ source.scala
 //                                           ^ source.scala
+
+   for {
+     sss <- { {} }
+//   ^^^ entity.name.parameter variable.parameter
+     qqq <- stuff
+//   ^^^ entity.name.parameter variable.parameter
+   }

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -386,6 +386,9 @@ object Foo
    case Nil =>
 //      ^^^ constant.language.scala
 
+   case _ ⇒ _
+//          ^ source.scala
+
    val abc @ `abc`
 // ^^^ keyword.declaration.stable.scala
 //     ^^^ entity.name variable.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -221,8 +221,8 @@ object Foo
    match
 // ^^^^^ keyword.control.flow.scala
 
-   case
-// ^^^^ keyword.control.flow.scala
+   case =>
+// ^^^^ keyword.declaration.scala
 
    macro
 // ^^^^^ keyword.scala
@@ -336,3 +336,52 @@ object Foo
   (a: Int)
 // ^ source.scala
 //    ^^^ storage.type.primitive.scala
+
+   case (abc: Foo, cba @ _) =>
+// ^^^^ keyword.declaration.scala
+//       ^^^ entity.name.parameter variable.parameter
+//            ^^^ entity.name.class
+//                 ^^^ entity.name variable.parameter
+//                       ^ keyword
+
+   case abc @ `abc` =>
+//      ^^^ entity.name variable.parameter
+//          ^ keyword
+//            ^^^^^ source.scala
+
+   case foo: (Int => Boolean) :: _ =>
+//                               ^ keyword
+
+   case /* testing */ =>
+//      ^^^^^^^^^^^^^ comment.block.scala
+
+   case // testing
+//      ^^^^^^^^^^ comment.line.double-slash.scala
+   =>
+
+   case 42 =>
+//      ^^ constant.numeric.scala
+
+   case 'a' =>
+//      ^^^ constant.character.literal.scala
+
+   case 'foo =>
+//      ^^^^ constant.other.symbol
+
+   case "foo" =>
+//      ^^^^^ string.quoted.double.scala
+
+   case """foo""" =>
+//      ^^^^^^^^^ string.quoted.triple.scala
+
+   case q"""..$foo""" =>
+//      ^^^^^^ string.quoted.triple.interpolated.scala
+//            ^^^^ variable.parameter
+//                ^^^ string.quoted.triple.interpolated.scala
+
+   case <foo/> =>
+//      ^^^^^^ text.xml
+//       ^^^ entity.name.tag
+
+   case Nil =>
+//      ^^^ constant.language.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -389,6 +389,10 @@ object Foo
    case _ ⇒ _
 //          ^ source.scala
 
+   case _ if stuff =>
+//        ^^ keyword.control.flow.scala
+//           ^^^^^ source.scala
+
    val abc @ `abc`
 // ^^^ keyword.declaration.stable.scala
 //     ^^^ entity.name variable.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -515,3 +515,10 @@ object Foo
 //        ^ - variable.parameter
 //          ^^^^ - variable.parameter
 //               ^^^ - variable.parameter
+
+  {
+    case foo.Bar => 42
+//       ^^^ - variable.parameter
+    case Bar.foo => 42
+//           ^^^ - variable.parameter
+  }

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -64,15 +64,15 @@ def foo(a: Int, b: Bar): Baz = 42
    def foo(implicit bar: Int): Unit
 //         ^^^^^^^^ storage.modifier.other
 
-val foo: Unit
-//^ keyword.declaration.stable.scala
-//  ^^^ entity.name.val.scala
-//       ^^^^ storage.type.primitive.scala
+   val foo: Unit
+// ^^^ keyword.declaration.stable.scala
+//     ^^^ entity.name.parameter
+//          ^^^^ storage.type.primitive.scala
 
-var foo: Unit
-//^ keyword.declaration.volatile.scala
-//  ^^^ entity.name.val.scala
-//       ^^^^ storage.type.primitive.scala
+   var foo: Unit
+// ^^^ keyword.declaration.volatile.scala
+//     ^^^ entity.name.var.declaration variable.parameter
+//          ^^^^ storage.type.primitive.scala
 
 class Foo[A](a: Bar) extends Baz with Bin
 // ^^ keyword.declaration.scala
@@ -385,3 +385,19 @@ object Foo
 
    case Nil =>
 //      ^^^ constant.language.scala
+
+   val abc @ `abc`
+// ^^^ keyword.declaration.stable.scala
+//     ^^^ entity.name variable.parameter
+//         ^ keyword
+//           ^^^^^ source.scala
+
+   _
+// ^ source.scala
+
+   val ble @ `abc` = _
+// ^^^ keyword.declaration.stable.scala
+//     ^^^ entity.name variable.parameter
+//         ^ keyword
+//           ^^^^^ source.scala
+//                   ^ source.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -430,3 +430,45 @@ object Foo
 //                             ^^^^^^^ keyword.declaration.scala
 //                                     ^^^^^ entity.other.inherited-class.scala
 //
+
+   for {
+// ^^^ keyword.control.flow.scala
+
+     a <- _
+//   ^ entity.name.parameter variable.parameter
+//        ^ source.scala
+
+     a ← _
+//   ^ entity.name.parameter variable.parameter
+//       ^ source.scala
+
+     (b, c @ _) <- _
+//    ^ entity.name.parameter variable.parameter
+//       ^ entity.name.parameter variable.parameter
+//         ^ keyword
+//           ^ keyword
+//                 ^ source.scala
+       _
+//     ^ source.scala
+
+     testing = _
+//   ^^^^^^^ entity.name.parameter variable.parameter
+//             ^ source.scala
+
+     testing = {
+//   ^^^^^^^ entity.name.parameter variable.parameter
+       testing = false
+//     ^^^^^^^ source.scala
+     }
+
+     testing = (
+//   ^^^^^^^ entity.name.parameter variable.parameter
+       testing = false
+//     ^^^^^^^ source.scala
+     )
+
+     val testing = 42
+//   ^^^ keyword.declaration.stable.scala
+//       ^^^^^^^ entity.name.parameter variable.parameter
+   } _
+//   ^ source.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -412,7 +412,7 @@ object Foo
    case object Thingy extends Other
 // ^^^^ keyword.declaration.scala
 //      ^^^^^^ keyword.declaration.scala
-//             ^^^^^^ entity.name.class.declaration
+//             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                            ^^^^^ entity.other.inherited-class.scala
 
@@ -425,7 +425,7 @@ object Foo
    case class Thingy(abc: Int) extends Other
 // ^^^^ keyword.declaration.scala
 //      ^^^^^ keyword.declaration.scala
-//            ^^^^^^ entity.name.class.declaration
+//            ^^^^^^ entity.name.class.scala
 //                   ^^^ variable.parameter
 //                             ^^^^^^^ keyword.declaration.scala
 //                                     ^^^^^ entity.other.inherited-class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -472,3 +472,17 @@ object Foo
 //       ^^^^^^^ entity.name.parameter variable.parameter
    } _
 //   ^ source.scala
+
+   for (a <- _; (b, c @ _) ← _; val abc = _) _
+// ^^^ keyword.control.flow.scala
+//      ^ entity.name.parameter variable.parameter
+//           ^ source.scala
+//               ^ entity.name.parameter variable.parameter
+//                  ^ entity.name.parameter variable.parameter
+//                    ^ keyword
+//                      ^ keyword
+//                           ^ source.scala
+//                              ^^^ keyword.declaration.stable.scala
+//                                  ^^^ entity.name.parameter variable.parameter
+//                                        ^ source.scala
+//                                           ^ source.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -408,3 +408,25 @@ object Foo
 //         ^ keyword
 //           ^^^^^ source.scala
 //                   ^ source.scala
+
+   case object Thingy extends Other
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^ keyword.declaration.scala
+//             ^^^^^^ entity.name.class.declaration
+//                    ^^^^^^^ keyword.declaration.scala
+//                            ^^^^^ entity.other.inherited-class.scala
+
+   case class
+// ^^^^ keyword.declaration.scala
+//      ^^^^^ keyword.declaration.scala
+
+=>     // this is here to act as a random terminator to the above partial syntax
+
+   case class Thingy(abc: Int) extends Other
+// ^^^^ keyword.declaration.scala
+//      ^^^^^ keyword.declaration.scala
+//            ^^^^^^ entity.name.class.declaration
+//                   ^^^ variable.parameter
+//                             ^^^^^^^ keyword.declaration.scala
+//                                     ^^^^^ entity.other.inherited-class.scala
+//

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -508,3 +508,10 @@ object Foo
 
   val baseSettings: Seq[Def.Setting[_]] = _
 //                                  ^ - keyword
+
+  for {
+    r <- blah
+  } yield r.copy(foo = a)
+//        ^ - variable.parameter
+//          ^^^^ - variable.parameter
+//               ^^^ - variable.parameter


### PR DESCRIPTION
Scala's variable definition syntax is quite rich, and Sublime doesn't (currently) handle it very well.  Additionally, several special syntactic forms are available in both `val` declarations and `case` pattern matches (the syntax is actually identical) which are not highlighted at all by Sublime.  Finally, complex patterns in `val` declarations and *any* patterns in `case` pattern matches are not currently considered for "go to definition", which is annoying.

This PR fixes all that.

- ![case example](http://i.imgur.com/qvOpC0d.png)
- ![val examples](http://i.imgur.com/M0WkCuM.png)

The orange italic parameters in the above are both considered for symbol matching, which enables go to definition jumping into pattern match extractors, as well as provides more accurate auto-complete.

There is a slight cost here.  Specifically, when you type `case`, you open up a new scope which highlights the *rest of your file* differently.  This scope is closed by either `=>` or `⇒`, but it does make the process of actually *typing* Scala in a left-to-right fashion a bit different.  If you use the `case`<kbd>TAB</kbd> snippet, this problem is resolved.  The additional wrinkle is if you write a syntactically *invalid* pattern match, you may see some weird syntax highlighting.  For example:

```scala
case f: Int => Boolean :: _ => f
```

This is not valid Scala, but it's a relatively easy mistake to make.  What will happen here is the first `=>` will terminate the pattern match scope and the `_` character will not be correctly highlighted.  I don't feel too bad about this since Scala will actually not compile the above, and the fix for the syntax highlighting is identical to the fix for the Scala parser: wrap it in parentheses:

```scala
case (f: Int => Boolean) :: _ => f
```

~~This PR does not currently address the problem of `for`-comprehensions, which are another instance of pattern matching syntax, but unfortunately one which is far more syntactically complex.  Specifically, I would need to do some sort of backtracking scope push on the `<-` and `←` characters, defining everything from the start of the line to that character to be in pattern match scope while within a `for` block, but any line which does *not* contain these characters gets parsed normally.  As far as I can tell, `.sublime-syntax` does not have a way of expressing this sort of thing.~~