### PR TITLE
[Java] More fixes!

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -7,11 +7,15 @@ file_extensions:
   - bsh
 scope: source.java
 variables:
-  primitives: \b(void|boolean|byte|char|short|int|float|long|double)\b
+  primitives: \b(boolean|byte|char|short|int|float|long|double)\b
+  primitives_with_void: \bvoid\b|{{primitives}}
 
   # source: http://stackoverflow.com/a/5205467/9815
   id: '(?:[\p{L}_$][\p{L}\p{N}_$]*)'
   qualified_id: '(?:(?:{{id}}\.)*{{id}})'
+
+  # utility lookaround
+  within_generics: '(?:<(?:[^<>]|<(?:[^<>]|<[^<>]*>)*>)*>)'  # handles 3 levels nesting
 
 contexts:
   prototype:
@@ -79,47 +83,119 @@ contexts:
           scope: punctuation.separator.property.java
     - match: '@\w*'
       scope: storage.type.annotation.java
+
   anonymous-classes-and-new:
-    - match: \b(?<!::)new\b
+    - match: \bnew\b
       scope: keyword.control.new.java
-      push:
-        - match: '(?<=\)|\])(?!\s*{)|(?<=})|(?=;)'
+      push: instantiation
+
+  instantiation:
+    - match: '{{primitives}}'
+      scope: storage.type.primitive.java
+      set: instantiation-arrays
+    - match: '{{qualified_id}}'
+      scope: support.class.java
+      set: instantiation-generics
+    - match: '(?=\S)'
+      pop: true
+
+  instantiation-generics:
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      set:
+        - meta_scope: meta.generic.java
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          set: instantiation-arrays
+        - include: generic-instantiation
+    - match: '(?=\S)'
+      set: instantiation-arrays
+
+  instantiation-arrays:
+    - match: \[
+      scope: punctuation.section.brackets.begin.java
+      set:
+        - meta_scope: meta.brackets.java
+        - match: \]
+          scope: punctuation.section.brackets.end.java
           pop: true
-        - match: '(\w+)\s*(?=\[)'
-          captures:
-            1: support.class.java
-          push:
-            - match: '}|(?=;|\))'
-              pop: true
-            - match: '\['
-              push:
-                - match: '\]'
-                  pop: true
-                - include: code
-            - match: "{"
-              push:
-                - match: "(?=})"
-                  pop: true
-                - include: code
-        - match: (?=\w.*(\(|$))
-          push:
-            - match: \)
-              pop: true
-            # - include: object-types
-            - match: \(
-              push:
-                - match: (?=\))
-                  pop: true
-                - include: code
-        - match: "{"
-          push:
-            - meta_scope: meta.inner-class.java
-            - match: "}"
-              pop: true
-            - include: class-body
+        - include: code
+    - match: \(
+      scope: punctuation.section.parens.begin.java
+      set:
+        - meta_scope: meta.parens.java
+        - match: \)
+          scope: punctuation.section.parens.end.java
+          set: instantiation-anon-class
+        - include: code
+    - match: '(?=\S)'
+      pop: true
+
+  instantiation-anon-class:
+    - match: \{
+      scope: punctuation.section.braces.begin.java
+      push:
+        - meta_scope: meta.class.anonymous-inner-class.java
+        - match: \}
+          scope: punctuation.section.braces.end.java
+          pop: true
+        - include: class-body
+    - match: (?=\S)
+      pop: true
+
   functions:
-    - match: '\b([a-zA-Z](?:[^\.<>\s]*))(?=(\s*<.+>)?\s*\()'
+    - match: '\b{{id}}(?=(\s*<.+>)?\s*\()'
       scope: variable.function.java
+
+  fields:
+    - match: '{{primitives}}(?=(\s*\[\s*\])?\s+{{id}})'
+      scope: storage.type.primitive.java
+      push: field-definition-arrays
+    - match: '\b{{qualified_id}}(?=(\s*{{within_generics}})?(\s*\[\s*\])?\s+{{id}})'
+      scope: storage.type.class.java
+      push: field-definition-generics
+
+  field-definition-generics:
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      set:
+        - meta_scope: meta.generic.java
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          set: field-definition-arrays
+        - include: generic-instantiation
+    - match: '(?=\S)'
+      set: field-definition-arrays
+
+  field-definition-arrays:
+    - match: \[
+      scope: punctuation.section.brackets.begin.java
+      set:
+        - match: \]
+          scope: punctuation.section.brackets.end.java
+          set: field-definition-name
+    - match: '(?=\S)'
+      set: field-definition-name
+
+  field-definition-name:
+    - match: '{{id}}'
+      pop: true
+
+  generic-instantiation:
+    - match: \?
+      scope: keyword.operator.wildcard.java
+    - match: \b(extends|super)\b
+      scope: keyword.declaration.extends.java
+    - match: '{{qualified_id}}'
+      scope: support.type.java
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      push:
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          pop: true
+        - include: generic-instantiation
+
   assertions:
     - match: \b(assert)\b
       scope: keyword.control.assert.java
@@ -184,6 +260,7 @@ contexts:
     - include: constants-and-special-vars
     - include: anonymous-classes-and-new
     - include: keywords
+    - include: fields
     - include: functions
     - include: storage-modifiers
     - include: strings
@@ -234,11 +311,18 @@ contexts:
                   pop: true
                 - include: class-body
   keywords:
+    - match: '::'
+      scope: keyword.control.method-reference.java
+      push:
+        - match: '{{id}}'
+          pop: true
+        - match: (?=\S)
+          pop: true
     - match: \b(goto|const)\b
       scope: invalid.illegal.java
     - match: \b(try|catch|finally|throw)\b
       scope: keyword.control.catch-exception.java
