### PR TITLE
[Markdown] improvements for lists in block quotes

### DIFF
--- a/Markdown/Indent%3A Raw.tmPreferences
+++ b/Markdown/Indent%3A Raw.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Indent: Raw Block</string>
 	<key>scope</key>
-	<string>markup.raw.block.markdown</string>
+	<string>text.html.markdown markup.raw</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -214,9 +214,23 @@ contexts:
             - include: indented-code-block
             - include: atx-heading
             - include: thematic-break
-            - match: '{{list_item}}'
+            - match: ([ ]{,3}(\d+))(\.)(\s)
               captures:
-                1: punctuation.definition.list_item.markdown
+                1: markup.list.numbered.markdown
+                2: markup.list.numbered.bullet.markdown
+                3: markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+                4: markup.list.numbered.markdown
+              push:
+                - meta_content_scope: markup.list.numbered.markdown meta.paragraph.list.markdown
+                - include: list-content
+            - match: ([ ]{,3})([*+-])(\s)
+              captures:
+                1: markup.list.unnumbered.markdown
+                2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+                3: markup.list.unnumbered.markdown
+              push:
+                - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown
+                - include: list-content
             - match: ^
               pop: true
             - include: list-paragraph
@@ -710,8 +724,14 @@ contexts:
     - match: ^
       pop: true
     - include: thematic-break
-    - include: inline-bold-italic-linebreak
-    - include: scope:text.html.basic
+    - match: (?=\S)
+      push:
+        - match: (?={{list_item}})
+          pop: true
+        - include: inline-bold-italic-linebreak
+        - include: scope:text.html.basic
+        - match: $
+          pop: true
   fenced-code-block:
     - match: |-
          (?x)

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -329,8 +329,12 @@ Paragraph followed immediately by a list, no blank line in between
 
 Paragraph followed immediately by a numbered list, no blank line in between
  1. list item 1
-| ^ markup.list.numbered punctuation.definition.list_item
+|^^^^^^^^^^^^^^^ markup.list.numbered
+|^^ markup.list.numbered.bullet
+| ^ punctuation.definition.list_item
+|   ^^^^^^^^^^^^ meta.paragraph.list
   more text - this punctuation should be ignored 2.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list
 |           ^ - punctuation.definition.list_item
 |                                                 ^ - punctuation.definition.list_item
 
@@ -344,9 +348,16 @@ because it doesn't begin with the number one:
 > - list item 1
 | ^ meta.block-level markup.quote punctuation.definition.list_item
 > - list item 2
-| ^ meta.block-level markup.quote punctuation.definition.list_item
+| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
+| ^^^^^^^^^^^^^^ meta.block-level markup.quote markup.list.unnumbered
+|   ^^^^^^^^^^^^ meta.paragraph.list
 >   1. sub list item
-|    ^ meta.block-level markup.quote punctuation.definition.list_item
+| <- meta.block-level markup.quote punctuation.definition.blockquote
+|^^^^^^^^^^^^^^^^^^^^ meta.block-level markup.quote
+|    ^ punctuation.definition.list_item
+|   ^^ markup.list.numbered.bullet
+| ^^^^^^^^^^^^^^^^^^^ markup.list.numbered
+|      ^^^^^^^^^^^^^^ meta.paragraph.list
 
 * this is a list
 
@@ -1347,3 +1358,18 @@ not a table |
 |`test | me |
 |^ invalid.deprecated.unescaped-backticks
 |      ^ punctuation.separator.table-cell
+
+1. test
+|  ^^^^^ markup.list.numbered meta.paragraph.list
+   - test
+|^^^^^^^^^ markup.list.unnumbered
+|  ^ markup.list.unnumbered.bullet punctuation.definition.list_item
+|    ^^^^^ meta.paragraph.list
+   - test
+|^^^^^^^^^ markup.list.unnumbered
+|  ^ markup.list.unnumbered.bullet punctuation.definition.list_item
+|    ^^^^^ meta.paragraph.list
+   test
+|^^^^^^^ markup.list.numbered meta.paragraph.list
+ ****test****
+|^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list - punctuation


### PR DESCRIPTION
tweaks the scopes for lists inside block quotes to be consistent with the lists outside block quotes