### PR TITLE
[LaTeX] Minor scope fixing

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -370,7 +370,7 @@ contexts:
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
-        3: punctuation.definition.brace.bebgin.latex
+        3: punctuation.definition.group.brace.begin.latex
         4: variable.parameter.function.latex
         5: punctuation.definition.group.brace.end.latex
       push:
@@ -1714,7 +1714,7 @@ contexts:
             - meta_content_scope: meta.environment.tabular.latex meta.function.column-spec.latex
             - include: array-preamble
             - match: '\}'
-              scope: meta.function.column-spec.latex punctuation.definition.group.brace.end.latex
+              scope: punctuation.definition.group.brace.end.latex
               set:
                 - meta_content_scope: meta.environment.tabular.latex
                 - match: '((\\)end)(\{)(tabular)(\})'


### PR DESCRIPTION
- fix typo in verbatim environment
- remove duplicate scope in tabular environment