### PR TITLE
[HTML] merged batch indentation rules to normal rules and annotated them

### DIFF
--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -21,11 +21,12 @@
 		<string><![CDATA[(?x)
 			^\s*                                                                         # the beginning of the line followed by any amount of whitespace
 			(
-			    <\?php\s*\b(if|else|elseif|for|foreach|while)\b.*:(?!.*end\1)            # php control keywords that don't end themselves on the same line
+			    <\?(php)?\s*\b(?<php_control_word>if|else|elseif|for|foreach|while)\b.*: # php control keywords
+			    (?!.*end\g<php_control_word>)                                            # - that don't end themselves on the same line
 			|   \{[^}"']*$                                                               # open curly braces that don't have close braces or string punctuation after them
 			|   <!--(?!.*-->)                                                            # comments that don't close themselves on the same line
 			|   <(?!\?|area|base|br|col|frame|hr|html|img|input|link|meta|param|[^>]*/>) # skip self closing tags (tags that end with />, as well as known self closing tags
-			        ([A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\1>)                           # valid tags that don't close themselves on the same line
+			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>>)      # valid tags that don't close themselves on the same line
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>

--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -9,24 +9,27 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                              # the beginning of the line followed by any amount of whitespace
+			^\s*                                                                                    # the beginning of the line followed by any amount of whitespace
 			(
-			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))                              # ending php control keywords
-			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                               # any valid close tag except html
-			|   -->                                                                           # closing comment punctuation
-			|   \}                                                                            # a closing brace
+			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))\b                                  # ending PHP control keywords
+			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                                     # any valid HTML close tag except "html"
+			|   -->                                                                                 # closing comment punctuation
+			|   \}                                                                                  # a closing curly brace
 			)
 		]]></string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                              # the beginning of the line followed by any amount of whitespace
+			^\s*                                                                                    # the beginning of the line followed by any amount of whitespace
 			(
-			    <\?(php)?\s*\b(?<php_control_word>if|else|elseif|for|foreach|while)\b.*:      # php control keywords
-			    (?!.*end\g<php_control_word>)                                                 # - that don't end themselves on the same line
-			|   \{[^}"']*$                                                                    # open curly braces that don't have close braces or string punctuation after them
-			|   <!--(?!.*-->)                                                                 # comments that don't close themselves on the same line
-			|   <(?!\?|(?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)|[^>]*/>) # skip self closing tags (tags that end with />, as well as known self closing tags
-			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>>)           # valid tags that don't close themselves on the same line
+			    <\?(php)?\s*\b                                                                      # an open PHP tag
+			    (
+			        (if|else|elseif)\b.*:(?!.*?endif\b)                                             # PHP if related statements not followed by an endif
+			    |   (?<php_control_word>for|foreach|while)\b.*:(?!.*?end\g<php_control_word>\b)     # PHP control keywords that don't end themselves on the same line
+			    )
+			|   \{[^}"']*$                                                                          # open curly braces that don't have close braces or string punctuation after them
+			|   <!--(?!.*-->)                                                                       # comments that don't close themselves on the same line
+			|   <(?!\?|(?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*/>)     # skip self closing tags (tags that end with />, as well as known self closing tags)
+			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>\s*>)              # valid HTML tags that don't close themselves on the same line
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>

--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -9,24 +9,24 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                         # the beginning of the line followed by any amount of whitespace
+			^\s*                                                                              # the beginning of the line followed by any amount of whitespace
 			(
-			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))                         # ending php control keywords
-			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                          # any valid close tag except html
-			|   -->                                                                      # closing comment punctuation
-			|   \}                                                                       # a closing brace
+			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))                              # ending php control keywords
+			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                               # any valid close tag except html
+			|   -->                                                                           # closing comment punctuation
+			|   \}                                                                            # a closing brace
 			)
 		]]></string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                         # the beginning of the line followed by any amount of whitespace
