### PR TITLE
[Python] f-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -668,8 +668,22 @@ contexts:
       scope: support.type.python
 
   constant-placeholder:
-    - match: '%(?i:\([a-z_]+\))?#?0?\-? ?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hlL]?[acdeEfFgGiorsuxX%]'
+    - match: |-
+        (?x)
+        %
+          ( \( ({{identifier}}) \) )? # mapping key
+          \#?            # alternate form
+          0?             # pad with zeros
+          \-?            # left-adjust
+          \ ?            # implicit sign
+          [+-]?          # sign
+          (\d*|\*)       # width
+          (\. (\d*|\*))? # precision
+          [hlL]?         # length modifier (but ignored)
+          [acdeEfFgGiorsuxX%]
       scope: constant.other.placeholder.python
+      captures:
+        2: variable.other.placeholder.python
     - match: '%(?:[aAwdbBmyYHIpMSfzZjUWcxX%]|-[dmHIMSj])'
       scope: constant.other.placeholder.python
     - match: '\{\{|\}\}'
@@ -682,9 +696,9 @@ contexts:
           (:            # format_spec
             (.? [<>=^])?       # fill align
             [ +-]?             # sign
-            \#?
+            \#?                # alternate form
             \d*                # width
-            ,?
+            ,?                 # thousands separator
             (\.\d+)?           # precision
             [bcdeEfFgGnosxX%]? # type
           )?

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -911,10 +911,10 @@ contexts:
   f-string-replacement:
     - clear_scopes: 1
     - match: \}
-      scope: meta.interpolation.python punctuation.definition.interpolation.end.python
+      scope: meta.interpolation.python punctuation.section.interpolation.end.python
       pop: true
     - match: \{
-      scope: punctuation.definition.interpolation.begin.python
+      scope: punctuation.section.interpolation.begin.python
       push:
         - meta_scope: meta.interpolation.python
         - match: (?=\})

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -889,39 +889,33 @@ contexts:
   f-string-replacement:
     - clear_scopes: 1
     - match: \}
-      scope: punctuation.definition.interpolation.end.python
+      scope: meta.interpolation.python punctuation.definition.interpolation.end.python
       pop: true
     - match: \{
       scope: punctuation.definition.interpolation.begin.python
       push:
-        - meta_content_scope: source.python.embedded
-        - match: (?=})
+        - meta_scope: meta.interpolation.python
+        - match: (?=\})
           pop: true
-        # This gets pretty hacky, but the reasoning is that we only want
-        # `source.python.embedded` on actual source, not the formatting.
-        - match: (?=![ars])
-          set:
-            - match: '![ars]'
-              scope: storage.modifier.conversion.python
-            - match: ''
-              set: f-string-format-spec
-        - match: (?=:)
-          set:
-            - match: ':'
-              set: f-string-format-spec
-        - match: \\
-          scope: invalid.illegal.backslash-in-fstring.python
-        - include: expressions
-
-  f-string-format-spec:
-    - meta_scope: constant.other.format-spec.python
-    # Because replacements can also be used *within* the format-spec,
-    # basically any character is valid and matching {{format_spec}} is useless.
-    # - match: '{{format_spec}}'
-    - match: (?=})
-      pop: true
-    - match: (?=\{)
-      push: f-string-replacement
+        - match: '![ars]'
+          scope: storage.modifier.conversion.python
+        - match: ':'
+          push:
+            - meta_scope: meta.format-spec.python constant.other.format-spec.python
+            # Because replacements can also be used *within* the format-spec,
+            # basically any character is valid and matching {{format_spec}} is useless.
+            # - match: '{{format_spec}}'
+            - match: (?=\})
+              pop: true
+            - include: f-string-content
+        - match: ''
+          push:
+            - meta_content_scope: source.python.embedded
+            - match: (?=![^=]|:|\})
+              pop: true
+            - match: \\
+              scope: invalid.illegal.backslash-in-fstring.python
+            - include: expressions
 
   string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -946,7 +946,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -957,7 +957,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -967,10 +967,10 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
-            - meta_scope: string.quoted.double.block.python
+            - meta_scope: meta.string.python string.quoted.double.block.python
             - match: '"""'
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -983,7 +983,7 @@ contexts:
                 - include: constant-placeholder
         - match: '(?=\S)'
           set:
-            - meta_scope: string.quoted.double.block.python
+            - meta_scope: meta.string.python string.quoted.double.block.python
             - match: '"""'
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -999,7 +999,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1038,10 +1038,10 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
-            - meta_scope: string.quoted.double.block.python
+            - meta_scope: meta.string.python string.quoted.double.block.python
             - match: '"""'
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1055,7 +1055,7 @@ contexts:
                 - include: constant-placeholder
         - match: '(?=\S)'
           set:
