### PR TITLE
[YAML] Change block scalar indicator scopes

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -457,10 +457,10 @@ contexts:
     # c-l+literal(n) | c-l+folded(n)
     - match: (?:(\|)|(>))([1-9])?([-+])?  # c-b-block-header(m,t)
       captures:
-        1: punctuation.definition.block.scalar.literal.yaml
-        2: punctuation.definition.block.scalar.folded.yaml
+        1: keyword.control.flow.block-scalar.literal.yaml
+        2: keyword.control.flow.block-scalar.folded.yaml
         3: constant.numeric.indentation-indicator.yaml
-        4: support.other.chomping-indicator.yaml
+        4: storage.modifier.chomping-indicator.yaml
       push:
         - meta_include_prototype: false
         - match: ^([ ]+)(?! )  # match first non-empty line to determine indentation level

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -11,19 +11,19 @@
 # Headers ############################
 # (note that block scalars may be empty)
 - |
-# ^ punctuation.definition.block.scalar.literal
+# ^ keyword.control.flow.block-scalar.literal
 
 - >
-# ^ punctuation.definition.block.scalar.folded
+# ^ keyword.control.flow.block-scalar.folded
 
 - >1
-# ^ punctuation.definition.block.scalar
+# ^ keyword.control.flow.block-scalar
 #  ^ constant.numeric.indentation-indicator
 
 - |1-
-# ^ punctuation.definition.block.scalar
+# ^ keyword.control.flow.block-scalar
 #  ^ constant.numeric.indentation-indicator
-#   ^ support.other
+#   ^ storage.modifier.chomping-indicator
 
 # Headers and content ################
 - |


### PR DESCRIPTION
Also from my unpushed branches.

`keyword.control.flow` and `storage.modifier` seem more appropriate and the characters are important enough to warrant a colored scope.