### PR TITLE
[Scala] Fixed nested scaladoc

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -92,28 +92,6 @@ contexts:
     - include: late-operators
 
   block-comments:
-    - match: /\*
-      push:
-        - meta_scope: comment.block.scala
-        - match: \*/
-          pop: true
-        - include: block-comments
-        - match: |-
-            (?x)
-            			(?! /\*)
-            			(?! \*/)
-
-  char-literal:
-    - match: '''\\?.'''
-      scope: constant.character.literal.scala
-
-  comments:
-    - match: (//).*$
-      scope: comment.line.double-slash.scala
-      captures:
-        1: punctuation.definition.comment.scala
-    - match: /\*\*/
-      scope: comment.block.empty.scala punctuation.definition.comment.scala
     - match: (^\s*)?/\*\*
       scope: punctuation.definition.comment.scala
       push:
@@ -125,6 +103,29 @@ contexts:
           scope: keyword.other.documentation.scaladoc.scala
         - match: '\{@link\s+[^\}]*\}'
           scope: keyword.other.documentation.scaladoc.link.scala
+        - include: block-comments
+    - match: /\*
+      push:
+        - meta_scope: comment.block.scala
+        - match: \*/
+          pop: true
+        - include: block-comments
+        - match: |-
+            (?x)
+            			(?! /\*)
+            			(?! \*/)
+    - match: /\*\*/
+      scope: comment.block.empty.scala punctuation.definition.comment.scala
+
+  char-literal:
+    - match: '''\\?.'''
+      scope: constant.character.literal.scala
+
+  comments:
+    - match: (//).*$
+      scope: comment.line.double-slash.scala
+      captures:
+        1: punctuation.definition.comment.scala
 
   ascription:
     - match: '{{typeprefix}}'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,26 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+   /*
+   /*
+   test
+// ^^^^ comment.block.scala
+   */
+   test
+// ^^^^ comment.block.scala
+   */
+   test
+// ^^^^ - comment
+
+
+   /**
+   /**
+   test
+// ^^^^ comment.block.documentation.scala
+   */
+   test
+// ^^^^ comment.block.documentation.scala
+   */
+   test
+// ^^^^ - comment


### PR DESCRIPTION
Scala allows nested comment blocks.  We correctly handle this for regular comments, but scaladoc is (still) sort of a mess and we weren't correctly nesting the scopes.  Fixed.