### PR TITLE
[Scala] Significant Improvements

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -7,26 +7,51 @@ file_extensions:
   - sbt
 scope: source.scala
 variables:
-  # lookahead/behind for operators
-  oplookbehind: '(?<=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
-  oplookahead: '(?=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
+  # lookaround for operators
+  nonopchar: '[[[:alpha:]]0-9\s\(\)\[\]\{\}]'
   # From http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html
   disallowed_as_operator: '[^\w\[\]\(\)\{\}''";,.`_\s]'
   operator_character: '[\p{Sm}\p{So}[{{disallowed_as_operator}}&&[\x20-\x7F]]]'
   upper: '[$_\p{Lu}]'
   # This is "letter", but without _ so we can ensure it is not last
   idcont: '[$\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{Nl}0-9]'
-  op: '(?:{{operator_character}}+)'
+
+  # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #}
+  op: |-
+    (?x:
+      [[^:=<@←⇒#]&&{{operator_character}}]+|
+      =[[^>]&&{{operator_character}}]+|
+      =>{{operator_character}}+|
+      <[[^\-]&&{{operator_character}}]+|
+      <-{{operator_character}}+|
+      [:@←⇒#]{{operator_character}}+
+    )
+
+  # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #, <%, <:, :<, +, -}
+  typeop: |-
+    (?x:
+      [[^:=<@←⇒#+\-]&&{{operator_character}}]+|
+      =[[^>]&&{{operator_character}}]+|
+      =>{{operator_character}}+|
+      <[[^\-%:]&&{{operator_character}}]+|
+      <-{{operator_character}}+|
+      :[^<]{{operator_character}}+|
+      :<{{operator_character}}+|
+      [@←⇒#+\-]{{operator_character}}+
+    )
+
   idrest: '(?:(?:{{idcont}}|_(?=[^{{operator_character}}]))*(?:_{{op}})?)'
   varid: '(?:\p{Ll}{{idrest}})'
   boundvarid: '(?:`{{varid}}`|{{varid}})'
   plainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{op}})'
+  typeplainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{typeop}})'
   id: '(?:{{plainid}}|`[^`]+`)'
+  typeid: '(?:{{typeplainid}}|`[^`]+`)'
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   rightarrow: '=>|⇒'
   upperid: '(?:\b\p{Lu}{{idrest}})'
-  typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
+  typeprefix: '(:)\s*'
   # hack to cover up to three levels of nested parentheses
   withinparens: '\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\)'
 
@@ -52,6 +77,8 @@ contexts:
     - include: keywords
     - include: imports
     - include: strings
+    - include: xml-literal
+    - include: operators
     - include: initialization
     - include: ascription
   main-post-lambdas:
@@ -60,7 +87,6 @@ contexts:
     - include: scala-symbol
     - include: empty-parentheses
     - include: braces
-    - include: xml-literal
     - include: late-keywords
 
   block-comments:
@@ -105,9 +131,8 @@ contexts:
   lambdas:
     - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
-        - match: '{{oplookbehind}}({{rightarrow}}){{oplookahead}}'
-          captures:
-            1: storage.type.function.arrow.scala
+        - match: '{{rightarrow}}'
+          scope: storage.type.function.arrow.scala
           pop: true
         - include: lambda-declaration
   lambda-declaration-base:
@@ -131,7 +156,7 @@ contexts:
   lambda-declaration:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?={{oplookbehind}}({{rightarrow}}){{oplookahead}})'
+        - match: '(?={{nonopchar}}({{rightarrow}}){{nonopchar}})'
           pop: true
         - include: delimited-type-expression
     - include: lambda-declaration-base
@@ -177,7 +202,7 @@ contexts:
             - match: '\]'
               pop: true
             - include: delimited-type-expression
-        - match: '{{oplookbehind}}(<:|>:){{oplookahead}}'
+        - match: '(<:|>:)'
           scope: keyword.operator
           set:
             - match: '(?=[\n\}\)\]])'
@@ -392,6 +417,12 @@ contexts:
           pop: true
         - include: delimited-type-expression
 
+  # we need to greedily capture operators to prevent (e.g.) :: being matched as an ascription
+  # it would be incorrect to scope operators specially, since they are just identifiers
+  # by pulling them out HERE though and refusing to scope them, we emulate lookbehind
+  operators:
+    - match: '{{op}}'   # no explicit scope, just pulling it out
+
   initialization:
     - match: '\b(new)(?:\s+|\b)'
       captures:
@@ -465,7 +496,7 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
-    - match: '{{oplookbehind}}(=){{oplookahead}}'
+    - match: '='
       scope: keyword.operator.assignment.scala
 
   late-keywords:
@@ -685,8 +716,10 @@ contexts:
         - match: \}
           pop: true
         - include: declarations
+    - match: =>|⇒
+      scope: keyword.operator.arrow.scala
   type-constraints:
-    - match: '{{oplookbehind}}(<:|>:|<%|\+|-|:){{oplookahead}}'
+    - match: '<:|>:|<%|\+|-|:'
       scope: keyword.operator.scala
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas
@@ -699,7 +732,7 @@ contexts:
     - match: '{{upperid}}'
       scope: support.class.scala
     - match: _
-    - match: '{{id}}'
+    - match: '{{typeid}}'
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
@@ -713,7 +746,7 @@ contexts:
     - match: '{{upperid}}'
       scope: support.class.scala
       set: single-type-expression-tail
-    - match: '{{id}}'
+    - match: '{{typeid}}'
       scope: support.type.scala
       set: single-type-expression-tail
     - include: base-type-expression

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -47,6 +47,7 @@ variables:
   plainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{op}})'
   typeplainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{typeop}})'
   id: '(?:{{plainid}}|`[^`]+`)'
+  idorunder: '(?:{{id}}|_)'
   typeid: '(?:{{typeplainid}}|`[^`]+`)'
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
@@ -130,7 +131,7 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=(_|{{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{idorunder}}|{{idorunder}}\s*:\s*{{idorunder}}|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{rightarrow}}'
           scope: storage.type.function.arrow.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -557,6 +557,10 @@ contexts:
       scope: keyword.operator.assignment.scala
     - match: '_'
       scope: variable.language.scala
+    - match: '\.'
+      scope: punctuation.accessor.scala
+    - match: ','
+      scope: punctuation.separator.scala
 
   nest-curly-and-self:
     - match: '\{'
@@ -687,6 +691,8 @@ contexts:
       scope: keyword.operator.other.scala
     - match: '_'
       scope: variable.language.scala
+    - match: ','
+      scope: punctuation.separator.scala
   val-pattern-match:
     - match: '{{upperid}}(?=[\s=])'
       scope: entity.name.parameter.scala
@@ -747,6 +753,8 @@ contexts:
       scope: keyword.operator.other.scala
     - match: '_'
       scope: variable.language.scala
+    - match: ','
+      scope: punctuation.separator.scala
 
   base-type-expression:
     - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -200,6 +200,7 @@ contexts:
       push: function-tparams-brackets
     - match: '\]'
       pop: true
+    - include: type-constraints
     - include: delimited-type-expression
 
   function-parameter-list:
@@ -246,6 +247,7 @@ contexts:
       pop: true
     - match: this
       scope: variable.language.scala
+    - include: type-constraints
     - include: delimited-type-expression
 
   class-parameter-list:
@@ -566,7 +568,7 @@ contexts:
       push:
         - match: \]
           pop: true
-        - include: main
+        - include: delimited-type-expression
     - match: '@|_'
       scope: keyword.other.scala
 
@@ -593,6 +595,9 @@ contexts:
         - match: \}
           pop: true
         - include: main
+  type-constraints:
+    - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:|<%|\+|-|:)(?=[a-zA-Z0-9\s\)\]\}])'
+      scope: keyword.operator
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -227,7 +227,7 @@ contexts:
         1: storage.type.scala
         2: entity.name.type.scala
       push:
-        - match: '(?=[\n\}\)\]])'
+        - match: '(?=[\n;\}\)\]])'
           pop: true
         - match: '\['
           push:
@@ -243,7 +243,7 @@ contexts:
         - match: '='
           scope: keyword.operator.assignment.scala
           set:
-            - match: '(?=[\n\}\)\]])'
+            - match: '(?=[\n;\}\)\]])'
               pop: true
             - include: delimited-type-expression
     - match: '\b(var)\s+({{id}})'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -108,7 +108,7 @@ contexts:
       scope: constant.character.literal.scala
 
   comments:
-    - match: (//).*$\n?
+    - match: (//).*$
       scope: comment.line.double-slash.scala
       captures:
         1: punctuation.definition.comment.scala
@@ -118,7 +118,7 @@ contexts:
       scope: punctuation.definition.comment.scala
       push:
         - meta_scope: comment.block.documentation.scala
-        - match: \*/(\s*\n)?
+        - match: \*/\s*$
           scope: punctuation.definition.comment.scala
           pop: true
         - match: (@\w+\s)
@@ -314,12 +314,10 @@ contexts:
       push: function-tparams-brackets
     - match: ':'
       push:
-        - match: '(?=[\B\s]=[\B\s])'
+        - match: '(?=[\{\};\n]|{{nonopchar}}={{nonopchar}})'
           pop: true
         - include: delimited-type-expression
-        - match: '(?=[\{\n])'
-          pop: true
-    - match: '(?=[\{=\n])'
+    - match: '(?=[\{\};\n]|{{nonopchar}}={{nonopchar}})'
       pop: true
 
   function-tparams-brackets:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -106,23 +106,30 @@ contexts:
             1: storage.type.function.arrow.scala
           pop: true
         - include: lambda-declaration
-  lambda-declaration:
+  lambda-declaration-base:
     - match: \(
       push:
         - match: \)
           pop: true
-        - include: lambda-declaration
+        - include: lambda-declaration-parens
+    - match: '{{id}}'
+      scope: variable.parameter
+  lambda-declaration-parens:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
-          pop: true
         - match: ','
           pop: true
         - match: '(?=\))'
           pop: true
         - include: delimited-type-expression
-    - match: '{{id}}'
-      scope: variable.parameter
+    - include: lambda-declaration-base
+  lambda-declaration:
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+          pop: true
+        - include: delimited-type-expression
+    - include: lambda-declaration-base
 
   base-types:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -521,8 +521,6 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
-    - match: '='
-      scope: keyword.operator.assignment.scala
 
   late-keywords:
     - match: \b(extends|with|forSome)\b
@@ -537,6 +535,8 @@ contexts:
       scope: storage.type.volatile.scala
     - match: \b(package)\b
       scope: keyword.control.scala
+    - match: '='
+      scope: keyword.operator.assignment.scala
 
   nest-curly-and-self:
     - match: '\{'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -490,11 +490,13 @@ contexts:
   strings:
     - match: '"""'
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.triple.scala
         - match: '"""(?!")'
           pop: true
     - match: (?<!\\)"
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.scala
         - match: '"'
           pop: true
@@ -506,6 +508,7 @@ contexts:
       captures:
         1: support.function.scala
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.triple.interpolated.scala
         - match: '"""(?!")'
           pop: true
@@ -514,6 +517,7 @@ contexts:
       captures:
         1: support.function.scala
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.interpolated.scala
         - match: '"'
           pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -828,4 +828,4 @@ contexts:
       scope: punctuation.accessor.scala
       set: single-type-expression
     - match: '(?=\S)'
-      pop: true
+      set: try-dispatch       # this is needed for initialization (new ...) and doesn't HURT elsewhere

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -121,6 +121,7 @@ contexts:
     - match: '{{typeprefix}}'
       push:
         - match: ','
+          scope: punctuation.separator.scala
           pop: true
         - match: '(?=\))'
           pop: true
@@ -182,6 +183,7 @@ contexts:
               pop: true
             - include: delimited-type-expression
         - match: '='
+          scope: keyword.operator.assignment.scala
           set:
             - match: '(?=[\n\}\)\]])'
               pop: true
@@ -220,9 +222,11 @@ contexts:
             1: keyword.control.flow.scala
           set:
             - match: '=>|⇒'
+              scope: keyword.other.arrow.scala
               pop: true
             - include: main-no-lambdas
         - match: '=>|⇒'
+          scope: keyword.other.arrow.scala
           pop: true
           captures:
             1: keyword.control.flow.scala
@@ -282,10 +286,12 @@ contexts:
                 - match: '(?=[=\)])'
                   pop: true
                 - match: ','
+                  scope: punctuation.separator.scala
                   pop: true
                 - include: delimited-type-expression
         - include: main
     - match: ':'
+      scope: punctuation.separator.scala
       push:
         - match: '(?=[\B\s]=[\B\s])'
           pop: true
@@ -310,7 +316,7 @@ contexts:
       push: class-tparams-brackets
     - match: '\]'
       pop: true
-    - match: this
+    - match: '\b(this|super)\b'
       scope: variable.language.scala
     - include: type-constraints
     - include: delimited-type-expression
@@ -331,6 +337,7 @@ contexts:
                 - match: '(?=[=\)])'
                   pop: true
                 - match: ','
+                  scope: punctuation.separator.scala
                   pop: true
                 - include: delimited-type-expression
         - include: main
@@ -385,7 +392,7 @@ contexts:
         - include: delimited-type-expression
 
   initialization:
-    - match: '\b(new)\s+'
+    - match: '\b(new)(?:\s+|\b)'
       captures:
         1: keyword.other.scala
       push: single-type-expression
@@ -411,6 +418,7 @@ contexts:
         - match: '^\s*(val)\s+'
           scope: keyword.declaration.stable.scala
         - match: <-|←|=
+          scope: keyword.operator.assignment.scala
           pop: true
         - include: pattern-match
     - match: '\{'
@@ -426,6 +434,7 @@ contexts:
     - include: main
   for-parens-body:
     - match: '<-|←|='
+      scope: keyword.operator.assignment.scala
       push:
         - match: ;
           pop: true
@@ -455,6 +464,8 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
+    - match: '{{oplookbehind}}(=){{oplookahead}}'
+      scope: keyword.operator.assignment.scala
 
   late-keywords:
     - match: \b(extends|with|forSome)\b
@@ -469,8 +480,6 @@ contexts:
       scope: storage.type.volatile.scala
     - match: \b(package)\b
       scope: keyword.control.scala
-    - match: \b(new)\b
-      scope: keyword.other.scala
 
   nest-curly-and-self:
     - match: '\{'
@@ -577,11 +586,17 @@ contexts:
     - include: strings
     - include: xml-literal
     - match: '`'
+      scope: punctuation.definition.identifier.scala
       push:
         - match: '`'
+          scope: punctuation.definition.identifier.scala
           pop: true
-    - match: '{{varid}}\.'
-    - match: '\.{{varid}}'
+    - match: '{{varid}}(\.)'
+      captures:
+        1: punctuation.accessor.scala
+    - match: '(\.){{varid}}'
+      captures:
+        1: punctuation.accessor.scala
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
     - match: \[
@@ -589,11 +604,13 @@ contexts:
         - match: \]
           pop: true
         - include: main
-    - match: '@|_'
-      scope: keyword.other.scala
+    - match: '@'
+      scope: keyword.operator.scala
+    - match: '_'
+      scope: variable.language.scala
   val-pattern-match:
     - match: '{{upperid}}(?=[\s=])'
-      scope: entity.name.parameter
+      scope: entity.name.parameter.scala
     - match: '{{typeprefix}}'
       push:
         - match: '(?=[\B\s]=[\B\s])'
@@ -620,11 +637,17 @@ contexts:
     - include: strings
     - include: xml-literal
     - match: '`'
+      scope: punctuation.definition.identifier.scala
       push:
         - match: '`'
+          scope: punctuation.definition.identifier.scala
           pop: true
-    - match: '{{varid}}\.'
-    - match: '\.{{varid}}'
+    - match: '{{varid}}(\.)'
+      captures:
+        1: punctuation.accessor.scala
+    - match: '(\.){{varid}}'
+      captures:
+        1: punctuation.accessor.scala
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
     - include: ascription
@@ -633,8 +656,10 @@ contexts:
         - match: \]
           pop: true
         - include: delimited-type-expression
-    - match: '@|_'
-      scope: keyword.other.scala
+    - match: '@'
+      scope: keyword.operator.scala
+    - match: '_'
+      scope: variable.language.scala
 
   base-type-expression:
     - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
@@ -658,15 +683,15 @@ contexts:
       push:
         - match: \}
           pop: true
