### PR TITLE
[Scala] Lambda Highlighting

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -200,6 +200,7 @@ contexts:
       push: function-tparams-brackets
     - match: '\]'
       pop: true
+    - include: type-constraints
     - include: delimited-type-expression
 
   function-parameter-list:
@@ -246,6 +247,7 @@ contexts:
       pop: true
     - match: this
       scope: variable.language.scala
+    - include: type-constraints
     - include: delimited-type-expression
 
   class-parameter-list:
@@ -566,7 +568,7 @@ contexts:
       push:
         - match: \]
           pop: true
-        - include: main
+        - include: delimited-type-expression
     - match: '@|_'
       scope: keyword.other.scala
 
@@ -593,6 +595,9 @@ contexts:
         - match: \}
           pop: true
         - include: main
+  type-constraints:
+    - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:|<%|\+|-|:)(?=[a-zA-Z0-9\s\)\]\}])'
+      scope: keyword.operator
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -106,23 +106,30 @@ contexts:
             1: storage.type.function.arrow.scala
           pop: true
         - include: lambda-declaration
-  lambda-declaration:
+  lambda-declaration-base:
     - match: \(
       push:
         - match: \)
           pop: true
-        - include: lambda-declaration
+        - include: lambda-declaration-parens
+    - match: '{{id}}'
+      scope: variable.parameter
+  lambda-declaration-parens:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
-          pop: true
         - match: ','
           pop: true
         - match: '(?=\))'
           pop: true
         - include: delimited-type-expression
-    - match: '{{id}}'
-      scope: variable.parameter
+    - include: lambda-declaration-base
+  lambda-declaration:
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+          pop: true
+        - include: delimited-type-expression
+    - include: lambda-declaration-base
 
   base-types:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -490,11 +490,13 @@ contexts:
   strings:
     - match: '"""'
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.triple.scala
         - match: '"""(?!")'
           pop: true
     - match: (?<!\\)"
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.scala
         - match: '"'
           pop: true
@@ -506,6 +508,7 @@ contexts:
       captures:
         1: support.function.scala
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.triple.interpolated.scala
         - match: '"""(?!")'
           pop: true
@@ -514,6 +517,7 @@ contexts:
       captures:
         1: support.function.scala
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.interpolated.scala
         - match: '"'
           pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -260,6 +260,8 @@ contexts:
       push:
         - match: '\)'
           pop: true
+        - match: '\b(val)\b'
+          scope: storage.type.scala
         - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
@@ -324,10 +326,10 @@ contexts:
         - include: delimited-type-expression
 
   initialization:
-    - match: '\b(new)\s+({{id}})'
+    - match: '\b(new)\s+'
       captures:
         1: keyword.other.scala
-        2: entity.name.class.scala
+      push: single-type-expression
 
   for-comprehension:
     - match: '\b(for)\s*\{'
@@ -529,7 +531,7 @@ contexts:
     - match: '@|_'
       scope: keyword.other.scala
   val-pattern-match:
-    - match: '{{upperid}}'
+    - match: '{{upperid}}(?=[\s=])'
       scope: entity.name.parameter
     - match: '{{typeprefix}}'
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -98,10 +98,10 @@ contexts:
 
   lambdas:
     # can't use a variable for this match either?
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[\s\B])'
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
         # strangely, we can't use a variable for this match
-        - match: '(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}])'
+        - match: '(?<=[[[:alpha:]]0-9\s\)\]\}])(=>)(?=[[[:alpha:]]0-9\s\)\]\}])'
           captures:
             1: storage.type.function.arrow.scala
           pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -123,6 +123,12 @@ contexts:
             - match: '\]'
               pop: true
             - include: delimited-type-expression
+        - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:)(?=[a-zA-Z0-9\s\)\]\}])'
+          scope: keyword.operator
+          set:
+            - match: '(?=[\n\}\)\]])'
+              pop: true
+            - include: delimited-type-expression
         - match: '='
           set:
             - match: '(?=[\n\}\)\]])'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -7,6 +7,9 @@ file_extensions:
   - sbt
 scope: source.scala
 variables:
+  # lookahead/behind for operators
+  oplookbehind: '(?<=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
+  oplookahead: '(?=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
   # From http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html
   disallowed_as_operator: '[^\w\[\]\(\)\{\}''";,.`_\s]'
   operator_character: '[\p{Sm}\p{So}[{{disallowed_as_operator}}&&[\x20-\x7F]]]'
@@ -22,7 +25,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
-  typeprefix: '(?<=[[[:alpha:]]0-9\s\)\]\}])(:)(?=[[[:alpha:]]0-9\s\)\]\}])\s*'
+  typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
 
 contexts:
   prototype:
@@ -97,11 +100,9 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    # can't use a variable for this match either?
     - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
-        # strangely, we can't use a variable for this match
-        - match: '(?<=[[[:alpha:]]0-9\s\)\]\}])(=>)(?=[[[:alpha:]]0-9\s\)\]\}])'
+        - match: '{{oplookbehind}}(=>){{oplookahead}}'
           captures:
             1: storage.type.function.arrow.scala
           pop: true
@@ -126,7 +127,7 @@ contexts:
   lambda-declaration:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+        - match: '(?={{oplookbehind}}(=>){{oplookahead}})'
           pop: true
         - include: delimited-type-expression
     - include: lambda-declaration-base
