### PR TITLE
[Markdown] Fix invalid first_line_match in MultiMarkdown.sublime-syntax

### DIFF
--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -2,7 +2,7 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 name: MultiMarkdown
-first_line_match: ^Format:\s*(?i:complete)\s*$
+first_line_match: (?i)^format:\s*complete\s*$
 scope: text.html.markdown.multimarkdown
 contexts:
   main:


### PR DESCRIPTION
Recently I received an issue about a `first_line_match` compiling error [here](https://github.com/jfcherng/Sublime-AutoSetSyntax/issues/6) hence I make this PR.

The `first_line_match` in `MultiMarkdown.sublime-syntax`:
- Cannot be compiled with Python's `re` module.
```python
>>> re.compile(r'^Format:\s*(?i:complete)\s*$')
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "./python3.3/re.py", line 214, in compile
  File "./python3.3/re.py", line 283, in _compile
  File "./python3.3/sre_compile.py", line 491, in compile
  File "./python3.3/sre_parse.py", line 747, in parse
  File "./python3.3/sre_parse.py", line 359, in _parse_sub
  File "./python3.3/sre_parse.py", line 708, in _parse
sre_constants.error: unknown extension
```
- According to [this](https://sublimetext.userecho.com/topics/4710-multimarkdown-mode-not-recognizing-format-complete-on-first-line-should-be-case-insensitive-for-keys/) report, the whole regex should be case insensitive.
