### PR TITLE
[LaTeX] Support braces in `\lstinline`

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -782,6 +782,15 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.lstinline.latex
         - include: general-optional-arguments
+        - match: '\{'
+          scope: punctuation.definition.group.brace.begin.latex
+          set:
+            - meta_include_prototype: false
+            - meta_scope: meta.group.brace.latex
+            - meta_content_scope: meta.environment.verbatim.lstinline.latex markup.raw.verb.latex
+            - match: '\}'
+              scope: meta.environment.verbatim.lstinline.latex punctuation.definition.group.brace.end.latex
+              pop: true
         - match: '(\W)'
           scope: punctuation.definition.verb.latex
           set:

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -293,6 +293,19 @@ class MyClass() {
 }
 \end{lstlisting}
 
+\lstinline{var x = 15;}
+% ^^^^^^^^^^^^^^^^^^^^^ meta.environment.verbatim.lstinline.latex
+%         ^^^^^^^^^^^^^ meta.group.brace.latex
+%         ^ punctuation.definition.group.brace.begin.latex
+%          ^^^^^^^^^^^ markup.raw.verb.latex
+%                     ^ punctuation.definition.group.brace.end.latex
+%                      ^ - meta.environment.verbatim.lstinline.latex
+
+\lstinline|var x = 15;|
+% ^^^^^^^^^^^^^^^^^^^^^ meta.environment.verbatim.lstinline.latex
+%          ^^^^^^^^^^^ markup.raw.verb.latex
+%                      ^ - meta.environment.verbatim.lstinline.latex
+
 
 % PACKAGE: minted
 % The minted package is used to highlight source code using


### PR DESCRIPTION
This resolves https://github.com/sublimehq/Packages/issues/568 as @merlinthered is right and `\lstinline{...}` is an experimental feature, see [listings documentation sec 4.2](https://www.ctan.org/pkg/listings).

