### PR TITLE
[Markdown] support lists in blockquotes, code fences, multiline inline code and multiline emphasis

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -8,6 +8,7 @@ file_extensions:
   - markdown
   - markdn
 scope: text.html.markdown
+comment: this definition aims to (eventually) meet CommonMark specifications http://spec.commonmark.org/
 variables:
     separator_line: |-
         (?x:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -113,12 +113,11 @@ contexts:
             \s*                        # Leading whitespace
             (\[)(.+?)(\])(:)           # Reference name
             [ \t]*                     # Optional whitespace
-            (<?)(\S+?)(>?)             # The url
-            {{link_title}}             # Optional link title
-            \s*                        # Optional whitespace
-            $
+            (?:
+              (<)([^>]+)(>)            # The url
+            | (\S+)                    # The url
+            )
         )
-      scope: meta.link.reference.def.markdown
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
@@ -127,15 +126,10 @@ contexts:
         5: punctuation.definition.link.begin.markdown
         6: markup.underline.link.markdown
         7: punctuation.definition.link.end.markdown
-        8: string.other.link.description.title.markdown
-        9: punctuation.definition.string.begin.markdown
-        10: punctuation.definition.string.end.markdown
-        11: string.other.link.description.title.markdown
-        12: punctuation.definition.string.begin.markdown
-        13: punctuation.definition.string.end.markdown
-        14: string.other.link.description.title.markdown
-        15: punctuation.definition.string.begin.markdown
-        16: punctuation.definition.string.end.markdown
+        8: markup.underline.link.markdown
+      push:
+        - meta_scope: meta.link.reference.def.markdown
+        - include: link-title
     - match: '^(?=\S)(?![=-]{3,}\s*$)'
       push:
         - meta_scope: meta.paragraph.markdown
@@ -433,7 +427,7 @@ contexts:
     - match: '[*_]+'
   hard-line-break:
     - match: '[ ]{2,}$'
-      scope: meta.hard-line-break.markdown
+      scope: meta.hard-line-break.markdown punctuation.definition.hard-line-break.markdown
     - match: '(\\)$\n'
       scope: meta.hard-line-break.markdown
       captures:
@@ -645,3 +639,44 @@ contexts:
     - include: link-text
     - include: image-inline
     - include: image-ref
+  link-title:
+    - match: \s*(')
+      captures:
+        1: punctuation.definition.string.begin.markdown
+      push:
+        - meta_scope: string.other.link.description.title.markdown
+        - match: \'
+          scope: punctuation.definition.string.end.markdown
+          set: after-link-title
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.link-title.markdown
+          pop: true
+    - match: \s*(")
+      captures:
+        1: punctuation.definition.string.begin.markdown
+      push:
+        - meta_scope: string.other.link.description.title.markdown
+        - match: \"
+          scope: punctuation.definition.string.end.markdown
+          set: after-link-title
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.link-title.markdown
+          pop: true
+    - match: \s*(\()
+      captures:
+        1: punctuation.definition.string.begin.markdown
+      push:
+        - meta_scope: string.other.link.description.title.markdown
+        - match: \)
+          scope: punctuation.definition.string.end.markdown
+          set: after-link-title
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.link-title.markdown
+          pop: true
+    - match: \s*
+      set: after-link-title
+  after-link-title:
+    - match: '(.*)$\n?'
+      captures:
+        1: invalid.illegal.expected-eol.markdown
+      pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -23,6 +23,14 @@ variables:
     block_heading: '(?:[#]{1,6}\s*)'
     block_raw: '(?:[ ]{4}|\t)'
     list_item: '(?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s)'
+    link_title: |-
+        (?x:[ \t]*                # Optional whitespace
+          (?:
+              ((\().+?(\)))       # Match title in parens…
+            | ((")[^"]+("))       # or in double quotes…
+            | ((')[^']+('))       # or in single quotes.
+          )?                      # Title is optional
+        )
 contexts:
   main:
     - match: |-
@@ -69,12 +77,7 @@ contexts:
             (\[)(.+?)(\])(:)           # Reference name
             [ \t]*                     # Optional whitespace
             (<?)(\S+?)(>?)             # The url
-            [ \t]*                     # Optional whitespace
-            (?:
-                  ((\().+?(\)))        # Match title in parens…
-                | ((")[^"]+("))        # or in double quotes
-                | ((')[^']+('))        # or in single quotes
-            )?                         # Title is optional
+            {{link_title}}             # Optional link title
             \s*                        # Optional whitespace
             $
         )
@@ -210,12 +213,7 @@ contexts:
                                 \(                         # Opening paren
                                     [ \t]*+                # Optional whitespace
                                     <?(.*?)>?              # URL
-                                    [ \t]*+                # Optional whitespace
-                                    (                      # Optional Title
-                                        (?<title>['"])
-                                        (.*?)
-                                        \k<title>
-                                    )?
+                                    {{link_title}}         # Optional Title
                                 \)
                             )
                         )
@@ -270,11 +268,7 @@ contexts:
                         ([ ])?                        # Space not allowed
                         (\()                          # Opening paren for url
                             (<?)(\S+?)(>?)            # The url
-                            [ \t]*                    # Optional whitespace
-                            (?:
-                                  ((\().+?(\)))       # Match title in parens…
-                                | ((").+?("))         # or in quotes.
-                            )?                        # Title is optional
+                            {{link_title}}            # Optional title
                             \s*                       # Optional whitespace
                         (\))
                      )
@@ -295,17 +289,21 @@ contexts:
         14: string.other.link.description.title.markdown
         15: punctuation.definition.string.begin.markdown
         16: punctuation.definition.string.end.markdown
-        17: punctuation.definition.metadata.end.markdown
+        17: string.other.link.description.title.markdown
+        18: punctuation.definition.string.begin.markdown
+        19: punctuation.definition.string.end.markdown
+        20: punctuation.definition.metadata.end.markdown
   image-ref:
-    - match: '\!(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
+    - match: '(\!)(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
       scope: meta.image.reference.markdown
       captures:
-        1: punctuation.definition.string.begin.markdown
-        2: string.other.link.description.markdown
-        4: punctuation.definition.string.end.markdown
-        5: punctuation.definition.constant.begin.markdown
-        6: constant.other.reference.link.markdown
-        7: punctuation.definition.constant.end.markdown
+        1: punctuation.definition.image.begin.markdown
+        2: punctuation.definition.string.begin.markdown
+        3: string.other.link.description.markdown
+        5: punctuation.definition.string.end.markdown
+        6: punctuation.definition.constant.begin.markdown
+        7: constant.other.reference.link.markdown
+        8: punctuation.definition.constant.end.markdown
   inline:
     - include: escape
     - include: ampersand
@@ -350,12 +348,7 @@ contexts:
                                 \(                      # Opening paren
                                     [ \t]*+             # Optional whitespace
                                     <?(.*?)>?           # URL
-                                    [ \t]*+             # Optional whitespace
-                                    (                   # Optional Title
-                                        (?<title>['"])
-                                        (.*?)
-                                        \k<title>
-                                    )?
+                                    {{link_title}}      # Optional Title
                                 \)
                             )
                         )
@@ -406,12 +399,8 @@ contexts:
                         ([ ])?                      # Space not allowed
                         (\()                        # Opening paren for url
                             (<?)(.*?)(>?)           # The url
-                            [ \t]*                  # Optional whitespace
-                            (?:
-                                  ((\().+?(\)))      # Match title in parens…
-                                | ((").+?("))        # or in quotes.
-                            )?                       # Title is optional
-                            \s*                      # Optional whitespace
+                            {{link_title}}          # Optional title
+                            \s*                     # Optional whitespace
                         (\))
                      )
       scope: meta.link.inline.markdown
@@ -430,7 +419,10 @@ contexts:
         13: string.other.link.description.title.markdown
         14: punctuation.definition.string.begin.markdown
         15: punctuation.definition.string.end.markdown
-        16: punctuation.definition.metadata.end.markdown
+        16: string.other.link.description.title.markdown
+        17: punctuation.definition.string.begin.markdown
+        18: punctuation.definition.string.end.markdown
+        19: punctuation.definition.metadata.end.markdown
   link-ref:
     - match: '(\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)([^\]]*+)(\])'
       scope: meta.link.reference.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -576,6 +576,7 @@ contexts:
     - meta_content_scope: meta.paragraph.list.markdown
     - match: ^
       pop: true
+    - include: thematic-break
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
   fenced-code-block:
@@ -606,8 +607,13 @@ contexts:
     - match: '`+'
       scope: invalid.deprecated.unescaped-backticks.markdown
   thematic-break:
-    - match: '{{thematic_break}}\n?'
-      scope: meta.separator.thematic-break.markdown
+    - match: '(?={{thematic_break}}$)'
+      push:
+        - meta_scope: meta.separator.thematic-break.markdown
+        - match: '[-_*]+'
+          scope: punctuation.definition.thematic-break.markdown
+        - match: '$\n?'
+          pop: true
   disable-markdown:
     - match: (</)(\1)(>)
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -99,14 +99,14 @@ contexts:
       push: 
         - meta_scope: meta.paragraph.markdown
         - match: |-
-            (?x)                        # pop out of this context when
+            (?x)                       # pop out of this context when
             ^(?:
-                \s*$                    # the line is blank (or only contains whitespace)
+                \s*$                   # the line is blank (or only contains whitespace)
             |   (?=
-                    {{block_quote}}     # a block quote begins the line
-                |   ^[ ]{,3}[*+-][ ]    # an unordered list item begins the line
-                |   ^[ ]{,3}\d+[.][ ]   # an ordered list item begins the line
-                |   ^\#                 # a block heading begins the line
+                    {{block_quote}}    # a block quote begins the line
+                |   [ ]{,3}[*+-][ ]    # an unordered list item begins the line
+                |   [ ]{,3}1[.][ ]     # an ordered list item with number "1" begins the line
+                |   \#                 # a block heading begins the line
                 )
             )
           pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -42,9 +42,9 @@ variables:
     balance: |-
         (?x:
           (?:
-            {{escape}}+                  # escape characters
-          | [^\[\]`]+                    # anything that isn't a square bracket or a backtick
-          | {{backticks}}                # inline code
+              {{escape}}+                  # escape characters
+          |   [^\[\]`\\]+                  # anything that isn't a square bracket or a backtick or the start of an escape character
+          |   {{backticks}}                # inline code
           )
         )
     balance_square_brackets: |-
@@ -66,6 +66,7 @@ variables:
               \s*                       # Optional whitespace
           (\))
         )
+    skip_html_tags: '(?:<[^>]+>)'
 contexts:
   main:
     - match: |-
@@ -227,18 +228,10 @@ contexts:
             (\*\*|\b__)(?=\S)                              # Open
             (?=
                 (
-                    <[^>]*+>                               # HTML tags
-                  | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
-                                                           # Raw
-                  | \\[\\`*_{}\[\]()#.!+\->]?+             # Escapes
-                  | \[
-                    (
-                            (?<square>                     # Named group
-                                [^\[\]\\]                  # Match most chars
-                              | \\.                        # Escaped chars
-                              | \[ \g<square>*+ \]         # Nested brackets
-                            )*+
-                        \]
+                    {{skip_html_tags}}                     # HTML tags
+                  | {{backticks}}                          # Raw
+                  | {{escape}}                             # Escapes
+                  | \[{{balance_square_brackets}}\]
                         (
                             (                              # Reference Link
                                 [ ]?                       # Optional space
@@ -252,7 +245,6 @@ contexts:
                                 \)
                             )
                         )
-                    )
                   | (?!(?<=\S)\1).                         # Everything besides
                                                            # style closer
                 )++
@@ -303,7 +295,7 @@ contexts:
       captures:
         1: punctuation.definition.image.begin.markdown
         2: punctuation.definition.string.begin.markdown
-      push: [image-inline_after_text, image-link-text]
+      push: [image-inline-after-text, image-link-text]
   image-link-text:
     - meta_scope: meta.image.inline.markdown
     - meta_content_scope: string.other.link.description.markdown
@@ -311,7 +303,7 @@ contexts:
     - match: \]
       scope: punctuation.definition.string.end.markdown
       pop: true
-  image-inline_after_text:
+  image-inline-after-text:
     - match: '{{url_and_title}}'
       captures:
         1: invalid.illegal.whitespace.markdown
@@ -332,16 +324,36 @@ contexts:
       scope: meta.image.inline.markdown
       pop: true
   image-ref:
-    - match: '(\!)(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
-      scope: meta.image.reference.markdown
+    - match: |-
+        (?x:
+          (\!)(\[)                          # Images start with ![
+          (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
+                \]                          # Closing square bracket
+                [ ]?                        # Space
+                \[                          # [
+                [^\]]+                      # anything other than ]
+                \]                          # ]
+          )
+        )
       captures:
         1: punctuation.definition.image.begin.markdown
         2: punctuation.definition.string.begin.markdown
-        3: string.other.link.description.markdown
-        5: punctuation.definition.string.end.markdown
-        6: punctuation.definition.constant.begin.markdown
-        7: constant.other.reference.link.markdown
-        8: punctuation.definition.constant.end.markdown
+      push: [image-ref-after-text, image-ref-text]
+  image-ref-text:
+    - meta_scope: meta.image.reference.markdown
+    - meta_content_scope: string.other.link.description.markdown
+    - include: link-text
+    - match: \]
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+  image-ref-after-text:
+    - match: '[ ]?(\[)([^\]]+)(\])'
+      captures:
+        1: punctuation.definition.constant.begin.markdown
+        2: constant.other.reference.link.markdown
+        3: punctuation.definition.constant.end.markdown
+      scope: meta.image.reference.markdown
+      pop: true
   inline:
     - include: escape
     - include: ampersand
@@ -365,18 +377,10 @@ contexts:
             (\*|\b_)(?=\S)                              # Open
             (?=
                 (
-                    <[^>]*+>                            # HTML tags
-                  | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
-                                                        # Raw
-                  | \\[\\`*_{}\[\]()#.!+\->]?+          # Escapes
-                  | \[
-                    (
-                            (?<square>                  # Named group
-                                [^\[\]\\]               # Match most chars
-                              | \\.                     # Escaped chars
-                              | \[ \g<square>*+ \]      # Nested brackets
-                            )*+
-                        \]
+                    {{skip_html_tags}}                  # HTML tags
+                  | {{backticks}}                       # Raw
+                  | {{escape}}                          # Escapes
+                  | \[{{balance_square_brackets}}\]
                         (
                             (                           # Reference Link
                                 [ ]?                    # Optional space
@@ -390,7 +394,6 @@ contexts:
                                 \)
                             )
                         )
-                    )
                   | \1\1                                # Must be bold closer
                   | (?!(?<=\S)\1).                      # Everything besides
                                                         # style closer
@@ -466,24 +469,64 @@ contexts:
       scope: meta.link.inline.markdown
       pop: true
   link-ref:
-    - match: '(\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)([^\]]*+)(\])'
-      scope: meta.link.reference.markdown
+    - match: |-
+        (?x:
+          (\[)
+          (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
+                \]                          # Closing square bracket
+                [ ]?                        # Space
+                \[                          # [
+                [^\]]+                      # anything other than ]
+                \]                          # ]
+          )
+        )
       captures:
         1: punctuation.definition.string.begin.markdown
-        2: string.other.link.title.markdown
-        4: punctuation.definition.string.end.markdown
-        5: punctuation.definition.constant.begin.markdown
-        6: constant.other.reference.link.markdown
-        7: punctuation.definition.constant.end.markdown
+      push: [link-ref-after-text, link-ref-link-text]
+  link-ref-link-text:
+    - meta_scope: meta.link.reference.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - include: link-text
+    - match: \]
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+  link-ref-after-text:
+    - match: '[ ]?(\[)([^\]]+)(\])'
+      captures:
+        1: punctuation.definition.constant.begin.markdown
+        2: constant.other.reference.link.markdown
+        3: punctuation.definition.constant.end.markdown
+      scope: meta.link.reference.markdown
+      pop: true
   link-ref-literal:
-    - match: '(\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(\])'
+    - match: |-
+        (?x:
+          (\[)
+          (?=
+              {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
+              \]                          # Closing square bracket
+              [ ]?                        # Space
+              \[                          # [
+              \]                          # ]
+          )
+        )
+      captures:
+        1: punctuation.definition.string.begin.markdown
+      push: [link-ref-literal-after-text, link-ref-literal-link-text]
+  link-ref-literal-link-text:
+    - meta_scope: meta.link.reference.literal.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - include: link-text
+    - match: \]
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+  link-ref-literal-after-text:
+    - match: '[ ]?(\[)(\])'
       scope: meta.link.reference.literal.markdown
       captures:
-        1: punctuation.definition.string.begin.markdown
-        2: string.other.link.title.markdown
-        4: punctuation.definition.string.end.markdown
-        5: punctuation.definition.constant.begin.markdown
-        6: punctuation.definition.constant.end.markdown
+        1: punctuation.definition.constant.begin.markdown
+        2: punctuation.definition.constant.end.markdown
+      pop: true
   list-paragraph:
     - include: block_raw
     - include: block_quote

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -66,9 +66,7 @@ variables:
               \s*                       # Optional whitespace
           (\))
         )
-    skip_self_closing_html_tags: '(?:<(?:hr|br)\b[^>]*>)'
-    skip_html_tag_content: '(?:<[^>]+[^<]*</[^>]+>)'
-    skip_html_tags: '(?:{{skip_self_closing_html_tags}}|{{skip_html_tag_content}})'
+    skip_html_tags: '(?:<[^>]+>)'
 contexts:
   main:
     - match: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -80,13 +80,13 @@ contexts:
         )
       scope: meta.link.reference.def.markdown
       captures:
-        1: punctuation.definition.constant.markdown
+        1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
-        3: punctuation.definition.constant.markdown
+        3: punctuation.definition.constant.end.markdown
         4: punctuation.separator.key-value.markdown
-        5: punctuation.definition.link.markdown
+        5: punctuation.definition.link.begin.markdown
         6: markup.underline.link.markdown
-        7: punctuation.definition.link.markdown
+        7: punctuation.definition.link.end.markdown
         8: string.other.link.description.title.markdown
         9: punctuation.definition.string.begin.markdown
         10: punctuation.definition.string.end.markdown
@@ -264,7 +264,7 @@ contexts:
   image-inline:
     - match: |-
         (?x:
-                        \!                            # Images start with !
+                        (\!)                          # Images start with !
                         (\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])
                                                       # Match the link text.
                         ([ ])?                        # Space not allowed
@@ -280,21 +280,22 @@ contexts:
                      )
       scope: meta.image.inline.markdown
       captures:
-        1: punctuation.definition.string.begin.markdown
-        2: string.other.link.description.markdown
-        4: punctuation.definition.string.end.markdown
-        5: invalid.illegal.whitespace.markdown
-        6: punctuation.definition.metadata.markdown
-        7: punctuation.definition.link.markdown
-        8: markup.underline.link.image.markdown
-        9: punctuation.definition.link.markdown
-        10: string.other.link.description.title.markdown
-        11: punctuation.definition.string.markdown
-        12: punctuation.definition.string.markdown
-        13: string.other.link.description.title.markdown
-        14: punctuation.definition.string.markdown
-        15: punctuation.definition.string.markdown
-        16: punctuation.definition.metadata.markdown
+        1: punctuation.definition.image.begin.markdown
+        2: punctuation.definition.string.begin.markdown
+        3: string.other.link.description.markdown
+        5: punctuation.definition.string.end.markdown
+        6: invalid.illegal.whitespace.markdown
+        7: punctuation.definition.metadata.begin.markdown
+        8: punctuation.definition.link.begin.markdown
+        9: markup.underline.link.image.markdown
+        10: punctuation.definition.link.end.markdown
+        11: string.other.link.description.title.markdown
+        12: punctuation.definition.string.begin.markdown
+        13: punctuation.definition.string.end.markdown
+        14: string.other.link.description.title.markdown
+        15: punctuation.definition.string.begin.markdown
+        16: punctuation.definition.string.end.markdown
+        17: punctuation.definition.metadata.end.markdown
   image-ref:
     - match: '\!(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
       scope: meta.image.reference.markdown
@@ -302,9 +303,9 @@ contexts:
         1: punctuation.definition.string.begin.markdown
         2: string.other.link.description.markdown
         4: punctuation.definition.string.end.markdown
-        5: punctuation.definition.constant.markdown
+        5: punctuation.definition.constant.begin.markdown
         6: constant.other.reference.link.markdown
-        7: punctuation.definition.constant.markdown
+        7: punctuation.definition.constant.end.markdown
   inline:
     - include: escape
     - include: ampersand
@@ -387,16 +388,16 @@ contexts:
     - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
       scope: meta.link.email.lt-gt.markdown
       captures:
-        1: punctuation.definition.link.markdown
+        1: punctuation.definition.link.begin.markdown
         2: markup.underline.link.markdown
-        4: punctuation.definition.link.markdown
+        4: punctuation.definition.link.end.markdown
   link-inet:
     - match: (<)((?:https?|ftp)://.*?)(>)
       scope: meta.link.inet.markdown
       captures:
-        1: punctuation.definition.link.markdown
+        1: punctuation.definition.link.begin.markdown
         2: markup.underline.link.markdown
-        3: punctuation.definition.link.markdown
+        3: punctuation.definition.link.end.markdown
   link-inline:
     - match: |-
         (?x:
@@ -419,17 +420,17 @@ contexts:
         2: string.other.link.title.markdown
         4: punctuation.definition.string.end.markdown
         5: invalid.illegal.whitespace.markdown
-        6: punctuation.definition.metadata.markdown
-        7: punctuation.definition.link.markdown
+        6: punctuation.definition.metadata.begin.markdown
+        7: punctuation.definition.link.begin.markdown
         8: markup.underline.link.markdown
-        9: punctuation.definition.link.markdown
+        9: punctuation.definition.link.end.markdown
         10: string.other.link.description.title.markdown
         11: punctuation.definition.string.begin.markdown
         12: punctuation.definition.string.end.markdown
         13: string.other.link.description.title.markdown
         14: punctuation.definition.string.begin.markdown
         15: punctuation.definition.string.end.markdown
-        16: punctuation.definition.metadata.markdown
+        16: punctuation.definition.metadata.end.markdown
   link-ref:
     - match: '(\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)([^\]]*+)(\])'
       scope: meta.link.reference.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -473,6 +473,7 @@ contexts:
     - match: ^
       pop: true
     - include: inline-bold-italic-linebreak
+    - include: scope:text.html.basic
   raw:
     - match: '(`+)([^`]|(?!(?<!`)\1(?!`))`)*+(\1)'
       scope: markup.raw.inline.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -224,18 +224,14 @@ contexts:
                 (?<=\S)\1                                  # Close
             )
       captures:
-        1: punctuation.definition.bold.markdown
+        1: punctuation.definition.bold.begin.markdown
       push:
         - meta_scope: markup.bold.markdown
         - match: (?<=\S)(\1)
           captures:
-            1: punctuation.definition.bold.markdown
+            1: punctuation.definition.bold.end.markdown
           pop: true
-        - match: "(?=<[^>]*?>)"
-          push:
-            - include: scope:text.html.basic
-            - match: (?<=>)
-              pop: true
+        - include: scope:text.html.basic
         - include: inline
         - include: italic
   bracket:
@@ -250,13 +246,13 @@ contexts:
   heading:
     - match: '\G(#{1,6})(?!#)\s*(?=\S)'
       captures:
-        1: punctuation.definition.heading.markdown
+        1: punctuation.definition.heading.begin.markdown
       push:
         - meta_scope: markup.heading.markdown
         - meta_content_scope: entity.name.section.markdown
         - match: \s*(#*)$\n?
           captures:
-            1: punctuation.definition.heading.markdown
+            1: punctuation.definition.heading.end.markdown
           pop: true
         - include: inline-bold-italic-linebreak
   image-inline:
@@ -360,18 +356,14 @@ contexts:
                 (?<=\S)\1                               # Close
             )
       captures:
-        1: punctuation.definition.italic.markdown
+        1: punctuation.definition.italic.begin.markdown
       push:
         - meta_scope: markup.italic.markdown
         - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
           captures:
-            1: punctuation.definition.italic.markdown
+            1: punctuation.definition.italic.end.markdown
           pop: true
-        - match: "(?=<[^>]*?>)"
-          push:
-            - include: scope:text.html.basic
-            - match: (?<=>)
-              pop: true
+        - include: scope:text.html.basic
         - include: inline
         - include: bold
   line-break:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -636,3 +636,6 @@ contexts:
         - include: link-text
         - match: \]
           pop: true
+    - include: bold
+    - include: italic
+    - include: hard-line-break

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -582,7 +582,20 @@ contexts:
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
   fenced-code-block:
-    - match: '^[ ]{0,3}(`{3,}(?![^`]+`)|~{3,}(?![^~]+~))([\w-]*).*$'
+    - match: |-
+         (?x)
+          ^[ ]{0,3}    # up to 3 spaces
+          (
+            `{3,}      #   3 or more backticks
+            (?![^`]+`) #   not followed by any more backticks on the same line
+            (?!`)      #   makes the {3,} possessive
+          |            # or
+            ~{3,}      #   3 or more tildas
+            (?![^~]+~) #   not followed by any more tildas on the same line
+            (?!~)      #   makes the {3,} possessive
+          )
+          ([\w-]*)     # any number of word characters or dashes
+          .*$          # all characters until eol
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: constant.other.language-name.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -66,7 +66,9 @@ variables:
               \s*                       # Optional whitespace
           (\))
         )
