### PR TITLE
[XML] Permit unescaped > in content

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -92,13 +92,13 @@ contexts:
         - match: ']]>'
           scope: punctuation.definition.string.end.xml
           pop: true
+    - match: ']]>'
+      scope: invalid.illegal.missing-entity.xml
     - include: should-be-entity
   should-be-entity:
     - match: '&'
       scope: invalid.illegal.bad-ampersand.xml
     - match: '<'
-      scope: invalid.illegal.missing-entity.xml
-    - match: '>'
       scope: invalid.illegal.missing-entity.xml
   double-quoted-string:
     - match: '"'

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -131,7 +131,7 @@
      text
 <!-- ^^^^ text -->
      >
-<!-- ^ text -->
+<!-- ^ text - punctuation - illegal -->
 
      <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
@@ -185,7 +185,7 @@
 <!--                             ^^^^^ string.quoted -->
 
      <element validinattr="a > b ]]> c"/>
-<!--                       ^^^^^^^^^^^ string.quoted -->
+<!--                       ^^^^^^^^^^^ string.quoted - punctuation - illegal -->
 
      <test
 foo="bar" />

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -130,6 +130,8 @@
 <!--                           ^ punctuation.definition.tag.end -->
      text
 <!-- ^^^^ text -->
+     >
+<!-- ^ text -->
 
      <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
@@ -181,6 +183,9 @@
 <!--                          ^ punctuation.separator.key-value -->
 <!--                            ^ punctuation.definition.string.begin -->
 <!--                             ^^^^^ string.quoted -->
+
+     <element validinattr="a > b ]]> c"/>
+<!--                       ^^^^^^^^^^^ string.quoted -->
 
      <test
 foo="bar" />
@@ -262,9 +267,9 @@ foo="bar" />
 <!-- ^ invalid.illegal.missing-entity -->
 <!--  ^ - invalid.illegal.missing-entity -->
 
-     >
-<!-- ^ invalid.illegal.missing-entity -->
-<!--  ^ - invalid.illegal.missing-entity -->
+     ]]>
+<!-- ^^^ invalid.illegal.missing-entity -->
+<!--    ^ - invalid.illegal.missing-entity -->
 
      <ns::tag ns::attr1="na" ns:2attr ="nope"></ns:t:ag>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->


### PR DESCRIPTION
Greater-than is actually valid in both text content and attribute values (see CharData and AttValue productions in XML 1.0 spec). Change should-be-entity pattern to reflect this.

The exception is that the sequence ]]> must not appear in text content (but it's OK in an attribute value, for some reason). Add missing-entity detection for that inside text content.