### PR TITLE
[Scala] Rewrote XML support

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -671,7 +671,7 @@ contexts:
       captures:
         1: entity.name.tag.xml
       push: xml-tag-decl
-    - match: '<\?\s*xml(?:.*[>$]|\b)'
+    - match: '<\?\s*xml(?:\s.*[>$]|\b)'
       scope: invalid.illegal.reserved-proc-instr.xml
     - match: '<\?\s*({{xml_qualified_name}})'
       captures:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -691,6 +691,7 @@ contexts:
     - meta_scope: text.xml
     - meta_include_prototype: false
     - include: xml-comments
+    - include: xml-entity
     - match: '\?>'
       pop: true
     - match: '/>'
@@ -708,14 +709,19 @@ contexts:
       captures:
         1: invalid.illegal.bad-attribute-name.xml
         2: punctuation.separator.key-value.xml
+    - include: xml-should-be-entity
   xml-attribute-val:
     - meta_scope: text.xml
     - meta_include_prototype: false
     - include: xml-comments
+    - include: xml-entity
+    - include: xml-should-be-entity
     - match: '"'
       scope: punctuation.definition.string.begin.xml
       set:
         - meta_scope: text.xml string.quoted.double.xml
+        - include: xml-entity
+        - include: xml-should-be-entity
         - match: '"'
           scope: punctuation.definition.string.end.xml
           set: xml-tag-decl
@@ -724,6 +730,8 @@ contexts:
       scope: punctuation.definition.string.begin.xml
       set:
         - meta_scope: text.xml string.quoted.single.xml
+        - include: xml-entity
+        - include: xml-should-be-entity
         - match: "'"
           scope: punctuation.definition.string.end.xml
           set: xml-tag-decl
@@ -735,10 +743,24 @@ contexts:
           scope: punctuation.definition.inline.end.xml
           set: xml-tag-decl
         - include: main
+  xml-should-be-entity:
+    - match: '&'
+      scope: invalid.illegal.bad-ampersand.xml
+    - match: '<'
+      scope: invalid.illegal.missing-entity.xml
+    - match: '>'
+      scope: invalid.illegal.missing-entity.xml
+  xml-entity:
+    - match: '(&)(?:{{xml_name}}|#[0-9]+|#x\h+)(;)'
+      scope: constant.character.entity.xml
+      captures:
+        1: punctuation.definition.constant.xml
+        2: punctuation.definition.constant.xml
   xml-mode:
     - meta_scope: text.xml
     - meta_include_prototype: false
     - include: xml-comments
+    - include: xml-entity
     - match: '\{'
       scope: punctuation.definition.inline.begin.xml
       push:
@@ -751,6 +773,7 @@ contexts:
         1: entity.name.tag.xml
       pop: true
     - include: xml-literal
+    - include: xml-should-be-entity
 
   val-pattern-match-main:
     - include: keywords

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -58,6 +58,15 @@ variables:
   typeprefix: '(:)\s*'
   # hack to cover up to three levels of nested parentheses
   withinparens: '\((?:[^\(\)]|\((?:[^\(\)]|\([^\(\)]*\))*\))*\)'
+  # This is the full XML Name production, but should not be used where namespaces
+  # are possible. Those locations should use a qualified_name.
+  xml_name: '[[:alpha:]:_][[:alnum:]:_.-]*'
+  # This is the form that allows a namespace prefix (ns:) followed by a local
+  # name. The captures are:
+  #  1: namespace prefix name
+  #  2: namespace prefix colon
+  #  3: local tag name
+  xml_qualified_name: '(?:([[:alpha:]_][[:alnum:]_.-]*)(:))?([[:alpha:]_][[:alnum:]_.-]*)'
 
 contexts:
   prototype:
@@ -655,21 +664,85 @@ contexts:
             - include: nest-curly-and-self
             - include: main
 
-  xml-attribute:
-    - match: '(\w+)=("[^"]*")'
-      captures:
-        1: entity.other.attribute-name.xml
-        2: string.quoted.double.xml
   xml-literal:
