### PR TITLE
[Go] Stops the default keyword from becoming entity.name.label

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -23,7 +23,7 @@ contexts:
     - include: expressions-early
     - include: initializers
     - include: block
-    - match: ^\s*({{identifier}})(:)(?!=)
+    - match: ^\s*((?!default){{identifier}})(:)(?!=)
       captures:
         1: entity.name.label.go
         2: punctuation.separator.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -72,11 +72,18 @@ contexts:
         - include: late-keywords
     - include: expressions-late
 
+  case-default:
+    - match: '\b(default|case)\b'
+      scope: keyword.control.go
+    - match: (,|:)
+      scope: punctuation.separator.go
+
   expressions:
     - include: expressions-early
     - include: expressions-late
 
   expressions-early:
+    - include: case-default
     - include: keywords
 
   expressions-late:

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -263,3 +263,11 @@ func (t funcTypeExample) foobar() {}
 //                       ^ entity.name.function
 //                             ^^ meta.function.parameters meta.group
 //                                ^^ meta.block
+
+func switchTest() {
+	switch {
+	default:
+	// <- keyword.control
+		return ""
+	}
+}

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -264,10 +264,41 @@ func (t funcTypeExample) foobar() {}
 //                             ^^ meta.function.parameters meta.group
 //                                ^^ meta.block
 
-func switchTest() {
+func () {
 	switch {
+	// <- keyword.control
+	//     ^ punctuation.definition.block.begin
+	case byte, rune, string:
+	// <- keyword.control
+	//   ^^^^ storage.type
+	//       ^ punctuation.separator
+	//         ^^^^ storage.type
+	//             ^ punctuation.separator
+	//               ^^^^^^ storage.type
+	//                     ^ punctuation.separator
+	case 1, 1.23, "str", 'c', true, false:
+	// <- keyword.control
+	//   ^ constant.numeric
+	//    ^ punctuation.separator
+	//      ^^^^ constant.numeric
+	//          ^ punctuation.separator
+	//            ^^^^^ string.quoted.double
+	//                 ^ punctuation.separator
+	//                   ^^^ string.quoted.single
+	//                      ^ punctuation.separator
+	//                        ^^^^ constant.language
+	//                            ^ punctuation.separator
+	//                              ^^^^^ constant.language
+	//                                   ^ punctuation.separator
+		fallthrough
+		// <- keyword.control
 	default:
 	// <- keyword.control
-		return ""
+	//     ^ punctuation.separator
 	}
+	// <- punctuation.definition.block.end
+
+	Label:
+	// <- entity.name.label
+	//   ^ punctuation.separator
 }


### PR DESCRIPTION
A small change to fix the highlighting of the default keyword in the Go syntax.