### PR TITLE
[ASP] fix small symbol transformation edge case

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -13,7 +13,7 @@ variables:
   comparison_operators: '[=><]'
   math_operators: '(?:[+*^&/\\-]|\b(?i:Mod)\b)'
   logical_operators: '\b(?i:And|Not|Or|Xor|Is)\b'
-  operators: '{{comparison_operators}}|{{math_operators}}|logical_operators}}'
+  operators: '{{comparison_operators}}|{{math_operators}}|{{logical_operators}}'
   literal_number: '&[hH]\h+&?|(?:(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?i:e[+-]?\d+)?)(?={{whitespace_or_end_of_statement}}|{{operators}}|[,)_])'
   reserved_words: '\b(?i:Class|Sub|Function|Const|Dim|ReDim|Public|Private|End|Preserve|Select|Case|If|Else|ElseIf|Then|For|Each|Next|ByRef|ByVal|Set|Call|New|Option|With|To|In|While|Wend|Until|Loop|On|GoTo|Resume|Let|Get|Exit|Do)\b' # Default|Step|Error|Property are not reserved words
   keywords: '\b(?i:Empty|False|Nothing|Null|True)\b'
@@ -318,17 +318,18 @@ contexts:
       set: inside_method
 
   after_method_name:
+    - meta_content_scope: meta.method.asp meta.method.identifier.asp
     - match: \(
-      scope: punctuation.section.parens.begin.asp
+      scope: meta.method.asp meta.method.identifier.asp punctuation.section.parens.begin.asp
       set:
-        - meta_scope: meta.method.asp meta.method.identifier.asp
         - match: \)
-          scope: punctuation.section.parens.end.asp
+          scope: meta.method.asp meta.method.identifier.asp punctuation.section.parens.end.asp
           pop: true
         - match: $
           set: not_end_of_statement
         - match: '(?=\S)'
           push:
+            - meta_scope: meta.method.asp meta.method.identifier.asp
             - match: '(?=\)|$)'
               pop: true
             - include: not_end_of_statement
@@ -346,7 +347,6 @@ contexts:
             - match: '(?:(?![,)])\S)+'
               scope: invalid.illegal.unexpected-token.asp
     - match: '\s+'
-      scope: meta.method.asp meta.method.identifier.asp
     - match: ':'
       scope: meta.method.asp punctuation.terminator.statement.asp
       pop: true

--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -171,9 +171,9 @@ contexts:
     - include: variable_definitions
 
   class_definitions:
-    - match: '\b(?i:Class)\s'
+    - match: '\b(?i:Class)[ \t]+'
       scope: storage.type.asp
-      push: [inside_class, class_name]
+      push: class_name
 
   class_name:
     - meta_scope: meta.class.asp meta.class.identifier.asp
@@ -181,7 +181,7 @@ contexts:
     - include: illegal_names
     - match: '{{identifier}}'
       scope: entity.name.class.asp
-      pop: true
+      set: inside_class
     - include: unexpected_token
 
   inside_class:
@@ -320,7 +320,7 @@ contexts:
   after_method_name:
     - meta_content_scope: meta.method.asp meta.method.identifier.asp
     - match: \(
-      scope: meta.method.asp meta.method.identifier.asp punctuation.section.parens.begin.asp
+      scope: punctuation.section.parens.begin.asp
       set:
         - match: \)
           scope: meta.method.asp meta.method.identifier.asp punctuation.section.parens.end.asp