-            - meta_scope: string.quoted.double.block.python
+            - meta_scope: meta.string.python string.quoted.double.block.python
             - match: '"""'
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1068,7 +1068,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.block.python
+        - meta_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1082,7 +1082,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1093,7 +1093,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1104,7 +1104,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1122,7 +1122,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1138,7 +1138,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1179,7 +1179,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1199,7 +1199,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1213,7 +1213,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.double.python
+        - meta_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1228,7 +1228,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1238,7 +1238,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1248,10 +1248,10 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
-            - meta_scope: string.quoted.single.block.python
+            - meta_scope: meta.string.python string.quoted.single.block.python
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1265,7 +1265,7 @@ contexts:
                 - include: constant-placeholder
         - match: '(?=\S)'
           set:
-            - meta_scope: string.quoted.single.block.python
+            - meta_scope: meta.string.python string.quoted.single.block.python
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1281,7 +1281,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1320,10 +1320,10 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
-            - meta_scope: string.quoted.single.block.python
+            - meta_scope: meta.string.python string.quoted.single.block.python
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1337,7 +1337,7 @@ contexts:
                 - include: constant-placeholder
         - match: '(?=\S)'
           set:
-            - meta_scope: string.quoted.single.block.python
+            - meta_scope: meta.string.python string.quoted.single.block.python
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
@@ -1350,7 +1350,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.block.python
+        - meta_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1364,7 +1364,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1375,7 +1375,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1386,7 +1386,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1404,7 +1404,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1420,7 +1420,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1462,7 +1462,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1482,7 +1482,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1496,7 +1496,7 @@ contexts:
         1: storage.type.string.python
         2: punctuation.definition.string.begin.python
       push:
-        - meta_scope: string.quoted.single.python
+        - meta_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -26,7 +26,17 @@ variables:
   path: '({{identifier}} *\. *)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH)\b
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
-
+  format_spec: |-
+    (?x:
+      (?:.? [<>=^])?     # fill align
+      [ +-]?             # sign
+      \#?                # alternate form
+      # technically, octal and hexadecimal integers are also supported as 'width', but rarely used
+      \d*                # width
+      ,?                 # thousands separator
+      (?:\.\d+)?         # precision
+      [bcdeEfFgGnosxX%]? # type
+    )
 contexts:
   main:
     - include: statements
@@ -667,45 +677,6 @@ contexts:
         )\b
       scope: support.type.python
 
-  constant-placeholder:
-    - match: |-
-        (?x)
-        %
-          ( \( ({{identifier}}) \) )? # mapping key
-          \#?            # alternate form
-          0?             # pad with zeros
-          \-?            # left-adjust
-          \ ?            # implicit sign
-          [+-]?          # sign
-          (\d*|\*)       # width
-          (\. (\d*|\*))? # precision
-          [hlL]?         # length modifier (but ignored)
-          [acdeEfFgGiorsuxX%]
-      scope: constant.other.placeholder.python
-      captures:
-        2: variable.other.placeholder.python
-    - match: '%(?:[aAwdbBmyYHIpMSfzZjUWcxX%]|-[dmHIMSj])'
-      scope: constant.other.placeholder.python
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.python
-    - match: |-
-        (?x)
-        \{
-          ([\w.\[\]]+)? # field_name
-          (! [rsa])?    # conversion
-          (:            # format_spec
-            (.? [<>=^])?       # fill align
-            [ +-]?             # sign
-            \#?                # alternate form
-            \d*                # width
-            ,?                 # thousands separator
-            (\.\d+)?           # precision
-            [bcdeEfFgGnosxX%]? # type
-          )?
-          # technically, octal and hexadecimal integers are also supported as 'width', but rarely used
-        \}
-      scope: constant.other.placeholder.python
-
   name:
     - match: '(?={{identifier}})'
       push:
@@ -870,6 +841,88 @@ contexts:
       scope: invalid.illegal.unclosed-string.python
       set: after-expression
 
