### PR TITLE
[Scala] Fixed incorrect scoping on qualified inheritence

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -574,6 +574,8 @@ contexts:
       set: class-inheritance-extends
 
   class-inheritance-extends-token:
+    - match: '{{id}}(?=\s*\.)'
+      scope: support.constant.scala
     - match: '{{id}}'
       scope: entity.other.inherited-class.scala
       set: class-inheritance-extends-token-after

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -575,7 +575,13 @@ contexts:
 
   class-inheritance-extends-token:
     - match: '{{id}}(?=\s*\.)'
-      scope: support.constant.scala
+      scope: entity.other.inherited-class.scala
+    - match: '(?=\.)'
+      push:
+        - meta_scope: entity.other.inherited-class.scala
+        - match: \.
+          scope: punctuation.accessor.scala
+          pop: true
     - match: '{{id}}'
       scope: entity.other.inherited-class.scala
       set: class-inheritance-extends-token-after

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1441,3 +1441,9 @@ def foo()
 def foo():
    42
 // ^^ constant.numeric.integer.scala
+
+class Foo extends Bar.Baz with bin.Baz
+//                ^^^ support.constant.scala - entity.other
+//                    ^^^ entity.other.inherited-class.scala
+//                             ^^^ support.constant.scala - entity.other
+//                                 ^^^ entity.other.inherited-class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1443,7 +1443,7 @@ def foo():
 // ^^ constant.numeric.integer.scala
 
 class Foo extends Bar.Baz with bin.Baz
-//                ^^^ support.constant.scala - entity.other
-//                    ^^^ entity.other.inherited-class.scala
-//                             ^^^ support.constant.scala - entity.other
-//                                 ^^^ entity.other.inherited-class.scala
+//                ^^^^^^^ entity.other.inherited-class.scala
+//                   ^ punctuation.accessor.scala
+//                             ^^^^^^^ entity.other.inherited-class.scala
+//                                ^ punctuation.accessor.scala


### PR DESCRIPTION
We were scoping `entity.other.inherited-class` without lookahead, which meant that any qualified identifiers ended up with the *leading* token scoped as the `inherited-class` while any trailing qualifiers (which were the actual class) were unscoped in master and outright broken with my other PR branches.

Leading qualifiers are now scoped as `support.constant`, which is basically accurate.  They may be a package name, but packages and objects in Scala are semantically almost identical, and objects are scoped as `support.constant`.  From the standpoint of the language specification, the only constraint is that the identifier is "stable" (which is to say, basically a constant).

As a random note, the scoping behavior changes when parentheses are introduced.  For example:

```scala
class Foo extends Bar
class Foo extends (Bar)
```

These are identical from Scala's perspective, but they will scope differently.  The reason for this is I will only attempt to apply the `inherited-class` scope at the top level of the type expression (and it is a *general* type expression, which cannot be evaluated without literally becoming scalac).  Most type expressions are restricted in `extends`/`with` clauses without parentheses, but once we're inside of the parentheses, all's fair.  For example:

```scala
class Foo extends (A ~> B)
```

In this case, the inherited class is `~>`!  There's no way we can figure that out in general.  So we just scope anything within parentheses as a type expression, just as we would within square brackets, following a colon or following a `type ... =` expression.