### PR TITLE
[RegExp] Comments in extended mode and scope adjustments

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -93,6 +93,7 @@ contexts:
       captures:
         1: keyword.control.set.regexp
       push:
+        - meta_scope: meta.set.regexp
         - match: ':(ascii|alnum|alpha|blank|cntrl|digit|graph|lower|print|punct|space|upper|word|xdigit):'
           scope: constant.other.posix-class.regexp
         - match: '\]'

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -282,5 +282,7 @@ contexts:
     - include: quantifiers
     - match: '\.'
       scope: keyword.other.any.regexp # https://github.com/sublimehq/Packages/issues/314
+    - match: \)
+      scope: invalid.illegal.unmatched-brace.regexp
     - match: .
       scope: meta.literal.regexp

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -59,11 +59,11 @@ contexts:
       set: [group-body, unexpected-quantifier-pop]
     - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
       captures:
-        1: meta.mode-modifier.regexp
+        1: storage.modifier.mode.regexp
         2: keyword.control.group.regexp
       pop: true
     - match: '\?(?:[ixms]*-)?[ixms]+:'
-      scope: meta.mode-modifier.regexp
+      scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
     - match: '(\?\d+)(\))'
       captures:

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -21,26 +21,59 @@ contexts:
     - match: ''
       push: base-literal
 
+  # This is the default context
+  base-literal:
+    - include: base
+    - include: literal
+
+  # This is the extended context
+  #
+  # The "-extended" prefixed contexts are necessary
+  # to keep the extended mode enabled in subgroups
+  # and disable it properly when it is unset (and in sets).
+  # Switching happens in the "group-start*" contexts.
+  base-literal-extended:
+    - include: base-extended
+    - include: literal
+
   base:
+    - include: group
+    - include: base-common
+
+  base-extended:
+    - include: group-extended
+    - include: extended-patterns # <- this is where the contexts differ
+    - include: base-common
+
+  base-common:
     - include: character-class
     - include: special-escaped-char
     - include: backslashes
     - include: escaped-char
     - include: charset
-    - include: group
     - include: operators
 
   base-group:
-    - include: base
     - match: '(?=\))'
       pop: true
-    - include: literal
+    - include: base-literal
 
-  base-literal:
-    - include: base
-    - include: literal
+  base-group-extended:
+    - match: '(?=\))'
+      pop: true
+    - include: base-literal-extended
 
-  group:
+  extended-patterns:
+    - match: '#'
+      scope: punctuation.definition.comment.regexp
+      push:
+        - meta_scope: comment.line.number-sign.regexp
+        - match: \n # does not close on `)`!
+          pop: true
+    - match: \s+
+      scope: meta.ignored-whitespace.regexp
+
+  group-comment:
     - match: \(\?#
       scope: punctuation.definition.comment.begin.regexp
       push:
@@ -48,20 +81,41 @@ contexts:
         - match: \)
           scope: punctuation.definition.comment.end.regexp
           pop: true
