### PR TITLE
Regexp scopes

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -210,7 +210,7 @@ contexts:
   group-body-extended:
     - meta_content_scope: meta.group.extended.regexp
     - match: \)
-      scope: meta.group.regexp keyword.control.group.regexp
+      scope: meta.group.extended.regexp keyword.control.group.regexp
       pop: true
     - include: base-group-extended
 

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -100,6 +100,26 @@ contexts:
       scope: keyword.control.group.regexp
       push: group-start-extended
 
+  group-start-common:
+    # Other modifiers (must come after other modifier matches)
+    - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
+      captures:
+        1: storage.modifier.mode.regexp
+        2: keyword.control.group.regexp
+      pop: true
+    - match: '(\?([+-]?\d+))(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: keyword.control.group.regexp
+      pop: true
+    - match: '(\?&(\w+))(\))'
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: keyword.control.group.regexp
+      pop: true
+
   group-start:
     - meta_scope: meta.group.regexp
     - match: '\?(<[=!]|>|=|:|!)'
@@ -111,12 +131,6 @@ contexts:
         1: storage.modifier.mode.regexp
         2: keyword.control.group.regexp
       set: [base-group-extended, unexpected-quantifier-pop]
-    # Other modifiers
-    - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
-      captures:
-        1: storage.modifier.mode.regexp
-        2: keyword.control.group.regexp
-      pop: true
     # Groups with 'x' mode
     - match: '\?[ims]*x[ixms]*(?:-[ims]+)?:'
       scope: storage.modifier.mode.regexp
@@ -125,21 +139,19 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ixms]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: '(\?[+-]?\d+)(\))'
-      captures:
-        1: keyword.other.backref-and-recursion.regexp
-        2: keyword.control.group.regexp
-      pop: true
-    - match: '(\?&\w+)(\))'
-      captures:
-        1: keyword.other.backref-and-recursion.regexp
-        2: keyword.control.group.regexp
-      pop: true
-    - match: '\?<\w+>'
+    - match: '\?<(\w+)>'
       scope: keyword.other.named-capture-group.regexp
