### PR TITLE
[LaTeX] Enable percent sign comments in pure TeX

### DIFF
--- a/LaTeX/Comments.tmPreferences
+++ b/LaTeX/Comments.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>text.tex.latex, text.bibtex</string>
+	<string>text.tex, text.bibtex</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
Currently comment toggling only works in LaTeX and not in pure TeX (https://github.com/SublimeText/LaTeXTools/issues/949).