### PR TITLE
[Matlab]Fix the block comment scope for the Matlab

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -62,12 +62,12 @@ contexts:
       scope: comment.double.percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab
-    - match: '(%\{)\s*\n'
+    - match: '^\s*(%\{)\s*\n'
       captures:
         1: punctuation.definition.comment.matlab
       push:
         - meta_scope: comment.block.percentage.matlab
-        - match: '(%\})\s*\n'
+        - match: '^\s*(%\})\s*\n'
           captures:
             1: punctuation.definition.comment.matlab
           pop: true

--- a/Matlab/Miscellaneous.tmPreferences
+++ b/Matlab/Miscellaneous.tmPreferences
@@ -42,13 +42,16 @@
 				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
-				<string>%{\n</string>
+				<string>%{
+</string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END_2</string>
 				<key>value</key>
-				<string>%}\n</string>
+				<string>
+%}
+</string>
 			</dict>
 		</array>
 		<key>smartTypingPairs</key>

--- a/Matlab/Miscellaneous.tmPreferences
+++ b/Matlab/Miscellaneous.tmPreferences
@@ -34,20 +34,20 @@
 		<array>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_START</string>
+				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
 				<string>% </string>
 			</dict>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_START_2</string>
+				<string>TM_COMMENT_START_3</string>
 				<key>value</key>
 				<string>%{
 </string>
 			</dict>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_END_2</string>
+				<string>TM_COMMENT_END_3</string>
 				<key>value</key>
 				<string>
 %}

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -35,14 +35,15 @@ end
 
 
 
+
 %---------------------------------------------
 % Syntax brackets/parens punctuation test
 
 x = [ 1.76 ]
 % <- source.matlab meta.variable.other.valid.matlab
 % ^ source.matlab keyword.operator.symbols.matlab
-%   ^ source.matlab punctuation.section.brackets.begin.matlab 
-%     ^ source.matlab meta.brackets.matlab constant.numeric.matlab  
+%   ^ source.matlab punctuation.section.brackets.begin.matlab
+%     ^ source.matlab meta.brackets.matlab constant.numeric.matlab
 %          ^ source.matlab punctuation.section.brackets.end.matlab
 
 
@@ -50,9 +51,10 @@ xAprox = fMetodoDeNewton( xi )
 %  <- source.matlab meta.variable.other.valid.matlab
 %      ^ source.matlab keyword.operator.symbols.matlab
 %        ^ source.matlab meta.variable.other.valid.matlab
-%                       ^ source.matlab punctuation.section.parens.begin.matlab 
+%                       ^ source.matlab punctuation.section.parens.begin.matlab
 %                         ^ source.matlab meta.parens.matlab meta.variable.other.valid.matlab
-%                            ^ source.matlab punctuation.section.parens.end.matlab 
+%                            ^ source.matlab punctuation.section.parens.end.matlab
+
 
 
 
@@ -60,20 +62,38 @@ xAprox = fMetodoDeNewton( xi )
 % Block comment test
 
 % Success case
-%{           
+%{
 x = 5
 % ^ source.matlab comment.block.percentage.matlab
-%}           
+%}
 
-% Failure case
+
+% Failure cases for opening `%{`
 %{           fail
 x = 5
 % ^ source.matlab keyword.operator.symbols.matlab
 %}
 
+fail = 5 %{
+x = 5
+% ^ source.matlab keyword.operator.symbols.matlab
+%}
+
+
+% Failure cases for closing `%}`
 %{
 %}           fail
 x = 5
 % ^ source.matlab comment.block.percentage.matlab
 %}
+
+%{
+fail = 5 %}
+x = 5
+% ^ source.matlab comment.block.percentage.matlab
+%}
+
+
+
+
 


### PR DESCRIPTION
### [Matlab]Fix the block comment scope for the Matlab

Fixed issue: 

1. https://github.com/sublimehq/Packages/issues/700