### PR TITLE
[Rust] remove empty match (too many | chars) from operator pattern

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -233,7 +233,7 @@ contexts:
       scope: punctuation.separator.rust
       push: after-operator
 
-    - match: '\.\.\.|\.\.||[-=<>&|!~@?+*/%^''#$]|\b_\b'
+    - match: '\.\.\.|\.\.|[-=<>&|!~@?+*/%^''#$]|\b_\b'
       scope: keyword.operator.rust
 
   block:


### PR DESCRIPTION
no new tests needed