+      captures:
+        1: entity.name.capture-group.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: \?\((<\w+>|'\w+'|\d+|R\d*|R&\w+)\)
+    - match: \?\((?:<(\w+)>|'(\w+)'|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
+      captures:
+        1: variable.other.backref-and-recursion.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: variable.other.backref-and-recursion.regexp
+        4: variable.other.backref-and-recursion.regexp
+        5: variable.other.backref-and-recursion.regexp
       set: [group-body, unexpected-quantifier-pop]
     - match: '\?\(DEFINE\)'
       scope: keyword.other.conditional.definition.regexp
@@ -147,6 +159,7 @@ contexts:
     - match: '\?(?=\(\?)'
       scope: keyword.other.conditional.regexp
       set: [group-body, base-group]
+    - include: group-start-common
     - match: ''
       set: [group-body, unexpected-quantifier-pop]
 
@@ -161,12 +174,6 @@ contexts:
         1: storage.modifier.mode.regexp
         2: keyword.control.group.regexp
       set: [base-group, unexpected-quantifier-pop]
-    # Other modifiers
-    - match: '(\?(?:[ixms]*-)?[ixms]+)(\))'
-      captures:
-        1: storage.modifier.mode.regexp
-        2: keyword.control.group.regexp
-      pop: true
     # Groups without 'x' mode
     - match: '\?[ims]*-[ims]*x[imxs]*:'
       scope: storage.modifier.mode.regexp
@@ -175,21 +182,19 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ims]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: '(\?[+-]?\d+)(\))'
-      captures:
-        1: keyword.other.backref-and-recursion.regexp
-        2: keyword.control.group.regexp
-      pop: true
-    - match: '(\?&\w+)(\))'
-      captures:
-        1: keyword.other.backref-and-recursion.regexp
-        2: keyword.control.group.regexp
-      pop: true
-    - match: '\?<\w+>'
+    - match: '\?<(\w+)>'
       scope: keyword.other.named-capture-group.regexp
+      captures:
+        1: entity.name.capture-group.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: \?\((<\w+>|'\w+'|\d+|R\d*|R&\w+)\)
+    - match: \?\((?:<(\w+)>|'(\w+)'|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
+      captures:
+        1: variable.other.backref-and-recursion.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: variable.other.backref-and-recursion.regexp
+        4: variable.other.backref-and-recursion.regexp
+        5: variable.other.backref-and-recursion.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
     - match: '\?\(DEFINE\)'
       scope: keyword.other.conditional.definition.regexp
@@ -197,6 +202,7 @@ contexts:
     - match: '\?(?=\(\?)'
       scope: keyword.other.conditional.regexp
       set: [group-body-extended, base-group-extended]
+    - include: group-start-common
     - match: ''
       set: [group-body-extended, unexpected-quantifier-pop]
 
@@ -273,10 +279,17 @@ contexts:
     - match: '\\[QEK]'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
-    - match: \\[kg](<\w+>|'\w+'|\{\w+\}|-?\d+)
+    - match: \\[kg](?:<(\w+)>|'(\w+)'|\{(\w+)\}|(-?\d+))
       scope: keyword.other.backref-and-recursion.regexp
-    - match: \\[1-9]\d*
+      captures:
+        1: variable.other.backref-and-recursion.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: variable.other.backref-and-recursion.regexp
+        4: variable.other.backref-and-recursion.regexp
+    - match: \\([1-9]\d*)
       scope: keyword.other.backref-and-recursion.regexp
+      captures:
+        1: variable.other.backref-and-recursion.regexp
 
   quantifiers:
     - match: '{{ranged_quantifier}}{{lazy_or_possessive}}'

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -284,6 +284,10 @@ where escape characters are ignored.\).
 # not a comment
 ^ - comment
 
+(?x:[ ] )
+#    ^ - meta.ignored-whitespace.regexp
+#      ^ meta.ignored-whitespace.regexp
+
 
 ###################
 ## References

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -23,6 +23,7 @@
 
 \1
 # <- keyword.other.backref-and-recursion
+#^ variable.other.backref-and-recursion.regexp
 
 \x{0ab}
 # <- constant.character.escape
@@ -288,33 +289,47 @@ where escape characters are ignored.\).
 ## References
 ###################
 
+(?<named_group>test)
+#^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
+#  ^^^^^^^^^^^ entity.name.capture-group.regexp
+#              ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
+
  \g{1}
 #^^^^^ keyword.other.backref-and-recursion.regexp - keyword.operator.quantifier.regexp
+#   ^ variable.other.backref-and-recursion.regexp
 
  \g1
 #^^^ keyword.other.backref-and-recursion.regexp
+#  ^ variable.other.backref-and-recursion.regexp
 
  \g{named_group}
 #^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#   ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
  \g'named_group'
 #^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#   ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
  \g<named_group>
 #^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#   ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
 (?1)
 #^^ keyword.other.backref-and-recursion.regexp
+# ^ variable.other.backref-and-recursion.regexp
 
 (1)
-#^ meta.literal.regexp - keyword.other.backref-and-recursion.regexp
+#^ meta.literal.regexp - keyword - variable
 
 (?&named_group)
 #^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#  ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
 (hello)(?-1)(?+1)(wow) relative capture groups are supported
 #       ^^^ keyword.other.backref-and-recursion.regexp
+#        ^^ variable.other.backref-and-recursion.regexp
 #            ^^^ keyword.other.backref-and-recursion.regexp
+#             ^^ variable.other.backref-and-recursion.regexp
 
 (hello)\g-1(wow)
 #      ^^^^ keyword.other.backref-and-recursion.regexp
@@ -322,10 +337,16 @@ where escape characters are ignored.\).
 (?x)(hello)(?-1)(?+1)(wow) relative capture groups are supported(?-x)
 #           ^^^ keyword.other.backref-and-recursion.regexp
 #                ^^^ keyword.other.backref-and-recursion.regexp
+#            ^^ variable.other.backref-and-recursion.regexp
+#                 ^^ variable.other.backref-and-recursion.regexp
 
-(?<named_group>test)
-#^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
-#              ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
+(?x)(?<named_group>test)(?&named_group)(?-x)
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.extended
+#    ^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
+#      ^^^^^^^^^^^ entity.name.capture-group.regexp
+#                  ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
+#                        ^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#                          ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
 
 ###################

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -1,12 +1,40 @@
 # SYNTAX TEST "Packages/Regular Expressions/RegExp.sublime-syntax"
 
