### PR TITLE
[CSS] Fixes incorrect font highlighting in #751

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -567,7 +567,7 @@ contexts:
             )\b
       scope: support.constant.property-value.css
       # Generic Font Families: https://www.w3.org/TR/CSS2/fonts.html
-    - match: \b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)\b
+    - match: \b((?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)(?=[;,]))\b
       scope: support.constant.font-name.css
 
   property-values:

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -567,7 +567,7 @@ contexts:
             )\b
       scope: support.constant.property-value.css
       # Generic Font Families: https://www.w3.org/TR/CSS2/fonts.html
-    - match: \b((?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)(?=[;,]))\b
+    - match: \b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)(?=[;,])\b
       scope: support.constant.font-name.css
 
   property-values:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -822,3 +822,9 @@
 /*^^^^^^^ meta.property-list */
 /*  ^^^ meta.property-name */
 }/*     ^ meta.property-value */
+
+:root {
+    --body-font: Raleway, Arial, Helvetica Neue, Helvetica, sans-serif;
+/*                               ^ -support.constant.font-name.css */
+/*                                               ^ support.constant.font-name.css */
+}


### PR DESCRIPTION
This addresses #751 - `Helvetica Neue` was getting highlighted as a generic font family while it shouldn't have been. I simply added a positive lookahead to ensure that after the indicated font family name is matched, it should be followed either by a comma `,` indicating another name is coming, or a semi-colon `;` indicating that the property's values are at an end.

If this isn't the best way to do this, I'm all ears.