-    - match: "</?([a-zA-Z0-9]+)"
+    - match: '</{{xml_qualified_name}}>?'
+      scope: invalid.illegal.bad-closing-tag.xml
+    - match: '<({{xml_qualified_name}})'
       captures:
         1: entity.name.tag.xml
+      push: xml-tag-decl
+  xml-comments:
+    - meta_scope: text.xml
+    - meta_include_prototype: false
+    - match: '<!--'
+      scope: punctuation.definition.comment.begin.xml
       push:
-        - meta_scope: text.xml
-        - match: /?>
+        - meta_scope: comment.block.xml
+        - match: '-->'
+          scope: punctuation.definition.comment.end.xml
           pop: true
-        - include: xml-literal
-        - include: xml-attribute
+  xml-tag-decl:
+    - meta_scope: text.xml
+    - meta_include_prototype: false
+    - include: xml-comments
+    - match: '/>'
+      pop: true
+    - match: '>'
+      set: xml-mode
+    - match: '(?:\s+|^){{xml_qualified_name}}\s*(=)'
+      captures:
+        1: entity.other.attribute-name.namespace.xml
+        2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
+        3: entity.other.attribute-name.localname.xml
+        4: punctuation.separator.key-value.xml
+      set: xml-attribute-val
+    - match: '(?:\s+|^)([[:alnum:]:_.-]+)\s*(=)'
+      captures:
+        1: invalid.illegal.bad-attribute-name.xml
+        2: punctuation.separator.key-value.xml
+  xml-attribute-val:
+    - meta_scope: text.xml
+    - meta_include_prototype: false
+    - include: xml-comments
+    - match: '"'
+      scope: punctuation.definition.string.begin.xml
+      set:
+        - meta_scope: text.xml string.quoted.double.xml
+        - match: '"'
+          scope: punctuation.definition.string.end.xml
+          set: xml-tag-decl
+        # TODO entities
+    - match: "'"
+      scope: punctuation.definition.string.begin.xml
+      set:
+        - meta_scope: text.xml string.quoted.single.xml
+        - match: "'"
+          scope: punctuation.definition.string.end.xml
+          set: xml-tag-decl
+        # TODO entities
+    - match: '\{'
+      scope: punctuation.definition.inline.begin.xml
+      set:
+        - match: '\}'
+          scope: punctuation.definition.inline.end.xml
+          set: xml-tag-decl
+        - include: main
+  xml-mode:
+    - meta_scope: text.xml
+    - meta_include_prototype: false
+    - include: xml-comments
+    - match: '\{'
+      scope: punctuation.definition.inline.begin.xml
+      push:
+        - match: '\}'
+          scope: punctuation.definition.inline.end.xml
+          pop: true
+        - include: main
+    - match: '</({{xml_qualified_name}})>'
+      captures:
+        1: entity.name.tag.xml
+      pop: true
+    - include: xml-literal
 
   val-pattern-match-main:
     - include: keywords

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -671,6 +671,12 @@ contexts:
       captures:
         1: entity.name.tag.xml
       push: xml-tag-decl
+    - match: '<\?\s*xml(?:.*[>$]|\b)'
+      scope: invalid.illegal.reserved-proc-instr.xml
+    - match: '<\?\s*({{xml_qualified_name}})'
+      captures:
+        1: entity.name.tag.xml
+      push: xml-tag-decl
   xml-comments:
     - meta_scope: text.xml
     - meta_include_prototype: false
@@ -685,6 +691,8 @@ contexts:
     - meta_scope: text.xml
     - meta_include_prototype: false
     - include: xml-comments
