### PR TITLE
[Scala] Fixed type alias declarations with leading newlines

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -304,10 +304,7 @@ contexts:
             - include: delimited-type-expression
         - match: '='
           scope: keyword.operator.assignment.scala
-          set:
-            - match: '(?=[\n;\}\)\]])'
-              pop: true
-            - include: delimited-type-expression
+          set: type-alias-body
     - match: '\b(var)\s+({{id}})'
       captures:
         1: storage.type.volatile.scala
@@ -363,6 +360,18 @@ contexts:
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
         - include: pattern-match
+
+  type-alias-body:
+    - match: \n
+      set: type-alias-body-newline
+    - match: '(?=[;\}\)\]])'
+      pop: true
+    - include: delimited-type-expression
+
+  type-alias-body-newline:
+    - include: decl-newline-double-check
+    - match: (?=\S)
+      set: type-alias-body
 
   case-body-first:
     - meta_content_scope: meta.block.case.first.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -458,7 +458,7 @@ contexts:
   # this is included when a single newline is found in a declaration
   # you should never push/set this context, only include
   decl-newline-double-check:
-    - match: '(?=[\{\}\)]|\b(case|class|def|val|var|trait|object|private|protected|for|while|if|final|sealed|implicit)\b)'
+    - match: '(?=[\{\}\)]|\b(case|class|def|val|var|trait|object|private|protected|for|while|if|final|sealed|implicit|type)\b)'
       pop: true
     - match: '\n'
       pop: true

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1611,3 +1611,12 @@ new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
 // ^^^^^^^^ storage.modifier.other.scala
 //          ^^^ storage.type.function.scala
 //              ^ entity.name.function.scala
+
+  type Foo =
+     Bar
+//   ^^^ support.class.scala
+
+  type Foo =
+
+     Bar
+//   ^^^ support.constant.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1620,3 +1620,8 @@ new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
 
      Bar
 //   ^^^ support.constant.scala
+
+   type Foo = Unit
+   type Bar = Unit
+//      ^^^ entity.name.type.scala
+//          ^ keyword.operator.assignment.scala


### PR DESCRIPTION
Just like with methods, it is valid to wrap a type alias definition onto the next line without delimiters.