-    skip_html_tags: '(?:<[^>]+>)'
+    skip_self_closing_html_tags: '(?:<(?:hr|br)\b[^>]*>)'
+    skip_html_tag_content: '(?:<[^>]+[^<]*</[^>]+>)'
+    skip_html_tags: '(?:{{skip_self_closing_html_tags}}|{{skip_html_tag_content}})'
 contexts:
   main:
     - match: |-
@@ -241,7 +243,11 @@ contexts:
                         )
                   | \*{3,}                              # not applicable
                   | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!\*\*).                           # Everything else besides style closer
+                  | (?!
+                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
+                    |   {{backticks}}
+                    |   {{escape}}
+                    |   \*\*).                          # Everything else besides style closer
                 )+
                 \*\*                                    # Close
             )
@@ -262,7 +268,7 @@ contexts:
         - include: italic
     - match: |-
         (?x)
-            (\b__)(?=\S)(?!_)                              # Open
+            (\b__)(?=\S)(?!_)                           # Open
             (?=
                 (?:
                     {{skip_html_tags}}                  # HTML tags
@@ -278,7 +284,11 @@ contexts:
                         )
                   | _{3,}                                # not applicable
                   | [ \t]_+                              # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!__).                              # Everything else besides style closer
+                  | (?!
+                        {{skip_html_tags}}               # emulate possessive quantifers by repeating patterns
+                    |   {{backticks}}
+                    |   {{escape}}
+                    |   __).                             # Everything else besides style closer
                 )+
                 __                                       # Close
             )
@@ -426,7 +436,11 @@ contexts:
                         )
                   | \*{2,}                              # Must be bold opener or closer or not applicable
                   | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!\*).                             # Everything else besides style closer
+                  | (?!
+                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
+                    |   {{backticks}}
+                    |   {{escape}}
+                    |   \*).                            # Everything else besides style closer
                 )+
                 \*                                      # Close
             )
@@ -447,7 +461,7 @@ contexts:
         - include: bold
     - match: |-
         (?x)
-            (\b_)(?=\S)(?!_)                              # Open
+            (\b_)(?=\S)(?!_)                            # Open
             (?=
                 (?:
                     {{skip_html_tags}}                  # HTML tags
@@ -463,7 +477,11 @@ contexts:
                         )
                   | _{2,}                               # Must be bold opener or closer or not applicable
                   | [ \t]_+                             # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!_).                              # Everything else besides style closer
+                  | (?!
+                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
+                    |   {{backticks}}
+                    |   {{escape}}
+                    |   _).                             # Everything else besides style closer
                 )+
                 _                                       # Close
             )
