### PR TITLE
Change default Markdown file extension from "mdown" to "md"

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -3,10 +3,10 @@
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Markdown
 file_extensions:
+  - md
   - mdown
   - markdown
   - markdn
-  - md
 scope: text.html.markdown
 contexts:
   main:


### PR DESCRIPTION
Requesting feedback from Sublime Text and other users.

The vast majority of Markdown files I see use .md; GitHub and BitBucket default to .md; Wikipedia lists .md first. Unless I'm in a bubble, .md seems to be much more common. Changing the default to the more common value will save time typing names for new files, and occasionally prevent the mistake of leaving it at the wrong value.