### PR TITLE
[Scala] Only index scoped packages

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -264,11 +264,20 @@ contexts:
         1: keyword.control.scala
         2: storage.type.class.scala
         3: entity.name.class.scala
-    - match: '\b(package)\s+([\w\.]+)'
+    - match: '\b(package)\s+({{id}}(?:\.{{id}})*)\s*\{'
+      captures:
+        1: keyword.control.scala
+        2: entity.name.namespace.scoped.scala
+      push:
+        - meta_scope: meta.namespace.scala
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(package)\s+({{id}}(?:\.{{id}})*)'
       scope: meta.namespace.scala
       captures:
         1: keyword.control.scala
-        2: entity.name.namespace.scala
+        2: entity.name.namespace.header.scala
     - match: '\b(case)\b'
       scope: keyword.other.declaration.scala
       push:

--- a/Scala/Symbols.tmPreferences
+++ b/Scala/Symbols.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala entity.name.val, source.scala entity.name.type, source.scala entity.name.namespace</string>
+	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala entity.name.val, source.scala entity.name.type, source.scala entity.name.namespace.scoped</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -3,7 +3,13 @@
 
 package fubar
 // ^^^^ keyword.control
-//      ^^^^^ entity.name.namespace.scala
+//      ^^^^^ entity.name.namespace.header.scala
+
+package fubar {
+// ^^^^ keyword.control.scala
+//      ^^^^^ entity.name.namespace.scoped.scala
+// <- meta.namespace.scala
+}
 
 import fubar.{Unit, Foo}
 // ^^^ keyword.other.import


### PR DESCRIPTION
This fixes #552.  To be clear:

```scala
package stuff    // not indexed

package stuff2 {
  // indexed
}
```

I'm using the scopes `entity.name.namespace.header` and `entity.name.namespace.scoped`.