### PR TITLE
[C#] Placeholders in multiline strings

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1415,10 +1415,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.cs
-    - match: '\{\d*\}'
-      scope: constant.other.placeholder.cs
+    - include: string_placeholders
     - match: '[^"]*$'
       scope: invalid.string.newline.cs
       pop: true
@@ -1430,7 +1427,7 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: escaped
-    - include: interpolation
+    - include: string_interpolation
     - match: '[^"{]*$'
       scope: invalid.string.newline.cs
       pop: true
@@ -1443,9 +1440,15 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
-    - include: interpolation
+    - include: string_interpolation
 
-  interpolation:
+  string_placeholders:
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.cs
+    - match: '\{\d*\}'
+      scope: constant.other.placeholder.cs
+
+  string_interpolation:
     - match: '\{\{|\}\}'
       scope: constant.character.escape.cs
     - match: '\{'
@@ -1471,6 +1474,7 @@ contexts:
     - meta_scope: string.quoted.double.raw.cs
     - match: '""'
       scope: constant.character.escape.cs
+    - include: string_placeholders
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -91,8 +91,16 @@ string format_string = "{0} and {1} like to go {{crazy}}";
 ///                                            ^^ constant.character.escape.cs
 ///                                                   ^^ constant.character.escape.cs
 
-string format_string _2 = "{}";
-///                        ^^ string constant.other.placeholder.cs
+string format_string_long = @"{0} and
+///                         ^^ string
+///                           ^^^ constant.other.placeholder.cs
+foo {1} like to go {{crazy}}";
+/// ^^^ constant.other.placeholder.cs
+///                ^^ constant.character.escape.cs
+///                       ^^ constant.character.escape.cs
+
+string format_string_2 = "{}";
+///                       ^^ string constant.other.placeholder.cs
 
 
 x[10][5] = 2;


### PR DESCRIPTION
Highlight `string.Format` replacements for `@"..."` strings, too.