### PR TITLE
[Java] handle dot access to fields named "class"

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -390,8 +390,9 @@ contexts:
       scope: keyword.operator.arithmetic.java
     - match: (!|&&|\|\|)
       scope: keyword.operator.logical.java
-    - match: \.
-      scope: punctuation.accessor.dot.java
+    - match: (\.)({{id}}(?!(\s*{{within_generics}})?\s*\(|{{id}}))?
+      captures:
+        1: punctuation.accessor.dot.java
     - match: ;
       scope: punctuation.terminator.java
 

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -390,9 +390,10 @@ contexts:
       scope: keyword.operator.arithmetic.java
     - match: (!|&&|\|\|)
       scope: keyword.operator.logical.java
-    - match: (\.)({{id}}(?!(\s*{{within_generics}})?\s*\(|{{id}}))?
+    - match: (\.)(class\b)?
       captures:
         1: punctuation.accessor.dot.java
+        2: support.variable.magic.java
     - match: ;
       scope: punctuation.terminator.java
 

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -256,3 +256,20 @@ new Foo<? super Bar>();
 
 new Foo<int>();
 //      ^^^ invalid.illegal.primitive-instantiation.java
+
+public class Test {
+
+    void test1() {
+        Foo.abc();
+//         ^ punctuation.accessor.dot.java
+//          ^^^ variable.function.java
+        Foo.class;
+//         ^ punctuation.accessor.dot.java
+//          ^^^^^ - storage.type.java
+//               ^ punctuation.terminator.java
+    }
+
+    void test2() {
+//       ^^^^^ entity.name.function.java
+    }
+}

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -265,7 +265,7 @@ public class Test {
 //          ^^^ variable.function.java
         Foo.class;
 //         ^ punctuation.accessor.dot.java
-//          ^^^^^ - storage.type.java
+//          ^^^^^ support.variable.magic.java - storage.type.java
 //               ^ punctuation.terminator.java
     }
 


### PR DESCRIPTION
to prevent highlighting breaking after `id.class` due to `class` being treated as a class definition, match the identifier if it isn't a function call (though it currently doesn't scope it, but this is existing behavior). This ensures that function calls are still handled correctly.