### PR TITLE
[PHP] fix magic method detection

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -501,7 +501,7 @@ contexts:
           scope: storage.type.function.php
         - match: '&'
           scope: storage.modifier.reference.php
-        - match: '(__(?:callStatic|call|construct|destruct|get|set|isset|unset|toString|clone|set_state|sleep|wakeup|autoload|invoke|debugInfo))'
+        - match: '(__(?:callStatic|call|construct|destruct|get|set|isset|unset|toString|clone|set_state|sleep|wakeup|autoload|invoke|debugInfo))\b'
           scope: entity.name.function.php support.function.magic.php
         - match: '{{identifier}}'
           scope: entity.name.function.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -829,6 +829,14 @@ class C {
 
     public function __toString()
 //                  ^^^^^^^^^^ entity.name.function.php support.function.magic.php
+//                            ^^ meta.function.parameters.php punctuation.definition.group
+    {
+        return $this->prop;
+    }
+
+    public function __toStringTest()
+//                  ^^^^^^^^^^^^^^ entity.name.function.php - support.function.magic.php
+//                                ^^ - entity.name.function.php - support.function.magic.php
     {
         return $this->prop;
     }


### PR DESCRIPTION
Fix bug when method name begins in a magic name but the identifier continues, so it shouldn't be counted as magic