### PR TITLE
[Regular Expressions] support backtracking control verbs

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -82,14 +82,20 @@ contexts:
           scope: punctuation.definition.comment.end.regexp
           pop: true
 
+  backtracking-control-verb:
+    - match: '\(\*(PRUNE|SKIP|THEN|COMMIT|FAIL|F|ACCEPT)\)'
+      scope: keyword.control.verb.regexp
+
   group:
     - include: group-comment
+    - include: backtracking-control-verb
     - match: \(
       scope: keyword.control.group.regexp
       push: group-start
 
   group-extended:
     - include: group-comment
+    - include: backtracking-control-verb
     - match: \(
       scope: keyword.control.group.regexp
       push: group-start-extended

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -452,3 +452,43 @@ hello++
 #^^^^^^^^^ keyword.other.conditional.definition.regexp
 #                     ^^^ keyword.other.backref-and-recursion.regexp
 (?-x)
+
+
+(?#http://www.boost.org/doc/libs/1_61_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html#boost_regex.syntax.perl_syntax.backtracking_control_verbs)
+
+'[^']*'(*SKIP)(*F)|" (?#http://stackoverflow.com/a/38638595/4473405)
+#      ^^^^^^^^^^^ keyword.control.verb.regexp
+ (*PRUNE) (*SKIP) (*THEN) (*COMMIT) (*FAIL) (*F) (*ACCEPT)
+#^^^^^^^^ keyword.control.verb.regexp
+#        ^ meta.literal.regexp - keyword.control.verb.regexp
+#         ^^^^^^^ keyword.control.verb.regexp
+#                ^ - keyword.control.verb.regexp
+#                 ^^^^^^^ keyword.control.verb.regexp
+#                        ^ - keyword.control.verb.regexp
+#                         ^^^^^^^^^ keyword.control.verb.regexp
+#                                  ^ - keyword.control.verb.regexp
+#                                   ^^^^^^^ keyword.control.verb.regexp
+#                                          ^ - keyword.control.verb.regexp
+#                                           ^^^^ keyword.control.verb.regexp
+#                                               ^ - keyword.control.verb.regexp
+#                                                ^^^^^^^^^ keyword.control.verb.regexp
+(*FA)
+#^ invalid.illegal.unexpected-quantifier.regexp
+(?x)
+ (*PRUNE) (*SKIP) (*THEN) (*COMMIT) (*FAIL) (*F) (*ACCEPT)
+#^^^^^^^^ keyword.control.verb.regexp
+#        ^ - meta.literal.regexp - keyword.control.verb.regexp
+#         ^^^^^^^ keyword.control.verb.regexp
+#                ^ - keyword.control.verb.regexp
+#                 ^^^^^^^ keyword.control.verb.regexp
+#                        ^ - keyword.control.verb.regexp
+#                         ^^^^^^^^^ keyword.control.verb.regexp
+#                                  ^ - keyword.control.verb.regexp
+#                                   ^^^^^^^ keyword.control.verb.regexp
+#                                          ^ - keyword.control.verb.regexp
+#                                           ^^^^ keyword.control.verb.regexp
+#                                               ^ - keyword.control.verb.regexp
+#                                                ^^^^^^^^^ keyword.control.verb.regexp
+(*FA)
+#^ invalid.illegal.unexpected-quantifier.regexp
+(?-x)


### PR DESCRIPTION
This PR adds scoping of backtracking control verbs, as per http://www.boost.org/doc/libs/1_61_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html#boost_regex.syntax.perl_syntax.backtracking_control_verbs

All tested in ST3's find panel and confirmed to be recognized, including the `(*F)` shorthand form of `(*FAIL)`, which isn't mentioned in the boost docs for some reason.