### PR TITLE
[XML] Handle prolog and PIs separately

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -25,7 +25,7 @@ variables:
 
 contexts:
   main:
-    - match: '(<\?)\s*({{qualified_name}})'
+    - match: '(<\?)(xml)(?=\s)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.xml
@@ -84,6 +84,15 @@ contexts:
           scope: punctuation.definition.tag.end.xml
           pop: true
         - include: tag-stuff
+    - match: '(<\?)((?![xX][mM][lL]){{qualified_name}})(?=\s|\?>)'
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.xml
+      push:
+        - meta_scope: meta.tag.preprocessor.xml
+        - match: \?>
+          scope: punctuation.definition.tag.end.xml
+          pop: true
     - include: entity
     - match: '<!\[CDATA\['
       scope: punctuation.definition.string.begin.xml

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -135,6 +135,13 @@
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
 <!--                                           ^ - string.unquoted.cdata -->
 
+     <?pi "markup" is <ignored>?>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^ entity.name.tag -->
+<!--                           ^^ punctuation.definition.tag.end -->
+<!--                             ^ - meta.tag.preprocessor -->
+
      <таĝñäᴹə ατţř="șƬűʃ⨍" >Contents</таĝñäᴹə>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
 <!-- ^ punctuation.definition.tag.begin -->


### PR DESCRIPTION
Currently we are using the same match for the <?xml ... ?> prolog at the start of a file, and <?other ... ?> processing instructions in document content. They look similar, but they're separate in the XML syntax and PIs don't have attribute/quoted-value constructs inside them.

Match <?xml with the current handling, and add simpler handling for processing instructions which doesn't look for attr-like structure in the content. This prevents eg stray apostrophes in PI content from triggering invalidity.

Exclude any targets beginning with XML (case insensitive) from being PIs as per the PITarget production, so they don't match the prolog. Tweak spaces to better match spec: ban space after <? for both prolog and PI; require space after <?xml, and require either space after PITarget or empty PI, so that invalid PI name chars are detected.
