### PR TITLE
[LaTeX] improve tests for parbox and makebox

### DIFF
--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -266,10 +266,14 @@ $\alpha_$
 \mbox{text}{text}
 %       ^ meta.function.box.latex
 %             ^ -meta.function.box.latex
-\parbox{text}{text}
+\parbox{text}{text}{text}
 %       ^ meta.function.box.latex
 %             ^ meta.function.box.latex
+%                    ^ -meta.function.box.latex
 
+\makebox   \break
+%        ^ meta.function.box.latex
+%           ^ -meta.function.box.latex
 
 % PACKAGE: comment
 % The comment package can be used to write block comment


### PR DESCRIPTION
For the general-*-arguments, the context is popped by the match '\}',  the non-space are not necessary
In other places, `set` was used in the match argument, those non-space matches are also not needed

PS: the test for `\parbox` is also improved.