### PR TITLE
[C#] use standard unclosed-string behavior

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1416,8 +1416,8 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
-    - match: '[^"]*$'
-      scope: invalid.string.newline.cs
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
       pop: true
 
   format_string:
@@ -1428,8 +1428,8 @@ contexts:
       pop: true
     - include: escaped
     - include: string_interpolation
-    - match: '[^"{]*$'
-      scope: invalid.string.newline.cs
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
       pop: true
 
   long_format_string:

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1427,7 +1427,15 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: escaped
-    - include: string_interpolation
+    - include: string_placeholder_escape
+    - match: \{
+      scope: punctuation.section.interpolation.begin.cs
+      push:
+        - meta_scope: meta.string.interpolated.cs source.cs
+        - clear_scopes: 2
+        - include: string_interpolation
+        - match: $
+          pop: true
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
@@ -1440,34 +1448,36 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
-    - include: string_interpolation
-
-  string_placeholders:
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.cs
-    - match: '\{\d*\}'
-      scope: constant.other.placeholder.cs
-
-  string_interpolation:
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.cs
-    - match: '\{'
+    - include: string_placeholder_escape
+    - match: \{
       scope: punctuation.section.interpolation.begin.cs
       push:
         - meta_scope: meta.string.interpolated.cs source.cs
         - clear_scopes: 2
-        - match: '\}'
-          scope: punctuation.section.interpolation.end.cs
-          pop: true
-        - match: '(,)\s*(-?\d+)?\s*(:?)\s*([^}]*)\s*(\})'
-          captures:
-            1: punctuation.separator.arguments.cs
-            2: constant.numeric.formatting.cs
-            3: punctuation.separator.cs
-            4: constant.other.format-spec.cs
-            5: punctuation.section.interpolation.end.cs
-          pop: true
-        - include: line_of_code_in
+        - include: string_interpolation
+
+  string_placeholder_escape:
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.cs
+
+  string_placeholders:
+    - include: string_placeholder_escape
+    - match: '\{\d*\}'
+      scope: constant.other.placeholder.cs
+
+  string_interpolation:
+    - match: '\}'
+      scope: punctuation.section.interpolation.end.cs
+      pop: true
+    - match: '(,)\s*(-?\d+)?\s*(:?)\s*([^}]*)\s*(\})'
+      captures:
+        1: punctuation.separator.arguments.cs
+        2: constant.numeric.formatting.cs
+        3: punctuation.separator.cs
+        4: constant.other.format-spec.cs
+        5: punctuation.section.interpolation.end.cs
+      pop: true
+    - include: line_of_code_in
 
   long_string:
     - meta_include_prototype: false

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -66,12 +66,12 @@ string interpolated = $"inner {t.Word,-30} {t.Responsibility,8:F2} {{";
 ///                                                                  ^ punctuation.definition.string.end
 
 string unclosed_string = "inner ;
-///                             ^ invalid.string.newline
+///                              ^ invalid.illegal.unclosed-string
 string bar = "bar"
 /// <- storage.type
 
 string unclosed_interpolation = $"inner {t.Word};
-///                                             ^ invalid.string.newline
+///                                              ^ invalid.illegal.unclosed-string.cs
 string foo = "foo";
 /// <- storage.type
 

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -84,6 +84,17 @@ string long_interpolation = $@"
 ";
 /// <- punctuation.definition.string.end
 
+string unclosed_interpolation = $"inner {
+///                                     ^ punctuation.section.interpolation.begin.cs
+///                                      ^ invalid.illegal.unclosed-string.cs
+
+/// <- - string
+
+string unclosed_interpolation = $"inner {2}
+///                                     ^ punctuation.section.interpolation.begin.cs
+///                                      ^ constant.numeric.cs
+///                                        ^ invalid.illegal.unclosed-string.cs
+
 string format_string = "{0} and {1} like to go {{crazy}}";
 ///                    ^ string
 ///                     ^^^ constant.other.placeholder.cs


### PR DESCRIPTION
This PR changes the unclosed string behavior in the C# syntax to match that of the other syntaxes, like Python, which scopes the new line character as invalid, which is less jarring than having the whole string appear as invalid.