### PR TITLE
[HTML] and [CSS] completions improvements

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -426,7 +426,7 @@ class CSSCompletions(sublime_plugin.EventListener):
     regex = None
 
     def on_query_completions(self, view, prefix, locations):
-        selector_scope = "source.css - meta.selector.css, text.html meta.attribute-with-value.style.html string.quoted punctuation.definition.string.end.html"
+        selector_scope = "source.css - meta.selector.css, text.html meta.attribute-with-value.style.html string.quoted - punctuation.definition.string.begin.html" # match inside a CSS document and inside the style attribute of a HTML tag, including just before the quote that closes the attribute value
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
         loc = locations[0]

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -426,7 +426,7 @@ class CSSCompletions(sublime_plugin.EventListener):
     regex = None
 
     def on_query_completions(self, view, prefix, locations):
-        selector_scope = "source.css - meta.selector.css"
+        selector_scope = "source.css - meta.selector.css, text.html meta.attribute-with-value.style.html string.quoted punctuation.definition.string.end.html"
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
         loc = locations[0]

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -426,7 +426,12 @@ class CSSCompletions(sublime_plugin.EventListener):
     regex = None
 
     def on_query_completions(self, view, prefix, locations):
-        selector_scope = "source.css - meta.selector.css, text.html meta.attribute-with-value.style.html string.quoted - punctuation.definition.string.begin.html" # match inside a CSS document and inside the style attribute of a HTML tag, including just before the quote that closes the attribute value
+        # match inside a CSS document and
+        # match inside the style attribute of HTML tags, incl. just before the quote that closes the attribute value
+        css_selector_scope = "source.css - meta.selector.css"
+        html_style_selector_scope = "text.html meta.attribute-with-value.style.html " + \
+                                    "string.quoted - punctuation.definition.string.begin.html"
+        selector_scope = css_selector_scope + ', ' + html_style_selector_scope
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
         loc = locations[0]

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -345,7 +345,8 @@ contexts:
         - match: "'"
           scope: string.quoted.single punctuation.definition.string.begin.html
           set:
-            - meta_scope: meta.attribute-with-value.style.html source.css
+            - meta_scope: meta.attribute-with-value.style.html
+            - meta_content_scope: source.css
             - match: "'"
               scope: string.quoted.single punctuation.definition.string.end.html
               pop: true

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -199,7 +199,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within HTML
-        if not view.match_selector(locations[0], "text.html - source"):
+        if not view.match_selector(locations[0], "text.html - source - string.quoted"):
             return []
 
         # check if we are inside a tag

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -112,11 +112,22 @@
         <div style="width: 100%"></div>
         ##  ^ - meta.attribute-with-value.style
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style
-        ##    ^ meta.attribute-with-value.style.html entity.other.attribute-name.style.html
-        ##         ^ - source.css
-        ##                     ^ - source.css
-        ##          ^ source.css meta.property-name.css support.type.property-name.css
-        ##                 ^ meta.property-value.css constant.numeric.css
+        ##   ^^^^^ meta.attribute-with-value.style.html entity.other.attribute-name.style.html
+        ##         ^ punctuation.definition.string.begin.html - source.css
+        ##          ^^^^^^^^^^^ source.css
+        ##                     ^ punctuation.definition.string.end.html - source.css
+        ##          ^^^^^ meta.property-name.css support.type.property-name.css
+        ##                 ^^^ meta.property-value.css constant.numeric.css
+        
+        <div style='width: 100%;'></div>
+        ##  ^ - meta.attribute-with-value.style
+        ##   ^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style
+        ##   ^^^^^ meta.attribute-with-value.style.html entity.other.attribute-name.style.html
+        ##         ^ punctuation.definition.string.begin.html - source.css
+        ##                      ^ punctuation.definition.string.end.html - source.css
+        ##          ^^^^^^^^^^^^ source.css
+        ##          ^^^^^ meta.property-name.css support.type.property-name.css
+        ##                 ^^^ meta.property-value.css constant.numeric.css
 
         <tag attr otherattr attr-with-dashes attr_with_underscores></tag>
         ##   ^ entity.other.attribute-name.html


### PR DESCRIPTION
- don't suggest HTML attribute names when typing inside a HTML attribute value string
- suggest CSS when typing at the end of a HTML style attribute, just before the closing quote

EDIT: also:
- make `style="..."` and `style='...'` consistent in HTML - previously, the single quotes were being scoped as `source.css`, which is incorrect.