+
+  group:
+    - include: group-comment
     - match: \(
       scope: keyword.control.group.regexp
       push: group-start
+
+  group-extended:
+    - include: group-comment
+    - match: \(
+      scope: keyword.control.group.regexp
+      push: group-start-extended
 
   group-start:
     - meta_scope: meta.group.regexp
     - match: '\?(<[=!]|>|=|:|!)'
       scope: constant.other.assertion.regexp
       set: [group-body, unexpected-quantifier-pop]
+    # Activates 'x' mode
+    - match: '(\?[ims]*x[ixms]*(?:-[ims]+)?)(\))'
+      captures:
+        1: storage.modifier.mode.regexp
+        2: keyword.control.group.regexp
+      set: [base-group-extended, unexpected-quantifier-pop]
+    # Other modifiers
     - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
       captures:
         1: storage.modifier.mode.regexp
         2: keyword.control.group.regexp
       pop: true
+    # Groups with 'x' mode
+    - match: '\?[ims]*x[ixms]*(?:-[ims]+)?:'
+      scope: storage.modifier.mode.regexp
+      set: [group-body-extended, unexpected-quantifier-pop]
+    # Other modifiers
     - match: '\?(?:[ixms]*-)?[ixms]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
@@ -81,12 +135,60 @@ contexts:
     - match: ''
       set: [group-body, unexpected-quantifier-pop]
 
+  group-start-extended:
+    - meta_scope: meta.group.extended.regexp
+    - match: '\?(<[=!]|>|=|:|!)'
+      scope: constant.other.assertion.regexp
+      set: [group-body-extended, unexpected-quantifier-pop]
+    # Deactivates 'x' mode
+    - match: '(\?[ims]*-[ims]*x[imxs]*)(\))'
+      captures:
+        1: storage.modifier.mode.regexp
+        2: keyword.control.group.regexp
+      set: [base-group, unexpected-quantifier-pop]
+    # Other modifiers
+    - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
+      captures:
+        1: storage.modifier.mode.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    # Groups without 'x' mode
+    - match: '\?[ims]*-[ims]*x[imxs]*:'
+      scope: storage.modifier.mode.regexp
+      set: [group-body, unexpected-quantifier-pop]
+    # Other modifiers
+    - match: '\?(?:[ixms]*-)?[ims]+:'
+      scope: storage.modifier.mode.regexp
+      set: [group-body-extended, unexpected-quantifier-pop]
+    - match: '(\?\d+)(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '(\?&\w+)(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '\?<\w+>'
+      scope: keyword.other.named-capture-group.regexp
+      set: [group-body-extended, unexpected-quantifier-pop]
+    - match: ''
+      set: [group-body-extended, unexpected-quantifier-pop]
+
   group-body:
     - meta_content_scope: meta.group.regexp
     - match: \)
       scope: meta.group.regexp keyword.control.group.regexp
       pop: true
     - include: base-group
+
+  group-body-extended:
+    - meta_content_scope: meta.group.extended.regexp
+    - match: \)
+      scope: meta.group.regexp keyword.control.group.regexp
+      pop: true
+    - include: base-group-extended
 
   charset:
     - match: '(\[\^?)]?'

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -152,9 +152,25 @@ hello++
 
 (?x)
 #^^ storage.modifier.mode.regexp
+#   ^ meta.ignored-whitespace
 
+# this is a comment
+#^^^^^^^^^^^^^^^^^^^ comment.line.number-sign
+# <- comment punctuation.definition.comment
 (?-ix)
 #^^^^ storage.modifier.mode.regexp
+
+# not a comment
+# <- - comment
+
+(
+    (?x)
+    # comment
+#   ^^^^^^^^^ comment
+   (?-x)
+) # no comment
+# <- keyword.control.group
+# ^ - comment
 
 (?sm-ixxs)
 #^^^^^^^^ storage.modifier.mode.regexp
@@ -172,6 +188,25 @@ hello++
 # ^^^^^ storage.modifier.mode.regexp
 #      ^ - storage.modifier.mode.regexp
 #           ^ keyword.control.group.regexp
+
+# not a comment
+^ - comment
+
+(?ix:
+#^^^^
+# comment
+#^^^^^^^^ comment.line.number-sign
+
+    (# also a comment)
+#    ^^^^^^^^^^^^^^^^^ comment
+    )
+
+ (?s-x: # not a comment)
+#       ^ - comment
+
+)
+# not a comment
+^ - comment
 
 (?abc)
 #^ invalid.illegal.unexpected-quantifier.regexp - storage.modifier.mode.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -135,6 +135,9 @@ hello**
 #<- meta.literal.regexp
 #^^^^ meta.literal.regexp
 
+)
+# <- invalid.illegal.unmatched-brace.regexp
+
 hello++
 #    ^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
 

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -151,31 +151,31 @@ hello++
 #  ^^^^ - invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
 
 (?x)
-#^^ meta.mode-modifier.regexp
+#^^ storage.modifier.mode.regexp
 
 (?-ix)
-#^^^^ meta.mode-modifier.regexp
+#^^^^ storage.modifier.mode.regexp
 
 (?sm-ixxs)
-#^^^^^^^^ meta.mode-modifier.regexp
+#^^^^^^^^ storage.modifier.mode.regexp
 
  (?i:hello)
 #^^^^^^^^^^ meta.group.regexp
 #^ keyword.control.group.regexp
-# ^^^ meta.mode-modifier.regexp
-#    ^ - meta.mode-modifier.regexp
+# ^^^ storage.modifier.mode.regexp
+#    ^ - storage.modifier.mode.regexp
 #         ^ keyword.control.group.regexp
 
  (?i-s:hello)
 #^^^^^^^^^^^^ meta.group.regexp
 #^ keyword.control.group.regexp
-# ^^^^^ meta.mode-modifier.regexp
-#      ^ - meta.mode-modifier.regexp
+# ^^^^^ storage.modifier.mode.regexp
+#      ^ - storage.modifier.mode.regexp
 #           ^ keyword.control.group.regexp
 
 (?abc)
-#^ invalid.illegal.unexpected-quantifier.regexp - meta.mode-modifier.regexp
-# ^^^ meta.literal.regexp - meta.mode-modifier.regexp
+#^ invalid.illegal.unexpected-quantifier.regexp - storage.modifier.mode.regexp
+# ^^^ meta.literal.regexp - storage.modifier.mode.regexp
 
  .*?
 #^ keyword.other.any.regexp - meta.literal.regexp
@@ -241,7 +241,7 @@ hello++
 #       ^ keyword.other.any.regexp
 #        ^^^ keyword.other.backref-and-recursion.regexp
 #               ^ keyword.control.anchors.regexp
-#            ^^ meta.group.regexp meta.group.regexp meta.mode-modifier.regexp
+#            ^^ meta.group.regexp meta.group.regexp storage.modifier.mode.regexp
 #                  ^^ constant.character.escape.regexp
 #                  ^^^ - keyword.other.backref-and-recursion.regexp
 

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -47,10 +47,11 @@
 \W
 # <- keyword.control.character-class
 
-[b-c]
-# <- keyword.control.set
-#   ^ keyword.control.set
-#^^^ constant.other.range
+ [b-c]
+#^^^^^ meta.set
+#^ keyword.control.set
+#    ^ keyword.control.set
+# ^^^ constant.other.range
 
 [\x00-\x{A}]
 # <- keyword.control.set
@@ -60,6 +61,7 @@
 #     ^^^^^ constant.character.escape
 
 [[a-z]&&[:ascii:]]
+#^^^^^ meta.set meta.set
 #     ^^ keyword.operator.intersection
 # ^^^ constant.other.range
 #        ^^^^^^^ constant.other.posix-class
@@ -225,6 +227,7 @@ hello++
 
 (?![a-z]+?)
 #^^ meta.group.regexp constant.other.assertion.regexp - meta.group.regexp meta.group.regexp
+#  ^^^^^ meta.set.regexp
 #  ^ keyword.control.set.regexp
 #      ^ keyword.control.set.regexp
 #   ^^^ constant.other.range.regexp


### PR DESCRIPTION
I implemented comment parsing for the regular expression syntax. This required tracking the extended mode state within groups and I had to duplicate a lot of base\* and group\* contexts, but it's working very nicely now.

Additionally, I changed a few minor things such as a more appropriate scope name for mode modifiers.