### PR TITLE
[Regular Expressions] support relative capture groups

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -160,7 +160,7 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ims]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: '(\?\d+)(\))'
+    - match: '(\?[+-]?\d+)(\))'
       captures:
         1: keyword.other.backref-and-recursion.regexp
         2: keyword.control.group.regexp

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -119,7 +119,7 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ixms]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: '(\?\d+)(\))'
+    - match: '(\?[+-]?\d+)(\))'
       captures:
         1: keyword.other.backref-and-recursion.regexp
         2: keyword.control.group.regexp
@@ -249,7 +249,7 @@ contexts:
     - match: '\\[QEK]'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
-    - match: \\[kg](<\w+>|'\w+'|\{\w+\}|\d+)
+    - match: \\[kg](<\w+>|'\w+'|\{\w+\}|-?\d+)
       scope: keyword.other.backref-and-recursion.regexp
     - match: \\[1-9]\d*
       scope: keyword.other.backref-and-recursion.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -276,6 +276,13 @@ hello++
 (?&named_group)
 #^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 
+(hello)(?-1)(?+1)(wow) relative capture groups are supported
+#       ^^^ keyword.other.backref-and-recursion.regexp
+#            ^^^ keyword.other.backref-and-recursion.regexp
+
+(hello)\g-1(wow)
+#      ^^^^ keyword.other.backref-and-recursion.regexp
+
 (?={2})
 #  ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
 

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -283,6 +283,10 @@ hello++
 (hello)\g-1(wow)
 #      ^^^^ keyword.other.backref-and-recursion.regexp
 
+(?x)(hello)(?-1)(?+1)(wow) relative capture groups are supported(?-x)
+#           ^^^ keyword.other.backref-and-recursion.regexp
+#                ^^^ keyword.other.backref-and-recursion.regexp
+
 (?={2})
 #  ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
 


### PR DESCRIPTION
`\g` allows to use `-` for previous capture groups
`(?\d)` allows to use `-` for previous capture groups and `+` for next capture groups

example:

> hellohellowowwow

would be matched by:

    (hello)\g-1(?+1)(wow)