### PR TITLE
[Scala] Fixed bug in val body lookahead

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1104,7 +1104,7 @@ contexts:
       scope: entity.name.val.scala
     - match: '{{typeprefix}}'
       push:
-        - match: '(?=[\B\s]=[\B\s])'
+        - match: '(?={{nonopchar}}={{nonopchar}})'
           pop: true
         - include: delimited-type-expression
         - match: '(?=[\{\n])'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1441,3 +1441,9 @@ def foo()
 def foo():
    42
 // ^^ constant.numeric.integer.scala
+
+val foo: Thing =42
+//              ^^ constant.numeric.integer.scala
+
+var foo: Thing =42
+//              ^^ constant.numeric.integer.scala


### PR DESCRIPTION
`val` was using an older technique for operator lookaround, which has now been fixed.