### PR TITLE
[Scala] Stateful class declaration and some meta scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -90,7 +90,6 @@ contexts:
   main-pre-lambdas:
     - include: storage-modifiers
     - include: declarations
-    - include: inheritance
     - include: for-comprehension
     - include: keywords
     - include: imports
@@ -579,19 +578,6 @@ contexts:
               scope: variable.import.scala
             - match: '_'
               scope: variable.language.underscore.scala
-
-  inheritance:
-    - match: '\b(extends|with)\s+([^\s\{\(\[\]]+)'
-      captures:
-        1: keyword.declaration.scala
-        2: entity.other.inherited-class.scala
-    - match: '\b(extends|with)\s+\('
-      captures:
-        1: keyword.declaration.scala
-      push:
-        - match: '\)'
-          pop: true
-        - include: delimited-type-expression
 
   # we need to greedily capture operators to prevent (e.g.) :: being matched as an ascription
   # it would be incorrect to scope operators specially, since they are just identifiers

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -485,9 +485,11 @@ contexts:
 
   class-pre-inheritance-early-initializer:
     - match: \{
+      scope: punctuation.section.braces.begin.scala
       push:
         - meta_scope: meta.class.body.scala
         - match: \}
+          scope: punctuation.section.braces.end.scala
           pop: true
         - include: main
     - match: '(?=\b(extends|with)\b)'
@@ -527,8 +529,10 @@ contexts:
       scope: entity.other.inherited-class.scala
       set: class-inheritance-extends-token-after
     - match: \(
+      scope: punctuation.section.parens.begin.scala
       set:
         - match: \)
+          scope: punctuation.section.parens.end.scala
           set: class-inheritance-with
         - include: delimited-type-expression
     - match: '\n'
@@ -541,13 +545,17 @@ contexts:
 
   class-inheritance-extends-token-after:
     - match: \(
+      scope: punctuation.section.parens.begin.scala
       push:
         - match: \)
+          scope: punctuation.section.parens.end.scala
           pop: true
         - include: main
     - match: \[
+      scope: punctuation.section.brackets.begin.scala
       push:
         - match: \]
+          scope: punctuation.section.brackets.end.scala
           pop: true
         - include: delimited-type-expression
     - match: (?=\b(with|extends)\b)
@@ -564,9 +572,11 @@ contexts:
 
   class-inheritance-early-initializer:
     - match: \{
+      scope: punctuation.section.braces.begin.scala
       push:
         - meta_scope: meta.class.body.scala
         - match: \}
+          scope: punctuation.section.braces.end.scala
           pop: true
         - include: main
     - match: '(?=\bwith\b)'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -477,6 +477,7 @@ contexts:
   class-pre-inheritance-early-initializer:
     - match: \{
       push:
+        - meta_scope: meta.class.body.scala
         - match: \}
           pop: true
         - include: main
@@ -555,6 +556,7 @@ contexts:
   class-inheritance-early-initializer:
     - match: \{
       push:
+        - meta_scope: meta.class.body.scala
         - match: \}
           pop: true
         - include: main

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -420,6 +420,8 @@ contexts:
       push: class-tparams-brackets
     - match: '(?=\b(extends|with)\b)'
       set: class-inheritance
+    - match: '(?=\{)'
+      set: class-pre-inheritance-early-initializer
     - match: '\n'
       set: class-type-parameter-list-newline
 
@@ -465,12 +467,30 @@ contexts:
     - match: '(?=\b(extends|with)\b)'
       set: class-inheritance
     - match: '(?=\{)'
-      pop: true
+      set: class-pre-inheritance-early-initializer
 
   class-parameter-list-newline:
     - include: decl-newline-double-check
     - match: '(?=\S)'
       set: class-parameter-list
+
+  class-pre-inheritance-early-initializer:
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: main
+    - match: '(?=\b(extends|with)\b)'
+      set: class-inheritance-extends
+    - match: '(?=\S)'
+      pop: true
+    - match: '\n'
+      set: class-pre-inheritance-early-initializer-newline
+
+  class-pre-inheritance-early-initializer-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-pre-inheritance-early-initializer
 
   class-inheritance:
     - include: class-inheritance-extends
