### PR TITLE
[Scala] Reworked auto-indentation

### DIFF
--- a/Scala/Indent-case.tmPreferences
+++ b/Scala/Indent-case.tmPreferences
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Indent (case)</string>
+  <key>scope</key>
+  <string>source.scala meta.block.case.scala - comment</string>
+  <key>settings</key>
+  <dict>
+    <key>decreaseIndentPattern</key>
+    <string>(?x)
+        ^ (.*\*/)? \s* \} .* $
+      | ^ (.*\*/)? \s* \) .* $
+      | ^ \s* case\b .* $
+    </string>
+  </dict>
+</dict>
+</plist>

--- a/Scala/Indent-case.tmPreferences
+++ b/Scala/Indent-case.tmPreferences
@@ -4,7 +4,7 @@
   <key>name</key>
   <string>Indent (case)</string>
   <key>scope</key>
-  <string>source.scala meta.block.case.scala - comment</string>
+  <string>source.scala meta.block.case.late - comment</string>
   <key>settings</key>
   <dict>
     <key>decreaseIndentPattern</key>

--- a/Scala/Indent.tmPreferences
+++ b/Scala/Indent.tmPreferences
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Indent</string>
+  <key>scope</key>
+  <string>source.scala - comment</string>
+  <key>settings</key>
+  <dict>
+    <key>increaseIndentPattern</key>
+    <string>(?x)
+        ^ .* \{ [^}"']* $
+      | ^ .* \( [^)"']* $
+      | ^ \s* case .* =&gt; \s* $
+    </string>
+    <key>decreaseIndentPattern</key>
+    <string>(?x)
+        ^ (.*\*/)? \s* \} .* $
+      | ^ (.*\*/)? \s* \) .* $
+    </string>
+    <key>bracketIndentNextLinePattern</key>
+    <string>(?x)
+        ^ .* = \s* $
+      | ^ .* (if|do|while) .* \) \s* $
+      | ^ .* else \s* $
+    </string>
+  </dict>
+</dict>
+</plist>

