### PR TITLE
[YAML] comment.line fix, scope changes

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -271,7 +271,7 @@ contexts:
       - match: (&)({{ns_anchor_name}})(\S+)?
         captures:
           1: keyword.control.property.anchor.yaml punctuation.anchor.yaml
-          2: entity.name.other.anchor.yaml
+          2: entity.name.type.anchor.yaml
           3: invalid.illegal.character.anchor.yaml
         pop: true
       # !Tag Handle

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -411,7 +411,7 @@ contexts:
         - include: flow-pair
         - include: flow-node
         - match: :(?=\s|$|{{c_flow_indicator}})
-          scope: punctuation.separator.mapping.key-value.yaml
+          scope: punctuation.separator.key-value.mapping.yaml
           set: flow-pair-value
     # Attempt to match plain-in scalars and highlight as "entity.name.tag",
     # if followed by a colon
@@ -442,7 +442,7 @@ contexts:
               pop: true
     - include: flow-node
     - match: :(?=\s|$|{{c_flow_indicator}}) # Empty mapping keys allowed
-      scope: meta.flow-pair.yaml punctuation.separator.mapping.key-value.yaml
+      scope: meta.flow-pair.yaml punctuation.separator.key-value.mapping.yaml
       push: flow-pair-value
 
   flow-pair-value:
@@ -496,7 +496,7 @@ contexts:
           pop: true
         - match: ^ *(:)
           captures:
-            1: punctuation.separator.mapping.key-value.yaml
+            1: punctuation.separator.key-value.mapping.yaml
           pop: true
         - match: ':'
           scope: invalid.illegal.expected-newline.yaml
@@ -527,7 +527,7 @@ contexts:
             - match: '{{_flow_scalar_end_plain_out}}'
               pop: true
     - match: :(?=\s|$)
-      scope: punctuation.separator.mapping.key-value.yaml
+      scope: punctuation.separator.key-value.mapping.yaml
 
   comment:
     # http://www.yaml.org/spec/1.2/spec.html#comment//

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -533,10 +533,17 @@ contexts:
     # http://www.yaml.org/spec/1.2/spec.html#comment//
     - match: | # l-comment
         (?x)
-        (?: ^ [ \t]* | [ \t]+ )
-        (?:(\#) \p{Print}* )?
-        (\n|\z)
-      scope: comment.line.number-sign.yaml
+        (?: ( ^ [ \t]* ) | [ \t]+ )
+        (?=#\p{Print}*$)
       captures:
-        1: punctuation.definition.comment.line.number-sign.yaml
+        1: punctuation.whitespace.comment.leading.yaml
+      set:
+        - meta_include_prototype: false
+        - match: (?!\G)
+          pop: true
+        - match: '#'
+          scope: punctuation.definition.comment.yaml
+            - meta_scope: comment.line.number-sign.yaml
+            - match: \n
+              pop: true
 ...

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -287,7 +287,7 @@ contexts:
     # http://yaml.org/spec/1.2/spec.html#alias//
     - match: (\*)({{ns_anchor_name}})([^\s\]},]\S*)?
       captures:
-        1: keyword.control.flow.alias.yaml punctuation.alias.yaml
+        1: keyword.control.flow.alias.yaml punctuation.definition.alias.yaml
         2: variable.other.alias.yaml
         3: invalid.illegal.character.anchor.yaml
 

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -10,12 +10,12 @@
 
 *alias
 #^^^^^ variable.other.alias
-# <- keyword.control.flow.alias punctuation.alias
+# <- keyword.control.flow.alias punctuation.definition.alias
 
 *al[ias]
 #^^      variable.other.alias
 #  ^^^^^ invalid.illegal.character
-# <- keyword.control.flow.alias punctuation.alias
+# <- keyword.control.flow.alias punctuation.definition.alias
 
 
 ##############################################################################

--- a/YAML/tests/syntax_test_general.yaml
+++ b/YAML/tests/syntax_test_general.yaml
@@ -10,6 +10,12 @@
 # <- comment.line.number-sign punctuation.definition.comment.line.number-sign
 #^^^^^^^^ comment.line.number-sign
 
+foo: bar 
+#       ^ -comment
+
+foo: bar # Baz
+#       ^ -comment
+#        ^ comment.line.number-sign
 
 ##############################################################################
 ## Document markers

--- a/YAML/tests/syntax_test_properties.yaml
+++ b/YAML/tests/syntax_test_properties.yaml
@@ -43,10 +43,10 @@ scalar !not-tag-handle
 # http://yaml.org/spec/1.2/spec.html#&%20anchor//
 
 &anchor
-#^^^^^^ entity.name.other.anchor
+#^^^^^^ entity.name.type.anchor
 # <- keyword.control.property.anchor punctuation.anchor
 &an[chor]
-#^^ entity.name.other.anchor
+#^^ entity.name.type.anchor
 #  ^^^^^^ invalid.illegal.character
 # <- keyword.control.property.anchor punctuation.anchor
 


### PR DESCRIPTION
Ported this grammar back to TextMate and had a few changes I made along the way. Note: I am not in any way familiar with SublimeText and did not test these changes. I believe I did the tests correctly but did not test them either.

233860f78a55fe0c5a8f873ed6754ec38e91ac39: The comment.line rule was matching way too much, it caught any line with trailing whitespace and any empty line. I totally rewrote the rule and made it a begin/end style rule to allow for injections.

The rest are just minor scope changes.