### PR TITLE
[Python] Use punctuation.accessor.dot

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -116,7 +116,7 @@ contexts:
               pop: true
         - include: dotted-name
         - match: (\.)
-          scope: punctuation.accessor.python
+          scope: punctuation.accessor.dot.python
         - match: (?=\S)
           pop: true
 
@@ -256,7 +256,7 @@ contexts:
     - include: dotted-name
     - match: '(\.) *(?={{identifier}})'
       captures:
-        1: punctuation.accessor.python
+        1: punctuation.accessor.dot.python
       push:
         - include: magic-function-names
         - include: magic-variable-names
@@ -301,7 +301,7 @@ contexts:
     # arbitrary attribute access
     - match: '\s*(\.)'
       captures:
-        1: punctuation.accessor.python
+        1: punctuation.accessor.dot.python
       push:
         - include: magic-function-names
         - include: magic-variable-names
@@ -432,7 +432,7 @@ contexts:
                 - meta_scope: entity.other.inherited-class.python
                 - match: '{{identifier}}(?: *(\.) *)?'
                   captures:
-                    1: punctuation.accessor.python
+                    1: punctuation.accessor.dot.python
                 - match: ''
                   pop: true
             - include: expressions
@@ -555,7 +555,7 @@ contexts:
               pop: true
             - match: ' *(\.) *(?={{identifier}})'
               captures:
-                1: punctuation.accessor.python
+                1: punctuation.accessor.dot.python
               set:
                 - include: dotted-name-specials
                 - match: '{{identifier}}(?=\s*\()'
@@ -575,7 +575,7 @@ contexts:
               pop: true
             - include: keyword-arguments
             - match: ','
-              scope: punctuation.separator.parameters.python
+              scope: punctuation.separator.arguments.python
             - include: inline-for
             - include: expressions
 
@@ -704,7 +704,7 @@ contexts:
       push:
         - match: ' *(\.) *(?={{identifier}})'
           captures:
-            1: punctuation.accessor.python
+            1: punctuation.accessor.dot.python
           push:
             - include: dotted-name-specials
             - include: generic-names

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -81,13 +81,13 @@ async
 
 myobj.method().attribute
 #^^^^^^^^^^^^^ meta.function-call
-#    ^ punctuation.accessor
+#    ^ punctuation.accessor.dot
 #     ^^^^^^ variable.function
-#             ^ punctuation.accessor
+#             ^ punctuation.accessor.dot
 
 'foo'.upper()
 #    ^^^^^^^^ meta.function-call
-#    ^ punctuation.accessor
+#    ^ punctuation.accessor.dot
 #     ^^^^^ variable.function
 
 func()
@@ -120,7 +120,7 @@ range(20)[10:2:-2]
 #             ^ punctuation.separator.slice
 
 myobj.attribute
-#    ^ punctuation.accessor
+#    ^ punctuation.accessor.dot
 
 "string"[12]
 #       ^^^^ meta.item-access - meta.structure
@@ -270,7 +270,7 @@ def _():
 #   ^^^^ support.function.builtin - keyword
     callback(print , print
 #            ^^^^^ - keyword
-#                  ^ punctuation.separator.parameters
+#                  ^ punctuation.separator.arguments
 #                    ^^^^^ - keyword
              , print)
 #              ^^^^^ - keyword
@@ -398,7 +398,7 @@ class MyClass(Inherited,
 #                      ^ punctuation.separator.inheritance
               module . Inherited2, metaclass=ABCMeta):
 #             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
-#                    ^ punctuation.accessor
+#                    ^ punctuation.accessor.dot
 #                                ^ punctuation.separator.inheritance
 #                                  ^^^^^^^^^ variable.parameter.class-inheritance
 #                                           ^ keyword.operator.assignment
@@ -417,7 +417,7 @@ class Unterminated(Inherited:
 @normal . decorator
 #^^^^^^^^^^^^^^^^^^ meta.statement.decorator
 # <- keyword.other.decorator
-#       ^ punctuation.accessor
+#       ^ punctuation.accessor.dot
 class Class():
 
     @wraps(method, 12)# comment
@@ -541,7 +541,7 @@ list(i for i in generator)
 list((i for i in generator), 123)
 #       ^^^^^^^^ meta.expression.generator
 #                         ^^^^^^^ - meta.expression.generator
-#                          ^ punctuation.separator.parameters
+#                          ^ punctuation.separator.arguments
 
 _ = [m
      for cls in self.__class__.mro()


### PR DESCRIPTION
Found this in my unpushed branches~

Imo it's a good idea to incldue the puncutation character in this scope name, similar to the comment punctuation. People might want different colors for `::` scopes in C++/Rust than for `->` in C or Php. Similarly, dots deserve their own scope name.