### PR TITLE
[XML] add [sublime-snippet] syntax definition

### DIFF
--- a/XML/Snippet Content.sublime-syntax
+++ b/XML/Snippet Content.sublime-syntax
@@ -3,6 +3,7 @@
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: text.sublime-snippet-content
 name: Sublime Text Snippet Content
+hidden: true
 contexts:
   main:
     - include: possible_caret

--- a/XML/Snippet Content.sublime-syntax
+++ b/XML/Snippet Content.sublime-syntax
@@ -1,0 +1,78 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+scope: text.sublime-snippet-content
+name: Sublime Text Snippet Content
+contexts:
+  main:
+    - include: possible_caret
+
+  possible_caret:
+    - match: '\\\$'
+      scope: constant.character.escape.sublime-snippet-content
+    - match: '\$(?=\{|\w)'
+      scope: keyword.other.caret.sublime-snippet-content
+      push: caret
+    - match: '\$'
+      scope: invalid.illegal.unescaped-dollar.sublime-snippet-content
+
+  caret:
+    - match: '(?:(\d+)|(PARAM\d+|SELECTION|TM_CURRENT_LINE|TM_CURRENT_WORD|TM_FILENAME|TM_FILEPATH|TM_FULLNAME|TM_LINE_INDEX|TM_LINE_NUMBER|TM_SELECTED_TEXT|TM_SOFT_TABS|TM_TAB_SIZE)\b)' # http://docs.sublimetext.info/en/latest/extensibility/snippets.html?highlight=snippet#environment-variables
+      captures:
+        1: constant.numeric.sublime-snippet-content
+        2: constant.language.sublime-snippet-content
+      pop: true
+    - match: '\{'
+      scope: keyword.other.caret.begin.sublime-snippet-content
+      set: [inside_caret, caret]
+    - match: '\w+'
+      scope: constant.other.sublime-snippet-content #invalid.illegal.unknown-variable.sublime-snippet-content
+      pop: true
+
+  inside_caret:
+    - match: '\}'
+      scope: keyword.other.caret.end.sublime-snippet-content
+      pop: true
+    - include: possible_caret
+    - match: ':'
+      scope: keyword.operator.alternation.sublime-snippet-content
+    - match: '/'
+      scope: keyword.operator.regexp.begin.sublime-snippet-content
+      push:
+        - match: '/'
+          scope: keyword.operator.regexp.end.sublime-snippet-content
+          set:
+            - match: '(/)([gims-]*)(?=\})' # x mode doesn't seem to work properly in snippets
+              captures:
+                1: keyword.operator.replacement.end.sublime-snippet-content
+                2: storage.modifier.mode.regexp.sublime-snippet-content
+              pop: true
+            - include: regex_replacement
+        - include: scope:source.regexp#base-literal
+
+  regex_replacement: # http://www.boost.org/doc/libs/1_56_0/libs/regex/doc/html/boost_regex/format/boost_format_syntax.html
+    - match: '\$\$'
+      scope: constant.character.escape.sublime-snippet-replacement
+    - match: '\$(\d+|\{\d+\}|&|\+(\{\w+\})?|^N)'
+      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+    - match: \$(MATCH|PREMATCH|POSTMATCH|\{\^(MATCH|PREMATCH|POSTMATCH)\}|[`']|LAST_PAREN_MATCH|LAST_SUBMATCH_RESULT)
+      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+    - match: '\\[1-9]'
+      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+    - match: '\\[aefnrtv()]'
+      scope: constant.character.escape.sublime-snippet-replacement
+    - match: '\\[lLuUE]'
+      scope: keyword.operator.case-conversion.sublime-snippet-replacement
+    - match: '\)'
+      scope: invalid.illegal.stray-bracket.sublime-snippet-replacement
+    - match: '\\x(\h{2}|\{\h{4}\})'
+      scope: constant.character.escape.sublime-snippet-replacement
+    - match: '\(\?([1-9]|\{\w+\})'
+      scope: keyword.other.backref-and-recursion.conditional.regexp.sublime-snippet-replacement
+      push:
+        - match: ':'
+          scope: keyword.operator.alternation.sublime-snippet-replacement
+        - match: '\)'
+          scope: keyword.other.backref-and-recursion.conditional.regexp.sublime-snippet-replacement
+          pop: true
+        - include: regex_replacement

--- a/XML/Snippet Content.sublime-syntax
+++ b/XML/Snippet Content.sublime-syntax
@@ -9,7 +9,7 @@ contexts:
     - include: possible_caret
 
   possible_caret:
-    - match: '\\\$'
+    - match: '\\[$}]'
       scope: constant.character.escape.sublime-snippet-content
     - match: '\$(?=\{|\w)'
       scope: meta.text-substitution.sublime-snippet-content keyword.other.caret.sublime-snippet-content

--- a/XML/Snippet Content.sublime-syntax
+++ b/XML/Snippet Content.sublime-syntax
@@ -11,13 +11,13 @@ contexts:
     - match: '\\\$'
       scope: constant.character.escape.sublime-snippet-content
     - match: '\$(?=\{|\w)'
-      scope: keyword.other.caret.sublime-snippet-content
+      scope: meta.text-substitution.sublime-snippet-content keyword.other.caret.sublime-snippet-content
       push: caret
     - match: '\$'
       scope: invalid.illegal.unescaped-dollar.sublime-snippet-content
 
   caret:
-    - match: '(?:(\d+)|(PARAM\d+|SELECTION|TM_CURRENT_LINE|TM_CURRENT_WORD|TM_FILENAME|TM_FILEPATH|TM_FULLNAME|TM_LINE_INDEX|TM_LINE_NUMBER|TM_SELECTED_TEXT|TM_SOFT_TABS|TM_TAB_SIZE)\b)' # http://docs.sublimetext.info/en/latest/extensibility/snippets.html?highlight=snippet#environment-variables
+    - match: '(?:(\d+(?!\w))|(PARAM\d+|SELECTION|TM_CURRENT_LINE|TM_CURRENT_WORD|TM_FILENAME|TM_FILEPATH|TM_FULLNAME|TM_LINE_INDEX|TM_LINE_NUMBER|TM_SELECTED_TEXT|TM_SOFT_TABS|TM_TAB_SIZE)\b)' # http://docs.sublimetext.info/en/latest/extensibility/snippets.html?highlight=snippet#environment-variables
       captures:
         1: constant.numeric.sublime-snippet-content
         2: constant.language.sublime-snippet-content
@@ -26,53 +26,70 @@ contexts:
       scope: keyword.other.caret.begin.sublime-snippet-content
       set: [inside_caret, caret]
     - match: '\w+'
-      scope: constant.other.sublime-snippet-content #invalid.illegal.unknown-variable.sublime-snippet-content
+      scope: meta.text-substitution.sublime-snippet-content constant.other.sublime-snippet-content #invalid.illegal.unknown-variable.sublime-snippet-content
       pop: true
 
   inside_caret:
+    - meta_scope: meta.text-substitution.sublime-snippet-content
     - match: '\}'
       scope: keyword.other.caret.end.sublime-snippet-content
       pop: true
     - include: possible_caret
     - match: ':'
       scope: keyword.operator.alternation.sublime-snippet-content
+      push:
+        - meta_content_scope: string.unquoted.text-substitution.sublime-snippet-content
+        - include: possible_caret
+        - match: '(?=\})'
+          pop: true
     - match: '/'
       scope: keyword.operator.regexp.begin.sublime-snippet-content
       push:
         - match: '/'
           scope: keyword.operator.regexp.end.sublime-snippet-content
           set:
-            - match: '(/)([gims-]*)(?=\})' # x mode doesn't seem to work properly in snippets
-              captures:
-                1: keyword.operator.replacement.end.sublime-snippet-content
-                2: storage.modifier.mode.regexp.sublime-snippet-content
-              pop: true
+            - match: '/'
+              scope: keyword.operator.replacement.end.sublime-snippet-content
+              set:
+                - match: '[gims-]*' # x mode doesn't seem to work properly in snippets
+                  scope: storage.modifier.mode.regexp.sublime-snippet-content
+                - match: '(?=\})'
+                  pop: true
+                - match: '[^}]+'
+                  scope: invalid.illegal.unexpected-token.sublime-snippet-content
             - include: regex_replacement
         - include: scope:source.regexp#base-literal
 
   regex_replacement: # http://www.boost.org/doc/libs/1_56_0/libs/regex/doc/html/boost_regex/format/boost_format_syntax.html
     - match: '\$\$'
-      scope: constant.character.escape.sublime-snippet-replacement
+      scope: constant.character.escape.regexp-replacement
     - match: '\$(\d+|\{\d+\}|&|\+(\{\w+\})?|^N)'
-      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+      scope: keyword.other.backref-and-recursion.regexp-replacement
     - match: \$(MATCH|PREMATCH|POSTMATCH|\{\^(MATCH|PREMATCH|POSTMATCH)\}|[`']|LAST_PAREN_MATCH|LAST_SUBMATCH_RESULT)
-      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+      scope: keyword.other.backref-and-recursion.regexp-replacement
     - match: '\\[1-9]'
-      scope: keyword.other.backref-and-recursion.regexp.sublime-snippet-replacement
+      scope: keyword.other.backref-and-recursion.regexp-replacement
     - match: '\\[aefnrtv()]'
-      scope: constant.character.escape.sublime-snippet-replacement
+      scope: constant.character.escape.regexp-replacement
     - match: '\\[lLuUE]'
-      scope: keyword.operator.case-conversion.sublime-snippet-replacement
+      scope: keyword.operator.case-conversion.regexp-replacement
     - match: '\)'
-      scope: invalid.illegal.stray-bracket.sublime-snippet-replacement
+      scope: meta.literal.regexp-replacement
     - match: '\\x(\h{2}|\{\h{4}\})'
-      scope: constant.character.escape.sublime-snippet-replacement
+      scope: constant.character.escape.regexp-replacement
     - match: '\(\?([1-9]|\{\w+\})'
-      scope: keyword.other.backref-and-recursion.conditional.regexp.sublime-snippet-replacement
+      scope: keyword.other.backref-and-recursion.conditional.regexp-replacement
       push:
+        - meta_scope: meta.group.conditional.regexp-replacement
         - match: ':'
-          scope: keyword.operator.alternation.sublime-snippet-replacement
+          scope: keyword.operator.alternation.regexp-replacement
         - match: '\)'
-          scope: keyword.other.backref-and-recursion.conditional.regexp.sublime-snippet-replacement
+          scope: keyword.other.backref-and-recursion.conditional.regexp-replacement
           pop: true
         - include: regex_replacement
+    - match: '\\\\'
+      scope: constant.character.escape.regexp-replacement
+    - match: '\\.'
+      scope: constant.character.escape.regexp-replacement
+    - match: '.'
+      scope: meta.literal.regexp-replacement

--- a/XML/Snippet.sublime-syntax
+++ b/XML/Snippet.sublime-syntax
@@ -1,0 +1,26 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+file_extensions:
+  - sublime-snippet
+name: Sublime Text Snippet
+scope: text.xml.sublime-snippet
+contexts:
+  main:
+    - match: '(<)(content)(>)(<!\[CDATA\[)'
+      captures:
+        1: meta.tag.xml punctuation.definition.tag.begin.xml
+        2: meta.tag.xml entity.name.tag.localname.xml
+        3: meta.tag.xml punctuation.definition.tag.end.xml
+        4: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+      push:
+        - meta_content_scope: string.unquoted.cdata.xml
+        - match: '(\]\]>)(</)(content)(>)'
+          captures:
+            1: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+            2: meta.tag.xml punctuation.definition.tag.begin.xml
+            3: meta.tag.xml entity.name.tag.localname.xml
+            4: meta.tag.xml punctuation.definition.tag.end.xml
+          pop: true
+        - include: scope:text.sublime-snippet-content
+    - include: scope:text.xml

--- a/XML/Snippet.sublime-syntax
+++ b/XML/Snippet.sublime-syntax
@@ -3,7 +3,7 @@
 # See http://www.sublimetext.com/docs/3/syntax.html
 file_extensions:
   - sublime-snippet
-name: Sublime Text Snippet
+name: Sublime Text Snippet (XML)
 scope: text.xml.sublime-snippet
 contexts:
   main:

--- a/XML/Snippet.sublime-syntax
+++ b/XML/Snippet.sublime-syntax
@@ -10,7 +10,7 @@ contexts:
     - match: '(<)(content)(>)'
       captures:
         1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
+        2: meta.tag.xml entity.name.tag.localname.xml meta.toc-list.snippet-content.sublime-snippet
         3: meta.tag.xml punctuation.definition.tag.end.xml
       push:
         - match: '<!\[CDATA\['
@@ -29,6 +29,16 @@ contexts:
             - include: snippet_content
         - match: '(?=\S)'
           set: inside_content
+    - match: '(<)(scope)(>)'
+      captures:
+        1: meta.tag.xml punctuation.definition.tag.begin.xml
+        2: meta.tag.xml entity.name.tag.localname.xml meta.toc-list.snippet-scope.sublime-snippet
+        3: meta.tag.xml punctuation.definition.tag.end.xml
+    - match: '(<)(tabTrigger)(>)'
+      captures:
+        1: meta.tag.xml punctuation.definition.tag.begin.xml
+        2: meta.tag.xml entity.name.tag.localname.xml meta.toc-list.snippet-trigger.sublime-snippet
+        3: meta.tag.xml punctuation.definition.tag.end.xml
     - include: scope:text.xml
   
   snippet_content:

--- a/XML/Snippet.sublime-syntax
+++ b/XML/Snippet.sublime-syntax
@@ -7,20 +7,38 @@ name: Sublime Text Snippet
 scope: text.xml.sublime-snippet
 contexts:
   main:
-    - match: '(<)(content)(>)(<!\[CDATA\[)'
+    - match: '(<)(content)(>)'
       captures:
         1: meta.tag.xml punctuation.definition.tag.begin.xml
         2: meta.tag.xml entity.name.tag.localname.xml
         3: meta.tag.xml punctuation.definition.tag.end.xml
-        4: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
       push:
-        - meta_content_scope: string.unquoted.cdata.xml
-        - match: '(\]\]>)(</)(content)(>)'
-          captures:
-            1: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-            2: meta.tag.xml punctuation.definition.tag.begin.xml
-            3: meta.tag.xml entity.name.tag.localname.xml
-            4: meta.tag.xml punctuation.definition.tag.end.xml
-          pop: true
-        - include: scope:text.sublime-snippet-content
+        - match: '<!\[CDATA\['
+          scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+          set:
+            - meta_content_scope: string.unquoted.cdata.xml
+            - match: '\]\]>'
+              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+              set:
+                - match: '<!\[CDATA\['
+                  set:
+                    - meta_scope: invalid.illegal.multiple-cdata-not-allowed.sublime-snippet-content
+                    - match: '\]\]>'
+                      pop: true
+                - include: inside_content
+            - include: snippet_content
+        - match: '(?=\S)'
+          set: inside_content
     - include: scope:text.xml
+  
+  snippet_content:
+    - include: scope:text.sublime-snippet-content
+  
+  inside_content:
+    - match: '(</)(content)(>)'
+      captures:
+        1: meta.tag.xml punctuation.definition.tag.begin.xml
+        2: meta.tag.xml entity.name.tag.localname.xml
+        3: meta.tag.xml punctuation.definition.tag.end.xml
+      pop: true
+    - include: snippet_content

--- a/XML/XML.sublime-settings
+++ b/XML/XML.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"hidden_extensions": ["rss", "sublime-snippet", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae"]
+	"hidden_extensions": ["rss", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae"]
 }

--- a/XML/syntax_test_snippet.xml
+++ b/XML/syntax_test_snippet.xml
@@ -9,12 +9,18 @@
 #            ^^^^^^^^^ punctuation.definition.string.begin
 
       Original: ${1:Hey, Joe!}
+#               ^^^^^^^^^^^^^^ meta.text-substitution
+#              ^ - meta.text-substitution
+#                             ^ - meta.text-substitution
 #               ^^ keyword.other.caret
 #                 ^ constant.numeric
 #                  ^ keyword.operator.alternation
 #                            ^ keyword.other.caret
 
 Transformation: ${1/./=/g}
+#               ^^^^^^^^^^ meta.text-substitution
+#              ^ - meta.text-substitution
+#                         ^ - meta.text-substitution
 #               ^^ keyword.other.caret
 #                 ^ constant.numeric
 #                  ^ keyword.operator.regexp.begin
@@ -25,6 +31,9 @@ Transformation: ${1/./=/g}
 #                        ^ keyword.other.caret
 
 Transformation: ${1/^(\w)|(?:_(\w))/(?1\u$1:)(?2 \u${2}:)/g}
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.text-substitution
+#              ^ - meta.text-substitution
+#                                                           ^ - meta.text-substitution
 #               ^^ keyword.other.caret
 #                 ^ constant.numeric
 #                  ^ keyword.operator.regexp.begin
@@ -34,6 +43,7 @@ Transformation: ${1/^(\w)|(?:_(\w))/(?1\u$1:)(?2 \u${2}:)/g}
 #                        ^ keyword.operator.alternation
 #                         ^^^^^^^^^ meta.group
 #                                  ^ keyword.operator.regexp.end
+#                                   ^^^^^^^^^ meta.group.conditional
 #                                   ^^^ keyword.other.backref-and-recursion.conditional
 #                                      ^^ keyword.operator.case-conversion
 #                                        ^^ keyword.other.backref-and-recursion
@@ -58,6 +68,9 @@ First Name: ${1:Joe}
 Second Name: ${2:Bloggs}
 Address: ${3:Main Street 1234}
 User name: ${4:$TM_FULLNAME}
+#          ^^^^^^^^^^^^^^^^^ meta.text-substitution
+#         ^ - meta.text-substitution
+#                           ^ - meta.text-substitution
 #          ^^ keyword.other.caret
 #            ^ constant.numeric
 #             ^ keyword.operator.alternation
@@ -66,6 +79,10 @@ User name: ${4:$TM_FULLNAME}
 #                          ^ keyword.other.caret
 
 Test: ${1:Nested ${2:Placeholder}}
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.text-substitution
+#                ^^^^^^^^^^^^^^^^ meta.text-substitution meta.text-substitution
+#    ^ - meta.text-substitution
+#                                 ^ - meta.text-substitution
 #     ^^ keyword.other.caret
 #       ^ constant.numeric
 #        ^ keyword.operator.alternation
@@ -73,6 +90,12 @@ Test: ${1:Nested ${2:Placeholder}}
 #                  ^ constant.numeric
 #                   ^ keyword.operator.alternation
 #                               ^^ keyword.other.caret
+
+No braces: $1 $SELECTION
+#          ^ keyword.other.caret
+#           ^ constant.numeric
+#             ^ keyword.other.caret
+#              ^^^^^^^^^ constant.language
 
 Literal dollar: \$5
 #               ^^ constant.character.escape - keyword
@@ -96,11 +119,12 @@ Literal dollar: \$5
 #                                                                   ^^ constant.character.escape - keyword
 #                                                                                           ^ keyword.operator.regexp.end
 #                                                                                            ^^^^^ keyword.other.backref-and-recursion.conditional
+#                                                                                                 ^ meta.literal
 #                                                                                                  ^ keyword.operator.alternation
 #                                                                                                   ^^ keyword.operator.case-conversion
 #                                                                                                     ^^ keyword.other.backref-and-recursion
 #                                                                                                           ^^^^^^^^^^^ keyword.other.backref-and-recursion.conditional
-#                                                                                                                      ^ - keyword.other.backref-and-recursion.conditional
+#                                                                                                                      ^ meta.literal - keyword.other.backref-and-recursion.conditional
 #                                                                                                                        ^^ keyword.other.backref-and-recursion
 #                                                                                                                           ^^ keyword.operator.case-conversion
 #                                                                                                                              ^ keyword.operator.replacement.end
@@ -108,16 +132,29 @@ Literal dollar: \$5
 #                                                                                                                                  ^ - keyword
 
 stray brackets:
- ${1/example)/)$$$0/}
+ ${1/example)/)$$$0\\ \../}
 #^ keyword.other.caret
 # ^ keyword.other.caret.begin
 #           ^ invalid.illegal
 #            ^ keyword.operator.regexp.end
