### PR TITLE
[Python] Decorator refactoring

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -91,7 +91,7 @@ contexts:
         - meta_scope: meta.statement.import.python
         - include: line-continuation-or-pop
         - include: import-alias
-        - include: dotted-name
+        - include: qualified-name
         - match: ','
           scope: punctuation.separator.import-list.python
         - match: (?=\S)
@@ -127,7 +127,7 @@ contexts:
                   pop: true
             - match: (?=\S)
               pop: true
-        - include: dotted-name
+        - include: qualified-name
         - match: (\.)
           scope: punctuation.accessor.dot.python
         - match: (?=\S)
@@ -257,13 +257,13 @@ contexts:
   line-expressions: # Always include this last!
     - include: expressions-common
     - include: line-continuation
-    - include: dotted-name
+    - include: qualified-name
 
   expressions: # Always include this last!
     # Differs from the line scope in that invalid-name matches will pop the current context
     - include: expressions-common
     - include: illegal-names-pop
-    - include: dotted-name
+    - include: qualified-name
     - match: '(\.) *(?={{identifier}})'
       captures:
         1: punctuation.accessor.dot.python
@@ -444,9 +444,6 @@ contexts:
                   pop: true
             - include: expressions
 
-  path:
-    - match: (?={{path}})
-
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\b'
       captures:
@@ -526,7 +523,7 @@ contexts:
           scope: keyword.other.decorator.python
         - include: line-continuation-or-pop
         - include: function-calls
-        - include: dotted-name
+        - include: qualified-name
 
   item-access:
     - match: '(?={{path}}\s*\[)'
@@ -539,7 +536,7 @@ contexts:
             - meta_content_scope: meta.item-access.python
             - match: '(?=\s*\[)'
               pop: true
