### PR TITLE
[YAML] Fix highlighting of keys at EOF

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -93,7 +93,7 @@ variables:
       (?=
           \s* $
         | \s+ \#
-        | \s* : \s
+        | \s* : (\s|$)
         | \s* : {{c_flow_indicator}}
         | {{c_flow_indicator}}
       )
@@ -104,7 +104,7 @@ variables:
       (?=
           \s* $
         | \s+ \#
-        | \s* : \s
+        | \s* : (\s|$)
       )
     )
 
@@ -514,7 +514,8 @@ contexts:
             | \s+ (?![#\s])
           )*
           \s*
-          :\s
+          :
+          (\s|$)
         )
       push:
         - include: flow-scalar-plain-out-implicit-type


### PR DESCRIPTION
Previously, a whitespace character was required to be matched (e.g. a `\n` newline) after a key, but when at EOF there is no character to be consumed.

Due to the nature of this change, it is impossible to test, but I verified that the fix works.