-#             ^ invalid.illegal
+#             ^ meta.literal
 #              ^^ constant.character.escape
-#                ^^ keyword.other.backref-and-recursion.regexp
-#                  ^ keyword.operator.replacement.end
-#                   ^ keyword.other.caret.end
+#                ^^ keyword.other.backref-and-recursion.regexp-replacement
+#                  ^^ constant.character.escape
+#                    ^ meta.literal
+#                     ^^ constant.character.escape
+#                       ^ meta.literal
+#                        ^ keyword.operator.replacement.end
+#                         ^ keyword.other.caret.end
+
+ ${1:default/no/regex$2/}
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.text-substitution
+#   ^ keyword.operator.alternation.sublime-snippet-content
+#    ^^^^^^^^^^^^^^^^^^^ string.unquoted.text-substitution
+#           ^ - keyword
+#              ^ - keyword
+#                    ^ keyword.other.caret
+#                     ^ constant.numeric
 
  $ 1.00
 #^ invalid.illegal.unescaped-dollar
@@ -130,6 +167,34 @@ stray brackets:
 
 ${My_Own_Constant}
 # ^^^^^^^^^^^^^^^ constant.other
+
+${1My_Own_Constant}
+# ^^^^^^^^^^^^^^^^ constant.other
+
+${10}
+# ^^ constant.numeric
+
+${1/test/abc/:substituation not valid here}
+#  ^ keyword.operator.regexp.begin
+#       ^ keyword.operator.regexp.end
+#           ^ keyword.operator.replacement.end
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.unexpected-token
+#                                         ^ keyword.other.caret.end - invalid
+
+${1/test/escaped slash\/real slash/gx} x mode not supported properly in snippets
+#  ^ keyword.operator.regexp.begin
+#       ^ keyword.operator.regexp.end
+#                     ^^ constant.character.escape
+#                      ^ - keyword.operator.replacement.end
+#                                 ^ keyword.operator.replacement.end
+#                                  ^ storage.modifier.mode
+#                                   ^ invalid.illegal.unexpected-token
+#                                    ^ keyword.other.caret.end - invalid
+
+It is possible to include a literal newline in the replacement: ${1/test/_
+ /}.
+#^ keyword.operator.replacement.end
+# ^ keyword.other.caret.end
 
  ]]></content>
 #^^^ string.unquoted.cdata punctuation.definition.string.end
