### PR TITLE
[JSON] strings can't span multiple lines, fix comment block detection

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -83,7 +83,11 @@ contexts:
         - match: '\}'
           scope: punctuation.definition.dictionary.end.json
           pop: true
-        - include: string
+        - match: '"'
+          scope: punctuation.definition.string.begin.json
+          push:
+            - meta_scope: meta.structure.dictionary.key.json string.quoted.double.json
+            - include: inside-string
         - include: comments
         - match: ":"
           scope: punctuation.separator.dictionary.key-value.json

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -101,27 +101,30 @@ contexts:
   string:
     - match: '"'
       scope: punctuation.definition.string.begin.json
-      push:
-        - meta_scope: string.quoted.double.json
-        - match: '"'
-          scope: punctuation.definition.string.end.json
-          pop: true
-        - match: |-
-            (?x:                # turn on extended mode
-              \\                # a literal backslash
-              (?:               # ...followed by...
-                ["\\/bfnrt]     # one of these characters
-                |               # ...or...
-                u               # a u
-                [0-9a-fA-F]{4}  # and four hex digits
-              )
-            )
-          scope: constant.character.escape.json
-        - match: \\.
-          scope: invalid.illegal.unrecognized-string-escape.json
-        - match: $\n?
-          scope: invalid.illegal.unclosed-string.json
-          pop: true
+      push: inside-string
+  inside-string:
+    - meta_scope: string.quoted.double.json
+    - match: '"'
+      scope: punctuation.definition.string.end.json
+      pop: true
+    - include: string-escape
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.json
+      pop: true
+  string-escape:
+    - match: |-
+        (?x:                # turn on extended mode
+          \\                # a literal backslash
+          (?:               # ...followed by...
+            ["\\/bfnrt]     # one of these characters
+            |               # ...or...
+            u               # a u
+            [0-9a-fA-F]{4}  # and four hex digits
+          )
+        )
+      scope: constant.character.escape.json
+    - match: \\.
+      scope: invalid.illegal.unrecognized-string-escape.json
   value:
     - include: constant
     - include: number

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
         - match: '[^\s\]]'
           scope: invalid.illegal.expected-array-separator.json
   comments:
-    - match: /\*\*
+    - match: /\*\*(?!/)
       scope: punctuation.definition.comment.json
       push:
         - meta_scope: comment.block.documentation.json
@@ -119,6 +119,9 @@ contexts:
           scope: constant.character.escape.json
         - match: \\.
           scope: invalid.illegal.unrecognized-string-escape.json
+        - match: $\n?
+          scope: invalid.illegal.unclosed-string.json
+          pop: true
   value:
     - include: constant
     - include: number

--- a/JavaScript/syntax_test_json.json
+++ b/JavaScript/syntax_test_json.json
@@ -33,9 +33,12 @@
 
   "E": 20e10,
 //     ^^^^^ constant.numeric.json
+//^^^ meta.structure.dictionary.key.json string.quoted.double.json
+//   ^ punctuation.separator.dictionary.key-value.json - meta.structure.dictionary.key.json
 
   "escape": "\n",
 //           ^^ constant.character.escape.json
+//          ^^^^ meta.structure.dictionary.value.json string.quoted.double.json - meta.structure.dictionary.key.json
 
   "illegal": "\.",
 //            ^^ invalid.illegal.unrecognized-string-escape.json
@@ -50,6 +53,12 @@
 // ^ meta.structure.dictionary.json comment.block.json
 //  ^ punctuation.separator.dictionary.key-value.json - comment
 //    ^^^^^^ meta.structure.dictionary.value.json string.quoted.double.json
+
+  "array2":
+    [
+      "foobar",
+//    ^^^^^^^^ meta.structure.array.json string.quoted.double.json - meta.structure.dictionary.key.json
+    ],
 
   []
 //^^ invalid.illegal.expected-dictionary-separator.json

--- a/JavaScript/syntax_test_json.json
+++ b/JavaScript/syntax_test_json.json
@@ -40,6 +40,18 @@
   "illegal": "\.",
 //            ^^ invalid.illegal.unrecognized-string-escape.json
 
+  "unterminated string
+//^^^^^^^^^^^^^^^^^^^^ string.quoted.double.json
+//                    ^ string.quoted.double.json invalid.illegal.unclosed-string.json
+
+// <- - string
+
+/**/: "test",
+// ^ meta.structure.dictionary.json comment.block.json
+//  ^ punctuation.separator.dictionary.key-value.json - comment
+//    ^^^^^^ meta.structure.dictionary.value.json string.quoted.double.json
+
   []
 //^^ invalid.illegal.expected-dictionary-separator.json
+
 }


### PR DESCRIPTION
- strings are not allowed to contain new line characters, so mark them as unterminated and pop from the string context when a new line is reached. See http://stackoverflow.com/a/16690186/4473405 for clarification
- update comment block detection to match the JavaScript syntax and fix an empty block comment not being seen as closed
- scope dictionary keys so they can be targeted by color schemes  #421 