### PR TITLE
[Markdown] reduce backtracking possibilities

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -8,22 +8,22 @@ file_extensions:
   - markdown
   - markdn
 scope: text.html.markdown
-comment: this definition aims to (eventually) meet CommonMark specifications http://spec.commonmark.org/
+comment: this definition aims to (eventually) meet CommonMark specifications http://spec.commonmark.org/ with GitHub Formatted Markdown extensions https://github.github.com/gfm/
 variables:
     thematic_break: |-
         (?x:
-            [ ]{,3}
-            (?:
-                    [-](?:[ ]{,2}[-]){2,}
-                |   [*](?:[ ]{,2}[*]){2,}
-                |   [_](?:[ ]{,2}[_]){2,}
+            [ ]{,3}                          # between 0 to 3 spaces
+            (?:                              # followed by one of the following:
+                    [-](?:[ ]{,2}[-]){2,}    # - a dash,        followed by the following at least twice: between 0 to 2 spaces followed by a dash
+                |   [*](?:[ ]{,2}[*]){2,}    # - a star,        followed by the following at least twice: between 0 to 2 spaces followed by a star
+                |   [_](?:[ ]{,2}[_]){2,}    # - an underscore, followed by the following at least twice: between 0 to 2 spaces followed by an underscore
             )
-            [ \t]*$
+            [ \t]*$                          # followed by any number of tabs or spaces, followed by the end of the line
         )
-    block_quote: '(?:[ ]{,3}>(?:.|$))'
-    atx_heading: '(?:[#]{1,6}\s*)'
-    indented_code_block: '(?:[ ]{4}|\t)'
-    list_item: '(?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s)'
+    block_quote: (?:[ ]{,3}>(?:.|$))         # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
+    atx_heading: (?:[#]{1,6}\s*)             # between 1 and 6 hashes, followed by any amount of whitespace
+    indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
+    list_item: (?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s) # between 0 and 3 spaces, followed by either: at least one integer and a full stop, or (a star, plus or dash), followed by whitespace
     link_title: |-
         (?x:[ \t]*                # Optional whitespace
           (?:
@@ -35,10 +35,10 @@ variables:
     escape: '\\[-`*_#+.!(){}\[\]\\>|]'
     backticks: |-
         (?x:
-            (`{4})(?=\S)[^`]+(?:[^`]+|(?!`{4})`*)*(`{4})(?!`)
-        |   (`{3})(?=\S)[^`]+(?:[^`]+|(?!`{3})`*)*(`{3})(?!`)
-        |   (`{2})(?=\S)[^`]+(?:[^`]+|(?!`{2})`*)*(`{2})(?!`)
-        |   (`{1})(?=\S)[^`]+(?:[^`]+|(?!`{1})`*)*(`{1})(?!`)
+            (`{4})(?![\s`])(?:[^`]+(?=`)|(?!`{4})`+(?!`))*(`{4})(?!`)  # 4 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 4 backticks, or at least one non backtick character) any number of times, followed by exactly 4 backticks
+        |   (`{3})(?![\s`])(?:[^`]+(?=`)|(?!`{3})`+(?!`))*(`{3})(?!`)  # 3 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 3 backticks, or at least one non backtick character) any number of times, followed by exactly 3 backticks
+        |   (`{2})(?![\s`])(?:[^`]+(?=`)|(?!`{2})`+(?!`))*(`{2})(?!`)  # 2 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 2 backticks, or at least one non backtick character) any number of times, followed by exactly 2 backticks
+        |   (`{1})(?![\s`])(?:[^`]+(?=`)|(?!`{1})`+(?!`))*(`{1})(?!`)  # 1 backtick,  followed by at least one non whitespace, non backtick character, followed by (                          at least one non backtick character) any number of times, followed by exactly 1 backtick
         )
     balance: |-
         (?x:
@@ -68,11 +68,24 @@ variables:
           (\))
         )
     html_entity: '&([a-zA-Z0-9]+|#\d+|#x\h+);'
-    skip_html_tags: '(?:<[^>]+>)'
+    skip_html_tags: (?:<[^>]+>)
     table_first_row: |-
         (?x:
             (?:{{balance_square_brackets}}*\|){2}       # at least 2 non-escaped pipe chars on the line
         |   (?!\s+\|){{balance_square_brackets}}+\|(?!\s+$){{balance_square_brackets}}+
+        )
+    fenced_code_block_start: |-
+        (?x:
+          ^[ ]{0,3}    # up to 3 spaces
+          (
+            `{3,}      #   3 or more backticks
+            (?![^`]+`) #   not followed by any more backticks on the same line
+            (?!`)      #   makes the {3,} possessive
+          |            # or
+            ~{3,}      #   3 or more tildas
+            (?![^~]+~) #   not followed by any more tildas on the same line
+            (?!~)      #   makes the {3,} possessive
+          )
         )
 contexts:
   main:
@@ -735,16 +748,7 @@ contexts:
   fenced-code-block:
     - match: |-
          (?x)
-          ^[ ]{0,3}    # up to 3 spaces
-          (
-            `{3,}      #   3 or more backticks
-            (?![^`]+`) #   not followed by any more backticks on the same line
-            (?!`)      #   makes the {3,} possessive
-          |            # or
-            ~{3,}      #   3 or more tildas
-            (?![^~]+~) #   not followed by any more tildas on the same line
-            (?!~)      #   makes the {3,} possessive
-          )
+          {{fenced_code_block_start}}
           ([\w-]*)     # any number of word characters or dashes
           .*$          # all characters until eol
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -753,7 +753,7 @@ contexts:
     - match: ^
       pop: true
     - include: thematic-break
