### PR TITLE
Add entity.name.constant to Java symbol index

### DIFF
--- a/Java/Symbol Index Include Constants.tmPreferences
+++ b/Java/Symbol Index Include Constants.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Constants</string>
+	<key>scope</key>
+	<string>(source.java) &amp; entity.name.constant</string>
+	<key>settings</key>
+	<dict>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
I realize the current syntax definition doesn't use this yet. I'm working on
upstreaming my Java syntax changes.