### PR TITLE
[Python] Update magic identifiers

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -799,13 +799,13 @@ contexts:
     - match: |-
         (?x)\b__(?:
           # generic object
-          class|dict|doc|bases
+          class|dict|doc|module|name|
           # module-specific / global
-          all|doc|debug|file|name|
+          all|debug|file|package|
           # functions & methods
-          annotations|code|defaults|func|globals|kwdefaults|self|qualname|
+          annotations|closure|code|defaults|func|globals|kwdefaults|self|qualname|
           # classes (attributes)
-          module|prepare|slots|metaclass|
+          bases|prepare|slots|metaclass|mro|
           # Python 2
           members|methods
         )__\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -776,17 +776,52 @@ contexts:
       pop: true
 
   magic-function-names:
+    # https://docs.python.org/2/reference/datamodel.html
+    # https://docs.python.org/3/reference/datamodel.html
     - match: |-
         (?x)\b__(?:
-          abs|add|aenter|aexit|aiter|anext|await|and|call|cmp|coerce|complex|
-          contains|del|delattr|delete|delitem|delslice|div|divmod|enter|eq|
-          exit|float|floordiv|ge|get|getattr|getattribute|getitem|getslice|
-          gt|hash|hex|iadd|iand|idiv|ifloordiv|ilshift|imod|imul|init|
-          int|invert|ior|ipow|irshift|isub|iter|itruediv|ixor|le|len|
-          long|lshift|lt|mod|mul|ne|neg|new|nonzero|oct|or|pos|pow|
-          radd|rand|rdiv|rdivmod|repr|rfloordiv|rlshift|rmod|rmul|ror|
-          rpow|rrshift|rshift|rsub|rtruediv|rxor|set|setattr|setitem|
-          setslice|str|sub|truediv|unicode|xor
+          # unary operators
+          invert|neg|pos|abs|
+          # binary operators
+          add|and|div|divmod|floordiv|lshift|mod|mul|or|pow|rshift|sub|truediv|xor|
+          contains|
+          # right-hand binary operators
+          radd|rand|rdiv|rdivmod|rfloordiv|rlshift|rmod|rmul|ror|rpow|rrshift|rsub|rtruediv|rxor|
+          # in-place operator assignments
+          iadd|iand|idiv|ifloordiv|ilshift|imod|imul|ior|ipow|irshift|isub|itruediv|ixor|
+          # comparisons
+          eq|ge|gt|le|lt|ne|
+          cmp|rcmp| # py2
+          # primary coercion
+          bool|str|
+          nonzero|unicode| # py2
+          # number coercion (converts something to a number)
+          bytes|complex|float|index|int|round|
+          long| # py2
+          # other "coercion"
+          format|len|length_hint|hash|repr|reversed|
+          coerce|hex|oct| # py2
+          # iterator (and 'await')
+          iter|next|
+          aiter|anext|
+          await|
+          # attribute and item access
+          delattr|delitem|delslice|
+          getattr|getattribute|getitem|getslice|
+          setattr|setitem|setslice|
+          dir|missing|
+          # context manager
+          enter|exit|
+          aenter|aexit|
+          # other class magic
+          call|del|init|new|
+          instancecheck|subclasscheck|
+          # pickling
+          getnewargs|getnewargs_ex|getstate|setstate|reduce|reduce_ex|
+          # descriptors
+          delete|get|set|
+          # class-specific
+          subclasses
         )__\b
       comment: these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
       scope: support.function.magic.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -801,6 +801,7 @@ contexts:
           # other "coercion"
           format|len|length_hint|hash|repr|reversed|
           coerce|hex|oct| # py2
+          fspath|
           # iterator (and 'await')
           iter|next|
           aiter|anext|
@@ -814,12 +815,12 @@ contexts:
           enter|exit|
           aenter|aexit|
           # other class magic
-          call|del|init|new|
+          call|del|init|new|init_subclass|
           instancecheck|subclasscheck|
           # pickling
           getnewargs|getnewargs_ex|getstate|setstate|reduce|reduce_ex|
           # descriptors
-          delete|get|set|
+          delete|get|set|set_name|
           # class-specific
           subclasses
         )__\b

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -77,6 +77,11 @@ __all__
 #^^^^^^ support.variable.magic
 __file__
 #^^^^^^^ support.variable.magic
+__missing__
+#^^^^^^^^^^ support.function.magic
+__bool__ __nonzero__
+#^^^^^^^ support.function.magic
+#        ^^^^^^^^^^^ support.function.magic
 
 
 ##################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -72,7 +72,11 @@ def
 # Currently, async and await are still recognized as valid identifiers unless in an "async" block
 async
 #^^^^ - invalid.illegal.name
-#
+
+__all__
+#^^^^^^ support.variable.magic
+__file__
+#^^^^^^^ support.variable.magic
 
 
 ##################


### PR DESCRIPTION
This is the last PR remaining for proper Python 3.6 support.

Important additions in this PR are `__bool__` and `__all__` (bugfix). The others will hardly get used.