### PR TITLE
[HTML] [CSS] completions before </style> and [HTML] meta.tag scope

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -443,7 +443,7 @@ class CSSCompletions(sublime_plugin.EventListener):
             # <style type="text/css">.test { f|</style>
             # i.e. after a "style" HTML open tag and immediately before the closing tag.
             # so we want to offer CSS completions here.
-            if view.match_selector(loc, 'text.html.basic meta.tag.style punctuation.definition.tag.begin.html') and \
+            if view.match_selector(loc, 'text.html meta.tag.style.end punctuation.definition.tag.begin.html') and \
                view.match_selector(loc - 1, selector_scope):
                 pass
             else:

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -429,16 +429,25 @@ class CSSCompletions(sublime_plugin.EventListener):
         # match inside a CSS document and
         # match inside the style attribute of HTML tags, incl. just before the quote that closes the attribute value
         css_selector_scope = "source.css - meta.selector.css"
-        html_style_selector_scope = "text.html meta.attribute-with-value.style.html " + \
+        html_style_attr_selector_scope = "text.html meta.attribute-with-value.style.html " + \
                                     "string.quoted - punctuation.definition.string.begin.html"
-        selector_scope = css_selector_scope + ', ' + html_style_selector_scope
+        selector_scope = css_selector_scope + ', ' + html_style_attr_selector_scope
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
         loc = locations[0]
 
         # When not inside CSS, don’t trigger
         if not view.match_selector(loc, selector_scope):
-            return []
+            # if the text immediately after the caret is a HTML style tag beginning, and the character before the
+            # caret matches the CSS scope, then probably the user is typing here (where | represents the caret):
+            # <style type="text/css">.test { f|</style>
+            # i.e. after a "style" HTML open tag and immediately before the closing tag.
+            # so we want to offer CSS completions here.
+            if view.match_selector(loc, 'text.html.basic meta.tag.style punctuation.definition.tag.begin.html') and \
+               view.match_selector(loc - 1, selector_scope):
+                pass
+            else:
+                return []
 
         if not self.props:
             self.props = parse_css_data()
@@ -446,7 +455,9 @@ class CSSCompletions(sublime_plugin.EventListener):
 
         l = []
         if (view.match_selector(loc, prop_value_scope) or
-            # This will catch scenarios like .foo {font-style: |}
+            # This will catch scenarios like:
+            # - .foo {font-style: |}
+            # - <style type="text/css">.foo { font-weight: b|</style> 
             view.match_selector(loc - 1, prop_value_scope)):
 
             alt_loc = loc - len(prefix)

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -67,19 +67,19 @@ contexts:
         - include: tag-stuff
     - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
       captures:
-        0: meta.tag.style.html
+        0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push:
         - match: (?i)(</)(style)(>)
           captures:
-            0: meta.tag.style.html
+            0: meta.tag.style.end.html
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.style.html
             3: punctuation.definition.tag.end.html
           pop: true
         - match: '>'
-          scope: meta.tag.style.html punctuation.definition.tag.end.html
+          scope: meta.tag.style.begin.html punctuation.definition.tag.end.html
           push:
             - meta_content_scope: source.css.embedded.html
             - include: 'scope:source.css'
@@ -88,25 +88,25 @@ contexts:
               pop: true
         - match: ''
           push:
-            - meta_scope: meta.tag.style.html
+            - meta_scope: meta.tag.style.begin.html
             - match: '(?=>)'
               pop: true
             - include: tag-stuff
     - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))'
       captures:
-        0: meta.tag.script.html
+        0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push:
         - match: (?i)(</)(script)(>)
           captures:
-            0: meta.tag.script.html
+            0: meta.tag.script.end.html
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.script.html
             3: punctuation.definition.tag.end.html
           pop: true
         - match: '>'
-          scope: meta.tag.script.html punctuation.definition.tag.end.html
+          scope: meta.tag.script.begin.html punctuation.definition.tag.end.html
           push:
             - meta_content_scope: source.js.embedded.html
             - include: 'scope:source.js'
@@ -115,7 +115,7 @@ contexts:
                pop: true
         - match: ''
           push:
-            - meta_scope: meta.tag.script.html
+            - meta_scope: meta.tag.script.begin.html
             - match: '(?=>)'
               pop: true
             - include: tag-stuff

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -67,44 +67,58 @@ contexts:
         - include: tag-stuff
     - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
       captures:
+        0: meta.tag.style.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push:
         - match: (?i)(</)(style)(>)
           captures:
+            0: meta.tag.style.html
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.style.html
             3: punctuation.definition.tag.end.html
           pop: true
-        - include: tag-stuff
         - match: '>'
-          scope: punctuation.definition.tag.end.html
+          scope: meta.tag.style.html punctuation.definition.tag.end.html
           push:
             - meta_content_scope: source.css.embedded.html
             - include: 'scope:source.css'
           with_prototype:
             - match: (?i)(?=</style)
               pop: true
+        - match: ''
+          push:
+            - meta_scope: meta.tag.style.html
+            - match: '(?=>)'
+              pop: true
+            - include: tag-stuff
     - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))'
       captures:
