### PR TITLE
[Python] fix for keyword.operator.assignment/keyword.operator.comparison issue #508

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -317,7 +317,7 @@ contexts:
   assignments:
     - match: \+=|-=|\*=|/=|//=|%=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
-    - match: '='
+    - match: '=(?!=)'
       scope: keyword.operator.assignment.python
 
   operators:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -928,6 +928,6 @@ x = 'hello\s world'
 # This is to test the difference between the assignment operator (=) and
 # the comparison operator (==)
 foo = bar()
-#   ^ - keyword.operator.assignment.python
+#   ^ keyword.operator.assignment.python
 foo == bar()
-#   ^^ - keyword.operator.comparison.python
+#   ^^ keyword.operator.comparison.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -924,3 +924,10 @@ x = 'hello\s world'
 
 # <- - meta
 # this test is to ensure we're not matching anything here anymore
+
+# This is to test the difference between the assignment operator (=) and
+# the comparison operator (==)
+foo = bar()
+#   ^ - keyword.operator.assignment.python
+foo == bar()
+#   ^^ - keyword.operator.comparison.python


### PR DESCRIPTION
Pretty self-explanatory. Single-line change in `sublime-syntax` file, two tests added, passes with flying colors.