### PR TITLE
[HTML] Support "text/paperscript" script tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -85,7 +85,7 @@ contexts:
           with_prototype:
             - match: (?i)(?=</style)
               pop: true
-    - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))'
+    - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!(java|paper)script).*)))'
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html


### PR DESCRIPTION
[PaperScript](http://paperjs.org/tutorials/getting-started/working-with-paper-js/#what-is-paperscript) is a slightly enriched JavaScript, adding support for operator overloading and a few other features developed for http://paperjs.org/

Standard JavaScript syntax highlighting can be used for PaperScript.

[See here](https://www.reddit.com/r/webdev/comments/4o8tz6/paperscript_syntax_highlighting_within_html_file/d4akcej/) for the origin of the approach to add support for inlined PaperScript in Sublime Text 3.