-^foo bar$
-# <- keyword.control.anchors
-#       ^ keyword.control.anchors
 
-\^foo bar\$
+###################
+## Anchors and escapes
+###################
+
+^foo \bbar$
+# <- keyword.control.anchors
+#    ^^ keyword.control.anchors
+#         ^ keyword.control.anchors
+
+\^foo \\bbar\$
  # <- constant.character.escape
-#         ^ constant.character.escape
+#     ^^ constant.character.escape
+#            ^ constant.character.escape
+
+\xg
+# <- invalid.illegal.character.escape
+
+\010
+# <- constant.character.escape
+
+\1
+# <- keyword.other.backref-and-recursion
+
+\x{0ab}
+# <- constant.character.escape
+#^^^^^^ constant.character.escape
+
+\W
+# <- keyword.control.character-class
+
+
+###################
+## Quantifiers
+###################
 
 \x00*
 # <- constant.character.escape
@@ -31,21 +59,78 @@
 (ab)++
 #   ^^ keyword.operator.quantifier
 
-\xg
-# <- invalid.illegal.character.escape
+(?abc)
+#^ invalid.illegal.unexpected-quantifier.regexp - storage.modifier.mode.regexp
+# ^^^ meta.literal.regexp - storage.modifier.mode.regexp
 
-\010
-# <- constant.character.escape
+ .*?
+#^ keyword.other.any.regexp - meta.literal.regexp
+# ^^ keyword.operator.quantifier.regexp
 
-\1
-# <- keyword.other.backref-and-recursion
+(?=.++\.??\|{2,3}|{2})
+#^^ constant.other.assertion.regexp
+#  ^ keyword.other.any.regexp - meta.literal.regexp
+#   ^^ keyword.operator.quantifier.regexp
+#     ^^ constant.character.escape.regexp
+#       ^^ keyword.operator.quantifier.regexp
+#         ^^ constant.character.escape.regexp
+#           ^^^^^ keyword.operator.quantifier.regexp
+#                 ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
 
-\x{0ab}
-# <- constant.character.escape
-#^^^^^^ constant.character.escape
+\G{2}
+# ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
 
-\W
-# <- keyword.control.character-class
+(?={2})
+#  ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+a{9}
+#^^^ keyword.operator.quantifier.regexp
+
+a{1,9}
+#^^^^^ keyword.operator.quantifier.regexp
+
+a{9,}
+#^^^^ keyword.operator.quantifier.regexp
+
+a{,9}
+#^^^^ - keyword.operator.quantifier.regexp
+
+a{,}
+#^^^ - keyword.operator.quantifier.regexp
+
+a{}
+#^^ - keyword.operator.quantifier.regexp
+
+|{1,2}
+#^^^^^ invalid.illegal.unexpected-quantifier.regexp
+
+hello**
+#     ^ invalid.illegal.unexpected-quantifier.regexp
+#<- meta.literal.regexp
+#^^^^ meta.literal.regexp
+
+)
+# <- invalid.illegal.unmatched-brace.regexp
+
+hello++
+#    ^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}?)
+#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}+)
+#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
+
+(\w{2}?+)
+#      ^ invalid.illegal.unexpected-quantifier.regexp
+
+[\w{1}+]
+#  ^^^^ - invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+
+
+###################
+## Sets
+###################
 
  [b-c]
 #^^^^^ meta.set
@@ -111,6 +196,11 @@
 #   ^ keyword.operator
 #       ^ keyword.control.group
 
+
+###################
+## Block comments
+###################
+
 (?#foobar)
 #^^^^^^^^^ meta.group comment.block.group
 # <- comment.block.group punctuation.definition.comment.begin
@@ -129,49 +219,10 @@ where escape characters are ignored.\).
 #                                    ^ punctuation.definition.comment.end.regexp
 #                                     ^ - comment.block.group.regexp
 
-a{9}
-#^^^ keyword.operator.quantifier.regexp
 
