### PR TITLE
[Scala] Added emergency bailout from pattern match mode

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -299,6 +299,8 @@ contexts:
           pop: true
           captures:
             1: keyword.control.flow.scala
+        - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
+          pop: true
         - include: pattern-match
 
   braces:


### PR DESCRIPTION
It's just a bit annoying typing `case` and seeing the rest of the file get eaten by `pattern-match` context.  This just checks for `\}` (which is guaranteed surrounding a case expression) or a `case` (i.e. we're typing not-the-last pattern in a block) and bails out there.

The only case this doesn't handle now is typing `case class`, which still behaves a bit unintuitively, but it's not as actively annoying as the case that I've fixed.