### PR TITLE
[XML] scope double hyphens in comments as invalid

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -61,6 +61,8 @@ contexts:
         - match: '-->'
           scope: punctuation.definition.comment.end.xml
           pop: true
+        - match: '-{2,}'
+          scope: invalid.illegal.double-hyphen-within-comment.xml
     - match: '(</?){{qualified_name}}([^/>\s]*)'
       captures:
         1: punctuation.definition.tag.begin.xml

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -295,3 +295,10 @@ foo="bar" />
 <!--                                                ^^^ invalid.illegal.bad-tag-name - entity.name.tag -->
 <!--                                                   ^ punctuation.definition.tag.end -->
 <!--                                                    ^ - meta.tag -->
+
+    <!-- comments containing double hyphens -- are illegal and can't be ended with more than 2 hyphens --->, so should end here: -->
+<!--                                        ^^ comment.block invalid.illegal.double-hyphen-within-comment -->
+<!--                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - invalid -->
+<!--                                                                                                   ^^^ comment.block invalid.illegal.double-hyphen-within-comment -->
+<!--                                                                                                                             ^^^ comment.block punctuation.definition.comment.end -->
+<!--                                                                                                                                ^ - comment -->


### PR DESCRIPTION
Tighten up XML comment scoping to indicate when invalid characters (double hyphens that don't close the comment) are used inside the comment.

From https://www.w3.org/TR/REC-xml/#sec-comments:

> `Comment	   ::=   	'<!--' ((Char - '-') | ('-' (Char - '-')))* '-->'`
> Note that the grammar does not allow a comment ending in `--->`. The following example is not well-formed.
>
> `<!-- B+, B, or B--->`