### PR TITLE
[YAML] Don't scope leading whitespace as comment

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -536,11 +536,14 @@ contexts:
     - match: | # l-comment
         (?x)
         (?: ^ [ \t]* | [ \t]+ )
-        (\#)
+        (?=\#)
       captures:
-        1: punctuation.definition.comment.line.number-sign.yaml
       push:
-        - meta_scope: comment.line.number-sign.yaml
-        - match: \n|\z
-          pop: true
+        - match: '#'
+          scope: punctuation.definition.comment.line.number-sign.yaml
+          set:
+          - meta_scope: comment.line.number-sign.yaml
+          - match: \n|\z
+            scope: comment.line.number-sign.yaml
+            pop: true
 ...

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -544,6 +544,5 @@ contexts:
           set:
           - meta_scope: comment.line.number-sign.yaml
           - match: \n|\z
-            scope: comment.line.number-sign.yaml
             pop: true
 ...

--- a/YAML/tests/syntax_test_general.yaml
+++ b/YAML/tests/syntax_test_general.yaml
@@ -10,6 +10,9 @@
 # <- comment.line.number-sign punctuation.definition.comment.line.number-sign
 #^^^^^^^^^ comment.line.number-sign
 
+   # comment
+#^^ - comment
+
 
 ##############################################################################
 ## Document markers


### PR DESCRIPTION
Just realized I had this branch lying around without opening a PR.

Should be self-explanatory.