-        - include: main
+        - include: declarations
   type-constraints:
     - match: '{{oplookbehind}}(<:|>:|<%|\+|-|:){{oplookahead}}'
-      scope: keyword.operator
+      scope: keyword.operator.scala
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala
     - match: '[\.#]'
-      scope: punctuation.separator
+      scope: punctuation.accessor.scala
     - include: base-types
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala
@@ -695,8 +720,7 @@ contexts:
       pop: true
   single-type-expression-tail:
     - match: '[\.#]'
-      scope: punctuation.separator
+      scope: punctuation.accessor.scala
       set: single-type-expression
-    - match: '\s+'
-    - match: '(?=.)'
+    - match: '(?=\S)'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -260,6 +260,8 @@ contexts:
       push:
         - match: '\)'
           pop: true
+        - match: '\b(val)\b'
+          scope: storage.type.scala
         - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
@@ -324,10 +326,10 @@ contexts:
         - include: delimited-type-expression
 
   initialization:
-    - match: '\b(new)\s+({{id}})'
+    - match: '\b(new)\s+'
       captures:
         1: keyword.other.scala
-        2: entity.name.class.scala
+      push: single-type-expression
 
   for-comprehension:
     - match: '\b(for)\s*\{'
@@ -529,7 +531,7 @@ contexts:
     - match: '@|_'
       scope: keyword.other.scala
   val-pattern-match:
-    - match: '{{upperid}}'
+    - match: '{{upperid}}(?=[\s=])'
       scope: entity.name.parameter
     - match: '{{typeprefix}}'
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -636,7 +636,6 @@ contexts:
 
   val-pattern-match-main:
     - include: keywords
-    - include: ascription
     - include: constants
     - include: char-literal
     - include: scala-symbol
@@ -661,6 +660,7 @@ contexts:
         - match: \]
           pop: true
         - include: main
+    - match: '{{op}}'     # let it fall through
     - match: '@'
       scope: keyword.operator.scala
     - match: '_'
@@ -707,6 +707,7 @@ contexts:
         1: punctuation.accessor.scala
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
+    - match: '{{op}}'   # let it fall through
     - include: ascription
     - match: \(
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -280,11 +280,11 @@ contexts:
             1: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
-              scope: keyword.other.arrow.scala
+              scope: keyword.operator.arrow.scala
               pop: true
             - include: main-no-lambdas
         - match: '{{rightarrow}}'
-          scope: keyword.other.arrow.scala
+          scope: keyword.operator.arrow.scala
           pop: true
           captures:
             1: keyword.control.flow.scala
@@ -427,10 +427,10 @@ contexts:
             - match: '({{id}})\s*({{rightarrow}})\s*({{id}})'
               captures:
                 1: variable.import.renamed-from.scala
-                2: keyword.other.arrow.scala
+                2: keyword.operator.arrow.scala
                 3: variable.import.renamed-to.scala
             - match: '{{rightarrow}}'
-              scope: keyword.other.arrow.scala
+              scope: keyword.operator.arrow.scala
             - match: '{{id}}'
               scope: variable.import.scala
             - match: '_'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -12,7 +12,7 @@ variables:
   # From http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html
   disallowed_as_operator: '[^\w\[\]\(\)\{\}''";,.`_\s]'
   operator_character: '[\p{Sm}\p{So}[{{disallowed_as_operator}}&&[\x20-\x7F]]]'
-  upper: '[$_\p{Lu}]'
+  upper: '[$\p{Lu}]'
   # This is "letter", but without _ so we can ensure it is not last
   idcont: '[$\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{Nl}0-9]'
 
@@ -40,8 +40,9 @@ variables:
       [@←⇒#+\-]{{operator_character}}+
     )
 
-  idrest: '(?:(?:{{idcont}}|_(?=[^{{operator_character}}]))*(?:_{{op}})?)'
-  varid: '(?:\p{Ll}{{idrest}})'
+  idrest: '(?:(?:{{idcont}}|_(?=[^{{operator_character}}]))*(?:_{{operator_character}}+)?)'
+  # an id that starts with lower-case OR underscore
+  varid: '(?:(?:\p{Ll}|_+(?={{idcont}})){{idrest}})'
   boundvarid: '(?:`{{varid}}`|{{varid}})'
   plainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{op}})'
   typeplainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{typeop}})'
@@ -87,6 +88,7 @@ contexts:
     - include: char-literal
     - include: scala-symbol
     - include: braces
+    - include: late-operators
 
   block-comments:
     - match: /\*
@@ -539,6 +541,11 @@ contexts:
       scope: storage.type.volatile.scala
     - match: \b(package)\b
       scope: keyword.control.scala
+
+  late-operators:
+    # catch all valid identifiers and let them fall through
+    # this prevents mixed operator identifiers from being partially highlighted
+    - match: '{{id}}'
     - match: '='
       scope: keyword.operator.assignment.scala
     - match: '_'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -144,7 +144,9 @@ contexts:
           pop: true
         - include: lambda-declaration-parens
     - match: '{{id}}'
-      scope: variable.parameter
+      scope: variable.parameter.scala
+    - match: '_'
+      scope: variable.language.scala
   lambda-declaration-parens:
     - match: '{{typeprefix}}'
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -98,10 +98,10 @@ contexts:
 
   lambdas:
     # can't use a variable for this match either?
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[\s\B])'
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
         # strangely, we can't use a variable for this match
-        - match: '(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}])'
+        - match: '(?<=[[[:alpha:]]0-9\s\)\]\}])(=>)(?=[[[:alpha:]]0-9\s\)\]\}])'
           captures:
             1: storage.type.function.arrow.scala
           pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -34,8 +34,8 @@ variables:
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
       <[[^\-%:]&&{{operator_character}}]+|
-      <-{{operator_character}}+|
-      :[^<]{{operator_character}}+|
+      <[:%\-]{{operator_character}}+|
+      :[[^<]&&{{operator_character}}]+|
       :<{{operator_character}}+|
       [@←⇒#+\-]{{operator_character}}+
     )
@@ -309,12 +309,14 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[=\)])'
+                - match: '(?=\))'
                   pop: true
                 - match: ','
                   scope: punctuation.separator.scala
                   pop: true
                 - include: delimited-type-expression
+                - match: '(?=[=])'
+                  pop: true
         - include: main
     - match: ':'
       scope: punctuation.separator.scala
@@ -360,12 +362,14 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[=\)])'
+                - match: '(?=\))'
                   pop: true
                 - match: ','
                   scope: punctuation.separator.scala
                   pop: true
                 - include: delimited-type-expression
+                - match: '(?=[=])'
+                  pop: true
         - include: main
     - match: '(?=([\{\n]|extends))'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -123,6 +123,12 @@ contexts:
             - match: '\]'
               pop: true
             - include: delimited-type-expression
+        - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:)(?=[a-zA-Z0-9\s\)\]\}])'
+          scope: keyword.operator
+          set:
+            - match: '(?=[\n\}\)\]])'
+              pop: true
+            - include: delimited-type-expression
         - match: '='
           set:
             - match: '(?=[\n\}\)\]])'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -24,6 +24,7 @@ variables:
   id: '(?:{{plainid}}|`[^`]+`)'
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
+  rightarrow: '=>|⇒'
   upperid: '(?:\b\p{Lu}{{idrest}})'
   typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
   # hack to cover up to three levels of nested parentheses
@@ -102,9 +103,9 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*=>[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
-        - match: '{{oplookbehind}}(=>){{oplookahead}}'
+        - match: '{{oplookbehind}}({{rightarrow}}){{oplookahead}}'
           captures:
             1: storage.type.function.arrow.scala
           pop: true
@@ -130,7 +131,7 @@ contexts:
   lambda-declaration:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?={{oplookbehind}}(=>){{oplookahead}})'
+        - match: '(?={{oplookbehind}}({{rightarrow}}){{oplookahead}})'
           pop: true
         - include: delimited-type-expression
     - include: lambda-declaration-base
@@ -221,11 +222,11 @@ contexts:
           captures:
             1: keyword.control.flow.scala
           set:
-            - match: '=>|⇒'
+            - match: '{{rightarrow}}'
               scope: keyword.other.arrow.scala
               pop: true
             - include: main-no-lambdas
-        - match: '=>|⇒'
+        - match: '{{rightarrow}}'
           scope: keyword.other.arrow.scala
           pop: true
           captures:
@@ -368,7 +369,7 @@ contexts:
             - match: |-
                 (?x) \s*
                 				([^\s.,}]+) \s*
-                				(=>) \s*
+                				({{rightarrow}}) \s*
                 				([^\s.,}]+) \s*
 
               captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -626,13 +626,13 @@ contexts:
     - match: '\$\{'
       scope: punctuation.definition.expression.scala
       push:
-        - meta_content_scope: source.scala.embedded
         - match: '\}'
           scope: punctuation.definition.expression.scala
           pop: true
         - match: ''
           push:
             - clear_scopes: 1
+            - meta_content_scope: source.scala.embedded
             - match: (?=\})
               pop: true
             - include: nest-curly-and-self

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -7,6 +7,9 @@ file_extensions:
   - sbt
 scope: source.scala
 variables:
+  # lookahead/behind for operators
+  oplookbehind: '(?<=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
+  oplookahead: '(?=[[[:alpha:]]0-9\s\(\)\[\]\{\}])'
   # From http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html
   disallowed_as_operator: '[^\w\[\]\(\)\{\}''";,.`_\s]'
   operator_character: '[\p{Sm}\p{So}[{{disallowed_as_operator}}&&[\x20-\x7F]]]'
@@ -22,7 +25,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
-  typeprefix: '(?<=[[[:alpha:]]0-9\s\)\]\}])(:)(?=[[[:alpha:]]0-9\s\)\]\}])\s*'
+  typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
 
 contexts:
   prototype:
@@ -97,11 +100,9 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    # can't use a variable for this match either?
     - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
-        # strangely, we can't use a variable for this match
-        - match: '(?<=[[[:alpha:]]0-9\s\)\]\}])(=>)(?=[[[:alpha:]]0-9\s\)\]\}])'
+        - match: '{{oplookbehind}}(=>){{oplookahead}}'
           captures:
             1: storage.type.function.arrow.scala
           pop: true
@@ -126,7 +127,7 @@ contexts:
   lambda-declaration:
     - match: '{{typeprefix}}'
       push:
-        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+        - match: '(?={{oplookbehind}}(=>){{oplookahead}})'
           pop: true
         - include: delimited-type-expression
     - include: lambda-declaration-base
@@ -170,7 +171,7 @@ contexts:
             - match: '\]'
               pop: true
             - include: delimited-type-expression
-        - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:)(?=[a-zA-Z0-9\s\)\]\}])'
+        - match: '{{oplookbehind}}(<:|>:){{oplookahead}}'
           scope: keyword.operator
           set:
             - match: '(?=[\n\}\)\]])'
@@ -655,7 +656,7 @@ contexts:
           pop: true
         - include: main
   type-constraints:
-    - match: '(?<=[a-zA-Z0-9\s\)\[\]\}])(<:|>:|<%|\+|-|:)(?=[a-zA-Z0-9\s\)\]\}])'
+    - match: '{{oplookbehind}}(<:|>:|<%|\+|-|:){{oplookahead}}'
       scope: keyword.operator
   delimited-type-expression:
     - match: "[αβ]"     # just here for type lambdas

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -237,7 +237,7 @@ contexts:
               pop: true
             - include: delimited-type-expression
         - match: '(<:|>:)'
-          scope: keyword.operator
+          scope: keyword.operator.bound.scala
           set:
             - match: '(?=[\n\}\)\]])'
               pop: true
@@ -793,7 +793,7 @@ contexts:
       scope: keyword.operator.varargs.scala
   type-constraints:
     - match: '<:|>:|<%|\+|-|:'
-      scope: keyword.operator.scala
+      scope: keyword.operator.bound.scala
   delimited-type-expression:
     - match: '\b(type)\b'
       scope: keyword.other.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -541,6 +541,8 @@ contexts:
       scope: keyword.control.scala
     - match: '='
       scope: keyword.operator.assignment.scala
+    - match: '_'
+      scope: variable.language.scala
 
   nest-curly-and-self:
     - match: '\{'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -82,12 +82,11 @@ contexts:
     - include: initialization
     - include: ascription
   main-post-lambdas:
+    - include: late-keywords
     - include: constants
     - include: char-literal
     - include: scala-symbol
-    - include: empty-parentheses
     - include: braces
-    - include: late-keywords
 
   block-comments:
     - match: /\*
@@ -165,8 +164,6 @@ contexts:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
   constants:
-    - match: '(?<![[[:alpha:]]0-9`\)])\(\)'
-      scope: constant.language.scala
     - match: \b(false|null|true|Nil|None)\b
       scope: constant.language.scala
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
@@ -177,6 +174,19 @@ contexts:
     # other upper-case stuff highlights as constant
     - match: '{{upperid}}'
       scope: support.constant.scala
+      push: try-dispatch
+    - match: '(?={{id}}\()'
+      push: try-dispatch
+    - match: '\(\)'
+      scope: constant.language.scala
+  try-dispatch:
+    - match: '(?:{{id}})?\('
+      push:
+        - match: \)
+          pop: true
+        - include: main
+    - match: '(?=[\S\n;])'
+      pop: true
 
   declarations:
     - match: '\b(def)\s+({{id}})'
@@ -373,10 +383,6 @@ contexts:
         - include: main
     - match: '(?=([\{\n]|extends))'
       pop: true
-
-  empty-parentheses:
-    - match: \(\)
-      scope: meta.parentheses.scala
 
   imports:
     - match: \b(import)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -175,16 +175,21 @@ contexts:
     - match: '{{upperid}}'
       scope: support.constant.scala
       push: try-dispatch