@@ -475,7 +493,6 @@ contexts:
               (?x)
                   [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
               |   [ \t]+_(?!_)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        
         - match: (\1)(?!\1)
           captures:
             1: punctuation.definition.italic.end.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -31,6 +31,41 @@ variables:
             | ((')[^']+('))       # or in single quotes.
           )?                      # Title is optional
         )
+    escape: '\\[-`*_#+.!(){}\[\]\\>]'
+    backticks: |-
+        (?x:
+            (````)(({{escape}})|[^`\\]+|`(?!```))+(````)
+        |   (``` )(({{escape}})|[^`\\]+|`(?!`` ))+(``` )
+        |   (``  )(({{escape}})|[^`\\]+|`(?!`  ))+(``  )
+        |   (`   )(({{escape}})|[^`\\]+         )+(`   )
+        )
+    balance: |-
+        (?x:
+          (?:
+            {{escape}}+                  # escape characters
+          | [^\[\]`]+                    # anything that isn't a square bracket or a backtick
+          | {{backticks}}                # inline code
+          )
+        )
+    balance_square_brackets: |-
+        (?x:
+          (?:
+            {{balance}}
+          | \[(?:                       # nested square brackets (one level deep)
+                [^\[\]`]+               #  anything that isn't a square bracket or a backtick
+                {{backticks}}?          #  balanced backticks
+              )*\]                      #  closing square bracket
+          )+                            # at least one character
+        )
+    url_and_title: |-
+        (?x:
+          ([ ])?                        # Space not allowed
+          (\()                          # Opening paren for url
+              (<?)(\S+?)(>?)            # The url
+              {{link_title}}            # Optional title
+              \s*                       # Optional whitespace
+          (\))
+        )
 contexts:
   main:
     - match: |-
@@ -241,7 +276,7 @@ contexts:
                         HTML grammar will not mark it up as invalid.
       scope: meta.other.valid-bracket.markdown
   escape:
-    - match: '\\[-`*_#+.!(){}\[\]\\>]'
+    - match: '{{escape}}'
       scope: constant.character.escape.markdown
   heading:
     - match: '\G(#{1,6})(?!#)\s*(?=\S)'
@@ -258,37 +293,44 @@ contexts:
   image-inline:
     - match: |-
         (?x:
-                        (\!)                          # Images start with !
-                        (\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])
-                                                      # Match the link text.
-                        ([ ])?                        # Space not allowed
-                        (\()                          # Opening paren for url
-                            (<?)(\S+?)(>?)            # The url
-                            {{link_title}}            # Optional title
-                            \s*                       # Optional whitespace
-                        (\))
-                     )
-      scope: meta.image.inline.markdown
+            (\!)(\[)                          # Images start with ![
+            (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
+                  \]                          # Closing square bracket
+                  [ ]?                        # Space not allowed, but we check for it anyway to mark it as invalid
+                  \(                          # Open paren
+            )
+         )
       captures:
         1: punctuation.definition.image.begin.markdown
         2: punctuation.definition.string.begin.markdown
-        3: string.other.link.description.markdown
-        5: punctuation.definition.string.end.markdown
-        6: invalid.illegal.whitespace.markdown
-        7: punctuation.definition.metadata.begin.markdown
-        8: punctuation.definition.link.begin.markdown
-        9: markup.underline.link.image.markdown
-        10: punctuation.definition.link.end.markdown
-        11: string.other.link.description.title.markdown
-        12: punctuation.definition.string.begin.markdown
-        13: punctuation.definition.string.end.markdown
-        14: string.other.link.description.title.markdown
-        15: punctuation.definition.string.begin.markdown
-        16: punctuation.definition.string.end.markdown
-        17: string.other.link.description.title.markdown
-        18: punctuation.definition.string.begin.markdown
-        19: punctuation.definition.string.end.markdown
-        20: punctuation.definition.metadata.end.markdown
+      push: [image-inline_after_text, image-link-text]
+  image-link-text:
+    - meta_scope: meta.image.inline.markdown
+    - meta_content_scope: string.other.link.description.markdown
+    - include: link-text
+    - match: \]
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+  image-inline_after_text:
+    - match: '{{url_and_title}}'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.metadata.begin.markdown
+        3: punctuation.definition.link.begin.markdown
+        4: markup.underline.link.image.markdown
+        5: punctuation.definition.link.end.markdown
+        6: string.other.link.description.title.markdown
+        7: punctuation.definition.string.begin.markdown
+        8: punctuation.definition.string.end.markdown
+        9: string.other.link.description.title.markdown
+        10: punctuation.definition.string.begin.markdown
+        11: punctuation.definition.string.end.markdown
+        12: string.other.link.description.title.markdown
+        13: punctuation.definition.string.begin.markdown
+        14: punctuation.definition.string.end.markdown
+        15: punctuation.definition.metadata.end.markdown
+      scope: meta.image.inline.markdown
+      pop: true
   image-ref:
     - match: '(\!)(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
       scope: meta.image.reference.markdown
@@ -386,35 +428,43 @@ contexts:
   link-inline:
     - match: |-
         (?x:
-                        (\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])
-                                                    # Match the link text.
-                        ([ ])?                      # Space not allowed
-                        (\()                        # Opening paren for url
-                            (<?)(.*?)(>?)           # The url
-                            {{link_title}}          # Optional title
-                            \s*                     # Optional whitespace
-                        (\))
-                     )
-      scope: meta.link.inline.markdown
+            (\[)
+            (?=
+                {{balance_square_brackets}}
+                \]
+                {{url_and_title}}
+            )
+        )
       captures:
         1: punctuation.definition.string.begin.markdown
-        2: string.other.link.title.markdown
-        4: punctuation.definition.string.end.markdown
-        5: invalid.illegal.whitespace.markdown
-        6: punctuation.definition.metadata.begin.markdown
-        7: punctuation.definition.link.begin.markdown
-        8: markup.underline.link.markdown
-        9: punctuation.definition.link.end.markdown
-        10: string.other.link.description.title.markdown
-        11: punctuation.definition.string.begin.markdown
-        12: punctuation.definition.string.end.markdown
-        13: string.other.link.description.title.markdown
-        14: punctuation.definition.string.begin.markdown
-        15: punctuation.definition.string.end.markdown
-        16: string.other.link.description.title.markdown
-        17: punctuation.definition.string.begin.markdown
-        18: punctuation.definition.string.end.markdown
-        19: punctuation.definition.metadata.end.markdown
+      push: [link-inline-after-text, link-inline-link-text]
+  link-inline-link-text:
+    - meta_scope: meta.link.inline.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - include: link-text
+    - match: \]
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+  link-inline-after-text:
+    - match: '{{url_and_title}}'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.metadata.begin.markdown
+        3: punctuation.definition.link.begin.markdown
+        4: markup.underline.link.markdown
+        5: punctuation.definition.link.end.markdown
+        6: string.other.link.description.title.markdown
+        7: punctuation.definition.string.begin.markdown
+        8: punctuation.definition.string.end.markdown
+        9: string.other.link.description.title.markdown
+        10: punctuation.definition.string.begin.markdown
+        11: punctuation.definition.string.end.markdown
+        12: string.other.link.description.title.markdown
+        13: punctuation.definition.string.begin.markdown
+        14: punctuation.definition.string.end.markdown
+        15: punctuation.definition.metadata.end.markdown
+      scope: meta.link.inline.markdown
+      pop: true
   link-ref:
     - match: '(\[)((?<square>[^\[\]\\]+|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)([^\]]*+)(\])'
       scope: meta.link.reference.markdown
@@ -460,11 +510,15 @@ contexts:
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
   raw:
-    - match: '(`+)([^`]|(?!(?<!`)\1(?!`))`)*+(\1)'
-      scope: markup.raw.inline.markdown
-      captures:
-        1: punctuation.definition.raw.markdown
-        3: punctuation.definition.raw.markdown
+    - match: '(`+)'
+      scope: punctuation.definition.raw.begin.markdown
+      push:
+        - meta_scope: markup.raw.inline.markdown
+        - match: '\\`'
+          scope: constant.character.escape.markdown
+        - match: '\1'
+          scope: punctuation.definition.raw.end.markdown
+          pop: true
   separator:
     - match: '{{separator_line}}\n?'
       scope: meta.separator.markdown
@@ -482,3 +536,11 @@ contexts:
       scope: meta.disable-markdown
       pop: true
     - include: scope:text.html.basic
+  link-text:
+    - include: escape
+    - include: raw
+    - match: \[ # nested square brackets are allowed
+      push:
+        - include: link-text
+        - match: \]
+          pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -22,6 +22,7 @@ variables:
     block_quote: '(?:[ ]{,3}>(?:.|$))'
     block_heading: '(?:[#]{1,6}\s*)'
     block_raw: '(?:[ ]{4}|\t)'
+    list_item: '(?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s)'
 contexts:
   main:
     - match: |-
@@ -162,13 +163,18 @@ contexts:
             (?=  {{block_raw}}
             |    {{block_heading}}
             |    {{separator_line}}
+            |    {{list_item}}
             )
           push:
             - include: block_raw
             - include: heading
             - include: separator
+            - match: '{{list_item}}'
+              captures:
+                1: punctuation.definition.list_item.markdown
             - match: ^
               pop: true
+            - include: list-paragraph
         - match: ''
           push:
             - match: $|^
@@ -375,7 +381,7 @@ contexts:
         - include: inline
         - include: bold
   line-break:
-    - match: " {2,}$"
+    - match: '[ ]{2,}$'
       scope: meta.dummy.line-break
   link-email:
     - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
@@ -444,18 +450,29 @@ contexts:
         5: punctuation.definition.constant.begin.markdown
         6: punctuation.definition.constant.end.markdown
   list-paragraph:
+    - include: block_raw
+    - include: block_quote
     - match: \G\s+(?=\S)
       push:
         - meta_scope: meta.paragraph.list.markdown
         - match: ^\s*$
           pop: true
-        - match: '^[ ]*([*+-])(?=\s)'
+        - match: '[ ]*([*+-])(?=\s)'
           captures:
             1: punctuation.definition.list_item.markdown
-        - match: '^[ ]*\d+(\.)(?=\s)'
+          push: list-content
+        - match: '[ ]*\d+(\.)(?=\s)'
           captures:
             1: punctuation.definition.list_item.markdown
-        - include: inline-bold-italic-linebreak
+          push: list-content
+        - match: '(?=\S)'
+          push:
+            - include: list-content
+  list-content:
+    - meta_content_scope: meta.paragraph.list.markdown
+    - match: ^
+      pop: true
+    - include: inline-bold-italic-linebreak
   raw:
     - match: '(`+)([^`]|(?!(?<!`)\1(?!`))`)*+(\1)'
       scope: markup.raw.inline.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -34,10 +34,10 @@ variables:
     escape: '\\[-`*_#+.!(){}\[\]\\>]'
     backticks: |-
         (?x:
-            (`{4})([^`]+|`(?!`{3}))+(`{4})
-        |   (`{3})([^`]+|`(?!`{2}))+(`{3})
-        |   (`{2})([^`]+|`(?!`{1}))+(`{2})
-        |   (`{1})([^`]+          )+(`{1})
+            (`{4})[^`]+(?:[^`]+|(?!`{4})`*)*(`{4})(?!`)
+        |   (`{3})[^`]+(?:[^`]+|(?!`{3})`*)*(`{3})(?!`)
+        |   (`{2})[^`]+(?:[^`]+|(?!`{2})`*)*(`{2})(?!`)
+        |   (`{1})[^`]+(?:[^`]+|(?!`{1})`*)*(`{1})(?!`)
         )
     balance: |-
         (?x:
@@ -643,13 +643,18 @@ contexts:
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
   raw:
-    - match: '(`+)'
-      scope: punctuation.definition.raw.begin.markdown
-      push:
-        - meta_scope: markup.raw.inline.markdown
-        - match: '\1'
-          scope: punctuation.definition.raw.end.markdown
-          pop: true
+    - match: '{{backticks}}'
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+        3: punctuation.definition.raw.begin.markdown
+        4: punctuation.definition.raw.end.markdown
+        5: punctuation.definition.raw.begin.markdown
+        6: punctuation.definition.raw.end.markdown
+        7: punctuation.definition.raw.begin.markdown
+        8: punctuation.definition.raw.end.markdown
+    - match: '`+'
   separator:
     - match: '{{separator_line}}\n?'
       scope: meta.separator.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -317,7 +317,7 @@ contexts:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
   heading:
-    - match: '\G(#{1,6})(?!#)\s*(?=\S)'
+    - match: '(#{1,6})(?!#)\s*(?=\S)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -620,7 +620,7 @@ contexts:
   list-paragraph:
     - include: block_raw
     - include: block_quote
-    - match: \G\s+(?=\S)
+    - match: \s+(?=\S)
       push:
         - meta_scope: meta.paragraph.list.markdown
         - match: ^\s*$
@@ -636,6 +636,8 @@ contexts:
         - match: '(?=\S)'
           push:
             - include: list-content
+    - match: '(?=\S)'
+      pop: true
   list-content:
     - meta_content_scope: meta.paragraph.list.markdown
     - match: ^

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -225,30 +225,62 @@ contexts:
   bold:
     - match: |-
         (?x)
-            (\*\*|\b__)(?=\S)(?!\1)                        # Open
+            (\*\*)(?=\S)(?!\*)                          # Open
             (?=
-                (
-                    {{skip_html_tags}}                     # HTML tags
-                  | {{backticks}}                          # Raw
-                  | {{escape}}                             # Escapes
+                (?:
+                    {{skip_html_tags}}                  # HTML tags
+                  | {{backticks}}                       # Raw
+                  | {{escape}}                          # Escapes
                   | \[{{balance_square_brackets}}\]
-                        (
-                            (                              # Reference Link
-                                [ ]?                       # Optional space
-                                \[[^\]]*\]                 # Optional Ref name
+                        (?:
+                            (?:                         # Reference Link
+                                [ ]?                    # Optional space
+                                \[[^\]]*\]              # Optional Ref name
                             )
                           | {{url_and_title}}
                         )
-                  | (?=[ \t]\1)[ \t]\1+                    # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!\1).                                # Everything else besides style closer
-                )++
-                \1                                         # Close
+                  | (?=[ \t]\*\*)[ \t]\*+               # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!\*\*).                           # Everything else besides style closer
+                )+
+                \*\*                                    # Close
             )
       captures:
         1: punctuation.definition.bold.begin.markdown
       push:
         - meta_scope: markup.bold.markdown
-        - match: (?<=\S)(\1)
+        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+          captures:
+            1: punctuation.definition.bold.end.markdown
+          pop: true
+        - include: scope:text.html.basic
+        - include: inline
+        - include: italic
+    - match: |-
+        (?x)
+            (\b__)(?=\S)(?!_)                              # Open
+            (?=
+                (?:
+                    {{skip_html_tags}}                  # HTML tags
+                  | {{backticks}}                       # Raw
+                  | {{escape}}                          # Escapes
+                  | \[{{balance_square_brackets}}\]
+                        (?:
+                            (?:                         # Reference Link
+                                [ ]?                    # Optional space
+                                \[[^\]]*\]              # Optional Ref name
+                            )
+                          | {{url_and_title}}
+                        )
+                  | (?=[ \t]__)[ \t]_+                   # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!__).                              # Everything else besides style closer
+                )+
+                __                                       # Close
+            )
+      captures:
+        1: punctuation.definition.bold.begin.markdown
+      push:
+        - meta_scope: markup.bold.markdown
+        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
@@ -368,25 +400,25 @@ contexts:
   italic:
     - match: |-
         (?x)