--- a/Scala/Indent.tmPreferences
+++ b/Scala/Indent.tmPreferences
@@ -11,7 +11,7 @@
     <string>(?x)
         ^ .* \{ [^}"']* $
       | ^ .* \( [^)"']* $
-      | ^ \s* case .* =&gt; \s* $
+      | ^ \s* case .* =&gt; .* $
     </string>
     <key>decreaseIndentPattern</key>
     <string>(?x)

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -295,8 +295,19 @@ contexts:
       captures:
         1: keyword.control.scala
         2: entity.name.namespace.header.scala
+
+    # case blocks have four meta scopes:
+    #
+    # - meta.block.case
+    # - meta.block.case.body
+    # - meta.block.case.late
+    # - meta.block.case.late.body
+    #
+    # This is so that auto-indentation can behave differently on the "non-first"
+    # case lines in a pattern match block, since the first line opens a scope,
+    # while the non-first lines close the previous scope AND open the next scope
     - match: '\b(case)\b'
-      scope: keyword.other.declaration.scala
+      scope: keyword.other.declaration.scala meta.block.case.scala
       push:
         - match: '\b(if)\b'
           captures:
@@ -308,19 +319,46 @@ contexts:
             - include: main-no-lambdas
         - match: '{{rightarrow}}'
           scope: keyword.operator.arrow.scala
-          set: case-body
+          set:
+            - meta_scope: meta.block.case.body.scala
+            - include: case-body
           captures:
             1: keyword.control.flow.scala
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
         - include: pattern-match
   case-body:
-    - meta_scope: meta.block.case.scala
     - match: '(?=\})'
       pop: true
     - match: '(?=\bcase\b)'
-      pop: true
+      set: case-late-decl
     - include: main
+  case-late-decl:
+    - meta_scope: meta.block.case.late.scala
+    - match: '\b(case)\b'
+      scope: keyword.other.declaration.scala
+      set:    # set vs push; late vs not-late above
+        - match: '\('
+          push:
+            - match: '\)'
+              pop: true
+            - include: pattern-match
+        - match: '\b(if)\b'
+          captures:
+            1: keyword.control.flow.scala
+          set:
+            - match: '{{rightarrow}}'
+              scope: keyword.operator.arrow.scala
+              pop: true
+            - include: main-no-lambdas
+        - match: '{{rightarrow}}'
+          scope: keyword.operator.arrow.scala
+          set:
+            - meta_scope: meta.block.case.late.body.scala   # late here!
+            - include: case-body
+          captures:
+            1: keyword.control.flow.scala
+        - include: pattern-match
 
   braces:
     - match: \[

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -308,12 +308,19 @@ contexts:
             - include: main-no-lambdas
         - match: '{{rightarrow}}'
           scope: keyword.operator.arrow.scala
-          pop: true
+          set: case-body
           captures:
             1: keyword.control.flow.scala
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
         - include: pattern-match
+  case-body:
+    - meta_scope: meta.block.case.scala
+    - match: '(?=\})'
+      pop: true
+    - match: '(?=\bcase\b)'
+      pop: true
+    - include: main
 
   braces:
     - match: \[

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -539,11 +539,13 @@ type Foo = Bar[A] forSome { type A }
 //                    ^^^^^^^ keyword.declaration.scala
 //                             ^^^ support.class
 
+{
    case class
 // ^^^^ keyword.other.declaration.scala
 //      ^^^^^ storage.type.class.scala
 
 =>     // this is here to act as a random terminator to the above partial syntax
+}
 
    case class Thingy(abc: Int) extends Other
 // ^^^^ storage.type.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -982,8 +982,10 @@ foo({ _: Unit => () })
   stuff: _*
 //       ^^ keyword.operator.varargs.scala
 
+{
   case _ @ _* =>
 //         ^^ keyword.operator.varargs.scala
+}
 
   val _ @ _* = things
 //        ^^ keyword.operator.varargs.scala
@@ -998,8 +1000,10 @@ foo.bar
 (foo, bar)
 //  ^ punctuation.separator.scala
 
+{
 case (foo, bar) =>
 //       ^ punctuation.separator.scala
+}
 
 val (foo, bar) = ???
 //      ^ punctuation.separator.scala


### PR DESCRIPTION
Scala's default auto-indentation has long been broken.  This makes it… uh… less broken.

Notably, this PR provides actual working support for auto-indenting `case` expressions.  For example:

``` scala
thing match {
  case foo =>
    stuff1
    stuff2

  case bar =>
    stuff3

    stuff4
}

println("hello world")
```

The above represents the idiomatic (and basically universally-accepted) indentation for `case` expressions.  It's very tricky to do this though, since the _first_ `case` represents an indent, while _all subsequent_ `case`s represent both an indent and a dedent.  So… tricky.

We do it with meta scoping.  There's a new `meta` scope which is applied by the mode, identifying first cases vs non-first cases.  That meta scoping is then used by the auto-indentation regular expressions to swap off the default case auto-indent (which only indents) and swap in the non-first auto-indent (which both indents and dedents).  Hurray?

Oh btw, for the record, scope-based filtering of the auto-indentation rules is determined by the scopes which are applied to the `\n` character on the line.  So you have to make sure that any such meta scoping is applied at the _end_ of the line, and not the beginning (this is the source of some contortion in the contexts).

There's one place where this trick doesn't work though.  If you take the above, select all and reindent it, you'll get the following:

``` scala
thing match {
  case foo =>
    stuff1
    stuff2

  case bar =>
    stuff3

    stuff4
  }

  println("hello world")
```

Yeah…  This is sadness.  It comes from the fact that Sublime does not provide a way to automatically indent (or in this case, dedent) multiple levels per line.  I made a suggestion on the forums as how this could be solved, but other than @FichteFoll, not many people chimed in.  (basically, I think indentation should be determined directly by meta scope (e.g. `meta.indent.1`, or perhaps repeated applications of `meta.indent`), without the clumsy secondary regexes in plist files)

This limitation also shows up in a couple other areas.  For example, the standard double-curly problem:

``` scala
{
  {
    foo
  }}

  bar
```

Hint: the above is _not_ correct, it's just what Sublime tries to do by default.

Anyway, I've been using these auto-indent rules for about a month now on varying code-bases, and I'm pretty confident they are about as correct as they can possibly be.  I haven't had any real "wtf" moments other than the closing curly on a pattern match, which I can't really do anything about.

I haven't addressed some specifically weird cases, like class or function declaration line wrapping.  This is intentional, mostly because those cases are extremely complicated and not at all standard in their handling.  If you want to auto-indent those things, use scalafmt.
