### PR TITLE
[ASP] support method definitions containing explicit array parens

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -329,16 +329,12 @@ contexts:
                 1: storage.modifier.reference.asp
                 2: variable.parameter.function.asp
               push:
-                - match: '(?=\)|$)'
-                  pop: true
-                - include: not_end_of_statement
-                - match: '\s*(,)\s*'
+                - match: '\s*(\()(\))\s*'
                   captures:
-                    1: punctuation.separator.parameter-declaration.asp
-                  pop: true
-                - match: '(?:(?![,)])\S)+'
-                  scope: invalid.illegal.unexpected-token.asp
-                  pop: true
+                    1: punctuation.section.array.begin.asp
+                    2: punctuation.section.array.end.asp
+                  set: after_method_param_name
+                - include: after_method_param_name
             - match: '(?:(?![,)])\S)+'
               scope: invalid.illegal.unexpected-token.asp
     - match: '\s+'
@@ -350,6 +346,18 @@ contexts:
     - match: $
       pop: true
     - include: unexpected_token
+
+  after_method_param_name:
+    - match: '(?=\)|$)'
+      pop: true
+    - include: not_end_of_statement
+    - match: '\s*(,)\s*'
+      captures:
+        1: punctuation.separator.parameter-declaration.asp
+      pop: true
+    - match: '(?:(?![,)])\S)+'
+      scope: invalid.illegal.unexpected-token.asp
+      pop: true
 
   inside_method:
     - meta_content_scope: meta.method.asp meta.method.body.asp

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -710,6 +710,17 @@
    '    ^^^^^^^^^^^^^^^^^^^^^ entity.name.function.asp - support.function.magic.event.asp
     End Sub
     
+    Sub Func_With_Explicit_Arrays(ByRef array_variable(), blah ())
+   '                                                  ^ punctuation.section.array.begin.asp
+   '                                                   ^ punctuation.section.array.end.asp
+   '                                                  ^^^^^^^^^^^^ - invalid
+   '                                                    ^ punctuation.separator.parameter-declaration.asp
+   '                                                      ^^^^ variable.parameter.function.asp
+   '                                                           ^ punctuation.section.array.begin.asp
+   '                                                            ^ punctuation.section.array.end.asp
+   '                                                             ^ punctuation.section.parameters.end.asp
+    End Sub
+    
     Sub Another_Test()rem
    '^^^ storage.type.function.asp
    '    ^^^^^^^^^^^^ entity.name.function.asp


### PR DESCRIPTION
In ASP, a method could be defined like:

    Sub Test1 (expect_array)
        Response.Write expect_array(1)
    End Sub

and it could also be defined like:

    Sub Test2 (expect_array())
        Response.Write(expect_array(1))
    End Sub

This PR is to ensure the latter case is highlighted correctly, as it is valid. (Interestingly, even in this case, ASP doesn't actually enforce that an array has to be passed, so it is mainly just a visual clue for the developer...)