### PR TITLE
[Scala] improve string highlighting

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -622,6 +622,17 @@ contexts:
         - match: \n
           scope: invalid.string.newline.scala
         - include: escaped
+    - match: '(f)(""")'
+      captures:
+        1: support.function.scala
+        2: punctuation.definition.string.begin.scala
+      push:
+        - include: f_string
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.interpolated.scala
+        - match: '"""'
+          scope: punctuation.definition.string.end.scala
+          pop: true
     - match: '({{alphaid}})(""")'
       captures:
         1: support.function.scala
@@ -639,7 +650,15 @@ contexts:
       captures:
         1: support.function.scala
         2: punctuation.definition.string.begin.scala
-      push: f_string
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.interpolated.scala
+        - include: f_string
+        - match: '"'
+          scope: punctuation.definition.string.end.scala
+          pop: true
+        - match: \n
+          scope: invalid.string.newline.scala
     - match: '({{alphaid}})"'
       captures:
         1: support.function.scala
@@ -664,12 +683,6 @@ contexts:
   # http://docs.oracle.com/javase/6/docs/api/java/util/Formatter.html#detail
   # /!\ this implementation may allow incorrect combinaisons
   f_string:
-    - meta_include_prototype: false
-    - meta_scope: string.quoted.interpolated.scala
-    - match: '"'
-      pop: true
-    - match: \n
-      scope: invalid.string.newline.scala
     - include: escaped
     - include: interpolated-vars-expressions
     # constant formatting

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -123,7 +123,7 @@ contexts:
       scope: comment.block.empty.scala punctuation.definition.comment.scala
 
   char-literal:
-    - match: '''\\?.'''
+    - match: '''({{escaped_char}}|.)'''
       scope: constant.character.literal.scala
 
   comments:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -602,36 +602,43 @@ contexts:
   # see http://www.scala-lang.org/docu/files/ScalaReference.pdf part 1.3.5-6 (page 18)
   strings:
     - match: '"""'
+      scope: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.triple.scala
         - match: '{{unicode_char}}'
           scope: constant.character.escape.scala
-        - match: '"""(?!")'
+        - match: '(""")(?!")'
+          scope: punctuation.definition.string.end.scala
           pop: true
     - match: '"'
+      scope: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.scala
         - match: '"'
+          scope: punctuation.definition.string.end.scala
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
         - include: escaped
-    - match: '({{alphaid}})"""'
+    - match: '({{alphaid}})(""")'
       captures:
         1: support.function.scala
+        2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.triple.interpolated.scala
         - match: '{{unicode_char}}'
           scope: constant.character.escape.scala
-        - match: '"""(?!")'
+        - match: '(""")(?!")'
+          scope: punctuation.definition.string.end.scala
           pop: true
         - include: interpolated-vars-expressions
-    - match: '(f)"'
+    - match: '(f)(")'
       captures:
         1: support.function.scala
+        2: punctuation.definition.string.begin.scala
       push: f_string
     - match: '({{alphaid}})"'
       captures:
@@ -640,6 +647,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: string.quoted.interpolated.scala
         - match: '"'
+          scope: punctuation.definition.string.end.scala
           pop: true
         - match: \n
           scope: invalid.string.newline.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -58,6 +58,10 @@ variables:
   withinparens: '(?:\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\))'
   withinbrackets: '(?:\[(?:[^\[\]]|\[(?:[^\[\]]|\[[^\[\]]*\])*\])*\])'
 
+  unicode_char: '\\u[0-9a-fA-F]{4}'
+  octal_char: '\\[0-7]{1,3}'
+  escaped_char: '\\[btnfr"''\\]|{{unicode_char}}|{{octal_char}}'
+
 contexts:
   prototype:
     - include: comments
@@ -595,11 +599,14 @@ contexts:
     - match: \b(@volatile|abstract|final|lazy|sealed|implicit|override|@transient|@native)\b
       scope: storage.modifier.other.scala
 
+  # see http://www.scala-lang.org/docu/files/ScalaReference.pdf part 1.3.5-6 (page 18)
   strings:
     - match: '"""'
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.triple.scala
+        - match: '{{unicode_char}}'
+          scope: constant.character.escape.scala
         - match: '"""(?!")'
           pop: true
     - match: '"'
@@ -610,14 +617,15 @@ contexts:
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
-        - match: \\.
-          scope: constant.character.escape.scala
+        - include: escaped
     - match: '({{alphaid}})"""'
       captures:
         1: support.function.scala
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.triple.interpolated.scala
+        - match: '{{unicode_char}}'
+          scope: constant.character.escape.scala
         - match: '"""(?!")'
           pop: true
         - include: interpolated-vars-expressions
@@ -631,9 +639,14 @@ contexts:
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
-        - match: \\.
-          scope: constant.character.escape.scala
+        - include: escaped
         - include: interpolated-vars-expressions
+
+  escaped:
+    - match: '{{escaped_char}}'
+      scope: constant.character.escape.scala
+    - match: \\
+      scope: invalid.illegal.lone-escape.scala
 
   interpolated-vars-expressions:
     - match: '(\$){{alphaid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -629,6 +629,10 @@ contexts:
         - match: '"""(?!")'
           pop: true
         - include: interpolated-vars-expressions
