### PR TITLE
[Scala] Some more bail-out double-checks on stateful class decls

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -567,6 +567,8 @@ contexts:
       pop: true
     - match: '\n'
       set: class-inheritance-extends-newline
+    - match: (?=\S)
+      pop: true
 
   class-inheritance-extends-newline:
     - include: decl-newline-double-check
@@ -586,6 +588,8 @@ contexts:
         - include: delimited-type-expression
     - match: '\n'
       set: class-inheritance-extends-token-newline
+    - match: (?=\S)
+      pop: true
 
   class-inheritance-extends-token-newline:
     - include: decl-newline-double-check
@@ -613,6 +617,8 @@ contexts:
       set: class-inheritance-early-initializer
     - match: '\n'
       set: class-inheritance-extends-token-after-newline
+    - match: (?=\S)
+      pop: true
 
   class-inheritance-extends-token-after-newline:
     - include: decl-newline-double-check
@@ -647,10 +653,10 @@ contexts:
     - match: \bwith\b
       scope: keyword.declaration.scala
       set: class-inheritance-extends-token
-    - match: '(?=\{)'
-      pop: true
     - match: '\n'
       set: class-inheritance-with-newline
+    - match: '(?=\S)'
+      pop: true
 
   class-inheritance-with-newline:
     - include: decl-newline-double-check

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1441,3 +1441,9 @@ def foo()
 def foo():
    42
 // ^^ constant.numeric.integer.scala
+
+class Foo extends Bar with {
+   import Thing._
+// ^^^^^^ keyword.other.import.scala
+//        ^^^^^ variable.package.scala
+}


### PR DESCRIPTION
Following my own advice…  Here's an example of where this is broken on master:

```scala
class Foo extends Bar with {
  import Foo._
}
```

The `import` is scoped as an inherited class, rather than a keyword, and the `Foo` isn't scoped at all.