-a{1,9}
-#^^^^^ keyword.operator.quantifier.regexp
-
-a{9,}
-#^^^^ keyword.operator.quantifier.regexp
-
-a{,9}
-#^^^^ - keyword.operator.quantifier.regexp
-
-a{,}
-#^^^ - keyword.operator.quantifier.regexp
-
-a{}
-#^^ - keyword.operator.quantifier.regexp
-
-|{1,2}
-#^^^^^ invalid.illegal.unexpected-quantifier.regexp
-
-hello**
-#     ^ invalid.illegal.unexpected-quantifier.regexp
-#<- meta.literal.regexp
-#^^^^ meta.literal.regexp
-
-)
-# <- invalid.illegal.unmatched-brace.regexp
-
-hello++
-#    ^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
-
-(\w{2}?)
-#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
-
-(\w{2}+)
-#  ^^^^ keyword.operator.quantifier.regexp - invalid.illegal.unexpected-quantifier.regexp
-
-(\w{2}?+)
-#      ^ invalid.illegal.unexpected-quantifier.regexp
-
-[\w{1}+]
-#  ^^^^ - invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+###################
+## Group Modifiers & Extended Mode
+###################
 
 (?x)
 #^^ storage.modifier.mode.regexp
@@ -180,8 +231,9 @@ hello++
 # this is a comment
 #^^^^^^^^^^^^^^^^^^^ comment.line.number-sign
 # <- comment punctuation.definition.comment
-(?-ix)
-#^^^^ storage.modifier.mode.regexp
+ (?-ix)
+# <- meta.ignored-whitespace
+# ^^^^ storage.modifier.mode.regexp
 
 # not a comment
 # <- - comment
@@ -231,26 +283,10 @@ hello++
 # not a comment
 ^ - comment
 
-(?abc)
-#^ invalid.illegal.unexpected-quantifier.regexp - storage.modifier.mode.regexp
-# ^^^ meta.literal.regexp - storage.modifier.mode.regexp
 
- .*?
-#^ keyword.other.any.regexp - meta.literal.regexp
-# ^^ keyword.operator.quantifier.regexp
-
-(?=.++\.??\|{2,3}|{2})
-#^^ constant.other.assertion.regexp
-#  ^ keyword.other.any.regexp - meta.literal.regexp
-#   ^^ keyword.operator.quantifier.regexp
-#     ^^ constant.character.escape.regexp
-#       ^^ keyword.operator.quantifier.regexp
-#         ^^ constant.character.escape.regexp
-#           ^^^^^ keyword.operator.quantifier.regexp
-#                 ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
-
-\G{2}
-# ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
+###################
+## References
+###################
 
  \g{1}
 #^^^^^ keyword.other.backref-and-recursion.regexp - keyword.operator.quantifier.regexp
@@ -287,12 +323,14 @@ hello++
 #           ^^^ keyword.other.backref-and-recursion.regexp
 #                ^^^ keyword.other.backref-and-recursion.regexp
 
-(?={2})
-#  ^^^ invalid.illegal.unexpected-quantifier.regexp - keyword.operator.quantifier.regexp
-
 (?<named_group>test)
 #^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
 #              ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
+
+
+###################
+## Assertions
+###################
 
 (?![a-z]+?)
 #^^ meta.group.regexp constant.other.assertion.regexp - meta.group.regexp meta.group.regexp
@@ -324,6 +362,11 @@ hello++
 #    ^^ keyword.control.character-class.regexp
 #      ^ keyword.operator.quantifier.regexp
 #       ^^ constant.character.escape.regexp - keyword.control.set.regexp
+
+
+###################
+## Conditionals
+###################
 
 (?<test>a)?b(?('test')c|d)
 #            ^^^^^^^^^ keyword.other.backref-and-recursion.conditional.regexp
@@ -390,6 +433,13 @@ hello++
 (?(DEFINE)(?<a>abcd))(?&a)
 #^^^^^^^^^ keyword.other.conditional.definition.regexp
 #                     ^^^ keyword.other.backref-and-recursion.regexp
+
+
+
+
+###################
+## Conditionals in Extended Mode
+###################
 
 (?x)
 (?<test>a)?b(?('test')c|d)


### PR DESCRIPTION
Added `entity.name.capture-group` and `variable.other.backref-and-recursion` scopes.

Tests where kinda all around the place, so I grouped them a little like in the Python tests.