+    - match: '(f)"'
+      captures:
+        1: support.function.scala
+      push: f_string
     - match: '({{alphaid}})"'
       captures:
         1: support.function.scala
@@ -647,6 +651,37 @@ contexts:
       scope: constant.character.escape.scala
     - match: \\
       scope: invalid.illegal.lone-escape.scala
+
+  # f_string, see:
+  # http://docs.oracle.com/javase/6/docs/api/java/util/Formatter.html#detail
+  # /!\ this implementation may allow incorrect combinaisons
+  f_string:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.interpolated.scala
+    - match: '"'
+      pop: true
+    - match: \n
+      scope: invalid.string.newline.scala
+    - include: escaped
+    - include: interpolated-vars-expressions
+    # constant formatting
+    - match: '%[%n]'
+      scope: constant.other.formatting.scala
+    # general formatting
+    - match: '%\-?#?[bBhHsS]'
+      scope: constant.other.formatting.scala
+    # character formatting
+    - match: '%\-?[cC]'
+      scope: constant.other.formatting.scala
+    # date-time formatting
+    - match: '%\-?[tT][HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc]?'
+      scope: constant.other.formatting.scala
+    # floating point formatting
+    - match: '%[\+\-# 0\(,]*[\.0-9]*[feEgGaA]'
+      scope: constant.other.formatting.scala
+    # integer formatting
+    - match: '%[\+\-# 0\(,]*[doxX]'
+      scope: constant.other.formatting.scala
 
   interpolated-vars-expressions:
     - match: '(\$){{alphaid}}'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -248,6 +248,16 @@ type Foo = Bar[A] forSome { type A }
 //                    ^ punctuation.definition.expression
 //                     ^^^ string.quoted.triple.interpolated.scala
 
+   f"formatted: x: $x%+,.3f ca"
+// ^ support.function
+//                  ^ variable.other.scala
+//                   ^^^^^^ constant.other.formatting.scala
+
+   f"formatted: date: $x%T "
+// ^ support.function
+//                    ^ variable.other.scala
+//                      ^^ constant.other.formatting.scala
+
    Unit
 // ^^^^ storage.type.primitive.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -191,6 +191,12 @@ type Foo = Bar[A] forSome { type A }
    0.045e-2
 // ^^^^^^^^ constant.numeric.float.scala
 
+   'a'
+// ^^^ constant.character.literal.scala
+
+   '\u1221'
+// ^^^^^^^^ constant.character.literal.scala
+
    true
 // ^^^^ constant.language.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -215,6 +215,19 @@ type Foo = Bar[A] forSome { type A }
    "testing"
 // ^^^^^^^^^ string.quoted.double.scala
 
+  "escaped chars: \u1221 \125 \n"
+//                ^^^^^^ constant.character.escape.scala
+//                        ^^^ constant.character.escape.scala
+//                            ^^ constant.character.escape.scala
+
+  "bad escaping: \p"
+//               ^ invalid.illegal.lone-escape.scala
+
+  """escaped in triple: \u1221 \125 \n"""
+//                      ^^^^^^ constant.character.escape.scala
+//                             ^^^ - constant.character.escape.scala
+//                                  ^^ - constant.character.escape.scala
+
    """testing"""
 // ^^^^^^^^^^^^^ string.quoted.triple.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -213,7 +213,9 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^^ variable.language.scala
 
    "testing"
+// ^ punctuation.definition.string.begin.scala
 // ^^^^^^^^^ string.quoted.double.scala
+//         ^ punctuation.definition.string.end.scala
 
   "escaped chars: \u1221 \125 \n"
 //                ^^^^^^ constant.character.escape.scala
@@ -224,9 +226,11 @@ type Foo = Bar[A] forSome { type A }
 //               ^ invalid.illegal.lone-escape.scala
 
   """escaped in triple: \u1221 \125 \n"""
+//^^^ punctuation.definition.string.begin.scala
 //                      ^^^^^^ constant.character.escape.scala
 //                             ^^^ - constant.character.escape.scala
 //                                  ^^ - constant.character.escape.scala
+//                                    ^^^ punctuation.definition.string.end.scala
 
    """testing"""
 // ^^^^^^^^^^^^^ string.quoted.triple.scala


### PR DESCRIPTION
As mentioned in #588 unicode escaped characters were improperly highlighted.
I also added support for octal characters, and check for improper escape sequences.

```scala
  "escaped chars: \u1221 \125 \n"
//                ^^^^^^ constant.character.escape.scala
//                        ^^^ constant.character.escape.scala
//                            ^^ constant.character.escape.scala

  "bad escaping: \p"
//               ^ invalid.illegal.lone-escape.scala

  """escaped in triple: \u1221 \125 \n"""
//                      ^^^^^^ constant.character.escape.scala
//                             ^^^ - constant.character.escape.scala
//                                  ^^ - constant.character.escape.scala
```

I also added support for "f-string" with a "printf" like escaping. I'm not sure which scope to use here.
```scala
   f"formatted: x: $x%+,.3f ca"
// ^ support.function
//                  ^ variable.other.scala
//                   ^^^^^^ constant.other.formatting.scala

   f"formatted: date: $x%T "
// ^ support.function
//                    ^ variable.other.scala
//                      ^^ constant.other.formatting.scala
```