@@ -170,7 +171,7 @@ contexts:
             - match: '\]'
               pop: true
             - include: delimited-type-expression
-        - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:)(?=[a-zA-Z0-9\s\)\]\}])'
+        - match: '{{oplookbehind}}(<:|>:){{oplookahead}}'
           scope: keyword.operator
           set:
             - match: '(?=[\n\}\)\]])'
@@ -655,7 +656,7 @@ contexts:
           pop: true
         - include: main
   type-constraints:
-    - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:|<%|\+|-|:)(?=[a-zA-Z0-9\s\)\]\}])'
+    - match: '{{oplookbehind}}(<:|>:|<%|\+|-|:){{oplookahead}}'
       scope: keyword.operator
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -121,7 +121,7 @@ contexts:
       push:
         - match: '(?=[=\n])'
           pop: true
-        - include: pattern-match
+        - include: val-pattern-match
     - match: '\b(package)\s+(object)\s+({{id}})'
       captures:
         1: keyword.control.scala
@@ -427,7 +427,7 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
-  pattern-match:
+  val-pattern-match:
     - include: comments
     - include: block-comments
     - include: keywords
@@ -444,6 +444,32 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: main
+    - match: '@|_'
+      scope: keyword.other.scala
+  pattern-match:
+    - include: comments
+    - include: block-comments
+    - include: keywords
+    - include: constants
+    - include: char-literal
+    - include: scala-symbol
+    - include: strings
+    - include: xml-literal
+    - match: '`'
+      push:
+        - match: '`'
+          pop: true
+    - match: '{{varid}}\.'
+    - match: '\.{{varid}}'
+    - match: '\b{{varid}}'
+      scope: variable.parameter.scala   # not indexed!
     - match: '{{upperid}}'
       scope: support.class.scala
     - match: \[

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,6 +22,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
+  typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
 
 contexts:
   main:
@@ -35,15 +36,15 @@ contexts:
     - include: block-comments
     - include: strings
     - include: initialization
+    - include: ascription
     - include: constants
     - include: char-literal
     - include: scala-symbol
     - include: empty-parentheses
     - include: braces
-    - include: parameter-list
-    - include: qualifiedClassName
     - include: xml-literal
     - include: late-keywords
+
   block-comments:
     - match: /\*
       push:
@@ -59,6 +60,7 @@ contexts:
   char-literal:
     - match: '''\\?.'''
       scope: constant.character.literal.scala
+
   comments:
     - match: (//).*$\n?
       scope: comment.line.double-slash.scala
@@ -77,6 +79,14 @@ contexts:
           scope: keyword.other.documentation.scaladoc.scala
         - match: '\{@link\s+[^\}]*\}'
           scope: keyword.other.documentation.scaladoc.link.scala
+
+  ascription:
+    - match: '{{typeprefix}}'
+      push: single-type-expression
+
+  base-types:
+    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+      scope: storage.type.primitive.scala
   constants:
     - match: \b(false|null|true|Nil|None)\b
       scope: constant.language.scala
@@ -84,8 +94,11 @@ contexts:
       scope: constant.numeric.scala
     - match: \b(this|super)\b
       scope: variable.language.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
-      scope: storage.type.primitive.scala
+    - include: base-types
+    # other upper-case stuff highlights as constant
+    - match: '{{upperid}}'
+      scope: support.constant.scala
+
   declarations:
     - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
       scope: comment.block.scala
@@ -93,9 +106,7 @@ contexts:
         - match: '\}\)#λ'
           scope: comment.block.scala
           pop: true
-        - match: "[αβ]"
-          scope: comment.block.empty.scala
-        - include: main
+        - include: delimited-type-expression
     - match: '\b(def)\s+({{id}})'
       captures:
         1: storage.type.function.scala
@@ -111,6 +122,14 @@ contexts:
       captures:
         1: storage.type.scala
         2: entity.name.type.scala
+      push:
+        - match: '\n'
+          pop: true
+        - match: '='
+          set:
+            - match: '\n'
+              pop: true
+            - include: delimited-type-expression
     - match: '\b(var)\s+({{id}})'
       captures:
         1: storage.type.volatile.scala
@@ -145,7 +164,13 @@ contexts:
           captures:
             1: keyword.control.flow.scala
         - include: pattern-match
+
   braces:
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: delimited-type-expression
     - match: \(
       push:
         - match: \)
@@ -156,35 +181,56 @@ contexts:
         - match: \}
           pop: true
         - include: main
+
   function-type-parameter-list:
     - match: '(?=\()'
       set: function-parameter-list
     - match: '\['
       push: function-tparams-brackets
-    - match: '(?=[:\{=\n])'
+    - match: ':'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
+    - match: '(?=[\{=\n])'
       pop: true
+
   function-tparams-brackets:
     - match: '\['
       push: function-tparams-brackets
     - match: '\]'
       pop: true
-    - include: main
+    - include: delimited-type-expression
+
   function-parameter-list:
     - match: '\('
       push:
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: main
         - match: '\)'
           pop: true
-        - match: '({{alphaid}})\s*:\s*'
+        - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
+          push:
+            - match: '{{typeprefix}}'
+              set:
+                - match: '(?=[,=\)])'
+                  pop: true
+                - match: ','
+                  pop: true
+                - include: delimited-type-expression
         - include: main
-    - match: '(?=[:\{=\n])'
+    - match: ':'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
+    - match: '(?=[\{=\n])'
       pop: true
+
   class-type-parameter-list:
     - match: '\b(private|protected)\b'
       scope: storage.modifier.access.scala
@@ -194,31 +240,40 @@ contexts:
       push: class-tparams-brackets
     - match: '(?=([\{\n]|extends))'
       pop: true
+
   class-tparams-brackets:
     - match: '\['
       push: class-tparams-brackets
     - match: '\]'
       pop: true
-    - include: main
+    - match: this
+      scope: variable.language.scala
+    - include: delimited-type-expression
+
   class-parameter-list:
     - match: '\('
       push:
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: main
         - match: '\)'
           pop: true
-        - match: '({{alphaid}})\s*:\s*'
+        - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
+          push:
+            - match: '{{typeprefix}}'
+              set:
+                - match: '(?=[,=\)])'
+                  pop: true
+                - match: ','
+                  pop: true
+                - include: delimited-type-expression
         - include: main
     - match: '(?=([\{\n]|extends))'
       pop: true
+
   empty-parentheses:
     - match: \(\)
       scope: meta.parentheses.scala
+
   imports:
     - match: \b(import)\s+
       captures:
@@ -249,16 +304,26 @@ contexts:
                 3: variable.import.renamed-to.scala
             - match: '([^\s.,}]+)'
               scope: variable.import.scala
+
   inheritance:
     - match: '(extends|with)\s+([^\s\{\(\[\]]+)'
       captures:
         1: keyword.declaration.scala
         2: entity.other.inherited-class.scala
+    - match: '(extends|with)\s+\('
+      captures:
+        1: keyword.declaration.scala
+      push:
+        - match: '\)'
+          pop: true
+        - include: delimited-type-expression
+
   initialization:
     - match: '\b(new)\s+({{id}})'
       captures:
         1: keyword.other.scala
         2: entity.name.class.scala
+
   for-comprehension:
     - match: '\b(for)\s*\{'
       captures:
@@ -312,6 +377,7 @@ contexts:
     - match: '\b(val)\b'
       scope: keyword.declaration.stable.scala
     - include: pattern-match
+
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
@@ -323,6 +389,7 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
+
   late-keywords:
     - match: \b(extends|with|forSome)\b
       scope: keyword.declaration.scala
@@ -338,6 +405,7 @@ contexts:
       scope: keyword.control.scala
     - match: \b(new)\b
       scope: keyword.other.scala
+
   nest-curly-and-self:
     - match: '\{'
       scope: punctuation.section.scope.scala
@@ -347,17 +415,17 @@ contexts:
           pop: true
         - include: nest-curly-and-self
     - include: main
-  qualifiedClassName:
-    - match: '{{upperid}}'
-      scope: support.class.scala
+
   scala-symbol:
     - match: '''{{plainid}}'
       scope: constant.other.symbol.scala
+
   storage-modifiers:
     - match: '\b(private\[\S+\]|protected\[\S+\]|private|protected)\b'
       scope: storage.modifier.access.scala
     - match: \b(@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b
       scope: storage.modifier.other.scala
+
   strings:
     - match: '"""'
       push:
@@ -393,6 +461,7 @@ contexts:
         - match: \\.
           scope: constant.character.escape.scala
         - include: interpolated-vars-expressions
+
   interpolated-vars-expressions:
     - match: '(\$){{alphaid}}'
       scope: variable.other.scala
@@ -412,6 +481,7 @@ contexts:
               pop: true
             - include: nest-curly-and-self
             - include: main
+
   xml-attribute:
     - match: '(\w+)=("[^"]*")'
       captures:
@@ -427,10 +497,12 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
+
   val-pattern-match-main:
     - include: comments
     - include: block-comments
     - include: keywords
+    - include: ascription
     - include: constants
     - include: char-literal
     - include: scala-symbol
@@ -452,18 +524,26 @@ contexts:
     - match: '@|_'
       scope: keyword.other.scala
   val-pattern-match:
+    - match: '{{upperid}}'
+      scope: entity.name.parameter
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
     - include: val-pattern-match-main
     - match: \(
       push:
         - match: \)
           pop: true
         - include: val-pattern-match-inner
-    - match: '{{upperid}}'
-      scope: entity.name.parameter
   val-pattern-match-inner:
     - include: val-pattern-match-main
     - match: '{{upperid}}'
       scope: support.class.scala
+
   pattern-match:
     - include: comments
     - include: block-comments
@@ -481,8 +561,7 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
-    - match: '{{upperid}}'
-      scope: support.class.scala
+    - include: ascription
     - match: \[
       push:
         - match: \]
@@ -490,3 +569,36 @@ contexts:
         - include: main
     - match: '@|_'
       scope: keyword.other.scala
+
+  base-type-expression:
+    - include: base-types
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+    - match: forSome
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: _
+    - match: '{{id}}'
+      scope: support.type.scala
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: base-type-expression
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: base-type-expression
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: main
+  delimited-type-expression:
+    - include: base-type-expression
+  single-type-expression:
+    - include: base-type-expression
+    - match: '(?=[\s,\)\}\]])'
+      pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -123,11 +123,16 @@ contexts:
         1: storage.type.scala
         2: entity.name.type.scala
       push:
-        - match: '\n'
+        - match: '(?=[\n\}\)\]])'
           pop: true
+        - match: '\['
+          push:
+            - match: '\]'
+              pop: true
+            - include: delimited-type-expression
         - match: '='
           set:
-            - match: '\n'
+            - match: '(?=[\n\}\)\]])'
               pop: true
             - include: delimited-type-expression
     - match: '\b(var)\s+({{id}})'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -25,18 +25,30 @@ variables:
   typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
 
 contexts:
+  prototype:
+    - include: comments
+    - include: block-comments
+
   main:
+    - include: main-pre-lambdas
+    - include: lambdas
+    - include: main-post-lambdas
+
+  main-no-lambdas:
+    - include: main-pre-lambdas
+    - include: main-post-lambdas
+
+  main-pre-lambdas:
     - include: storage-modifiers
     - include: declarations
     - include: inheritance
     - include: for-comprehension
     - include: keywords
     - include: imports
-    - include: comments
-    - include: block-comments
     - include: strings
     - include: initialization
     - include: ascription
+  main-post-lambdas:
     - include: constants
     - include: char-literal
     - include: scala-symbol
@@ -83,6 +95,34 @@ contexts:
   ascription:
     - match: '{{typeprefix}}'
       push: single-type-expression
+
+  lambdas:
+    # can't use a variable for this match either?
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[\s\B])'
+      push:
+        # strangely, we can't use a variable for this match
+        - match: '(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}])'
+          captures:
+            1: storage.type.function.arrow.scala
+          pop: true
+        - include: lambda-declaration
+  lambda-declaration:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: lambda-declaration
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+          pop: true
+        - match: ','
+          pop: true
+        - match: '(?=\))'
+          pop: true
+        - include: delimited-type-expression
+    - match: '{{id}}'
+      scope: variable.parameter
 
   base-types:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
@@ -163,7 +203,14 @@ contexts:
             - match: '\)'
               pop: true
             - include: pattern-match
-        - match: '=>|⇒|\b(if)\b'
+        - match: '\b(if)\b'
+          captures:
+            1: keyword.control.flow.scala
+          set:
+            - match: '=>|⇒'
+              pop: true
+            - include: main-no-lambdas
+        - match: '=>|⇒'
           pop: true
           captures:
             1: keyword.control.flow.scala
@@ -290,7 +337,6 @@ contexts:
         - meta_scope: meta.import.scala
         - match: '(?<=[\n;])'
           pop: true
-        - include: comments
         - match: '([^\s{;.]+)\s*\.\s*'
           scope: variable.package.scala
         - match: '([^\s{;.]+)\s*'
@@ -507,8 +553,6 @@ contexts:
         - include: xml-attribute
 
   val-pattern-match-main:
-    - include: comments
-    - include: block-comments
     - include: keywords
     - include: ascription
     - include: constants
@@ -553,8 +597,6 @@ contexts:
       scope: support.class.scala
 
   pattern-match:
-    - include: comments
-    - include: block-comments
     - include: keywords
     - include: constants
     - include: char-literal

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -608,18 +608,25 @@ contexts:
   single-type-expression:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
-      pop: true
+      set: single-type-expression-tail
     - match: "[αβ]"   # this mostly exists for type lambdas
       scope: comment.block.empty.scala
-      pop: true
+      set: single-type-expression-tail
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala
     - match: '{{upperid}}'
       scope: support.class.scala
-      pop: true
+      set: single-type-expression-tail
     - match: '{{id}}'
       scope: support.type.scala
-      pop: true
+      set: single-type-expression-tail
     - include: base-type-expression
     - match: '(?=[\s,\)\}\]])'
+      pop: true
+  single-type-expression-tail:
+    - match: '[\.#]'
+      scope: punctuation.separator
+      set: single-type-expression
+    - match: '\s+'
+    - match: '(?=.)'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -440,8 +440,8 @@ contexts:
       push:
         - match: '`'
           pop: true
-    - match: '\b[a-z][a-zA-Z0-9_]*\.'
-    - match: '\.[a-z][a-zA-Z0-9_]*\b'
+    - match: '{{varid}}\.'
+    - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
     - match: '{{upperid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -594,6 +594,8 @@ contexts:
           pop: true
         - include: main
   delimited-type-expression:
+    - match: '[\.#]'
+      scope: punctuation.separator
     - include: base-types
     - match: "[αβ]"   # this mostly exists for type lambdas
       scope: comment.block.empty.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -26,6 +26,8 @@ variables:
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
   typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
+  # hack to cover up to three levels of nested parentheses
+  withinparens: '\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\)'
 
 contexts:
   prototype:
@@ -100,7 +102,7 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{oplookbehind}}(=>){{oplookahead}}'
           captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -427,7 +427,7 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
-  val-pattern-match:
+  val-pattern-match-main:
     - include: comments
     - include: block-comments
     - include: keywords
@@ -444,8 +444,6 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
-    - match: '{{upperid}}'
-      scope: support.class.scala
     - match: \[
       push:
         - match: \]
@@ -453,6 +451,19 @@ contexts:
         - include: main
     - match: '@|_'
       scope: keyword.other.scala
+  val-pattern-match:
+    - include: val-pattern-match-main
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: val-pattern-match-inner
+    - match: '{{upperid}}'
+      scope: entity.name.parameter
+  val-pattern-match-inner:
+    - include: val-pattern-match-main
+    - match: '{{upperid}}'
+      scope: support.class.scala
   pattern-match:
     - include: comments
     - include: block-comments

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -100,13 +100,6 @@ contexts:
       scope: support.constant.scala
 
   declarations:
-    - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
-      scope: comment.block.scala
-      push:
-        - match: '\}\)#λ'
-          scope: comment.block.scala
-          pop: true
-        - include: delimited-type-expression
     - match: '\b(def)\s+({{id}})'
       captures:
         1: storage.type.function.scala
@@ -578,6 +571,13 @@ contexts:
       scope: keyword.other.scala
 
   base-type-expression:
+    - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
+      scope: comment.block.scala
+      push:
+        - match: '\}\)#λ'
+          scope: comment.block.scala
+          pop: true
+        - include: delimited-type-expression
     - match: \(
       push:
         - match: \)
@@ -594,11 +594,11 @@ contexts:
           pop: true
         - include: main
   delimited-type-expression:
+    - match: "[αβ]"     # just here for type lambdas
+      scope: comment.block.empty.scala
     - match: '[\.#]'
       scope: punctuation.separator
     - include: base-types
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala
     - match: '{{upperid}}'
@@ -608,11 +608,10 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - match: "[αβ]"     # just here for type lambdas
+      scope: comment.block.empty.scala
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
-      set: single-type-expression-tail
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
       set: single-type-expression-tail
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,7 +22,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
-  typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
+  typeprefix: '(?<=[[[:alpha:]]0-9\s\)\]\}])(:)(?=[[[:alpha:]]0-9\s\)\]\}])\s*'
 
 contexts:
   prototype:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -220,7 +220,7 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[,=\)])'
+                - match: '(?=[=\)])'
                   pop: true
                 - match: ','
                   pop: true
@@ -268,7 +268,7 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[,=\)])'
+                - match: '(?=[=\)])'
                   pop: true
                 - match: ','
                   pop: true
@@ -578,34 +578,48 @@ contexts:
       scope: keyword.other.scala
 
   base-type-expression:
-    - include: base-types
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
-    - match: forSome
-      scope: keyword.declaration.scala
-    - match: '{{upperid}}'
-      scope: support.class.scala
-    - match: _
-    - match: '{{id}}'
-      scope: support.type.scala
     - match: \(
       push:
         - match: \)
           pop: true
-        - include: base-type-expression
+        - include: delimited-type-expression
     - match: \[
       push:
         - match: \]
           pop: true
-        - include: base-type-expression
+        - include: delimited-type-expression
     - match: \{
       push:
         - match: \}
           pop: true
         - include: main
   delimited-type-expression:
+    - include: base-types
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+    - match: '\b(forSome)\b'
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: _
+    - match: '{{id}}'
+      scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+      scope: storage.type.primitive.scala
+      pop: true
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+      pop: true
+    - match: '\b(forSome)\b'
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+      pop: true
+    - match: '{{id}}'
+      scope: support.type.scala
+      pop: true
     - include: base-type-expression
     - match: '(?=[\s,\)\}\]])'
       pop: true

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -741,3 +741,7 @@ type Foo >: Bar
 "testing /*comments*/"
 //       ^^^^^^^^^^^^ string.quoted.double
 //       ^^^^^^^^^^^^ - comment
+
+   cb: ((Throwable \/ Unit) => Unit) => 42
+// ^^ variable.parameter
+//                                   ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -623,3 +623,6 @@ new (Foo ~> Bar)
 
    val Stuff(f1, v1) = ???
 //     ^^^^^ support.constant.scala
+
+new Foo(new Foo)
+//      ^^^ keyword.other.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -130,6 +130,11 @@ object Foo
 //                   ^^^ support.class.scala
 
 
+  type Foo[A, B, C] = Bar
+//         ^ support.class
+//            ^ support.class
+//               ^ support.class
+
 type Foo = Bar {
   def baz: Int
 //    ^^^ entity.name.function
@@ -587,3 +592,13 @@ type Foo = Bar[A] forSome { type A }
    val (Foo, x) = 42
 //      ^^^ support.constant.scala
 //           ^ entity.name.parameter
+
+{
+  Set[Foo[A, A] forSome { type A }, A]
+//                                  ^ support.class
+}
+    def foo: Int
+//      ^^^ entity.name.function
+
+// fubar
+// <- source.scala comment.line.double-slash

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -638,3 +638,9 @@ new Foo#Bar#Baz
 //      ^^^ support.class.scala
 //         ^ punctuation.separator
 //          ^^^ support.class.scala
+
+type Foo = Foo.Bar
+//            ^ punctuation.separator
+
+type Foo = Foo#Bar
+//            ^ punctuation.separator

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -11,6 +11,17 @@ import fubar.{Unit, Foo}
 //     ^^^^^ variable.package.scala
 //            ^^^^ variable.import.scala
 
+def foo: Baz = 42
+//^ storage.type.function.scala
+//  ^^^ entity.name.function.scala
+//       ^^^ support.class
+//             ^^ constant.numeric.scala
+
+def foo: Baz => Bar = 42
+//       ^^^ support.class
+//              ^^^ support.class
+
+
 def foo(a: Int, b: Bar): Baz = 42
 //^ storage.type.function.scala
 //  ^^^ entity.name.function.scala
@@ -91,6 +102,14 @@ class Foo[A](a: Bar) extends Baz with Bin
 //                          ^ variable.parameter
 //                                  ^ variable.parameter
 
+class Foo(x: Int = 42)
+//               ^ - support
+//                 ^^ constant.numeric
+
+def foo(x: Int = 42)
+//             ^ - support
+//               ^^ constant.numeric
+
 trait Foo
 // ^^ storage.type.class.scala
 //    ^^^ entity.name.class
@@ -98,6 +117,30 @@ trait Foo
 object Foo
 // ^^^ storage.type.class.scala
 //     ^^^ entity.name.class
+
+   type Foo = Bar
+// ^^^^ storage.type.scala
+//      ^^^ entity.name.type.scala
+//            ^^^ support.class.scala
+
+   type Foo = Bar => Baz
+// ^^^^ storage.type.scala
+//      ^^^ entity.name.type.scala
+//            ^^^ support.class.scala
+//                   ^^^ support.class.scala
+
+
+type Foo = Bar {
+  def baz: Int
+//    ^^^ entity.name.function
+}
+
+type Foo = Bar[A] forSome { type A }
+//                ^^^^^^^ keyword.declaration.scala
+
+   type Foo
+   Bar
+// ^^^ support.constant
 
    42
 // ^^ constant.numeric.scala
@@ -189,7 +232,7 @@ object Foo
 // ^^^^^^^ storage.type.primitive.scala
 
    String
-// ^^^^^^ support.class
+// ^^^^^^ support.constant
 
    // this is a comment
 // ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
@@ -339,6 +382,9 @@ object Foo
 // ^ source.scala
 //    ^^^ storage.type.primitive.scala
 
+   a: Foo
+//    ^^^ support.class
+
    case (abc: Foo, cba @ _) =>
 // ^^^^ keyword.other.declaration.scala
 //       ^^^ variable.parameter
@@ -417,6 +463,13 @@ object Foo
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                            ^^^^^ entity.other.inherited-class.scala
+
+   case object Thingy extends (Foo => Bar)
+// ^^^^ keyword.other.declaration.scala
+//      ^^^^^^ keyword.control.class.scala
+//             ^^^^^^ entity.name.class.scala
+//                    ^^^^^^^ keyword.declaration.scala
+//                             ^^^ support.class
 
    case class
 // ^^^^ keyword.other.declaration.scala
@@ -500,7 +553,7 @@ object Foo
    for {
      back <- Traverse[Option]
 //   ^^^^ variable.parameter
-//           ^^^^^^^^ support.class
+//           ^^^^^^^^ support.constant
 //                    ^^^^^^ support.class
        .traverse[Free, Stuff](res) { r => }
 //      ^^^^^^^^ - entity.name
@@ -511,6 +564,7 @@ object Foo
 
   val baseSettings: Seq[Def.Setting[_]] = _
 //    ^^^^^^^^^^^^ entity.name.parameter.scala
+//                  ^^^ support.class
 //                                  ^ - keyword
 
   for {
@@ -531,5 +585,5 @@ object Foo
 //     ^^^ entity.name.parameter
 
    val (Foo, x) = 42
-//      ^^^ support.class.scala
+//      ^^^ support.constant.scala
 //           ^ entity.name.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -602,3 +602,24 @@ type Foo = Bar[A] forSome { type A }
 
 // fubar
 // <- source.scala comment.line.double-slash
+
+new Foo
+//  ^^^ support.class.scala
+
+new (Foo ~> Bar)
+//   ^^^ support.class.scala
+//       ^^ support.type.scala
+//          ^^^ support.class.scala
+
+  class Foo(val bar: Baz) extends AnyVal
+//          ^^^ storage.type.scala
+//                        ^^^^^^^ keyword.declaration.scala
+//                                ^^^^^^ entity.other.inherited-class.scala
+
+  class Foo(implicit bar: Baz) extends AnyVal
+//          ^^^^^^^^ storage.modifier.other
+//                             ^^^^^^^ keyword.declaration.scala
+//                                     ^^^^^^ entity.other.inherited-class.scala
+
+   val Stuff(f1, v1) = ???
+//     ^^^^^ support.constant.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -667,3 +667,11 @@ class Foo[A <% Int]
 
 class Foo[A: Int]
 //         ^ keyword.operator
+
+type Foo <: Bar
+//       ^^ keyword.operator
+//          ^^^ support.class
+
+type Foo >: Bar
+//       ^^ keyword.operator
+//          ^^^ support.class

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -728,3 +728,7 @@ type Foo >: Bar
    a =>42
 // ^ variable.parameter
 //     ^^ constant.numeric.scala
+
+  (a: Int => Boolean) => 42
+//        ^^ support.type
+//           ^^^^^^^ storage.type

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -675,3 +675,49 @@ type Foo <: Bar
 type Foo >: Bar
 //       ^^ keyword.operator
 //          ^^^ support.class
+
+   { a => ??? }
+//   ^ variable.parameter
+
+   { (a, b) => ??? }
+//    ^ variable.parameter
+//       ^ variable.parameter
+
+   { a: Int => ??? }
+//   ^ variable.parameter
+//      ^^^ storage.type.primitive.scala
+
+   { (a: Int, b: Int) => ??? }
+//    ^ variable.parameter
+//       ^^^ storage.type.primitive.scala
+//            ^ variable.parameter
+//               ^^^ storage.type.primitive.scala
+
+   (a) => ???
+//  ^ variable.parameter
+
+   (a, b) => ???
+//  ^ variable.parameter
+//     ^ variable.parameter
+
+   (a: Int) => ???
+//  ^ variable.parameter
+//     ^^^ storage.type.primitive.scala
+
+   (a: Int, b: Int) => ???
+//  ^ variable.parameter
+//     ^^^ storage.type.primitive.scala
+//          ^ variable.parameter
+//             ^^^ storage.type.primitive.scala
+
+   a => ???
+// ^ variable.parameter
+
+   a: Int => ???
+// ^ variable.parameter
+//    ^^^ storage.type.primitive.scala
+
+   case _ if thing =>
+// ^^^^ keyword.other.declaration.scala
+//           ^^^^^ - variable.parameter
+//                 ^^ - storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -737,3 +737,7 @@ type Foo >: Bar
 // ^ variable.parameter
 //    ^^^ support.class
 //           ^^^^^^^ keyword.declaration.scala
+
+"testing /*comments*/"
+//       ^^^^^^^^^^^^ string.quoted.double
+//       ^^^^^^^^^^^^ - comment

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -526,3 +526,10 @@ object Foo
     case Bar.foo => 42
 //           ^^^ - entity.name
   }
+
+   val Foo = 42
+//     ^^^ entity.name.parameter
+
+   val (Foo, x) = 42
+//      ^^^ support.class.scala
+//           ^ entity.name.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -358,18 +358,18 @@ type Foo = Bar[A] forSome { type A }
    override
 // ^^^^^^^^ storage.modifier.other
 
-   ({ type λ[α] = Foo[α] })#λ
-// ^^^^^^^^^^^^^^ comment.block.scala
-//                ^^^ support.class
-//                    ^ comment.block.empty.scala
-//                       ^^^^ comment.block.scala
+   val t: ({ type λ[α] = Foo[α] })#λ
+//        ^^^^^^^^^^^^^^ comment.block.scala
+//                       ^^^ support.class
+//                           ^ comment.block.empty.scala
+//                              ^^^^ comment.block.scala
 
-   ({ type λ[α, β] = Foo[α, β] })#λ
-// ^^^^^^^^^^^^^^^^^ comment.block.scala
-//                   ^^^ support.class
-//                       ^ comment.block.empty.scala
-//                          ^ comment.block.empty.scala
-//                             ^^^^ comment.block.scala
+   val t: ({ type λ[α, β] = Foo[α, β] })#λ
+//        ^^^^^^^^^^^^^^^^^ comment.block.scala
+//                          ^^^ support.class
+//                              ^ comment.block.empty.scala
+//                                 ^ comment.block.empty.scala
+//                                    ^^^^ comment.block.scala
 
    a :: b :: Nil
 // ^^^^^^^^^ source.scala
@@ -644,3 +644,8 @@ type Foo = Foo.Bar
 
 type Foo = Foo#Bar
 //            ^ punctuation.separator
+
+val x: OptionT[({ type λ[α] = Foo[α, Int] })#λ, String] = ???
+//             ^^^^^^^^^^^^^^ comment.block
+//                                ^ comment.block.empty
+//                                        ^^^^ comment.block

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -732,3 +732,8 @@ type Foo >: Bar
   (a: Int => Boolean) => 42
 //        ^^ support.type
 //           ^^^^^^^ storage.type
+
+  (a: Foo[A] forSome { type A }) => 42
+// ^ variable.parameter
+//    ^^^ support.class
+//           ^^^^^^^ keyword.declaration.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -471,7 +471,7 @@ type Foo = Bar[A] forSome { type A }
 
    case object Thingy extends (Foo => Bar)
 // ^^^^ keyword.other.declaration.scala
-//      ^^^^^^ keyword.control.class.scala
+//      ^^^^^^ storage.type.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                             ^^^ support.class

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -721,3 +721,10 @@ type Foo >: Bar
 // ^^^^ keyword.other.declaration.scala
 //           ^^^^^ - variable.parameter
 //                 ^^ - storage.type.function.arrow
+
+   a =>a
+// ^ variable.parameter
+
+   a =>42
+// ^ variable.parameter
+//     ^^ constant.numeric.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -649,3 +649,21 @@ val x: OptionT[({ type λ[α] = Foo[α, Int] })#λ, String] = ???
 //             ^^^^^^^^^^^^^^ comment.block
 //                                ^ comment.block.empty
 //                                        ^^^^ comment.block
+
+class Foo[+A]
+//        ^ keyword.operator
+
+class Foo[-A]
+//        ^ keyword.operator
+
+class Foo[A <: Int]
+//          ^^ keyword.operator
+
+class Foo[A >: Int]
+//          ^^ keyword.operator
+
+class Foo[A <% Int]
+//          ^^ keyword.operator
+
+class Foo[A: Int]
+//         ^ keyword.operator

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -626,3 +626,15 @@ new (Foo ~> Bar)
 
 new Foo(new Foo)
 //      ^^^ keyword.other.scala
+
+new Foo.Bar.Baz
+//     ^ punctuation.separator
+//      ^^^ support.class.scala
+//         ^ punctuation.separator
+//          ^^^ support.class.scala
+
+new Foo#Bar#Baz
+//     ^ punctuation.separator
+//      ^^^ support.class.scala
+//         ^ punctuation.separator
+//          ^^^ support.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -341,13 +341,13 @@ object Foo
 
    case (abc: Foo, cba @ _) =>
 // ^^^^ keyword.other.declaration.scala
-//       ^^^ entity.name.parameter
+//       ^^^ variable.parameter
 //            ^^^ support.class
-//                 ^^^ entity.name.parameter
+//                 ^^^ variable.parameter
 //                       ^ keyword
 
    case abc @ `abc` =>
-//      ^^^ entity.name.parameter
+//      ^^^ variable.parameter
 //          ^ keyword
 //            ^^^^^ - entity.name
 
@@ -437,16 +437,16 @@ object Foo
 // ^^^ keyword.control.flow.scala
 
      a <- _
-//   ^ entity.name.parameter
+//   ^ variable.parameter
 //        ^ - keyword
 
      a ← _
-//   ^ entity.name.parameter
+//   ^ variable.parameter
 //       ^ - entity.name
 
      (b, c @ _) <- _
-//    ^ entity.name.parameter
-//       ^ entity.name.parameter
+//    ^ variable.parameter
+//       ^ variable.parameter
 //         ^ keyword
 //           ^ keyword
 //                 ^ - keyword
@@ -454,54 +454,55 @@ object Foo
 //     ^ - entity.name
 
      testing = _
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
 //             ^ - keyword
 
      testing = {
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
        testing = false
 //     ^^^^^^^ - entity.name
      }
 
      testing = (
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
        testing = false
 //     ^^^^^^^ - entity.name
      )
 
      val testing = 42
 //   ^^^ keyword.declaration.stable.scala
-//       ^^^^^^^ entity.name.parameter
+//       ^^^^^^^ variable.parameter
    } _
 //   ^ - entity.name
 
    for (a <- _; (b, c @ _) ← _; val abc = _) _
 // ^^^ keyword.control.flow.scala
-//      ^ entity.name.parameter
+//      ^ variable.parameter
 //           ^ - keyword
-//               ^ entity.name.parameter
-//                  ^ entity.name.parameter
+//               ^ variable.parameter
+//                  ^ variable.parameter
 //                    ^ keyword
 //                      ^ keyword
 //                           ^ - keyword
 //                              ^^^ storage.type.stable.scala
 //                                  ^^^ entity.name.parameter
+//                                       TODO the above scope needs to be changed
 //                                        ^ - keyword
 //                                           ^ - keyword
 
    for {
      sss <- { {} }
-//   ^^^ entity.name.parameter
+//   ^^^ variable.parameter
      qqq <- stuff
-//   ^^^ entity.name.parameter
+//   ^^^ variable.parameter
    }
 
    for {
      back <- Traverse[Option]
-//   ^^^^ entity.name.parameter
+//   ^^^^ variable.parameter
 //           ^^^^^^^^ support.class
 //                    ^^^^^^ support.class
-       .traverse[Free, Stuff](res) { r =>
+       .traverse[Free, Stuff](res) { r => }
 //      ^^^^^^^^ - entity.name
 //                            ^^^ - entity.name
 //                                   ^ - entity.name
@@ -509,6 +510,7 @@ object Foo
 
 
   val baseSettings: Seq[Def.Setting[_]] = _
+//    ^^^^^^^^^^^^ entity.name.parameter.scala
 //                                  ^ - keyword
 
   for {


### PR DESCRIPTION
Dependent on #561 

More or less mirrors the JavaScript highlighting.  For example:

```scala
xs map { x => x + 1 }
```

The `x` to the left of the `=>` is highlighted as `variable.parameter` (it's the parameter to the lambda), while `=>` is highlighted as `storage.type.function.arrow`, which mirrors JavaScript.  I thought about using a different scope here, since the scoping guidelines are a bit unclear on this point, but in practice this one seems to work extremely well.  I also considered changing the scope of the `=>` in `case ... =>` expressions to *also* be `support.type.function.arrow`, which wouldn't necessarily be inaccurate (though `case` does not really define a lambda), but in practice the different scoping actually helps a *ton* in reading code.  I was actually really surprised at the difference this makes.

Due to the way the lookahead works, the `=>` must be on the same line as the lambda parameters, which is very definitely idiomatic and far and away the most common way to write Scala.

This PR also adjusts a few pre-existing regexes that dealt with operator lookaround, notably the type prefix identification in #561.  Due to the fact that lambda parameter blocks introduce a new delimited type expression scope, this PR is inextricably dependent on #561.

I also moved comments into the prototype section, sort of randomly.  I was tired of including them everywhere.  There might be one or two lingering issues from this, but I think I got them all.