### PR TITLE
[Python] Fix single-quoted f-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1479,8 +1479,6 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
-        - include: escaped-unicode-char
-        - include: escaped-char
         - include: line-continuation-inside-string
         - include: f-string-content
     # Single-line f-string
@@ -1493,6 +1491,8 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: escaped-unicode-char
+        - include: escaped-char
         - include: line-continuation-inside-string
         - include: f-string-content
     # Single-line string, unicode or not, starting with a SQL keyword

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -498,10 +498,13 @@ F'''string'''
 #^^ storage.type.string
 #^^^^^^^^^^ meta.string.interpolated string.quoted.single
 
+rf'\r\n' f'\r\n'
+#  ^^^^ - constant
+#          ^^^^ constant.character.escape
 
-# FIXME The opening brace incorrectly gets its scope stack reset
-# due to https://github.com/SublimeTextIssues/Core/issues/1526.
-# Thus, the following tests on it are failing.
+rf"\r\n" f"\r\n"
+#  ^^^^ - constant
+#          ^^^^ constant.character.escape
 
 f"{something}"
 #^^^^^^^^^^^^ meta.string.interpolated
@@ -545,10 +548,6 @@ rf"{value:{width!s:d}}"
 #          ^^^^^ source source.python.embedded
 #               ^^ storage.modifier.conversion
 #                 ^^ constant.other.format-spec
-
-rf'\r\n' f'\r\n'
-#  ^^^^ - constant
-#          ^^^^ constant.character.escape
 
 F""" {} {\} }
 #^^^^^^^^^^^ meta.string.interpolated

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -546,6 +546,10 @@ rf"{value:{width!s:d}}"
 #               ^^ storage.modifier.conversion
 #                 ^^ constant.other.format-spec
 
+rf'\r\n' f'\r\n'
+#  ^^^^ - constant
+#          ^^^^ constant.character.escape
+
 F""" {} {\} }
 #^^^^^^^^^^^ meta.string.interpolated
 #^^^ punctuation.definition.string.begin


### PR DESCRIPTION
The escape sequences includes went into the wrong match sub-context.