### PR TITLE
[Scala] Some minor refinements/bugfixes in patmat highlighting

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -281,11 +281,6 @@ contexts:
     - match: '\b(case)\b'
       scope: keyword.other.declaration.scala
       push:
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: pattern-match
         - match: '\b(if)\b'
           captures:
             1: keyword.control.flow.scala
@@ -728,7 +723,7 @@ contexts:
     - match: '{{upperid}}'
       scope: support.class.scala
 
-  pattern-match:
+  base-pattern-match:
     - include: keywords
     - include: base-constants
     - include: char-literal
@@ -753,12 +748,6 @@ contexts:
     - match: '\b{{varid}}'
       scope: variable.parameter.scala   # not indexed!
     - match: '{{op}}'   # let it fall through
-    - include: ascription
-    - match: \(
-      push:
-        - match: \)
-          pop: true
-        - include: pattern-match
     - match: \[
       push:
         - match: \]
@@ -772,6 +761,26 @@ contexts:
       scope: variable.language.underscore.scala
     - match: ','
       scope: punctuation.separator.scala
+  nested-pattern-match:
+    - include: base-pattern-match
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=[,\)@])'
+          pop: true
+        - include: delimited-type-expression
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: nested-pattern-match
+  pattern-match:
+    - include: base-pattern-match
+    - include: ascription
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: nested-pattern-match
 
   base-type-expression:
     # \x{03BB} = λ, \x{03B1} = α, \x{03B2} = β

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -678,7 +678,10 @@ contexts:
         - match: '`'
           scope: punctuation.definition.identifier.scala
           pop: true
-    - match: '{{varid}}(\.)'
+    - match: '{{varid}}(?:(\.){{varid}})+'
+      captures:
+        1: punctuation.accessor.scala
+    - match: '{{varid}}(\.)'    # redundant to catch {{varid}}.{{upperid}}
       captures:
         1: punctuation.accessor.scala
     - match: '(\.){{varid}}'
@@ -737,7 +740,10 @@ contexts:
         - match: '`'
           scope: punctuation.definition.identifier.scala
           pop: true
-    - match: '{{varid}}(\.)'
+    - match: '{{varid}}(?:(\.){{varid}})+'
+      captures:
+        1: punctuation.accessor.scala
+    - match: '{{varid}}(\.)'    # redundant to catch {{varid}}.{{upperid}}
       captures:
         1: punctuation.accessor.scala
     - match: '(\.){{varid}}'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,9 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+{
+   case (x, y: Int => String) => ()
+//                 ^^ keyword.operator.arrow.scala
+//                    ^^^^^^ support.class.scala
+}

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -616,10 +616,10 @@ type Foo = Bar[A] forSome { type A }
 
   {
     case foo.Bar => 42
-//       ^^^ - entity.name
+//       ^^^ - variable
 //          ^ punctuation.accessor.scala
     case Bar.foo => 42
-//           ^^^ - entity.name
+//           ^^^ - variable
 //          ^ punctuation.accessor.scala
   }
 
@@ -1029,4 +1029,9 @@ val Stuff(thing, other) = ???
    case (x, y: Int => String) => ()
 //                 ^^ keyword.operator.arrow.scala
 //                    ^^^^^^ support.class.scala
+}
+
+{
+   case (foo.bar, _) => ()
+//           ^^^ - variable
 }


### PR DESCRIPTION
- It is legal to have a full (delimited) type expression within a pattern match parenthetical
- Greedy matching caused us to miss a few accessor cases and incorrectly highlight them as bindings