+  constant-placeholder:
+    - match: |-
+        (?x)
+        %
+          ( \( ({{identifier}}) \) )? # mapping key
+          \#?            # alternate form
+          0?             # pad with zeros
+          \-?            # left-adjust
+          \ ?            # implicit sign
+          [+-]?          # sign
+          (\d*|\*)       # width
+          (\. (\d*|\*))? # precision
+          [hlL]?         # length modifier (but ignored)
+          [acdeEfFgGiorsuxX%]
+      scope: constant.other.placeholder.python
+      captures:
+        2: variable.other.placeholder.python
+    - match: '%(?:[aAwdbBmyYHIpMSfzZjUWcxX%]|-[dmHIMSj])'
+      scope: constant.other.placeholder.python
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.python
+    - match: |-
+        (?x)
+        \{
+          (?: [\w.\[\]]+)?         # field_name
+          (   ! [ars])?            # conversion
+          (   : {{format_spec}} )? # format_spec
+        \}
+      scope: constant.other.placeholder.python
+      captures:
+        1: storage.modifier.conversion.python
+        2: constant.other.format-spec.python
+
+  f-string-content:
+    # https://www.python.org/dev/peps/pep-0498/
+    # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
+    - match: \{\s*\}
+      scope: invalid.illegal.empty-expression.python
+    - match: (?=\{)
+      push: f-string-replacement
+    - match: \}
+      scope: invalid.illegal.stray-brace.python
+
+  f-string-replacement:
+    - clear_scopes: 1
+    - match: \}
+      scope: punctuation.definition.interpolation.end.python
+      pop: true
+    - match: \{
+      scope: punctuation.definition.interpolation.begin.python
+      push:
+        - meta_content_scope: source.python.embedded
+        - match: (?=})
+          pop: true
+        # This gets pretty hacky, but the reasoning is that we only want
+        # `source.python.embedded` on actual source, not the formatting.
+        - match: (?=![ars])
+          set:
+            - match: '![ars]'
+              scope: storage.modifier.conversion.python
+            - match: ''
+              set: f-string-format-spec
+        - match: (?=:)
+          set:
+            - match: ':'
+              set: f-string-format-spec
+        - match: \\
+          scope: invalid.illegal.backslash-in-fstring.python
+        - include: expressions
+
+  f-string-format-spec:
+    - meta_scope: constant.other.format-spec.python
+    # Because replacements can also be used *within* the format-spec,
+    # basically any character is valid and matching {{format_spec}} is useless.
+    # - match: '{{format_spec}}'
+    - match: (?=})
+      pop: true
+    - match: (?=\{)
+      push: f-string-replacement
+
   string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
     - match: '([uU]?R)(""")'
@@ -939,6 +992,30 @@ contexts:
           with_prototype:
             - match: '(?=""")'
               pop: true
+    # Triple-quoted raw f-string
+    - match: ((?i)fr|rf)(""")
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.double.block.python
+        - match: '"""'
+          scope: punctuation.definition.string.begin.python
+          set: after-expression
+        - include: f-string-content
+    # Triple-quoted f-string
+    - match: ((?i)f|f)(""")
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.double.block.python
+        - match: '"""'
+          scope: punctuation.definition.string.begin.python
+          set: after-expression
+        - include: escaped-unicode-char
+        - include: escaped-char
+        - include: f-string-content
     # Triple-quoted string, unicode or not, will detect SQL
     - match: '([uU]?)(""")'
       captures:
@@ -1054,6 +1131,32 @@ contexts:
             - match: '(?="|\n)'
               pop: true
           push: 'scope:source.regexp.python'
+    # Single-line raw f-string
+    - match: ((?i)fr|rf)(")
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.double.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
+          set: after-expression
+        - include: line-continuation-inside-string
+        - include: f-string-content
+    # Single-line f-string
+    - match: ((?i)f|f)(")
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.double.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
+          set: after-expression
+        - include: escaped-unicode-char
+        - include: escaped-char
+        - include: line-continuation-inside-string
+        - include: f-string-content
     # Single-line string, unicode or not, starting with a SQL keyword
     - match: '([uU]?)(")(?={{sql_indicator}})'
       captures:
@@ -1171,6 +1274,30 @@ contexts:
             - match: (?=''')
               pop: true
           push: 'scope:source.regexp.python'
+    # Triple-quoted raw f-string
+    - match: ((?i)fr|rf)(''')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.single.block.python
+        - match: "'''"
+          scope: punctuation.definition.string.begin.python
+          set: after-expression
+        - include: f-string-content
+    # Triple-quoted f-string
+    - match: ((?i)f|f)(''')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.single.block.python
+        - match: "'''"
+          scope: punctuation.definition.string.begin.python
+          set: after-expression
+        - include: escaped-unicode-char
+        - include: escaped-char
+        - include: f-string-content
     # Triple-quoted string, unicode or not, will detect SQL
     - match: ([uU]?)(''')
       captures:
@@ -1287,6 +1414,32 @@ contexts:
               pop: true
             - include: line-continuation-inside-string
           push: 'scope:source.regexp.python'
+    # Single-line raw f-string
+    - match: ((?i)fr|rf)(')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.single.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
+          set: after-expression
+        - include: escaped-unicode-char
+        - include: escaped-char
+        - include: line-continuation-inside-string
+        - include: f-string-content
+    # Single-line f-string
+    - match: ((?i)f|f)(')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.string.begin.python
+      push:
+        - meta_scope: meta.string.interpolated.python string.quoted.single.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
+          set: after-expression
+        - include: line-continuation-inside-string
+        - include: f-string-content
     # Single-line string, unicode or not, starting with a SQL keyword
     - match: '([uU]?)('')(?={{sql_indicator}})'
       captures:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -868,19 +868,23 @@ contexts:
     # https://docs.python.org/3.6/library/string.html#formatstrings
     - match: |- # simple form
         (?x)
-        \{
+        (\{)
           (?: [\w.\[\]]+)?         # field_name
           (   ! [ars])?            # conversion
           (   : {{format_spec}} )? # format_spec
-        \}
+        (\})
       scope: constant.other.placeholder.python
       captures:
-        1: storage.modifier.conversion.python
-        2: constant.other.format-spec.python
+        1: punctuation.definition.placeholder.begin.python
+        2: storage.modifier.conversion.python
+        3: constant.other.format-spec.python
+        4: punctuation.definition.placeholder.end.python
     - match: \{(?=[^\}]+\{) # complex (nested) form
+      scope: punctuation.definition.placeholder.begin.python
       push:
         - meta_scope: constant.other.placeholder.python
         - match: \}
+          scope: punctuation.definition.placeholder.end.python
           pop: true
         - match: '[\w.\[\]]+'
         - match: '![ars]'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -221,7 +221,6 @@ contexts:
     - include: strings
     - include: function-calls
     - include: item-access
-    - include: line-continuation
     - match: \(
       scope: punctuation.section.group.begin.python
       push:
@@ -244,10 +243,8 @@ contexts:
 
   line-expressions: # Always include this last!
     - include: expressions-common
+    - include: line-continuation
     - include: dotted-name
-    # For debugging
-    # - match: \S
-    #   scope: invalid.illegal.unmatched
 
   expressions: # Always include this last!
     # Differs from the line scope in that invalid-name matches will pop the current context
@@ -264,9 +261,6 @@ contexts:
         - include: generic-names
         - match: ''
           pop: true
-    # For debugging
-    # - match: \S
-    #   scope: invalid.illegal.unmatched
 
   after-expression:
     # direct function call
@@ -502,7 +496,8 @@ contexts:
           scope: punctuation.separator.annotation.return.python
         - match: '(?=:)'
           set: function-after-parameters
-        - include: expressions # includes line-continuation
+        - include: line-continuation-or-pop
+        - include: expressions
     - match: ':'
       scope: punctuation.section.function.begin.python
       pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -866,6 +866,9 @@ contexts:
     - match: (\\)$\n?
       captures:
         1: punctuation.separator.continuation.line.python
+    - match: \n
+      scope: invalid.illegal.unclosed-string.python
+      set: after-expression
 
   string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -903,12 +906,12 @@ contexts:
               scope: punctuation.definition.string.end.python
               set: after-expression
             - match: ''
+              push: scope:source.sql
               with_prototype:
                 - match: '(?=""")'
                   pop: true
                 - include: escaped-unicode-char
                 - include: constant-placeholder
-              push: 'scope:source.sql'
         - match: '(?=\S)'
           set:
             - meta_scope: string.quoted.double.block.python
@@ -916,11 +919,11 @@ contexts:
               scope: punctuation.definition.string.end.python
               set: after-expression
             - match: ''
+              push: scope:source.regexp.python
               with_prototype:
                 - match: '(?=""")'
                   pop: true
                 - include: escaped-unicode-char
-              push: 'scope:source.regexp.python'
     # Triple-quoted raw string, bytes, will use regex
     - match: '([bB]r|r[bB])(""")'
       captures:
@@ -932,10 +935,10 @@ contexts:
           scope: punctuation.definition.string.end.python
           set: after-expression
         - match: ''
+          push: scope:source.regexp.python
           with_prototype:
             - match: '(?=""")'
               pop: true
-          push: 'scope:source.regexp.python'
     # Triple-quoted string, unicode or not, will detect SQL
     - match: '([uU]?)(""")'
       captures:
@@ -950,13 +953,13 @@ contexts:
               scope: punctuation.definition.string.end.python
               set: after-expression
             - match: ''
+              push: scope:source.sql
               with_prototype:
                 - match: '(?=""")'
                   pop: true
                 - include: escaped-unicode-char
                 - include: escaped-char
                 - include: constant-placeholder
-              push: 'scope:source.sql'
         - match: '(?=\S)'
           set:
             - meta_scope: string.quoted.double.block.python
@@ -987,10 +990,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: line-continuation-inside-string
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -1000,10 +1001,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: line-continuation-inside-string
     # Single-line raw string, unicode or not, starting with a SQL keyword
@@ -1013,18 +1012,17 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-string
         - match: ''
+          push: scope:source.sql
           with_prototype:
             - match: '(?="|\n)'
               pop: true
             - include: constant-placeholder
             - include: line-continuation-inside-string
-          push: 'scope:source.sql'
     # Single-line raw string, unicode or not, treated as regex
     - match: '([uU]?r)(")'
       captures:
@@ -1032,10 +1030,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - match: ''
           with_prototype:
@@ -1050,10 +1046,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - match: ''
           with_prototype:
@@ -1067,12 +1061,12 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-string
         - match: ''
+          push: scope:source.sql
           with_prototype:
             - match: '(?="|\n)'
               pop: true
@@ -1080,7 +1074,6 @@ contexts:
             - include: escaped-unicode-char
             - include: line-continuation-inside-string
             - include: constant-placeholder
-          push: 'scope:source.sql'
     # Single-line string, unicode or not
     - match: '([uU]?)(")'
       captures:
@@ -1088,10 +1081,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: escaped-char
         - include: escaped-unicode-char
@@ -1104,10 +1095,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.double.python
-        - match: '(")|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: '"'
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: escaped-char
         - include: line-continuation-inside-string
@@ -1148,13 +1137,13 @@ contexts:
               scope: punctuation.definition.string.end.python
               set: after-expression
             - match: ''
+              push: scope:source.sql
               with_prototype:
                 - match: (?=''')
                   pop: true
                 - include: escaped-char
                 - include: escaped-unicode-char
                 - include: constant-placeholder
-              push: 'scope:source.sql'
         - match: '(?=\S)'
           set:
             - meta_scope: string.quoted.single.block.python
@@ -1196,13 +1185,13 @@ contexts:
               scope: punctuation.definition.string.end.python
               set: after-expression
             - match: ''
+              push: scope:source.sql
               with_prototype:
                 - match: (?=''')
                   pop: true
                 - include: escaped-char
                 - include: escaped-unicode-char
                 - include: constant-placeholder
-              push: 'scope:source.sql'
         - match: '(?=\S)'
           set:
             - meta_scope: string.quoted.single.block.python
@@ -1233,10 +1222,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: line-continuation-inside-string
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -1246,10 +1233,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: line-continuation-inside-string
     # Single-line raw string, unicode or not, starting with a SQL keyword
@@ -1259,18 +1244,17 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-string
         - match: ''
+          push: scope:source.sql
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
             - include: line-continuation-inside-string
             - include: constant-placeholder
-          push: 'scope:source.sql'
     # Single-line raw string, unicode or not, treated as regex
     - match: '([uU]?r)('')'
       captures:
@@ -1278,10 +1262,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - match: ''
           with_prototype:
@@ -1296,10 +1278,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - match: ''
           with_prototype:
@@ -1314,12 +1294,12 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-string
         - match: ''
+          push: scope:source.sql
           with_prototype:
             - match: '(?=''|\n)'
               pop: true
@@ -1327,7 +1307,6 @@ contexts:
             - include: escaped-unicode-char
             - include: line-continuation-inside-string
             - include: constant-placeholder
-          push: 'scope:source.sql'
     # Single-line string, unicode or not
     - match: '([uU]?)('')'
       captures:
@@ -1335,10 +1314,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: escaped-char
         - include: escaped-unicode-char
@@ -1351,10 +1328,8 @@ contexts:
         2: punctuation.definition.string.begin.python
       push:
         - meta_scope: string.quoted.single.python
-        - match: '('')|(\n)'
-          captures:
-            1: punctuation.definition.string.end.python
-            2: invalid.illegal.unclosed-string.python
+        - match: "'"
+          scope: punctuation.definition.string.end.python
           set: after-expression
         - include: escaped-char
         - include: line-continuation-inside-string

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -679,7 +679,22 @@ contexts:
       scope: constant.other.placeholder.python
     - match: '\{\{|\}\}'
       scope: constant.character.escape.python
-    - match: '\{([\w.\[\]]*)(:.?[<>=^]?)?[ +-]?\d*,?(\.\d+)?!?[abcdeEfFgGnorsxX%]?\}'
+    - match: |-
+        (?x)
+        \{
+          ([\w.\[\]]+)? # field_name
+          (! [rsa])?    # conversion
+          (:            # format_spec
+            (.? [<>=^])?       # fill align
+            [ +-]?             # sign
+            \#?
+            \d*                # width
+            ,?
+            (\.\d+)?           # precision
+            [bcdeEfFgGnosxX%]? # type
+          )?
+          # technically, octal and hexadecimal integers are also supported as 'width', but rarely used
+        \}
       scope: constant.other.placeholder.python
 
   name:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -842,7 +842,7 @@ contexts:
       set: after-expression
 
   constant-placeholder:
-    - match: |-
+    - match: |- # printf style
         (?x)
         %
           ( \( ({{identifier}}) \) )? # mapping key
@@ -862,7 +862,11 @@ contexts:
       scope: constant.other.placeholder.python
     - match: '\{\{|\}\}'
       scope: constant.character.escape.python
-    - match: |-
+    - include: formatting-syntax
+
+  formatting-syntax:
+    # https://docs.python.org/3.6/library/string.html#formatstrings
+    - match: |- # simple form
         (?x)
         \{
           (?: [\w.\[\]]+)?         # field_name
@@ -873,6 +877,20 @@ contexts:
       captures:
         1: storage.modifier.conversion.python
         2: constant.other.format-spec.python
+    - match: \{(?=[^\}]+\{) # complex (nested) form
+      push:
+        - meta_scope: constant.other.placeholder.python
+        - match: \}
+          pop: true
+        - match: '[\w.\[\]]+'
+        - match: '![ars]'
+          scope: storage.modifier.conversion.python
+        - match: ':'
+          push:
+            - meta_scope: meta.format-spec.python constant.other.format-spec.python
+            - match: (?=\})
+              pop: true
+            - include: formatting-syntax
 
   f-string-content:
     # https://www.python.org/dev/peps/pep-0498/

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -412,9 +412,6 @@ sql = b'just some \
 #^^^^^^^^^^ string.quoted.single
 #         ^ punctuation.definition.string.end.python
 
-# <- - meta
-# this test is to ensure we're not matching anything here anymore
-
 # https://docs.python.org/3/library/string.html#formatspec
 "First, thou shalt count to {0}"  # References first positional argument
 #                           ^^^ constant.other.placeholder.python
@@ -445,3 +442,6 @@ sql = b'just some \
 #             ^^ constant.other.placeholder.python
 #               ^ - constant.other.placeholder.python
 #                ^^ constant.other.placeholder.python
+
+# <- - meta
+# this test is to ensure we're not matching anything here anymore

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -5,6 +5,7 @@
 ###############################
 
 var = "\x00 \xaa \xAF \070 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE}"
+#     ^ meta.string.python
 #      ^^^^ constant.character.escape.hex
 #           ^^^^ constant.character.escape.hex
 #                ^^^^ constant.character.escape.hex
@@ -23,7 +24,7 @@ var = "\x00 \xaa \xAF \070 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE
 #                                                                       ^^^^^^^^^ constant.character.escape.unicode
 
 conn.execute("SELECT * FROM foobar")
-#              ^ keyword.other.DML.sql
+#              ^ meta.string.python keyword.other.DML.sql
 
 conn.execute('SELECT * FROM foobar')
 #              ^ keyword.other.DML.sql
@@ -44,7 +45,7 @@ conn.execute(u'SELECT * FROM foobar')
 
 # In this example, the Python string is raw, so the \b should be a SQL escape
 conn.execute(r"SELECT * FROM foobar WHERE baz = '\b")
-#              ^ keyword.other.DML.sql
+#              ^ meta.string.python keyword.other.DML.sql
 #                                                 ^ constant.character.escape.sql
 
 # This tests to ensure the Python placeholder will be highlighted even in a raw SQL string
@@ -65,7 +66,7 @@ conn.execute(r"""SELECT * FROM foobar WHERE %s and foo = '\t'""")
 
 # Capital R prevents all syntax embedding
 conn.execute(R'SELECT * FROM foobar')
-#              ^ - keyword.other.DML.sql
+#              ^ meta.string.python - keyword.other.DML.sql
 
 conn.execute(R"SELECT * FROM foobar")
 #              ^ - keyword.other.DML.sql
@@ -82,7 +83,7 @@ conn.execute(u"""SELECT * FROM foobar WHERE %s and foo = '\t'""")
 #                                                          ^ constant.character.escape.python
 
 regex = r'\b ([fobar]*){1}(?:a|b)?'
-#         ^ keyword.control.anchor.regexp
+#         ^ meta.string.python keyword.control.anchor.regexp
 #                       ^ keyword.operator.quantifier.regexp
 
 regex = r'.* # Not a comment (yet)'
@@ -128,7 +129,7 @@ string = """
 """
 
 string = r"""
-#         ^^^ string.quoted.double.block
+#         ^^^ meta.string.python string.quoted.double.block
 """
 
 string = r"""
@@ -352,7 +353,7 @@ rb'''This is a \n (test|with), %s no unicode \uDEAD'''
 #                                              ^^^^ - constant
 rB'''This is a \n (test|with), %s no unicode \uDEAD'''
 # <- storage.type.string
-# ^^^ string.quoted.single punctuation.definition.string.begin
+# ^^^ meta.string.python string.quoted.single punctuation.definition.string.begin
 #              ^^ constant.character.escape.backslash.regexp
 #                      ^ keyword.operator.or.regexp
 #                              ^^ - constant

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -453,7 +453,10 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 #         ^^^^^ constant.other.format-spec
 
 "result: {value:{width}.{precision}}"
-
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.placeholder
+#              ^^^^^^^^^^^^^^^^^^^^ meta.format-spec.python
+#               ^^^^^^^ constant.other.placeholder constant.other.placeholder
+#                       ^^^^^^^^^^^ constant.other.placeholder constant.other.placeholder
 
 f"string"
 # <- storage.type.string

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -489,8 +489,8 @@ f"{something}"
 #^^^^^^^^^^^^ meta.string.interpolated
 # <- storage.type.string
 #^ punctuation.definition.string.begin
-# ^ punctuation.definition.interpolation.begin
-#           ^ punctuation.definition.interpolation.end
+# ^ punctuation.section.interpolation.begin
+#           ^ punctuation.section.interpolation.end
 #            ^ punctuation.definition.string.end
 #  ^^^^^^^^^ source source.python.embedded
 #              ^ source - meta, string, source source
@@ -502,7 +502,7 @@ f"{True!a:02f}"
 #      ^^^^^^^ - source source.python.embedded
 #      ^^ storage.modifier.conversion - constant.other.format-spec
 #        ^^^^ constant.other.format-spec
-#            ^ punctuation.definition.interpolation.end
+#            ^ punctuation.section.interpolation.end
 #             ^ punctuation.definition.string.end
 #              ^ source - meta, string, source source
 
@@ -535,6 +535,11 @@ F""" {} {\} }
 #        ^ invalid.illegal.backslash-in-fstring
 #           ^ invalid.illegal.stray-brace
 """
+
+f" {
+%   ^ invalid.illegal.unclosed-string
+   # TODO make this test pass
+    }"
 
 f'   \
  {1 + 2!a:02f}'

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -4,22 +4,6 @@
 # Strings and embedded syntaxes
 ###############################
 
-"Testing {:,.2f}".format(1000)
-#        ^^^^^^^ constant.other.placeholder
-
-"Testing {0:>9,}".format(1000)
-#        ^^^^^^^ constant.other.placeholder
-
-"Testing {:j^9,}".format(1000)
-#        ^^^^^^^ constant.other.placeholder
-
-datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
-#                                    ^^^^^^^^^^ constant.other.placeholder
-
-"My String %% %s"
-#          ^^ constant.other.placeholder
-#             ^^ constant.other.placeholder
-
 var = "\x00 \xaa \xAF \070 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE}"
 #      ^^^^ constant.character.escape.hex
 #           ^^^^ constant.character.escape.hex
@@ -433,6 +417,8 @@ sql = b'just some \
 #                   ^^^^^^^^ constant.other.placeholder.python
 "More {!a}"                       # Calls ascii() on the argument first
 #     ^^^^ constant.other.placeholder.python
+"More {!a: <10s}"                 # Calls ascii() on the argument first, then formats
+#     ^^^^^^^^^^ constant.other.placeholder.python
 "Escaped {{0}}"                   # outputs: "Escaped {0}"
 #        ^^^^^ - constant.other.placeholder.python
 #        ^^ constant.character.escape.python
@@ -442,6 +428,22 @@ sql = b'just some \
 #             ^^ constant.other.placeholder.python
 #               ^ - constant.other.placeholder.python
 #                ^^ constant.other.placeholder.python
+
+datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
+#                                    ^^^^^^^^^^ constant.other.placeholder
+
+"My String %% %s"
+#          ^^ constant.other.placeholder
+#             ^^ constant.other.placeholder
+
+"Testing {:,.2f}".format(1000)
+#        ^^^^^^^ constant.other.placeholder
+
+"Testing {0:>9,}".format(1000)
+#        ^^^^^^^ constant.other.placeholder
+
+"Testing {:j^9,}".format(1000)
+#        ^^^^^^^ constant.other.placeholder
 
 # <- - meta
 # this test is to ensure we're not matching anything here anymore

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -436,6 +436,11 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 #          ^^ constant.other.placeholder
 #             ^^ constant.other.placeholder
 
+"My String %(s)s %s"
+#          ^^^^^ constant.other.placeholder
+#            ^ variable.other.placeholder
+#                ^^ constant.other.placeholder
+
 "Testing {:,.2f}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
 

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -413,6 +413,7 @@ sql = b'just some \
 #                 ^^^^^^^^^^^^ constant.other.placeholder.python
 "Harold's a clever {0!s}"         # Calls str() on the argument first
 #                  ^^^^^ constant.other.placeholder.python
+#                    ^^ storage.modifier.conversion.python
 "Bring out the holy {name!r}"     # Calls repr() on the argument first
 #                   ^^^^^^^^ constant.other.placeholder.python
 "More {!a}"                       # Calls ascii() on the argument first
@@ -449,6 +450,85 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 
 "Testing {:j^9,}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
+#         ^^^^^ constant.other.format-spec
+
+"result: {value:{width}.{precision}}"
+
+
+f"string"
+# <- storage.type.string
+#^^^^^^^^ string.quoted.double
+
+ RF"""string"""
+#^^ storage.type.string
+#^^^^^^^^^^^^^^ meta.string.interpolated string.quoted.double.block
+
+F'''string'''
+# <- storage.type.string
+#^^^^^^^^^^^^ meta.string.interpolated string.quoted.single.block
+
+ rf'string'
+#^^ storage.type.string
+#^^^^^^^^^^ meta.string.interpolated string.quoted.single
+
+
+# FIXME The opening brace incorrectly gets its scope stack reset
+# due to https://github.com/SublimeTextIssues/Core/issues/1526.
+# Thus, the following tests on it are failing.
+
+f"{something}"
+#^^^^^^^^^^^^ meta.string.interpolated
+# <- storage.type.string
+#^ punctuation.definition.string.begin
+# ^ punctuation.definition.interpolation.begin
+#           ^ punctuation.definition.interpolation.end
+#            ^ punctuation.definition.string.end
+#  ^^^^^^^^^ source source.python.embedded
+#              ^ source - meta, string, source source
+
+f"{True!a:02f}"
+#^^^^^^^^^^^^^^ meta.string.interpolated
+# ^ - source source.python.embedded
+#  ^^^^ source source.python.embedded constant.language
+#      ^^^^^^^ - source source.python.embedded
+#      ^^ storage.modifier.conversion - constant.other.format-spec
+#        ^^^^ constant.other.format-spec
+#            ^ punctuation.definition.interpolation.end
+#             ^ punctuation.definition.string.end
+#              ^ source - meta, string, source source
+
+f"result: {value:{width}.{precision}}\n"
+#         ^ - source source
+#          ^^^^^ source source.python.embedded
+#               ^^ - source source
+#                 ^^^^^ source source.python.embedded
+#                       ^ - source source
+#                         ^^^^^^^^^ source source.python.embedded
+#                                  ^^ - source source
+#                                    ^^ constant.character.escape
+
+rf"{value:{width!s:d}}"
+#^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+#          ^^^^^ source source.python.embedded
+#               ^^ storage.modifier.conversion
+#                 ^^ constant.other.format-spec
+
+F""" {} {\} }
+#^^^^^^^^^^^ meta.string.interpolated
+#^^^ punctuation.definition.string.begin
+#    ^^ invalid.illegal.empty-expression
+#        ^ invalid.illegal.backslash-in-fstring
+#           ^ invalid.illegal.stray-brace
+"""
+
+f'   \
+ {1 + 2!a:02f}'
+#^^^^^^^^^^^^^^ meta.string.interpolated
+# ^^^^^ source source.python.embedded
+
+f'
+# ^ invalid.illegal.unclosed-string
+
 
 # <- - meta
 # this test is to ensure we're not matching anything here anymore

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -444,6 +444,8 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 
 "Testing {:,.2f}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
+#        ^ punctuation.definition.placeholder.begin
+#              ^ punctuation.definition.placeholder.end
 
 "Testing {0:>9,}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
@@ -455,8 +457,11 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 "result: {value:{width}.{precision}}"
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.placeholder
 #              ^^^^^^^^^^^^^^^^^^^^ meta.format-spec.python
+#        ^ punctuation.definition.placeholder.begin
 #               ^^^^^^^ constant.other.placeholder constant.other.placeholder
+#               ^ punctuation.definition.placeholder.begin
 #                       ^^^^^^^^^^^ constant.other.placeholder constant.other.placeholder
+#                                 ^^ punctuation.definition.placeholder.end
 
 f"string"
 # <- storage.type.string

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -506,7 +506,13 @@ f"result: {value:{width}.{precision}}\n"
 #                         ^^^^^^^^^ source source.python.embedded
 #                                  ^^ - source source
 #                                    ^^ constant.character.escape
-
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.python
+#               ^^^^^^^^^^^^^^^^^^^^ meta.format-spec.python
+#          ^^^^^^ - meta.interpolation.python meta.interpolation.python
+#                ^^^^^^^ meta.interpolation.python meta.interpolation.python
+#                       ^ - meta.interpolation.python meta.interpolation.python
+#                        ^^^^^^^^^^^ meta.interpolation.python meta.interpolation.python
+#                                   ^^^ - meta.interpolation.python meta.interpolation.python
 rf"{value:{width!s:d}}"
 #^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
 #          ^^^^^ source source.python.embedded


### PR DESCRIPTION
Adds support for the largest syntax addition to Python 3.6. Normal string placeholders have also been revised.

See #694.