-            (\*|\b_)(?=\S)(?!\1)                        # Open
+            (\*)(?=\S)(?!\*)                            # Open
             (?=
-                (
+                (?:
                     {{skip_html_tags}}                  # HTML tags
                   | {{backticks}}                       # Raw
                   | {{escape}}                          # Escapes
                   | \[{{balance_square_brackets}}\]
-                        (
-                            (                           # Reference Link
+                        (?:
+                            (?:                         # Reference Link
                                 [ ]?                    # Optional space
                                 \[[^\]]*\]              # Optional Ref name
                             )
                           | {{url_and_title}}
                         )
-                  | \1\1                                # Must be bold closer
-                  | (?=[ \t]\1)[ \t]\1+                 # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!\1).                             # Everything else besides style closer
-                )++
-                \1                                      # Close
+                  | \*\*                                # Must be bold closer
+                  | (?=[ \t]\*)[ \t]\*+                 # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!\*).                             # Everything else besides style closer
+                )+
+                \*                                      # Close
             )
       captures:
         1: punctuation.definition.italic.begin.markdown
@@ -399,6 +431,40 @@ contexts:
         - include: scope:text.html.basic
         - include: inline
         - include: bold
+    - match: |-
+        (?x)
+            (\b_)(?=\S)(?!_)                              # Open
+            (?=
+                (?:
+                    {{skip_html_tags}}                  # HTML tags
+                  | {{backticks}}                       # Raw
+                  | {{escape}}                          # Escapes
+                  | \[{{balance_square_brackets}}\]
+                        (?:
+                            (?:                         # Reference Link
+                                [ ]?                    # Optional space
+                                \[[^\]]*\]              # Optional Ref name
+                            )
+                          | {{url_and_title}}
+                        )
+                  | __                                  # Must be bold closer
+                  | (?=[ \t]_)[ \t]_+                   # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!_).                              # Everything else besides style closer
+                )+
+                _                                       # Close
+            )
+      captures:
+        1: punctuation.definition.italic.begin.markdown
+      push:
+        - meta_scope: markup.italic.markdown
+        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+          captures:
+            1: punctuation.definition.italic.end.markdown
+          pop: true
+        - include: scope:text.html.basic
+        - include: inline
+        - include: bold
+    - match: '[*_]+'
   line-break:
     - match: '[ ]{2,}$'
       scope: meta.dummy.line-break

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -137,7 +137,7 @@ contexts:
         15: punctuation.definition.string.begin.markdown
         16: punctuation.definition.string.end.markdown
     - match: '^(?=\S)(?![=-]{3,}\s*$)'
-      push: 
+      push:
         - meta_scope: meta.paragraph.markdown
         - match: |-
             (?x)                       # pop out of this context when
@@ -224,32 +224,7 @@ contexts:
     - match: '{{indented_code_block}}.*$\n?'
       scope: markup.raw.block.markdown
   bold:
-    - match: |-
-        (?x)
-            (\*\*)(?=\S)(?!\*)                          # Open
-            (?=
-                (?:
-                    {{skip_html_tags}}                  # HTML tags
-                  | {{backticks}}                       # Raw
-                  | {{escape}}                          # Escapes
-                  | \[{{balance_square_brackets}}\]
-                        (?:
-                            (?:                         # Reference Link
-                                [ ]?                    # Optional space
-                                \[[^\]]*\]              # Optional Ref name
-                            )
-                          | {{url_and_title}}
-                        )
-                  | \*{3,}                              # not applicable
-                  | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!
-                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
-                    |   {{backticks}}
-                    |   {{escape}}
-                    |   \*\*).                          # Everything else besides style closer
-                )+
-                \*\*                                    # Close
-            )
+    - match: '(\*\*)(?=\S)(?!\*)(?:_)?'
       captures:
         1: punctuation.definition.bold.begin.markdown
       push:
@@ -258,39 +233,21 @@ contexts:
               (?x)
                   [ \t]*\*{3,}     # if there are more than 3 its not applicable to be bold or italic
               |   [ \t]+\*\*+      # whitespace followed by 2 or more is also not applicable
-        - match: (\1)(?!\1)
+              |   ^\*\*            # emphasis can't be closed at the start of the line
+        - match: (\*\*)
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
         - include: scope:text.html.basic
         - include: inline
         - include: italic
-    - match: |-
-        (?x)
-            (\b__)(?=\S)(?!_)                           # Open
-            (?=
-                (?:
-                    {{skip_html_tags}}                  # HTML tags
-                  | {{backticks}}                       # Raw
-                  | {{escape}}                          # Escapes
-                  | \[{{balance_square_brackets}}\]
-                        (?:
-                            (?:                         # Reference Link
-                                [ ]?                    # Optional space
-                                \[[^\]]*\]              # Optional Ref name
-                            )
-                          | {{url_and_title}}
-                        )
-                  | _{3,}                                # not applicable
-                  | [ \t]_+                              # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!
-                        {{skip_html_tags}}               # emulate possessive quantifers by repeating patterns
-                    |   {{backticks}}
-                    |   {{escape}}
-                    |   __).                             # Everything else besides style closer
-                )+
-                __                                       # Close
-            )
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.bold.markdown
+          pop: true
+        - match: '^(?={{list_item}})'
+          pop: true
+        - include: hard-line-break
+    - match: '(\b__)(?=\S)(?!_)(?:\*)?'
       captures:
         1: punctuation.definition.bold.begin.markdown
       push:
@@ -299,13 +256,20 @@ contexts:
               (?x)
                   [ \t]*_{3,}    # if there are more than 3 its not applicable to be bold or italic
               |   [ \t]+__+      # whitespace followed by 2 or more is also not applicable
-        - match: (\1)(?!\1)
+              |   ^__            # emphasis can't be closed at the start of the line
+        - match: (__\b)
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
         - include: scope:text.html.basic
         - include: inline
         - include: italic
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.bold.markdown
+          pop: true
+        - match: '^(?={{list_item}})'
+          pop: true
+        - include: hard-line-break
   bracket:
     - match: '<(?![a-z/?\$!])'
       comment: |
@@ -419,32 +383,7 @@ contexts:
     - include: inline-bold-italic
     - include: hard-line-break
   italic:
-    - match: |-
-        (?x)
-            (\*)(?=\S)(?!\*)                            # Open
-            (?=
-                (?:
-                    {{skip_html_tags}}                  # HTML tags
-                  | {{backticks}}                       # Raw
-                  | {{escape}}                          # Escapes
-                  | \[{{balance_square_brackets}}\]
-                        (?:
-                            (?:                         # Reference Link
-                                [ ]?                    # Optional space
-                                \[[^\]]*\]              # Optional Ref name
-                            )
-                          | {{url_and_title}}
-                        )
-                  | \*{2,}                              # Must be bold opener or closer or not applicable
-                  | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!
-                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
-                    |   {{backticks}}
-                    |   {{escape}}
-                    |   \*).                            # Everything else besides style closer
-                )+
-                \*                                      # Close
-            )
+    - match: '(\*)(?=\S)(?!\*)'
       captures:
         1: punctuation.definition.italic.begin.markdown
       push:
@@ -453,39 +392,22 @@ contexts:
               (?x)
                   [ \t]*\*{3,}   # if there are more than 3 its not applicable to be bold or italic
               |   [ \t]+\*(?!\*) # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        - match: (\1)(?!\1)
+              |   ^\*(?!\*)      # emphasis can't be closed at the start of the line
+        - match: (\*)(?!\*)
           captures:
             1: punctuation.definition.italic.end.markdown
           pop: true
         - include: scope:text.html.basic
         - include: inline
         - include: bold
-    - match: |-
-        (?x)
-            (\b_)(?=\S)(?!_)                            # Open
-            (?=
-                (?:
-                    {{skip_html_tags}}                  # HTML tags
-                  | {{backticks}}                       # Raw
-                  | {{escape}}                          # Escapes
-                  | \[{{balance_square_brackets}}\]
-                        (?:
-                            (?:                         # Reference Link
-                                [ ]?                    # Optional space
-                                \[[^\]]*\]              # Optional Ref name
-                            )
-                          | {{url_and_title}}
-                        )
-                  | _{2,}                               # Must be bold opener or closer or not applicable
-                  | [ \t]_+                             # Match whitespace followed by the style closer because it doesn't close the style
-                  | (?!
-                        {{skip_html_tags}}              # emulate possessive quantifers by repeating patterns
-                    |   {{backticks}}
-                    |   {{escape}}
-                    |   _).                             # Everything else besides style closer
-                )+
-                _                                       # Close
-            )
+        - match: '\*+'
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.italic.markdown
+          pop: true
+        - match: '^(?={{list_item}})'
+          pop: true
+        - include: hard-line-break
+    - match: '(\b_)(?=\S)(?!_)'
       captures:
         1: punctuation.definition.italic.begin.markdown
       push:
