### PR TITLE
[Python] Relax regex comments a bit

### DIFF
--- a/Python/Regular Expressions (Python).sublime-syntax
+++ b/Python/Regular Expressions (Python).sublime-syntax
@@ -6,67 +6,77 @@ scope: source.regexp.python
 hidden: true
 contexts:
   main:
-    - match: '\\[bBAZzG]|\^|\$'
-      scope: keyword.control.anchor.regexp
-    - match: '\\[1-9][0-9]?'
-      scope: keyword.other.back-reference.regexp
-    - match: '[?+*][?+]?|\{(\d+,\d+|\d+,|,\d+|\d+)\}\??'
-      scope: keyword.operator.quantifier.regexp
-    - match: \|
-      scope: keyword.operator.or.regexp
-    - match: '\(\?\#'
-      push:
-        - meta_scope: comment.block.regexp
-        - match: \)
-          pop: true
-    - match: '(?<=^|\s)#\s[[a-zA-Z0-9,. \t?!-:][^\x{00}-\x{7F}]]*$'
-      comment: We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.
+    - match: (#)[^]\[(){}^$+*?\\|"']*$
+      comment:
+        We are restrictive in what we allow to go after the comment character to avoid
+        false positives, since the availability of comments depend on regexp flags.
       scope: comment.line.number-sign.regexp
-    - match: '\(\?[iLmsux]+\)'
-      scope: keyword.other.option-toggle.regexp
-    - match: '(\()(\?P=([a-zA-Z_][a-zA-Z_0-9]*\w*))(\))'
-      scope: keyword.other.back-reference.named.regexp
-    - match: (\()((\?=)|(\?!)|(\?<=)|(\?<!))
       captures:
-        1: punctuation.definition.group.regexp
-        2: punctuation.definition.group.assertion.regexp
-        3: meta.assertion.look-ahead.regexp
-        4: meta.assertion.negative-look-ahead.regexp
-        5: meta.assertion.look-behind.regexp
-        6: meta.assertion.negative-look-behind.regexp
+        1: punctuation.definition.comment.regexp
+    - match: (?=\S)
       push:
-        - meta_scope: meta.group.assertion.regexp
-        - match: (\))
+        - match: (?=\s)
+          pop: true
+        - match: '\\[bBAZzG]|\^|\$'
+          scope: keyword.control.anchor.regexp
+        - match: '\\[1-9][0-9]?'
+          scope: keyword.other.back-reference.regexp
+        - match: '[?+*][?+]?|\{(\d+,\d+|\d+,|,\d+|\d+)\}\??'
+          scope: keyword.operator.quantifier.regexp
+        - match: \|
+          scope: keyword.operator.or.regexp
+        - match: '\(\?\#'
+          push:
+            - meta_scope: comment.block.regexp
+            - match: \)
+              pop: true
+        - match: '\(\?[iLmsux]+\)'
+          scope: keyword.other.option-toggle.regexp
+        - match: '(\()(\?P=([a-zA-Z_][a-zA-Z_0-9]*\w*))(\))'
+          scope: keyword.other.back-reference.named.regexp
+        - match: (\()((\?=)|(\?!)|(\?<=)|(\?<!))
           captures:
             1: punctuation.definition.group.regexp
-          pop: true
-        - include: main
-    - match: '(\()(\?\(([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)\))'
-      comment: we can make this more sophisticated to match the | character that separates yes-pattern from no-pattern, but it's not really necessary.
-      captures:
-        1: punctuation.definition.group.regexp
-        2: punctuation.definition.group.assertion.conditional.regexp
-        3: entity.name.section.back-reference.regexp
-      push:
-        - meta_scope: meta.group.assertion.conditional.regexp
-        - match: (\))
-          pop: true
-        - include: main
-    - match: '(\()((\?P<)([a-z]\w*)(>)|(\?:))?'
-      captures:
-        1: punctuation.definition.group.regexp
-        3: punctuation.definition.group.capture.regexp
-        4: entity.name.section.group.regexp
-        5: punctuation.definition.group.capture.regexp
-        6: punctuation.definition.group.no-capture.regexp
-      push:
-        - meta_scope: meta.group.regexp
-        - match: (\))
+            2: punctuation.definition.group.assertion.regexp
+            3: meta.assertion.look-ahead.regexp
+            4: meta.assertion.negative-look-ahead.regexp
+            5: meta.assertion.look-behind.regexp
+            6: meta.assertion.negative-look-behind.regexp
+          push:
+            - meta_scope: meta.group.assertion.regexp
+            - match: (\))
+              captures:
+                1: punctuation.definition.group.regexp
+              pop: true
+            - include: main
+        - match: '(\()(\?\(([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)\))'
+          comment:
+            We can make this more sophisticated to match the | character that separates
+            yes-pattern from no-pattern, but it's not really necessary.
           captures:
             1: punctuation.definition.group.regexp
-          pop: true
-        - include: main
-    - include: character-class
+            2: punctuation.definition.group.assertion.conditional.regexp
+            3: entity.name.section.back-reference.regexp
+          push:
+            - meta_scope: meta.group.assertion.conditional.regexp
+            - match: (\))
+              pop: true
+            - include: main
+        - match: '(\()((\?P<)([a-z]\w*)(>)|(\?:))?'
+          captures:
+            1: punctuation.definition.group.regexp
+            3: punctuation.definition.group.capture.regexp
+            4: entity.name.section.group.regexp
+            5: punctuation.definition.group.capture.regexp
+            6: punctuation.definition.group.no-capture.regexp
+          push:
+            - meta_scope: meta.group.regexp
+            - match: (\))
+              captures:
+                1: punctuation.definition.group.regexp
+              pop: true
+            - include: main
+        - include: character-class
   character-class:
     - match: '\\[wWsSdDhH]|\.'
       scope: constant.character.character-class.regexp

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -710,6 +710,14 @@ regex = r'\b ([fobar]*){1}(?:a|b)?'
 #         ^ keyword.control.anchor.regexp
 #                       ^ keyword.operator.quantifier.regexp
 
+regex = r'.* # Not a comment (yet)'
+#                                 ^ punctuation.definition.string.end.python - comment
+#                                  ^ - invalid
+
+regex = r".* # Not a comment (yet)"
+#                                 ^ punctuation.definition.string.end.python - comment
+#                                  ^ - invalid
+
 regex = r'''\b ([fobar]*){1}(?:a|b)?'''
 #           ^ keyword.control.anchor.regexp
 #                         ^ keyword.operator.quantifier.regexp
@@ -748,12 +756,28 @@ string = r"""
 #         ^^^ string.quoted.double.block
 """
 
+string = r"""
+    # An indented comment.
+#  ^ - comment
+#   ^ comment.line.number-sign.regexp
+### <<This comment>> @includes some &punctutation.
+# <- comment.line.number-sign.regexp
+"""
+
 string = '''
 #        ^^^ string.quoted.single.block
 '''
 
 string = r'''
 #         ^^^ string.quoted.single.block
+'''
+
+string = r'''
+    # An indented comment.
+#  ^ - comment
+#   ^ comment.line.number-sign.regexp
+### <<This comment>> @includes some &punctutation.
+# <- comment.line.number-sign.regexp
 '''
 
 query = \


### PR DESCRIPTION
Added a few punctuation symbols, none of which is a regex meta-character.

Also, I suppose dash should be escaped, because `[!-:]` actually means `[!"#$%&'()*+,\-./0123456789:]`.