### PR TITLE
[LaTeX] Add match for \path command to make it behave like \url and \href

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -573,7 +573,7 @@ contexts:
         - include: general-1-argument-with-options
 
   url:
-    - match: '((\\)(?:url|href))(\{)([^}]*)(\})'
+    - match: '((\\)(?:url|href|path))(\{)([^}]*)(\})'
       scope: meta.function.link.url.latex
       captures:
         1: support.function.url.latex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -100,6 +100,11 @@
 % ^ support.function.url.latex
 %     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.latex
 
+\path{$HOME/path/to/file}
+% ^^^^^^^^^^^^^^^^^^^^^^ meta.function.link.url.latex
+% ^ support.function.url.latex
+%     ^^^^^^^^^^^^^^^^^^ markup.underline.link.latex
+
 
 % INCLUDE COMMANDS
 


### PR DESCRIPTION
Text inside the \path command was not treated special. This broke highlighting if the path contained special characters (e.g. $).

I'm not sure if there are multiple \path commands in different packages that behave differently. I am using the one from the hyperref package to typeset file paths. In my case, they sometimes contain environment variables, starting with $. Unlike for the \url command, which is highlighted correctly, a $ inside a \path would lead to the following text being highlighted as if it was set in math mode. This pull request fixes this.