@@ -494,13 +416,20 @@ contexts:
               (?x)
                   [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
               |   [ \t]+_(?!_)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        - match: (\1)(?!\1)
+              |   ^_(?!_)       # emphasis can't be closed at the start of the line
+        - match: (_\b)
           captures:
             1: punctuation.definition.italic.end.markdown
           pop: true
         - include: scope:text.html.basic
         - include: inline
         - include: bold
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.italic.markdown
+          pop: true
+        - match: '^(?={{list_item}})'
+          pop: true
+        - include: hard-line-break
     - match: '[*_]+'
   hard-line-break:
     - match: '[ ]{2,}$'

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -10,7 +10,7 @@ file_extensions:
 scope: text.html.markdown
 comment: this definition aims to (eventually) meet CommonMark specifications http://spec.commonmark.org/
 variables:
-    separator_line: |-
+    thematic_break: |-
         (?x:
             [ ]{,3}
             (?:
@@ -21,8 +21,8 @@ variables:
             [ \t]*$
         )
     block_quote: '(?:[ ]{,3}>(?:.|$))'
-    block_heading: '(?:[#]{1,6}\s*)'
-    block_raw: '(?:[ ]{4}|\t)'
+    atx_heading: '(?:[#]{1,6}\s*)'
+    indented_code_block: '(?:[ ]{4}|\t)'
     list_item: '(?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s)'
     link_title: |-
         (?x:[ \t]*                # Optional whitespace
@@ -73,9 +73,9 @@ contexts:
     - match: |-
         (?x)^
         (?=  {{block_quote}}
-        |    {{block_raw}}(?!$)
-        |    {{block_heading}}
-        |    {{separator_line}}
+        |    {{indented_code_block}}(?!$)
+        |    {{atx_heading}}
+        |    {{thematic_break}}
         )
       comment: |
         We could also use an empty end match and set
@@ -83,10 +83,10 @@ contexts:
                         pattern will only match stuff matched by the sub-patterns.
       push:
         - meta_scope: meta.block-level.markdown
-        - include: block_quote
-        - include: block_raw
-        - include: heading
-        - include: separator
+        - include: block-quote
+        - include: indented-code-block
+        - include: atx-heading
+        - include: thematic-break
         - match: ''
           pop: true
     - match: '^[ ]{0,3}([*+-])(?=\s)'
@@ -147,21 +147,21 @@ contexts:
                     {{block_quote}}    # a block quote begins the line
                 |   [ ]{,3}[*+-][ ]    # an unordered list item begins the line
                 |   [ ]{,3}1[.][ ]     # an ordered list item with number "1" begins the line
-                |   \#                 # a block heading begins the line
+                |   \#                 # an ATX heading begins the line
                 )
             )
           pop: true
         - include: inline-bold-italic-linebreak
         - include: scope:text.html.basic
         - match: '^(={3,})(?=[ \t]*$)'
-          scope: markup.heading.1.markdown
+          scope: markup.heading.1.setext.markdown
           captures:
-            1: punctuation.definition.heading.markdown
+            1: punctuation.definition.heading.setext.markdown
           pop: true
         - match: '^(-{3,})(?=[ \t]*$)'
-          scope: markup.heading.2.markdown
+          scope: markup.heading.2.setext.markdown
           captures:
-            1: punctuation.definition.heading.markdown
+            1: punctuation.definition.heading.setext.markdown
           pop: true
   ampersand:
     - match: "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)"
@@ -169,7 +169,7 @@ contexts:
         Markdown will convert this for us. We match it so that the
                         HTML grammar will not mark it up as invalid.
       scope: meta.other.valid-ampersand.markdown
-  block_quote:
+  block-quote:
     - match: '[ ]{,3}(>)[ ]?'
       comment: |
         We terminate the block quote when seeing an empty line, a
@@ -186,7 +186,7 @@ contexts:
         - match: |-
             (?x)^
             (?=  \s*$
-            |    {{separator_line}}
+            |    {{thematic_break}}
             |    {{block_quote}}
             )
           pop: true
@@ -197,18 +197,18 @@ contexts:
           push:
             - match: ^
               pop: true
-            - include: block_quote
+            - include: block-quote
         - match: |-
             (?x)
-            (?=  {{block_raw}}
-            |    {{block_heading}}
-            |    {{separator_line}}
+            (?=  {{indented_code_block}}
+            |    {{atx_heading}}
+            |    {{thematic_break}}
             |    {{list_item}}
             )
           push:
-            - include: block_raw
-            - include: heading
-            - include: separator
+            - include: indented-code-block
+            - include: atx-heading
+            - include: thematic-break
             - match: '{{list_item}}'
               captures:
                 1: punctuation.definition.list_item.markdown
@@ -220,8 +220,8 @@ contexts:
             - match: $|^
               pop: true
             - include: inline-bold-italic-linebreak
-  block_raw:
-    - match: '{{block_raw}}.*$\n?'
+  indented-code-block:
+    - match: '{{indented_code_block}}.*$\n?'
       scope: markup.raw.block.markdown
   bold:
     - match: |-
@@ -315,7 +315,7 @@ contexts:
   escape:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
-  heading:
+  atx-heading:
     - match: '(#{1,6})(?!#)\s*(?=\S)'
       captures:
         1: punctuation.definition.heading.begin.markdown
@@ -326,7 +326,7 @@ contexts:
           captures:
             1: punctuation.definition.heading.end.markdown
           pop: true
-        - include: inline-bold-italic-linebreak
+        - include: inline-bold-italic
   image-inline:
     - match: |-
         (?x:
@@ -406,16 +406,18 @@ contexts:
     - include: raw
     - include: image-inline
     - include: link-inline
-    - include: link-inet
-    - include: link-email
+    - include: autolink-inet
+    - include: autolink-email
     - include: image-ref
     - include: link-ref-literal
     - include: link-ref
-  inline-bold-italic-linebreak:
+  inline-bold-italic:
     - include: inline
     - include: bold
     - include: italic
-    - include: line-break
+  inline-bold-italic-linebreak:
+    - include: inline-bold-italic
+    - include: hard-line-break
   italic:
     - match: |-
         (?x)
@@ -500,17 +502,21 @@ contexts:
         - include: inline
         - include: bold
     - match: '[*_]+'
-  line-break:
+  hard-line-break:
     - match: '[ ]{2,}$'
-      scope: meta.dummy.line-break
-  link-email:
+      scope: meta.hard-line-break.markdown
+    - match: '(\\)$\n'
+      scope: meta.hard-line-break.markdown
+      captures:
+        1: constant.character.escape.markdown
+  autolink-email:
     - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
       scope: meta.link.email.lt-gt.markdown
       captures:
         1: punctuation.definition.link.begin.markdown
         2: markup.underline.link.markdown
         4: punctuation.definition.link.end.markdown
-  link-inet:
+  autolink-inet:
     - match: (<)((?:https?|ftp)://.*?)(>)
       scope: meta.link.inet.markdown
       captures:
@@ -617,8 +623,8 @@ contexts:
         2: punctuation.definition.constant.end.markdown
       pop: true
   list-paragraph:
-    - include: block_raw
-    - include: block_quote
+    - include: indented-code-block
+    - include: block-quote
     - match: \s+(?=\S)
       push:
         - meta_scope: meta.paragraph.list.markdown
@@ -643,7 +649,7 @@ contexts:
       pop: true
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
-  raw:
+  fenced-code-block:
     - match: '^[ ]{0,3}(`{3,}(?![^`]+`)|~{3,}(?![^~]+~))([\w-]*).*$'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
@@ -653,6 +659,7 @@ contexts:
         - match: '[ ]{,3}\1\s*$'
           scope: punctuation.definition.raw.code-fence.end.markdown
           pop: true
+  code-span:
     - match: (`+)(?=\S)(?!`)
       scope: punctuation.definition.raw.begin.markdown
       push:
@@ -664,11 +671,14 @@ contexts:
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
+  raw:
+    - include: fenced-code-block
+    - include: code-span
     - match: '`+'
       scope: invalid.deprecated.unescaped-backticks.markdown
-  separator:
-    - match: '{{separator_line}}\n?'
-      scope: meta.separator.markdown
+  thematic-break:
+    - match: '{{thematic_break}}\n?'
+      scope: meta.separator.thematic-break.markdown
   disable-markdown:
     - match: (</)(\1)(>)
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -468,7 +468,7 @@ contexts:
   link-inline-link-text:
     - meta_scope: meta.link.inline.markdown
     - meta_content_scope: string.other.link.title.markdown
-    - include: link-text
+    - include: link-text-allow-image
     - match: \]
       scope: punctuation.definition.string.end.markdown
       pop: true
@@ -510,7 +510,7 @@ contexts:
   link-ref-link-text:
     - meta_scope: meta.link.reference.markdown
     - meta_content_scope: string.other.link.title.markdown
-    - include: link-text
+    - include: link-text-allow-image
     - match: \]
       scope: punctuation.definition.string.end.markdown
       pop: true
@@ -540,7 +540,7 @@ contexts:
   link-ref-literal-link-text:
     - meta_scope: meta.link.reference.literal.markdown
     - meta_content_scope: string.other.link.title.markdown
-    - include: link-text
+    - include: link-text-allow-image
     - match: \]
       scope: punctuation.definition.string.end.markdown
       pop: true
@@ -630,6 +630,7 @@ contexts:
     - include: scope:text.html.basic
   link-text:
     - include: escape
+    - include: ampersand
     - include: raw
     - match: \[ # nested square brackets are allowed
       push:
@@ -639,3 +640,8 @@ contexts:
     - include: bold
     - include: italic
     - include: hard-line-break
+    - include: scope:text.html.basic
+  link-text-allow-image:
+    - include: link-text
+    - include: image-inline
+    - include: image-ref

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -34,10 +34,10 @@ variables:
     escape: '\\[-`*_#+.!(){}\[\]\\>]'
     backticks: |-
         (?x:
-            (`{4})[^`]+(?:[^`]+|(?!`{4})`*)*(`{4})(?!`)
-        |   (`{3})[^`]+(?:[^`]+|(?!`{3})`*)*(`{3})(?!`)
-        |   (`{2})[^`]+(?:[^`]+|(?!`{2})`*)*(`{2})(?!`)
-        |   (`{1})[^`]+(?:[^`]+|(?!`{1})`*)*(`{1})(?!`)
+            (`{4})(?=\S)[^`]+(?:[^`]+|(?!`{4})`*)*(`{4})(?!`)
+        |   (`{3})(?=\S)[^`]+(?:[^`]+|(?!`{3})`*)*(`{3})(?!`)
+        |   (`{2})(?=\S)[^`]+(?:[^`]+|(?!`{2})`*)*(`{2})(?!`)
+        |   (`{1})(?=\S)[^`]+(?:[^`]+|(?!`{1})`*)*(`{1})(?!`)
         )
     balance: |-
         (?x:
@@ -643,17 +643,6 @@ contexts:
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
   raw:
-    - match: '{{backticks}}'
-      scope: markup.raw.inline.markdown
-      captures:
-        1: punctuation.definition.raw.begin.markdown
-        2: punctuation.definition.raw.end.markdown
-        3: punctuation.definition.raw.begin.markdown
-        4: punctuation.definition.raw.end.markdown
-        5: punctuation.definition.raw.begin.markdown
-        6: punctuation.definition.raw.end.markdown
-        7: punctuation.definition.raw.begin.markdown
-        8: punctuation.definition.raw.end.markdown
     - match: '^[ ]{0,3}(`{3,}(?![^`]+`)|~{3,}(?![^~]+~))([\w-]*).*$'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
@@ -662,6 +651,17 @@ contexts:
         - meta_scope: markup.raw.code-fence.markdown
         - match: '[ ]{,3}\1\s*$'
           scope: punctuation.definition.raw.code-fence.end.markdown
+          pop: true
+    - match: (`+)(?=\S)(?!`)
+      scope: punctuation.definition.raw.begin.markdown
+      push:
+        - meta_scope: markup.raw.inline.markdown
+        - match: \1(?!`)
+          scope: punctuation.definition.raw.end.markdown
+          pop: true
+        - match: '`+'
+        - match: ^\s*$\n?
+          scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
     - match: '`+'
       scope: invalid.deprecated.unescaped-backticks.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -37,18 +37,12 @@ contexts:
                         pattern will only match stuff matched by the sub-patterns.
       push:
         - meta_scope: meta.block-level.markdown
-        - match: |-
-            (?x)^
-            (?!  {{block_quote}}
-            |    {{block_raw}}
-            |    {{block_heading}}
-            |    {{separator_line}}
-            )
-          pop: true
         - include: block_quote
         - include: block_raw
         - include: heading
         - include: separator
+        - match: ''
+          pop: true
     - match: '^[ ]{0,3}([*+-])(?=\s)'
       captures:
         1: punctuation.definition.list_item.markdown
@@ -105,13 +99,14 @@ contexts:
       push: 
         - meta_scope: meta.paragraph.markdown
         - match: |-
-            (?x)
+            (?x)                        # pop out of this context when
             ^(?:
-                \s*$
+                \s*$                    # the line is blank (or only contains whitespace)
             |   (?=
-                    {{block_quote}}
-                |   ^[ ]{,3}[*+-][ ]
-                |   ^\#
+                    {{block_quote}}     # a block quote begins the line
+                |   ^[ ]{,3}[*+-][ ]    # an unordered list item begins the line
+                |   ^[ ]{,3}\d+[.][ ]   # an ordered list item begins the line
+                |   ^\#                 # a block heading begins the line
                 )
             )
           pop: true
@@ -134,11 +129,15 @@ contexts:
                         HTML grammar will not mark it up as invalid.
       scope: meta.other.valid-ampersand.markdown
   block_quote:
-    - match: '\G[ ]{,3}(>)[ ]?'
+    - match: '[ ]{,3}(>)[ ]?'
       comment: |
         We terminate the block quote when seeing an empty line, a
-                        separator or a line with leading > characters. The latter is
-                        to “reset” the quote level for quoted lines.
+        separator or a line with leading > characters. The latter is
+        to “reset” the quote level for quoted lines.
+        The idea here is to match block level elements first, then once
+        we have confirmed there are no block level elements left, move to
+        matching inline markdown. This prevents block level elements being
+        detected when they shouldn't be.
       captures:
         1: punctuation.definition.blockquote.markdown
       push:
@@ -151,7 +150,7 @@ contexts:
             )
           pop: true
         - match: |-
-            (?x)\G
+            (?x)
             (?=  {{block_quote}}
             )
           push:
@@ -159,7 +158,7 @@ contexts:
               pop: true
             - include: block_quote
         - match: |-
-            (?x)\G
+            (?x)
             (?=  {{block_raw}}
             |    {{block_heading}}
             |    {{separator_line}}
@@ -170,20 +169,13 @@ contexts:
             - include: separator
             - match: ^
               pop: true
-        - match: |-
-            (?x)\G
-            (?!  $
-            |    {{block_quote}}
-            |    {{block_raw}}
-            |    {{block_heading}}
-            |    {{separator_line}}
-            )
+        - match: ''
           push:
             - match: $|^
               pop: true
             - include: inline-bold-italic-linebreak
   block_raw:
-    - match: '\G{{block_raw}}.*$\n?'
+    - match: '{{block_raw}}.*$\n?'
       scope: markup.raw.block.markdown
   bold:
     - match: |-
@@ -471,7 +463,7 @@ contexts:
         1: punctuation.definition.raw.markdown
         3: punctuation.definition.raw.markdown
   separator:
-    - match: '\G{{separator_line}}\n?'
+    - match: '{{separator_line}}\n?'
       scope: meta.separator.markdown
   disable-markdown:
     - match: (</)(\1)(>)

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -239,7 +239,8 @@ contexts:
                             )
                           | {{url_and_title}}
                         )
-                  | (?=[ \t]\*\*)[ \t]\*+               # Match whitespace followed by the style closer because it doesn't close the style
+                  | \*{3,}                              # not applicable
+                  | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
                   | (?!\*\*).                           # Everything else besides style closer
                 )+
                 \*\*                                    # Close
@@ -248,7 +249,11 @@ contexts:
         1: punctuation.definition.bold.begin.markdown
       push:
         - meta_scope: markup.bold.markdown
-        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+        - match: |-
+              (?x)
+                  [ \t]*\*{3,}     # if there are more than 3 its not applicable to be bold or italic
+              |   [ \t]+\*\*+      # whitespace followed by 2 or more is also not applicable
+        - match: (\1)(?!\1)
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
@@ -271,7 +276,8 @@ contexts:
                             )
                           | {{url_and_title}}
                         )
-                  | (?=[ \t]__)[ \t]_+                   # Match whitespace followed by the style closer because it doesn't close the style
+                  | _{3,}                                # not applicable
+                  | [ \t]_+                              # Match whitespace followed by the style closer because it doesn't close the style
                   | (?!__).                              # Everything else besides style closer
                 )+
                 __                                       # Close
@@ -280,7 +286,11 @@ contexts:
         1: punctuation.definition.bold.begin.markdown
       push:
         - meta_scope: markup.bold.markdown
-        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+        - match: |-
+              (?x)
+                  [ \t]*_{3,}    # if there are more than 3 its not applicable to be bold or italic
+              |   [ \t]+__+      # whitespace followed by 2 or more is also not applicable
+        - match: (\1)(?!\1)
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
@@ -414,8 +424,8 @@ contexts:
                             )
                           | {{url_and_title}}
                         )
-                  | \*\*                                # Must be bold closer
-                  | (?=[ \t]\*)[ \t]\*+                 # Match whitespace followed by the style closer because it doesn't close the style
+                  | \*{2,}                              # Must be bold opener or closer or not applicable
+                  | [ \t]\*+                            # Match whitespace followed by the style closer because it doesn't close the style
                   | (?!\*).                             # Everything else besides style closer
                 )+
                 \*                                      # Close
@@ -424,7 +434,11 @@ contexts:
         1: punctuation.definition.italic.begin.markdown
       push:
         - meta_scope: markup.italic.markdown
-        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+        - match: |-
+              (?x)
+                  [ \t]*\*{3,}   # if there are more than 3 its not applicable to be bold or italic
+              |   [ \t]+\*(?!\*) # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        - match: (\1)(?!\1)
           captures:
             1: punctuation.definition.italic.end.markdown
           pop: true
@@ -447,8 +461,8 @@ contexts:
                             )
                           | {{url_and_title}}
                         )
-                  | __                                  # Must be bold closer
-                  | (?=[ \t]_)[ \t]_+                   # Match whitespace followed by the style closer because it doesn't close the style
+                  | _{2,}                               # Must be bold opener or closer or not applicable
+                  | [ \t]_+                             # Match whitespace followed by the style closer because it doesn't close the style
                   | (?!_).                              # Everything else besides style closer
                 )+
                 _                                       # Close
@@ -457,7 +471,12 @@ contexts:
         1: punctuation.definition.italic.begin.markdown
       push:
         - meta_scope: markup.italic.markdown
-        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+        - match: |-
+              (?x)
+                  [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
+              |   [ \t]+_(?!_)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        
+        - match: (\1)(?!\1)
           captures:
             1: punctuation.definition.italic.end.markdown
           pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -546,8 +546,16 @@ contexts:
         2: punctuation.definition.constant.end.markdown
       pop: true
   list-paragraph:
-    - include: indented-code-block
-    - include: block-quote
+    - match: '^(?=\s+(?![>+*\s-]))(?={{indented_code_block}})'
+      push:
+        - include: indented-code-block
+        - match: $
+          pop: true
+    - match: '^(?=\s+{{block_quote}})'
+      push:
+        - include: block-quote
+        - match: $
+          pop: true
     - match: \s+(?=\S)
       push:
         - meta_scope: meta.paragraph.list.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -225,7 +225,7 @@ contexts:
   bold:
     - match: |-
         (?x)
-            (\*\*|\b__)(?=\S)                              # Open
+            (\*\*|\b__)(?=\S)(?!\1)                        # Open
             (?=
                 (
                     {{skip_html_tags}}                     # HTML tags
@@ -235,20 +235,14 @@ contexts:
                         (
                             (                              # Reference Link
                                 [ ]?                       # Optional space
-                                \[[^\]]*+\]                # Ref name
+                                \[[^\]]*\]                 # Optional Ref name
                             )
-                          | (                              # Inline Link
-                                \(                         # Opening paren
-                                    [ \t]*+                # Optional whitespace
-                                    <?(.*?)>?              # URL
-                                    {{link_title}}         # Optional Title
-                                \)
-                            )
+                          | {{url_and_title}}
                         )
-                  | (?!(?<=\S)\1).                         # Everything besides
-                                                           # style closer
+                  | (?=[ \t]\1)[ \t]\1+                    # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!\1).                                # Everything else besides style closer
                 )++
-                (?<=\S)\1                                  # Close
+                \1                                         # Close
             )
       captures:
         1: punctuation.definition.bold.begin.markdown
@@ -374,7 +368,7 @@ contexts:
   italic:
     - match: |-
         (?x)
-            (\*|\b_)(?=\S)                              # Open
+            (\*|\b_)(?=\S)(?!\1)                        # Open
             (?=
                 (
                     {{skip_html_tags}}                  # HTML tags
@@ -384,21 +378,15 @@ contexts:
                         (
                             (                           # Reference Link
                                 [ ]?                    # Optional space
-                                \[[^\]]*+\]             # Ref name
+                                \[[^\]]*\]              # Optional Ref name
                             )
-                          | (                           # Inline Link
-                                \(                      # Opening paren
-                                    [ \t]*+             # Optional whitespace
-                                    <?(.*?)>?           # URL
-                                    {{link_title}}      # Optional Title
-                                \)
-                            )
+                          | {{url_and_title}}
                         )
                   | \1\1                                # Must be bold closer
-                  | (?!(?<=\S)\1).                      # Everything besides
-                                                        # style closer
+                  | (?=[ \t]\1)[ \t]\1+                 # Match whitespace followed by the style closer because it doesn't close the style
+                  | (?!\1).                             # Everything else besides style closer
                 )++
-                (?<=\S)\1                               # Close
+                \1                                      # Close
             )
       captures:
         1: punctuation.definition.italic.begin.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -654,7 +654,17 @@ contexts:
         6: punctuation.definition.raw.end.markdown
         7: punctuation.definition.raw.begin.markdown
         8: punctuation.definition.raw.end.markdown
