### PR TITLE
[Scala] Fixed scaladoc termination prior to EOL

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -118,7 +118,7 @@ contexts:
       scope: punctuation.definition.comment.scala
       push:
         - meta_scope: comment.block.documentation.scala
-        - match: \*/\s*$
+        - match: \*/
           scope: punctuation.definition.comment.scala
           pop: true
         - match: (@\w+\s)

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,9 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+/** private */ class Foo
+//             ^^^^^ storage.type.class
+
+   foo
+// ^^^ - comment


### PR DESCRIPTION
I have no idea why the match had previously enforced that the `*/` was the last thing on the line, but there's no reason for it and it breaks stuff.