### PR TITLE
[Rust] improved comment scoping

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -758,27 +758,33 @@ contexts:
   comments:
     - include: block-comments
     - match: "//[!/]"
+      scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.line.documentation.rust
-        - match: $
+        - match: $\n?
           pop: true
     - match: //
+      scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.line.double-slash.rust
-        - match: $
+        - match: $\n?
           pop: true
 
   block-comments:
     - match: '/\*[!\*][^\*/]'
+      scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.block.documentation.rust
         - match: \*/
+          scope: punctuation.definition.comment.rust
           pop: true
         - include: block-comments
     - match: /\*
+      scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.block.rust
         - match: \*/
+          scope: punctuation.definition.comment.rust
           pop: true
         - include: block-comments
 

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -1,14 +1,16 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 // Line comments
-// <- comment.line.double-slash
-// ^^^^^^^^^^^^^ comment.line.double-slash
+// <- comment.line.double-slash punctuation.definition.comment
+// ^^^^^^^^^^^^^^ comment.line.double-slash
+
+// <- - comment
 /// Line doc comments
 // <- comment.line.documentation
 // ^^^^^^^^^^^^^ comment.line.documentation
 
 /*!
-// <- comment.block.documentation
+// <- comment.block.documentation punctuation.definition.comment
  // <- comment.block.documentation
 //^ comment.block.documentation
 Block doc comments


### PR DESCRIPTION
This updates the Rust syntax to scope the newline after line comments, and the punctuation that begins and ends comments, in line with the other syntaxes.