### PR TITLE
[CSS] don't treat a pipe (|) char as a valid prop name for completions

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -433,7 +433,7 @@ def parse_css_data():
         # Append values that are allowed for all properties
         allowed_values += ['all', 'inherit', 'initial', 'unset']
 
-        for name in names.split():
+        for name in names.split(' | '):
             props[name] = sorted(allowed_values)
 
     return props


### PR DESCRIPTION
This fixes #794, whereby `|` was being treated as a property name to be included in completions suggestions, when it shouldn't be.