-    - match: '\?|:'
+    - match: '\?|(?:[:](?=[^:]))'
       scope: keyword.control.java
     - match: \b(return|break|case|continue|default|do|while|for|switch|if|else)\b
       scope: keyword.control.java
@@ -350,6 +434,14 @@ contexts:
     - match: '(?=\))'
       pop: true
   parameter-after:
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      push:
+        - meta_scope: meta.generic.java
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          pop: true
+        - include: generic-instantiation
     - match: '\.\.\.'
       scope: keyword.operator.varargs.java
     - match: '(\[)\s*(\])'

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -593,6 +593,7 @@ contexts:
             - match: '<'
               scope: punctuation.definition.generic.begin.java
               set:
+                - meta_scope: meta.generic.java
                 - match: '>'
                   scope: punctuation.definition.generic.end.java
                   pop: true

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -16,6 +16,7 @@ variables:
 
   # utility lookaround
   within_generics: '(?:<(?:[^<>]|<(?:[^<>]|<[^<>]*>)*>)*>)'  # handles 3 levels nesting
+  lambda_lookahead: '(\([^)]*\)|{{id}})\s*->'
 
 contexts:
   prototype:
@@ -182,6 +183,8 @@ contexts:
       pop: true
 
   generic-instantiation:
+    - match: '{{primitives}}'
+      scope: invalid.illegal.primitive-instantiation.java
     - match: \?
       scope: keyword.operator.wildcard.java
     - match: \b(extends|super)\b
@@ -256,6 +259,7 @@ contexts:
           pop: true
         - include: code
     - include: assertions
+    - include: lambdas
     - include: parens
     - include: constants-and-special-vars
     - include: anonymous-classes-and-new
@@ -452,12 +456,51 @@ contexts:
       scope: variable.parameter.java
       set: parameters
 
+  lambdas:
+    - match: '(?={{lambda_lookahead}})'
+      push: lambda-params
+
+  lambda-params:
+    - meta_scope: meta.lambda.parameters.java
+    - match: \(
+      scope: punctuation.section.parens.begin.java
+      set:
+        - meta_scope: meta.lambda.parameters.paren.java
+        - match: \)
+          scope: punctuation.section.parens.end.java
+          set: lambda-arrow
+        - match: (?=(\s*{{id}}\s*,)*\s*{{id}}\s*\))
+          push: lambda-params-simple
+        - match: (?=\S)
+          push: parameters
+    - match: '{{id}}'
+      scope: variable.parameter.java
+      set: lambda-arrow
+
+  lambda-params-simple:
+    - match: '{{id}}'
+      scope: variable.parameter.java
+    - match: ','
+      scope: punctuation.separator.java
+    - match: (?=\S)
+      pop: true
+
+  lambda-arrow:
+    - match: ->
+      scope: storage.type.lambda.java
+      set:
+        - meta_scope: meta.lambda.body.java
+        - match: (?=[)};])
+          pop: true
+        - include: code
+
   parens:
     - match: \(
       push:
         - match: \)
           pop: true
         - include: code
+
   primitive-arrays:
     - match: '\b(?:void|boolean|byte|char|short|int|float|long|double)(\[\])*\b'
       scope: storage.type.primitive.array.java
@@ -488,14 +531,27 @@ contexts:
           pop: true
         - match: \\.
           scope: constant.character.escape.java
+
   throws:
     - match: \bthrows\b
       scope: storage.modifier.java
       push:
         - meta_scope: meta.throwables.java
-        - match: "(?={|;)"
+        - match: (?=\{|;)
           pop: true
-        # - include: object-types
+        - match: '{{qualified_id}}'
+          scope: support.class.java
+          push:
+            - match: '<'
+              scope: punctuation.definition.generic.begin.java
+              set:
+                - match: '>'
+                  scope: punctuation.definition.generic.end.java
+                  pop: true
+                - include: generic-instantiation
+            - match: (?=\S)
+              pop: true
+
   values:
     - include: strings
     # - include: object-types

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -153,7 +153,7 @@ contexts:
       scope: storage.type.primitive.java
       push: field-definition-arrays
     - match: '\b{{qualified_id}}(?=(\s*{{within_generics}})?(\s*\[\s*\])?\s+{{id}})'
-      scope: storage.type.class.java
+      # scope: storage.type.class.java
       push: field-definition-generics
 
   field-definition-generics:
@@ -190,7 +190,6 @@ contexts:
     - match: \b(extends|super)\b
       scope: keyword.declaration.extends.java
     - match: '{{qualified_id}}'
-      scope: support.type.java
     - match: '<'
       scope: punctuation.definition.generic.begin.java
       push:
@@ -364,8 +363,9 @@ contexts:
           push:
             - meta_scope: meta.method.identifier.java
             - match: \)
+              scope: meta.method.identifier.java
               pop: true
