### PR TITLE
[Scala] Fixed single-line class declarations with bodies

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -419,7 +419,7 @@ contexts:
       set: class-parameter-list
     - match: '\['
       push: class-tparams-brackets
-    - match: '(?=extends|with)'
+    - match: '(?=\{|extends|with)'
       pop: true
     - match: '\n'
       set: class-type-parameter-list-newline

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1254,3 +1254,7 @@ for (
   abc = () => 42
 //         ^^ storage.type.function.arrow.scala
 )
+
+trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
+//                     ^^^^ storage.type.scala
+//                               ^ keyword.operator.assignment.scala


### PR DESCRIPTION
For example;

```scala
class Foo { val bar = 42 }
```

The `{` was not properly detected, and so the entire line was considered part of the class meta definition, meaning that the `val`, the `42` and so on were not properly highlighted by the `main` context.