### PR TITLE
[Scala] Fixed lambda lookahead for bare ascriptions with type parameters

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -55,7 +55,8 @@ variables:
   upperid: '(?:\b\p{Lu}{{idrest}})'
   typeprefix: '(:)\s*'
   # hack to cover up to three levels of nested parentheses
-  withinparens: '\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\)'
+  withinparens: '(?:\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\))'
+  withinbrackets: '(?:\[(?:[^\[\]]|\[(?:[^\[\]]|\[[^\[\]]*\])*\])*\])'
 
 contexts:
   prototype:
@@ -131,7 +132,7 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{idorunder}}|{{idorunder}}\s*:\s*{{idorunder}}|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{idorunder}}|{{idorunder}}\s*:\s*{{id}}{{withinbrackets}}?|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{rightarrow}}'
           scope: storage.type.function.arrow.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,7 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+   x: List[Int] => ()
+// ^ variable.parameter.scala
+//              ^^ storage.type.function.arrow.scala


### PR DESCRIPTION
Lambda lookahead didn't correctly identify the following scenario:

```scala
x: List[Int] => ???
```

This is now using the same hack that I had to use for parentheses matched lookahead, which means it will break with over 3 levels of bracket nesting.