### PR TITLE
[Scala] Misc fixes to functions and lambdas

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -350,7 +350,7 @@ contexts:
       set: function-return-type-definition
     - match: '\n'
       set: function-type-parameter-list-newline
-    - match: '(?=[\{\};]|{{nonopchar}}={{nonopchar}})'
+    - match: '(?=[\{\};]|{{nonopchar}}?={{nonopchar}})'
       pop: true
 
   function-type-parameter-list-newline:
@@ -369,7 +369,7 @@ contexts:
   function-return-type-definition:
     - match: '\n'
       set: function-return-type-definition-newline
-    - match: '(?=[\{\};]|{{nonopchar}}={{nonopchar}})'
+    - match: '(?=[\{\};]|{{nonopchar}}?={{nonopchar}})'
       pop: true
     - include: delimited-type-expression
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -148,7 +148,8 @@ contexts:
       push: single-type-expression
 
   lambdas:
-    - match: '(?=({{idorunder}}|{{idorunder}}\s*:\s*{{id}}{{withinbrackets}}?|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
+    # lambda lookahead
+    - match: '(?=({{idorunder}}|{{idorunder}}\s*:\s*{{id}}\s*{{withinbrackets}}?(\s*[\.#]\s*{{id}}\s*{{withinbrackets}}?)*|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{rightarrow}}'
           scope: storage.type.function.arrow.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -347,7 +347,7 @@ contexts:
     - match: '\['
       push: function-tparams-brackets
     - match: ':'
-      push: function-return-type-definition
+      set: function-return-type-definition
     - match: '\n'
       set: function-type-parameter-list-newline
     - match: '(?=[\{\};]|{{nonopchar}}={{nonopchar}})'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -550,15 +550,6 @@ contexts:
           scope: keyword.operator.assignment.scala
           pop: true
         - include: pattern-match
-    - match: '\{'
-      push:
-        - match: '\}'
-          pop: true
-        - include: main
-    - match: '\('
-      push:
-        - match: '\)'
-          pop: true
         - include: main
     - include: main
   for-parens-body:
@@ -576,16 +567,6 @@ contexts:
       pop: true
     - match: ;
       pop: true
-    - match: '\{'
-      push:
-        - match: '\}'
-          pop: true
-        - include: main
-    - match: '\('
-      push:
-        - match: '\)'
-          pop: true
-        - include: main
     - include: main
 
   keywords:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -401,7 +401,7 @@ contexts:
         - include: main
     - match: ':'
       scope: punctuation.separator.scala
-      push: function-return-type-definition
+      set: function-return-type-definition
     - match: '\n'
       set: function-parameter-list-newline
     - match: '(?=[\{=])'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -709,9 +709,10 @@ contexts:
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
-    - match: '({{alphaid}})"'
+    - match: '({{alphaid}})(")'
       captures:
         1: support.function.scala
+        2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.interpolated.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1235,3 +1235,6 @@ def foo: Map[Bar]=42
     }
     thing
 //  ^^^^^ - variable
+
+    s"thingy "
+//   ^ punctuation.definition.string.begin.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1218,3 +1218,6 @@ def test
    def foo: Map[Bar]
    def connectionMap: Unit
 // ^^^ storage.type.function.scala
+
+def foo: Map[Bar]=42
+//                ^^ constant.numeric.integer.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1221,3 +1221,11 @@ def test
 
 def foo: Map[Bar]=42
 //                ^^ constant.numeric.integer.scala
+
+   x: Foo.Bar => ()
+// ^ variable.parameter.scala
+//            ^^ storage.type.function.arrow.scala
+
+   x: Foo#Bar => ()
+// ^ variable.parameter.scala
+//            ^^ storage.type.function.arrow.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1229,3 +1229,9 @@ def foo: Map[Bar]=42
    x: Foo#Bar => ()
 // ^ variable.parameter.scala
 //            ^^ storage.type.function.arrow.scala
+
+    object Stuff {
+      case
+    }
+    thing
+//  ^^^^^ - variable

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1238,3 +1238,8 @@ def foo: Map[Bar]=42
 
     s"thingy "
 //   ^ punctuation.definition.string.begin.scala
+
+   def thing(): Other
+   def boo: Int
+// ^^^ storage.type.function.scala
+//     ^^^ entity.name.function.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1213,3 +1213,8 @@ def test
     (arg: String)
     (arg: String) = arg
 //   ^^^ variable.parameter.scala
+
+// the following test is paired together
+   def foo: Map[Bar]
+   def connectionMap: Unit
+// ^^^ storage.type.function.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1243,3 +1243,14 @@ def foo: Map[Bar]=42
    def boo: Int
 // ^^^ storage.type.function.scala
 //     ^^^ entity.name.function.scala
+
+for {
+  abc = () => 42
+//         ^^ storage.type.function.arrow.scala
+}
+
+
+for (
+  abc = () => 42
+//         ^^ storage.type.function.arrow.scala
+)


### PR DESCRIPTION
The new double-newline detection stuff was a bit broken w.r.t. abstract function declarations, resulting in syntax highlighting being effectively disabled for large chunks of files.  Also, operator boundary detection in lookahead was a bit too overaggressive on function `=` operators (probably similarly on `val`/`var`, but I haven't checked yet).  Lambdas with bare parameters ascribed with fully-quantified types were not detected by the lookahead.  Finally, there was a missing punctuation scope on interpolated non-triple strings.