-    - match: (?=\S)
+    - match: (?=\S)(?!{{list_item}})
       push:
         - match: (?={{list_item}})
           pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -35,25 +35,19 @@ variables:
     escape: '\\[-`*_#+.!(){}\[\]\\>|]'
     backticks: |-
         (?x:
-            (`{4})(?![\s`])(?:[^`]+(?=`)|(?!`{4})`+(?!`))*(`{4})(?!`)  # 4 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 4 backticks, or at least one non backtick character) any number of times, followed by exactly 4 backticks
-        |   (`{3})(?![\s`])(?:[^`]+(?=`)|(?!`{3})`+(?!`))*(`{3})(?!`)  # 3 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 3 backticks, or at least one non backtick character) any number of times, followed by exactly 3 backticks
-        |   (`{2})(?![\s`])(?:[^`]+(?=`)|(?!`{2})`+(?!`))*(`{2})(?!`)  # 2 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 2 backticks, or at least one non backtick character) any number of times, followed by exactly 2 backticks
-        |   (`{1})(?![\s`])(?:[^`]+(?=`)|(?!`{1})`+(?!`))*(`{1})(?!`)  # 1 backtick,  followed by at least one non whitespace, non backtick character, followed by (                          at least one non backtick character) any number of times, followed by exactly 1 backtick
-        )
-    balance: |-
-        (?x:
-          (?:
-              {{escape}}+                  # escape characters
-          |   [^\[\]`\\]+                  # anything that isn't a square bracket or a backtick or the start of an escape character
-          |   {{backticks}}                # inline code
-          )
+            (`{4})(?![\s`])(?:[^`]+(?=`)|(?!`{4})`+(?!`))+(`{4})(?!`)  # 4 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
+        |   (`{3})(?![\s`])(?:[^`]+(?=`)|(?!`{3})`+(?!`))+(`{3})(?!`)  # 3 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
+        |   (`{2})(?![\s`])(?:[^`]+(?=`)|(?!`{2})`+(?!`))+(`{2})(?!`)  # 2 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
+        |   (`{1})(?![\s`])(?:[^`]+(?=`)|(?!`{1})`+(?!`))+(`{1})(?!`)  # 1 backtick,  followed by at least one non whitespace, non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
         )
     balance_square_brackets: |-
         (?x:
           (?:
-            {{balance}}
+            {{escape}}+                 # escape characters
+          | [^\[\]`\\]+(?=[\[\]`\\]|$)  # anything that isn't a square bracket or a backtick or the start of an escape character
+          | {{backticks}}               # inline code
           | \[(?:                       # nested square brackets (one level deep)
-                [^\[\]`]+               #  anything that isn't a square bracket or a backtick
+                [^\[\]`]+(?=[\[\]`])    #  anything that isn't a square bracket or a backtick
                 {{backticks}}?          #  balanced backticks
               )*\]                      #  closing square bracket
           )+                            # at least one character
@@ -69,10 +63,34 @@ variables:
         )
     html_entity: '&([a-zA-Z0-9]+|#\d+|#x\h+);'
     skip_html_tags: (?:<[^>]+>)