@@ -523,7 +543,7 @@ contexts:
     - match: (?=\b(with|extends)\b)
       set: class-inheritance-with
     - match: (?=\{)
-      pop: true
+      set: class-inheritance-early-initializer
     - match: '\n'
       set: class-inheritance-extends-token-after-newline
 
@@ -531,6 +551,24 @@ contexts:
     - include: decl-newline-double-check
     - match: '(?=\S)'
       set: class-inheritance-extends-token-after
+
+  class-inheritance-early-initializer:
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: main
+    - match: '(?=\bwith\b)'
+      set: class-inheritance-with
+    - match: '(?=\S)'
+      pop: true
+    - match: '\n'
+      set: class-inheritance-early-initializer-newline
+
+  class-inheritance-early-initializer-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-inheritance-early-initializer
 
   class-inheritance-with:
     - match: \bextends\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -317,18 +317,27 @@ contexts:
 
   braces:
     - match: \[
+      scope: punctuation.definition.generic.begin.scala
       push:
+        - meta_scope: meta.generic.scala
         - match: \]
+          scope: punctuation.definition.generic.end.scala
           pop: true
         - include: delimited-type-expression
     - match: \(
+      scope: punctuation.section.group.begin.scala
       push:
+        - meta_scope: meta.group.scala
         - match: \)
+          scope: punctuation.section.group.end.scala
           pop: true
         - include: main
     - match: \{
+      scope: punctuation.section.block.begin.scala
       push:
+        - meta_scope: meta.block.scala
         - match: \}
+          scope: punctuation.section.block.end.scala
           pop: true
         - include: main
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -419,8 +419,8 @@ contexts:
       set: class-parameter-list
     - match: '\['
       push: class-tparams-brackets
-    - match: '(?=extends|with)'
-      pop: true
+    - match: '(?=\b(extends|with)\b)'
+      set: class-inheritance
     - match: '\n'
       set: class-type-parameter-list-newline
 
@@ -463,13 +463,92 @@ contexts:
         - include: main
     - match: '\n'
       set: class-parameter-list-newline
-    - match: '(?=([\{]|extends))'
+    - match: '(?=\b(extends|with)\b)'
+      set: class-inheritance
+    - match: '(?=\{)'
       pop: true
 
   class-parameter-list-newline:
     - include: decl-newline-double-check
     - match: '(?=\S)'
       set: class-parameter-list
+
+  class-inheritance:
+    - include: class-inheritance-extends
+
+  class-inheritance-extends:
+    - match: \bwith\b
+      scope: invalid.keyword.with-before-extends.scala
+      pop: true
+    - match: \bextends\b
+      scope: keyword.declaration.scala
+      set: class-inheritance-extends-token
+    - match: '(?=\{)'
+      pop: true
+    - match: '\n'
+      set: class-inheritance-extends-newline
+
+  class-inheritance-extends-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-inheritance
+
+  class-inheritance-extends-token:
+    - match: '{{id}}'
+      scope: entity.other.inherited-class.scala
+      set: class-inheritance-extends-token-after
+    - match: \(
+      set:
+        - match: \)
+          set: class-inheritance-with
+        - include: delimited-type-expression
+    - match: '\n'
+      set: class-inheritance-extends-token-newline
+
+  class-inheritance-extends-token-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-inheritance-extends-token
+
+  class-inheritance-extends-token-after:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: main
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: delimited-type-expression
+    - match: (?=\b(with|extends)\b)
+      set: class-inheritance-with
+    - match: (?=\{)
+      pop: true
+    - match: '\n'
+      set: class-inheritance-extends-token-after-newline
+
+  class-inheritance-extends-token-after-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-inheritance-extends-token-after
+
+  class-inheritance-with:
+    - match: \bextends\b
+      scope: invalid.keyword.extends-after-extends.scala
+      pop: true
+    - match: \bwith\b
+      scope: keyword.declaration.scala
+      set: class-inheritance-extends-token
+    - match: '(?=\{)'
+      pop: true
+    - match: '\n'
+      set: class-inheritance-with-newline
+
+  class-inheritance-with-newline:
+    - include: decl-newline-double-check
+    - match: '(?=\S)'
+      set: class-inheritance-with
 
   imports:
     - match: \b(import)\b
@@ -584,7 +663,11 @@ contexts:
       scope: keyword.operator.word.scala
 
   late-keywords:
-    - match: \b(extends|with|forSome)\b
+    - match: \bextends\b
+      scope: invalid.keyword.dangling-extends.scala
+    - match: \bwith\b
+      scope: invalid.keyword.dangling-with.scala
+    - match: \bforSome\b
       scope: keyword.declaration.scala
     - match: \b(class|trait|object)\b
       scope: storage.type.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -365,10 +365,10 @@ type Foo = Bar[A] forSome { type A }
 // ^^^ keyword.other.scala
 
    extends
-// ^^^^^^^ keyword.declaration.scala
+// ^^^^^^^ invalid.keyword.dangling-extends.scala
 
    with
-// ^^^^ keyword.declaration.scala
+// ^^^^ invalid.keyword.dangling-with.scala
 
    class
 // ^^^^^ storage.type.class.scala
@@ -1258,3 +1258,21 @@ for (
   abc = () => 42
 //         ^^ storage.type.function.arrow.scala
 )
+
+   extends
+// ^^^^^^^ invalid.keyword.dangling-extends.scala
+
+   with
+// ^^^^ invalid.keyword.dangling-with.scala
+
+class Foo with Bar
+//        ^^^^ invalid.keyword.with-before-extends.scala
+
+class Foo extends Bar extends Baz
+//                    ^^^^^^^ invalid.keyword.extends-after-extends.scala
+
+class Foo extends Bar[A with B](42)
+//                    ^ support.class.scala
+//                      ^^^^ keyword.declaration.scala
+//                           ^ support.class.scala
+//                              ^^ constant.numeric.integer.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1294,3 +1294,21 @@ class Foo extends Bar {
 
 // <- meta.class.body.scala
 }
+
+   {
+// ^ punctuation.section.block.begin.scala
+     // <- meta.block.scala
+   }
+// ^ punctuation.section.block.end.scala
+
+   (
+// ^ punctuation.section.group.begin.scala
+     // <- meta.group.scala
+     )
+//   ^ punctuation.section.group.end.scala
+
+   [
+// ^ punctuation.definition.generic.begin.scala
+     // <- meta.generic.scala
+     ]
+//   ^ punctuation.definition.generic.end.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1284,3 +1284,13 @@ class Foo extends Bar { val x = 42 } with Baz
 class Foo { val x = 42 } extends Bar with Baz
 //                       ^^^^^^^ keyword.declaration.scala
 //                               ^^^ entity.other.inherited-class.scala
+
+class Foo {
+
+// <- meta.class.body.scala
+}
+
+class Foo extends Bar {
+
+// <- meta.class.body.scala
+}

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1278,10 +1278,14 @@ class Foo extends Bar[A with B](42)
 //                              ^^ constant.numeric.integer.scala
 
 class Foo extends Bar { val x = 42 } with Baz
+//                    ^ punctuation.section.braces.begin.scala
+//                                 ^ punctuation.section.braces.end.scala
 //                                   ^^^^ keyword.declaration.scala
 //                                        ^^^ entity.other.inherited-class.scala
 
 class Foo { val x = 42 } extends Bar with Baz
+//        ^ punctuation.section.braces.begin.scala
+//                     ^ punctuation.section.braces.end.scala
 //                       ^^^^^^^ keyword.declaration.scala
 //                               ^^^ entity.other.inherited-class.scala
 
@@ -1312,3 +1316,15 @@ class Foo extends Bar {
      // <- meta.generic.scala
      ]
 //   ^ punctuation.definition.generic.end.scala
+
+class Foo extends Bar(42)
+//                   ^ punctuation.section.parens.begin.scala
+//                      ^ punctuation.section.parens.end.scala
+
+class Foo extends (Int => String)
+//                ^ punctuation.section.parens.begin.scala
+//                              ^ punctuation.section.parens.end.scala
+
+class Foo extends Bar[Int]
+//                   ^ punctuation.section.brackets.begin.scala
+//                       ^ punctuation.section.brackets.end.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1276,3 +1276,11 @@ class Foo extends Bar[A with B](42)
 //                      ^^^^ keyword.declaration.scala
 //                           ^ support.class.scala
 //                              ^^ constant.numeric.integer.scala
+
+class Foo extends Bar { val x = 42 } with Baz
+//                                   ^^^^ keyword.declaration.scala
+//                                        ^^^ entity.other.inherited-class.scala
+
+class Foo { val x = 42 } extends Bar with Baz
+//                       ^^^^^^^ keyword.declaration.scala
+//                               ^^^ entity.other.inherited-class.scala


### PR DESCRIPTION
Scala has a very rich class declaration syntax with some constraints (such as you cannot use `with` before `extends`, and cannot use multiple `extends`).  For this reason, we have long punted on this and just popped out as soon as we saw those sorts of contexts, which led to certain things being highlighted sub-optimally.  Additionally, it outright prevented ever accurately assigning the `meta.class.body` scope.

This is now fixed, and the meta scope is applied.  Additionally, support has been added for flagging certain completely-invalid syntaxes as `invalid`.  I additionally fixed some low-hanging meta scoping in other areas.  Lots more work to do here.