### PR TITLE
[PHP] Ensure namespace elements and separators are scoped with their class

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -119,7 +119,9 @@ contexts:
       captures:
         1: keyword.control.exception.catch.php
       push:
-        - meta_scope: meta.catch.php
+        - meta_scope: meta.catch.php meta.path.php
+        - match: '(\\)'
+          scope: punctuation.separator.namespace.php
         - match: '({{identifier}})\s*((\$+){{identifier}})\s*\)'
           captures:
             1: support.class.exception.php
@@ -309,6 +311,7 @@ contexts:
         # verbatim and the indexer should find the name in the original source
         # file.
         - match: '(\\)?({{identifier}})(?!\\)'
+          scope: meta.path.php
           captures:
             1: punctuation.separator.namespace.php
             2: support.class.php
@@ -627,6 +630,7 @@ contexts:
     - match: '(?={{path}})'
       push:
         - include: class-builtin
+          meta_scope: meta.path.php
         - include: identifier-parts
         - match: '(\\)?({{identifier}})(?!\\)'
           captures:

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -524,10 +524,39 @@ class B
 try {
 // <- keyword.control.exception
     echo inverse(5) . "\n";
-    throw new Exception('Error!');
+    throw new \Exception('Error!');
 //  ^ keyword.control.exception
+//            ^^^^^^^^^^ meta.path.php
+//            ^ punctuation.separator.namespace.php
+//             ^^^^^^^^^ support.class
+    throw new \Custom\Exception('Error!');
+//  ^ keyword.control.exception
+//            ^^^^^^^^^^^^^^^^^ meta.path.php
+//            ^ punctuation.separator.namespace.php
+//             ^^^^^^ support.other.namespace.php
+//                   ^ punctuation.separator.namespace.php
+//                    ^^^^^^^^^ support.class
 } catch (Exception $e) {
 //^ keyword.control.exception
+//       ^^^^^^^^^ meta.path.php
+//       ^^^^^^^^^ support.class.exception.php
+//                 ^^ variable.other.php
+    echo 'Caught exception: ', $e->getMessage(), "\n";
+} catch (\Exception $e) {
+//^ keyword.control.exception
+//       ^^^^^^^^^^ meta.path.php
+//       ^ punctuation.separator.namespace.php
+//        ^^^^^^^^^ support.class.exception.php
+//                  ^^ variable.other.php
+    echo 'Caught exception: ', $e->getMessage(), "\n";
+} catch (\Custom\Exception $e) {
+//^ keyword.control.exception
+//       ^^^^^^^^^^^^^^^^^ meta.path.php
+//       ^ punctuation.separator.namespace.php
+//        ^^^^^^ support.other.namespace.php
+//              ^ punctuation.separator.namespace.php
+//               ^^^^^^^^^ support.class.exception.php
+//                         ^^ variable.other.php
     echo 'Caught exception: ', $e->getMessage(), "\n";
 } finally {
 //^ keyword.control.exception


### PR DESCRIPTION
Some of the recent changes meant that the leading slash was not scoped with the class name, this meant tooling was unable to tell if the code was using a local `Exception` class or the global `\Exception` class.

This pr fixes that, along with scoping the entire namespace as the class too