### PR TITLE
[XML] first line match SOAP Envelope

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -10,7 +10,7 @@ file_extensions:
   - rss
   - opml
   - svg
-first_line_match: '^<\?xml '
+first_line_match: '^(?:<\?xml\s|\s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>)'
 scope: text.xml
 variables:
   # This is the full XML Name production, but should not be used where namespaces

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -10,7 +10,12 @@ file_extensions:
   - rss
   - opml
   - svg
-first_line_match: '^(?:<\?xml\s|\s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>)'
+first_line_match: |-
+    (?x)
+    ^(?:
+        <\?xml\s
+     |  \s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>
+     )
 scope: text.xml
 variables:
   # This is the full XML Name production, but should not be used where namespaces


### PR DESCRIPTION
Quite often, when working with web services and web service logs, the XML declaration is omitted. Rather than add more file extensions, I thought it would be a good idea to try to match a [SOAP envelope](http://schemas.xmlsoap.org/soap/envelope/) on the first line of the file to know that it is an XML document, and make the out-of-box experience better for web service developers. :)

(We could, if we wanted, detect any valid XML element (with a namespace, to avoid false positives), but I think just detecting SOAP is enough for now.)

This also tweaks the XML declaration first line match slightly, because the following is valid, as is a tab immediately after `<?xml`:

```xml
<?xml
	version="1.0" encoding="UTF-8"?>
```