-    - match: '(?={{id}}\()'
+    - match: '{{id}}(?=[\(\[])'
       push: try-dispatch
     - match: '\(\)'
       scope: constant.language.scala
   try-dispatch:
-    - match: '(?:{{id}})?\('
+    - match: '\('
       push:
         - match: \)
           pop: true
         - include: main
+    - match: '\['
+      push:
+        - match: \]
+          pop: true
+        - include: delimited-type-expression
     - match: '(?=[\S\n;])'
       pop: true
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -121,7 +121,7 @@ contexts:
       push:
         - match: '(?=[=\n])'
           pop: true
-        - include: pattern-match
+        - include: val-pattern-match
     - match: '\b(package)\s+(object)\s+({{id}})'
       captures:
         1: keyword.control.scala
@@ -427,7 +427,7 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
-  pattern-match:
+  val-pattern-match:
     - include: comments
     - include: block-comments
     - include: keywords
@@ -444,6 +444,32 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: main
+    - match: '@|_'
+      scope: keyword.other.scala
+  pattern-match:
+    - include: comments
+    - include: block-comments
+    - include: keywords
+    - include: constants
+    - include: char-literal
+    - include: scala-symbol
+    - include: strings
+    - include: xml-literal
+    - match: '`'
+      push:
+        - match: '`'
+          pop: true
+    - match: '{{varid}}\.'
+    - match: '\.{{varid}}'
+    - match: '\b{{varid}}'
+      scope: variable.parameter.scala   # not indexed!
     - match: '{{upperid}}'
       scope: support.class.scala
     - match: \[

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -379,33 +379,29 @@ contexts:
       scope: meta.parentheses.scala
 
   imports:
-    - match: \b(import)\s+
-      captures:
-        1: keyword.other.import.scala
+    - match: \b(import)\b
+      scope: keyword.other.import.scala
       push:
         - meta_scope: meta.import.scala
-        - match: '(?<=[\n;])'
+        - match: '(?=[\n;])'
           pop: true
-        - match: '([^\s{;.]+)\s*\.\s*'
+        - match: '(?:{{id}}\.)+{{id}}?'
           scope: variable.package.scala
-        - match: '([^\s{;.]+)\s*'
+        - match: '{{id}}'
           scope: variable.import.scala
         - match: "{"
           push:
             - meta_scope: meta.import.selector.scala
             - match: "}"
               pop: true
-            - match: |-
-                (?x) \s*
-                				([^\s.,}]+) \s*
-                				({{rightarrow}}) \s*
-                				([^\s.,}]+) \s*
-
+            - match: '({{id}})\s*({{rightarrow}})\s*({{id}})'
               captures:
                 1: variable.import.renamed-from.scala
                 2: keyword.other.arrow.scala
                 3: variable.import.renamed-to.scala
-            - match: '([^\s.,}]+)'
+            - match: '{{rightarrow}}'
+              scope: keyword.other.arrow.scala
+            - match: '{{id}}'
               scope: variable.import.scala
 
   inheritance:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -417,6 +417,8 @@ contexts:
           scope: variable.package.scala
         - match: '{{id}}'
           scope: variable.import.scala
+        - match: '_'
+          scope: variable.language.scala
         - match: "{"
           push:
             - meta_scope: meta.import.selector.scala
@@ -431,6 +433,8 @@ contexts:
               scope: keyword.other.arrow.scala
             - match: '{{id}}'
               scope: variable.import.scala
+            - match: '_'
+              scope: variable.language.scala
 
   inheritance:
     - match: '\b(extends|with)\s+([^\s\{\(\[\]]+)'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,6 +22,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
+  typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
 
 contexts:
   main:
@@ -35,15 +36,15 @@ contexts:
     - include: block-comments
     - include: strings
     - include: initialization
+    - include: ascription
     - include: constants
     - include: char-literal
     - include: scala-symbol
     - include: empty-parentheses
     - include: braces
-    - include: parameter-list
-    - include: qualifiedClassName
     - include: xml-literal
     - include: late-keywords
+
   block-comments:
     - match: /\*
       push:
@@ -59,6 +60,7 @@ contexts:
   char-literal:
     - match: '''\\?.'''
       scope: constant.character.literal.scala
+
   comments:
     - match: (//).*$\n?
       scope: comment.line.double-slash.scala
@@ -77,6 +79,14 @@ contexts:
           scope: keyword.other.documentation.scaladoc.scala
         - match: '\{@link\s+[^\}]*\}'
           scope: keyword.other.documentation.scaladoc.link.scala
+
+  ascription:
+    - match: '{{typeprefix}}'
+      push: single-type-expression
+
+  base-types:
+    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+      scope: storage.type.primitive.scala
   constants:
     - match: \b(false|null|true|Nil|None)\b
       scope: constant.language.scala
@@ -84,8 +94,11 @@ contexts:
       scope: constant.numeric.scala
     - match: \b(this|super)\b
       scope: variable.language.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
-      scope: storage.type.primitive.scala
+    - include: base-types
+    # other upper-case stuff highlights as constant
+    - match: '{{upperid}}'
+      scope: support.constant.scala
+
   declarations:
     - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
       scope: comment.block.scala
@@ -93,9 +106,7 @@ contexts:
         - match: '\}\)#λ'
           scope: comment.block.scala
           pop: true
-        - match: "[αβ]"
-          scope: comment.block.empty.scala
-        - include: main
+        - include: delimited-type-expression
     - match: '\b(def)\s+({{id}})'
       captures:
         1: storage.type.function.scala
@@ -111,6 +122,14 @@ contexts:
       captures:
         1: storage.type.scala
         2: entity.name.type.scala
+      push:
+        - match: '\n'
+          pop: true
+        - match: '='
+          set:
+            - match: '\n'
+              pop: true
+            - include: delimited-type-expression
     - match: '\b(var)\s+({{id}})'
       captures:
         1: storage.type.volatile.scala
@@ -145,7 +164,13 @@ contexts:
           captures:
             1: keyword.control.flow.scala
         - include: pattern-match
+
   braces:
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: delimited-type-expression
     - match: \(
       push:
         - match: \)
@@ -156,35 +181,56 @@ contexts:
         - match: \}
           pop: true
         - include: main
+
   function-type-parameter-list:
     - match: '(?=\()'
       set: function-parameter-list
     - match: '\['
       push: function-tparams-brackets
-    - match: '(?=[:\{=\n])'
+    - match: ':'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
+    - match: '(?=[\{=\n])'
       pop: true
+
   function-tparams-brackets:
     - match: '\['
       push: function-tparams-brackets
     - match: '\]'
       pop: true
-    - include: main
+    - include: delimited-type-expression
+
   function-parameter-list:
     - match: '\('
       push:
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: main
         - match: '\)'
           pop: true
-        - match: '({{alphaid}})\s*:\s*'
+        - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
+          push:
+            - match: '{{typeprefix}}'
+              set:
+                - match: '(?=[,=\)])'
+                  pop: true
+                - match: ','
+                  pop: true
+                - include: delimited-type-expression
         - include: main
-    - match: '(?=[:\{=\n])'
+    - match: ':'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
+    - match: '(?=[\{=\n])'
       pop: true
+
   class-type-parameter-list:
     - match: '\b(private|protected)\b'
       scope: storage.modifier.access.scala
@@ -194,31 +240,40 @@ contexts:
       push: class-tparams-brackets
     - match: '(?=([\{\n]|extends))'
       pop: true
+
   class-tparams-brackets:
     - match: '\['
       push: class-tparams-brackets
     - match: '\]'
       pop: true
-    - include: main
+    - match: this
+      scope: variable.language.scala
+    - include: delimited-type-expression
+
   class-parameter-list:
     - match: '\('
       push:
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: main
         - match: '\)'
           pop: true
-        - match: '({{alphaid}})\s*:\s*'
+        - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala
+          push:
+            - match: '{{typeprefix}}'
+              set:
+                - match: '(?=[,=\)])'
+                  pop: true
+                - match: ','
+                  pop: true
+                - include: delimited-type-expression
         - include: main
     - match: '(?=([\{\n]|extends))'
       pop: true
+
   empty-parentheses:
     - match: \(\)
       scope: meta.parentheses.scala
+
   imports:
     - match: \b(import)\s+
       captures:
@@ -249,16 +304,26 @@ contexts:
                 3: variable.import.renamed-to.scala
             - match: '([^\s.,}]+)'
               scope: variable.import.scala
+
   inheritance:
     - match: '(extends|with)\s+([^\s\{\(\[\]]+)'
       captures:
         1: keyword.declaration.scala
         2: entity.other.inherited-class.scala
+    - match: '(extends|with)\s+\('
+      captures:
+        1: keyword.declaration.scala
+      push:
+        - match: '\)'
+          pop: true
+        - include: delimited-type-expression
+
   initialization:
     - match: '\b(new)\s+({{id}})'
       captures:
         1: keyword.other.scala
         2: entity.name.class.scala
+
   for-comprehension:
     - match: '\b(for)\s*\{'
       captures:
@@ -312,6 +377,7 @@ contexts:
     - match: '\b(val)\b'
       scope: keyword.declaration.stable.scala
     - include: pattern-match
+
   keywords:
     - match: \b(return|throw)\b
       scope: keyword.control.flow.jump.scala
@@ -323,6 +389,7 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
+
   late-keywords:
     - match: \b(extends|with|forSome)\b
       scope: keyword.declaration.scala
@@ -338,6 +405,7 @@ contexts:
       scope: keyword.control.scala
     - match: \b(new)\b
       scope: keyword.other.scala
+
   nest-curly-and-self:
     - match: '\{'
       scope: punctuation.section.scope.scala
@@ -347,17 +415,17 @@ contexts:
           pop: true
         - include: nest-curly-and-self
     - include: main
