### PR TITLE
[Scala] Various stateful bailout bugs

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -399,10 +399,12 @@ contexts:
       push: function-tparams-brackets
     - match: ':'
       set: function-return-type-definition
-    - match: '\n'
-      set: function-type-parameter-list-newline
     - match: '(?=[\{\};]|{{nonopchar}}?={{nonopchar}})'
       pop: true
+    - match: (?=\S)
+      pop: true
+    - match: '\n'
+      set: function-type-parameter-list-newline
 
   function-type-parameter-list-newline:
     - include: decl-newline-double-check
@@ -423,6 +425,8 @@ contexts:
     - match: '(?=[\{\};]|{{nonopchar}}?={{nonopchar}})'
       pop: true
     - include: delimited-type-expression
+    - match: (?=\S)
+      pop: true
 
   function-return-type-definition-newline:
     - include: decl-newline-double-check
@@ -457,7 +461,7 @@ contexts:
       set: function-return-type-definition
     - match: '\n'
       set: function-parameter-list-newline
-    - match: '(?=[\{=])'
+    - match: '(?=\S)'
       pop: true
 
   function-parameter-list-newline:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -387,7 +387,7 @@ contexts:
   # this is included when a single newline is found in a declaration
   # you should never push/set this context, only include
   decl-newline-double-check:
-    - match: '(?=[\{\}\)]|\b(class|def|val|var|trait|object|private|protected|for|while|if|)\b)'
+    - match: '(?=[\{\}\)]|\b(case|class|def|val|var|trait|object|private|protected|for|while|if)\b)'
       pop: true
     - match: '\n'
       pop: true
@@ -473,7 +473,7 @@ contexts:
     - match: '\['
       push: class-tparams-brackets
     - match: '(?=\b(extends|with)\b)'
-      set: class-inheritance
+      set: class-inheritance-extends
     - match: '(?=\{)'
       set: class-pre-inheritance-early-initializer
     - match: '\n'
@@ -519,12 +519,12 @@ contexts:
                 - match: '(?=[=])'
                   pop: true
         - include: main
-    - match: '\n'
-      set: class-parameter-list-newline
     - match: '(?=\b(extends|with)\b)'
-      set: class-inheritance
+      set: class-inheritance-extends
     - match: '(?=\{)'
       set: class-pre-inheritance-early-initializer
+    - match: '\n'
+      set: class-parameter-list-newline
 
   class-parameter-list-newline:
     - include: decl-newline-double-check
@@ -552,9 +552,6 @@ contexts:
     - match: '(?=\S)'
       set: class-pre-inheritance-early-initializer
 
-  class-inheritance:
-    - include: class-inheritance-extends
-
   class-inheritance-extends:
     - match: \bwith\b
       scope: invalid.keyword.with-before-extends.scala
@@ -570,7 +567,7 @@ contexts:
   class-inheritance-extends-newline:
     - include: decl-newline-double-check
     - match: '(?=\S)'
-      set: class-inheritance
+      set: class-inheritance-extends
 
   class-inheritance-extends-token:
     - match: '{{id}}'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1413,3 +1413,19 @@ class Foo extends (Int => String)
 class Foo extends Bar[Int]
 //                   ^ punctuation.section.brackets.begin.scala
 //                       ^ punctuation.section.brackets.end.scala
+
+class Foo
+    extends Bar
+//  ^^^^^^^ keyword.declaration.scala
+//          ^^^ entity.other.inherited-class.scala
+
+class Foo extends Bar
+    with Baz
+//  ^^^^ keyword.declaration.scala
+//       ^^^ entity.other.inherited-class.scala
+
+class Foo extends Bar
+    with Baz
+    with Bin
+//  ^^^^ keyword.declaration.scala
+//       ^^^ entity.other.inherited-class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1429,3 +1429,15 @@ class Foo extends Bar
     with Bin
 //  ^^^^ keyword.declaration.scala
 //       ^^^ entity.other.inherited-class.scala
+
+def foo
+   42
+// ^^ constant.numeric.integer.scala
+
+def foo()
+   42
+// ^^ constant.numeric.integer.scala
+
+def foo():
+   42
+// ^^ constant.numeric.integer.scala


### PR DESCRIPTION
Random best practice that's worth documenting somewhere…  When you have any sort of stateful context chain, make sure each link in the chain *ends* with the following:

```yaml
- match: (?=\S)
  pop: true
```

Anything you don't recognize, you should just bail on.

Another best practice: don't accidentally match on double word boundary by having a trailing pipe character.