### PR TITLE
[Python] Stricter string placeholders

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -646,11 +646,13 @@ contexts:
       scope: support.type.python
 
   constant-placeholder:
-    - match: '(?i)%(%|(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z])'
+    - match: '%(?i:\([a-z_]+\))?#?0?\-? ?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hlL]?[acdeEfFgGiorsuxX%]'
+      scope: constant.other.placeholder.python
+    - match: '%(?:[aAwdbBmyYHIpMSfzZjUWcxX%]|-[dmHIMSj])'
       scope: constant.other.placeholder.python
     - match: '\{\{|\}\}'
       scope: constant.character.escape.python
-    - match: '(?i)\{([!\[\].,:\w ]+)?\}'
+    - match: '\{([\w.\[\]]*)(:.?[<>=^]?)?[ +-]?\d*,?(\.\d+)?!?[abcdeEfFgGnorsxX%]?\}'
       scope: constant.other.placeholder.python
 
   name:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -603,6 +603,12 @@ illegal = 1LL << 08 | 0b010203 | 0xAbraCadabra
 "Testing {:,.2f}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
 
+"Testing {0:>9,}".format(1000)
+#        ^^^^^^^ constant.other.placeholder
+
+"Testing {:j^9,}".format(1000)
+#        ^^^^^^^ constant.other.placeholder
+
 datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 #                                    ^^^^^^^^^^ constant.other.placeholder
 


### PR DESCRIPTION
Also match `{:>3}` and other padding formats. Match `strftime` formats separately and simply.

It's a little weird not seeing the `{!a}` format in the spec (which I discovered when the existing test failed), but I tried it in a Python3 interpreter, and it does indeed work. It is somewhat unclear to me where the `!` can fall, and under what circumstances.

If this change breaks existing code highlighting, please give me examples in syntax test format.

https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
https://docs.python.org/3/library/string.html#format-specification-mini-language
http://strftime.org/