+    balance_square_brackets_and_emphasis: |-
+        (?x:
+          (?:
+            {{escape}}+                     # escape characters
+          | [^\[\]`\\_*]+(?=[\[\]`\\_*]|$)  # anything that isn't a square bracket, a backtick, the start of an escape character, or an emphasis character
+          | {{backticks}}                   # inline code
+          | \[(?:                           # nested square brackets (one level deep)
+                [^\[\]`]+(?=[\[\]`])        #  anything that isn't a square bracket or a backtick
+                {{backticks}}?              #  balanced backticks
+              )*\]                          #  closing square bracket
+          )+                                # at least one character
+        )
+    balance_square_brackets_and_pipes: |-
+        (?x:
+          (?:
+            {{escape}}+                     # escape characters
+          | [^\[\]`\\|]+(?=[\[\]`\\|]|$)    # anything that isn't a square bracket, a backtick, the start of an escape character, or a pipe
+          | {{backticks}}                   # inline code
+          | \[(?:                           # nested square brackets (one level deep)
+                [^\[\]`]+(?=[\[\]`])        #  anything that isn't a square bracket or a backtick
+                {{backticks}}?              #  balanced backticks
+              )*\]                          #  closing square bracket
+          )+                                # at least one character
+        )
     table_first_row: |-
         (?x:
-            (?:{{balance_square_brackets}}*\|){2}       # at least 2 non-escaped pipe chars on the line
-        |   (?!\s+\|){{balance_square_brackets}}+\|(?!\s+$){{balance_square_brackets}}+
+            (?:{{balance_square_brackets_and_pipes}}*\|){2}           # at least 2 non-escaped pipe chars on the line
+        |   (?!\s+\|){{balance_square_brackets_and_pipes}}\|(?!\s+$)  # something other than whitespace followed by a pipe char, followed by something other than whitespace and the end of the line
         )
     fenced_code_block_start: |-
         (?x:
@@ -777,7 +795,7 @@ contexts:
     - match: '`+'
       scope: invalid.deprecated.unescaped-backticks.markdown
   thematic-break:
-    - match: '(?={{thematic_break}}$)'
+    - match: '(?={{thematic_break}})'
       push:
         - meta_scope: meta.separator.thematic-break.markdown
         - match: '[-_*]+'
@@ -857,7 +875,7 @@ contexts:
         1: invalid.illegal.expected-eol.markdown
       pop: true
   table:
-    - match: (?={{table_first_row}})
+    - match: ^(?={{table_first_row}})
       push:
         - meta_content_scope: meta.table.header.markdown
         - match: \|
@@ -891,10 +909,10 @@ contexts:
                     - match: |- # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell, emphasis in table cells can't span multiple lines
                         (?x)
                         (?=
-                            \*  (?!\*){{balance_square_brackets}}+\*  (?!\*)
-                        |   \*\*      {{balance_square_brackets}}+\*\*
-                        |   _   (?!_) {{balance_square_brackets}}+_   (?!_)
-                        |   __        {{balance_square_brackets}}+__
+                            \*  (?!\*){{balance_square_brackets_and_emphasis}}+\*  (?!\*)
+                        |   \*\*      {{balance_square_brackets_and_emphasis}}+\*\*
+                        |   _   (?!_) {{balance_square_brackets_and_emphasis}}+_   (?!_)
+                        |   __        {{balance_square_brackets_and_emphasis}}+__
                         )
                       push:
                         - include: bold

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -97,12 +97,10 @@ variables:
           ^[ ]{0,3}    # up to 3 spaces
           (
             `{3,}      #   3 or more backticks
-            (?![^`]+`) #   not followed by any more backticks on the same line
-            (?!`)      #   makes the {3,} possessive
+            (?![^`]*`) #   not followed by any more backticks on the same line
           |            # or
             ~{3,}      #   3 or more tildas
-            (?![^~]+~) #   not followed by any more tildas on the same line
-            (?!~)      #   makes the {3,} possessive
+            (?![^~]*~) #   not followed by any more tildas on the same line
           )
         )
 contexts:


### PR DESCRIPTION
this PR reduces the number of backtracking possibilities for regex engines like Oniguruma that use backtracking, and also explains the regex patterns better.

a simple Markdown snippet with a missing end backtick like

    ``he`lloworld`

will now fail in 73 steps rather than over 5000!