@@ -144,7 +209,13 @@ ${My_Own_Constant}
     <scope>text</scope>
 </snippet>
 
+<!-- NOTE: multiple payloads inside a sublime-snippet file are not supported
+           but they are in this test file to avoid the need for using multiple
+           test files, and to test the interactions between different scenarios
+-->
+
 <content> no cdata ${1} </content>
+#                  ^^^^ meta.text-substitution
 #                  ^^ keyword.other.caret
 #                    ^ constant.numeric
 #                     ^ keyword.other.caret
@@ -153,6 +224,7 @@ ${My_Own_Constant}
 <content>
     <![CDATA[ cdata on a
     different line ${1} ]]> </content>
+#                  ^^^^ meta.text-substitution
 #                  ^^ keyword.other.caret
 #                    ^ constant.numeric
 #                     ^ keyword.other.caret
@@ -165,6 +237,8 @@ ${My_Own_Constant}
 
     <![CDATA[ example ${1} ]]>
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.multiple-cdata-not-allowed
+#  ^ - invalid
+#                             ^ - invalid
 </content>
 #^^^^^^^^^ meta.tag
 
@@ -173,6 +247,7 @@ ${My_Own_Constant}
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
 #                                        ^ - string
 #                     ^^^^^^^^^^ - meta.tag
