### PR TITLE
[Scala] Corrected issue with anonymous AnyRef inner class scoping

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -524,7 +524,15 @@ contexts:
     - match: '\b(new)(?:\s+|\b)'
       captures:
         1: keyword.other.scala
-      push: single-type-expression
+      push:
+        # anonymous inner class AnyRef declaration syntax
+        - match: '(?=\{)'
+          pop: true
+        # emergency bail-out for better experience while typing
+        - match: '(?=[\n\}\),])'
+          pop: true
+        - match: '(?=\S)'
+          set: single-type-expression
 
   for-comprehension:
     - match: '\b(for)\s*\{'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1254,3 +1254,8 @@ for (
   abc = () => 42
 //         ^^ storage.type.function.arrow.scala
 )
+
+new {
+   "foo"
+// ^^^^^ string.quoted.double.scala
+}


### PR DESCRIPTION
Scala supports a C#-like syntax for declaring anonymous inner classes with structural types that extend `AnyRef`.  Like so:

```scala
val x = new {
  def foo = 42
}

x.foo  // => 42
```

This syntax is very rarely used, because it's quite slow to evaluate, but it does exist.  We were previously scoping this incorrectly, since the braces were considered part of a valid single-line type declaration.  This meant that the class body was scoped as a type, which is obviously incorrect.  It is now fixed.

Amusingly, as you can see from the above snippet, we weren't the only ones to forget about this construct when building a syntax highlighting for Scala.