-            - include: dotted-name
+            - include: qualified-name
         - match: \[
           scope: meta.item-access.python punctuation.section.brackets.begin.python
           push:
@@ -685,10 +682,29 @@ contexts:
       push:
         - include: name-specials
         - include: generic-names
+        - match: ''
+          pop: true
+
+  dotted-name:
+    - match: '\s*(\.)\s*(?={{identifier}})'
+      captures:
+        1: punctuation.accessor.dot.python
+      push:
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+
+  qualified-name:
+    - match: '(?={{path}})'
+      push:
+        - meta_scope: meta.qualified-name.python
+        - include: name
+        - include: dotted-name
+        - match: ''
+          pop: true
 
   name-specials:
-    - match: '(?!{{identifier_continue}})'
-      pop: true
     - include: builtin-functions
     - include: builtin-types
     - include: builtin-exceptions
@@ -697,22 +713,7 @@ contexts:
     - include: magic-variable-names
     - include: language-variables
 
-  dotted-name:
-    - match: '(?={{path}})'
-      push:
-        - match: ' *(\.) *(?={{identifier}})'
-          captures:
-            1: punctuation.accessor.dot.python
-          push:
-            - include: dotted-name-specials
-            - include: generic-names
-        - match: '(?!{{identifier_continue}})'
-          pop: true
-        - include: name
-
   dotted-name-specials:
-    - match: '(?!{{identifier_continue}})'
-      pop: true
     - include: magic-function-names
     - include: magic-variable-names
     - include: illegal-names
@@ -727,7 +728,8 @@ contexts:
     - include: generic-names
 
   generic-names:
-    - match: "{{identifier}}"
+    - match: '{{identifier}}'
+      scope: meta.generic-name.python
 
   illegal-names:
     - match: \b{{illegal_names}}\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -820,12 +820,12 @@ contexts:
       push:
         # This prevents strings after a continuation from being a docstring
         - include: strings
-        - match: '(?=\S)'
+        - match: (?=\S|^\s*$)
           pop: true
 
   line-continuation-or-pop:
     - include: line-continuation
-    - match: $|(?=;|#)
+    - match: (?=\s*($|;|#))
       pop: true
 
   magic-function-names:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -516,14 +516,48 @@ contexts:
       pop: true
 
   decorators:
-    - match: '^\s*(?=@)'
+    - match: ^\s*(?=@)
       push:
-        - meta_content_scope: meta.statement.decorator.python
+        # Due to line continuations, we don't know whether this is a "function call" yet
+        - meta_content_scope: meta.annotation.python
         - match: '@'
-          scope: keyword.other.decorator.python
+          scope: punctuation.definition.annotation.python
+        - match: $
+          pop: true
         - include: line-continuation-or-pop
-        - include: function-calls
-        - include: qualified-name
+        - match: (?=\.?\s*{{path}}\s*\() # now we do
+          set: [decorator-function-call-wrapper, qualified-name-until-leaf]
+        - match: (?=\.?\s*{{path}})
+          push: [decorator-wrapper, qualified-name-until-leaf]
+        - match: \S
+          scope: invalid.illegal.character.python
+          pop: true
+
+  decorator-wrapper:
+    - meta_scope: meta.annotation.python
+    - match: '{{identifier}}'
+      scope: meta.qualified-name.python variable.annotation.python
+    - match: ''
+      pop: true
+
+  decorator-function-call-wrapper:
+    - meta_scope: meta.annotation.function.python
+    - match: '{{identifier}}'
+      scope: meta.qualified-name.python variable.annotation.function.python
+    - match: \)
+      scope: punctuation.section.arguments.end.python
+      set: after-expression
+    - match: \(
+      scope: punctuation.section.arguments.begin.python
+      push:
+        - meta_content_scope: meta.annotation.arguments.python
+        - match: (?=\))
+          pop: true
+        - include: keyword-arguments
+        - match: ','
+          scope: punctuation.separator.arguments.python
+        - include: inline-for
+        - include: expressions
 
   item-access:
     - match: '(?={{path}}\s*\[)'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -677,6 +677,7 @@ contexts:
         	SystemExit|StopIteration|NotImplemented|KeyboardInterrupt|GeneratorExit
         )\b
       scope: support.type.exception.python
+
   builtin-functions:
     - match: |-
         (?x)\b(

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -548,41 +548,27 @@ contexts:
             - include: expressions
 
   function-calls:
-    - match: '(?=\.?{{path}}\s*\()'
+    - match: '(?=(\.\s*)?{{path}}\s*\()'
+      push: [function-call-wrapper, qualified-name-until-leaf]
+
+  function-call-wrapper:
+    - meta_scope: meta.function-call.python
+    - match: '{{identifier}}'
+      scope: meta.qualified-name.python variable.function.python
+    - match: \)
+      scope: punctuation.section.arguments.end.python
+      set: after-expression
+    - match: \(
+      scope: punctuation.section.arguments.begin.python
       push:
-        - meta_scope: meta.function-call.python
-        - match: \)
-          scope: punctuation.section.arguments.end.python
-          set: after-expression
-        - match: '(?=\.?{{path}}\s*\()'
-          push:
-            - match: (?=\s*\()
-              pop: true
-            - match: ' *(\.) *(?={{identifier}})'
-              captures:
-                1: punctuation.accessor.dot.python
-              set:
-                - include: dotted-name-specials
-                - match: '{{identifier}}(?=\s*\()'
-                  scope: variable.function.python
-                - include: generic-names
-            - match: '(?={{identifier}})'
-              push:
-                - include: name-specials
-                - match: '{{identifier}}(?=\s*\()'
-                  scope: variable.function.python
-                - include: generic-names
-        - match: \(
-          scope: punctuation.section.arguments.begin.python
-          push:
-            - meta_content_scope: meta.function-call.arguments.python
-            - match: (?=\))
-              pop: true
-            - include: keyword-arguments
-            - match: ','
-              scope: punctuation.separator.arguments.python
-            - include: inline-for
-            - include: expressions
+        - meta_content_scope: meta.function-call.arguments.python
+        - match: (?=\))
+          pop: true
+        - include: keyword-arguments
+        - match: ','
+          scope: punctuation.separator.arguments.python
+        - include: inline-for
+        - include: expressions
 
   lambda:
     - match: \b(lambda)(?=\s|:|$)
@@ -703,6 +689,39 @@ contexts:
         - include: dotted-name
         - match: ''
           pop: true
+
+  qualified-name-until-leaf:
+    # Push this together with another context to match a qualified name
+    # until the last non-special identifier (if any).
+    # This allows the leaf to be scoped individually.
+    - meta_scope: meta.qualified-name.python
+    - include: name-specials
+    # If a line continuation follows, this may or may not be the last leaf (most likley not though)
+    - match: '{{identifier}}(?=\s*\\)'
+      scope: meta.generic-name.python
+    - match: (?={{identifier}}\s*\.)
+      push:
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: (\.)\s*(?={{identifier}}\s*\.)
+      captures:
+        1: punctuation.accessor.dot.python
+      push:
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: (\.)\s*(?={{identifier}})
+      captures:
+        1: punctuation.accessor.dot.python
+      set:
+        - include: dotted-name-specials
+        - match: ''
+          pop: true
+    - match: (?=\S|$)
+      pop: true
 
   name-specials:
     - include: builtin-functions

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -471,21 +471,68 @@ class Unterminated(Inherited:
 #                           ^ invalid.illegal
 
 
-@normal . decorator
-#^^^^^^^^^^^^^^^^^^ meta.statement.decorator
-# <- keyword.other.decorator
-#       ^ punctuation.accessor.dot
+##################
+# Decorators
+##################
+
+@ normal . decorator
+# <- meta.annotation punctuation.definition.annotation
+#^^^^^^^^^^^^^^^^^^^ meta.annotation
+# ^^^^^^^^^^^^^^^^^^ meta.qualified-name
+# ^^^^^^ meta.generic-name - variable.annotation
+#          ^^^^^^^^^ variable.annotation
+#        ^ punctuation.accessor.dot
+#                   ^ - meta.annotation
 class Class():
 
-    @wraps(method, 12)# comment
-#^^^ - meta.statement.decorator
-#   ^^^^^^^^^^^^^^^^^^ meta.statement.decorator
-#   ^ keyword.other.decorator
-#    ^^^^^^^^^^^^^^^^^ meta.function-call
-#                     ^^^^^^^^^ comment
+    @functools.wraps(method, 12, kwarg=None)# comment
+#^^^ - meta.annotation
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.function
+#   ^ punctuation.definition.annotation
+#    ^^^^^^^^^^^^^^^ meta.qualified-name
+#    ^^^^^^^^^ meta.generic-name - variable.annotation
+#             ^ punctuation.accessor.dot
+#              ^^^^^ variable.annotation.function
+#                   ^ punctuation.section.arguments.begin
+#                          ^ punctuation.separator.arguments
+#                            ^^ constant.numeric
+#                                ^^^^^ variable.parameter
+#                                     ^ keyword.operator
+#                                      ^^^^ constant.language
+#                              ^ punctuation.separator.arguments
+#                                          ^ punctuation.section.arguments.end
+#                                           ^^^^^^^^^ comment - meta.annotation
     def wrapper(self):
-        (self, __class__)
-        pass
+        return self.__class__(method)
+
+    @deco #comment
+#^^^ - meta.annotation
+#   ^^^^^ meta.annotation
+#    ^^^^ meta.qualified-name variable.annotation.function
+#        ^^ - meta.annotation
+#         ^^^^^^^^ comment
+
+    @staticmethod
+#   ^^^^^^^^^^^^^ meta.annotation
+#    ^^^^^^^^^^^^ support.function.builtin
+#                ^ - meta.annotation
+
+    @deco[4]
+#        ^ invalid.illegal.character
+
+    @deco \
+        . rator
+#       ^^^^^^^ meta.annotation
+#       ^ punctuation.accessor.dot
+
+    @ deco \
+        . rator()
+#       ^^^^^^^ meta.annotation.function
+#         ^^^^^ variable.annotation.function
+
+    @ deco \
+#     ^^^^ meta.qualified-name meta.generic-name - variable.annotation
+#          ^ punctuation.separator.continuation.line
 
 
 ##################

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -534,6 +534,11 @@ class Class():
 #     ^^^^ meta.qualified-name meta.generic-name - variable.annotation
 #          ^ punctuation.separator.continuation.line
 
+    @deco \
+
+    def f(): pass
+#   ^^^ storage.type.function - meta.decorator
+
 
 ##################
 # Collection literals and generators

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -96,6 +96,54 @@ open.open.open
 
 
 ##################
+# Function Calls
+##################
+
+identifier()
+#^^^^^^^^^^^ meta.function-call
+#^^^^^^^^^ meta.qualified-name variable.function
+#         ^ punctuation.section.arguments.begin
+#          ^ punctuation.section.arguments.end
+
+dotted.identifier(12, True)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+#                 ^^^^^^^^ meta.function-call.arguments
+#^^^^^^^^^^^^^^^^ meta.qualified-name
+#^^^^^^ - variable.function
+#     ^ punctuation.accessor.dot
+#      ^^^^^^^^^^ variable.function
+
+open.__new__(12, True)
+#^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+#^^^ support.function.builtin
+#   ^ punctuation.accessor.dot
+#    ^^^^^^^ support.function.magic
+
+TypeError()
+#^^^^^^^^ support.type.exception
+#
+module.TypeError()
+#^^^^^^^^^^^^^^^ meta.function-call
+#      ^^^^^^^^^ - support
+#      ^^^^^^^^^ variable.function
+
+open.open.open()
+#^^^ support.function.builtin
+#   ^ punctuation.accessor.dot
+#    ^^^^^^^^^ - support
+#         ^^^^ variable.function
+#
+
+if p.type not in ('NUMBER', 'INTEGER'):
+#             ^^ keyword.operator - meta.function-call invalid
+
+call(from='no')
+#^^^^^^^^^^^^^^ meta.function-call
+#    ^^^^ invalid.illegal.name
+#        ^ keyword.operator.assignment
+#         ^^^^ string
+
+##################
 # Expressions
 ##################
 
@@ -138,11 +186,6 @@ def _():
 #          ^^ invalid.illegal.name
 #              ^^ invalid.illegal.name
 
-    call(from='no')
-#   ^^^^^^^^^^^^^^^ meta.function-call
-#        ^^^^ invalid.illegal.name
-#            ^ keyword.operator.assignment
-#             ^^^^ string
     lambda
 #   ^^^^^^ storage.type.function.inline
 
@@ -157,14 +200,10 @@ myobj.method().attribute
 #     ^^^^^^ variable.function
 #             ^ punctuation.accessor.dot
 
-'foo'.upper()
-#    ^^^^^^^^ meta.function-call
+'foo'. upper()
+#    ^^^^^^^^^ meta.function-call
 #    ^ punctuation.accessor.dot
-#     ^^^^^ variable.function
-
-func()
-#^^^^^ meta.function-call
-#^^^ variable.function
+#      ^^^^^ variable.function
 
 func()(1, 2)
 # <- meta.function-call

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -64,24 +64,34 @@ import re; re.compile(r'')
 # Identifiers
 ##################
 
+identifier
+#^^^^^^^^^ meta.qualified-name meta.generic-name
+
 class
 #^^^^ storage.type.class
 def
 #^^ storage.type.function
 
-# Currently, async and await are still recognized as valid identifiers unless in an "async" block
+# async and await are still recognized as valid identifiers unless in an "async" block
 async
 #^^^^ - invalid.illegal.name
 
 __all__
-#^^^^^^ support.variable.magic
+#^^^^^^ meta.qualified-name support.variable.magic - meta.generic-name
 __file__
 #^^^^^^^ support.variable.magic
 __missing__
 #^^^^^^^^^^ support.function.magic
-__bool__ __nonzero__
+__bool__ abc.__nonzero__
 #^^^^^^^ support.function.magic
-#        ^^^^^^^^^^^ support.function.magic
+#            ^^^^^^^^^^^ support.function.magic
+
+TypeError module.TypeError
+#^^^^^^^^ support.type.exception
+#                ^^^^^^^^^ - support
+
+open.open.open
+#    ^^^^^^^^^ - support
 
 
 ##################
@@ -127,9 +137,6 @@ myobj[1][2](0)
 range(20)[10:2:-2]
 #           ^ punctuation.separator.slice
 #             ^ punctuation.separator.slice
-
-myobj.attribute
-#    ^ punctuation.accessor.dot
 
 "string"[12]
 #       ^^^^ meta.item-access - meta.structure

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -15,6 +15,7 @@ This is a variable docstring, as supported by sphinx and epydoc
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
 """
 
+
 ##################
 # Imports
 ##################
@@ -95,6 +96,58 @@ open.open.open
 
 
 ##################
+# Expressions
+##################
+
+def _():
+    yield from
+#   ^^^^^ keyword.control.flow.yield
+#         ^^^^ keyword.control.flow.yield-from
+
+    yield fromsomething
+#         ^^^^ - keyword
+
+    a if b else c
+#     ^^ keyword.control.flow
+#          ^^^^ keyword.control.flow
+
+    c = lambda: pass
+#       ^^^^^^^ meta.function.inline
+#       ^^^^^^ storage.type.function.inline
+#             ^ punctuation.section.function.begin
+#               ^^^^ keyword
+
+    _(lambda x, y: 10)
+#     ^^^^^^^^^^^^ meta.function.inline
+#     ^^^^^^ storage.type.function.inline
+#           ^^^^^ meta.function.inline.parameters
+#            ^ variable.parameter
+#             ^ punctuation.separator.parameters
+#               ^ variable.parameter
+#                  ^^ constant.numeric
+
+    lambda \
+        a, \
+        b=2: pass
+#       ^^^^ meta.function.inline
+#        ^ keyword.operator.assignment
+#          ^ punctuation.section.function.begin
+#            ^^^^ keyword
+
+    lambda as, in=2: pass
+#          ^^ invalid.illegal.name
+#              ^^ invalid.illegal.name
+
+    call(from='no')
+#   ^^^^^^^^^^^^^^^ meta.function-call
+#        ^^^^ invalid.illegal.name
+#            ^ keyword.operator.assignment
+#             ^^^^ string
+    lambda
+#   ^^^^^^ storage.type.function.inline
+
+
+##################
 # Compound expressions
 ##################
 
@@ -157,6 +210,45 @@ range(20)[10:2:-2]
 1[12]
 #^^^^ - meta.item-access
 
+
+##################
+# print & exec
+##################
+
+def _():
+    print (file=None)
+#   ^^^^^ support.function.builtin - keyword
+    print . __class__
+#   ^^^^^ support.function.builtin - keyword
+    print "keyword"
+#   ^^^^^ keyword.other.print
+    print __init__
+#   ^^^^^ keyword.other.print
+#
+    exec 123
+#   ^^^^ keyword
+    exec ("print('ok')")
+#   ^^^^ support.function.builtin - keyword
+    callback(print , print
+#            ^^^^^ - keyword
+#                  ^ punctuation.separator.arguments
+#                    ^^^^^ - keyword
+             , print)
+#              ^^^^^ - keyword
+
+    some \
+      print \
+#     ^^^^^ keyword.other.print
+
+    func(
+        print
+#       ^^^^^ support.function.builtin - keyword
+    )
+
+    print
+#   ^^^^^ keyword.other.print
+
+
 ##################
 # Block statements
 ##################
@@ -212,96 +304,6 @@ def _():
 #                                    ^ punctuation.section.block.with
         await something()
 #       ^^^^^ keyword.other.await
-
-
-
-##################
-# Expressions
-##################
-
-def _():
-    yield from
-#   ^^^^^ keyword.control.flow.yield
-#         ^^^^ keyword.control.flow.yield-from
-
-    yield fromsomething
-#         ^^^^ - keyword
-
-    a if b else c
-#     ^^ keyword.control.flow
-#          ^^^^ keyword.control.flow
-
-    c = lambda: pass
-#       ^^^^^^^ meta.function.inline
-#       ^^^^^^ storage.type.function.inline
-#             ^ punctuation.section.function.begin
-#               ^^^^ keyword
-
-    _(lambda x, y: 10)
-#     ^^^^^^^^^ meta.function.inline
-#     ^^^^^^ storage.type.function.inline
-#           ^^^^^ meta.function.inline.parameters
-#            ^ variable.parameter
-#             ^ punctuation.separator.parameters
-#               ^ variable.parameter
-#                  ^^ constant.numeric
-
-    lambda \
-        a, \
-        b=2: pass
-#       ^^^^ meta.function.inline
-#        ^ keyword.operator.assignment
-#          ^ punctuation.section.function.begin
-#            ^^^^ keyword
-
-    lambda as, in=2: pass
-#          ^^ invalid.illegal.name
-#              ^^ invalid.illegal.name
-    call(from='no')
-#   ^^^^^^^^^^^^^^^ meta.function-call
-#        ^^^^ invalid.illegal.name
-#            ^ keyword.operator.assignment
-#             ^^^^ string
-    lambda
-#   ^^^^^^ storage.type.function.inline
-
-
-##################
-# print & exec
-##################
-
-def _():
-    print (file=None)
-#   ^^^^^ support.function.builtin - keyword
-    print . __class__
-#   ^^^^^ support.function.builtin - keyword
-    print "keyword"
-#   ^^^^^ keyword.other.print
-    print __init__
-#   ^^^^^ keyword.other.print
-#
-    exec 123
-#   ^^^^ keyword
-    exec ("print('ok')")
-#   ^^^^ support.function.builtin - keyword
-    callback(print , print
-#            ^^^^^ - keyword
-#                  ^ punctuation.separator.arguments
-#                    ^^^^^ - keyword
-             , print)
-#              ^^^^^ - keyword
-
-    some \
-      print \
-#     ^^^^^ keyword.other.print
-
-    func(
-        print
-#       ^^^^^ support.function.builtin - keyword
-    )
-
-    print
-#   ^^^^^ keyword.other.print
 
 
 ##################


### PR DESCRIPTION
**Requires https://github.com/SublimeTextIssues/Core/issues/1190 to be fixed before merging!**

---

When trying to implement proper scoping according to #709 and #737, I noticed that I would have to rebuild almost the entire `function-calls` scope for decorators only with different scope names. Since I religiously hate duplicated code (especially considering I would have to duplicate it *twice*), I worked on refactoring how qualified names are matched instead and `qualified-name-until-leaf` was born. 

Unfortunately, it is affected by the bug described in https://github.com/SublimeTextIssues/Core/issues/1190 and thus is not ready to be merged yet. The following 17 failing tests should be fixed when this bug is fixed:

```
Packages/Python/syntax_test_python.py:102:2: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:3: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:4: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:5: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:6: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:7: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:8: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:9: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:102:10: [meta.qualified-name variable.function] does not match scope [source.python meta.function-call.python]
Packages/Python/syntax_test_python.py:508:7: [meta.annotation] does not match scope [source.python invalid.illegal.character.python]
Packages/Python/syntax_test_python.py:508:8: [meta.annotation] does not match scope [source.python]
Packages/Python/syntax_test_python.py:508:9: [meta.annotation] does not match scope [source.python]
Packages/Python/syntax_test_python.py:508:6: [meta.qualified-name variable.annotation.function] does not match scope [source.python meta.annotation.python meta.annotation.python meta.qualified-name.python]
Packages/Python/syntax_test_python.py:508:7: [meta.qualified-name variable.annotation.function] does not match scope [source.python invalid.illegal.character.python]
Packages/Python/syntax_test_python.py:508:8: [meta.qualified-name variable.annotation.function] does not match scope [source.python]
Packages/Python/syntax_test_python.py:508:9: [meta.qualified-name variable.annotation.function] does not match scope [source.python]
Packages/Python/syntax_test_python.py:520:10: [invalid.illegal.character] does not match scope [source.python meta.structure.list.python punctuation.section.list.begin.python]
FAILED: 17 of 3525 assertions in 2 files failed
```


Note: I am unsure if I split the commits correctly (and tests are passing after each of them).