### PR TITLE
[Objective-C] Add support for Objective-C specific format specifier

### DIFF
--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -110,6 +110,8 @@ contexts:
           scope: punctuation.definition.string.end.objc
           pop: true
         - include: scope:source.c#string_escaped_char
+        - match: '%@'
+          scope: constant.other.placeholder.objc
         - include: scope:source.c#string_placeholder
 
   unique-keywords:

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -518,3 +518,14 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
+
+
+/////////////////////////////////////////////
+// Objective-C specific format specifiers
+/////////////////////////////////////////////
+
+print ("%@", @"String")
+/*      ^ invalid.illegal.placeholder.c */
+
+NSLog (@"%@", @"String")
+/*       ^ constant.other.placeholder.objc */


### PR DESCRIPTION
This request fixes #781 for Objective-C (and Objective-C++ by extension) by including an extra match for the relevant specifier while processing an Objective-C specific string.

I included two extra syntax tests in order to verify that this works only inside of a constant object string and not in a standard C string.