### PR TITLE
[Scala] < is a valid operator (when not followed by alphabeticals)

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,6 +22,7 @@ variables:
       [[^:=<@\x{2190}\x{21D2}#]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
+      <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-]&&{{operator_character}}]+|
       <-{{operator_character}}+|
       [:@\x{2190}\x{21D2}#]{{operator_character}}+
@@ -33,6 +34,7 @@ variables:
       [[^:=<@\x{2190}\x{21D2}#+\-]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
+      <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-%:]&&{{operator_character}}]+|
       <[:%\-]{{operator_character}}+|
       :[[^<]&&{{operator_character}}]+|

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,7 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+def <(a: Int) = 42
+//  ^ entity.name.function.scala
+//    ^ variable.parameter.scala


### PR DESCRIPTION
In master, `<` (by itself) is not considered a valid identifier.  This PR fixes this case while respecting XML literals.  Note that there is one situation that will be improperly highlighted at present.  Consider the following:

```scala
x<y
x< y
x <y
x < y
```

The first of the four will be improperly highlighted (it will assume that `<` indicates an XML literal, rather than an operator).  All of the remaining three will be handled correctly by the syntax highlighting, including the third (which *correctly* identifies `<` as part of an XML literal).  I'm not sure how to handle the first one without some combinations of contortions or lookbehind, and it's super-rare anyway – as demonstrated by the fact that Martin Odersky was one of two people (total!) to correctly identify the parsing rules which govern this token – so I'm not going to stress out about it.