### PR TITLE
[Markdown] support GFM autolinks

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -440,6 +440,8 @@ contexts:
         1: punctuation.definition.link.begin.markdown
         2: markup.underline.link.markdown
         4: punctuation.definition.link.end.markdown
+    - match: '[\w.+-]+@[\w-]+(\.((?![._-][\W])[\w_-])+)+(?![_-])'
+      scope: markup.underline.link.markdown
   autolink-inet:
     - match: (<)((?:https?|ftp)://.*?)(>)
       scope: meta.link.inet.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -67,6 +67,7 @@ variables:
               \s*                       # Optional whitespace
           (\))
         )
+    html_entity: '&([a-zA-Z0-9]+|#\d+|#x\h+);'
     skip_html_tags: '(?:<[^>]+>)'
 contexts:
   main:
@@ -158,7 +159,7 @@ contexts:
             1: punctuation.definition.heading.setext.markdown
           pop: true
   ampersand:
-    - match: "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)"
+    - match: (?!{{html_entity}})&
       comment: |
         Markdown will convert this for us. We match it so that the
                         HTML grammar will not mark it up as invalid.
@@ -446,6 +447,24 @@ contexts:
         1: punctuation.definition.link.begin.markdown
         2: markup.underline.link.markdown
         3: punctuation.definition.link.end.markdown
+    - match: (((https|http|ftp)://)|www\.)[\w-]+(\.[\w-]+)+
+      scope: markup.underline.link.markdown
+      push: # After a valid domain, zero or more non-space non-< characters may follow
+        - match: (?=[?!.,:*_~]*[\s<]) # Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be considered part of the autolink, though they may be included in the interior of the link
+          pop: true
+        - match: (?={{html_entity}}[?!.,:*_~]*[\s<]) # If an autolink ends in a semicolon (;), we check to see if it appears to resemble an entity reference; if the preceding text is & followed by one or more alphanumeric characters. If so, it is excluded from the autolink
+          pop: true
+        - match: \( # When an autolink ends in ), we scan the entire autolink for the total number of parentheses. If there is a greater number of closing parentheses than opening ones, we don’t consider the last character part of the autolink, in order to facilitate including an autolink inside a parenthesis
+          push:
+            - meta_scope: markup.underline.link.markdown
+            - match: (?=[?!.,:*_~]*[\s<])
+              pop: true
+            - match: \)
+              pop: true
+        - match: (?=\)[?!.,:*_~]*[\s<])
+          pop: true
+        - match: '[^?!.,:*_~\s<&(]+|\S'
+          scope: markup.underline.link.markdown
   link-inline:
     - match: |-
         (?x:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -234,6 +234,36 @@ _ _ _ _ _ _ _
 <ftp://test.com/>
 | ^^^^^^^^^^^^^^ meta.paragraph meta.link.inet markup.underline.link
 
+Visit www.commonmark.org/help for more information.
+|     ^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                            ^^^^^^^^^^^^^^^^^^^^^^^ - markup.underline.link
+Visit www.commonmark.org.
+|     ^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
+|                       ^^ - markup.underline.link
+Visit www.commonmark.org/a.b.
+|     ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
+|                           ^ - markup.underline.link
+www.google.com/search?q=(business))+ok
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                     ^ - markup.underline.link
+www.commonmark.org/he<lp>
+|^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                    ^ - markup.underline.link
+http://commonmark.org
+|^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+www.google.com/search?q=commonmark&hl=en
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                       ^ - markup.underline.link
+www.google.com/search?q=commonmark&hl;
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                 ^^^^ constant.character.entity.html - markup.underline.link
+(Visit https://encrypted.google.com/search?q=Markup+(business))
+|      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                                             ^^ - markup.underline.link
+Anonymous FTP is available at ftp://foo.bar.baz.
+|                             ^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                              ^^ - markup.underline.link
+
 this is a raw ampersand & does not require HTML escaping
 |                       ^ meta.other.valid-ampersand
 

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -264,6 +264,24 @@ Anonymous FTP is available at ftp://foo.bar.baz.
 |                             ^^^^^^^^^^^^^^^^^ markup.underline.link
 |                                              ^^ - markup.underline.link
 
+foo@bar.baz
+|^^^^^^^^^^ markup.underline.link
+hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.underline.link
+|                                       ^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+ a.b-c_d@a.b
+|^^^^^^^^^^^ markup.underline.link
+|           ^ - markup.underline.link
+a.b-c_d@a.b.
+|^^^^^^^^^^ markup.underline.link
+|          ^^ - markup.underline.link
+ a.b-c_d@a.b-
+|^^^^^^^^^^^^^ - markup.underline.link
+ a.b-c_d@a.b_
+|^^^^^^^^^^^^^ - markup.underline.link
+ test@test.test.me
+|^^^^^^^^^^^^^^^^^ markup.underline.link
+
 this is a raw ampersand & does not require HTML escaping
 |                       ^ meta.other.valid-ampersand
 


### PR DESCRIPTION
This enhances the Markdown syntax by adding support for autolinks as defined by the GitHub Formatted Markdown specification: https://github.github.com/gfm/#autolinks-extension-