### PR TITLE
[Python] Fix line-continuations in strings for real

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -726,20 +726,6 @@ contexts:
     - include: illegal-names
     - include: generic-names
 
-  escaped-char:
-    - match: '(\\x\h{2})|(\\[0-7]{3})|(\\[\\"''abfnrtv])'
-      captures:
-        1: constant.character.escape.hex.python
-        2: constant.character.escape.octal.python
-        3: constant.character.escape.python
-
-  escaped-unicode-char:
-    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[a-zA-Z ]+\})'
-      captures:
-        1: constant.character.escape.unicode.16-bit-hex.python
-        2: constant.character.escape.unicode.32-bit-hex.python
-        3: constant.character.escape.unicode.name.python
-
   generic-names:
     - match: "{{identifier}}"
 
@@ -786,11 +772,6 @@ contexts:
     - include: line-continuation
     - match: $|(?=;|#)
       pop: true
-
-  line-continuation-inside-string:
-    - match: (\\)$\n?
-      captures:
-        1: punctuation.separator.continuation.line.python
 
   magic-function-names:
     - match: |-
@@ -840,6 +821,25 @@ contexts:
           - match: '\2'
             scope: punctuation.definition.comment.end.python
             pop: true
+
+  escaped-char:
+    - match: '(\\x\h{2})|(\\[0-7]{3})|(\\[\\"''abfnrtv])'
+      captures:
+        1: constant.character.escape.hex.python
+        2: constant.character.escape.octal.python
+        3: constant.character.escape.python
+
+  escaped-unicode-char:
+    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[a-zA-Z ]+\})'
+      captures:
+        1: constant.character.escape.unicode.16-bit-hex.python
+        2: constant.character.escape.unicode.32-bit-hex.python
+        3: constant.character.escape.unicode.name.python
+
+  line-continuation-inside-string:
+    - match: (\\)$\n?
+      captures:
+        1: punctuation.separator.continuation.line.python
 
   string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -966,7 +966,7 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
-        - include: escaped-unicode-char
+        - include: line-continuation-inside-string
     # Single-line capital R raw string, bytes, no syntax embedding
     - match: '([bB]R|R[bB])(")'
       captures:
@@ -979,6 +979,7 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
+        - include: line-continuation-inside-string
     # Single-line raw string, unicode or not, starting with a SQL keyword
     - match: '([uU]?r)(")(?={{sql_indicator}})'
       captures:
@@ -995,8 +996,8 @@ contexts:
           with_prototype:
             - match: '(?="|\n)'
               pop: true
-            - include: escaped-unicode-char
             - include: constant-placeholder
+            - include: line-continuation-inside-string
           push: 'scope:source.sql'
     # Single-line raw string, unicode or not, treated as regex
     - match: '([uU]?r)(")'
@@ -1014,7 +1015,7 @@ contexts:
           with_prototype:
             - match: '(?="|\n)'
               pop: true
-            - include: escaped-unicode-char
+            - include: line-continuation-inside-string
           push: 'scope:source.regexp.python'
     # Single-line raw string, bytes, treated as regex
     - match: '([bB]r|r[bB])(")'
@@ -1049,8 +1050,9 @@ contexts:
           with_prototype:
             - match: '(?="|\n)'
               pop: true
-            - include: escaped-unicode-char
             - include: escaped-char
+            - include: escaped-unicode-char
+            - include: line-continuation-inside-string
             - include: constant-placeholder
           push: 'scope:source.sql'
     # Single-line string, unicode or not
@@ -1065,10 +1067,10 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
-        - include: escaped-unicode-char
         - include: escaped-char
-        - include: constant-placeholder
+        - include: escaped-unicode-char
         - include: line-continuation-inside-string
+        - include: constant-placeholder
     # Single-line string, bytes
     - match: '([bB])(")'
       captures:
@@ -1082,6 +1084,7 @@ contexts:
             2: invalid.illegal.unclosed-string.python
           set: after-expression
         - include: escaped-char
+        - include: line-continuation-inside-string
         - include: constant-placeholder
 
   string-quoted-single-block:
