### PR TITLE
[Python] Context exiting fixes (+ minor additions)

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -404,34 +404,37 @@ contexts:
             - include: entity-name-class
             - match: ''
               pop: true
-        - match: '(?=\()'
+        - match: \(
+          scope: punctuation.section.inheritance.begin.python
           set:
-            - match: \(
-              scope: punctuation.section.inheritance.begin.python
+            - meta_scope: meta.class.inheritance.python
+            - match: \)
+              scope: punctuation.section.inheritance.end.python
               set:
-                - meta_scope: meta.class.inheritance.python
-                - match: \)
-                  scope: punctuation.section.inheritance.end.python
-                  set:
-                    - include: line-continuation-or-pop
-                    - match: ':'
-                      scope: meta.class.python punctuation.section.class.begin.python
-                      pop: true
-                    - match: (?=\S)
-                      pop: true
+                - include: line-continuation-or-pop
                 - match: ':'
-                  scope: invalid.illegal.no-closing-parens.python
+                  scope: meta.class.python punctuation.section.class.begin.python
                   pop: true
-                - match: ','
-                  scope: punctuation.separator.inheritance.python
-                - match: '(?={{path}})'
-                  push:
-                    - meta_scope: entity.other.inherited-class.python
-                    - include: identifier-parts
-                    - match: '{{identifier}}'
-                    - match: '(?=\S)'
-                      pop: true
-                - include: expressions
+                - match: (?=\S)
+                  pop: true
+            - match: ':'
+              scope: invalid.illegal.no-closing-parens.python
+              pop: true
+            - match: ','
+              scope: punctuation.separator.inheritance.python
+            - include: illegal-names-pop
+            - match: (?={{path}})
+              push:
+                - meta_scope: entity.other.inherited-class.python
+                - match: '{{identifier}}(?: *(\.) *)?'
+                  captures:
+                    1: punctuation.accessor.python
+                - match: ''
+                  pop: true
+            - include: expressions
+
+  path:
+    - match: (?={{path}})
 
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\b'
@@ -627,11 +630,6 @@ contexts:
           scope: punctuation.separator.key-value.python
         - include: inline-for
         - include: expressions
-
-  identifier-parts:
-    - match: '{{identifier}} *(\.)'
-      captures:
-        1: punctuation.accessor.python
 
   builtin-exceptions:
     - match: |-

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -62,7 +62,7 @@ contexts:
       scope: keyword.other.assert.python
     - match: \b(del)\b
       scope: keyword.other.del.python
-    - match: \b(print)\b(?! *($|[,.()\]}]))
+    - match: \b(print)\b(?! *([,.()\]}]))
       scope: keyword.other.print.python
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1334,16 +1334,11 @@ contexts:
         - meta_scope: meta.expression.generator.python
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
-          set:
-            - meta_scope: meta.expression.generator.python
-            - match: '(?=[)\]}])'
-              pop: true
-            - include: inline-if  # not necessary but more explicit
-            - include: inline-for
-            - include: expressions
+          pop: true
         - match: '(?=[)\]}])'
           scope: invalid.illegal.missing-in.python
           pop: true
+        - include: illegal-names-pop
         - include: target-list
 
   inline-if:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -423,6 +423,10 @@ contexts:
             - match: ','
               scope: punctuation.separator.inheritance.python
             - include: illegal-names-pop
+            - match: ({{identifier}}) *(=)
+              captures:
+                1: variable.parameter.class-inheritance.python
+                2: keyword.operator.assignment.python
             - match: (?={{path}})
               push:
                 - meta_scope: entity.other.inherited-class.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -260,9 +260,9 @@ def _():
     print . __class__
 #   ^^^^^ support.function.builtin - keyword
     print "keyword"
-#   ^^^^^ keyword
+#   ^^^^^ keyword.other.print
     print __init__
-#   ^^^^^ keyword
+#   ^^^^^ keyword.other.print
 #
     exec 123
 #   ^^^^ keyword
@@ -275,6 +275,17 @@ def _():
              , print)
 #              ^^^^^ - keyword
 
+    some \
+      print \
+#     ^^^^^ keyword.other.print
+
+    func(
+        print
+#       ^^^^^ support.function.builtin - keyword
+    )
+
+    print
+#   ^^^^^ keyword.other.print
 
 
 ##################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -505,27 +505,27 @@ myset = {"key", True, key2, [-1], {}}
 
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
-#              ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#              ^^^^^^^^ meta.expression.generator
 #              ^^^ keyword.control.flow.for.generator
 #                    ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
-#          ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#          ^^^^^^^^ meta.expression.generator
 #          ^^^ keyword.control.flow.for.generator
 #                ^^ keyword.control.flow.for.in
 set_ = {i for i in range(100)}
 #      ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
-#         ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#         ^^^^^^^^ meta.expression.generator
 #         ^^^ keyword.control.flow.for.generator
 #               ^^ keyword.control.flow.for.in
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
-#             ^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#             ^^^^^^^^ meta.expression.generator
 #             ^^^ keyword.control.flow.for.generator
 #                   ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#          ^^^^^^^^ meta.expression.generator
 #                              ^^ keyword.control.flow.if.inline
 #                                       ^^^^ keyword.control.flow.else.inline
 
@@ -535,9 +535,9 @@ list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #                                                 ^^ keyword.operator.logical
 
 list(i for i in generator)
-#      ^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#      ^^^^^^^^ meta.expression.generator
 list((i for i in generator), 123)
-#       ^^^^^^^^^^^^^^^^^^ meta.expression.generator
+#       ^^^^^^^^ meta.expression.generator
 #                         ^^^^^^^ - meta.expression.generator
 #                          ^ punctuation.separator.parameters
 
@@ -665,6 +665,11 @@ matrix @ multiplication
 #      ^ keyword.operator.matrix.python
 
 
+
+##################
+# Context "Fail Early"
+##################
+
 # Pop contexts gracefully
 def func(unclosed, parameters: if else
     pass
@@ -675,3 +680,18 @@ def func(unclosed, parameters: if else
 def another_func():
 #^^ -invalid
     pass
+
+
+x = [
+for x in y:
+    break
+#   ^^^^^ invalid.illegal.name
+#        ^ - meta.structure.list
+
+
+with open(x) as y:
+#^^^ -invalid
+#            ^^ - invalid
+
+]
+#<- invalid.illegal.stray.brace.square

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -398,6 +398,7 @@ class MyClass(Inherited,
 #                      ^ punctuation.separator.inheritance
               module . Inherited2, metaclass=ABCMeta):
 #             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
+#                    ^ punctuation.accessor
 #                                ^ punctuation.separator.inheritance
 #                                  TODO
     ur'''
@@ -695,3 +696,8 @@ with open(x) as y:
 
 ]
 #<- invalid.illegal.stray.brace.square
+
+class Class(object
+    def __init__(self):
+#   ^^^ invalid.illegal.name
+#      ^ - meta.class

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -400,7 +400,8 @@ class MyClass(Inherited,
 #             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
 #                    ^ punctuation.accessor
 #                                ^ punctuation.separator.inheritance
-#                                  TODO
+#                                  ^^^^^^^^^ variable.parameter.class-inheritance
+#                                           ^ keyword.operator.assignment
     ur'''
 #   ^^ storage.type.string
     This is a test of docstrings


### PR DESCRIPTION
- Fixes additional cases mentioned in #500.
- Also fixes #699 (print statement).
- Also adds highlighting for keyword arguments in class inheritance, notably `metaclass`.

Thanks to @pdknsk for the reports.