### PR TITLE
[Regular Expressions] better named capture group support

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -113,7 +113,7 @@ contexts:
         2: variable.other.backref-and-recursion.regexp
         3: keyword.control.group.regexp
       pop: true
-    - match: '(\?&(\w+))(\))'
+    - match: '(\?&([\w-]+))(\))'
       captures:
         1: keyword.other.backref-and-recursion.regexp
         2: variable.other.backref-and-recursion.regexp
@@ -139,20 +139,28 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ixms]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: \?(?:<([^>]+)>|'([^']+)')
+    - match: \?(?:(<)([^>]+)(>)|(')([^']+)('))
       scope: keyword.other.named-capture-group.regexp
       captures:
-        1: entity.name.capture-group.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: entity.name.capture-group.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
+        5: entity.name.capture-group.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: \?\((?:<([^>]+)>|'([^']+)'|(\d+)|R(\d*)|R&(\w+))\)
+    - match: \?\((?:(<)([^>]+)(>)|(')([^']+)(')|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
       captures:
-        1: variable.other.backref-and-recursion.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: variable.other.backref-and-recursion.regexp
-        3: variable.other.backref-and-recursion.regexp
-        4: variable.other.backref-and-recursion.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
         5: variable.other.backref-and-recursion.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
+        7: variable.other.backref-and-recursion.regexp
+        8: variable.other.backref-and-recursion.regexp
+        9: variable.other.backref-and-recursion.regexp
       set: [group-body, unexpected-quantifier-pop]
     - match: '\?\(DEFINE\)'
       scope: keyword.other.conditional.definition.regexp
@@ -183,20 +191,28 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ims]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: \?(?:<([^>]+)>|'([^']+)')
+    - match: \?(?:(<)([^>]+)(>)|(')([^']+)('))
       scope: keyword.other.named-capture-group.regexp
       captures:
-        1: entity.name.capture-group.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: entity.name.capture-group.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
+        5: entity.name.capture-group.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: \?\((?:<([^>]+)>|'([^']+)'|(\d+)|R(\d*)|R&(\w+))\)
+    - match: \?\((?:(<)([^>]+)(>)|(')([^']+)(')|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
       captures:
-        1: variable.other.backref-and-recursion.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: variable.other.backref-and-recursion.regexp
-        3: variable.other.backref-and-recursion.regexp
-        4: variable.other.backref-and-recursion.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
         5: variable.other.backref-and-recursion.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
+        7: variable.other.backref-and-recursion.regexp
+        8: variable.other.backref-and-recursion.regexp
+        9: variable.other.backref-and-recursion.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
     - match: '\?\(DEFINE\)'
       scope: keyword.other.conditional.definition.regexp
@@ -281,13 +297,19 @@ contexts:
     - match: '\\[QEK]'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
-    - match: \\[kg](?:<([^>]+)>|'([^']+)'|\{([^}]+)\}|(-?\d+))
+    - match: \\[kg](?:(<)([^>]+)(>)|(')([^']+)(')|(\{)([^}]+)(\})|(-?\d+))
       scope: keyword.other.backref-and-recursion.regexp
       captures:
-        1: variable.other.backref-and-recursion.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: variable.other.backref-and-recursion.regexp
-        3: variable.other.backref-and-recursion.regexp
-        4: variable.other.backref-and-recursion.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
+        5: variable.other.backref-and-recursion.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
+        7: punctuation.definition.capture-group-name.begin.regexp
+        8: variable.other.backref-and-recursion.regexp
+        9: punctuation.definition.capture-group-name.end.regexp
+        10: variable.other.backref-and-recursion.regexp
     - match: \\([1-9]\d*)
       scope: keyword.other.backref-and-recursion.regexp
       captures:

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -139,12 +139,13 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ixms]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: '\?<(\w+)>'
+    - match: \?(?:<([^>]+)>|'([^']+)')
       scope: keyword.other.named-capture-group.regexp
       captures:
         1: entity.name.capture-group.regexp
+        2: entity.name.capture-group.regexp
       set: [group-body, unexpected-quantifier-pop]
-    - match: \?\((?:<(\w+)>|'(\w+)'|(\d+)|R(\d*)|R&(\w+))\)
+    - match: \?\((?:<([^>]+)>|'([^']+)'|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
       captures:
         1: variable.other.backref-and-recursion.regexp
@@ -182,12 +183,13 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ims]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: '\?<(\w+)>'
+    - match: \?(?:<([^>]+)>|'([^']+)')
       scope: keyword.other.named-capture-group.regexp
       captures:
         1: entity.name.capture-group.regexp
