### PR TITLE
[Scala] add support for annotations

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -166,9 +166,7 @@ contexts:
       push:
         - match: ','
           scope: punctuation.separator.arguments.scala
-        - include: strings
-        - include: constants
-        - include: initialization
+        - include: main
         - match: \)
           scope: punctuation.definition.arguments.end.scala
           pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -179,7 +179,7 @@ contexts:
           scope: punctuation.definition.arguments.end.scala
           pop: true
         - include: delimited-type-expression
-    - match: (?!\()
+    - match: (?!\(|\[)
       pop: true
 
   lambdas:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -149,20 +149,6 @@ contexts:
       push: single-type-expression
 
   annotation:
-    - match: '@specialized'
-      scope: storage.modifier.annotation.scala
-      push:
-      - match: \(
-        scope: punctuation.definition.arguments.begin.scala
-        set:
-          - include: base-types
-          - match: ','
-            scope: punctuation.separator.arguments.scala
-          - match: \)
-            scope: punctuation.definition.arguments.end.scala
-            pop: true
-      - match: (?!\()
-        pop: true
     - match: '@{{plainid}}\.'
       scope: storage.modifier.annotation.scala
       push:
@@ -178,7 +164,7 @@ contexts:
   annotation-parameters:
     - match: \(
       scope: punctuation.definition.arguments.begin.scala
-      set:
+      push:
         - match: ','
           scope: punctuation.separator.arguments.scala
         - include: strings
@@ -187,6 +173,13 @@ contexts:
         - match: \)
           scope: punctuation.definition.arguments.end.scala
           pop: true
+    - match: \[
+      scope: punctuation.definition.arguments.begin.scala
+      push:
+        - match: \]
+          scope: punctuation.definition.arguments.end.scala
+          pop: true
+        - include: delimited-type-expression
     - match: (?!\()
       pop: true
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -148,43 +148,45 @@ contexts:
       push: single-type-expression
 
   annotation:
-    - match: '(@){{plainid}}\.'
+    - match: '(@)({{plainid}})(\.)'
+      scope: storage.modifier.annotation.scala
       captures:
-        0: storage.modifier.annotation.scala
         1: punctuation.definition.annotation.scala
+        3: punctuation.accessor.scala
       push:
         - meta_scope: meta.annotation.scala
-        - match: '{{plainid}}\.'
+        - match: '({{plainid}})(\.)'
           scope: storage.modifier.annotation.scala
+          captures:
+            2: punctuation.accessor.scala
         - match: '{{plainid}}'
           scope: storage.modifier.annotation.scala
           set: annotation-parameters
-    - match: '(@){{plainid}}'
+    - match: '(@)({{plainid}})'
+      scope: storage.modifier.annotation.scala
       captures:
-        0: storage.modifier.annotation.scala
         1: punctuation.definition.annotation.scala
       push: annotation-parameters
 
   annotation-parameters:
     - meta_scope: meta.annotation.scala
     - match: \(
-      scope: punctuation.definition.arguments.annotation.begin.scala
+      scope: punctuation.section.arguments.annotation.begin.scala
       push:
         - match: ','
           scope: punctuation.separator.arguments.annotation.scala
         - match: \)
-          scope: punctuation.definition.arguments.annotation.end.scala
+          scope: punctuation.section.arguments.annotation.end.scala
           pop: true
         - include: main
     - match: \[
-      scope: punctuation.definition.arguments.annotation.begin.scala
+      scope: punctuation.section.arguments.annotation.begin.scala
       push:
         - match: \]
-          scope: punctuation.definition.arguments.annotation.end.scala
+          scope: punctuation.section.arguments.annotation.end.scala
           pop: true
         - include: delimited-type-expression
-    - match: \s*
-    - match: (?![(\[])
+    - match: (?!\s*[(\[])
       pop: true
 
   lambdas:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -103,7 +103,6 @@ contexts:
   main-post-lambdas:
     - include: late-keywords
     - include: constants
-    - include: char-literal
     - include: scala-symbol
     - include: braces
     - include: late-operators
@@ -169,7 +168,7 @@ contexts:
           scope: punctuation.separator.arguments.scala
         - include: strings
         - include: constants
-        - include: char-literal
+        - include: initialization
         - match: \)
           scope: punctuation.definition.arguments.end.scala
           pop: true
@@ -244,6 +243,7 @@ contexts:
     - include: base-types
   constants:
     - include: base-constants
+    - include: char-literal
     # other upper-case stuff highlights as constant
     - match: '{{upperid}}'
       scope: support.constant.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -162,19 +162,19 @@ contexts:
 
   annotation-parameters:
     - match: \(
-      scope: punctuation.definition.arguments.begin.scala
+      scope: punctuation.definition.arguments.annotation.begin.scala
       push:
         - match: ','
-          scope: punctuation.separator.arguments.scala
+          scope: punctuation.separator.arguments.annotation.scala
         - include: main
         - match: \)
-          scope: punctuation.definition.arguments.end.scala
+          scope: punctuation.definition.arguments.annotation.end.scala
           pop: true
     - match: \[
-      scope: punctuation.definition.arguments.begin.scala
+      scope: punctuation.definition.arguments.annotation.begin.scala
       push:
         - match: \]
-          scope: punctuation.definition.arguments.end.scala
+          scope: punctuation.definition.arguments.annotation.end.scala
           pop: true
         - include: delimited-type-expression
     - match: (?!\(|\[)

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1120,13 +1120,17 @@ contexts:
     - match: '{{typeid}}'
       scope: support.type.scala
       set: single-type-expression-tail
+    - match: (?=@{{plainid}})
+      set: single-type-expression-tail
     - include: base-type-expression
-    # the '@' indicates the beginning of an annotation
-    - match: '(?=@)'
-      pop: true
-    - match: '(?=[\s$,\)\}\]])'
+    - match: '(?=[\s,\)\}\]])'
       pop: true
   single-type-expression-tail:
+    - match: (?=@{{plainid}})
+      set:
+        - include: annotation
+        - match: '(?=\S)'
+          set: single-type-expression-tail
     - match: '[\.#]'
       scope: punctuation.accessor.scala
       set: single-type-expression

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -148,28 +148,34 @@ contexts:
       push: single-type-expression
 
   annotation:
-    - match: '@{{plainid}}\.'
-      scope: storage.modifier.annotation.scala
+    - match: '(@){{plainid}}\.'
+      captures:
+        0: storage.modifier.annotation.scala
+        1: punctuation.definition.annotation.scala
       push:
+        - meta_scope: meta.annotation.scala
         - match: '{{plainid}}\.'
           scope: storage.modifier.annotation.scala
         - match: '{{plainid}}'
           scope: storage.modifier.annotation.scala
           set: annotation-parameters
-    - match: '@{{plainid}}'
-      scope: storage.modifier.annotation.scala
+    - match: '(@){{plainid}}'
+      captures:
+        0: storage.modifier.annotation.scala
+        1: punctuation.definition.annotation.scala
       push: annotation-parameters
 
   annotation-parameters:
+    - meta_scope: meta.annotation.scala
     - match: \(
       scope: punctuation.definition.arguments.annotation.begin.scala
       push:
         - match: ','
           scope: punctuation.separator.arguments.annotation.scala
-        - include: main
         - match: \)
           scope: punctuation.definition.arguments.annotation.end.scala
           pop: true
+        - include: main
     - match: \[
       scope: punctuation.definition.arguments.annotation.begin.scala
       push:
@@ -177,7 +183,8 @@ contexts:
           scope: punctuation.definition.arguments.annotation.end.scala
           pop: true
         - include: delimited-type-expression
-    - match: (?!\(|\[)
+    - match: \s*
+    - match: (?![(\[])
       pop: true
 
   lambdas:
@@ -1112,8 +1119,8 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail
     - include: base-type-expression
+    # the '@' indicates the beginning of an annotation
     - match: '(?=@)'
-      comment: the '@' indicates the beginning of an annotation
       pop: true
     - match: '(?=[\s$,\)\}\]])'
       pop: true

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -149,21 +149,21 @@ contexts:
 
   annotation:
     - match: '(@)({{plainid}})(\.)'
-      scope: storage.modifier.annotation.scala
+      scope: variable.annotation.scala
       captures:
         1: punctuation.definition.annotation.scala
         3: punctuation.accessor.scala
       push:
         - meta_scope: meta.annotation.scala
         - match: '({{plainid}})(\.)'
-          scope: storage.modifier.annotation.scala
+          scope: variable.annotation.scala
           captures:
             2: punctuation.accessor.scala
         - match: '{{plainid}}'
-          scope: storage.modifier.annotation.scala
+          scope: variable.annotation.scala
           set: annotation-parameters
     - match: '(@)({{plainid}})'
-      scope: storage.modifier.annotation.scala
+      scope: variable.annotation.scala
       captures:
         1: punctuation.definition.annotation.scala
       push: annotation-parameters

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1098,7 +1098,6 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
-    - include: annotation
     - match: '\b(type)\b'
       scope: keyword.other.scala
     - match: '[\x{03B1}\x{03B2}]'     # just here for type lambdas
@@ -1115,6 +1114,9 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail
     - include: base-type-expression
+    - match: '(?=@)'
+      comment: the '@' indicates the beginning of an annotation
+      pop: true
     - match: '(?=[\s$,\)\}\]])'
       pop: true
   single-type-expression-tail:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -99,6 +99,7 @@ contexts:
     - include: operators
     - include: initialization
     - include: ascription
+    - include: annotation
   main-post-lambdas:
     - include: late-keywords
     - include: constants
@@ -146,6 +147,48 @@ contexts:
   ascription:
     - match: '{{typeprefix}}'
       push: single-type-expression
+
+  annotation:
+    - match: '@specialized'
+      scope: storage.modifier.annotation.scala
+      push:
+      - match: \(
+        scope: punctuation.definition.arguments.begin.scala
+        set:
+          - include: base-types
+          - match: ','
+            scope: punctuation.separator.arguments.scala
+          - match: \)
+            scope: punctuation.definition.arguments.end.scala
+            pop: true
+      - match: (?!\()
+        pop: true
+    - match: '@{{plainid}}\.'
+      scope: storage.modifier.annotation.scala
+      push:
+        - match: '{{plainid}}\.'
+          scope: storage.modifier.annotation.scala
+        - match: '{{plainid}}'
+          scope: storage.modifier.annotation.scala
+          set: annotation-parameters
+    - match: '@{{plainid}}'
+      scope: storage.modifier.annotation.scala
+      push: annotation-parameters
+
+  annotation-parameters:
+    - match: \(
+      scope: punctuation.definition.arguments.begin.scala
+      set:
+        - match: ','
+          scope: punctuation.separator.arguments.scala
+        - include: strings
+        - include: constants
+        - include: char-literal
+        - match: \)
+          scope: punctuation.definition.arguments.end.scala
+          pop: true
+    - match: (?!\()
+      pop: true
 
   lambdas:
     # lambda lookahead
@@ -1043,6 +1086,7 @@ contexts:
     - match: '<:|>:|<%|\+|-|:'
       scope: keyword.operator.bound.scala
   delimited-type-expression:
+    - include: annotation
     - match: '\b(type)\b'
       scope: keyword.other.scala
     - match: '\b(with)\b'
@@ -1061,6 +1105,7 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - include: annotation
     - match: '\b(type)\b'
       scope: keyword.other.scala
     - match: '[\x{03B1}\x{03B2}]'     # just here for type lambdas

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -675,7 +675,7 @@ contexts:
   storage-modifiers:
     - match: '\b(private\[\S+\]|protected\[\S+\]|private|protected)\b'
       scope: storage.modifier.access.scala
-    - match: \b(@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b
+    - match: \b(abstract|final|lazy|sealed|implicit|override)\b
       scope: storage.modifier.other.scala
 
   # see http://www.scala-lang.org/docu/files/ScalaReference.pdf part 1.3.5-6 (page 18)

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1293,8 +1293,10 @@ trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 
 @transient @volatile var m: Int
 // ^^ storage.modifier.annotation
+//         ^^ storage.modifier.annotation
 
 String @local
+//     ^ punctuation.definition.annotation.scala
 //     ^^ storage.modifier.annotation
 
 (e: @unchecked) match { ... }
@@ -1318,5 +1320,14 @@ trait Function0[@specialized(Unit, Int, Double) T] {
 //               ^^ storage.modifier.annotation
 //                           ^^ storage.type.primitive
 //                                              ^ support.class
+//              ^ punctuation.definition.annotation.scala
+//              ^ meta.annotation.scala
+//                                            ^ meta.annotation.scala
+//                                             ^ - meta.annotation.scala
+//                               ^ punctuation.separator.arguments.annotation.scala
   def apply: T
 }
+
+x: Foo @volatile with Bar
+//          ^^ storage.modifier.annotation
+//               ^^ keyword.declaration

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1285,3 +1285,34 @@ def foo(a: String* )
 trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 //                     ^^^^ storage.type.scala
 //                               ^ keyword.operator.assignment.scala
+
+// annotation examples from: http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html
+@deprecated("Use D", "1.0") class C { ... }
+// ^^ storage.modifier.annotation
+//            ^^ string
+
+@transient @volatile var m: Int
+// ^^ storage.modifier.annotation
+
+String @local
+//     ^^ storage.modifier.annotation
+
+(e: @unchecked) match { ... }
+//  ^^ storage.modifier.annotation
+//              ^^^^^ keyword.control.flow.scala
+
+// more complex:
+@scala.beans.BeanProperty
+//  ^^^^^^^^^^^^^^^^^^^^^ storage.modifier.annotation
+
+(e: Int @unchecked) match { ... }
+//  ^^ storage.type.primitive
+//      ^^ storage.modifier.annotation
+//                  ^^^^^ keyword.control.flow.scala
+
+trait Function0[@specialized(Unit, Int, Double) T] {
+//               ^^ storage.modifier.annotation
+//                           ^^ storage.type.primitive
+//                                              ^ support.class
+  def apply: T
+}

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1310,6 +1310,10 @@ String @local
 //      ^^ storage.modifier.annotation
 //                  ^^^^^ keyword.control.flow.scala
 
+@obsolete("this class is horrible don't use it", alpha=3)
+//  ^^ storage.modifier.annotation
+//            ^ string
+//                                                     ^ constant.numeric.integer
 trait Function0[@specialized(Unit, Int, Double) T] {
 //               ^^ storage.modifier.annotation
 //                           ^^ storage.type.primitive

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1288,8 +1288,11 @@ trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 
 // annotation examples from: http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html
 @deprecated("Use D", "1.0") class C { ... }
+// <- meta.annotation.scala
 // ^^ storage.modifier.annotation
 //            ^^ string
+//                        ^ meta.annotation.scala
+//                         ^ - meta.annotation.scala
 
 @transient @volatile var m: Int
 // ^^ storage.modifier.annotation
@@ -1306,6 +1309,7 @@ String @local
 // more complex:
 @scala.beans.BeanProperty
 //  ^^^^^^^^^^^^^^^^^^^^^ storage.modifier.annotation
+//    ^ punctuation.accessor.scala
 
 (e: Int @unchecked) match { ... }
 //  ^^ storage.type.primitive

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1289,39 +1289,39 @@ trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 // annotation examples from: http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html
 @deprecated("Use D", "1.0") class C { ... }
 // <- meta.annotation.scala
-// ^^ storage.modifier.annotation
+// ^^ variable.annotation
 //            ^^ string
 //                        ^ meta.annotation.scala
 //                         ^ - meta.annotation.scala
 
 @transient @volatile var m: Int
-// ^^ storage.modifier.annotation
-//         ^^ storage.modifier.annotation
+// ^^ variable.annotation
+//         ^^ variable.annotation
 
 String @local
 //     ^ punctuation.definition.annotation.scala
-//     ^^ storage.modifier.annotation
+//     ^^ variable.annotation
 
 (e: @unchecked) match { ... }
-//  ^^ storage.modifier.annotation
+//  ^^ variable.annotation
 //              ^^^^^ keyword.control.flow.scala
 
 // more complex:
 @scala.beans.BeanProperty
-//  ^^^^^^^^^^^^^^^^^^^^^ storage.modifier.annotation
+//  ^^^^^^^^^^^^^^^^^^^^^ variable.annotation
 //    ^ punctuation.accessor.scala
 
 (e: Int @unchecked) match { ... }
 //  ^^ storage.type.primitive
-//      ^^ storage.modifier.annotation
+//      ^^ variable.annotation
 //                  ^^^^^ keyword.control.flow.scala
 
 @obsolete("this class is horrible don't use it", alpha=3)
-//  ^^ storage.modifier.annotation
+//  ^^ variable.annotation
 //            ^ string
 //                                                     ^ constant.numeric.integer
 trait Function0[@specialized(Unit, Int, Double) T] {
-//               ^^ storage.modifier.annotation
+//               ^^ variable.annotation
 //                           ^^ storage.type.primitive
 //                                              ^ support.class
 //              ^ punctuation.definition.annotation.scala
@@ -1333,9 +1333,9 @@ trait Function0[@specialized(Unit, Int, Double) T] {
 }
 
 x: Foo @volatile with Bar @foo.bar @bar with Baz
-//          ^^ storage.modifier.annotation.scala
+//          ^^ variable.annotation.scala
 //               ^^ keyword.declaration.scala
 //                    ^^^ support.class.scala
-//                        ^^^^^^^^ storage.modifier.annotation.scala
-//                                 ^^^^ storage.modifier.annotation.scala
+//                        ^^^^^^^^ variable.annotation.scala
+//                                 ^^^^ variable.annotation.scala
 //                                           ^^^ support.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1332,6 +1332,10 @@ trait Function0[@specialized(Unit, Int, Double) T] {
   def apply: T
 }
 
-x: Foo @volatile with Bar
-//          ^^ storage.modifier.annotation
-//               ^^ keyword.declaration
+x: Foo @volatile with Bar @foo.bar @bar with Baz
+//          ^^ storage.modifier.annotation.scala
+//               ^^ keyword.declaration.scala
+//                    ^^^ support.class.scala
+//                        ^^^^^^^^ storage.modifier.annotation.scala
+//                                 ^^^^ storage.modifier.annotation.scala
+//                                           ^^^ support.class.scala


### PR DESCRIPTION
As mentioned in #588, I propose to add support for annotations.
I based myself on http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html .

I used the scope `storage.modifier.annotation.scala` on annotations.
This provide coloring in most themes due to `storage.modifier`and is easily customizable.

``` scala
@deprecated("Use D", "1.0") class C { ... }
// ^^ storage.modifier.annotation
//            ^^ string

@transient @volatile var m: Int
// ^^ storage.modifier.annotation

String @local
//     ^^ storage.modifier.annotation

(e: @unchecked) match { ... }
//  ^^ storage.modifier.annotation
//              ^^^^^ keyword.control.flow.scala

// more complex:
@scala.beans.BeanProperty
//  ^^^^^^^^^^^^^^^^^^^^^ storage.modifier.annotation

(e: Int @unchecked) match { ... }
//  ^^ storage.type.primitive
//      ^^ storage.modifier.annotation
//                  ^^^^^ keyword.control.flow.scala

trait Function0[@specialized(Unit, Int, Double) T] {
//               ^^ storage.modifier.annotation
//                           ^^ storage.type.primitive
//                                              ^ support.class
  def apply: T
}

```

**Note**
I match annotations with `{{plainid}}` regex, but we might want to support something more complex in the future.

I handle `@specialized` separately because it's the only annotation I know that uses type parameters between `(`.