-            - include: parameters
+            - include: method-parameters
         - match: (?=\w.*\s+\w+\s*\()
           push:
             - meta_scope: meta.method.return-type.java
@@ -424,20 +424,56 @@ contexts:
       captures:
         1: keyword.operator.dereference.java
 
-  parameters:
+  method-parameters:
+    - meta_scope: meta.method.identifier.java
     - match: \bfinal\b
       scope: storage.modifier.java
     - match: '{{primitives}}'
       scope: storage.type.primitive.java
-      set: parameter-after
+      set: method-parameter-after
     - match: '{{qualified_id}}'
-      scope: support.class.java
-      set: parameter-after
+      # scope: storage.type.java
+      set: method-parameter-after
+    - match: ','
+      scope: punctuation.separator.java
+    - match: \)
+      pop: true
+  method-parameter-after:
+    - meta_scope: meta.method.identifier.java
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      push:
+        - meta_scope: meta.method.identifier.java
+        - meta_scope: meta.generic.java
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          pop: true
+        - include: generic-instantiation
+    - match: '\.\.\.'
+      scope: keyword.operator.varargs.java
+    - match: '(\[)\s*(\])'
+      captures:
+        1: punctuation.section.brackets.begin.java
+        2: punctuation.section.brackets.end.java
+    - match: '{{id}}'
+      scope: variable.parameter.java
+      set: method-parameters
+
+  # duplicated due to the meta scope
+  raw-parameters:
+    - match: \bfinal\b
+      scope: storage.modifier.java
+    - match: '{{primitives}}'
+      scope: storage.type.primitive.java
+      set: raw-parameter-after
+    - match: '{{qualified_id}}'
+      # scope: storage.type.java
+      set: raw-parameter-after
     - match: ','
       scope: punctuation.separator.java
     - match: '(?=\))'
       pop: true
-  parameter-after:
+  raw-parameter-after:
     - match: '<'
       scope: punctuation.definition.generic.begin.java
       push:
@@ -454,7 +490,7 @@ contexts:
         2: punctuation.section.brackets.end.java
     - match: '{{id}}'
       scope: variable.parameter.java
-      set: parameters
+      set: raw-parameters
 
   lambdas:
     - match: '(?={{lambda_lookahead}})'
@@ -472,7 +508,7 @@ contexts:
         - match: (?=(\s*{{id}}\s*,)*\s*{{id}}\s*\))
           push: lambda-params-simple
         - match: (?=\S)
-          push: parameters
+          push: raw-parameters
     - match: '{{id}}'
       scope: variable.parameter.java
       set: lambda-arrow
@@ -540,7 +576,7 @@ contexts:
         - match: (?=\{|;)
           pop: true
         - match: '{{qualified_id}}'
-          scope: support.class.java
+          # scope: support.class.java
           push:
             - match: '<'
               scope: punctuation.definition.generic.begin.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -341,7 +341,7 @@ contexts:
 
   keywords:
     - match: '::'
-      scope: punctuation.accessor.java
+      scope: punctuation.accessor.double-colon.java
       push:
         - match: '{{id}}'
           scope: variable.function.reference.java
@@ -374,7 +374,7 @@ contexts:
     - match: (!|&&|\|\|)
       scope: keyword.operator.logical.java
     - match: \.
-      scope: punctuation.accessor.java
+      scope: punctuation.accessor.dot.java
     - match: ;
       scope: punctuation.terminator.java
 

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -6,6 +6,13 @@ file_extensions:
   - java
   - bsh
 scope: source.java
+variables:
+  primitives: \b(void|boolean|byte|char|short|int|float|long|double)\b
+
+  # source: http://stackoverflow.com/a/5205467/9815
+  id: '(?:[\p{L}_$][\p{L}\p{N}_$]*)'
+  qualified_id: '(?:(?:{{id}}\.)*{{id}})'
+
 contexts:
   main:
     - include: package
@@ -47,7 +54,7 @@ contexts:
   all-types:
     - include: primitive-arrays
     - include: primitive-types
-    - include: object-types
+    # - include: object-types
   annotations:
     - match: '(@[^ (]+)(\()'
       captures:
@@ -75,7 +82,7 @@ contexts:
           pop: true
         - match: '(\w+)\s*(?=\[)'
           captures:
-            1: storage.type.java
+            1: support.class.java
           push:
             - match: '}|(?=;|\))'
               pop: true
@@ -93,7 +100,7 @@ contexts:
           push:
             - match: \)
               pop: true
-            - include: object-types
+            # - include: object-types
             - match: \(
               push:
                 - match: (?=\))
@@ -329,14 +336,31 @@ contexts:
       scope: entity.other.inherited-class.java
       captures:
         1: keyword.operator.dereference.java
+
   parameters:
     - match: \bfinal\b
       scope: storage.modifier.java
-    - include: primitive-arrays
-    - include: primitive-types
-    - include: object-types
-    - match: \w+
+    - match: '{{primitives}}'
+      scope: storage.type.primitive.java
+      set: parameter-after
+    - match: '{{qualified_id}}'
+      scope: support.class.java
+      set: parameter-after
+    - match: ','
+      scope: punctuation.separator.java
+    - match: '(?=\))'
+      pop: true
+  parameter-after:
+    - match: '\.\.\.'
+      scope: keyword.operator.varargs.java
+    - match: '(\[)\s*(\])'
+      captures:
+        1: punctuation.section.brackets.begin.java
+        2: punctuation.section.brackets.end.java
+    - match: '{{id}}'
       scope: variable.parameter.java
