### PR TITLE
Update Scala.sublime-syntax

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -108,6 +108,8 @@ contexts:
     - include: late-operators
 
   block-comments:
+    - match: /\*\*/
+      scope: comment.block.empty.scala
     - match: /\*\*
       scope: punctuation.definition.comment.scala
       push:
@@ -130,8 +132,6 @@ contexts:
             (?x)
             			(?! /\*)
             			(?! \*/)
-    - match: /\*\*/
-      scope: comment.block.empty.scala punctuation.definition.comment.scala
 
   char-literal:
     - match: '''({{escaped_char}}|.)'''

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -306,6 +306,10 @@ type Foo = Bar[A] forSome { type A }
 // <- comment.block.documentation.scala
 */
 
+  /**/0xff
+//^^^^ comment.block.empty.scala
+//    ^^^^ - comment
+
    if
 // ^^ keyword.control.flow.scala
 


### PR DESCRIPTION
This small change fixes a bug with the display of the comment `/**/` which was functioning as an unclosed block-comment.

This is fixed by moving the matching of `/**/` ahead of `/**`