### PR TITLE
[Markdown] add table support

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -719,8 +719,17 @@ contexts:
               |    \s*$
               )
           pop: true
-        - match: ^(\s*:?-+:?)?(\s*\|\s*:?-+:?)+(\s*\|)? #(?=^[-\s:|]+$).+
-          scope: punctuation.separator.table-header.markdown
+        - match: (?=^(\s*:?-+:?)?(\s*\|\s*:?-+:?)+(\s*\|)?\s*$)
+          push:
+            - meta_scope: meta.table-header-separator.markdown
+            - match: \|
+              scope: punctuation.separator.table-cell.markdown
+            - match: ':'
+              scope: punctuation.definition.table-cell-alignment.markdown
+            - match: -+
+              scope: punctuation.definition.table-header-separator.markdown
+            - match: $\n?
+              pop: true
         - match: \|
           scope: punctuation.separator.table-cell.markdown
         - include: inline-bold-italic

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -728,7 +728,7 @@ contexts:
                 - match: $\n?
                   set:
                     - meta_content_scope: meta.table.markdown
-                    - match: |-
+                    - match: |- # The table is broken at the first empty line, or beginning of another block-level structure
                           (?x)^
                           (?=  {{block_quote}}
                           |    {{indented_code_block}}(?!$)
@@ -739,7 +739,6 @@ contexts:
                       pop: true
                     - match: \|
                       scope: punctuation.separator.table-cell.markdown
-                    - include: inline
                     - match: |- # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell, emphasis in table cells can't span multiple lines
                         (?x)
                         (?=
@@ -753,3 +752,10 @@ contexts:
                         - include: italic
                         - match: ''
                           pop: true
+                    - match: |-
+                        (?x)
+                        (?!{{backticks}})
+                        `+
+                      scope: invalid.deprecated.unescaped-backticks.markdown
+                    - include: inline
+                    

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -69,7 +69,11 @@ variables:
         )
     skip_html_tags: (?:<[^>]+>)
     non_pipe_or_escaped: (?:[^|\\]|\\.)
-    table_row: ^{{non_pipe_or_escaped}}+\||\|{{non_pipe_or_escaped}}*\|
+    table_row: |-
+        (?x:
+            ^(?!\s*\|){{non_pipe_or_escaped}}+\|     # the beginning of the line, followed by at least one non-pipe, non-whitespace char, followed by a non-escaped pipe
+        |   ^(?:{{non_pipe_or_escaped}}*\|){2}       # or at least 2 non-escaped pipe chars on the line
+        )
 contexts:
   main:
     - match: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -32,7 +32,7 @@ variables:
             | ((')[^']+('))       # or in single quotes.
           )?                      # Title is optional
         )
-    escape: '\\[-`*_#+.!(){}\[\]\\>]'
+    escape: '\\[-`*_#+.!(){}\[\]\\>|]'
     backticks: |-
         (?x:
             (`{4})(?=\S)[^`]+(?:[^`]+|(?!`{4})`*)*(`{4})(?!`)
@@ -67,7 +67,9 @@ variables:
               \s*                       # Optional whitespace
           (\))
         )
-    skip_html_tags: '(?:<[^>]+>)'
+    skip_html_tags: (?:<[^>]+>)
+    non_pipe_or_escaped: (?:[^|\\]|\\.)
+    table_row: ^{{non_pipe_or_escaped}}+\||\|{{non_pipe_or_escaped}}*\|
 contexts:
   main:
     - match: |-
@@ -76,6 +78,7 @@ contexts:
         |    {{indented_code_block}}(?!$)
         |    {{atx_heading}}
         |    {{thematic_break}}
+        |    {{table_row}}
         )
       comment: |
         We could also use an empty end match and set
@@ -87,6 +90,7 @@ contexts:
         - include: indented-code-block
         - include: atx-heading
         - include: thematic-break
+        - include: table
         - match: ''
           pop: true
     - match: '^[ ]{0,3}([*+-])(?=\s)'
@@ -700,3 +704,21 @@ contexts:
       captures:
         1: invalid.illegal.expected-eol.markdown
       pop: true
+  table:
+    - match: (?={{table_row}})
+      push:
+        - meta_content_scope: meta.table.markdown
+        - match: |-
+              (?x)^
+              (?=  {{block_quote}}
+              |    {{indented_code_block}}(?!$)
+              |    {{atx_heading}}
+              |    {{thematic_break}}
+              |    \s*$
+              )
+          pop: true
+        - match: ^(\s*:?-+:?)?(\s*\|\s*:?-+:?)+(\s*\|)? #(?=^[-\s:|]+$).+
+          scope: punctuation.separator.table-header.markdown
+        - match: \|
+          scope: punctuation.separator.table-cell.markdown
+        - include: inline-bold-italic

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -68,11 +68,9 @@ variables:
           (\))
         )
     skip_html_tags: (?:<[^>]+>)
-    non_pipe_or_escaped: (?:[^|\\]|\\.)
-    table_row: |-
+    table_first_row: |-
         (?x:
-            ^(?!\s*\|){{non_pipe_or_escaped}}+\|     # the beginning of the line, followed by at least one non-pipe, non-whitespace char, followed by a non-escaped pipe
-        |   ^(?:{{non_pipe_or_escaped}}*\|){2}       # or at least 2 non-escaped pipe chars on the line
+            (?:{{balance_square_brackets}}*\|){2}       # at least 2 non-escaped pipe chars on the line
         )
 contexts:
   main:
@@ -82,7 +80,7 @@ contexts:
         |    {{indented_code_block}}(?!$)
         |    {{atx_heading}}
         |    {{thematic_break}}
-        |    {{table_row}}
+        |    {{table_first_row}}
         )
       comment: |
         We could also use an empty end match and set
@@ -709,7 +707,7 @@ contexts:
         1: invalid.illegal.expected-eol.markdown
       pop: true
   table:
-    - match: (?={{table_row}})
+    - match: (?={{table_first_row}})
       push:
         - meta_content_scope: meta.table.markdown
         - match: |-

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1119,3 +1119,45 @@ text
 
 abc
 | <- meta.paragraph - markup.list
+
+| foo | bar |
+| <- meta.block-level meta.table punctuation.separator.table-cell
+|     ^ meta.block-level meta.table punctuation.separator.table-cell
+|           ^ meta.block-level meta.table punctuation.separator.table-cell
+| ^^^^ meta.block-level meta.table - punctuation.separator.table-cell
+| --- | --- |
+| ^^^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+| baz | bim |
+| <- meta.block-level meta.table punctuation.separator.table-cell
+
+| <- - meta.block-level - meta.table
+
+| abc | defghi |
+:-: | -----------:
+|^^^^^^^^^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+bar | baz
+|   ^ meta.block-level meta.table punctuation.separator.table-cell
+
+| f\|oo  |
+| <- meta.block-level meta.table punctuation.separator.table-cell
+|  ^^ meta.block-level meta.table constant.character.escape - punctuation.separator.table-cell
+|        ^ meta.block-level meta.table punctuation.separator.table-cell
+| ------ |
+|^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+| b `|` az |
+|   ^^^ meta.block-level meta.table markup.raw.inline - punctuation.separator.table-header
+|          ^ meta.block-level meta.table punctuation.separator.table-cell
+| b **|** im |
+| <- meta.block-level meta.table punctuation.separator.table-cell
+|   ^^^^^ meta.block-level meta.table markup.bold - punctuation.separator.table-cell
+|            ^ meta.block-level meta.table punctuation.separator.table-cell
+
+| abc | def |
+| --- | --- |
+| bar | baz |
+|^^^^^^^^^^^^^ meta.block-level meta.table
+test
+|^^^^ meta.block-level meta.table
+> bar
+| <- meta.block-level markup.quote punctuation.definition.blockquote - meta.table
+

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1199,3 +1199,6 @@ not a table |
 |^^^^^^ - markup.bold
 |      ^ punctuation.separator.table-cell
 |           ^ punctuation.separator.table-cell
+|`test | me |
+|^ invalid.deprecated.unescaped-backticks
+|      ^ punctuation.separator.table-cell

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1126,7 +1126,7 @@ abc
 |           ^ meta.block-level meta.table punctuation.separator.table-cell
 | ^^^^ meta.block-level meta.table - punctuation.separator.table-cell
 | --- | --- |
-| ^^^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+| ^^^^^^^^^^^ meta.block-level meta.table meta.table-header-separator
 | baz | bim |
 | <- meta.block-level meta.table punctuation.separator.table-cell
 
@@ -1134,7 +1134,12 @@ abc
 
 | abc | defghi |
 :-: | -----------:
-|^^^^^^^^^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+|^^^^^^^^^^^^^^^^^ meta.block-level meta.table meta.table-header-separator
+| <- punctuation.definition.table-cell-alignment
+|^ punctuation.definition.table-header-separator
+|   ^ punctuation.separator.table-cell
+|     ^^^^^^^^^^^ punctuation.definition.table-header-separator
+|                ^ punctuation.definition.table-cell-alignment - punctuation.definition.table-header-separator
 bar | baz
 |   ^ meta.block-level meta.table punctuation.separator.table-cell
 
@@ -1143,9 +1148,9 @@ bar | baz
 |  ^^ meta.block-level meta.table constant.character.escape - punctuation.separator.table-cell
 |        ^ meta.block-level meta.table punctuation.separator.table-cell
 | ------ |
-|^^^^^^^^^ meta.block-level meta.table punctuation.separator.table-header
+|^^^^^^^^^ meta.block-level meta.table meta.table-header-separator
 | b `|` az |
-|   ^^^ meta.block-level meta.table markup.raw.inline - punctuation.separator.table-header
+|   ^^^ meta.block-level meta.table markup.raw.inline - meta.table-header-separator
 |          ^ meta.block-level meta.table punctuation.separator.table-cell
 | b **|** im |
 | <- meta.block-level meta.table punctuation.separator.table-cell

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1161,3 +1161,21 @@ test
 > bar
 | <- meta.block-level markup.quote punctuation.definition.blockquote - meta.table
 
+`|` this `|` example `|` is not a table `|`
+| ^ punctuation.definition.raw.end - meta.table
+| nor is this | because it is not at block level, it immediately follows a paragraph |
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.table
+
+| First Header  | Second Header | Third Header         |
+| :------------ | :-----------: | -------------------: |
+| First row     | Data          | Very long data entry |
+| Second row    | **Cell**      | *Cell*               |
+| Third row     | Cell that spans across two columns  ||
+| ^^^^^^^^^^^^^^ meta.block-level meta.table
+|                                                     ^^ punctuation.separator.table-cell
+
+ | table that doesn't start at column 0 |
+  | ---- |
+  | blah |
+| ^^^^^^^^ meta.table
+| ^ punctuation.separator.table-cell


### PR DESCRIPTION
this PR adds table support to the Markdown syntax, as per https://github.github.com/gfm/#tables-extension-