+      set: parameters
+
   parens:
     - match: \(
       push:
@@ -347,7 +371,7 @@ contexts:
     - match: '\b(?:void|boolean|byte|char|short|int|float|long|double)(\[\])*\b'
       scope: storage.type.primitive.array.java
   primitive-types:
-    - match: \b(?:void|boolean|byte|char|short|int|float|long|double)\b
+    - match: '{{primitives}}'
       scope: storage.type.primitive.java
   storage-modifiers:
     - match: \b(public|private|protected|static|final|native|synchronized|strictfp|abstract|threadsafe|transient|default|volatile)\b
@@ -378,8 +402,8 @@ contexts:
         - meta_scope: meta.throwables.java
         - match: "(?={|;)"
           pop: true
-        - include: object-types
+        # - include: object-types
   values:
     - include: strings
-    - include: object-types
+    # - include: object-types
     - include: constants-and-special-vars

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -341,7 +341,7 @@ contexts:
 
   keywords:
     - match: '::'
-      scope: keyword.operator.method-reference.java
+      scope: punctuation.accessor.java
       push:
         - match: '{{id}}'
           scope: variable.function.reference.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -167,7 +167,7 @@ contexts:
       scope: storage.type.primitive.java
       push: field-definition-arrays
     - match: '\b{{qualified_id}}(?=(\s*{{within_generics}})?(\s*\[\s*\])?\s+{{id}})'
-      # scope: storage.type.class.java
+      scope: support.class.java
       push: field-definition-generics
 
   field-definition-generics:
@@ -204,6 +204,7 @@ contexts:
     - match: \b(extends|super)\b
       scope: keyword.declaration.extends.java
     - match: '{{qualified_id}}'
+      scope: support.type.java
     - match: '<'
       scope: punctuation.definition.generic.begin.java
       push:
@@ -421,7 +422,7 @@ contexts:
       scope: storage.type.primitive.java
       set: method-parameter-after
     - match: '{{qualified_id}}'
-      # scope: storage.type.java
+      scope: support.class.java
       set: method-parameter-after
     - match: ','
       scope: punctuation.separator.java
@@ -456,7 +457,7 @@ contexts:
       scope: storage.type.primitive.java
       set: raw-parameter-after
     - match: '{{qualified_id}}'
-      # scope: storage.type.java
+      scope: support.class.java
       set: raw-parameter-after
     - match: ','
       scope: punctuation.separator.java
@@ -565,7 +566,7 @@ contexts:
         - match: (?=\{|;)
           pop: true
         - match: '{{qualified_id}}'
-          # scope: support.class.java
+          scope: support.class.java
           push:
             - match: '<'
               scope: punctuation.definition.generic.begin.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -145,8 +145,21 @@ contexts:
       pop: true
 
   functions:
-    - match: '\b{{id}}(?=(\s*<.+>)?\s*\()'
+    - match: '\b{{id}}(?=(\s*{{within_generics}})?\s*\()'
       scope: variable.function.java
+      push: function-generics
+
+  function-generics:
+    - match: '<'
+      scope: punctuation.definition.generic.begin.java
+      push:
+        - meta_scope: meta.generic.java
+        - match: '>'
+          scope: punctuation.definition.generic.end.java
+          pop: true
+        - include: generic-instantiation
+    - match: '(?=\S)'
+      pop: true
 
   fields:
     - match: '{{primitives}}(?=(\s*\[\s*\])?\s+{{id}})'

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -341,9 +341,10 @@ contexts:
 
   keywords:
     - match: '::'
-      scope: keyword.control.method-reference.java
+      scope: keyword.operator.method-reference.java
       push:
         - match: '{{id}}'
+          scope: variable.function.reference.java
           pop: true
         - match: (?=\S)
           pop: true

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -61,10 +61,11 @@ contexts:
           pop: true
         - match: (?=\n)
           pop: true
+
   all-types:
     - include: primitive-arrays
     - include: primitive-types
-    # - include: object-types
+
   annotations:
     - match: '(@[^ (]+)(\()'
       captures:
@@ -254,6 +255,7 @@ contexts:
             - match: "(?=})"
               pop: true
             - include: class-body
+
   class-body:
     - include: class
     - include: enums
@@ -261,6 +263,7 @@ contexts:
     - include: annotations
     - include: storage-modifiers
     - include: code
+
   code:
     - include: class
     - match: "{"
@@ -326,6 +329,7 @@ contexts:
                 - match: "}"
                   pop: true
                 - include: class-body
+
   keywords:
     - match: '::'
       scope: keyword.control.method-reference.java
@@ -363,6 +367,7 @@ contexts:
       scope: punctuation.accessor.java
     - match: ;
       scope: punctuation.terminator.java
+
   methods:
     - match: '(?=\w.*\s+)(?=[^=;]+\()'
       push:
@@ -392,50 +397,21 @@ contexts:
             - match: "(?=})"
               pop: true
             - include: code
-  object-types:
-    - match: '\b((?:[a-z]\w*\.)*[A-Z]+\w*)<'
-      push:
-        - meta_scope: storage.type.generic.java
-        - match: '>|[^\w\s,\?<\[\].]'
-          pop: true
-        - include: object-types
-        - match: <
-          comment: This is just to support <>'s with no actual type prefix
-          push:
-            - meta_scope: storage.type.generic.java
-            - match: '>|[^\w\s,\[\]<]'
-              pop: true
-    - match: '\b((?:[a-z]\w*\.)*[A-Z]+\w*)(?=\[)'
-      push:
-        - meta_scope: storage.type.object.array.java
-        - match: '(?=[^\]\s])'
-          pop: true
-        - match: '\['
-          push:
-            - match: '\]'
-              pop: true
-            - include: code
-    - match: '\b(?:[a-z]\w*(\.))*[A-Z]+\w*\b'
-      scope: storage.type.java
-      captures:
-        1: keyword.operator.dereference.java
+
   object-types-inherited:
-    - match: '\b((?:[a-z]\w*\.)*[A-Z]+\w*)<'
-      push:
-        - meta_scope: entity.other.inherited-class.java
-        - match: '>|[^\w\s,<]'
-          pop: true
-        - include: object-types
-        - match: <
-          comment: This is just to support <>'s with no actual type prefix
-          push:
-            - meta_scope: storage.type.generic.java
-            - match: '>|[^\w\s,<]'
-              pop: true
-    - match: '\b(?:[a-z]\w*(\.))*[A-Z]+\w*'
+    - match: '\b{{qualified_id}}\b(?=\s*<)'
       scope: entity.other.inherited-class.java
-      captures:
-        1: keyword.operator.dereference.java
+      push:
+        - match: '<'
+          scope: punctuation.definition.generic.begin.java
+          set:
+            - meta_scope: meta.generic.java
+            - match: '>'
+              scope: punctuation.definition.generic.end.java
+              pop: true
+            - include: generic-instantiation
+    - match: '\b{{qualified_id}}\b'
+      scope: entity.other.inherited-class.java
 
   method-parameters:
     - meta_scope: meta.method.identifier.java
@@ -603,5 +579,4 @@ contexts:
 
   values:
     - include: strings
-    # - include: object-types
     - include: constants-and-special-vars

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -224,18 +224,26 @@ contexts:
           scope: keyword.operator.assert.expression-separator.java
         - include: code
   class:
-    - match: '(?=\w?[\w\s]*(?:class|(?:@)?interface|enum)\s+\w+)'
+    - match: '(?=\w?[\w\s]*(?:class|(?:@)?interface|enum)(\s+\w+|\b))'
       push:
         - meta_scope: meta.class.java
         - match: "}"
           scope: punctuation.section.class.end.java
           pop: true
         - include: storage-modifiers
-        - match: (\bclass|(?:@)?\binterface|\benum)(?:\s+|\b)(\w+)
+        - match: (\bclass|(?:@)?\binterface|\benum)(?:\s+(\w+)|\b)
           scope: meta.class.identifier.java
           captures:
             1: storage.type.java
             2: entity.name.class.java
+        - match: '<'
+          scope: punctuation.definition.generic.begin.java
+          push:
+            - meta_scope: meta.generic.java
+            - match: '>'
+              scope: punctuation.definition.generic.end.java
+              pop: true
+            - include: generic-instantiation
         - match: \bextends\b
           scope: keyword.declaration.extends.java
           push:
@@ -385,6 +393,14 @@ contexts:
               scope: meta.method.identifier.java
               pop: true
             - include: method-parameters
+        - match: '<'
+          scope: punctuation.definition.generic.begin.java
+          push:
+            - meta_scope: meta.generic.java
+            - match: '>'
+              scope: punctuation.definition.generic.end.java
+              pop: true
+            - include: generic-instantiation
         - match: (?=\w.*\s+\w+\s*\()
           push:
             - meta_scope: meta.method.return-type.java
@@ -448,6 +464,8 @@ contexts:
     - match: '{{id}}'
       scope: variable.parameter.java
       set: method-parameters
+    - match: (?=\S)
+      pop: true
 
   # duplicated due to the meta scope
   raw-parameters:
@@ -481,6 +499,8 @@ contexts:
     - match: '{{id}}'
       scope: variable.parameter.java
       set: raw-parameters
+    - match: (?=\S)
+      pop: true
 
   lambdas:
     - match: '(?={{lambda_lookahead}})'

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -14,10 +14,15 @@ variables:
   qualified_id: '(?:(?:{{id}}\.)*{{id}})'
 
 contexts:
+  prototype:
+    - include: comments
+
   main:
+    - include: comments
     - include: package
     - include: import
     - include: code
+
   package:
     - match: '\bpackage\b'
       scope: keyword.other.package.java
@@ -133,7 +138,6 @@ contexts:
           scope: punctuation.section.class.end.java
           pop: true
         - include: storage-modifiers
-        - include: comments
         - match: (\bclass|(?:@)?\binterface|\benum)(?:\s+|\b)(\w+)
           scope: meta.class.identifier.java
           captures:
@@ -146,7 +150,6 @@ contexts:
             - match: '(?={|\bimplements\b)'
               pop: true
             - include: object-types-inherited
-            - include: comments
         - match: \b(implements)\b
           scope: keyword.declaration.implements.java
           push:
@@ -154,7 +157,6 @@ contexts:
             - match: '(?=\bextends\b|\{)'
               pop: true
             - include: object-types-inherited
-            - include: comments
         - match: "{"
           push:
             - meta_scope: meta.class.body.java
@@ -162,7 +164,6 @@ contexts:
               pop: true
             - include: class-body
   class-body:
-    - include: comments
     - include: class
     - include: enums
     - include: methods
@@ -170,7 +171,6 @@ contexts:
     - include: storage-modifiers
     - include: code
   code:
-    - include: comments
     - include: class
     - match: "{"
       push:
@@ -221,7 +221,6 @@ contexts:
       push:
         - match: "(?=;|})"
           pop: true
-        - include: comments
         - match: \w+
           scope: constant.other.enum.java
           push:
@@ -380,6 +379,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.java
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.java
         - match: '"'
           scope: punctuation.definition.string.end.java
@@ -389,6 +389,7 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.begin.java
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.java
         - match: "'"
           scope: punctuation.definition.string.end.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -415,6 +415,8 @@ contexts:
             - match: "(?=})"
               pop: true
             - include: code
+        - match: (?=\S)
+          pop: true
 
   object-types-inherited:
     - match: '\b{{qualified_id}}\b(?=\s*<)'

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -322,7 +322,7 @@ contexts:
       scope: invalid.illegal.java
     - match: \b(try|catch|finally|throw)\b
       scope: keyword.control.catch-exception.java
-    - match: '\?|(?:[:](?=[^:]))'
+    - match: '\?|:'
       scope: keyword.control.java
     - match: \b(return|break|case|continue|default|do|while|for|switch|if|else)\b
       scope: keyword.control.java
@@ -343,8 +343,8 @@ contexts:
       scope: keyword.operator.arithmetic.java
     - match: (!|&&|\|\|)
       scope: keyword.operator.logical.java
-    - match: (?<=\S)\.(?=\S)
-      scope: keyword.operator.dereference.java
+    - match: \.
+      scope: punctuation.accessor.java
     - match: ;
       scope: punctuation.terminator.java
   methods:

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -385,14 +385,12 @@ contexts:
         - match: "}|(?=;)"
           pop: true
         - include: storage-modifiers
-        - match: (\w+)\s*\(
+        - match: (\w+)\s*(\()
           captures:
             1: entity.name.function.java
+            2: punctuation.section.parens.begin.java
           push:
             - meta_scope: meta.method.identifier.java
-            - match: \)
-              scope: meta.method.identifier.java
-              pop: true
             - include: method-parameters
         - match: '<'
           scope: punctuation.definition.generic.begin.java
@@ -446,6 +444,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.java
     - match: \)
+      scope: punctuation.section.parens.end.java
       pop: true
   method-parameter-after:
     - meta_scope: meta.method.identifier.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -184,13 +184,34 @@ class InvalidStuff
    volatile
 // ^^^^^^^^ storage.modifier.java
 
-   foo()
+   foo();
 // ^^^ variable.function.java
-   Foo()
+   Foo();
 // ^^^ variable.function.java
-   foo ()
+   foo ();
 // ^^^ variable.function.java
-   foo<int>()
+   foo<int>();
 // ^^^ variable.function.java
-   foo <int>()
+   foo <int>();
 // ^^^ variable.function.java
+
+   a -> 42;
+// ^ variable.parameter.java
+//   ^^ storage.type.lambda.java
+//      ^^ constant.numeric
+
+   a -> { return 42; };
+//      ^^^^^^^^^^^^^^ meta.lambda.body.java
+
+   (a, b) -> 42;
+//  ^ variable.parameter.java
+//     ^ variable.parameter.java
+//        ^^ storage.type.lambda.java
+//           ^^ constant.numeric
+
+   (int a, Foo<Integer>[] b) -> 42;
+//  ^^^ storage.type.primitive
+//      ^ variable.parameter.java
+//                    ^ variable.parameter.java
+//                       ^^ storage.type.lambda.java
+//                          ^^ constant.numeric

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -104,17 +104,18 @@ public class SyntaxTest {
 //                                      ^^ keyword.operator.method-reference.java
     }
 
-    private static void anotherMethod() throws MyException {
+    private static void anotherMethod() throws MyException<Abc> {
 //  ^^^^^^^ storage.modifier.java
 //          ^^^^^^ storage.modifier.java
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method.java
 //                      ^^^^^^^^^^^^^^^ meta.method.identifier.java
 //                                     ^^^^^^^^^^^^^^^^^^^^^^ - meta.method.identifier.java
-//                                                         ^^ meta.method.body.java
+//                                                              ^^ meta.method.body.java
 //                 ^^^^ meta.method.return-type.java storage.type
 //                      ^^^^^^^^^^^^^ entity.name.function.java
 //                                      ^^^^^^ storage.modifier.java
-//                                             ^^^^^^^^^^^ meta.throwables.java
+//                                             ^^^^^^^^^^^^^^^^ meta.throwables.java
+//                                                        ^^^^^ meta.generic.java
         throw new MyException
                 ("hello (world)");
 //                              ^ - string

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -62,7 +62,7 @@ public class SyntaxTest {
             .collect(Collectors.toCollection(ArrayList::new)));
 //                                                      ^^^ meta.method.body.java - keyword.control.new.java
 //                                                      ^^^ variable.function.reference.java
-//                                                    ^^ punctuation.accessor.java
+//                                                    ^^ punctuation.accessor.double-colon.java
         anotherMethod();
         try (Stream<String> lines = Files.lines(path)) {
 //      ^^^ keyword.control.catch-exception.java
@@ -101,7 +101,7 @@ public class SyntaxTest {
 //                                     ^^^^^^ support.type.java
 //                                             ^^^^ variable.parameter.java
         args.stream().forEach(System.out::println);
-//                                      ^^ punctuation.accessor.java
+//                                      ^^ punctuation.accessor.double-colon.java
     }
 
     private static void anotherMethod() throws MyException<Abc> {

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -121,6 +121,9 @@ class ExtendsTest implements Foo {}
 //                ^^^^^^^^^^ keyword.declaration.implements.java
 //                           ^^^ entity.other.inherited-class.java
 
+class Foo<A> extends Bar<? extends A> {}
+//                         ^^^^^^^ meta.definition.class.inherited.classes.java keyword.declaration.extends.java
+
 class AnyClass {
 //    ^^^^^^^^ entity.name.class.java
     int bar; // this comment() is recognized as code
@@ -216,3 +219,4 @@ new Foo<? super Bar>();
 
 new Foo<int>();
 //      ^^^ invalid.illegal.primitive-instantiation.java
+

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -50,8 +50,10 @@ public class SyntaxTest {
 //                                          ^^ meta.method.body.java
 //                ^^^^ meta.method.return-type.java storage.type
 //                     ^^^^ entity.name.function.java
+//                         ^ punctuation.section.parens.begin.java
 //                           ^^^^^ support.class.java
 //                                    ^^^^ variable.parameter.java
+//                                        ^ punctuation.section.parens.end.java
         String[] strings = new String[5];
 //                        ^^^^^^^^^^^^^^ meta.assignment.rhs.java
 //                         ^^^ keyword.control.new.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -172,9 +172,9 @@ class InvalidStuff
 // ^^^ variable.function.java
    foo ();
 // ^^^ variable.function.java
-   foo<int>();
+   foo<A>();
 // ^^^ variable.function.java
-   foo <int>();
+   foo <B>();
 // ^^^ variable.function.java
 
    a -> 42;

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -27,7 +27,6 @@ public class SyntaxTest {
     private String memberString2 = new String("Hello");
     private String memberString3 = String.valueOf("Hello");
 //  ^^^^^^^ storage.modifier.java
-//          ^^^^^^ storage.type.java
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.assignment.rhs.java
 //                               ^ keyword.operator.assignment.java
 //                                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.assignment.rhs.java
@@ -49,7 +48,6 @@ public class SyntaxTest {
 //                                          ^^ meta.method.body.java
 //                ^^^^ meta.method.return-type.java storage.type
 //                     ^^^^ entity.name.function.java
-//                          ^^^^^ storage.type.java
 //                                    ^^^^ variable.parameter.java
         String[] strings = new String[5];
 //                        ^^^^^^^^^^^^^^ meta.assignment.rhs.java
@@ -58,13 +56,10 @@ public class SyntaxTest {
         printList(Arrays.stream(args)
             .collect(Collectors.toCollection(ArrayList::new)));
 //                                                      ^^^ meta.method.body.java - keyword.control.new.java
-//                                                    ^^ keyword.control.java
-//                                           ^^^^^^^^^ storage.type.java
-//                   ^^^^^^^^^^ storage.type.java
+//                                                    ^^ keyword.control.method-reference.java
         anotherMethod();
         try (Stream<String> lines = Files.lines(path)) {
 //      ^^^ keyword.control.catch-exception.java
-//           ^^^^^^^^^^^^^^ storage.type.generic.java
 //                                 ^^^^^^^^^^^^^^^^^^ meta.assignment.rhs.java
 //                                                   ^ meta.method.body.java - meta.assignment.rhs.java
             lines.forEach(System.out::println);
@@ -96,11 +91,9 @@ public class SyntaxTest {
 //                                                   ^^ meta.method.body.java
 //                 ^^^^ meta.method.return-type.java storage.type
 //                      ^^^^^^^^^ entity.name.function.java
-//                                ^^^^^^^^^^^^ storage.type.generic.java
 //                                             ^^^^ variable.parameter.java
         args.stream().forEach(System.out::println);
-//                            ^^^^^^ storage.type.java
-//                                      ^^ keyword.control.java
+//                                      ^^ keyword.control.method-reference.java
     }
 
     private static void anotherMethod() throws MyException {
@@ -113,7 +106,7 @@ public class SyntaxTest {
 //                 ^^^^ meta.method.return-type.java storage.type
 //                      ^^^^^^^^^^^^^ entity.name.function.java
 //                                      ^^^^^^ storage.modifier.java
-//                                             ^^^^^^^^^^^ meta.throwables.java storage.type.java
+//                                             ^^^^^^^^^^^ meta.throwables.java
         throw new MyException
                 ("hello (world)");
 //                              ^ - string
@@ -161,17 +154,6 @@ public enum FooBaz {
 //  ^^^^^^^^^^^^^^^^ comment.line
 }
 
-class AnotherClass
-{
-// <- meta.class.body.java
-    Map<FileManagerFileData, String> fileData;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ storage.type.generic.java
-//                                           ^ punctuation.terminator.java
-    Map<FileManager.FileData, String> fileData;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ storage.type.generic.java
-//                                            ^ punctuation.terminator.java
-}
-
 class InvalidStuff
 {
     goto
@@ -212,6 +194,25 @@ class InvalidStuff
    (int a, Foo<Integer>[] b) -> 42;
 //  ^^^ storage.type.primitive
 //      ^ variable.parameter.java
-//                    ^ variable.parameter.java
-//                       ^^ storage.type.lambda.java
-//                          ^^ constant.numeric
+//                        ^ variable.parameter.java
+//                           ^^ storage.type.lambda.java
+//                              ^^ constant.numeric
+
+new Foo<Abc>();
+//     ^^^^^ meta.generic.java
+//     ^ punctuation.definition.generic.begin.java
+//         ^ punctuation.definition.generic.end.java
+
+new Foo<?>();
+//      ^ keyword.operator.wildcard.java
+
+new Foo<? extends Bar>();
+//      ^ keyword.operator.wildcard.java
+//        ^^^^^^^ keyword.declaration.extends.java
+
+new Foo<? super Bar>();
+//      ^ keyword.operator.wildcard.java
+//        ^^^^^ keyword.declaration.extends.java
+
+new Foo<int>();
+//      ^^^ invalid.illegal.primitive-instantiation.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -59,13 +59,15 @@ public class SyntaxTest {
         printList(Arrays.stream(args)
             .collect(Collectors.toCollection(ArrayList::new)));
 //                                                      ^^^ meta.method.body.java - keyword.control.new.java
-//                                                    ^^ keyword.control.method-reference.java
+//                                                      ^^^ variable.function.reference.java
+//                                                    ^^ keyword.operator.method-reference.java
         anotherMethod();
         try (Stream<String> lines = Files.lines(path)) {
 //      ^^^ keyword.control.catch-exception.java
 //                                 ^^^^^^^^^^^^^^^^^^ meta.assignment.rhs.java
 //                                                   ^ meta.method.body.java - meta.assignment.rhs.java
             lines.forEach(System.out::println);
+//                                    ^^^^^^^ variable.function.reference.java
         }
         for (int i = 0; i < 10; i+= 2) {
 //      ^^^ keyword.control
@@ -97,7 +99,7 @@ public class SyntaxTest {
 //                                     ^^^^^^ support.type.java
 //                                             ^^^^ variable.parameter.java
         args.stream().forEach(System.out::println);
-//                                      ^^ keyword.control.method-reference.java
+//                                      ^^ keyword.operator.method-reference.java
     }
 
     private static void anotherMethod() throws MyException {

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -25,8 +25,10 @@ public class SyntaxTest {
 //                      ^ meta.class.body.java
     private String memberString = "Hello";
     private String memberString2 = new String("Hello");
+//                                     ^^^^^^ support.class.java
     private String memberString3 = String.valueOf("Hello");
 //  ^^^^^^^ storage.modifier.java
+//          ^^^^^^ support.class.java
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.assignment.rhs.java
 //                               ^ keyword.operator.assignment.java
 //                                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.assignment.rhs.java
@@ -48,6 +50,7 @@ public class SyntaxTest {
 //                                          ^^ meta.method.body.java
 //                ^^^^ meta.method.return-type.java storage.type
 //                     ^^^^ entity.name.function.java
+//                           ^^^^^ support.class.java
 //                                    ^^^^ variable.parameter.java
         String[] strings = new String[5];
 //                        ^^^^^^^^^^^^^^ meta.assignment.rhs.java
@@ -91,6 +94,7 @@ public class SyntaxTest {
 //                                                   ^^ meta.method.body.java
 //                 ^^^^ meta.method.return-type.java storage.type
 //                      ^^^^^^^^^ entity.name.function.java
+//                                     ^^^^^^ support.type.java
 //                                             ^^^^ variable.parameter.java
         args.stream().forEach(System.out::println);
 //                                      ^^ keyword.control.method-reference.java
@@ -197,12 +201,14 @@ class InvalidStuff
    (int a, Foo<Integer>[] b) -> 42;
 //  ^^^ storage.type.primitive
 //      ^ variable.parameter.java
+//         ^^^ support.class.java
 //                        ^ variable.parameter.java
 //                           ^^ storage.type.lambda.java
 //                              ^^ constant.numeric
 
 new Foo<Abc>();
 //     ^^^^^ meta.generic.java
+//      ^^^ support.type.java
 //     ^ punctuation.definition.generic.begin.java
 //         ^ punctuation.definition.generic.end.java
 

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -126,6 +126,8 @@ class ExtendsTest implements Foo {}
 //                           ^^^ entity.other.inherited-class.java
 
 class Foo<A> extends Bar<? extends A> {}
+//       ^^^ meta.generic.java
+//        ^ support.type.java
 //                         ^^^^^^^ meta.definition.class.inherited.classes.java keyword.declaration.extends.java
 
 class AnyClass {
@@ -141,6 +143,13 @@ class AnyClass {
         System.out.println("Printed: " + finality);
 //                                     ^ keyword.operator
     }
+
+    public abstract <A> void test(A thing);
+//                  ^^^ meta.generic.java
+//                   ^ support.type.java
+
+    public void test2(Type) abc
+//                          ^^^ - variable.parameter
 }
 
 public enum FooBaz {

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -62,7 +62,7 @@ public class SyntaxTest {
             .collect(Collectors.toCollection(ArrayList::new)));
 //                                                      ^^^ meta.method.body.java - keyword.control.new.java
 //                                                      ^^^ variable.function.reference.java
-//                                                    ^^ keyword.operator.method-reference.java
+//                                                    ^^ punctuation.accessor.java
         anotherMethod();
         try (Stream<String> lines = Files.lines(path)) {
 //      ^^^ keyword.control.catch-exception.java
@@ -101,7 +101,7 @@ public class SyntaxTest {
 //                                     ^^^^^^ support.type.java
 //                                             ^^^^ variable.parameter.java
         args.stream().forEach(System.out::println);
-//                                      ^^ keyword.operator.method-reference.java
+//                                      ^^ punctuation.accessor.java
     }
 
     private static void anotherMethod() throws MyException<Abc> {


### PR DESCRIPTION
Lots of stuff.  In no particular order:

- Removed all of the lookbehind (updates #481)
- Added support for lambdas (I'm pretty sure anyway…)
- Fixed scoping of `?`, `extends` and `super` inside of generics
- Removed a metric boatload of `storage.type`
- Fixed some random punctuation scoping that was incorrect (including `.`)
- Added kitchy `invalid` scoping on primitive-instantiated generics (it's pretty safe to say these will always be invalid, given how generics are implemented on the JVM)
- Implemented full-state field declaration parsing

There's a bit of a question here though, and I don't know the answer.  Specifically:

```java
private String memberString = "Hello";
```

What should the scope of `String` be?  Clearly, if we replace `String` with `int`, the answer is `storage.type.primitive.java` with some additional meta scoping for fun.  But it's a lot less clear what we do if it's a non-primitive type.

The C++ mode says "no scoping at all", which is certainly a perspective I can rationalize.  The Scala mode says either `support.class.java` or `support.type.java` (probably the former, since Java is *super* class-oriented).  The strict reading of the scoping guidelines says `storage.type.java`.

Initially, I tried `storage.type`, but then I ran into the following signature:

```java
private Map<Foo, Bar> map = null;
```

Should the `storage.type` just cover the `Map`?  Or should it cover the whole type?  Both look very weird.  And what if the type contains a wildcard, resulting in some `keyword.operator` scoping in the *middle* of our `storage.type`?  That doesn't make any sense.

By the same token, extending the Scala `support.class`/`support.type` regime to Java also has some problems.  `<` is just a more syntactically heavyweight token than `[`, which means that Java's generics just seem more visually intrusive when the operators are not colored uniformly with the surrounding types.  Or maybe I'm just used to reading Scala.  Either way, it seems pretty darn weird.

I left the `support.type` and `support.class` scopes commented out, just so I can remember where they need to be rematerialized.  For the time being, we're just going to go with the C++ mode's minimalist scoping, rather than Scala's rich (and complicated) scoping.  Java types are a lot closer to C++ types (in terms of average complexity) than Scala types, so I think that's somewhat justifiable, even if it does make code look a little plain.

Anyway, I think the only remaining item for the Java mode is to fix annotations, which you could argue is pending a resolution on #709.

---

**Disclaimer**  I do not use Java on a regular basis.  Or at all, really.  So unlike the Scala mode, I'm not dogfooding any of this.  I'm happy to fix bugs and corner cases, but I'm probably not going to find them myself.