### PR TITLE
[JavaScript] Add support for string ES6 method definitions

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1097,9 +1097,8 @@ contexts:
                 - include: either-function-declaration
                 - match: '(?=\S)'
                   pop: true
-        # An opening parenthesis is not allowed after a literal key; that makes
-        # it a method declaration instead, below.
-        - match: "(?=\"|')(?!.+\\()"
+        - include: method-declaration
+        - match: "(?=\"|')"
           push:
             - meta_scope: meta.object-literal.key.js
             - include: literal-string
@@ -1123,7 +1122,6 @@ contexts:
             - match: "(?=\\}|,|('[^']*'|\"[^\"]*\"|{{identifier}})\\s*:)"
               pop: true
             - include: expressions
-        - include: method-declaration
         - include: comments
 
   method-declaration:
@@ -1158,7 +1156,7 @@ contexts:
         - include: comments
         - match: '(?=\S)'
           pop: true
-    - match: (?='.*'|".*")
+    - match: (?=('[^\\]*'|"[^\\]*")\s*\()
       push:
         - meta_content_scope: meta.function.declaration.js
         - match: "'"
@@ -1196,7 +1194,7 @@ contexts:
         - include: comments
         - match: '(?=\S)'
           pop: true
-    - match: '({{identifier}})\s*'
+    - match: '({{identifier}})\s*(?=\()'
       scope: meta.function.declaration.js
       captures:
         1: entity.name.function.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1097,7 +1097,7 @@ contexts:
                 - include: either-function-declaration
                 - match: '(?=\S)'
                   pop: true
-        # An ppening parenthesis is not allowed after a literal key; that makes
+        # An opening parenthesis is not allowed after a literal key; that makes
         # it a method declaration instead, below.
         - match: "(?=\"|')(?!.+\\()"
           push:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1097,7 +1097,9 @@ contexts:
                 - include: either-function-declaration
                 - match: '(?=\S)'
                   pop: true
-        - match: "(?=\"|')"
+        # An ppening parenthesis is not allowed after a literal key; that makes
+        # it a method declaration instead, below.
+        - match: "(?=\"|')(?!.+\\()"
           push:
             - meta_scope: meta.object-literal.key.js
             - include: literal-string
@@ -1144,6 +1146,44 @@ contexts:
         2: entity.name.function.js
         3: punctuation.definition.symbol.end.js
       push:
+        - include: function-declaration-parameters
+        - match: '\{'
+          scope: punctuation.definition.block.js
+          push:
+            - meta_scope: meta.block.js
+            - match: '\}'
+              scope: punctuation.definition.block.js
+              pop: true
+            - include: statements
+        - include: comments
+        - match: '(?=\S)'
+          pop: true
+    - match: (?='.*'|".*")
+      push:
+        - meta_content_scope: meta.function.declaration.js
+        - match: "'"
+          scope: punctuation.definition.string.begin.js
+          push:
+            - meta_scope: string.quoted.single.js
+            - meta_content_scope: entity.name.function.js
+            - match: (')|(\n)
+              captures:
+                1: punctuation.definition.string.end.js
+                2: invalid.illegal.newline.js
+              pop: true
+            - include: string-content
+        - match: '"'
+          scope: punctuation.definition.string.begin.js
+          push:
+            - meta_scope: string.quoted.double.js
+            - meta_content_scope: entity.name.function.js
+            - match: (")|(\n)
+              captures:
+                1: punctuation.definition.string.end.js
+                2: invalid.illegal.newline.js
+              pop: true
+            - include: string-content
+        - match: \s*
         - include: function-declaration-parameters
         - match: '\{'
           scope: punctuation.definition.block.js

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -301,13 +301,18 @@ var obj = {
     qux()
 //  ^^^^^ meta.function.declaration - meta.function.anonymous
     // <- entity.name.function
-    {}
+    {},
+
+    'funcStringMethod'() {
+//  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous
+    // ^ entity.name.function
+    },
 
     static foo(bar) {
 //  ^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous
     // ^ storage.type
     //      ^entity.name.function
-    }
+    },
 
     *baz(){
 //  ^^^^^^ meta.function.declaration - meta.function.anonymous

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -236,6 +236,9 @@ var obj = {
 //                              ^ punctuation.definition.brackets
 //                               ^ punctuation.separator.key-value
 
+    "": true,
+    // <- meta.object-literal.key
+
     "key4": true,
     // <- meta.object-literal.key string.quoted.double
     //    ^ punctuation.separator.key-value - string
@@ -307,6 +310,16 @@ var obj = {
 //  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous
     // ^ entity.name.function
     },
+
+    'funcStringMethodWithSameLineColon'() { var foo = { name: 'jeff' }; },
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous
+    // ^ entity.name.function
+
+    "key (": true,
+    // <- meta.object-literal.key
+
+    "key \"(": true,
+    // <- meta.object-literal.key
 
     static foo(bar) {
 //  ^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -321,6 +321,9 @@ var obj = {
     "key \"(": true,
     // <- meta.object-literal.key
 
+    "key '(": true,
+    // <- meta.object-literal.key
+
     static foo(bar) {
 //  ^^^^^^^^^^^^^^^ meta.function.declaration - meta.function.anonymous
     // ^ storage.type


### PR DESCRIPTION
Which had previously been mistaken for object literal keys. The fix entails
adding a new form of method declaration, using a string method name; and
giving that precedence over object literal key matching.

Fixes https://github.com/sublimehq/Packages/issues/861.