### PR TITLE
[Ruby] make `.rb` the default file extension

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -41,6 +41,7 @@ name: Ruby
 # ternary operator rule, precedence stuff, symbol rule.
 # but also consider 'a.b?(:c)' ??
 file_extensions:
+  - rb
   - Appraisals
   - Berksfile
   - Brewfile
@@ -60,7 +61,6 @@ file_extensions:
   - rake
   - Rakefile
   - Rantfile
-  - rb
   - rbx
   - rjs
   - ruby.rail


### PR DESCRIPTION
When saving new files, the suggested extension is `.Appraisals`, apparently because its first in the list -- a regression introduced by 84396b2cfc7ad2ddb289c3d5bfecf4ae6a1a4f7d.

Moving `.rb` to the top solves this issue