+        2: entity.name.capture-group.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: \?\((?:<(\w+)>|'(\w+)'|(\d+)|R(\d*)|R&(\w+))\)
+    - match: \?\((?:<([^>]+)>|'([^']+)'|(\d+)|R(\d*)|R&(\w+))\)
       scope: keyword.other.backref-and-recursion.conditional.regexp
       captures:
         1: variable.other.backref-and-recursion.regexp
@@ -279,7 +281,7 @@ contexts:
     - match: '\\[QEK]'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
-    - match: \\[kg](?:<(\w+)>|'(\w+)'|\{(\w+)\}|(-?\d+))
+    - match: \\[kg](?:<([^>]+)>|'([^']+)'|\{([^}]+)\}|(-?\d+))
       scope: keyword.other.backref-and-recursion.regexp
       captures:
         1: variable.other.backref-and-recursion.regexp

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -352,6 +352,18 @@ where escape characters are ignored.\).
 #                        ^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #                          ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
+(?'foo-t'a+)(b+)\g<foo-t>
+#^^^^^^^^ keyword.other.named-capture-group.regexp
+#               ^^^ keyword.other.backref-and-recursion.regexp
+#                  ^^^^^ variable.other.backref-and-recursion.regexp
+
+(?'&a+\'a)b\g'&a+\'(?x)(?'a- -'a)b\g{a- -}(?-x)
+#  ^^^^ entity.name.capture-group.regexp
+#             ^^^^ variable.other.backref-and-recursion.regexp
+#                         ^^^^ entity.name.capture-group.regexp
+#                              ^ meta.literal.regexp
+#                                    ^^^^ variable.other.backref-and-recursion.regexp
+#                                         ^ keyword.control.group.regexp
 
 ###################
 ## Assertions

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -348,21 +348,38 @@ where escape characters are ignored.\).
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.extended
 #    ^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
 #      ^^^^^^^^^^^ entity.name.capture-group.regexp
+#     ^ punctuation.definition.capture-group-name.begin.regexp
+#                 ^ punctuation.definition.capture-group-name.end.regexp
 #                  ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
 #                        ^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #                          ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 
+(?x)(?<named-group>test)(?&named-group)(?-x)
+#     ^ punctuation.definition.capture-group-name.begin.regexp
+#                 ^ punctuation.definition.capture-group-name.end.regexp
+#                        ^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+
 (?'foo-t'a+)(b+)\g<foo-t>
 #^^^^^^^^ keyword.other.named-capture-group.regexp
-#               ^^^ keyword.other.backref-and-recursion.regexp
+# ^ punctuation.definition.capture-group-name.begin.regexp
+#       ^ punctuation.definition.capture-group-name.end.regexp
+#               ^^^^^^^^^ keyword.other.backref-and-recursion.regexp
+#                 ^ punctuation.definition.capture-group-name.begin.regexp
+#                       ^ punctuation.definition.capture-group-name.end.regexp
 #                  ^^^^^ variable.other.backref-and-recursion.regexp
 
 (?'&a+\'a)b\g'&a+\'(?x)(?'a- -'a)b\g{a- -}(?-x)
 #  ^^^^ entity.name.capture-group.regexp
+# ^ punctuation.definition.capture-group-name.begin.regexp
+#      ^ punctuation.definition.capture-group-name.end.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
 #             ^^^^ variable.other.backref-and-recursion.regexp
+#                 ^ punctuation.definition.capture-group-name.end.regexp
 #                         ^^^^ entity.name.capture-group.regexp
 #                              ^ meta.literal.regexp
+#                                   ^ punctuation.definition.capture-group-name.begin.regexp
 #                                    ^^^^ variable.other.backref-and-recursion.regexp
+#                                        ^ punctuation.definition.capture-group-name.end.regexp
 #                                         ^ keyword.control.group.regexp
 
 ###################
@@ -407,8 +424,10 @@ where escape characters are ignored.\).
 
 (?<test>a)?b(?('test')c|d)
 #            ^^^^^^^^^ keyword.other.backref-and-recursion.conditional.regexp
-(?<test>a)?b(?(<test>)c|d)
-#            ^^^^^^^^^ keyword.other.backref-and-recursion.conditional.regexp
+(?<test>a)?b(?(<test->)c|d)
+#            ^^^^^^^^^^ keyword.other.backref-and-recursion.conditional.regexp
+#              ^ punctuation.definition.capture-group-name.begin.regexp
+#                    ^ punctuation.definition.capture-group-name.end.regexp
 (a)?b(?(1)c|d)
 #     ^^^^ keyword.other.backref-and-recursion.conditional.regexp
 (?(?!\d)a|b)


### PR DESCRIPTION
This PR correctly allows non-word characters in capture group names, and scopes the punctuation surrounding the capture group names, so that color schemes can target it to make the punctuation visually stand out from the name.