### PR TITLE
[JSON] Meta scopes for mapping and sequence

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -96,13 +96,13 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.begin.json
           push:
-            - meta_scope: meta.key.json string.quoted.double.json
+            - meta_scope: meta.mapping.key.json string.quoted.double.json
             - include: inside-string
         - include: comments
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json
           push:
-            - meta_scope: meta.value.json
+            - meta_scope: meta.mapping.value.json
             - match: '(,)|(?=\})'
               captures:
                 1: punctuation.separator.mapping.pair.json

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -20,6 +20,13 @@ scope: source.json
 contexts:
   main:
     - include: value
+  value:
+    - include: constant
+    - include: number
+    - include: string
+    - include: array
+    - include: object
+    - include: comments
   array:
     - match: '\['
       scope: punctuation.section.array.begin.json
@@ -132,10 +139,3 @@ contexts:
       scope: constant.character.escape.json
     - match: \\.
       scope: invalid.illegal.unrecognized-string-escape.json
-  value:
-    - include: constant
-    - include: number
-    - include: string
-    - include: array
-    - include: object
-    - include: comments

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -96,13 +96,13 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.begin.json
           push:
-            - meta_scope: meta.structure.dictionary.key.json string.quoted.double.json
+            - meta_scope: meta.key.json string.quoted.double.json
             - include: inside-string
         - include: comments
         - match: ":"
           scope: punctuation.separator.dictionary.key-value.json
           push:
-            - meta_scope: meta.structure.dictionary.value.json
+            - meta_scope: meta.value.json
             - match: '(,)|(?=\})'
               captures:
                 1: punctuation.separator.dictionary.pair.json

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -18,6 +18,8 @@ file_extensions:
   - Pipfile.lock
 scope: source.json
 contexts:
+  prototype:
+    - include: comments
   main:
     - include: value
   value:
@@ -26,7 +28,6 @@ contexts:
     - include: string
     - include: array
     - include: object
-    - include: comments
   array:
     - match: '\['
       scope: punctuation.section.sequence.begin.json
@@ -45,12 +46,14 @@ contexts:
       scope: punctuation.definition.comment.json
       push:
         - meta_scope: comment.block.documentation.json
+        - meta_include_prototype: false
         - match: \*/
           pop: true
     - match: /\*
       scope: punctuation.definition.comment.json
       push:
         - meta_scope: comment.block.json