+    - match: '\?>'
+      pop: true
     - match: '/>'
       pop: true
     - match: '>'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -22,6 +22,7 @@ variables:
       [[^:=<@\x{2190}\x{21D2}#]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
+      <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-]&&{{operator_character}}]+|
       <-{{operator_character}}+|
       [:@\x{2190}\x{21D2}#]{{operator_character}}+
@@ -33,6 +34,7 @@ variables:
       [[^:=<@\x{2190}\x{21D2}#+\-]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]+|
       =>{{operator_character}}+|
+      <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-%:]&&{{operator_character}}]+|
       <[:%\-]{{operator_character}}+|
       :[[^<]&&{{operator_character}}]+|

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1084,3 +1084,16 @@ def <(a: Int) = 42
 
    <!-- not a comment -->
 // ^^^^^^^^^^^^^^^^^^^^^^ - comment
+
+   <foo a="&" b="<" c=">"/>
+//         ^ invalid.illegal.bad-ampersand.xml
+//               ^ invalid.illegal.missing-entity.xml
+//                     ^ invalid.illegal.missing-entity.xml
+
+   <foo a="&amp;"/>
+//          ^^^ constant.character.entity.xml
+
+   <foo>
+     &amp;
+<!-- ^^^^^ constant.character.entity.xml -->
+   </foo>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1078,6 +1078,9 @@ def <(a: Int) = 42
    <?xml
 // ^^^^^ invalid.illegal.reserved-proc-instr.xml
 
+   <?xmll?>
+// ^^^^^^^^ - invalid
+
    <?foo thing="false"?>
 //   ^^^ entity.name.tag.xml
 //             ^^^^^^^ string.quoted.double.xml

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1024,3 +1024,7 @@ xs: Foo with Bar
 val Stuff(thing, other) = ???
 //        ^^^^^ entity.name.val.scala
 //               ^^^^^ entity.name.val.scala
+
+def <(a: Int) = 42
+//  ^ entity.name.function.scala
+//    ^ variable.parameter.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1071,3 +1071,16 @@ def <(a: Int) = 42
 
    </thing>
 // invalid.illegal.bad-closing-tag.xml
+
+   <?xml version="1.0"?>
+// ^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.reserved-proc-instr.xml
+
+   <?xml
+// ^^^^^ invalid.illegal.reserved-proc-instr.xml
+
+   <?foo thing="false"?>
+//   ^^^ entity.name.tag.xml
+//             ^^^^^^^ string.quoted.double.xml
+
+   <!-- not a comment -->
+// ^^^^^^^^^^^^^^^^^^^^^^ - comment

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1028,3 +1028,46 @@ val Stuff(thing, other) = ???
 def <(a: Int) = 42
 //  ^ entity.name.function.scala
 //    ^ variable.parameter.scala
+
+   <thing foo="42"/>
+//  ^^^^^ text.xml entity.name.tag.xml
+//        ^^^ text.xml entity.other.attribute-name.localname.xml
+//            ^ text.xml string.quoted.double.xml punctuation.definition.string.begin.xml
+//             ^^ text.xml string.quoted.double.xml
+//               ^ text.xml string.quoted.double.xml punctuation.definition.string.end.xml
+
+   <!-- not a comment -->
+// ^^^^^^^^^^^^^^^^^^^^^^ - comment
+
+   <foo bar="test" baz='test' bin={ 42 }>
+<!--                   ^ text.xml string.quoted.single.xml punctuation.definition.string.begin.xml -->
+<!--                        ^ text.xml string.quoted.single.xml punctuation.definition.string.end.xml -->
+<!--                                ^^ source.scala constant.numeric.integer.scala -->
+     {
+       42 + "thing"
+//     ^^ source.scala constant.numeric.integer.scala
+//          ^^^^^^^ source.scala string.quoted.double.scala
+       // comments!
+//     ^^^^^^^^^^^^ source.scala comment.line.double-slash.scala
+
+       <nested/>
+//      ^^^^^^ entity.name.tag.xml
+     }
+
+     "stuff"
+<!-- ^^^^^^^ - string -->
+
+     <!-- comments -->
+<!-- ^^^^^^^^^^^^^^^^^ comment.block.xml -->
+
+     <thing/>
+
+     <more>
+       more tags!
+       /* not a comment */
+<!--   ^^^^^^^^^^^^^^^^^^^ - comment -->
+     </more>
+   </foo>
+
+   </thing>
+// invalid.illegal.bad-closing-tag.xml


### PR DESCRIPTION
As mentioned in #588.  This fixes some long-standing bugs in XML literals, including failure to correctly scope embedded Scala within attribute declarations, as well as generally not obeying the XML spec on names, entities, and really much of anything.  Depends on #613, since I didn't want to redo the lookahead changes.