### PR TITLE
[LaTeX] Escaped backslash before item in begin{}-end{} snippet

### DIFF
--- a/LaTeX/Snippets/begin{}-end{}.sublime-snippet
+++ b/LaTeX/Snippets/begin{}-end{}.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\\begin{${1:env}}
-	${1/(enumerate|itemize|list)|(description)|.*/(?1:\item )(?2:\item)/}$0
+	${1/(enumerate|itemize|list)|(description)|.*/(?1:\\item )(?2:\\item)/}$0
 \\end{${1:env}}]]></content>
 	<tabTrigger>begin</tabTrigger>
 	<scope>text.tex.latex</scope>


### PR DESCRIPTION
This issue has been raised in https://github.com/SublimeText/LaTeXTools/issues/817

Previously the snippet for begin{}-end{} added `item` instead of `\item` in list environments (enumerate, itemize, list, description)