### PR TITLE
Improve optional arguments in LaTeX syntax

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -64,6 +64,7 @@ contexts:
           pop: true
         - include: general-constants
         - include: general-commands
+        - include: global-braces
         - match: '[A-Za-z[:digit:]-]*(?=\s*\=)'
           scope: variable.parameter.bracket.latex
 


### PR DESCRIPTION
The current syntax had problems recognizing braces in optional arguments as for example in 
````latex
\begin{defn}[{\parencite[Definition]{Article}}]
\begin{figure}[caption={Action of \( S^1 \) by rotation on \( \R^2 \).}]
````
This is fixed with this PR.
I found the `syntax_test_latex.tex` where you apparently collect tests. But I didn't understand the "test syntax" in order to create a test for this PR. 