### PR TITLE
[C#] @ escapes reserved words

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -37,7 +37,7 @@ variables:
   type_suffix_capture: '(\?)?{{brackets_capture}}?(?:\s*(\*))?'
 
   reserved: '(?:abstract|as|base|break|case|catch|checked|class|const|continue|default|delegate|do|else|enum|event|explicit|extern|finally|fixed|for|foreach|goto|if|implicit|in|interface|internal|is|lock|nameof|namespace|new|null|operator|out|override|params|private|protected|public|readonly|ref|return|sealed|sizeof|stackalloc|static|string|struct|switch|this|throw|try|typeof|unchecked|unsafe|using|virtual|volatile|while)'
-  name: '(?:@{{reserved}}|@{{base_type}}|@var|{{name_normal}})'
+  name: '(?:@{{reserved}}|@{{base_type}}|@var|@?{{name_normal}})'
 
   start_char: '(?:{{unicode_char}}|[_\p{L}])'
   other_char: '(?:{{unicode_char}}|[_0-9\p{L}])'
@@ -880,6 +880,11 @@ contexts:
         - include: type_argument
     - match: \bconst\b
       scope: storage.modifier.cs
+    - match: '(var|dynamic)\s+({{reserved}}|{{base_type}})\s*(=)'
+      captures:
+        1: storage.type.variable.cs
+        2: invalid.illegal.cs
+        3: keyword.operator.assignment.variable.cs
     - match: '(var|dynamic)\s+({{name}})\s*(=)'
       captures:
         1: storage.type.variable.cs
@@ -1119,7 +1124,8 @@ contexts:
     - match: \b(value)\b
       scope: variable.language.cs
     - include: keywords
-    - match: \b(let|select|equals|from|in|where|join|orderby|group|by|on|into|into|ascending|descending)\b
+    # Cannot neg-ahead "(" because clauses can follow several of the sql words
+    - match: \b(let|select|equals|from|in|where|join|orderby|group|by|on|into|into|ascending|descending)\b(?!\s*[.,;+=&\|\[\]\)])
       scope: keyword.other.sql.cs
     - match: \?\.
       scope: punctuation.accessor.null-coalescing.cs

--- a/C#/syntax_test_c#.cs
+++ b/C#/syntax_test_c#.cs
@@ -62,6 +62,29 @@ public partial class Employee
 {
     public void DoWork()
     {
+        var group = MakeGroup();
+        //  ^^^^^ variable.other.cs - keyword
+
+        var contents1 = group.GetContents();
+        //              ^^^^^ variable.other.cs - keyword
+
+        var contents2 = @group.GetContents();
+        //              ^^^^^^ variable.other.cs - keyword
+
+        var @void = MakeGroup();
+        //  ^^^^^ variable.other.cs - keyword
+
+        var void = MakeGroup();
+        //  ^^^^ invalid.illegal - variable, keyword
+
+        var subvoid1 = void.GetContents();
+        //             ^^^^ - variable # Technically illegal in this context, but at least it's not marked as a variable.
+
+        var subvoid2 = @void.GetContents();
+        //             ^^^^^ variable.other.cs - keyword
+
+        var msg = from + " " + to;
+        //        ^^^^ variable.other.cs - keyword
     }
 }
 


### PR DESCRIPTION
You can use `@` to tell C# that a normally-reserved word is not to be used in its normal context. [MSDN reference.][msdn]

```cs
var group = MakeGroup();
// Current syntax gets this right.

var contents1 = group.GetContents();
// Current syntax marks `group` as 'keyword.other.sql.cs',
// which is not technically correct because the code compiles
// fine, but it doesn't bother me too much.

var contents2 = @group.GetContents();
// Current syntax marks `group` as 'keyword.other.sql.cs'
// and `@` as 'invalid.illegal.reserved-char.cs', which is wrong.
```

I notice that `@void` already does what it ought to, and added tests for those, too.

[msdn]: https://msdn.microsoft.com/en-us/library/x53a06bb.aspx
[l40]: https://github.com/sublimehq/Packages/blob/master/C%23/C%23.sublime-syntax#L40
[l1122]: https://github.com/sublimehq/Packages/blob/master/C%23/C%23.sublime-syntax#L1122