+#                                ^^^^ meta.text-substitution
 #                                ^^ keyword.other.caret
 #                                  ^ constant.numeric
 #                                   ^ keyword.other.caret

--- a/XML/syntax_test_snippet.xml
+++ b/XML/syntax_test_snippet.xml
@@ -143,3 +143,38 @@ ${My_Own_Constant}
     <!-- Optional: Scope the tab trigger will be active in -->
     <scope>text</scope>
 </snippet>
+
+<content> no cdata ${1} </content>
+#                  ^^ keyword.other.caret
+#                    ^ constant.numeric
+#                     ^ keyword.other.caret
+#                       ^^^^^^^^^^ meta.tag
+
+<content>
+    <![CDATA[ cdata on a
+    different line ${1} ]]> </content>
+#                  ^^ keyword.other.caret
+#                    ^ constant.numeric
+#                     ^ keyword.other.caret
+
+<content>
+    <![CDATA[ example ${1} ]]>
+#                     ^^ keyword.other.caret
+#                       ^ constant.numeric
+#                        ^ keyword.other.caret
+
+    <![CDATA[ example ${1} ]]>
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.multiple-cdata-not-allowed
+</content>
+#^^^^^^^^^ meta.tag
+
+<content>
+    <![CDATA[ example </content> ${1} ]]>
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+#                                        ^ - string
+#                     ^^^^^^^^^^ - meta.tag
+#                                ^^ keyword.other.caret
+#                                  ^ constant.numeric
+#                                   ^ keyword.other.caret
+</content>
+#^^^^^^^^^ meta.tag