+    - match: '^[ ]{0,3}(`{3,}(?![^`]+`)|~{3,}(?![^~]+~))([\w-]*).*$'
+      captures:
+        1: punctuation.definition.raw.code-fence.begin.markdown
+        2: constant.other.language-name.markdown
+      push:
+        - meta_scope: markup.raw.code-fence.markdown
+        - match: '[ ]{,3}\1\s*$'
+          scope: punctuation.definition.raw.code-fence.end.markdown
+          pop: true
     - match: '`+'
+      scope: invalid.deprecated.unescaped-backticks.markdown
   separator:
     - match: '{{separator_line}}\n?'
       scope: meta.separator.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -34,10 +34,10 @@ variables:
     escape: '\\[-`*_#+.!(){}\[\]\\>]'
     backticks: |-
         (?x:
-            (````)(({{escape}})|[^`\\]+|`(?!```))+(````)
-        |   (``` )(({{escape}})|[^`\\]+|`(?!`` ))+(``` )
-        |   (``  )(({{escape}})|[^`\\]+|`(?!`  ))+(``  )
-        |   (`   )(({{escape}})|[^`\\]+         )+(`   )
+            (`{4})([^`]+|`(?!`{3}))+(`{4})
+        |   (`{3})([^`]+|`(?!`{2}))+(`{3})
+        |   (`{2})([^`]+|`(?!`{1}))+(`{2})
+        |   (`{1})([^`]+          )+(`{1})
         )
     balance: |-
         (?x:
@@ -59,7 +59,7 @@ variables:
         )
     url_and_title: |-
         (?x:
-          ([ ])?                        # Space not allowed
+          ([ ])?                        # Space not allowed, but we check for it anyway to mark it as invalid
           (\()                          # Opening paren for url
               (<?)(\S+?)(>?)            # The url
               {{link_title}}            # Optional title
@@ -557,8 +557,6 @@ contexts:
       scope: punctuation.definition.raw.begin.markdown
       push:
         - meta_scope: markup.raw.inline.markdown
-        - match: '\\`'
-          scope: constant.character.escape.markdown
         - match: '\1'
           scope: punctuation.definition.raw.end.markdown
           pop: true

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -44,16 +44,17 @@ Here is a [blank reference link][].
 |                               ^ punctuation.definition.constant.begin
 |                                ^ punctuation.definition.constant.end
 
-Here is a ![Image Alt Text](htts://example.com/cat.git).
+Here is a ![Image Alt Text](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
 |          ^ punctuation.definition.string.begin
 |                         ^ punctuation.definition.string.end
 |                          ^ punctuation.definition.metadata
-|                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                                                     ^ punctuation.definition.metadata
+|                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                      ^ punctuation.definition.metadata
 
 Here is a ![Image Ref Alt][1].
 |         ^^^^^^^^^^^^^^^^^^^ meta.image.reference
+|         ^ punctuation.definition.image.begin
 |          ^ punctuation.definition.string.begin
 |                        ^ punctuation.definition.string.end
 |                         ^ punctuation.definition.constant
@@ -319,10 +320,26 @@ because it doesn't begin with the number one:
 - `code` - <a name="demo"></a>
 | ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw
 |          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html
- 3. [see `demo`](#demo)
+ 3. [see `demo`](#demo "demo")
 | ^ punctuation.definition.list_item
 |    ^^^^^^^^^^ string.other.link.title
-    Here is a ![example image](https://test.com/sublime.gif "A demonstration").
+|               ^ punctuation.definition.metadata.begin
+|                      ^ punctuation.definition.string.begin
+|                           ^ punctuation.definition.string.end
+|                            ^ punctuation.definition.metadata.end
+    [see `demo`](#demo (demo))
+|    ^^^^^^^^^^ string.other.link.title
+|               ^ punctuation.definition.metadata.begin
+|                      ^ punctuation.definition.string.begin
+|                           ^ punctuation.definition.string.end
+|                            ^ punctuation.definition.metadata.end
+    [see `demo`](#demo 'demo')
+|    ^^^^^^^^^^ string.other.link.title
+|               ^ punctuation.definition.metadata.begin
+|                      ^ punctuation.definition.string.begin
+|                           ^ punctuation.definition.string.end
+|                            ^ punctuation.definition.metadata.end
+    Here is a ![example image](https://test.com/sublime.png "A demonstration").
 |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
 |             ^ punctuation.definition.image.begin
 |              ^ punctuation.definition.string.begin
@@ -330,6 +347,30 @@ because it doesn't begin with the number one:
 |                             ^ punctuation.definition.metadata
 |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
 |                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
+|                                                           ^ punctuation.definition.string.begin
+|                                                                           ^ punctuation.definition.string.end
+|                                                                            ^ punctuation.definition.metadata
+    Here is a ![example image](https://test.com/sublime.png 'A demonstration').
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
+|             ^ punctuation.definition.image.begin
+|              ^ punctuation.definition.string.begin
+|                            ^ punctuation.definition.string.end
+|                             ^ punctuation.definition.metadata
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
+|                                                           ^ punctuation.definition.string.begin
+|                                                                           ^ punctuation.definition.string.end
+|                                                                            ^ punctuation.definition.metadata
+    Here is a ![example image](https://test.com/sublime.png (A demonstration)).
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
+|             ^ punctuation.definition.image.begin
+|              ^ punctuation.definition.string.begin
+|                            ^ punctuation.definition.string.end
+|                             ^ punctuation.definition.metadata
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
+|                                                           ^ punctuation.definition.string.begin
+|                                                                           ^ punctuation.definition.string.end
 |                                                                            ^ punctuation.definition.metadata
 
   <!-- HTML comment -->

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -519,9 +519,26 @@ for (var i = 0; i < 10; i++) {
 |         ^^ - punctuation
 |              ^^^ punctuation.definition.raw.end
 ```testing``123````
-| <- invalid
-|         ^^ invalid
-|              ^^^^ invalid
+| <- punctuation.definition.raw.begin
+|        ^ - punctuation
+|            ^^^^ - punctuation
+```
+| <- punctuation.definition.raw.end
+``testing`123````
+| <- punctuation.definition.raw.begin
+|        ^ - punctuation
+|            ^^^^ - punctuation
+more text``
+|        ^^ punctuation.definition.raw.end
+``text
+
+| <- invalid.illegal.non-terminated.raw
+text
+| <- - markup.raw
+
+inline backticks must be followed by non-whitespace `` characters``
+|                                                   ^^ invalid.deprecated.unescaped-backticks
+|                                                                ^^ invalid.deprecated.unescaped-backticks
 
 ~~~~ 
 | <- punctuation.definition.raw.code-fence.begin

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -452,3 +452,16 @@ the following is not bold ** test ****
 the following is not italic _ test ____
 |                           ^ - punctuation.definition.italic.begin
 |                                  ^^^^ - punctuation.definition.italic
+
+more **tests *** ** here**
+|    ^^ punctuation.definition.bold.begin
+|            ^^^^^^ - punctuation.definition
+|                       ^^ punctuation.definition.bold.end
+more __tests *** ** *example __ here__
+|    ^^ punctuation.definition.bold.begin
+|            ^^^^^^^^^^^^^^^^^^^^^^^ - punctuation.definition
+|                                   ^^ punctuation.definition.bold.end
+more _tests <span class="test_">here</span>_
+|    ^ punctuation.definition.italic.begin
+|                            ^ - punctuation.definition
+|                                          ^ punctuation.definition.italic.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -112,7 +112,8 @@ Paragraph break.
 Paragraph break.
 
 --------
-|^^^^^^^ meta.separator
+|^^^^^^^^ meta.block-level meta.separator.thematic-break
+|^^^^^^^ punctuation.definition.thematic-break
 
 [1]: https://google.com
 | <- meta.link.reference.def
@@ -205,12 +206,24 @@ paragraph
 
 - - - -
 | ^^^^^^ meta.block-level meta.separator
-
+| ^ punctuation.definition.thematic-break
+|   ^ punctuation.definition.thematic-break
+|     ^ punctuation.definition.thematic-break
+|  ^ - punctuation
 * * * * *
 | ^^^^^^^^ meta.block-level meta.separator
 
 _ _ _ _ _ _ _
 | ^^^^^^^^^^^^ meta.block-level meta.separator
+| ^ punctuation.definition.thematic-break
+|   ^ punctuation.definition.thematic-break
+|  ^ - punctuation
+
+-  -  -  - 
+| <- meta.block-level meta.separator.thematic-break punctuation.definition.thematic-break
+|^^ - punctuation
+|  ^ punctuation
+|        ^ punctuation
 
 <mailto:test+test@test.com>
 | ^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.email.lt-gt markup.underline.link
@@ -949,3 +962,19 @@ blah*
 | <- markup.list.unnumbered meta.paragraph.list markup.italic invalid.illegal.non-terminated.italic
   still a list item
 | ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list
+- * * * * * * *
+| <- punctuation.definition.list_item
+| ^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.paragraph.list meta.separator.thematic-break
+| ^ punctuation.definition.thematic-break
+|   ^ punctuation.definition.thematic-break
+|     ^ punctuation.definition.thematic-break
+|       ^ punctuation.definition.thematic-break
+|         ^ punctuation.definition.thematic-break
+|           ^ punctuation.definition.thematic-break
+|             ^ punctuation.definition.thematic-break
+|  ^ - punctuation.definition.thematic-break
+|    ^ - punctuation.definition.thematic-break
+|      ^ - punctuation.definition.thematic-break
+|        ^ - punctuation.definition.thematic-break
+|          ^ - punctuation.definition.thematic-break
+|            ^ - punctuation.definition.thematic-break

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -902,11 +902,11 @@ hello world ````test````
 |          ^ punctuation.definition.raw.end
 
 hard line break  
-|              ^^ meta.hard-line-break
+|              ^^ meta.hard-line-break punctuation.definition.hard-line-break
 hard line break\
 |              ^ meta.hard-line-break constant.character.escape
 hard line break     
-|              ^^^^^ meta.hard-line-break
+|              ^^^^^ meta.hard-line-break punctuation.definition.hard-line-break
 soft line break 
 |              ^^ - meta.hard-line-break
 soft line break
@@ -1042,3 +1042,39 @@ _foo [**bar**](/url)_
 |^^^^^^^^^^^ meta.link.reference.def constant.other.reference.link
 |            ^ punctuation.separator.key-value
 |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+
+[//]: # (This is a comment without a line-break.)
+|     ^ meta.link.reference.def markup.underline.link
+|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.description.title
+
+[//]: # (This is a comment with a
+|     ^ meta.link.reference.def markup.underline.link
+|       ^ punctuation.definition.string.begin
+        line-break.)
+|                  ^ punctuation.definition.string.end
+
+[//]: # (testing)blah
+|       ^ punctuation.definition.string.begin
+|^^^^^^^^^^^^^^^^ meta.link.reference.def
+|               ^ punctuation.definition.string.end
+|                ^^^^ invalid.illegal.expected-eol
+
+[//]: # (testing
+blah
+| <- meta.link.reference.def string.other.link.description.title
+
+| <- invalid.illegal.non-terminated.link-title
+text
+| <- meta.paragraph - meta.link.reference.def
+
+[foo]: <bar> "test"
+|      ^ punctuation.definition.link.begin
+|       ^^^ markup.underline.link
+|          ^ punctuation.definition.link.end
+|            ^^^^^^ string.other.link.description.title
+
+[foo]: <bar>> "test"
+|      ^ punctuation.definition.link.begin
+|       ^^^ markup.underline.link
+|          ^ punctuation.definition.link.end
+|           ^^^^^^^^ invalid.illegal.expected-eol

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -504,3 +504,10 @@ _test <span>text **formatted**</span>_
 |                                            ^^ punctuation
 |                                               ^ punctuation
 |                                                    ^ punctuation
+```testing``123```
+| <- punctuation.definition.raw.begin
+|         ^^ - punctuation
+|              ^^^ punctuation.definition.raw.end
+```testing``123````
+| <- - punctuation
+| ^^^^^^^^^^^^^^^^^ - punctuation

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -432,3 +432,9 @@ _italic text <span>HTML element</span> end of italic text_
 |     ^^ punctuation.definition.raw.begin
 |                                                     ^^ punctuation.definition.raw.end
 |                                                       ^ punctuation.definition.string.end
+`inline markup <span></span>`
+|              ^^^^^^^^^^^^^ markup.raw.inline - meta.tag.inline.any.html
+escaped backtick \`this is not code\`
+|                ^^ constant.character.escape
+|                                  ^^ constant.character.escape
+|                  ^^^^^^^^^^^^^^^^ - markup.raw.inline

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -573,6 +573,12 @@ hard line break
 |              ^^ meta.hard-line-break
 hard line break\
 |              ^ meta.hard-line-break constant.character.escape
+hard line break     
+|              ^^^^^ meta.hard-line-break
+soft line break 
+|              ^^ - meta.hard-line-break
+soft line break
+|             ^^ - meta.hard-line-break
 
 ### foo  
 |      ^^^ - meta.hard-line-break

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1000,3 +1000,45 @@ _foo [**bar**](/url)_
 |                   ^ punctuation.definition.italic.end
 |     ^^ punctuation.definition.bold.begin
 |          ^^ punctuation.definition.bold.end
+
+
+1. Open `Command Palette` using menu item `Tools → Command Palette...`
+|^ markup.list.numbered punctuation.definition.list_item
+|                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list markup.raw.inline
+2. Choose `Package Control: Install Package`
+
+[**Read more &#8594;**][details]
+|^^ punctuation.definition.bold.begin
+|            ^^^^^^^ constant.character.entity.html
+|                   ^^ punctuation.definition.bold.end
+|                       ^^^^^^^ constant.other.reference.link
+
+[Read more &#8594;][details]
+|          ^^^^^^^ constant.character.entity.html
+|                   ^^^^^^^ constant.other.reference.link
+
+[Read more <span style="font-weight: bold;">&#8594;</span>][details]
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|                       ^^^^^^^^^^^^^^^^^^ source.css
+|                                           ^^^^^^^ constant.character.entity.html
+|                                                           ^^^^^^^ constant.other.reference.link
+
+[![Cool ★ Image - Click to Enlarge][img-example]][img-example]
+|^ punctuation.definition.image.begin
+|                                   ^^^^^^^^^^^ constant.other.reference.link
+|                                               ^ punctuation.definition.string.end
+|                                                 ^^^^^^^^^^^ constant.other.reference.link
+
+[![Cool ★ Image - Click to Enlarge](http://www.sublimetext.com/anim/rename2_packed.png)](http://www.sublimetext.com/anim/rename2_packed.png)
+|^ punctuation.definition.image.begin
+|                                  ^ punctuation.definition.metadata.begin
+|                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                                                     ^ punctuation.definition.metadata.end
+|                                                                                       ^ punctuation.definition.metadata.begin
+|                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                                                                                                                          ^ punctuation.definition.metadata.end
+
+[img-example]: http://www.sublimetext.com/anim/rename2_packed.png
+|^^^^^^^^^^^ meta.link.reference.def constant.other.reference.link
+|            ^ punctuation.separator.key-value
+|              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -465,3 +465,42 @@ more _tests <span class="test_">here</span>_
 |    ^ punctuation.definition.italic.begin
 |                            ^ - punctuation.definition
 |                                          ^ punctuation.definition.italic.end
+_more `tests_` here_
+| <- punctuation.definition.italic.begin
+|     ^^^^^^^^ markup.raw.inline
+|                  ^ punctuation.definition.italic.end
+__more `tests__` here__
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+_test <span>text_ not formatted</span>
+| <- - punctuation
+|               ^ - punctuation
+__test <span>text__ not formatted</span>
+| <- - punctuation
+|                ^^ - punctuation
+*test <span>text* not formatted</span>
+| <- - punctuation
+|               ^ - punctuation
+**test <span>text** not formatted</span>
+| <- - punctuation
+|                ^^ - punctuation
+_test <span>text **formatted**</span>_
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+*test <span>text __formatted__</span>*
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+*test <span>text __formatted__</span>* **more** _text_
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+|                                      ^^ punctuation
+|                                            ^^ punctuation
+|                                               ^ punctuation
+|                                                    ^ punctuation

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -315,3 +315,10 @@ because it doesn't begin with the number one:
 * list continues
 | <- markup.list.unnumbered punctuation.definition.list_item - markup.raw.block
 * list continues
+
+- `code` - <a name="demo"></a>
+| ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html
+ 3. [see `demo`](#demo)
+| ^ punctuation.definition.list_item
+|    ^^^^^^^^^^ string.other.link.title

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -381,3 +381,39 @@ because it doesn't begin with the number one:
 |  ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.section
 |                            ^ - entity.name.section
 |                             ^^ punctuation.definition.heading
+
+*italic text <span>HTML element</span> end of italic text*
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+_italic text <span>HTML element</span> end of italic text_
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+**bold text <span>HTML element</span> end of bold text**
+| <- punctuation.definition.bold
+|                                                     ^^ punctuation.definition.bold
+|           ^^^^^^ meta.tag.inline.any.html
+|                             ^^^^^^^ meta.tag.inline.any.html
+
+__bold text <span>HTML element</span> end of bold text__
+| <- punctuation.definition.bold
+|                                                     ^^ punctuation.definition.bold
+|           ^^^^^^ meta.tag.inline.any.html
+|                             ^^^^^^^ meta.tag.inline.any.html
+
+*italic text <span>HTML element</span> end of italic text*
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+_italic text <span>HTML element</span> end of italic text_
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -74,19 +74,19 @@ Here is a ![Image Ref Alt][1].
 
 Paragraph break.
 
-  - Ordered list item
+  - Unordered list item
 | ^ punctuation.definition.list_item
 | ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
-  - Ordered list item #2
+  - Unordered list item #2
 | ^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
 | ^ punctuation.definition.list_item
 
 Paragraph break.
 
-  * Ordered list item
+  * Unordered list item
 | ^ punctuation.definition.list_item
 | ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
-  + Ordered list item #2
+  + Unordered list item #2
 | ^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
 | ^ punctuation.definition.list_item
     + Subitem 1
@@ -172,8 +172,18 @@ non-disabled markdown
 > Followed by more quoted text that is not nested
 | <- meta.block-level markup.quote punctuation.definition.blockquote - markup.quote markup.quote
 
+> Here is a quote block
+This quote continues on.  Line breaking is OK in markdown
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block-level markup.quote
+> Here it is again
+| <- punctuation.definition.blockquote
+
 paragraph
 | <- meta.paragraph - meta.block-level
+
+>     > this is code in a quote block, not a nested quote
+| <- punctuation.definition.blockquote
+|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block - markup.quote markup.quote
 
 Code block below:
 

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -272,3 +272,12 @@ __perform__complicated__task
 Paragraph followed immediately by a list, no blank line in between
 - list item 1
 | <- markup.list.unnumbered punctuation.definition.list_item
+
+Paragraph followed immediately by a numbered list, no blank line in between
+ 1. list item 1
+| ^ markup.list.numbered punctuation.definition.list_item
+
+Paragraph not followed immediately by a numbered list,
+because it doesn't begin with the number one:
+ 2. text
+| ^ - markup.list.numbered - punctuation.definition.list_item

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -47,7 +47,7 @@ Here is a [blank reference link][].
 Here is a ![Image Alt Text](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
 |          ^ punctuation.definition.string.begin
-|                         ^ punctuation.definition.string.end
+|                         ^ punctuation.definition.string.end - string
 |                          ^ punctuation.definition.metadata
 |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
 |                                                      ^ punctuation.definition.metadata
@@ -417,3 +417,25 @@ _italic text <span>HTML element</span> end of italic text_
 |                                                        ^ punctuation.definition.italic
 |            ^^^^^^ meta.tag.inline.any.html
 |                              ^^^^^^^ meta.tag.inline.any.html
+
+[link `containing \` backticks`](#backticks)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|     ^ punctuation.definition.raw.begin
+|                 ^^ constant.character.escape
+|                             ^ punctuation.definition.raw.end
+|                              ^ punctuation.definition.string.end
+[link [containing] [square] brackets](#backticks)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|                                   ^ punctuation.definition.string.end
+[link `containing square] brackets] in backticks`[]](#wow)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|     ^ punctuation.definition.raw.begin
+|                                               ^ punctuation.definition.raw.end
+|                                                  ^ punctuation.definition.string.end
+[link ``containing square]`\`` brackets[[][] in backticks``](#wow)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline
+|     ^^ punctuation.definition.raw.begin
+|                          ^^ constant.character.escape
+|                                                        ^^ punctuation.definition.raw.end
+|                                                          ^ punctuation.definition.string.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -473,18 +473,18 @@ __more `tests__` here__
 | <- punctuation.definition.bold.begin
 |      ^^^^^^^^^ markup.raw.inline
 |                    ^^ punctuation.definition.bold.end
-_test <span>text_ not formatted</span>
-| <- - punctuation
-|               ^ - punctuation
+_test <span>text_ foobar</span>
+| <- punctuation
+|               ^ punctuation.definition.italic.end
 __test <span>text__ not formatted</span>
-| <- - punctuation
-|                ^^ - punctuation
+| <- punctuation
+|                ^^ punctuation.definition.bold.end
 *test <span>text* not formatted</span>
-| <- - punctuation
-|               ^ - punctuation
+| <- punctuation
+|               ^ punctuation.definition.italic.end
 **test <span>text** not formatted</span>
-| <- - punctuation
-|                ^^ - punctuation
+| <- punctuation
+|                ^^ punctuation.definition.bold.end
 _test <span>text **formatted**</span>_
 | <- punctuation
 |                ^^ punctuation
@@ -504,6 +504,17 @@ _test <span>text **formatted**</span>_
 |                                            ^^ punctuation
 |                                               ^ punctuation
 |                                                    ^ punctuation
+*test <span>text* __formatted</span>__
+| <- punctuation
+|               ^ punctuation
+|                 ^^ punctuation
+|                                   ^^ punctuation
+
+__test <span>text__ *formatted</span>*
+| <- punctuation
+|                ^^ punctuation
+|                   ^ punctuation
+|                                    ^ punctuation
 
 ```js
 | <- punctuation.definition.raw.code-fence.begin

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -418,12 +418,6 @@ _italic text <span>HTML element</span> end of italic text_
 |            ^^^^^^ meta.tag.inline.any.html
 |                              ^^^^^^^ meta.tag.inline.any.html
 
-[link `containing \` backticks`](#backticks)
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
-|     ^ punctuation.definition.raw.begin
-|                 ^^ constant.character.escape
-|                             ^ punctuation.definition.raw.end
-|                              ^ punctuation.definition.string.end
 [link [containing] [square] brackets](#backticks)
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
 |                                   ^ punctuation.definition.string.end
@@ -432,10 +426,9 @@ _italic text <span>HTML element</span> end of italic text_
 |     ^ punctuation.definition.raw.begin
 |                                               ^ punctuation.definition.raw.end
 |                                                  ^ punctuation.definition.string.end
-[link ``containing square]`\`` brackets[[][] in backticks``](#wow)
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
-|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline
+[link ``containing square]` brackets[[][] in backticks``](#wow)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.title
+|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline
 |     ^^ punctuation.definition.raw.begin
-|                          ^^ constant.character.escape
-|                                                        ^^ punctuation.definition.raw.end
-|                                                          ^ punctuation.definition.string.end
+|                                                     ^^ punctuation.definition.raw.end
+|                                                       ^ punctuation.definition.string.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -258,23 +258,6 @@ underlined heading followed by another one that should be treated as a normal pa
 =====
 | <- - markup.heading
 
-This text is _bold_, but this__text__is neither bold_nor_italic
-|            ^ punctuation.definition.italic
-|             ^^^^ markup.italic
-|                 ^ punctuation.definition.italic
-|                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.bold - markup.italic
-_perform_complicated_task
-| <- punctuation.definition.italic
-|       ^ punctuation.definition.italic
-|^^^^^^^ markup.italic
-|        ^^^^^^^^^^^^^^^^^ - markup.italic
-__perform__complicated__task
-| <- punctuation.definition.bold
-|^ punctuation.definition.bold
-|        ^^ punctuation.definition.bold
-|^^^^^^^^ markup.bold
-|          ^^^^^^^^^^^^^^^^^^ - markup.bold
-
 Paragraph followed immediately by a list, no blank line in between
 - list item 1
 | <- markup.list.unnumbered punctuation.definition.list_item
@@ -438,6 +421,323 @@ escaped backtick \`this is not code\`
 |                ^^ constant.character.escape
 |                                  ^^ constant.character.escape
 |                  ^^^^^^^^^^^^^^^^ - markup.raw.inline
+
+Example 328:
+*foo bar*
+| <- punctuation.definition.italic.begin
+|       ^ punctuation.definition.italic.end
+
+Example 329:
+This is not emphasis, because the opening `*` is followed by whitespace, and hence not part of a left-flanking delimiter run:
+a * foo bar*
+| ^^^^^^^^^^^ - punctuation
+
+Example 332:
+Intraword emphasis with `*` is permitted:
+foo*bar*
+|  ^ punctuation.definition.italic.begin
+|      ^ punctuation.definition.italic.end
+Example 333:
+5*6*78
+|^ punctuation.definition.italic.begin
+|  ^ punctuation.definition.italic.end
+
+Example 334:
+_foo bar_
+| <- punctuation.definition.italic.begin
+|       ^ punctuation.definition.italic.end
+
+Example 335:
+This is not emphasis, because the opening `_` is followed by whitespace:
+_ foo bar_
+| <- - punctuation
+| ^^^^^^^^^ - punctuation
+
+Example 336:
+This is not emphasis, because the opening `_` is preceded by an alphanumeric and followed by punctuation:
+a_"foo"_
+|^^^^^^^^ - punctuation
+
+Example 337:
+Emphasis with `_` is not allowed inside words:
+foo_bar_
+|  ^^^^^ - punctuation
+
+Example 338:
+5_6_78
+|^^^^^ - punctuation
+
+Example 339:
+пристаням_стремятся_
+|        ^^^^^^^^^^^ - punctuation
+
+aa_"bb"_cc_
+| ^ - punctuation
+|      ^ punctuation.definition.italic.begin
+|         ^ punctuation.definition.italic.end
+
+Example 341:
+foo-_(bar)_
+|   ^ punctuation.definition.italic.begin
+|         ^ punctuation.definition.italic.end
+
+*foo bar *
+| <- punctuation.definition.italic.begin
+|        ^ - punctuation
+*
+| <- - punctuation
+abc*
+|  ^ punctuation.definition.italic.end
+
+Example 347:
+*foo*bar
+| <- punctuation.definition.italic.begin
+|   ^ punctuation.definition.italic.end
+
+Example 348:
+_foo bar _
+| <- punctuation.definition.italic.begin
+|        ^ - punctuation
+_
+| <- - punctuation
+abc_
+|  ^ punctuation.definition.italic.end
+
+Intraword emphasis is disallowed for `_`:
+_foo_bar
+| <- punctuation.definition.italic.begin
+|   ^ - punctuation
+abc_
+|  ^ punctuation.definition.italic.end
+
+Example 353:
+_foo_bar_baz_
+| <- punctuation.definition.italic.begin
+|   ^^^^^ - punctuation
+|           ^ punctuation.definition.italic.end
+
+Example 354:
+_(bar)_.
+| <-  punctuation.definition.italic.begin
+|     ^ punctuation.definition.italic.end
+
+Example 355:
+ **foo bar**
+|^^ punctuation.definition.bold.begin
+|         ^^ punctuation.definition.bold.end
+
+Example 356:
+** foo bar**
+| <- - punctuation
+|         ^^ - punctuation
+
+Example 358:
+foo**bar**
+|  ^^ punctuation.definition.bold.begin
+|       ^^ punctuation.definition.bold.end
+
+Example 359:
+ __foo bar__
+|^^ punctuation.definition.bold.begin
+|         ^^ punctuation.definition.bold.end
+
+Example 360:
+This is not strong emphasis, because the opening delimiter is followed by whitespace:
+__ foo bar__
+| <- - punctuation
+|         ^^ - punctuation
+
+Example 361:
+__
+| <- - punctuation
+
+Example 362:
+a__"foo"__
+|^^^^^^^^^ - punctuation
+
+Example 363:
+Intraword strong emphasis is forbidden with `__`:
+foo__bar__
+|  ^^^^^^^ - punctuation
+
+Example 364:
+5__6__78
+|^^^^^^^ - punctuation
+
+Example 367:
+foo-__(bar)__
+|   ^^ punctuation.definition.bold.begin
+|          ^^ punctuation.definition.bold.end
+
+Example 368:
+**foo bar **
+| <- punctuation.definition.bold.begin
+|         ^^ - punctuation
+abc**
+|  ^^ punctuation.definition.bold.end
+
+Example 373:
+Intraword emphasis:
+ **foo**bar
+|^^ punctuation.definition.bold.begin
+|     ^^ punctuation.definition.bold.end
+
+Example 374:
+ __foo bar __
+|^^ punctuation.definition.bold.begin
+|          ^^ - punctuation
+abc__
+|  ^^ punctuation.definition.bold.end
+
+Example 376:
+_(__foo__)_
+| <- punctuation.definition.italic.begin
+| ^^ punctuation.definition.bold.begin
+|      ^^ punctuation.definition.bold.end
+|         ^ punctuation.definition.italic.end
+
+Example 377:
+Intraword strong emphasis is forbidden with `__`:
+__foo__bar
+| <- punctuation.definition.bold.begin
+|    ^^ - punctuation
+abc__
+|  ^^ punctuation.definition.bold.end
+
+Example 379:
+__foo__bar__baz__
+| <- punctuation.definition.bold.begin
+|              ^^ punctuation.definition.bold.end
+|    ^^^^^^^^^^ - punctuation
+
+Example 380:
+This is strong emphasis, even though the closing delimiter is both left- and right-flanking, because it is followed by punctuation:
+__(bar)__.
+| <- punctuation.definition.bold.begin
+|      ^^ punctuation.definition.bold.end
+
+Example 381:
+*foo [bar](/url)*
+| <- punctuation.definition.italic.begin
+|               ^ punctuation.definition.italic.end
+|    ^^^^^^^^^^^ meta.link.inline
+
+Example 382:
+*foo
+| <- punctuation.definition.italic.begin
+bar*
+|  ^ punctuation.definition.italic.end
+
+Example 383:
+_foo __bar__ baz_
+| <- punctuation.definition.italic.begin
+|    ^^ punctuation.definition.bold.begin
+|         ^^ punctuation.definition.bold.end
+|               ^ punctuation.definition.italic.end
+
+Example 394:
+** is not an empty emphasis
+| <- - punctuation
+|^ - punctuation
+
+Example 395:
+**** is not an empty strong emphasis
+| <- - punctuation
+|^^^ - punctuation
+
+Example 396:
+**foo [bar](/url)**
+| <- punctuation.definition.bold.begin
+|     ^^^^^^^^^^^ meta.link.inline
+|                ^^ punctuation.definition.bold.end
+
+Example 397:
+**foo
+| <- punctuation.definition.bold.begin
+bar**
+|  ^^ punctuation.definition.bold.end
+
+Example 398:
+__foo _bar_ baz__
+| <- punctuation.definition.bold.begin
+|     ^ punctuation.definition.italic.begin
+|         ^ punctuation.definition.italic.end
+|              ^^ punctuation.definition.bold.end
+
+Example 408:
+__ is not an empty emphasis
+| <- - punctuation
+|^ - punctuation
+
+Example 409:
+____ is not an empty strong emphasis
+| <- - punctuation
+|^^^ - punctuation
+
+
+Example 410:
+foo ***
+|   ^^^ - punctuation
+
+Example 411:
+foo *\**
+|   ^ punctuation.definition.italic.begin
+|    ^^ constant.character.escape
+|      ^ punctuation.definition.italic.end
+
+Example 412:
+foo *_*
+|   ^ punctuation.definition.italic.begin
+|    ^ - punctuation
+|     ^ punctuation.definition.italic.end
+
+Example 414:
+foo **\***
+|   ^^ punctuation.definition.bold.begin
+|     ^^ constant.character.escape
+|       ^^ punctuation.definition.bold.end
+
+Example 415:
+foo **_**
+|   ^^ punctuation.definition.bold.begin
+|     ^ - punctuation
+|      ^^ punctuation.definition.bold.end
+
+Example 422:
+foo ___
+|   ^^^^ - punctuation
+
+Example 423:
+foo _\__
+|   ^ punctuation.definition.italic.begin
+|    ^^ constant.character.escape
+|      ^ punctuation.definition.italic.end
+
+Example 424:
+foo _*_
+|   ^ punctuation.definition.italic.begin
+|    ^ - punctuation
+|     ^ punctuation.definition.italic.end
+
+Example 426:
+foo __\___
+|   ^^ punctuation.definition.bold.begin
+|     ^^ constant.character.escape
+|       ^^ punctuation.definition.bold.end
+
+Example 427:
+
+foo __*__
+|   ^^ punctuation.definition.bold.begin
+|     ^ - punctuation
+|      ^^ punctuation.definition.bold.end
+
+This text is _bold_, but this__text__is neither bold_nor_italic
+|            ^ punctuation.definition.italic
+|             ^^^^ markup.italic
+|                 ^ punctuation.definition.italic
+|                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.bold - markup.italic
+
 the following is italic *and doesn't end here * but does end here*
 |                       ^ punctuation.definition.italic.begin
 |                                             ^ - punctuation.definition.italic
@@ -457,14 +757,19 @@ more **tests *** ** here**
 |    ^^ punctuation.definition.bold.begin
 |            ^^^^^^ - punctuation.definition
 |                       ^^ punctuation.definition.bold.end
-more __tests *** ** *example __ here__
+more __tests *** ** example __ here__
 |    ^^ punctuation.definition.bold.begin
-|            ^^^^^^^^^^^^^^^^^^^^^^^ - punctuation.definition
-|                                   ^^ punctuation.definition.bold.end
+|            ^^^^^^^^^^^^^^^^^^^^^^ - punctuation.definition
+|                                  ^^ punctuation.definition.bold.end
 more _tests <span class="test_">here</span>_
 |    ^ punctuation.definition.italic.begin
 |                            ^ - punctuation.definition
 |                                          ^ punctuation.definition.italic.end
+more _tests <span class="test_">_here</span>_
+|    ^ punctuation.definition.italic.begin
+|                            ^ - punctuation.definition
+|                               ^ - punctuation
+|                                           ^ punctuation.definition.italic.end
 _more `tests_` here_
 | <- punctuation.definition.italic.begin
 |     ^^^^^^^^ markup.raw.inline
@@ -473,6 +778,20 @@ __more `tests__` here__
 | <- punctuation.definition.bold.begin
 |      ^^^^^^^^^ markup.raw.inline
 |                    ^^ punctuation.definition.bold.end
+**more `tests__` here**
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+**more `tests**` here**
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+*more `tests__` here**
+| <- punctuation.definition.italic.begin
+|                   ^^ - punctuation
+abc*
+|  ^ punctuation.definition.italic.end
+
 _test <span>text_ foobar</span>
 | <- punctuation
 |               ^ punctuation.definition.italic.end
@@ -588,3 +907,45 @@ soft line break
 `inline code with trailing spaces  
 |                                ^^^ - meta.hard-line-break
 not a hard line break`
+
+*test
+
+| <- invalid.illegal.non-terminated.italic
+abc*
+|  ^ - punctuation
+
+_test
+
+| <- invalid.illegal.non-terminated.italic
+abc_
+|  ^ - punctuation
+
+**test
+
+| <- invalid.illegal.non-terminated.bold
+abc**
+|  ^^ - punctuation
+
+__test
+
+| <- invalid.illegal.non-terminated.bold
+abc__
+|  ^^ - punctuation
+
+__test\
+|     ^ meta.hard-line-break constant.character.escape
+testing__
+
+- test *testing
+blah*
+|   ^ markup.list.unnumbered meta.paragraph.list markup.italic punctuation.definition.italic.end
+- fgh
+- *ghgh
+| ^ markup.list.unnumbered meta.paragraph.list meta.paragraph.list markup.italic punctuation.definition.italic.begin
+- fgfg
+| <- markup.list.unnumbered meta.paragraph.list punctuation.definition.list_item
+- _test
+
+| <- markup.list.unnumbered meta.paragraph.list markup.italic invalid.illegal.non-terminated.italic
+  still a list item
+| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -95,6 +95,11 @@ Paragraph break.
     + Subitem
     + Another subitem
 |   ^ meta.paragraph.list punctuation.definition.list_item
+      + Nested Subitem
+|     ^ punctuation.definition.list_item
+        + Nested + Subitem
+|       ^ punctuation.definition.list_item
+|                ^ - punctuation.definition.list_item
 
 Paragraph break.
 
@@ -276,8 +281,37 @@ Paragraph followed immediately by a list, no blank line in between
 Paragraph followed immediately by a numbered list, no blank line in between
  1. list item 1
 | ^ markup.list.numbered punctuation.definition.list_item
+  more text - this punctuation should be ignored 2.
+|           ^ - punctuation.definition.list_item
+|                                                 ^ - punctuation.definition.list_item
 
 Paragraph not followed immediately by a numbered list,
 because it doesn't begin with the number one:
  2. text
 | ^ - markup.list.numbered - punctuation.definition.list_item
+
+
+> Block quote with list items
+> - list item 1
+| ^ meta.block-level markup.quote punctuation.definition.list_item
+> - list item 2
+| ^ meta.block-level markup.quote punctuation.definition.list_item
+>   1. sub list item
+|    ^ meta.block-level markup.quote punctuation.definition.list_item
+
+* this is a list
+
+   > This is a blockquote.
+|  ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
+
+ This is a paragraph still part of the 
+ list item
+| ^^^^^^^^^ markup.list.unnumbered meta.paragraph.list
+
+* Lorem ipsum
+
+        This is a code block
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered markup.raw.block
+* list continues
+| <- markup.list.unnumbered punctuation.definition.list_item - markup.raw.block
+* list continues

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -438,3 +438,17 @@ escaped backtick \`this is not code\`
 |                ^^ constant.character.escape
 |                                  ^^ constant.character.escape
 |                  ^^^^^^^^^^^^^^^^ - markup.raw.inline
+the following is italic *and doesn't end here * but does end here*
+|                       ^ punctuation.definition.italic.begin
+|                                             ^ - punctuation.definition.italic
+|                                                                ^ punctuation.definition.italic.end
+the following is bold **and doesn't end here ** but does end here**
+|                     ^^ punctuation.definition.bold.begin
+|                                            ^^ - punctuation.definition.bold
+|                                                                ^^ punctuation.definition.bold.end
+the following is not bold ** test ****
+|                         ^^ - punctuation.definition.bold.begin
+|                                 ^^^^ - punctuation.definition.bold
+the following is not italic _ test ____
+|                           ^ - punctuation.definition.italic.begin
+|                                  ^^^^ - punctuation.definition.italic

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -564,3 +564,21 @@ inline backticks must be followed by non-whitespace `` characters``
 hello world ````test````
 |           ^^^^^^^^^^^^ markup.raw.inline
 |                       ^ - markup.raw
+
+`foo `` bar`
+|    ^^^^^^ markup.raw.inline - punctuation
+|          ^ punctuation.definition.raw.end
+
+hard line break  
+|              ^^ meta.hard-line-break
+hard line break\
+|              ^ meta.hard-line-break constant.character.escape
+
+### foo  
+|      ^^^ - meta.hard-line-break
+### foo\
+|      ^ - meta.hard-line-break
+
+`inline code with trailing spaces  
+|                                ^^^ - meta.hard-line-break
+not a hard line break`

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -888,6 +888,15 @@ inline backticks must be followed by non-whitespace `` characters``
  ~~~~
 | ^^^ punctuation.definition.raw.code-fence.end
 
+~~~~~test~
+| ^^^^^^^^^ meta.paragraph - punctuation - constant - markup.raw
+
+~~~~~~test
+| ^^^^ punctuation.definition.raw.code-fence.begin
+|     ^^^^ constant.other.language-name
+~~~~~~
+| ^^^^^ punctuation.definition.raw.code-fence.end
+
 ```test
 |  ^^^^ constant.other.language-name
   ```

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -978,3 +978,25 @@ blah*
 |        ^ - punctuation.definition.thematic-break
 |          ^ - punctuation.definition.thematic-break
 |            ^ - punctuation.definition.thematic-break
+  still a list item
+| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list
+
+Example 407:
+**foo [*bar*](/url)**
+| <- punctuation.definition.bold.begin
+|     ^^^^^^^^^^^^^ markup.bold meta.link.inline
+|                  ^^ punctuation.definition.bold.end
+|      ^ punctuation.definition.italic.begin
+|          ^ punctuation.definition.italic.end
+**foo [_bar_](/url)**
+| <- punctuation.definition.bold.begin
+|     ^^^^^^^^^^^^^ markup.bold meta.link.inline
+|                  ^^ punctuation.definition.bold.end
+|      ^ punctuation.definition.italic.begin
+|          ^ punctuation.definition.italic.end
+_foo [**bar**](/url)_
+| <- punctuation.definition.italic.begin
+|    ^^^^^^^^^^^^^^^ markup.italic meta.link.inline
+|                   ^ punctuation.definition.italic.end
+|     ^^ punctuation.definition.bold.begin
+|          ^^ punctuation.definition.bold.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -322,3 +322,21 @@ because it doesn't begin with the number one:
  3. [see `demo`](#demo)
 | ^ punctuation.definition.list_item
 |    ^^^^^^^^^^ string.other.link.title
+    Here is a ![example image](https://test.com/sublime.gif "A demonstration").
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
+|             ^ punctuation.definition.image.begin
+|              ^ punctuation.definition.string.begin
+|                            ^ punctuation.definition.string.end
+|                             ^ punctuation.definition.metadata
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
+|                                                                            ^ punctuation.definition.metadata
+
+  <!-- HTML comment -->
+| ^^^^^^^^^^^^^^^^^^^^^ comment.block.html
+
+## Heading with ending hashes ##
+| <- punctuation.definition.heading
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.section
+|                            ^ - entity.name.section
+|                             ^^ punctuation.definition.heading

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -504,10 +504,35 @@ _test <span>text **formatted**</span>_
 |                                            ^^ punctuation
 |                                               ^ punctuation
 |                                                    ^ punctuation
+
+```js
+| <- punctuation.definition.raw.code-fence.begin
+|  ^^ constant.other.language-name
+for (var i = 0; i < 10; i++) {
+    console.log(i);
+}
+```
+| <- punctuation.definition.raw.code-fence.end
+
 ```testing``123```
 | <- punctuation.definition.raw.begin
 |         ^^ - punctuation
 |              ^^^ punctuation.definition.raw.end
 ```testing``123````
-| <- - punctuation
-| ^^^^^^^^^^^^^^^^^ - punctuation
+| <- invalid
+|         ^^ invalid
+|              ^^^^ invalid
+
+~~~~ 
+| <- punctuation.definition.raw.code-fence.begin
+ ~~~~
+| ^^^ punctuation.definition.raw.code-fence.end
+
+```test
+|  ^^^^ constant.other.language-name
+  ```
+| ^^^ punctuation.definition.raw.code-fence.end
+
+hello world ````test````
+|           ^^^^^^^^^^^^ markup.raw.inline
+|                       ^ - markup.raw

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1078,3 +1078,35 @@ text
 |       ^^^ markup.underline.link
 |          ^ punctuation.definition.link.end
 |           ^^^^^^^^ invalid.illegal.expected-eol
+
+- a
+  - b
+    - c
+      - d
+|     ^ punctuation.definition.list_item
+        text here
+|       ^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - markup.raw.block
+
+            code here
+            | ^^^^^^^^ markup.raw.block
+
+      - e
+|     ^ punctuation.definition.list_item
+
+            code here
+
+            >     block quote code here
+|           ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
+|                 ^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered markup.quote markup.raw.block
+
+            > > test
+|           ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
+|             ^ markup.list.unnumbered markup.quote markup.quote punctuation.definition.blockquote - markup.raw.block
+
+      - f
+|     ^ markup.list.unnumbered punctuation.definition.list_item
+        1. test
+|        ^ punctuation.definition.list_item
+
+abc
+| <- meta.paragraph - markup.list


### PR DESCRIPTION
This PR simplifies a few contexts, removes a few incompatible regexs (mainly `\G`) and adds support for lists in blockquotes, plus includes a few more tests.