### PR TITLE
[Markdown] MultiMarkdown: better header support

### DIFF
--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -4,15 +4,17 @@
 name: MultiMarkdown
 first_line_match: (?i)^format:\s*complete\s*$
 scope: text.html.markdown.multimarkdown
+variables:
+  header: ((?=[A-Za-z0-9])[\w -]+)(:)
 contexts:
   main:
-    - match: '^([A-Za-z0-9]+)(:)\s*'
+    - match: '^{{header}}\s*'
       captures:
         1: keyword.other.multimarkdown
         2: punctuation.separator.key-value.multimarkdown
       push:
         - meta_scope: meta.header.multimarkdown
-        - match: "^$|^(?=[A-Za-z0-9]+:)"
+        - match: '^$|^(?={{header}})'
           pop: true
         - match: .+
           comment: |
@@ -20,9 +22,7 @@ contexts:
                                     (for the parent rule) is that we do not want
                                     newlines to be marked as string.unquoted
           scope: string.unquoted.multimarkdown
-    - match: "^(?!=[A-Za-z0-9]+:)"
+    - match: ''
       push:
         - meta_scope: meta.content.multimarkdown
-        - match: ^(?=not)possible$
-          pop: true
         - include: scope:text.html.markdown

--- a/Markdown/syntax_test_multimarkdown.md
+++ b/Markdown/syntax_test_multimarkdown.md
@@ -1,0 +1,35 @@
+T: SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
+Title:   A Sample MultiMarkdown Document
+T: ^^ meta.header.multimarkdown keyword.other.multimarkdown
+T:   ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T:                                      ^ meta.header.multimarkdown - string
+Author:  Fletcher T. Penney
+T:^^^^ meta.header.multimarkdown keyword.other.multimarkdown
+T:    ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+Date:    February 9, 2011
+Comment: This is a comment intended to demonstrate
+         metadata that spans multiple lines, yet
+         is treated as a single value.
+T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T:                                    ^ meta.header.multimarkdown - string
+Test:    And this is a new key-value pair
+With-Dash: Test
+T: ^^^^^^ meta.header.multimarkdown keyword.other.multimarkdown
+T:       ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
+T:         ^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+With Space: Test
+T: ^^^^^^^ meta.header.multimarkdown keyword.other.multimarkdown
+T:        ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
+T:          ^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+             /* Some more style. */
+             </style>
+T:           ^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+
+T: <- meta.content.multimarkdown - meta.header.multimarkdown
+# Heading
+| <- markup.heading punctuation.definition.heading
+|^^^^^^^^ markup.heading


### PR DESCRIPTION
This PR adds better header support to the MultiMarkdown syntax, and adds a syntax test for it. The rules for the header were taken from http://fletcher.github.io/peg-multimarkdown/index
This fixes https://github.com/SublimeTextIssues/DefaultPackages/issues/162