### PR TITLE
[Rust] Patch for catastrophic backtracking

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -624,7 +624,8 @@ contexts:
       pop: true
 
   impl-for:
-    - match: '(?=\s*(?:::|{{identifier}}|\$|<)+(<.*?>)?\s+for\s+)'
+    # inline {{identifier}} and use possesive quantifiers to avoid catastrophic backtracking in non-Sublime implementations
+    - match: '(?=\s*(?:::|[[:alpha:]][_[:alnum:]]*+|_[_[:alnum:]]++|\$|<)++(<.*?>)?\s+for\s+)'
       set:
         - meta_scope: meta.impl.rust
         - include: comments

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -6,7 +6,7 @@ file_extensions:
   - rs
 scope: source.rust
 variables:
-  identifier: '(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)'
+  identifier: '(?:(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)(?![_[:alnum:]]))' # include a negative lookahead at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
   escaped_byte: '\\(x\h{2}|n|r|t|0|"|''|\\)'
   escaped_char: '\\(x\h{2}|n|r|t|0|"|''|\\|u\{\h{1,6}\})'
   int_suffixes: 'i8|i16|i32|i64|isize|u8|u16|u32|u64|usize'
@@ -624,8 +624,7 @@ contexts:
       pop: true
 
   impl-for:
-    # inline {{identifier}} and use possesive quantifiers to avoid catastrophic backtracking in non-Sublime implementations
-    - match: '(?=\s*(?:::|[[:alpha:]][_[:alnum:]]*+|_[_[:alnum:]]++|\$|<)++(<.*?>)?\s+for\s+)'
+    - match: '(?=\s*(?:::|{{identifier}}|\$|<)++(<.*?>)?\s+for\s+)'
       set:
         - meta_scope: meta.impl.rust
         - include: comments

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -624,7 +624,7 @@ contexts:
       pop: true
 
   impl-for:
-    - match: '(?=\s*(?:::|{{identifier}}|\$|<)++(<.*?>)?\s+for\s+)'
+    - match: '(?=\s*(?:::|{{identifier}}|\$|<)+(<.*?>)?\s+for\s+)'
       set:
         - meta_scope: meta.impl.rust
         - include: comments

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -6,7 +6,7 @@ file_extensions:
   - rs
 scope: source.rust
 variables:
-  identifier: '(?:(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)(?![_[:alnum:]]))' # include a negative lookahead at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
+  identifier: '(?:(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)\b)' # include a word boundary at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
   escaped_byte: '\\(x\h{2}|n|r|t|0|"|''|\\)'
   escaped_char: '\\(x\h{2}|n|r|t|0|"|''|\\|u\{\h{1,6}\})'
   int_suffixes: 'i8|i16|i32|i64|isize|u8|u16|u32|u64|usize'

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -945,3 +945,7 @@ fn abc() {
 //                   ^ punctuation.separator.continuation.line.rust
          world, there is no whitespace between hello and world in the output", 0o202u64);
 }
+
+impl ApplicationPreferenceseeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee {
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.impl.rust
+}


### PR DESCRIPTION
Non-Sublime implementations of sublime-syntax that use Oniguruma take exponential time to parse `impl SomeIdentifier {` lines without this change. See https://github.com/trishume/syntect/issues/33.

I'm pretty sure syntect is the only non-Sublime project that uses these files so I understand if you'd prefer not to merge this PR. I'm just submitting this to ask if you are open to it. I notice some other syntaxes use possessive quantifiers for speed, but those are probably left over from before sregex.

Otherwise I'll probably have to add hacky patches to the version of sublimehq/Packages I bundle with syntect.

@wbond 