### PR TITLE
[LaTeX] missing iota and Iota commands

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -114,7 +114,7 @@ contexts:
         - include: macro-braces
 
   greeks:
-    - match: ((\\)(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|gamma|kappa|lambda|mu|nu|xi|pi|varpi|rho|varrho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega))(?=\b|_)
+    - match: ((\\)(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|gamma|kappa|lambda|mu|nu|xi|pi|varpi|rho|varrho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega))(?=\b|_)
       captures:
         1: keyword.other.greek.math.tex
         2: punctuation.definition.backslash.tex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -254,6 +254,12 @@ f(x) = x^2
 % ^ meta.environment.math.block
 \end{equation}
 
+$\iota$
+% ^ keyword.other.greek.math.tex
+
+$\Iota$
+% ^ support.function.math.tex
+
 $\alpha _$
 % ^ keyword.other.greek.math.tex
 %       ^ keyword.operator.math.tex


### PR DESCRIPTION
the `\iota` and `\Iota` are missing.