@@ -1095,7 +1098,6 @@ contexts:
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
-        - include: escaped-unicode-char
     # Triple-quoted capital R raw string, bytes, no syntax embedding
     - match: ([bB]R|R[bB])(''')
       captures:
@@ -1123,6 +1125,7 @@ contexts:
               with_prototype:
                 - match: (?=''')
                   pop: true
+                - include: escaped-char
                 - include: escaped-unicode-char
                 - include: constant-placeholder
               push: 'scope:source.sql'
@@ -1170,8 +1173,8 @@ contexts:
               with_prototype:
                 - match: (?=''')
                   pop: true
-                - include: escaped-unicode-char
                 - include: escaped-char
+                - include: escaped-unicode-char
                 - include: constant-placeholder
               push: 'scope:source.sql'
         - match: '(?=\S)'
@@ -1180,8 +1183,8 @@ contexts:
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
-            - include: escaped-unicode-char
             - include: escaped-char
+            - include: escaped-unicode-char
             - include: constant-placeholder
     # Triple-quoted string, bytes, no syntax embedding
     - match: ([bB])(''')
@@ -1209,7 +1212,7 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
-        - include: escaped-unicode-char
+        - include: line-continuation-inside-string
     # Single-line capital R raw string, bytes, no syntax embedding
     - match: '([bB]R|R[bB])('')'
       captures:
@@ -1222,6 +1225,7 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
+        - include: line-continuation-inside-string
     # Single-line raw string, unicode or not, starting with a SQL keyword
     - match: '([uU]?r)('')(?={{sql_indicator}})'
       captures:
@@ -1238,7 +1242,7 @@ contexts:
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
-            - include: escaped-unicode-char
+            - include: line-continuation-inside-string
             - include: constant-placeholder
           push: 'scope:source.sql'
     # Single-line raw string, unicode or not, treated as regex
@@ -1257,7 +1261,7 @@ contexts:
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
-            - include: escaped-unicode-char
+            - include: line-continuation-inside-string
           push: 'scope:source.regexp.python'
     # Single-line raw string, bytes, treated as regex
     - match: '([bB]r|r[bB])('')'
@@ -1275,6 +1279,7 @@ contexts:
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
+            - include: line-continuation-inside-string
           push: 'scope:source.regexp.python'
     # Single-line string, unicode or not, starting with a SQL keyword
     - match: '([uU]?)('')(?={{sql_indicator}})'
@@ -1292,8 +1297,9 @@ contexts:
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
-            - include: escaped-unicode-char
             - include: escaped-char
+            - include: escaped-unicode-char
+            - include: line-continuation-inside-string
             - include: constant-placeholder
           push: 'scope:source.sql'
     # Single-line string, unicode or not
@@ -1308,10 +1314,10 @@ contexts:
             1: punctuation.definition.string.end.python
             2: invalid.illegal.unclosed-string.python
           set: after-expression
-        - include: escaped-unicode-char
         - include: escaped-char
-        - include: constant-placeholder
+        - include: escaped-unicode-char
         - include: line-continuation-inside-string
+        - include: constant-placeholder
     # Single-line string, bytes
     - match: '([bB])('')'
       captures:
@@ -1325,6 +1331,7 @@ contexts:
             2: invalid.illegal.unclosed-string.python
           set: after-expression
         - include: escaped-char
+        - include: line-continuation-inside-string
         - include: constant-placeholder
 
   strings:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -841,7 +841,7 @@ contexts:
             scope: punctuation.definition.comment.end.python
             pop: true
 
-  string-quoted-double:
+  string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
     - match: '([uU]?R)(""")'
       captures:
@@ -952,13 +952,15 @@ contexts:
           set: after-expression
         - include: escaped-char
         - include: constant-placeholder
+
+  string-quoted-double:
     # Single-line capital R raw string, unicode or not, no syntax embedding
     - match: '([uU]?R)(")'
       captures:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -971,7 +973,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -983,7 +985,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1002,7 +1004,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1020,7 +1022,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1037,7 +1039,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1057,7 +1059,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1073,7 +1075,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: string.quoted.double.python
         - match: '(")|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1082,7 +1084,7 @@ contexts:
         - include: escaped-char
         - include: constant-placeholder
 