+			^\s*                                                                              # the beginning of the line followed by any amount of whitespace
 			(
-			    <\?(php)?\s*\b(?<php_control_word>if|else|elseif|for|foreach|while)\b.*: # php control keywords
-			    (?!.*end\g<php_control_word>)                                            # - that don't end themselves on the same line
-			|   \{[^}"']*$                                                               # open curly braces that don't have close braces or string punctuation after them
-			|   <!--(?!.*-->)                                                            # comments that don't close themselves on the same line
-			|   <(?!\?|area|base|br|col|frame|hr|html|img|input|link|meta|param|[^>]*/>) # skip self closing tags (tags that end with />, as well as known self closing tags
-			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>>)      # valid tags that don't close themselves on the same line
+			    <\?(php)?\s*\b(?<php_control_word>if|else|elseif|for|foreach|while)\b.*:      # php control keywords
+			    (?!.*end\g<php_control_word>)                                                 # - that don't end themselves on the same line
+			|   \{[^}"']*$                                                                    # open curly braces that don't have close braces or string punctuation after them
+			|   <!--(?!.*-->)                                                                 # comments that don't close themselves on the same line
+			|   <(?!\?|(?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)|[^>]*/>) # skip self closing tags (tags that end with />, as well as known self closing tags
+			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>>)           # valid tags that don't close themselves on the same line
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>

--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -13,7 +13,7 @@
 			(
 			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))\b                                  # ending PHP control keywords
 			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                                     # any valid HTML close tag except "html"
-			|   -->                                                                                 # closing comment punctuation
+			|   (<!\[endif\])?-->                                                                   # closing comment punctuation, optionally preceded by an end "comment selector"
 			|   \}                                                                                  # a closing curly brace
 			)
 		]]></string>

--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -9,29 +9,24 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*
-			<\?(php)?\s+(else(if)?|end(if|for(each)?|while))
-		]]></string>
-		<key>batchDecreaseIndentPattern</key>
-		<string><![CDATA[(?x)
-			^\s*
-			(</(?!html)
-			  [A-Za-z0-9-]+\b[^>]*>
-			|-->
-			|<\?(php)?\s+(else(if)?|end(if|for(each)?|while))
-			|\}
+			^\s*                                                                         # the beginning of the line followed by any amount of whitespace
+			(
+			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))                         # ending php control keywords
+			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                          # any valid close tag except html
+			|   -->                                                                      # closing comment punctuation
+			|   \}                                                                       # a closing brace
 			)
 		]]></string>
 		<key>increaseIndentPattern</key>
-		<string><![CDATA[^\s*<\?php\s*\b(if|else|elseif|for|foreach|while)\b.*:(?!.*end\1)]]></string>
-		<key>batchIncreaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*
-			<(?!\?|area|base|br|col|frame|hr|html|img|input|link|meta|param|[^>]*/>)
-			  ([A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\1>)
-			|<!--(?!.*-->)
-			|<\?php.+?\b(if|else(?:if)?|for(?:each)?|while)\b.*:(?!.*end\1)
-			|\{[^}"']*$
+			^\s*                                                                         # the beginning of the line followed by any amount of whitespace
+			(
+			    <\?php\s*\b(if|else|elseif|for|foreach|while)\b.*:(?!.*end\1)            # php control keywords that don't end themselves on the same line
+			|   \{[^}"']*$                                                               # open curly braces that don't have close braces or string punctuation after them
+			|   <!--(?!.*-->)                                                            # comments that don't close themselves on the same line
+			|   <(?!\?|area|base|br|col|frame|hr|html|img|input|link|meta|param|[^>]*/>) # skip self closing tags (tags that end with />, as well as known self closing tags
+			        ([A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\1>)                           # valid tags that don't close themselves on the same line
+			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>
 		<string><![CDATA[<!DOCTYPE(?!.*>)]]></string>


### PR DESCRIPTION
solves the problem with HTML unexpectedly unindenting as you type, and allows indentation to be increased and decreased as expected while typing HTML tags (previously one had to rely on pressing <kbd>Enter</kbd> inside an empty tag or using batch reindentation) - https://github.com/SublimeTextIssues/Core/issues/1583