--- a/ASP/Symbol List.tmPreferences
+++ b/ASP/Symbol List.tmPreferences
@@ -10,11 +10,11 @@
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>
-		s/^\s*(.*)(\[[^\]]*\])?\s*\(.*/$1$2/g;
-		s/(\[[^\]]*\])?|\b_\b\s*/$1/g;
-		s/\s{2,}/ /g;
-		</string>
+		<string><![CDATA[
+			s/^\s*(.*)(\[[^\]]*\])?\s*\(.*/$1$2/g; (?# this removes leading whitespace and everything after and including the first open paren that does not occur inside square brackets.)
+			s/(\[[^\]]*\])?|\b_\b\s*/$1/g; (?# this ignores anything in square brackets, and finds an underscore line continuation character and any whitespace following it, and replaces it with nothing. We don't have to worry about comments, because they are not allowed after an underscore.)
+			s/\s{2,}/ /g; (?# this collapses multiple spaces.)
+		]]></string>
 	</dict>
 </dict>
 </plist>

--- a/ASP/Symbol List.tmPreferences
+++ b/ASP/Symbol List.tmPreferences
@@ -11,9 +11,11 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string><![CDATA[
-			s/^\s*(.*)(\[[^\]]*\])?\s*\(.*/$1$2/g; (?# this removes leading whitespace and everything after and including the first open paren that does not occur inside square brackets.)
-			s/(\[[^\]]*\])?|\b_\b\s*/$1/g; (?# this ignores anything in square brackets, and finds an underscore line continuation character and any whitespace following it, and replaces it with nothing. We don't have to worry about comments, because they are not allowed after an underscore.)
-			s/\s{2,}/ /g; (?# this collapses multiple spaces.)
+			s/(\[[^\]]*\])|\b_\b\s*|\(.*|(\s{2,})/$1(?2 )/g; (?# this ignores anything in square brackets, and:
+			- finds an underscore line continuation character and any whitespace following it, and replaces it with nothing
+			- finds an open paren and anything following it, and replaces it with nothing
+			- collapses multiple spaces into one
+			We don't have to worry about comments, because they are not allowed after an underscore.)
 		]]></string>
 	</dict>
 </dict>

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -50,11 +50,12 @@
    '^^^^^^^^^^^^^^^ keyword
     
     Class TestClass
-   '^^^^^^^^^^^^^^^ meta.class.asp meta.class.identifier.asp
+   '^^^^^^^^^^^^^^^ meta.class.asp meta.class.identifier.asp - meta.class.body.asp
    '^^^^^ storage.type.asp
    '      ^^^^^^^^^ meta.class.asp meta.class.identifier.asp entity.name.class.asp
         ' comment
        '^^^^^^^^^^ comment.line.apostrophe.asp
+       '<- meta.class.body.asp - meta.class.identifier.asp
         Private m_NameVar
        '^^^^^^^ storage.modifier.asp - meta.method.identifier.asp
        '        ^^^^^^^^^ variable.other.asp
@@ -141,7 +142,8 @@
         
         Private Property Set Category(categoryParam) Set m_CategoryVar = categoryParam End Property
        '^^^^^^^ storage.modifier.asp
-       '        ^^^^^^^^^^^^ meta.method.asp meta.method.identifier.asp storage.type.function.asp - meta.method.body.asp
+       '        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.asp meta.class.body.asp meta.method.asp meta.method.identifier.asp - meta.method.identifier.asp meta.method.identifier.asp - meta.method.body.asp
+       '        ^^^^^^^^^^^^ storage.type.function.asp
        '                     ^^^^^^^^ entity.name.function.asp
        '                             ^ punctuation.section.parens.begin.asp
        '                              ^^^^^^^^^^^^^ variable.parameter.function.asp
@@ -203,15 +205,15 @@
     
     Class TestClass2 Public Sub TestSub () Response.Write("wow") End Sub End Class
    '^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.asp
-   '^^^^^^^^^^^^^^^^ meta.class.identifier.asp
+   '^^^^^^^^^^^^^^^^ meta.class.identifier.asp - meta.class.body.asp - meta.class.identifier.asp meta.class.identifier.asp
    '^^^^^ storage.type.asp
    '      ^^^^^^^^^^ entity.name.class.asp
-   '                ^ - meta.class.identifier.asp
+   '                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.body.asp - meta.class.identifier.asp
    '                 ^^^^^^^^^^^^^^^^^^^^^ meta.method.asp meta.method.identifier.asp
    '                 ^^^^^^ storage.modifier.asp
    '                        ^^^ storage.type.function.asp
    '                            ^^^^^^^ entity.name.function.asp
-   '                                    ^^ punctuation.section.parens
+   '                                    ^^ punctuation.section.parens - meta.method.identifier.asp meta.method.identifier.asp
    '                                      ^ meta.method.asp meta.method.body.asp - meta.method.identifier.asp
    '                                                             ^^^^^^ storage.type.function.end.asp
    '                                                                     ^^^^^^^^^ meta.class.body.asp


### PR DESCRIPTION
This fixes a small symbol transformation edge case in the ASP package.
The edge case was a method definition without arguments & parens, where the method name was in square brackets and contained an open paren - before this fix it got cut off at the open paren.

i.e. `function [test_abc-def#123)_(ghgh]`