### PR TITLE
[C#] Fix numeric suffixes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -112,7 +112,7 @@ contexts:
   constants:
     - match: \b(true|false|null|this|base)\b
       scope: constant.language.source.cs
-    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
+    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(M|m|D|d|F|f|L|l|U|u|UL|ul|Ul|uL|LU|lu|Lu|lU)?\b'
       scope: constant.numeric.source.cs
     - match: '@"'
       scope: punctuation.definition.string.begin.source.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -113,7 +113,9 @@ contexts:
     - match: \b(true|false|null|this|base)\b
       scope: constant.language.source.cs
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(M|m|D|d|F|f|L|l|U|u|UL|ul|Ul|uL|LU|lu|Lu|lU)?\b'
-      scope: constant.numeric.source.cs
+      captures:
+        1: constant.numeric.source.cs
+        10: storage.type.numeric.cs
     - match: '@"'
       scope: punctuation.definition.string.begin.source.cs
       push:

--- a/C#/syntax_test_c#.cs
+++ b/C#/syntax_test_c#.cs
@@ -77,37 +77,53 @@ public class Coo
 class Syntax
 {
     public decimal decimal1 = 1.0m;
-    //                        ^^^^ constant.numeric.source.cs
+    //                        ^^^  constant.numeric.source.cs
+    //                           ^ storage.type.numeric.cs
     public decimal decimal2 = 2.0M;
-    //                        ^^^^ constant.numeric.source.cs
+    //                        ^^^  constant.numeric.source.cs
+    //                           ^ storage.type.numeric.cs
     public double double1 = 1.0d;
-    //                      ^^^^ constant.numeric.source.cs
+    //                      ^^^  constant.numeric.source.cs
+    //                         ^ storage.type.numeric.cs
     public double double2 = 2.0D;
-    //                      ^^^^ constant.numeric.source.cs
+    //                      ^^^  constant.numeric.source.cs
+    //                         ^ storage.type.numeric.cs
     public float float1 = 1.0f;
-    //                    ^^^^ constant.numeric.source.cs
+    //                    ^^^  constant.numeric.source.cs
+    //                       ^ storage.type.numeric.cs
     public float float2 = 2.0F;
-    //                    ^^^^ constant.numeric.source.cs
+    //                    ^^^  constant.numeric.source.cs
+    //                       ^ storage.type.numeric.cs
     public long long1 = 1l;
-    //                  ^^ constant.numeric.source.cs
-    public long long2 = 2l;
-    //                  ^^ constant.numeric.source.cs
+    //                  ^  constant.numeric.source.cs
+    //                   ^ storage.type.numeric.cs
+    public long long2 = 2L;
+    //                  ^  constant.numeric.source.cs
+    //                   ^ storage.type.numeric.cs
     public ulong ulong1 = 1ul;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong2 = 2UL;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong3 = 3lu;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong4 = 4LU;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong5 = 5uL;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong6 = 6Ul;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong7 = 7lU;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong ulong8 = 8Lu;
-    //                    ^^^ constant.numeric.source.cs
+    //                    ^   constant.numeric.source.cs
+    //                     ^^ storage.type.numeric.cs
     public ulong bad = 1UU;
-    //                 ^^^ meta.class.body.source.cs
+    //                  ^^ - storage.type.numeric.cs
 }

--- a/C#/syntax_test_c#.cs
+++ b/C#/syntax_test_c#.cs
@@ -4,8 +4,8 @@ class X
 // ^ storage.modifier
 {
 
-	[Usage("Foo bar")]
-	// ^ meta.method.attribute
+    [Usage("Foo bar")]
+    // ^ meta.method.attribute
     void Run([Usage("help text")] int x, int y)
     // ^ storage.type
     //    ^ entity.name.function
@@ -72,4 +72,42 @@ public class Coo
     int Zoo()
     //  ^ entity.name.function
     {}
+}
+
+class Syntax
+{
+    public decimal decimal1 = 1.0m;
+    //                        ^^^^ constant.numeric.source.cs
+    public decimal decimal2 = 2.0M;
+    //                        ^^^^ constant.numeric.source.cs
+    public double double1 = 1.0d;
+    //                      ^^^^ constant.numeric.source.cs
+    public double double2 = 2.0D;
+    //                      ^^^^ constant.numeric.source.cs
+    public float float1 = 1.0f;
+    //                    ^^^^ constant.numeric.source.cs
+    public float float2 = 2.0F;
+    //                    ^^^^ constant.numeric.source.cs
+    public long long1 = 1l;
+    //                  ^^ constant.numeric.source.cs
+    public long long2 = 2l;
+    //                  ^^ constant.numeric.source.cs
+    public ulong ulong1 = 1ul;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong2 = 2UL;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong3 = 3lu;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong4 = 4LU;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong5 = 5uL;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong6 = 6Ul;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong7 = 7lU;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong ulong8 = 8Lu;
+    //                    ^^^ constant.numeric.source.cs
+    public ulong bad = 1UU;
+    //                 ^^^ meta.class.body.source.cs
 }


### PR DESCRIPTION
The numeric suffixes included many types that aren't valid C# suffixes and did not include suffixes for double and decimal.  This provides a proper list according to the MSDN docs:

Decimal (M, m): https://msdn.microsoft.com/en-us/library/364x0z75.aspx
Double (D, d): https://msdn.microsoft.com/en-us/library/678hzkk9.aspx
Float (F, f): https://msdn.microsoft.com/en-us/library/b1e65aza.aspx
Long (L, l): https://msdn.microsoft.com/en-us/library/ctetwysk.aspx
ULong (U, u, UL, ul, Ul, uL, LU, lu, Lu, lU): https://msdn.microsoft.com/en-us/library/t98873t4.aspx

There is nothing for int, byte, sbyte, short, and ushort.