### PR TITLE
[Matlab] Fixed the block comment scope for the Matlab syntax

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -62,7 +62,7 @@ contexts:
       scope: comment.double.percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab
-    - match: '%\{'
+    - match: '%\{\s*\n'
       captures:
         1: punctuation.definition.comment.matlab
       push:

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -62,12 +62,12 @@ contexts:
       scope: comment.double.percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab
-    - match: '%\{\s*\n'
+    - match: '(%\{)\s*\n'
       captures:
         1: punctuation.definition.comment.matlab
       push:
         - meta_scope: comment.block.percentage.matlab
-        - match: '%\}\s*\n'
+        - match: '(%\})\s*\n'
           captures:
             1: punctuation.definition.comment.matlab
           pop: true

--- a/Matlab/Miscellaneous.tmPreferences
+++ b/Matlab/Miscellaneous.tmPreferences
@@ -38,6 +38,18 @@
 				<key>value</key>
 				<string>% </string>
 			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>%{\n</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>%}\n</string>
+			</dict>
 		</array>
 		<key>smartTypingPairs</key>
 		<array>

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -56,4 +56,24 @@ xAprox = fMetodoDeNewton( xi )
 
 
 
+%---------------------------------------------
+% Block comment test
+
+% Success case
+%{           
+x = 5
+% ^ source.matlab comment.block.percentage.matlab
+%}           
+
+% Failure case
+%{           fail
+x = 5
+% ^ source.matlab keyword.operator.symbols.matlab
+%}
+
+%{
+%}           fail
+x = 5
+% ^ source.matlab comment.block.percentage.matlab
+%}
 


### PR DESCRIPTION
### Fixed the block comment scope for the Matlab syntax

Originaly pointed out on: 
1. https://forum.sublimetext.com/t/matlab-syntax-highlighting-error-on-mac-10-11-4-build-3114/23429/2

Tests results after this work:
1. ![image](https://cloud.githubusercontent.com/assets/5332158/19008459/c06ad3b4-8741-11e6-9f86-15b98d0bde3c.png)