+        0: meta.tag.script.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push:
         - match: (?i)(</)(script)(>)
           captures:
+            0: meta.tag.script.html
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.script.html
             3: punctuation.definition.tag.end.html
           pop: true
-        - include: tag-stuff
         - match: '>'
-          scope: punctuation.definition.tag.end.html
+          scope: meta.tag.script.html punctuation.definition.tag.end.html
           push:
             - meta_content_scope: source.js.embedded.html
             - include: 'scope:source.js'
           with_prototype:
              - match: (?i)(?=</script)
                pop: true
+        - match: ''
+          push:
+            - meta_scope: meta.tag.script.html
+            - match: '(?=>)'
+              pop: true
+            - include: tag-stuff
     - match: (</?)((?i:body|head|html)\b)
       captures:
         1: punctuation.definition.tag.begin.html

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -199,7 +199,8 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within HTML
-        if not view.match_selector(locations[0], "text.html - source - string.quoted - meta.tag.style punctuation.definition.tag.begin"):
+        if not view.match_selector(locations[0],
+           "text.html - source - string.quoted - meta.tag.style.end punctuation.definition.tag.begin"):
             return []
 
         # check if we are inside a tag

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -199,7 +199,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within HTML
-        if not view.match_selector(locations[0], "text.html - source - string.quoted"):
+        if not view.match_selector(locations[0], "text.html - source - string.quoted - meta.tag.style punctuation.definition.tag.begin"):
             return []
 
         # check if we are inside a tag

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -8,26 +8,35 @@
     <head>
         <title>Test HTML</title>
         <script type="text/javascript"><!--
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.html
         ## ^ entity.name.tag.script - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
+        ##                             ^ - meta.tag.script
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
             }
         //--></script>
         ## ^ source.js.embedded.html
-        ##      ^ entity.name.tag.script.html - source.js.embedded.html
+        ##     ^^^^^^ entity.name.tag.script.html
+        ##   ^^^^^^^^^ meta.tag.script.html - source.js.embedded.html
+        ##            ^ - meta.tag.script.html
         <style type="text/css">
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.html
         ## ^ entity.name.tag.style.html
         ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
+        ##                     ^ - meta.tag.style.html
             h2 {
             ## <- entity.name.tag.css
                 font-family: "Arial";
                 ##             ^ string.quoted.double.css
             }
         </style>
-        ## ^ entity.name.tag.style.html - source.css.embedded.html
+        ##^^^^^ entity.name.tag.style.html
+        ##<- meta.tag.style.html - source.css.embedded.html
+        ##^^^^^^ meta.tag.style.html - source.css.embedded.html
+        ##      ^ - meta.tag.style.html
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.inline.any.html entity.name.tag.inline.any.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -8,10 +8,10 @@
     <head>
         <title>Test HTML</title>
         <script type="text/javascript"><!--
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
-        ##                             ^ - meta.tag.script
+        ##                             ^ - meta.tag
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
@@ -19,14 +19,14 @@
         //--></script>
         ## ^ source.js.embedded.html
         ##     ^^^^^^ entity.name.tag.script.html
-        ##   ^^^^^^^^^ meta.tag.script.html - source.js.embedded.html
-        ##            ^ - meta.tag.script.html
+        ##   ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##            ^ - meta.tag
         <style type="text/css">
-        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.html
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html
         ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
-        ##                     ^ - meta.tag.style.html
+        ##                     ^ - meta.tag
             h2 {
             ## <- entity.name.tag.css
                 font-family: "Arial";
@@ -34,9 +34,9 @@
             }
         </style>
         ##^^^^^ entity.name.tag.style.html
-        ##<- meta.tag.style.html - source.css.embedded.html
-        ##^^^^^^ meta.tag.style.html - source.css.embedded.html
-        ##      ^ - meta.tag.style.html
+        ##<- meta.tag.style.end.html - source.css.embedded.html
+        ##^^^^^^ meta.tag.style.end.html - source.css.embedded.html
+        ##      ^ - meta.tag
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.inline.any.html entity.name.tag.inline.any.html


### PR DESCRIPTION
[HTML] meta.tag scopes were missing on style and script tags.

suggest [CSS] completions immediately before `</style>`. This was suggested at https://github.com/sublimehq/Packages/pull/532#issuecomment-240342983

Note: this change will still require auto-completion to be triggered manually when the cursor is just before `</style>` (when using ST without any modifications). This is just like the other PR, whereby typing just before the closing `"` in a style attribute also requires a manual trigger.  There are a few reasons for this:
- when ST checks scopes [for autocompletion], it checks at the character after the caret, which would be `<` in this case, with the scope `text.html.basic meta.tag.style.html punctuation.definition.tag.begin.html`
- In the default `auto_complete_selector` preference, `punctuation.definition.tag.begin` is specifically excluded from the `meta.tag` scope.
- only the CSS itself has a `source` scope, which is picked up by the default `auto_complete_selector` preference. The character that closes the CSS scope in the HTML document (`<` here, `"` in the style attribute) doesn't.

Obviously, users can work around the above "limitation" by overriding their preference. But anyway, this PR also fixes the problem whereby HTML tags were being offered when manually triggering the autocompletion immediately before the `</style>`.
