### PR TITLE
[Rust] scope simple string line continuation characters

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -858,6 +858,8 @@ contexts:
           scope: punctuation.definition.string.end.rust
           pop: true
         - include: escaped-char
+        - match: '(\\)$'
+          scope: punctuation.separator.continuation.line.rust
 
   raw-string:
     - match: (r)(#*)"
@@ -882,6 +884,8 @@ contexts:
           pop: true
         - include: escaped-char
         - include: format-escapes
+        - match: '(\\)$'
+          scope: punctuation.separator.continuation.line.rust
 
   format-raw-string:
     - match: (r)(#*)"

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -937,3 +937,9 @@ pub const FOO: Option<[i32; 1]> = Some([1]);
 //                        ^ punctuation.separator
 //                          ^ constant.numeric
 //                           ^ punctuation.definition.group.end.rust
+
+fn abc() {
+    println!("{}hello\
+//                   ^ punctuation.separator.continuation.line.rust
+         world, there is no whitespace between hello and world in the output", 0o202u64);
+}


### PR DESCRIPTION
https://doc.rust-lang.org/book/strings.html 

> String literals can span multiple lines. There are two forms. The first will include the newline and the leading spaces:
> 
> ```rust
> let s = "foo
>     bar";
> 
> assert_eq!("foo\n    bar", s);Run
> ```
> 
> The second, with a `\`, trims the spaces and the newline:
> 
> ```rust
> let s = "foo\
>     bar";
> 
> assert_eq!("foobar", s);
> ```

This PR scopes the `\` the same way Python does.