+        - meta_include_prototype: false
         - match: \*/
           pop: true
     - match: (//).*$\n?
@@ -98,7 +101,6 @@ contexts:
           push:
             - meta_scope: meta.mapping.key.json string.quoted.double.json
             - include: inside-string
-        - include: comments
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json
           push:
@@ -118,6 +120,7 @@ contexts:
       push: inside-string
   inside-string:
     - meta_scope: string.quoted.double.json
+    - meta_include_prototype: false
     - match: '"'
       scope: punctuation.definition.string.end.json
       pop: true

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -29,17 +29,17 @@ contexts:
     - include: comments
   array:
     - match: '\['
-      scope: punctuation.section.array.begin.json
+      scope: punctuation.section.sequence.begin.json
       push:
-        - meta_scope: meta.structure.array.json
+        - meta_scope: meta.sequence.json
         - match: '\]'
-          scope: punctuation.section.array.end.json
+          scope: punctuation.section.sequence.end.json
           pop: true
         - include: value
         - match: ","
-          scope: punctuation.separator.array.json
+          scope: punctuation.separator.sequence.json
         - match: '[^\s\]]'
-          scope: invalid.illegal.expected-array-separator.json
+          scope: invalid.illegal.expected-sequence-separator.json
   comments:
     - match: /\*\*(?!/)
       scope: punctuation.definition.comment.json
@@ -87,11 +87,11 @@ contexts:
   object:
     # a JSON object
     - match: '\{'
-      scope: punctuation.section.dictionary.begin.json
+      scope: punctuation.section.mapping.begin.json
       push:
-        - meta_scope: meta.structure.dictionary.json
+        - meta_scope: meta.mapping.json
         - match: '\}'
-          scope: punctuation.section.dictionary.end.json
+          scope: punctuation.section.mapping.end.json
           pop: true
         - match: '"'
           scope: punctuation.definition.string.begin.json
@@ -100,18 +100,18 @@ contexts:
             - include: inside-string
         - include: comments
         - match: ":"
-          scope: punctuation.separator.dictionary.key-value.json
+          scope: punctuation.separator.mapping.key-value.json
           push:
             - meta_scope: meta.value.json
             - match: '(,)|(?=\})'
               captures:
-                1: punctuation.separator.dictionary.pair.json
+                1: punctuation.separator.mapping.pair.json
               pop: true
             - include: value
             - match: '[^\s,]'
-              scope: invalid.illegal.expected-dictionary-separator.json
+              scope: invalid.illegal.expected-mapping-separator.json
         - match: '[^\s\}]'
-          scope: invalid.illegal.expected-dictionary-separator.json
+          scope: invalid.illegal.expected-mapping-separator.json
   string:
     - match: '"'
       scope: punctuation.definition.string.begin.json

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -99,21 +99,32 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.begin.json
           push:
+            - clear_scopes: 1
             - meta_scope: meta.mapping.key.json string.quoted.double.json
             - include: inside-string
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json
           push:
-            - meta_scope: meta.mapping.value.json
             - match: '(,)|(?=\})'
               captures:
-                1: punctuation.separator.mapping.pair.json
+                1: invalid.illegal.expected-mapping-value.json
               pop: true
-            - include: value
-            - match: '[^\s,]'
-              scope: invalid.illegal.expected-mapping-separator.json
+            - match: (?=\S)
+              set:
+                - clear_scopes: 1
+                - meta_scope: meta.mapping.value.json
+                - include: value
+                - match: ''
+                  set:
+                    - match: '(,)|(?=\s*\})'
+                      captures:
+                        1: punctuation.separator.mapping.pair.json
+                      pop: true
+                    - match: '\s(?=[^\s,])|[^\s,]'
+                      scope: invalid.illegal.expected-mapping-separator.json
+                      pop: true
         - match: '[^\s\}]'
-          scope: invalid.illegal.expected-mapping-separator.json
+          scope: invalid.illegal.expected-mapping-key.json
   string:
     - match: '"'
       scope: punctuation.definition.string.begin.json

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -19,7 +19,7 @@
 
   "string": "string",
 //          ^        punctuation.definition.string.begin.json
-//          ^^^^^^^^ meta.structure.dictionary.value.json string.quoted.double.json
+//          ^^^^^^^^ meta.value.json string.quoted.double.json
 //                 ^ punctuation.definition.string.end.json
 
   "bool": false,
@@ -33,12 +33,12 @@
 
   "E": 20e10,
 //     ^^^^^ constant.numeric.json
-//^^^ meta.structure.dictionary.key.json string.quoted.double.json
-//   ^ punctuation.separator.dictionary.key-value.json - meta.structure.dictionary.key.json
+//^^^ meta.key.json string.quoted.double.json
+//   ^ punctuation.separator.dictionary.key-value.json - meta.key
 
   "escape": "\n",
 //           ^^ constant.character.escape.json
-//          ^^^^ meta.structure.dictionary.value.json string.quoted.double.json - meta.structure.dictionary.key.json
+//          ^^^^ meta.value.json string.quoted.double.json - meta.structure.dictionary.key.json
 
   "illegal": "\.",
 //            ^^ invalid.illegal.unrecognized-string-escape.json
@@ -52,12 +52,12 @@
 /**/: "test",
 // ^ meta.structure.dictionary.json comment.block.json
 //  ^ punctuation.separator.dictionary.key-value.json - comment
-//    ^^^^^^ meta.structure.dictionary.value.json string.quoted.double.json
+//    ^^^^^^ meta.value.json string.quoted.double.json
 
   "array2":
     [
       "foobar",
-//    ^^^^^^^^ meta.structure.array.json string.quoted.double.json - meta.structure.dictionary.key.json
+//    ^^^^^^^^ meta.structure.array.json string.quoted.double.json - meta.key
     ],
 
   []

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -19,7 +19,7 @@
 
   "string": "string",
 //          ^        punctuation.definition.string.begin.json
-//          ^^^^^^^^ meta.value.json string.quoted.double.json
+//          ^^^^^^^^ meta.mapping.value.json string.quoted.double.json
 //                 ^ punctuation.definition.string.end.json
 
   "bool": false,
@@ -33,12 +33,12 @@
 
   "E": 20e10,
 //     ^^^^^ constant.numeric.json
-//^^^ meta.key.json string.quoted.double.json
-//   ^ punctuation.separator.mapping.key-value.json - meta.key
+//^^^ meta.mapping.key.json string.quoted.double.json
+//   ^ punctuation.separator.mapping.key-value.json - meta.mapping.key
 
   "escape": "\n",
 //           ^^ constant.character.escape.json
-//          ^^^^ meta.value.json string.quoted.double.json - meta.key
+//          ^^^^ meta.mapping.value.json string.quoted.double.json - meta.mapping.key
 
   "illegal": "\.",
 //            ^^ invalid.illegal.unrecognized-string-escape.json
@@ -52,12 +52,12 @@
 /**/: "test",
 // ^ meta.mapping.json comment.block.json
 //  ^ punctuation.separator.mapping.key-value.json - comment
-//    ^^^^^^ meta.value.json string.quoted.double.json
+//    ^^^^^^ meta.mapping.value.json string.quoted.double.json
 
   "array2":
     [
       "foobar",
-//    ^^^^^^^^ meta.value meta.sequence.json string.quoted.double.json - meta.key
+//    ^^^^^^^^ meta.mapping.value meta.sequence.json string.quoted.double.json - meta.mapping.key
     ],
 
   []

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -1,29 +1,39 @@
 // SYNTAX TEST "Packages/JavaScript/JSON.sublime-syntax"
 
 {
-  "dict": { }
-//        ^^^ meta.mapping.json
-//        ^   punctuation.section.mapping.begin.json
-//          ^ punctuation.section.mapping.end.json
+// <- meta.mapping.json punctuation.section.mapping.begin.json
+  "bool": false,
+//^^^^^^ meta.mapping.key.json
+//^^^^^^^^^^^^^^ - meta.mapping meta.mapping
+//        ^^^^^ constant.language.json
 
-,
+  "dict": { "key": "value" }
+//        ^^^^^^^^^^^^^^^^^^ meta.mapping.value.json meta.mapping - meta.mapping meta.mapping meta.mapping
+//        ^   punctuation.section.mapping.begin.json
+//                         ^ punctuation.section.mapping.end.json
+//        ^^ meta.mapping.value.json meta.mapping.json
+//          ^^^^^ meta.mapping.key.json string.quoted.double.json
+//               ^^ meta.mapping.value.json meta.mapping.json
+//                 ^^^^^^^ meta.mapping.value.json meta.mapping.value.json string.quoted.double.json
+//                        ^^ meta.mapping.value.json meta.mapping.json
+
+, ,
 // <- punctuation.separator.mapping.pair.json
+//^ invalid.illegal.expected-mapping-key.json
 
   "sep": {},
 //     ^ punctuation.separator.mapping.key-value.json
 
-  "array": [ ],
-//         ^^^ meta.sequence.json
+  "array": [ /**/ ],
+//         ^^^^^^^^ meta.mapping.value.json meta.sequence.json
 //         ^   punctuation.section.sequence.begin.json
-//           ^ punctuation.section.sequence.end.json
+//           ^^^^ comment.block.json
+//                ^ punctuation.section.sequence.end.json
 
   "string": "string",
 //          ^        punctuation.definition.string.begin.json
 //          ^^^^^^^^ meta.mapping.value.json string.quoted.double.json
 //                 ^ punctuation.definition.string.end.json
-
-  "bool": false,
-//        ^^^^^ constant.language.json
 
   "num": 20.09,
 //       ^^^^^ constant.numeric.json
@@ -58,9 +68,12 @@
     [
       "foobar",
 //    ^^^^^^^^ meta.mapping.value meta.sequence.json string.quoted.double.json - meta.mapping.key
-    ],
+    ]
 
-  []
-//^^ invalid.illegal.expected-mapping-separator.json
+   [],
+//^ invalid.illegal.expected-mapping-separator.json
+// ^^^ invalid.illegal.expected-mapping-key.json
 
+  "typing json": {}
+  ,,,, "another key": false,
 }

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -2,20 +2,20 @@
 
 {
   "dict": { }
-//        ^^^ meta.structure.dictionary.json
-//        ^   punctuation.section.dictionary.begin.json
-//          ^ punctuation.section.dictionary.end.json
+//        ^^^ meta.mapping.json
+//        ^   punctuation.section.mapping.begin.json
+//          ^ punctuation.section.mapping.end.json
 
 ,
-// <- punctuation.separator.dictionary.pair.json
+// <- punctuation.separator.mapping.pair.json
 
   "sep": {},
-//     ^ punctuation.separator.dictionary.key-value.json
+//     ^ punctuation.separator.mapping.key-value.json
 
   "array": [ ],
-//         ^^^ meta.structure.array.json
-//         ^   punctuation.section.array.begin.json
-//           ^ punctuation.section.array.end.json
+//         ^^^ meta.sequence.json
+//         ^   punctuation.section.sequence.begin.json
+//           ^ punctuation.section.sequence.end.json
 
   "string": "string",
 //          ^        punctuation.definition.string.begin.json
@@ -34,11 +34,11 @@
   "E": 20e10,
 //     ^^^^^ constant.numeric.json
 //^^^ meta.key.json string.quoted.double.json
-//   ^ punctuation.separator.dictionary.key-value.json - meta.key
+//   ^ punctuation.separator.mapping.key-value.json - meta.key
 
   "escape": "\n",
 //           ^^ constant.character.escape.json
-//          ^^^^ meta.value.json string.quoted.double.json - meta.structure.dictionary.key.json
+//          ^^^^ meta.value.json string.quoted.double.json - meta.key
 
   "illegal": "\.",
 //            ^^ invalid.illegal.unrecognized-string-escape.json
@@ -50,17 +50,17 @@
 // <- - string
 
 /**/: "test",
-// ^ meta.structure.dictionary.json comment.block.json
-//  ^ punctuation.separator.dictionary.key-value.json - comment
+// ^ meta.mapping.json comment.block.json
+//  ^ punctuation.separator.mapping.key-value.json - comment
 //    ^^^^^^ meta.value.json string.quoted.double.json
 
   "array2":
     [
       "foobar",
-//    ^^^^^^^^ meta.structure.array.json string.quoted.double.json - meta.key
+//    ^^^^^^^^ meta.value meta.sequence.json string.quoted.double.json - meta.key
     ],
 
   []
-//^^ invalid.illegal.expected-dictionary-separator.json
+//^^ invalid.illegal.expected-mapping-separator.json
 
 }


### PR DESCRIPTION
In direct response to #421.

Use `meta.key` and `meta.value` for key and value tokens respectively. In the process, generalize `meta.sequence` and `meta.mapping` (and "fix" their punctuation scopes).

Investigation on how this might affect third-party color schemes should likely be performed, for the latter change only, which I doubt had any special coloring applied.
The scopes changed in the first change have only been added in https://github.com/sublimehq/Packages/commit/5e24e2b77f6ee16e2fbc705558d393b0f1d58485 (https://github.com/sublimehq/Packages/pull/816), which hasn't been part of any build yet.