-  string-quoted-single:
+  string-quoted-single-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
     - match: ([uU]?R)(''')
       captures:
@@ -1193,13 +1195,15 @@ contexts:
           set: after-expression
         - include: escaped-char
         - include: constant-placeholder
+
+  string-quoted-single:
     # Single-line capital R raw string, unicode or not, no syntax embedding
     - match: '([uU]?R)('')'
       captures:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1212,7 +1216,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1224,7 +1228,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1243,7 +1247,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1261,7 +1265,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1278,7 +1282,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1298,7 +1302,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1314,7 +1318,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: string.quoted.single.python
         - match: '('')|(\n)'
           captures:
             1: punctuation.definition.string.end.python
@@ -1324,7 +1328,10 @@ contexts:
         - include: constant-placeholder
 
   strings:
+    # block versions must be matched first
+    - include: string-quoted-double-block
     - include: string-quoted-double
+    - include: string-quoted-single-block
     - include: string-quoted-single
 
   inline-for:

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -310,7 +310,7 @@ RB'''This is a \n test, %s no unicode \uDEAD'''
 #                                     ^^^^^^ - constant
 
 # Lowercase r raw bytes are interpreted as regex
-br'This is a \n (test|with), %s no unicode \UDEAD'
+br'This is a \n (test|with), %s no unicode \uDEAD'
 # <- storage.type.string
 # ^ string.quoted.single punctuation.definition.string.begin
 #            ^^ constant.character.escape.backslash.regexp
@@ -318,7 +318,7 @@ br'This is a \n (test|with), %s no unicode \UDEAD'
 #                            ^^ - constant
 #                                          ^^ constant.character.escape.backslash.regexp
 #                                            ^^^^ - constant
-Br'This is a \n (test|with), %s no unicode \UDEAD'
+Br'This is a \n (test|with), %s no unicode \uDEAD'
 # <- storage.type.string
 # ^ string.quoted.single punctuation.definition.string.begin
 #            ^^ constant.character.escape.backslash.regexp
@@ -326,7 +326,7 @@ Br'This is a \n (test|with), %s no unicode \UDEAD'
 #                            ^^ - constant
 #                                          ^^ constant.character.escape.backslash.regexp
 #                                            ^^^^ - constant
-rb'This is a \n (test|with), %s no unicode \UDEAD'
+rb'This is a \n (test|with), %s no unicode \uDEAD'
 # <- storage.type.string
 # ^ string.quoted.single punctuation.definition.string.begin
 #            ^^ constant.character.escape.backslash.regexp
@@ -334,7 +334,7 @@ rb'This is a \n (test|with), %s no unicode \UDEAD'
 #                            ^^ - constant
 #                                          ^^ constant.character.escape.backslash.regexp
 #                                            ^^^^ - constant
-rB'This is a \n (test|with), %s no unicode \UDEAD'
+rB'This is a \n (test|with), %s no unicode \uDEAD'
 # <- storage.type.string
 # ^ string.quoted.single punctuation.definition.string.begin
 #            ^^ constant.character.escape.backslash.regexp
@@ -342,7 +342,7 @@ rB'This is a \n (test|with), %s no unicode \UDEAD'
 #                            ^^ - constant
 #                                          ^^ constant.character.escape.backslash.regexp
 #                                            ^^^^ - constant
-br'''This is a \n (test|with), %s no unicode \UDEAD'''
+br'''This is a \n (test|with), %s no unicode \uDEAD'''
 # <- storage.type.string
 # ^^^ string.quoted.single punctuation.definition.string.begin
 #              ^^ constant.character.escape.backslash.regexp
@@ -350,7 +350,7 @@ br'''This is a \n (test|with), %s no unicode \UDEAD'''
 #                              ^^ - constant
 #                                            ^^ constant.character.escape.backslash.regexp
 #                                              ^^^^ - constant
-Br'''This is a \n (test|with), %s no unicode \UDEAD'''
+Br'''This is a \n (test|with), %s no unicode \uDEAD'''
 # <- storage.type.string
 # ^^^ string.quoted.single punctuation.definition.string.begin
 #              ^^ constant.character.escape.backslash.regexp
@@ -358,7 +358,7 @@ Br'''This is a \n (test|with), %s no unicode \UDEAD'''
 #                              ^^ - constant
 #                                            ^^ constant.character.escape.backslash.regexp
 #                                              ^^^^ - constant
-rb'''This is a \n (test|with), %s no unicode \UDEAD'''
+rb'''This is a \n (test|with), %s no unicode \uDEAD'''
 # <- storage.type.string
 # ^^^ string.quoted.single punctuation.definition.string.begin
 #              ^^ constant.character.escape.backslash.regexp
@@ -366,7 +366,7 @@ rb'''This is a \n (test|with), %s no unicode \UDEAD'''
 #                              ^^ - constant
 #                                            ^^ constant.character.escape.backslash.regexp
 #                                              ^^^^ - constant
-rB'''This is a \n (test|with), %s no unicode \UDEAD'''
+rB'''This is a \n (test|with), %s no unicode \uDEAD'''
 # <- storage.type.string
 # ^^^ string.quoted.single punctuation.definition.string.begin
 #              ^^ constant.character.escape.backslash.regexp
@@ -394,6 +394,23 @@ world'
 x = 'hello\s world'
 #         ^^ - punctuation.separator.continuation.line.python
 #          ^^^^^^^^ - invalid.illegal.unexpected-text.python
+
+sql = "SELECT `name` FROM `users` \
+    WHERE `password` LIKE 'abc'"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double source.sql
+#                              ^ punctuation.definition.string.end.python
+
+sql = Ur"SELECT `name` FROM `users` \
+    WHERE `password` LIKE 'abc'"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double source.sql
+#                              ^ punctuation.definition.string.end.python
+
+sql = b'just some \
+#     ^^^^^^^^^^^^^^ string.quoted.single.python - invalid.illegal.unclosed-string.python, \
+#                 ^ punctuation.separator.continuation.line.python, \
+    string'
+#^^^^^^^^^^ string.quoted.single
+#         ^ punctuation.definition.string.end.python
 
 # <- - meta
 # this test is to ensure we're not matching anything here anymore
@@ -428,4 +445,3 @@ x = 'hello\s world'
 #             ^^ constant.other.placeholder.python
 #               ^ - constant.other.placeholder.python
 #                ^^ constant.other.placeholder.python
-

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -376,19 +376,19 @@ rB'''This is a \n (test|with), %s no unicode \UDEAD'''
 #                                              ^^^^ - constant
 
 x = "hello \
-#   ^^^^^^^^^ string.quoted.double.block.python - invalid.illegal.unclosed-string.python, \
+#   ^^^^^^^^^ string.quoted.double.python - invalid.illegal.unclosed-string.python, \
 #          ^ punctuation.separator.continuation.line.python, \
 world"
-#^^^^^ string.quoted.double.block.python
-#     ^ - string.quoted.double.block.python
+#^^^^^ string.quoted.double.python
+#     ^ - string.quoted.double.python
 #    ^ punctuation.definition.string.end.python
 
 x = 'hello \
-#   ^^^^^^^^^ string.quoted.single.block.python - invalid.illegal.unclosed-string.python, \
+#   ^^^^^^^^^ string.quoted.single.python - invalid.illegal.unclosed-string.python, \
 #          ^ punctuation.separator.continuation.line.python, \
 world'
-#^^^^^ string.quoted.single.block.python
-#     ^ - string.quoted.single.block.python
+#^^^^^ string.quoted.single.python
+#     ^ - string.quoted.single.python
 #    ^ punctuation.definition.string.end.python
 
 x = 'hello\s world'


### PR DESCRIPTION
Follow-up on #397.

Also, raw strings don't have any escape sequences.