-  qualifiedClassName:
-    - match: '{{upperid}}'
-      scope: support.class.scala
+
   scala-symbol:
     - match: '''{{plainid}}'
       scope: constant.other.symbol.scala
+
   storage-modifiers:
     - match: '\b(private\[\S+\]|protected\[\S+\]|private|protected)\b'
       scope: storage.modifier.access.scala
     - match: \b(@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b
       scope: storage.modifier.other.scala
+
   strings:
     - match: '"""'
       push:
@@ -393,6 +461,7 @@ contexts:
         - match: \\.
           scope: constant.character.escape.scala
         - include: interpolated-vars-expressions
+
   interpolated-vars-expressions:
     - match: '(\$){{alphaid}}'
       scope: variable.other.scala
@@ -412,6 +481,7 @@ contexts:
               pop: true
             - include: nest-curly-and-self
             - include: main
+
   xml-attribute:
     - match: '(\w+)=("[^"]*")'
       captures:
@@ -427,10 +497,12 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
+
   val-pattern-match-main:
     - include: comments
     - include: block-comments
     - include: keywords
+    - include: ascription
     - include: constants
     - include: char-literal
     - include: scala-symbol
@@ -452,18 +524,26 @@ contexts:
     - match: '@|_'
       scope: keyword.other.scala
   val-pattern-match:
+    - match: '{{upperid}}'
+      scope: entity.name.parameter
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=[\B\s]=[\B\s])'
+          pop: true
+        - include: delimited-type-expression
+        - match: '(?=[\{\n])'
+          pop: true
     - include: val-pattern-match-main
     - match: \(
       push:
         - match: \)
           pop: true
         - include: val-pattern-match-inner
-    - match: '{{upperid}}'
-      scope: entity.name.parameter
   val-pattern-match-inner:
     - include: val-pattern-match-main
     - match: '{{upperid}}'
       scope: support.class.scala
+
   pattern-match:
     - include: comments
     - include: block-comments
@@ -481,8 +561,7 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
-    - match: '{{upperid}}'
-      scope: support.class.scala
+    - include: ascription
     - match: \[
       push:
         - match: \]
@@ -490,3 +569,36 @@ contexts:
         - include: main
     - match: '@|_'
       scope: keyword.other.scala
+
+  base-type-expression:
+    - include: base-types
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+    - match: forSome
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: _
+    - match: '{{id}}'
+      scope: support.type.scala
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: base-type-expression
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: base-type-expression
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: main
+  delimited-type-expression:
+    - include: base-type-expression
+  single-type-expression:
+    - include: base-type-expression
+    - match: '(?=[\s,\)\}\]])'
+      pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -696,7 +696,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.scala
   val-pattern-match:
-    - match: '{{upperid}}(?=[\s=])'
+    - match: '{{upperid}}(?=[\s=:])'
       scope: entity.name.parameter.scala
     - match: '{{typeprefix}}'
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -146,7 +146,7 @@ contexts:
     - match: '{{id}}'
       scope: variable.parameter.scala
     - match: '_'
-      scope: variable.language.scala
+      scope: variable.language.underscore.scala
   lambda-declaration-parens:
     - match: '{{typeprefix}}'
       push:
@@ -418,7 +418,7 @@ contexts:
         - match: '{{id}}'
           scope: variable.import.scala
         - match: '_'
-          scope: variable.language.scala
+          scope: variable.language.underscore.scala
         - match: "{"
           push:
             - meta_scope: meta.import.selector.scala
@@ -434,7 +434,7 @@ contexts:
             - match: '{{id}}'
               scope: variable.import.scala
             - match: '_'
-              scope: variable.language.scala
+              scope: variable.language.underscore.scala
 
   inheritance:
     - match: '\b(extends|with)\s+([^\s\{\(\[\]]+)'
@@ -558,7 +558,7 @@ contexts:
     - match: '='
       scope: keyword.operator.assignment.scala
     - match: '_'
-      scope: variable.language.scala
+      scope: variable.language.underscore.scala
     - match: '\.'
       scope: punctuation.accessor.scala
     - match: ','
@@ -688,11 +688,11 @@ contexts:
         - include: main
     - match: '{{op}}'     # let it fall through
     - match: '@'
-      scope: keyword.operator.scala
+      scope: keyword.operator.at.scala
     - match: '_\*'
-      scope: keyword.operator.other.scala
+      scope: keyword.operator.varargs.scala
     - match: '_'
-      scope: variable.language.scala
+      scope: variable.language.underscore.scala
     - match: ','
       scope: punctuation.separator.scala
   val-pattern-match:
@@ -750,11 +750,11 @@ contexts:
           pop: true
         - include: delimited-type-expression
     - match: '@'
-      scope: keyword.operator.scala
+      scope: keyword.operator.at.scala
     - match: '_\*'
-      scope: keyword.operator.other.scala
+      scope: keyword.operator.varargs.scala
     - match: '_'
-      scope: variable.language.scala
+      scope: variable.language.underscore.scala
     - match: ','
       scope: punctuation.separator.scala
 
@@ -784,7 +784,7 @@ contexts:
     - match: =>|⇒
       scope: keyword.operator.arrow.scala
     - match: '_\*'
-      scope: keyword.operator.other.scala
+      scope: keyword.operator.varargs.scala
   type-constraints:
     - match: '<:|>:|<%|\+|-|:'
       scope: keyword.operator.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -138,6 +138,8 @@ contexts:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
   constants:
+    - match: '(?<![[[:alpha:]]0-9`\)])\(\)'
+      scope: constant.language.scala
     - match: \b(false|null|true|Nil|None)\b
       scope: constant.language.scala
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -164,7 +164,7 @@ contexts:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
   constants:
-    - match: \b(false|null|true|Nil|None)\b
+    - match: \b(false|null|true)\b
       scope: constant.language.scala
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
       scope: constant.numeric.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -168,7 +168,7 @@ contexts:
   base-types:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
-  constants:
+  base-constants:
     - match: \b(false|null|true)\b
       scope: constant.language.scala
     # TODO negation
@@ -188,6 +188,8 @@ contexts:
     - match: \b(this|super)\b
       scope: variable.language.scala
     - include: base-types
+  constants:
+    - include: base-constants
     # other upper-case stuff highlights as constant
     - match: '{{upperid}}'
       scope: support.constant.scala
@@ -660,7 +662,7 @@ contexts:
 
   val-pattern-match-main:
     - include: keywords
-    - include: constants
+    - include: base-constants
     - include: char-literal
     - include: scala-symbol
     - include: strings
@@ -678,6 +680,8 @@ contexts:
     - match: '(\.){{varid}}'
       captures:
         1: punctuation.accessor.scala
+    - match: '{{upperid}}'
+      scope: support.constant.scala
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
     - match: \[
@@ -717,7 +721,7 @@ contexts:
 
   pattern-match:
     - include: keywords
-    - include: constants
+    - include: base-constants
     - include: char-literal
     - include: scala-symbol
     - include: strings
@@ -735,6 +739,8 @@ contexts:
     - match: '(\.){{varid}}'
       captures:
         1: punctuation.accessor.scala
+    - match: '{{upperid}}'
+      scope: support.constant.scala
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
     - match: '{{op}}'   # let it fall through

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -679,6 +679,8 @@ contexts:
     - match: '{{op}}'     # let it fall through
     - match: '@'
       scope: keyword.operator.scala
+    - match: '_\*'
+      scope: keyword.operator.other.scala
     - match: '_'
       scope: variable.language.scala
   val-pattern-match:
@@ -737,6 +739,8 @@ contexts:
         - include: delimited-type-expression
     - match: '@'
       scope: keyword.operator.scala
+    - match: '_\*'
+      scope: keyword.operator.other.scala
     - match: '_'
       scope: variable.language.scala
 
@@ -765,6 +769,8 @@ contexts:
         - include: declarations
     - match: =>|⇒
       scope: keyword.operator.arrow.scala
+    - match: '_\*'
+      scope: keyword.operator.other.scala
   type-constraints:
     - match: '<:|>:|<%|\+|-|:'
       scope: keyword.operator.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -470,7 +470,7 @@ contexts:
   for-braces-body:
     - match: '^(?=([^<←=\{\}]|<[^\-])+(<-|←|=[\s\b]))'
       push:
-        - match: '^\s*(val)\s+'
+        - match: '\b(val)\b'
           scope: storage.type.stable.scala
         - match: <-|←|=
           scope: keyword.operator.assignment.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -123,11 +123,16 @@ contexts:
         1: storage.type.scala
         2: entity.name.type.scala
       push:
-        - match: '\n'
+        - match: '(?=[\n\}\)\]])'
           pop: true
+        - match: '\['
+          push:
+            - match: '\]'
+              pop: true
+            - include: delimited-type-expression
         - match: '='
           set:
-            - match: '\n'
+            - match: '(?=[\n\}\)\]])'
               pop: true
             - include: delimited-type-expression
     - match: '\b(var)\s+({{id}})'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -25,18 +25,30 @@ variables:
   typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
 
 contexts:
+  prototype:
+    - include: comments
+    - include: block-comments
+
   main:
+    - include: main-pre-lambdas
+    - include: lambdas
+    - include: main-post-lambdas
+
+  main-no-lambdas:
+    - include: main-pre-lambdas
+    - include: main-post-lambdas
+
+  main-pre-lambdas:
     - include: storage-modifiers
     - include: declarations
     - include: inheritance
     - include: for-comprehension
     - include: keywords
     - include: imports
-    - include: comments
-    - include: block-comments
     - include: strings
     - include: initialization
     - include: ascription
+  main-post-lambdas:
     - include: constants
     - include: char-literal
     - include: scala-symbol
@@ -83,6 +95,34 @@ contexts:
   ascription:
     - match: '{{typeprefix}}'
       push: single-type-expression
+
+  lambdas:
+    # can't use a variable for this match either?
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[\s\B])'
+      push:
+        # strangely, we can't use a variable for this match
+        - match: '(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}])'
+          captures:
+            1: storage.type.function.arrow.scala
+          pop: true
+        - include: lambda-declaration
+  lambda-declaration:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: lambda-declaration
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=(?<=[a-zA-Z0-9\s\)\]\}])(=>)(?=[a-zA-Z0-9\s\)\]\}]))'
+          pop: true
+        - match: ','
+          pop: true
+        - match: '(?=\))'
+          pop: true
+        - include: delimited-type-expression
+    - match: '{{id}}'
+      scope: variable.parameter
 
   base-types:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
@@ -163,7 +203,14 @@ contexts:
             - match: '\)'
               pop: true
             - include: pattern-match
-        - match: '=>|⇒|\b(if)\b'
+        - match: '\b(if)\b'
+          captures:
+            1: keyword.control.flow.scala
+          set:
+            - match: '=>|⇒'
+              pop: true
+            - include: main-no-lambdas
+        - match: '=>|⇒'
           pop: true
           captures:
             1: keyword.control.flow.scala
@@ -290,7 +337,6 @@ contexts:
         - meta_scope: meta.import.scala
         - match: '(?<=[\n;])'
           pop: true
-        - include: comments
         - match: '([^\s{;.]+)\s*\.\s*'
           scope: variable.package.scala
         - match: '([^\s{;.]+)\s*'
@@ -507,8 +553,6 @@ contexts:
         - include: xml-attribute
 
   val-pattern-match-main:
-    - include: comments
-    - include: block-comments
     - include: keywords
     - include: ascription
     - include: constants
@@ -553,8 +597,6 @@ contexts:
       scope: support.class.scala
 
   pattern-match:
-    - include: comments
-    - include: block-comments
     - include: keywords
     - include: constants
     - include: char-literal

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -608,18 +608,25 @@ contexts:
   single-type-expression:
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
-      pop: true
+      set: single-type-expression-tail
     - match: "[αβ]"   # this mostly exists for type lambdas
       scope: comment.block.empty.scala
-      pop: true
+      set: single-type-expression-tail
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala
     - match: '{{upperid}}'
       scope: support.class.scala
-      pop: true
+      set: single-type-expression-tail
     - match: '{{id}}'
       scope: support.type.scala
-      pop: true
+      set: single-type-expression-tail
     - include: base-type-expression
     - match: '(?=[\s,\)\}\]])'
+      pop: true
+  single-type-expression-tail:
+    - match: '[\.#]'
+      scope: punctuation.separator
+      set: single-type-expression
+    - match: '\s+'
+    - match: '(?=.)'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -440,8 +440,8 @@ contexts:
       push:
         - match: '`'
           pop: true
-    - match: '\b[a-z][a-zA-Z0-9_]*\.'
-    - match: '\.[a-z][a-zA-Z0-9_]*\b'
+    - match: '{{varid}}\.'
+    - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
     - match: '{{upperid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -594,6 +594,8 @@ contexts:
           pop: true
         - include: main
   delimited-type-expression:
+    - match: '[\.#]'
+      scope: punctuation.separator
     - include: base-types
     - match: "[αβ]"   # this mostly exists for type lambdas
       scope: comment.block.empty.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -525,10 +525,6 @@ contexts:
       scope: keyword.operator.assignment.scala
 
   late-keywords:
-    - match: '(\.)(type)\b'
-      captures:
-        1: punctuation.accessor.scala
-        2: keyword.other.scala
     - match: \b(extends|with|forSome)\b
       scope: keyword.declaration.scala
     - match: \b(class|trait|object)\b
@@ -756,6 +752,8 @@ contexts:
     - match: '<:|>:|<%|\+|-|:'
       scope: keyword.operator.scala
   delimited-type-expression:
+    - match: '\b(type)\b'
+      scope: keyword.other.scala
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala
     - match: '[\.#]'
@@ -770,6 +768,8 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - match: '\b(type)\b'
+      scope: keyword.other.scala
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -683,7 +683,7 @@ contexts:
     - match: '{{upperid}}'
       scope: support.constant.scala
     - match: '\b{{varid}}'
-      scope: entity.name.parameter.scala
+      scope: entity.name.val.scala
     - match: \[
       push:
         - match: \]
@@ -700,7 +700,7 @@ contexts:
       scope: punctuation.separator.scala
   val-pattern-match:
     - match: '{{upperid}}(?=[\s=:])'
-      scope: entity.name.parameter.scala
+      scope: entity.name.val.scala
     - match: '{{typeprefix}}'
       push:
         - match: '(?=[\B\s]=[\B\s])'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -26,6 +26,8 @@ variables:
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
   typeprefix: '{{oplookbehind}}(:){{oplookahead}}\s*'
+  # hack to cover up to three levels of nested parentheses
+  withinparens: '\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\)'
 
 contexts:
   prototype:
@@ -100,7 +102,7 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|\([^\)]*\))\s*=>[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*=>[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{oplookbehind}}(=>){{oplookahead}}'
           captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -19,7 +19,7 @@ variables:
   # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #}
   op: |-
     (?x:
-      [[^:=<@←⇒#]&&{{operator_character}}]+|
+      [[^:=<@←⇒#]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
       <[[^\-]&&{{operator_character}}]+|
@@ -30,7 +30,7 @@ variables:
   # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #, <%, <:, :<, +, -}
   typeop: |-
     (?x:
-      [[^:=<@←⇒#+\-]&&{{operator_character}}]+|
+      [[^:=<@←⇒#+\-]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
       <[[^\-%:]&&{{operator_character}}]+|

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -454,7 +454,7 @@ contexts:
     - match: '^(?=([^<←=\{\}]|<[^\-])+(<-|←|=[\s\b]))'
       push:
         - match: '^\s*(val)\s+'
-          scope: keyword.declaration.stable.scala
+          scope: storage.type.stable.scala
         - match: <-|←|=
           scope: keyword.operator.assignment.scala
           pop: true
@@ -474,6 +474,8 @@ contexts:
     - match: '<-|←|='
       scope: keyword.operator.assignment.scala
       push:
+        - match: '(?=\))'
+          pop: true
         - match: ;
           pop: true
         - match: '\{'
@@ -488,7 +490,7 @@ contexts:
             - include: main
         - include: main
     - match: '\b(val)\b'
-      scope: keyword.declaration.stable.scala
+      scope: storage.type.stable.scala
     - include: pattern-match
 
   keywords:
@@ -689,6 +691,11 @@ contexts:
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
     - include: ascription
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: pattern-match
     - match: \[
       push:
         - match: \]

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -409,11 +409,11 @@ contexts:
               scope: variable.import.scala
 
   inheritance:
-    - match: '(extends|with)\s+([^\s\{\(\[\]]+)'
+    - match: '\b(extends|with)\s+([^\s\{\(\[\]]+)'
       captures:
         1: keyword.declaration.scala
         2: entity.other.inherited-class.scala
-    - match: '(extends|with)\s+\('
+    - match: '\b(extends|with)\s+\('
       captures:
         1: keyword.declaration.scala
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -218,7 +218,7 @@ contexts:
       push: function-type-parameter-list
     - match: '\b(case\s+)?(class|trait|object)(?:\s+({{id}}))'
       captures:
-        1: keyword.other.declaration.scala
+        1: storage.type.class.scala
         2: storage.type.class.scala
         3: entity.name.class.scala
       push: class-type-parameter-list

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -130,7 +130,7 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=(_|{{id}}|{{id}}\s*:\s*{{id}}|{{id}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{rightarrow}}'
           scope: storage.type.function.arrow.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -427,7 +427,7 @@ contexts:
           pop: true
         - include: xml-literal
         - include: xml-attribute
-  val-pattern-match:
+  val-pattern-match-main:
     - include: comments
     - include: block-comments
     - include: keywords
@@ -444,8 +444,6 @@ contexts:
     - match: '\.{{varid}}'
     - match: '\b{{varid}}'
       scope: entity.name.parameter.scala
-    - match: '{{upperid}}'
-      scope: support.class.scala
     - match: \[
       push:
         - match: \]
@@ -453,6 +451,19 @@ contexts:
         - include: main
     - match: '@|_'
       scope: keyword.other.scala
+  val-pattern-match:
+    - include: val-pattern-match-main
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: val-pattern-match-inner
+    - match: '{{upperid}}'
+      scope: entity.name.parameter
+  val-pattern-match-inner:
+    - include: val-pattern-match-main
+    - match: '{{upperid}}'
+      scope: support.class.scala
   pattern-match:
     - include: comments
     - include: block-comments

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -468,7 +468,7 @@ contexts:
           pop: true
         - include: for-parens-body
   for-braces-body:
-    - match: '^(?=([^<←=\{\}]|<[^\-])+(<-|←|=[\s\b]))'
+    - match: '^(?=([^<←=\{\}]|<[^\-])+({{nonopchar}}(<-|←|=){{nonopchar}}))'
       push:
         - match: '\b(val)\b'
           scope: storage.type.stable.scala
@@ -488,27 +488,31 @@ contexts:
         - include: main
     - include: main
   for-parens-body:
+    - match: '\b(if)\b'
+      scope: keyword.control.flow.scala
+      push: for-parens-expr
     - match: '<-|←|='
       scope: keyword.operator.assignment.scala
-      push:
-        - match: '(?=\))'
-          pop: true
-        - match: ;
-          pop: true
-        - match: '\{'
-          push:
-            - match: '\}'
-              pop: true
-            - include: main
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: main
-        - include: main
+      push: for-parens-expr
     - match: '\b(val)\b'
       scope: storage.type.stable.scala
     - include: pattern-match
+  for-parens-expr:
+    - match: '(?=\))'
+      pop: true
+    - match: ;
+      pop: true
+    - match: '\{'
+      push:
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\('
+      push:
+        - match: '\)'
+          pop: true
+        - include: main
+    - include: main
 
   keywords:
     - match: \b(return|throw)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -100,13 +100,6 @@ contexts:
       scope: support.constant.scala
 
   declarations:
-    - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
-      scope: comment.block.scala
-      push:
-        - match: '\}\)#λ'
-          scope: comment.block.scala
-          pop: true
-        - include: delimited-type-expression
     - match: '\b(def)\s+({{id}})'
       captures:
         1: storage.type.function.scala
@@ -578,6 +571,13 @@ contexts:
       scope: keyword.other.scala
 
   base-type-expression:
+    - match: '\(\{\s*type\s+λ\[α(\[_\])?(,\s*β(\[_\])?)?\]\s*='
+      scope: comment.block.scala
+      push:
+        - match: '\}\)#λ'
+          scope: comment.block.scala
+          pop: true
+        - include: delimited-type-expression
     - match: \(
       push:
         - match: \)
@@ -594,11 +594,11 @@ contexts:
           pop: true
         - include: main
   delimited-type-expression:
+    - match: "[αβ]"     # just here for type lambdas
+      scope: comment.block.empty.scala
     - match: '[\.#]'
       scope: punctuation.separator
     - include: base-types
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala
     - match: '{{upperid}}'
@@ -608,11 +608,10 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - match: "[αβ]"     # just here for type lambdas
+      scope: comment.block.empty.scala
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
-      set: single-type-expression-tail
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
       set: single-type-expression-tail
     - match: '\b(forSome)\b'
       scope: keyword.declaration.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -540,7 +540,7 @@ contexts:
         - meta_scope: string.quoted.triple.scala
         - match: '"""(?!")'
           pop: true
-    - match: (?<!\\)"
+    - match: '"'
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,7 +22,7 @@ variables:
   alphaid: (?:{{upper}}{{idrest}}|{{varid}})
   # Custom productions
   upperid: '(?:\b\p{Lu}{{idrest}})'
-  typeprefix: '(?<=[a-zA-Z0-9\s\)\]\}])(:)(?=[a-zA-Z0-9\s\)\]\}])\s*'
+  typeprefix: '(?<=[[[:alpha:]]0-9\s\)\]\}])(:)(?=[[[:alpha:]]0-9\s\)\]\}])\s*'
 
 contexts:
   prototype:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -789,6 +789,8 @@ contexts:
   delimited-type-expression:
     - match: '\b(type)\b'
       scope: keyword.other.scala
+    - match: '\b(with)\b'
+      scope: keyword.declaration.scala
     - match: "[αβ]"     # just here for type lambdas
       scope: comment.block.empty.scala
     - match: '[\.#]'
@@ -819,11 +821,15 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail
     - include: base-type-expression
-    - match: '(?=[\s,\)\}\]])'
+    - match: '(?=[\s$,\)\}\]])'
       pop: true
   single-type-expression-tail:
     - match: '[\.#]'
       scope: punctuation.accessor.scala
+      set: single-type-expression
+    - match: '\b(with)(?:\s+|\b)'
+      captures:
+        1: keyword.declaration.scala
       set: single-type-expression
     - match: '(?=\S)'
       set: try-dispatch       # this is needed for initialization (new ...) and doesn't HURT elsewhere

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -166,8 +166,20 @@ contexts:
   constants:
     - match: \b(false|null|true)\b
       scope: constant.language.scala
-    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
-      scope: constant.numeric.scala
+    # TODO negation
+    # source: http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#floating-point-literals
+    - match: |-
+        (?x)
+          \b(?:[0-9]+\.[0-9]+(?:[eE][+\-]?[0-9]+)?[fFdD]?)\b|
+          (?:\.[0-9]+(?:[eE][+\-]?[0-9]+)?[fFdD]?)\b|
+          \b(?:[0-9]+(?:[eE][+\-]?[0-9]+)[fFdD]?)\b|
+          \b(?:[0-9]+(?:[eE][+\-]?[0-9]+)?[fFdD])\b
+      scope: constant.numeric.float.scala
+    # source: http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#integer-literals
+    - match: '\b(?:0[xX][0-9a-fA-F]+[lL]?)\b'
+      scope: constant.numeric.hex.scala
+    - match: '\b(?:(?:0|[1-9][0-9]*)[lL]?)\b'
+      scope: constant.numeric.integer.scala
     - match: \b(this|super)\b
       scope: variable.language.scala
     - include: base-types
@@ -513,6 +525,10 @@ contexts:
       scope: keyword.operator.assignment.scala
 
   late-keywords:
+    - match: '(\.)(type)\b'
+      captures:
+        1: punctuation.accessor.scala
+        2: keyword.other.scala
     - match: \b(extends|with|forSome)\b
       scope: keyword.declaration.scala
     - match: \b(class|trait|object)\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -216,7 +216,7 @@ contexts:
         1: storage.type.function.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
-    - match: '\b(case\s+)?(class|trait|object)(?:\s+([^\s\{\(\[]+))?'
+    - match: '\b(case\s+)?(class|trait|object)(?:\s+({{id}}))'
       captures:
         1: keyword.other.declaration.scala
         2: storage.type.class.scala
@@ -665,6 +665,7 @@ contexts:
     - include: scala-symbol
     - include: strings
     - include: xml-literal
+    - include: late-keywords
     - match: '`'
       scope: punctuation.definition.identifier.scala
       push:
@@ -721,6 +722,7 @@ contexts:
     - include: scala-symbol
     - include: strings
     - include: xml-literal
+    - include: late-keywords
     - match: '`'
       scope: punctuation.definition.identifier.scala
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -220,7 +220,7 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[,=\)])'
+                - match: '(?=[=\)])'
                   pop: true
                 - match: ','
                   pop: true
@@ -268,7 +268,7 @@ contexts:
           push:
             - match: '{{typeprefix}}'
               set:
-                - match: '(?=[,=\)])'
+                - match: '(?=[=\)])'
                   pop: true
                 - match: ','
                   pop: true
@@ -578,34 +578,48 @@ contexts:
       scope: keyword.other.scala
 
   base-type-expression:
-    - include: base-types
-    - match: "[αβ]"   # this mostly exists for type lambdas
-      scope: comment.block.empty.scala
-    - match: forSome
-      scope: keyword.declaration.scala
-    - match: '{{upperid}}'
-      scope: support.class.scala
-    - match: _
-    - match: '{{id}}'
-      scope: support.type.scala
     - match: \(
       push:
         - match: \)
           pop: true
-        - include: base-type-expression
+        - include: delimited-type-expression
     - match: \[
       push:
         - match: \]
           pop: true
-        - include: base-type-expression
+        - include: delimited-type-expression
     - match: \{
       push:
         - match: \}
           pop: true
         - include: main
   delimited-type-expression:
+    - include: base-types
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+    - match: '\b(forSome)\b'
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+    - match: _
+    - match: '{{id}}'
+      scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+      scope: storage.type.primitive.scala
+      pop: true
+    - match: "[αβ]"   # this mostly exists for type lambdas
+      scope: comment.block.empty.scala
+      pop: true
+    - match: '\b(forSome)\b'
+      scope: keyword.declaration.scala
+    - match: '{{upperid}}'
+      scope: support.class.scala
+      pop: true
+    - match: '{{id}}'
+      scope: support.type.scala
+      pop: true
     - include: base-type-expression
     - match: '(?=[\s,\)\}\]])'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -534,6 +534,8 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
+    - match: \b(eq)\b
+      scope: keyword.operator.word.scala
 
   late-keywords:
     - match: \b(extends|with|forSome)\b

--- a/Scala/Symbols.tmPreferences
+++ b/Scala/Symbols.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala entity.name.val, source.scala entity.name.type, source.scala entity.name.parameter, source.scala entity.name.namespace</string>
+	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala entity.name.val, source.scala entity.name.type, source.scala entity.name.namespace</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -732,6 +732,13 @@ type Foo >: Bar
 //          ^ variable.parameter
 //             ^^^ storage.type.primitive.scala
 
+   (a: Int, b: Int) ⇒ ???
+//  ^ variable.parameter
+//     ^^^ storage.type.primitive.scala
+//          ^ variable.parameter
+//             ^^^ storage.type.primitive.scala
+//                  ^ storage.type.function.arrow
+
    a => ???
 // ^ variable.parameter
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -965,3 +965,6 @@ val (foo, bar) = ???
 
 foo eq bar
 //  ^^ keyword.operator.word.scala
+
+new Config()
+//        ^^ - constant

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -950,3 +950,15 @@ foo({ _: Unit => () })
 s"testing ${things} and more!"
 //          ^^^^^^ - string
 //          ^^^^^^ source.scala.embedded
+
+foo.bar
+// ^ punctuation.accessor.scala
+
+(foo, bar)
+//  ^ punctuation.separator.scala
+
+case (foo, bar) =>
+//       ^ punctuation.separator.scala
+
+val (foo, bar) = ???
+//      ^ punctuation.separator.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -822,3 +822,32 @@ class Foo(a: A =:= B = null)
 
 class Foo(a: A :: B)
 //             ^^ support.type.scala
+
+import foo
+// <- meta.import.scala
+//     ^^^ variable.import.scala
+
+import foo; import bar
+//     ^^^ variable.import.scala
+//          ^^^^^^ keyword.other.import.scala
+//                 ^^^ variable.import.scala
+
+import foo.bar
+//     ^^^^^^^ variable.package.scala
+
+import foo.{bar, bar => baz, bar=>baz}
+//         ^^^^^^^^^^^^^^^^^ meta.import.selector.scala
+//          ^^^ variable.import.scala
+//               ^^^ variable.import.renamed-from.scala
+//                   ^^ keyword.other.arrow.scala
+//                      ^^^ variable.import.renamed-to.scala
+//                           ^^^ variable.import.renamed-from.scala
+//                              ^^ keyword.other.arrow.scala
+//                                ^^^ variable.import.renamed-to.scala
+
+
+import foo.{
+   bar => bin
+// ^^^ variable.import.renamed-from.scala
+//        ^^^ variable.import.renamed-to.scala
+}

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -559,10 +559,10 @@ type Foo = Bar[A] forSome { type A }
      val testing = 42
 //   ^^^ storage.type.stable.scala
 //       ^^^^^^^ variable.parameter
-   } _
-//   ^ - variable.language.scala
+   } abc
+//   ^^^ - variable.parameter
 
-   for (a <- _; (b, c @ _) ← _; val abc = _) _
+   for (a <- _; (b, c @ _) ← d; val abc = e) f
 // ^^^ keyword.control.flow.scala
 //      ^ variable.parameter
 //           ^ - keyword
@@ -571,11 +571,11 @@ type Foo = Bar[A] forSome { type A }
 //                    ^ keyword.operator.scala
 //                      ^ variable.language.scala
 //                         ^ keyword.operator.assignment.scala
-//                           ^ - variable.language.scala
+//                           ^ - variable.parameter
 //                              ^^^ storage.type.stable.scala
 //                                  ^^^ variable.parameter
-//                                        ^ - variable.language.scala
-//                                           ^ - variable.language.scala
+//                                        ^ - variable.parameter
+//                                           ^ - variable.parameter
 
    for {
      sss <- { {} }
@@ -911,3 +911,6 @@ for {
 for (if things >= stuff)
 //      ^^^^^^ - variable.parameter
 //                ^^^^^ - variable.parameter
+
+   _
+// ^ variable.language.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -923,3 +923,6 @@ foo_=
 
 foo_
 // ^ - variable.language
+
+foo({ _ => () })
+//      ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -741,3 +741,7 @@ type Foo >: Bar
 "testing /*comments*/"
 //       ^^^^^^^^^^^^ string.quoted.double
 //       ^^^^^^^^^^^^ - comment
+
+   cb: ((Throwable \/ Unit) => Unit) => 42
+// ^^ variable.parameter
+//                                   ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -925,7 +925,9 @@ foo_
 // ^ - variable.language
 
 foo({ _ => () })
+//    ^ variable.language.scala
 //      ^^ storage.type.function.arrow
 
 foo({ _: Unit => () })
+//    ^ variable.language.scala
 //            ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -759,7 +759,7 @@ type Foo >: Bar
 //     ^^ constant.numeric.scala
 
   (a: Int => Boolean) => 42
-//        ^^ support.type
+//        ^^ keyword.operator.arrow.scala
 //           ^^^^^^^ storage.type
 
   (a: Foo[A] forSome { type A }) => 42
@@ -788,4 +788,5 @@ foo(())
 
    cb: ((Throwable \/ Unit) => Unit) => 42
 // ^^ variable.parameter
+//                 ^^ support.type.scala
 //                                   ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -623,3 +623,6 @@ new (Foo ~> Bar)
 
    val Stuff(f1, v1) = ???
 //     ^^^^^ support.constant.scala
+
+new Foo(new Foo)
+//      ^^^ keyword.other.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -15,11 +15,13 @@ def foo: Baz = 42
 //^ storage.type.function.scala
 //  ^^^ entity.name.function.scala
 //       ^^^ support.class
+//           ^ keyword.operator.assignment.scala
 //             ^^ constant.numeric.scala
 
 def foo: Baz => Bar = 42
 //       ^^^ support.class
 //              ^^^ support.class
+//                  ^ keyword.operator.assignment.scala
 
 
 def foo(a: Int, b: Bar): Baz = 42
@@ -29,6 +31,7 @@ def foo(a: Int, b: Bar): Baz = 42
 //         ^^^ storage.type.primitive.scala
 //                 ^^^ support.class
 //                       ^^^ support.class
+//                           ^ keyword.operator.assignment.scala
 //                             ^^ constant.numeric.scala
 
    def +(a: Int)
@@ -104,10 +107,12 @@ class Foo[A](a: Bar) extends Baz with Bin
 
 class Foo(x: Int = 42)
 //               ^ - support
+//               ^ keyword.operator.assignment.scala
 //                 ^^ constant.numeric
 
 def foo(x: Int = 42)
 //             ^ - support
+//             ^ keyword.operator.assignment.scala
 //               ^^ constant.numeric
 
 trait Foo
@@ -121,11 +126,13 @@ object Foo
    type Foo = Bar
 // ^^^^ storage.type.scala
 //      ^^^ entity.name.type.scala
+//          ^ keyword.operator.assignment.scala
 //            ^^^ support.class.scala
 
    type Foo = Bar => Baz
 // ^^^^ storage.type.scala
 //      ^^^ entity.name.type.scala
+//          ^ keyword.operator.assignment.scala
 //            ^^^ support.class.scala
 //                   ^^^ support.class.scala
 
@@ -134,6 +141,7 @@ object Foo
 //         ^ support.class
 //            ^ support.class
 //               ^ support.class
+//                  ^ keyword.operator.assignment.scala
 
 type Foo = Bar {
   def baz: Int
@@ -395,15 +403,19 @@ type Foo = Bar[A] forSome { type A }
 //       ^^^ variable.parameter
 //            ^^^ support.class
 //                 ^^^ variable.parameter
-//                       ^ keyword
+//                       ^ variable.language.scala
+//                          ^^ keyword.other.arrow.scala
 
    case abc @ `abc` =>
 //      ^^^ variable.parameter
-//          ^ keyword
-//            ^^^^^ - entity.name
+//          ^ keyword.operator.scala
+//            ^ punctuation.definition.identifier.scala
+//                ^ punctuation.definition.identifier.scala
+//                  ^^ keyword.other.arrow.scala
+//            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
-//                               ^ keyword
+//                               ^ variable.language.scala
 
    case /* testing */ =>
 //      ^^^^^^^^^^^^^ comment.block.scala
@@ -449,7 +461,9 @@ type Foo = Bar[A] forSome { type A }
    val abc @ `abc`
 // ^^^ storage.type.stable.scala
 //     ^^^ entity.name.parameter
-//         ^ keyword
+//         ^ keyword.operator.scala
+//           ^ punctuation.definition.identifier.scala
+//               ^ punctuation.definition.identifier.scala
 //           ^^^^^ - entity.name
 
    _
@@ -458,8 +472,9 @@ type Foo = Bar[A] forSome { type A }
    val ble @ `abc` = _
 // ^^^ storage.type.stable.scala
 //     ^^^ entity.name.parameter
-//         ^ keyword
+//         ^ keyword.operator.scala
 //           ^^^^^ - entity.name
+//                 ^ keyword.operator.assignment.scala
 //                   ^ - keyword
 
    case object Thingy extends Other
@@ -496,42 +511,47 @@ type Foo = Bar[A] forSome { type A }
 
      a <- _
 //   ^ variable.parameter
+//     ^^ keyword.operator.assignment.scala
 //        ^ - keyword
 
      a ← _
 //   ^ variable.parameter
+//     ^ keyword.operator.assignment.scala
 //       ^ - entity.name
 
      (b, c @ _) <- _
 //    ^ variable.parameter
 //       ^ variable.parameter
-//         ^ keyword
-//           ^ keyword
+//         ^ keyword.operator.scala
+//           ^ variable.language.scala
+//              ^^ keyword.operator.assignment.scala
 //                 ^ - keyword
        _
 //     ^ - entity.name
 
      testing = _
 //   ^^^^^^^ variable.parameter
-//             ^ - keyword
+//           ^ keyword.operator.assignment.scala
+//             ^ - variable.operator.scala
 
      testing = {
 //   ^^^^^^^ variable.parameter
        testing = false
 //     ^^^^^^^ - entity.name
+//             ^ keyword.operator.assignment.scala
      }
 
      testing = (
 //   ^^^^^^^ variable.parameter
        testing = false
-//     ^^^^^^^ - entity.name
+//     ^^^^^^^ - variable.parameter
      )
 
      val testing = 42
 //   ^^^ keyword.declaration.stable.scala
 //       ^^^^^^^ variable.parameter
    } _
-//   ^ - entity.name
+//   ^ - variable.language.scala
 
    for (a <- _; (b, c @ _) ← _; val abc = _) _
 // ^^^ keyword.control.flow.scala
@@ -539,14 +559,14 @@ type Foo = Bar[A] forSome { type A }
 //           ^ - keyword
 //               ^ variable.parameter
 //                  ^ variable.parameter
-//                    ^ keyword
-//                      ^ keyword
-//                           ^ - keyword
+//                    ^ keyword.operator.scala
+//                      ^ variable.language.scala
+//                           ^ - variable.language.scala
 //                              ^^^ storage.type.stable.scala
 //                                  ^^^ entity.name.parameter
 //                                       TODO the above scope needs to be changed
-//                                        ^ - keyword
-//                                           ^ - keyword
+//                                        ^ - variable.language.scala
+//                                           ^ - variable.language.scala
 
    for {
      sss <- { {} }
@@ -582,8 +602,10 @@ type Foo = Bar[A] forSome { type A }
   {
     case foo.Bar => 42
 //       ^^^ - entity.name
+//          ^ punctuation.accessor.scala
     case Bar.foo => 42
 //           ^^^ - entity.name
+//          ^ punctuation.accessor.scala
   }
 
    val Foo = 42
@@ -628,22 +650,22 @@ new Foo(new Foo)
 //      ^^^ keyword.other.scala
 
 new Foo.Bar.Baz
-//     ^ punctuation.separator
+//     ^ punctuation.accessor.scala
 //      ^^^ support.class.scala
-//         ^ punctuation.separator
+//         ^ punctuation.accessor.scala
 //          ^^^ support.class.scala
 
 new Foo#Bar#Baz
-//     ^ punctuation.separator
+//     ^ punctuation.accessor.scala
 //      ^^^ support.class.scala
-//         ^ punctuation.separator
+//         ^ punctuation.accessor.scala
 //          ^^^ support.class.scala
 
 type Foo = Foo.Bar
-//            ^ punctuation.separator
+//            ^ punctuation.accessor.scala
 
 type Foo = Foo#Bar
-//            ^ punctuation.separator
+//            ^ punctuation.accessor.scala
 
 val x: OptionT[({ type λ[α] = Foo[α, Int] })#λ, String] = ???
 //             ^^^^^^^^^^^^^^ comment.block

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -16,7 +16,7 @@ def foo: Baz = 42
 //  ^^^ entity.name.function.scala
 //       ^^^ support.class
 //           ^ keyword.operator.assignment.scala
-//             ^^ constant.numeric.scala
+//             ^^ constant.numeric.integer.scala
 
 def foo: Baz => Bar = 42
 //       ^^^ support.class
@@ -32,7 +32,7 @@ def foo(a: Int, b: Bar): Baz = 42
 //                 ^^^ support.class
 //                       ^^^ support.class
 //                           ^ keyword.operator.assignment.scala
-//                             ^^ constant.numeric.scala
+//                             ^^ constant.numeric.integer.scala
 
    def +(a: Int)
 // ^^^ storage.type.function.scala
@@ -156,25 +156,34 @@ type Foo = Bar[A] forSome { type A }
 // ^^^ support.constant
 
    42
-// ^^ constant.numeric.scala
+// ^^ constant.numeric.integer.scala
+
+   .421
+// ^^^^ constant.numeric.float.scala
 
    42D
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.float.scala
 
    42d
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.float.scala
 
    42F
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.float.scala
 
    42f
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.float.scala
 
    42L
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.integer.scala
 
    42l
-// ^^^ constant.numeric.scala
+// ^^^ constant.numeric.integer.scala
+
+   0x0aF9123
+// ^^^^^^^^^ constant.numeric.hex.scala
+
+   0.045e-2
+// ^^^^^^^^ constant.numeric.float.scala
 
    true
 // ^^^^ constant.language.scala
@@ -208,7 +217,7 @@ type Foo = Bar[A] forSome { type A }
 // ^ support.function
 //           ^^ variable.other
 //              ^^ punctuation.definition.expression
-//                ^^ constant.numeric.scala
+//                ^^ constant.numeric.integer.scala
 //                  ^ punctuation.definition.expression
 
    s"""testing $a ${42}"""
@@ -216,7 +225,7 @@ type Foo = Bar[A] forSome { type A }
 // ^ support.function
 //             ^^ variable.other
 //                ^^ punctuation.definition.expression
-//                  ^^ constant.numeric.scala
+//                  ^^ constant.numeric.integer.scala
 //                    ^ punctuation.definition.expression
 //                     ^^^ string.quoted.triple.interpolated.scala
 
@@ -425,7 +434,7 @@ type Foo = Bar[A] forSome { type A }
    =>
 
    case 42 =>
-//      ^^ constant.numeric.scala
+//      ^^ constant.numeric.integer.scala
 
    case 'a' =>
 //      ^^^ constant.character.literal.scala
@@ -756,7 +765,7 @@ type Foo >: Bar
 
    a =>42
 // ^ variable.parameter
-//     ^^ constant.numeric.scala
+//     ^^ constant.numeric.integer.scala
 
   (a: Int => Boolean) => 42
 //        ^^ keyword.operator.arrow.scala
@@ -868,3 +877,10 @@ import foo.{
 for {} yield ()
 //     ^^^^^ keyword.control.flow.scala
 //           ^^ constant.language.scala
+
+   42.bar
+//   ^ - constant.numeric.scala
+
+ m.type baz
+// ^^^^ keyword.other.scala
+//      ^^^ - entity.name

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -412,19 +412,19 @@ type Foo = Bar[A] forSome { type A }
 //       ^^^ variable.parameter
 //            ^^^ support.class
 //                 ^^^ variable.parameter
-//                       ^ variable.language.scala
+//                       ^ variable.language.underscore.scala
 //                          ^^ keyword.operator.arrow.scala
 
    case abc @ `abc` =>
 //      ^^^ variable.parameter
-//          ^ keyword.operator.scala
+//          ^ keyword.operator.at.scala
 //            ^ punctuation.definition.identifier.scala
 //                ^ punctuation.definition.identifier.scala
 //                  ^^ keyword.operator.arrow.scala
 //            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
-//                               ^ variable.language.scala
+//                               ^ variable.language.underscore.scala
 
    case /* testing */ =>
 //      ^^^^^^^^^^^^^ comment.block.scala
@@ -470,7 +470,7 @@ type Foo = Bar[A] forSome { type A }
    val abc @ `abc`
 // ^^^ storage.type.stable.scala
 //     ^^^ entity.name.parameter
-//         ^ keyword.operator.scala
+//         ^ keyword.operator.at.scala
 //           ^ punctuation.definition.identifier.scala
 //               ^ punctuation.definition.identifier.scala
 //           ^^^^^ - entity.name
@@ -481,7 +481,7 @@ type Foo = Bar[A] forSome { type A }
    val ble @ `abc` = _
 // ^^^ storage.type.stable.scala
 //     ^^^ entity.name.parameter
-//         ^ keyword.operator.scala
+//         ^ keyword.operator.at.scala
 //           ^^^^^ - entity.name
 //                 ^ keyword.operator.assignment.scala
 //                   ^ - keyword
@@ -531,8 +531,8 @@ type Foo = Bar[A] forSome { type A }
      (b, c @ _) <- _
 //    ^ variable.parameter
 //       ^ variable.parameter
-//         ^ keyword.operator.scala
-//           ^ variable.language.scala
+//         ^ keyword.operator.at.scala
+//           ^ variable.language.underscore.scala
 //              ^^ keyword.operator.assignment.scala
 //                 ^ - keyword
        _
@@ -568,8 +568,8 @@ type Foo = Bar[A] forSome { type A }
 //           ^ - keyword
 //               ^ variable.parameter
 //                  ^ variable.parameter
-//                    ^ keyword.operator.scala
-//                      ^ variable.language.scala
+//                    ^ keyword.operator.at.scala
+//                      ^ variable.language.underscore.scala
 //                         ^ keyword.operator.assignment.scala
 //                           ^ - variable.parameter
 //                              ^^^ storage.type.stable.scala
@@ -875,10 +875,10 @@ import foo.{
 }
 
 import foo._
-//         ^ variable.language.scala
+//         ^ variable.language.underscore.scala
 
 import foo.{Foo => _}
-//                 ^ variable.language.scala
+//                 ^ variable.language.underscore.scala
 
 for {} yield ()
 //     ^^^^^ keyword.control.flow.scala
@@ -919,7 +919,7 @@ for (if things >= stuff)
 //                ^^^^^ - variable.parameter
 
    _
-// ^ variable.language.scala
+// ^ variable.language.underscore.scala
 
 foo._1
 //  ^ - variable.language.scala
@@ -931,21 +931,21 @@ foo_
 // ^ - variable.language
 
 foo({ _ => () })
-//    ^ variable.language.scala
+//    ^ variable.language.underscore.scala
 //      ^^ storage.type.function.arrow
 
 foo({ _: Unit => () })
-//    ^ variable.language.scala
+//    ^ variable.language.underscore.scala
 //            ^^ storage.type.function.arrow
 
   stuff: _*
-//       ^^ keyword.operator.other.scala
+//       ^^ keyword.operator.varargs.scala
 
   case _ @ _* =>
-//         ^^ keyword.operator.other.scala
+//         ^^ keyword.operator.varargs.scala
 
   val _ @ _* = things
-//        ^^ keyword.operator.other.scala
+//        ^^ keyword.operator.varargs.scala
 
 s"testing ${things} and more!"
 //          ^^^^^^ - string

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -914,3 +914,12 @@ for (if things >= stuff)
 
    _
 // ^ variable.language.scala
+
+foo._1
+//  ^ - variable.language.scala
+
+foo_=
+//  ^ - keyword
+
+foo_
+// ^ - variable.language

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -130,6 +130,11 @@ object Foo
 //                   ^^^ support.class.scala
 
 
+  type Foo[A, B, C] = Bar
+//         ^ support.class
+//            ^ support.class
+//               ^ support.class
+
 type Foo = Bar {
   def baz: Int
 //    ^^^ entity.name.function
@@ -587,3 +592,13 @@ type Foo = Bar[A] forSome { type A }
    val (Foo, x) = 42
 //      ^^^ support.constant.scala
 //           ^ entity.name.parameter
+
+{
+  Set[Foo[A, A] forSome { type A }, A]
+//                                  ^ support.class
+}
+    def foo: Int
+//      ^^^ entity.name.function
+
+// fubar
+// <- source.scala comment.line.double-slash

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -881,6 +881,8 @@ for {} yield ()
    42.bar
 //   ^ - constant.numeric.scala
 
- m.type baz
-// ^^^^ keyword.other.scala
-//      ^^^ - entity.name
+  baz[m.type]
+//      ^^^^ keyword.other.scala
+
+foo: m.type
+//     ^^^^ keyword.other.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -638,3 +638,9 @@ new Foo#Bar#Baz
 //      ^^^ support.class.scala
 //         ^ punctuation.separator
 //          ^^^ support.class.scala
+
+type Foo = Foo.Bar
+//            ^ punctuation.separator
+
+type Foo = Foo#Bar
+//            ^ punctuation.separator

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1008,3 +1008,13 @@ xs: Foo with Bar
 //   ^^^^^^ string.quoted.interpolated.scala
 //            ^^^^^ - storage.type
 //                               ^^^^^ string.quoted.interpolated.scala
+
+{
+  case Stuff(thing, other) =>
+//           ^^^^^ variable.parameter.scala
+//                  ^^^^^ variable.parameter.scala
+}
+
+val Stuff(thing, other) = ???
+//        ^^^^^ entity.name.parameter.scala
+//               ^^^^^ entity.name.parameter.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -11,6 +11,17 @@ import fubar.{Unit, Foo}
 //     ^^^^^ variable.package.scala
 //            ^^^^ variable.import.scala
 
+def foo: Baz = 42
+//^ storage.type.function.scala
+//  ^^^ entity.name.function.scala
+//       ^^^ support.class
+//             ^^ constant.numeric.scala
+
+def foo: Baz => Bar = 42
+//       ^^^ support.class
+//              ^^^ support.class
+
+
 def foo(a: Int, b: Bar): Baz = 42
 //^ storage.type.function.scala
 //  ^^^ entity.name.function.scala
@@ -91,6 +102,14 @@ class Foo[A](a: Bar) extends Baz with Bin
 //                          ^ variable.parameter
 //                                  ^ variable.parameter
 
+class Foo(x: Int = 42)
+//               ^ - support
+//                 ^^ constant.numeric
+
+def foo(x: Int = 42)
+//             ^ - support
+//               ^^ constant.numeric
+
 trait Foo
 // ^^ storage.type.class.scala
 //    ^^^ entity.name.class
@@ -98,6 +117,30 @@ trait Foo
 object Foo
 // ^^^ storage.type.class.scala
 //     ^^^ entity.name.class
+
+   type Foo = Bar
+// ^^^^ storage.type.scala
+//      ^^^ entity.name.type.scala
+//            ^^^ support.class.scala
+
+   type Foo = Bar => Baz
+// ^^^^ storage.type.scala
+//      ^^^ entity.name.type.scala
+//            ^^^ support.class.scala
+//                   ^^^ support.class.scala
+
+
+type Foo = Bar {
+  def baz: Int
+//    ^^^ entity.name.function
+}
+
+type Foo = Bar[A] forSome { type A }
+//                ^^^^^^^ keyword.declaration.scala
+
+   type Foo
+   Bar
+// ^^^ support.constant
 
    42
 // ^^ constant.numeric.scala
@@ -189,7 +232,7 @@ object Foo
 // ^^^^^^^ storage.type.primitive.scala
 
    String
-// ^^^^^^ support.class
+// ^^^^^^ support.constant
 
    // this is a comment
 // ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
@@ -339,6 +382,9 @@ object Foo
 // ^ source.scala
 //    ^^^ storage.type.primitive.scala
 
+   a: Foo
+//    ^^^ support.class
+
    case (abc: Foo, cba @ _) =>
 // ^^^^ keyword.other.declaration.scala
 //       ^^^ variable.parameter
@@ -417,6 +463,13 @@ object Foo
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                            ^^^^^ entity.other.inherited-class.scala
+
+   case object Thingy extends (Foo => Bar)
+// ^^^^ keyword.other.declaration.scala
+//      ^^^^^^ keyword.control.class.scala
+//             ^^^^^^ entity.name.class.scala
+//                    ^^^^^^^ keyword.declaration.scala
+//                             ^^^ support.class
 
    case class
 // ^^^^ keyword.other.declaration.scala
@@ -500,7 +553,7 @@ object Foo
    for {
      back <- Traverse[Option]
 //   ^^^^ variable.parameter
-//           ^^^^^^^^ support.class
+//           ^^^^^^^^ support.constant
 //                    ^^^^^^ support.class
        .traverse[Free, Stuff](res) { r => }
 //      ^^^^^^^^ - entity.name
@@ -511,6 +564,7 @@ object Foo
 
   val baseSettings: Seq[Def.Setting[_]] = _
 //    ^^^^^^^^^^^^ entity.name.parameter.scala
+//                  ^^^ support.class
 //                                  ^ - keyword
 
   for {
@@ -531,5 +585,5 @@ object Foo
 //     ^^^ entity.name.parameter
 
    val (Foo, x) = 42
-//      ^^^ support.class.scala
+//      ^^^ support.constant.scala
 //           ^ entity.name.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -602,3 +602,24 @@ type Foo = Bar[A] forSome { type A }
 
 // fubar
 // <- source.scala comment.line.double-slash
+
+new Foo
+//  ^^^ support.class.scala
+
+new (Foo ~> Bar)
+//   ^^^ support.class.scala
+//       ^^ support.type.scala
+//          ^^^ support.class.scala
+
+  class Foo(val bar: Baz) extends AnyVal
+//          ^^^ storage.type.scala
+//                        ^^^^^^^ keyword.declaration.scala
+//                                ^^^^^^ entity.other.inherited-class.scala
+
+  class Foo(implicit bar: Baz) extends AnyVal
+//          ^^^^^^^^ storage.modifier.other
+//                             ^^^^^^^ keyword.declaration.scala
+//                                     ^^^^^^ entity.other.inherited-class.scala
+
+   val Stuff(f1, v1) = ???
+//     ^^^^^ support.constant.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -770,17 +770,23 @@ type Foo >: Bar
    ()
 // ^^ constant.language.scala
 
+   Foo()
+// ^^^ support.constant.scala
+//    ^^ - constant.language.scala
+
 foo()
 // ^^ - constant.language.scala
 
 foo()()
 //   ^^ - constant.language.scala
 
-foo(())
+foo(())()
 //  ^^ constant.language.scala
+//     ^^ - constant.language.scala
 
    () => 42
 // ^^ - constant.language.scala
+//    ^^ storage.type.function.arrow
 
 "testing /*comments*/"
 //       ^^^^^^^^^^^^ string.quoted.double
@@ -851,3 +857,7 @@ import foo.{
 // ^^^ variable.import.renamed-from.scala
 //        ^^^ variable.import.renamed-to.scala
 }
+
+for {} yield ()
+//     ^^^^^ keyword.control.flow.scala
+//           ^^ constant.language.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -962,3 +962,6 @@ case (foo, bar) =>
 
 val (foo, bar) = ???
 //      ^ punctuation.separator.scala
+
+foo eq bar
+//  ^^ keyword.operator.word.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -667,3 +667,11 @@ class Foo[A <% Int]
 
 class Foo[A: Int]
 //         ^ keyword.operator
+
+type Foo <: Bar
+//       ^^ keyword.operator
+//          ^^^ support.class
+
+type Foo >: Bar
+//       ^^ keyword.operator
+//          ^^^ support.class

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -968,3 +968,6 @@ foo eq bar
 
 new Config()
 //        ^^ - constant
+
+val A: Foo = stuff
+//  ^ entity.name.parameter.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -728,3 +728,7 @@ type Foo >: Bar
    a =>42
 // ^ variable.parameter
 //     ^^ constant.numeric.scala
+
+  (a: Int => Boolean) => 42
+//        ^^ support.type
+//           ^^^^^^^ storage.type

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -900,3 +900,14 @@ offset >= 0
 
 val chunk #: h = ???
 //           ^ entity.name.parameter
+
+for {
+  if things >= stuff
+//   ^^^^^^ - variable.parameter
+//             ^^^^^ - variable.parameter
+}
+
+
+for (if things >= stuff)
+//      ^^^^^^ - variable.parameter
+//                ^^^^^ - variable.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -874,6 +874,12 @@ import foo.{
 //        ^^^ variable.import.renamed-to.scala
 }
 
+import foo._
+//         ^ variable.language.scala
+
+import foo.{Foo => _}
+//                 ^ variable.language.scala
+
 for {} yield ()
 //     ^^^^^ keyword.control.flow.scala
 //           ^^ constant.language.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -487,14 +487,14 @@ type Foo = Bar[A] forSome { type A }
 //                   ^ - keyword
 
    case object Thingy extends Other
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ storage.type.class.scala
 //      ^^^^^^ storage.type.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                            ^^^^^ entity.other.inherited-class.scala
 
    case object Thingy extends (Foo => Bar)
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ storage.type.class.scala
 //      ^^^^^^ storage.type.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
@@ -507,7 +507,7 @@ type Foo = Bar[A] forSome { type A }
 =>     // this is here to act as a random terminator to the above partial syntax
 
    case class Thingy(abc: Int) extends Other
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ storage.type.class.scala
 //      ^^^^^ storage.type.class.scala
 //            ^^^^^^ entity.name.class.scala
 //                   ^^^ variable.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -889,3 +889,6 @@ foo: m.type
 
    ==
 // ^^ - keyword
+
+offset >= 0
+//     ^^ - keyword

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -982,3 +982,21 @@ type Maybe[A] = { type Inner = A; def x: Int }
      _ <- fooinConns.map(_.map(t => { }))
 //     ^^ keyword.operator.assignment.scala
    } yield ()
+
+new Foo with Bar with Baz
+//      ^^^^ keyword.declaration.scala
+//           ^^^ support.class.scala
+//               ^^^^ keyword.declaration.scala
+//                    ^^^ support.class.scala
+
+type Thing = Foo with Bar with Baz
+//               ^^^^ keyword.declaration.scala
+//                    ^^^ support.class.scala
+
+Foo[Foo with Bar]
+//      ^^^^ keyword.declaration.scala
+//           ^^^ support.class.scala
+
+xs: Foo with Bar
+//      ^^^^ keyword.declaration.scala
+//           ^^^ support.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -675,3 +675,49 @@ type Foo <: Bar
 type Foo >: Bar
 //       ^^ keyword.operator
 //          ^^^ support.class
+
+   { a => ??? }
+//   ^ variable.parameter
+
+   { (a, b) => ??? }
+//    ^ variable.parameter
+//       ^ variable.parameter
+
+   { a: Int => ??? }
+//   ^ variable.parameter
+//      ^^^ storage.type.primitive.scala
+
+   { (a: Int, b: Int) => ??? }
+//    ^ variable.parameter
+//       ^^^ storage.type.primitive.scala
+//            ^ variable.parameter
+//               ^^^ storage.type.primitive.scala
+
+   (a) => ???
+//  ^ variable.parameter
+
+   (a, b) => ???
+//  ^ variable.parameter
+//     ^ variable.parameter
+
+   (a: Int) => ???
+//  ^ variable.parameter
+//     ^^^ storage.type.primitive.scala
+
+   (a: Int, b: Int) => ???
+//  ^ variable.parameter
+//     ^^^ storage.type.primitive.scala
+//          ^ variable.parameter
+//             ^^^ storage.type.primitive.scala
+
+   a => ???
+// ^ variable.parameter
+
+   a: Int => ???
+// ^ variable.parameter
+//    ^^^ storage.type.primitive.scala
+
+   case _ if thing =>
+// ^^^^ keyword.other.declaration.scala
+//           ^^^^^ - variable.parameter
+//                 ^^ - storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -946,3 +946,7 @@ foo({ _: Unit => () })
 
   val _ @ _* = things
 //        ^^ keyword.operator.other.scala
+
+s"testing ${things} and more!"
+//          ^^^^^^ - string
+//          ^^^^^^ source.scala.embedded

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -886,3 +886,6 @@ for {} yield ()
 
 foo: m.type
 //     ^^^^ keyword.other.scala
+
+   ==
+// ^^ - keyword

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -971,3 +971,7 @@ new Config()
 
 val A: Foo = stuff
 //  ^ entity.name.parameter.scala
+
+type Maybe[A] = { type Inner = A; def x: Int }
+//                                ^^ storage.type.function.scala
+//                                    ^ entity.name.function.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -548,7 +548,7 @@ type Foo = Bar[A] forSome { type A }
      )
 
      val testing = 42
-//   ^^^ keyword.declaration.stable.scala
+//   ^^^ storage.type.stable.scala
 //       ^^^^^^^ variable.parameter
    } _
 //   ^ - variable.language.scala
@@ -561,10 +561,10 @@ type Foo = Bar[A] forSome { type A }
 //                  ^ variable.parameter
 //                    ^ keyword.operator.scala
 //                      ^ variable.language.scala
+//                         ^ keyword.operator.assignment.scala
 //                           ^ - variable.language.scala
 //                              ^^^ storage.type.stable.scala
-//                                  ^^^ entity.name.parameter
-//                                       TODO the above scope needs to be changed
+//                                  ^^^ variable.parameter
 //                                        ^ - variable.language.scala
 //                                           ^ - variable.language.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -737,3 +737,7 @@ type Foo >: Bar
 // ^ variable.parameter
 //    ^^^ support.class
 //           ^^^^^^^ keyword.declaration.scala
+
+"testing /*comments*/"
+//       ^^^^^^^^^^^^ string.quoted.double
+//       ^^^^^^^^^^^^ - comment

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -774,8 +774,15 @@ type Foo >: Bar
 // ^^^ support.constant.scala
 //    ^^ - constant.language.scala
 
-foo()
+  Foo[A]()
+//      ^^ - constant.language.scala
+
+  foo[A]()
+//      ^^ - constant.language.scala
+
+foo() bar ()
 // ^^ - constant.language.scala
+//        ^^ constant.language.scala
 
 foo()()
 //   ^^ - constant.language.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -526,3 +526,10 @@ object Foo
     case Bar.foo => 42
 //           ^^^ - entity.name
   }
+
+   val Foo = 42
+//     ^^^ entity.name.parameter
+
+   val (Foo, x) = 42
+//      ^^^ support.class.scala
+//           ^ entity.name.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -358,18 +358,18 @@ type Foo = Bar[A] forSome { type A }
    override
 // ^^^^^^^^ storage.modifier.other
 
-   ({ type λ[α] = Foo[α] })#λ
-// ^^^^^^^^^^^^^^ comment.block.scala
-//                ^^^ support.class
-//                    ^ comment.block.empty.scala
-//                       ^^^^ comment.block.scala
+   val t: ({ type λ[α] = Foo[α] })#λ
+//        ^^^^^^^^^^^^^^ comment.block.scala
+//                       ^^^ support.class
+//                           ^ comment.block.empty.scala
+//                              ^^^^ comment.block.scala
 
-   ({ type λ[α, β] = Foo[α, β] })#λ
-// ^^^^^^^^^^^^^^^^^ comment.block.scala
-//                   ^^^ support.class
-//                       ^ comment.block.empty.scala
-//                          ^ comment.block.empty.scala
-//                             ^^^^ comment.block.scala
+   val t: ({ type λ[α, β] = Foo[α, β] })#λ
+//        ^^^^^^^^^^^^^^^^^ comment.block.scala
+//                          ^^^ support.class
+//                              ^ comment.block.empty.scala
+//                                 ^ comment.block.empty.scala
+//                                    ^^^^ comment.block.scala
 
    a :: b :: Nil
 // ^^^^^^^^^ source.scala
@@ -644,3 +644,8 @@ type Foo = Foo.Bar
 
 type Foo = Foo#Bar
 //            ^ punctuation.separator
+
+val x: OptionT[({ type λ[α] = Foo[α, Int] })#λ, String] = ???
+//             ^^^^^^^^^^^^^^ comment.block
+//                                ^ comment.block.empty
+//                                        ^^^^ comment.block

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -926,3 +926,6 @@ foo_
 
 foo({ _ => () })
 //      ^^ storage.type.function.arrow
+
+foo({ _: Unit => () })
+//            ^^ storage.type.function.arrow

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -732,3 +732,8 @@ type Foo >: Bar
   (a: Int => Boolean) => 42
 //        ^^ support.type
 //           ^^^^^^^ storage.type
+
+  (a: Foo[A] forSome { type A }) => 42
+// ^ variable.parameter
+//    ^^^ support.class
+//           ^^^^^^^ keyword.declaration.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -738,6 +738,21 @@ type Foo >: Bar
 //    ^^^ support.class
 //           ^^^^^^^ keyword.declaration.scala
 
+   ()
+// ^^ constant.language.scala
+
+foo()
+// ^^ - constant.language.scala
+
+foo()()
+//   ^^ - constant.language.scala
+
+foo(())
+//  ^^ constant.language.scala
+
+   () => 42
+// ^^ - constant.language.scala
+
 "testing /*comments*/"
 //       ^^^^^^^^^^^^ string.quoted.double
 //       ^^^^^^^^^^^^ - comment

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -790,3 +790,35 @@ foo(())
 // ^^ variable.parameter
 //                 ^^ support.type.scala
 //                                   ^^ storage.type.function.arrow
+
+def foo(a: A <:< B)
+//           ^^^ support.type.scala
+
+def foo(a: A >:> B)
+//           ^^^ support.type.scala
+
+def foo(a: A =:= B)
+//           ^^^ support.type.scala
+
+def foo(a: A =:= B = null)
+//                 ^ keyword.operator.assignment.scala
+//                   ^^^^ constant.language.scala
+
+def foo(a: A :: B)
+//           ^^ support.type.scala
+
+class Foo(a: A <:< B)
+//             ^^^ support.type.scala
+
+class Foo(a: A >:> B)
+//             ^^^ support.type.scala
+
+class Foo(a: A =:= B)
+//             ^^^ support.type.scala
+
+class Foo(a: A =:= B = null)
+//                   ^ keyword.operator.assignment.scala
+//                     ^^^^ constant.language.scala
+
+class Foo(a: A :: B)
+//             ^^ support.type.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -471,7 +471,7 @@ type Foo = Bar[A] forSome { type A }
 
    case object Thingy extends (Foo => Bar)
 // ^^^^ keyword.other.declaration.scala
-//      ^^^^^^ keyword.control.class.scala
+//      ^^^^^^ storage.type.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                             ^^^ support.class

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -186,10 +186,10 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^ constant.language.scala
 
    Nil
-// ^^^ constant.language.scala
+// ^^^ support.constant.scala
 
    None
-// ^^^^ constant.language.scala
+// ^^^^ support.constant.scala
 
    this
 // ^^^^ variable.language.scala
@@ -381,11 +381,11 @@ type Foo = Bar[A] forSome { type A }
 
    a :: b :: Nil
 // ^^^^^^^^^ source.scala
-//           ^^^ constant.language.scala
+//           ^^^ support.constant.scala
 
   (a :: b :: Nil)
 // ^^^^^^^^^ source.scala
-//           ^^^ constant.language.scala
+//           ^^^ support.constant.scala
 
    a: Int
 // ^^ source.scala
@@ -448,7 +448,7 @@ type Foo = Bar[A] forSome { type A }
 //      ^^^^^^ text.xml
 //       ^^^ entity.name.tag
 
-   case Nil =>
+   case true =>
 //      ^^^ constant.language.scala
 
    case _ ⇒ _

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -721,3 +721,10 @@ type Foo >: Bar
 // ^^^^ keyword.other.declaration.scala
 //           ^^^^^ - variable.parameter
 //                 ^^ - storage.type.function.arrow
+
+   a =>a
+// ^ variable.parameter
+
+   a =>42
+// ^ variable.parameter
+//     ^^ constant.numeric.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -413,14 +413,14 @@ type Foo = Bar[A] forSome { type A }
 //            ^^^ support.class
 //                 ^^^ variable.parameter
 //                       ^ variable.language.scala
-//                          ^^ keyword.other.arrow.scala
+//                          ^^ keyword.operator.arrow.scala
 
    case abc @ `abc` =>
 //      ^^^ variable.parameter
 //          ^ keyword.operator.scala
 //            ^ punctuation.definition.identifier.scala
 //                ^ punctuation.definition.identifier.scala
-//                  ^^ keyword.other.arrow.scala
+//                  ^^ keyword.operator.arrow.scala
 //            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
@@ -861,10 +861,10 @@ import foo.{bar, bar => baz, bar=>baz}
 //         ^^^^^^^^^^^^^^^^^ meta.import.selector.scala
 //          ^^^ variable.import.scala
 //               ^^^ variable.import.renamed-from.scala
-//                   ^^ keyword.other.arrow.scala
+//                   ^^ keyword.operator.arrow.scala
 //                      ^^^ variable.import.renamed-to.scala
 //                           ^^^ variable.import.renamed-from.scala
-//                              ^^ keyword.other.arrow.scala
+//                              ^^ keyword.operator.arrow.scala
 //                                ^^^ variable.import.renamed-to.scala
 
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -931,3 +931,12 @@ foo({ _ => () })
 foo({ _: Unit => () })
 //    ^ variable.language.scala
 //            ^^ storage.type.function.arrow
+
+  stuff: _*
+//       ^^ keyword.operator.other.scala
+
+  case _ @ _* =>
+//         ^^ keyword.operator.other.scala
+
+  val _ @ _* = things
+//        ^^ keyword.operator.other.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -975,3 +975,10 @@ val A: Foo = stuff
 type Maybe[A] = { type Inner = A; def x: Int }
 //                                ^^ storage.type.function.scala
 //                                    ^ entity.name.function.scala
+
+   for {
+// ^^^ keyword.control.flow.scala
+      stuff = sequenceU.map(_.flatten) // thingy
+     _ <- fooinConns.map(_.map(t => { }))
+//     ^^ keyword.operator.assignment.scala
+   } yield ()

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -892,3 +892,11 @@ foo: m.type
 
 offset >= 0
 //     ^^ - keyword
+
+{
+  case chunk #: h =>
+//              ^ variable.parameter
+}
+
+val chunk #: h = ???
+//           ^ entity.name.parameter

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -649,3 +649,21 @@ val x: OptionT[({ type λ[α] = Foo[α, Int] })#λ, String] = ???
 //             ^^^^^^^^^^^^^^ comment.block
 //                                ^ comment.block.empty
 //                                        ^^^^ comment.block
+
+class Foo[+A]
+//        ^ keyword.operator
+
+class Foo[-A]
+//        ^ keyword.operator
+
+class Foo[A <: Int]
+//          ^^ keyword.operator
+
+class Foo[A >: Int]
+//          ^^ keyword.operator
+
+class Foo[A <% Int]
+//          ^^ keyword.operator
+
+class Foo[A: Int]
+//         ^ keyword.operator

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1000,3 +1000,11 @@ Foo[Foo with Bar]
 xs: Foo with Bar
 //      ^^^^ keyword.declaration.scala
 //           ^^^ support.class.scala
+
+   classTag[U]
+// ^^^^^ - storage.type
+
+   s"before ${classTag[U] stuff} after"
+//   ^^^^^^ string.quoted.interpolated.scala
+//            ^^^^^ - storage.type
+//                               ^^^^^ string.quoted.interpolated.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -626,3 +626,15 @@ new (Foo ~> Bar)
 
 new Foo(new Foo)
 //      ^^^ keyword.other.scala
+
+new Foo.Bar.Baz
+//     ^ punctuation.separator
+//      ^^^ support.class.scala
+//         ^ punctuation.separator
+//          ^^^ support.class.scala
+
+new Foo#Bar#Baz
+//     ^ punctuation.separator
+//      ^^^ support.class.scala
+//         ^ punctuation.separator
+//          ^^^ support.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -80,7 +80,7 @@ def foo(a: Int, b: Bar): Baz = 42
 
    val foo: Unit
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.parameter
+//     ^^^ entity.name.val
 //          ^^^^ storage.type.primitive.scala
 
    var foo: Unit
@@ -469,7 +469,7 @@ type Foo = Bar[A] forSome { type A }
 
    val abc @ `abc`
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.parameter
+//     ^^^ entity.name.val
 //         ^ keyword.operator.at.scala
 //           ^ punctuation.definition.identifier.scala
 //               ^ punctuation.definition.identifier.scala
@@ -480,7 +480,7 @@ type Foo = Bar[A] forSome { type A }
 
    val ble @ `abc` = _
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.parameter
+//     ^^^ entity.name.val
 //         ^ keyword.operator.at.scala
 //           ^^^^^ - entity.name
 //                 ^ keyword.operator.assignment.scala
@@ -597,7 +597,7 @@ type Foo = Bar[A] forSome { type A }
 
 
   val baseSettings: Seq[Def.Setting[_]] = _
-//    ^^^^^^^^^^^^ entity.name.parameter.scala
+//    ^^^^^^^^^^^^ entity.name.val.scala
 //                  ^^^ support.class
 //                                  ^ - keyword
 
@@ -618,11 +618,11 @@ type Foo = Bar[A] forSome { type A }
   }
 
    val Foo = 42
-//     ^^^ entity.name.parameter
+//     ^^^ entity.name.val
 
    val (Foo, x) = 42
 //      ^^^ support.constant.scala
-//           ^ entity.name.parameter
+//           ^ entity.name.val
 
 {
   Set[Foo[A, A] forSome { type A }, A]
@@ -905,7 +905,7 @@ offset >= 0
 }
 
 val chunk #: h = ???
-//           ^ entity.name.parameter
+//           ^ entity.name.val
 
 for {
   if things >= stuff
@@ -970,7 +970,7 @@ new Config()
 //        ^^ - constant
 
 val A: Foo = stuff
-//  ^ entity.name.parameter.scala
+//  ^ entity.name.val.scala
 
 type Maybe[A] = { type Inner = A; def x: Int }
 //                                ^^ storage.type.function.scala
@@ -1016,5 +1016,5 @@ xs: Foo with Bar
 }
 
 val Stuff(thing, other) = ???
-//        ^^^^^ entity.name.parameter.scala
-//               ^^^^^ entity.name.parameter.scala
+//        ^^^^^ entity.name.val.scala
+//               ^^^^^ entity.name.val.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -341,13 +341,13 @@ object Foo
 
    case (abc: Foo, cba @ _) =>
 // ^^^^ keyword.other.declaration.scala
-//       ^^^ entity.name.parameter
+//       ^^^ variable.parameter
 //            ^^^ support.class
-//                 ^^^ entity.name.parameter
+//                 ^^^ variable.parameter
 //                       ^ keyword
 
    case abc @ `abc` =>
-//      ^^^ entity.name.parameter
+//      ^^^ variable.parameter
 //          ^ keyword
 //            ^^^^^ - entity.name
 
@@ -437,16 +437,16 @@ object Foo
 // ^^^ keyword.control.flow.scala
 
      a <- _
-//   ^ entity.name.parameter
+//   ^ variable.parameter
 //        ^ - keyword
 
      a ← _
-//   ^ entity.name.parameter
+//   ^ variable.parameter
 //       ^ - entity.name
 
      (b, c @ _) <- _
-//    ^ entity.name.parameter
-//       ^ entity.name.parameter
+//    ^ variable.parameter
+//       ^ variable.parameter
 //         ^ keyword
 //           ^ keyword
 //                 ^ - keyword
@@ -454,54 +454,55 @@ object Foo
 //     ^ - entity.name
 
      testing = _
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
 //             ^ - keyword
 
      testing = {
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
        testing = false
 //     ^^^^^^^ - entity.name
      }
 
      testing = (
-//   ^^^^^^^ entity.name.parameter
+//   ^^^^^^^ variable.parameter
        testing = false
 //     ^^^^^^^ - entity.name
      )
 
      val testing = 42
 //   ^^^ keyword.declaration.stable.scala
-//       ^^^^^^^ entity.name.parameter
+//       ^^^^^^^ variable.parameter
    } _
 //   ^ - entity.name
 
    for (a <- _; (b, c @ _) ← _; val abc = _) _
 // ^^^ keyword.control.flow.scala
-//      ^ entity.name.parameter
+//      ^ variable.parameter
 //           ^ - keyword
-//               ^ entity.name.parameter
-//                  ^ entity.name.parameter
+//               ^ variable.parameter
+//                  ^ variable.parameter
 //                    ^ keyword
 //                      ^ keyword
 //                           ^ - keyword
 //                              ^^^ storage.type.stable.scala
 //                                  ^^^ entity.name.parameter
+//                                       TODO the above scope needs to be changed
 //                                        ^ - keyword
 //                                           ^ - keyword
 
    for {
      sss <- { {} }
-//   ^^^ entity.name.parameter
+//   ^^^ variable.parameter
      qqq <- stuff
-//   ^^^ entity.name.parameter
+//   ^^^ variable.parameter
    }
 
    for {
      back <- Traverse[Option]
-//   ^^^^ entity.name.parameter
+//   ^^^^ variable.parameter
 //           ^^^^^^^^ support.class
 //                    ^^^^^^ support.class
-       .traverse[Free, Stuff](res) { r =>
+       .traverse[Free, Stuff](res) { r => }
 //      ^^^^^^^^ - entity.name
 //                            ^^^ - entity.name
 //                                   ^ - entity.name
@@ -509,6 +510,7 @@ object Foo
 
 
   val baseSettings: Seq[Def.Setting[_]] = _
+//    ^^^^^^^^^^^^ entity.name.parameter.scala
 //                                  ^ - keyword
 
   for {


### PR DESCRIPTION
Several adjustments, fixes, enhancements and general better-ness:

- Indexing
  + `for`/`case` variables are no longer indexed
  + Initialization (i.e. `new`) are no longer erroneously indexed (#560)
  + Upper-case `val` declarations are indexed in base position, and considered constants in more complex patterns
- Type expressions are identified and parsed (subsumes #549)
  + Upper-case identifiers are now highlighted as constant references
  + Upper-case types are now highlighted as class references
  + Symbols in type position are highlighted as types
  + Underscores in type position… don't have a highlighting
  + Bounds (`<:`, `>:`, `<%`, `+`, `-` and `:`) are highlighted as special operators in type position
  + Dereferencing is identified (`#` and `.`)
  + Type lambdas are more stable now
  + `.type` is given special highlighting, since it is not a declaration when it appears in type position
  + `_*` is given special highlighting (also in pattern matching).  Note that we don't specially highlight the `*` type suffix yet, though we probably should.
- Lambdas are identified and highlighted (#558)
  + There are limitations to this.  Specifically, if your parameter block contains more than three nested parentheses sets, it will not be identified
  + Another limitation is that the parameters must be on the same line as the `=>` token
- Identifier regexes have been significantly improved
  + Invalid identifiers will no longer parse as operators (e.g. `:`, `_`, `<-` and others)
  + Prefix `_` characters are allowed (e.g. `_foo` is a valid identifier)
- The `_` operator is now scoped as a language variable in expression and pattern positions
- Assignment in all its forms has been given the appropriate scoping
- The `()` constant is now highlighted as such (similar to `true`/`false`)
- Numeric regexes have been rewritten entirely, based on the spec
  + Color schemes which highlight floats/integers/hex distinctly will now do so with Scala literals
  + The expression `42.toString` will no longer incorrectly highlight the `.` as part of the numeric
  + One deviation from the Scala spec here: `-12` will *not* highlight the `-` as part of the numeric.  This is sort of semantically justifiable (it can be viewed as a unary operator on `Int`), and it doesn't look horrible.  The main reason I did it is because it would require extreme contortion of the `op` regex
  + Octal literals are not highlighted, as they are no longer part of the language (e.g. `042` will not scope as anything).  I considered scoping these as `invalid.deprecated`, since that's exactly what they now are, but I can't remember how long ago they were removed.
- **All lookbehind has been removed.**  Previously, lookbehind was used for strings and imports, for no particularly good reason.  I would expect this should lead to significantly better performance, both on indexing and on highlighting, though I haven't actually noticed a difference.  Also, I have occasionally seen the indexer crash on some code (not very repeatably, and I saw it in master as often as on this PR), and when the indexer has crashed it produced a stack trace indicating that Oniguruma is still being used.  I wonder if we have some sort of regex weirdness somewhere that is forcing the fallback?
- Import matching has been completely rewritten and is now more robust
- `Nil` and `None` are no longer highlighted as primitives (since they aren't)
- A lot of random word boundary and keyword stuff that *was* broken is now fixed
  + As an example, classes/traits/objects who's name ends with "`extends`" or "`with`" no longer completely break highlighting at their declaration site
- Handling of default parameters in method and class definitions is now substantially more robust
- Comments are now more consistently handled (there may still be some latent bugs with this, but I think I got them all)
- Punctuation is now given the appropriate scoping (e.g. `.` is scoped as `punctuation.accessor.scala`).  Most color schemes ignore this, but it's good practice.
- Interpolated expressions within `${...}` blocks inside of strings now highlight with base scopes, rather than as if they were just part of the string.  (#580)
- `eq` is now considered a keyword (in particular, a word operator similar to Ruby's `and`)