### PR TITLE
[Graphviz] improvements

### DIFF
--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -5,9 +5,18 @@ name: Graphviz (DOT)
 file_extensions:
   - dot
   - DOT
+  - gv
 scope: source.dot
 contexts:
   main:
+    - include: expressions
+
+  expressions:
+    - match: \b((sub|di)?graph)\b\s+((cluster)?\w+)\b
+      captures:
+        1: storage.type.dot
+        3: entity.name.graph.dot
+        4: meta.annotation.dot variable.annotation.cluster.dot
     - match: \b(node|edge|graph|digraph|subgraph|strict)\b
       scope: storage.type.dot
     - match: \b(bottomlabel|color|comment|distortion|fillcolor|fixedsize|fontcolor|fontname|fontsize|group|height|label|layer|orientation|peripheries|regular|shape|shapefile|sides|skew|style|toplabel|URL|width|z)\b
@@ -16,6 +25,12 @@ contexts:
       scope: support.constant.attribute.edge.dot
     - match: \b(bgcolor|center|clusterrank|color|comment|compound|concentrate|fillcolor|fontname|fontpath|fontsize|label|labeljust|labelloc|layers|margin|mclimit|nodesep|nslimit|nslimit1|ordering|orientation|page|pagedir|quantum|rank|rankdir|ranksep|ratio|remincross|rotate|samplepoints|searchsize|size|style|URL)\b
       scope: support.constant.attribute.graph.dot
+    - match: '-[->]'
+      scope: punctuation.operator.relationship.dot
+    - match: '='
+      scope: keyword.operator.assignment.dot
+    - match: ';'
+      scope: punctuation.separator.statement.dot
     - match: '"'
       scope: punctuation.definition.string.begin.dot
       push:
@@ -25,6 +40,57 @@ contexts:
           pop: true
         - match: \\.
           scope: constant.character.escape.dot