--- a/XML/syntax_test_snippet.xml
+++ b/XML/syntax_test_snippet.xml
@@ -2,7 +2,7 @@
 <snippet>
     <content><![CDATA[
 #   ^^^^^^^^^ meta.tag
-#    ^^^^^^^ entity.name.tag.localname
+#    ^^^^^^^ entity.name.tag.localname meta.toc-list.snippet-content
 #   ^ punctuation.definition.tag.begin
 #           ^ punctuation.definition.tag.end
 #            ^^^^^^^^^^ string.unquoted.cdata - meta.tag
@@ -205,8 +205,10 @@ It is possible to include a literal newline in the replacement: ${1/test/_
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment
     <tabTrigger>test-snippet</tabTrigger>
 #   ^^^^^^^^^^^^ meta.tag
+#    ^^^^^^^^^^ meta.toc-list.snippet-trigger
     <!-- Optional: Scope the tab trigger will be active in -->
     <scope>text</scope>
+#    ^^^^^ meta.toc-list.snippet-scope
 </snippet>
 
 <!-- NOTE: multiple payloads inside a sublime-snippet file are not supported

--- a/XML/syntax_test_snippet.xml
+++ b/XML/syntax_test_snippet.xml
@@ -1,0 +1,145 @@
+# SYNTAX TEST "Packages/XML/Snippet.sublime-syntax"
+<snippet>
+    <content><![CDATA[
+#   ^^^^^^^^^ meta.tag
+#    ^^^^^^^ entity.name.tag.localname
+#   ^ punctuation.definition.tag.begin
+#           ^ punctuation.definition.tag.end
+#            ^^^^^^^^^^ string.unquoted.cdata - meta.tag
+#            ^^^^^^^^^ punctuation.definition.string.begin
+
+      Original: ${1:Hey, Joe!}
+#               ^^ keyword.other.caret
+#                 ^ constant.numeric
+#                  ^ keyword.operator.alternation
+#                            ^ keyword.other.caret
+
+Transformation: ${1/./=/g}
+#               ^^ keyword.other.caret
+#                 ^ constant.numeric
+#                  ^ keyword.operator.regexp.begin
+#                   ^ keyword.other.any
+#                    ^ keyword.operator.regexp.end
+#                      ^ keyword.operator.replacement.end
+#                       ^ storage.modifier.mode.regexp
+#                        ^ keyword.other.caret
+
+Transformation: ${1/^(\w)|(?:_(\w))/(?1\u$1:)(?2 \u${2}:)/g}
+#               ^^ keyword.other.caret
+#                 ^ constant.numeric
+#                  ^ keyword.operator.regexp.begin
+#                   ^ keyword.control.anchors
+#                    ^^^^ meta.group
+#                     ^^ keyword.control.character-class
+#                        ^ keyword.operator.alternation
+#                         ^^^^^^^^^ meta.group
+#                                  ^ keyword.operator.regexp.end
+#                                   ^^^ keyword.other.backref-and-recursion.conditional
+#                                      ^^ keyword.operator.case-conversion
+#                                        ^^ keyword.other.backref-and-recursion
+#                                          ^ keyword.operator.alternation
+#                                           ^ keyword.other.backref-and-recursion.conditional
+#                                            ^^^ keyword.other.backref-and-recursion.conditional
+#                                                ^^ keyword.operator.case-conversion
+#                                                  ^^^^ keyword.other.backref-and-recursion
+#                                                      ^ keyword.operator.alternation
+#                                                       ^ keyword.other.backref-and-recursion.conditional
+#                                                        ^ keyword.operator.replacement.end
+#                                                         ^ storage.modifier.mode.regexp
+#                                                          ^ keyword.other.caret
+
+      Original: ${1:text_in_snail_case}
+#               ^^ keyword.other.caret
+#                 ^ constant.numeric
+#                  ^ keyword.operator.alternation
+#                                     ^ keyword.other.caret
+
+First Name: ${1:Joe}
+Second Name: ${2:Bloggs}
+Address: ${3:Main Street 1234}
+User name: ${4:$TM_FULLNAME}
+#          ^^ keyword.other.caret
+#            ^ constant.numeric
+#             ^ keyword.operator.alternation
+#              ^ keyword.other.caret
+#               ^^^^^^^^^^^ constant.language
+#                          ^ keyword.other.caret
+
+Test: ${1:Nested ${2:Placeholder}}
+#     ^^ keyword.other.caret
+#       ^ constant.numeric
+#        ^ keyword.operator.alternation
+#                ^^ keyword.other.caret
+#                  ^ constant.numeric
+#                   ^ keyword.operator.alternation
+#                               ^^ keyword.other.caret
+
+Literal dollar: \$5
+#               ^^ constant.character.escape - keyword
+#                 ^ - constant.numeric
+
+\label{sec:${TM_FILENAME:${SELECTION/(?i:(?<example>á))|\\\w+\{(.*?)\}|\\(.)|(\w)|([^\w\\]+)/(?{5}_:\L$2${3}(?{example}a:\4)\E)/g}}}
+#     ^ - keyword
+#         ^ - keyword
+#          ^ keyword.other.caret
+#           ^ keyword.other.caret.begin
+#            ^^^^^^^^^^^ constant.language
+#                       ^ keyword.operator.alternation
+#                        ^ keyword.other.caret
+#                         ^ keyword.other.caret.begin
+#                          ^^^^^^^^^ constant.language
+#                                   ^ keyword.operator.regexp.begin
+#                                    ^^^^^^^^^^^^^^^^^^ meta.group
+#                                                       ^^ constant.character.escape
+#                                                           ^ keyword.operator.quantifier.regexp
+#                                                            ^^ constant.character.escape - keyword
+#                                                                   ^^ constant.character.escape - keyword
+#                                                                                           ^ keyword.operator.regexp.end
+#                                                                                            ^^^^^ keyword.other.backref-and-recursion.conditional
+#                                                                                                  ^ keyword.operator.alternation
+#                                                                                                   ^^ keyword.operator.case-conversion
+#                                                                                                     ^^ keyword.other.backref-and-recursion
+#                                                                                                           ^^^^^^^^^^^ keyword.other.backref-and-recursion.conditional
+#                                                                                                                      ^ - keyword.other.backref-and-recursion.conditional
+#                                                                                                                        ^^ keyword.other.backref-and-recursion
+#                                                                                                                           ^^ keyword.operator.case-conversion
+#                                                                                                                              ^ keyword.operator.replacement.end
+#                                                                                                                                ^^ keyword.other.caret.end
+#                                                                                                                                  ^ - keyword
+
+stray brackets:
+ ${1/example)/)$$$0/}
+#^ keyword.other.caret
+# ^ keyword.other.caret.begin
+#           ^ invalid.illegal
+#            ^ keyword.operator.regexp.end
+#             ^ invalid.illegal
+#              ^^ constant.character.escape
+#                ^^ keyword.other.backref-and-recursion.regexp
+#                  ^ keyword.operator.replacement.end
+#                   ^ keyword.other.caret.end
+
+ $ 1.00
+#^ invalid.illegal.unescaped-dollar
+
+ ${0:$TM_SELECTED_TEXT}
+#  ^ constant
+#     ^^^^^^^^^^^^^^^^ constant
+#   ^^ - constant
+#                     ^ - constant
+
+${My_Own_Constant}
+# ^^^^^^^^^^^^^^^ constant.other
+
+ ]]></content>
+#^^^ string.unquoted.cdata punctuation.definition.string.end
+#   ^^^^^^^^^^ meta.tag - string
+#   ^^ punctuation.definition.tag.begin
+#            ^ punctuation.definition.tag.end
+    <!-- Optional: Tab trigger to activate the snippet -->
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment
+    <tabTrigger>test-snippet</tabTrigger>
+#   ^^^^^^^^^^^^ meta.tag
+    <!-- Optional: Scope the tab trigger will be active in -->
+    <scope>text</scope>
+</snippet>

--- a/XML/syntax_test_snippet.xml
+++ b/XML/syntax_test_snippet.xml
@@ -165,6 +165,13 @@ stray brackets:
 #   ^^ - constant
 #                     ^ - constant
 
+ ${0:$TM_SELECTED_TEXT\}}
+#  ^ constant
+#     ^^^^^^^^^^^^^^^^ constant.language
+#   ^^ - constant
+#                     ^^ constant.character.escape
+#                       ^ - constant
+
 ${My_Own_Constant}
 # ^^^^^^^^^^^^^^^ constant.other
 


### PR DESCRIPTION
...which will highlight as plain XML initially, until the content is reached, whereby it will also highlight (nested) placeholders and their optional regular expression replacements
