### PR TITLE
[C++] Fix none highlighted preprocessor definitions in extern C blocks.

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -184,6 +184,16 @@ contexts:
           scope: punctuation.section.block.begin.c++
           set:
             - meta_scope: meta.extern-c.c++
+            - match: '^\s*(#\s*ifdef)\s*__cplusplus\s*'
+              scope: meta.preprocessor.c++
+              captures:
+                1: keyword.control.import.c++
+              set:
+                - match: '\}'
+                  scope: punctuation.section.block.end.c++
+                  pop: true
+                - include: preprocessor-global
+                - include: global
             - match: '\}'
               scope: punctuation.section.block.end.c++
               pop: true

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -184,14 +184,6 @@ contexts:
           scope: punctuation.section.block.begin.c++
           set:
             - meta_scope: meta.extern-c.c++
-            - match: '^\s*(#\s*ifdef)\s*__cplusplus\s*'
-              scope: meta.preprocessor.c++
-              captures:
-                1: keyword.control.import.c++
-              set:
-                - match: '\}'
-                  scope: punctuation.section.block.end.c++
-                  pop: true
             - match: '\}'
               scope: punctuation.section.block.end.c++
               pop: true

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -777,6 +777,24 @@ void test_in_extern_c_block()
 {
 }
 #else
+
+/* temporary C++ preprocessor block */
+#ifdef __cplusplus
+/*                <- meta.preprocessor */
+/*   <- keyword.control.import */
+# ifndef _Bool
+/*            <- meta.preprocessor */
+/*      <- keyword.control.import */
+   typedef bool _Bool;   /* semi-hackish: C++ has no _Bool; bool is builtin */
+/* ^ storage.type */
+/*              ^ entity.name.type.typedef */
+# endif
+/*     <- meta.preprocessor */
+/*     <- keyword.control.import */
+#endif
+/*    <- meta.preprocessor */
+/*    <- keyword.control.import */
+
 void test_in_extern_c_block()
 /*   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function */
 /*                         ^^ meta.function.parameters meta.group */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -67,6 +67,8 @@ contexts:
                 - match: '\}'
                   scope: punctuation.section.block.end.objc++
                   pop: true
+                - include: preprocessor-global
+                - include: global
             - match: '\}'
               scope: punctuation.section.block.end.objc++
               pop: true

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -777,6 +777,24 @@ void test_in_extern_c_block()
 {
 }
 #else
+
+/* temporary C++ preprocessor block */
+#ifdef __cplusplus
+/*                <- meta.preprocessor */
+/*   <- keyword.control.import */
+# ifndef _Bool
+/*            <- meta.preprocessor */
+/*      <- keyword.control.import */
+   typedef bool _Bool;   /* semi-hackish: C++ has no _Bool; bool is builtin */
+/* ^ storage.type */
+/*              ^ entity.name.type.typedef */
+# endif
+/*     <- meta.preprocessor */
+/*     <- keyword.control.import */
+#endif
+/*    <- meta.preprocessor */
+/*    <- keyword.control.import */
+
 void test_in_extern_c_block()
 /*   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function */
 /*                         ^^ meta.function.parameters meta.group */


### PR DESCRIPTION
While reading some C++ headers (_cffi_include.h) I recently found some blocks
not being highlighted at all. Everything from the second `__cplusplus` to the
the final `}` keeps unhighlighted.

```C++
#include <Python.h>
#ifdef __cplusplus
extern "C" {
#endif

#ifdef __cplusplus       // THE LAST HIGHLIGHTED LINE
# ifndef _Bool
   typedef bool _Bool;   /* semi-hackish: C++ has no _Bool; bool is builtin */
# endif
#endif

#ifdef __cplusplus
}                        // HIGHLIGHTED AGAIN
#endif
```

With `#ifdef __cplusplus` within an `extern "C" {` block an empty scope is set
to stack causing this issue. This issue is fixed by removing this block at all.

So the `global` and `global-preprocessor` scopes are used within external C blocks
for highlighting.