+        - match: '[{}|]'
+          scope: punctuation.separator.memory-block.dot
+    - include: braces
+    - include: brackets
+    - include: embedded-html
+    - include: comments
+
+  # http://www.graphviz.org/content/node-shapes#html
+  embedded-html:
+    - match: '<'
+      scope: punctuation.section.embedded.begin.dot
+      push:
+        - meta_content_scope: source.dot.embedded.html
+        - match: '((>)?\s*)(>)'
+          captures:
+            1: source.dot.embedded.html
+            2: punctuation.definition.tag.end.html
+            3: punctuation.section.embedded.end.dot
+          pop: true
+        - match: ''
+          push:
+            - include: 'scope:text.html.basic'
+          with_prototype:
+            - match: '(?=>\s*>)'
+              pop: true
+
+  braces:
+    - match: \{
+      scope: punctuation.definition.group.begin.dot
+      push:
+        - meta_scope: meta.group.dot
+        - match: \}
+          scope: punctuation.definition.group.end.dot
+          pop: true
+        - match: ',|;'
+          scope: punctuation.separator.dot
+        - include: expressions
+
+  brackets:
+    - match: \[
+      scope: punctuation.definition.attributes.begin.dot
+      push:
+        - meta_scope: meta.attributes.dot
+        - match: \]
+          scope: punctuation.definition.attributes.end.dot
+          pop: true
+        - match: ',|;'
+          scope: punctuation.separator.dot
+        - include: expressions
+
+  comments:
     - match: (//).*$\n?
       scope: comment.line.double-slash.dot
       captures:

--- a/Graphviz/Indentation Rules.tmPreferences
+++ b/Graphviz/Indentation Rules.tmPreferences
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Indentation Rules</string>
+    <key>scope</key>
+    <string>source.dot</string>
+    <key>settings</key>
+    <dict>
+        <key>decreaseIndentPattern</key>
+        <string>(?x)
+        ^ (.*\*/)? \s* \} .* $
+        </string>
+        <key>increaseIndentPattern</key>
+        <string>(?x)
+        ^ .* \{ [^}"']* $
+        </string>
+
+        <key>unIndentedLinePattern</key>
+        <string>^\s*((/\*|.*\*/|//|#).*)?$</string>
+    </dict>
+</dict>
+</plist>

--- a/Graphviz/Symbol List.tmPreferences
+++ b/Graphviz/Symbol List.tmPreferences
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Symbol List</string>
+    <key>scope</key>
+    <string>source.dot entity.name.graph</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>
+        s/^cluster_?(.*)/$1 \(clustered\)/g;
+        </string>
+    </dict>
+</dict>
+</plist>

--- a/Graphviz/syntax_test_dot.dot
+++ b/Graphviz/syntax_test_dot.dot
@@ -15,11 +15,15 @@
 
 graph n {}
 // <- storage.type.dot
+//    ^ entity.name.graph.dot
 
 node n { size="str" }
 //            ^     punctuation.definition.string.begin.dot
 //            ^^^^^ string.quoted.double.dot
 //                ^ punctuation.definition.string.end.dot
+//     ^              punctuation.definition.group.begin.dot
+//     ^^^^^^^^^^^^^^ meta.group.dot
+//                  ^ punctuation.definition.group.end.dot
 
 edge n { main="\n" }
 //             ^^ constant.character.escape.dot
@@ -30,5 +34,43 @@ node n { color="" }
 edge n { lhead="" }
 //       ^^^^^ support.constant.attribute.edge.dot
 
-graph n { page=""}
+graph n { page="" }
 //        ^^^^ support.constant.attribute.graph.dot
+
+graph cluster_n {
+//    ^^^^^^^^^ entity.name.graph.dot
+//    ^^^^^^^   meta.annotation.dot variable.annotation.cluster.dot
+    t -> n;
+//    ^^        punctuation.operator.relationship.dot
+}
+
+// Loosely taken from http://www.graphviz.org/content/node-shapes#html
+digraph structs {
+    node [shape=plaintext]
+    struct1 [label=<
+//                ^    keyword.operator.assignment.dot
+//                 ^   punctuation.section.embedded.begin.dot
+//                  ^^ source.dot.embedded.html
+<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+//                                              ^ punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
+  <TR><TD>left</TD><TD PORT="f1">mid dle</TD><TD PORT="f2">right</TD></TR>
+</TABLE>>];
+// ^^^^      source.dot.embedded.html
+// ^^^^^     source.dot.embedded.html
+//     ^     punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
+//      ^    punctuation.section.embedded.end.dot - source.dot.embedded.html
+    struct2 [label=<
+//                ^    keyword.operator.assignment.dot
+//                 ^   punctuation.section.embedded.begin.dot
+//                  ^^ source.dot.embedded.html
+<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+//                                              ^ punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
+  <TR><TD PORT="f0">one</TD><TD>two</TD></TR>
+</TABLE> >];
+// ^^^^       source.dot.embedded.html
+// ^^^^^^     source.dot.embedded.html
+//     ^      punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
+//       ^    punctuation.section.embedded.end.dot - source.dot.embedded.html
+    struct1:f1 -> struct2:f0;
+    struct2:f0 -> struct1:f2;
+}


### PR DESCRIPTION
- Add scopes for lots of punctuation.
- Add `.gv` as additional file extension.
- Add graph names to file indexing.
- Steal some indentation code that I don't understand particularly well.
  - If there's some documentation I should look at, please feel free to point me at it.
- Add basic support for HTML labels. This is a little buggy, but still much more functional than it used to be.

If there are comments on the scopes, I'm happy to change them. Particular attention should be paid to [these lines](https://github.com/michaelblyons/SublimeText-Packages/blob/3fc25bd5cba0a2db6b9ca517cc8a6fa29a368a16/Graphviz/DOT.sublime-syntax#L15-L19) where I picked an arbitrary scope both for what a `graph` _is_ and also what the `cluster` prefix means for `subgraph`. I absolutely think the `cluster` prefix should be separately and unambiguously identified because it fundamentally changes the output layout, but I may not have picked a great scope for it.
