### PR TITLE
[HTML] allow HTML autocompletion inside PHP HTML heredoc strings

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -199,8 +199,8 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within HTML
-        if not view.match_selector(locations[0],
-           "text.html - (source - source text.html) - string.quoted - meta.tag.style.end punctuation.definition.tag.begin"):
+        if not view.match_selector(locations[0], "text.html - (source - source text.html)"
+           " - string.quoted - meta.tag.style.end punctuation.definition.tag.begin"):
             return []
 
         # check if we are inside a tag

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -200,7 +200,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within HTML
         if not view.match_selector(locations[0],
-           "text.html - source - string.quoted - meta.tag.style.end punctuation.definition.tag.begin"):
+           "text.html - (source - source text.html) - string.quoted - meta.tag.style.end punctuation.definition.tag.begin"):
             return []
 
         # check if we are inside a tag

--- a/PHP/PHP.sublime-completions
+++ b/PHP/PHP.sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "source.php - variable.other.php",
+	"scope": "source.php - variable.other.php - source.php meta.embedded.html",
 
 	"completions":
 	[


### PR DESCRIPTION
allow HTML autocompletion inside PHP HTML heredoc strings

i.e.

```
<?php echo <<<HTML
<!-- here, when user types for e.g. `sect`, it should suggest <section> -->
HTML;
?>
```
