### PR TITLE
[C] Fix indentation level

### DIFF
--- a/C++/Indentation Rules.tmPreferences
+++ b/C++/Indentation Rules.tmPreferences
@@ -23,7 +23,7 @@
 		<key>bracketIndentNextLinePattern</key>
 		<string>(?x)
 		^ \s* \b(if|while|else)\b [^;]* $
-		| ^ \s* \b(for)\b .* $
+		|   ^ \s* \bfor\b (?:[^;]++|;[ ]+(?!$))+ \s* $
 		</string>
 
 		<key>unIndentedLinePattern</key>


### PR DESCRIPTION
Fix indentation level after for loops without body (fix [#868](https://github.com/sublimehq/Packages/issues/868)).