### PR TITLE
[Markdown] don't scope consecutive bullet points that start a list

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -134,6 +134,8 @@ contexts:
         - meta_content_scope: markup.list.unnumbered.markdown
         - match: ^(?=\S)
           pop: true
+        - match: (?={{list_item}})
+          push: list-content
         - include: list-paragraph
     - match: '^([ ]{0,3})(\d+(\.))(?=\s)'
       captures:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1373,3 +1373,10 @@ not a table |
 |^^^^^^^ markup.list.numbered meta.paragraph.list
  ****test****
 |^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list - punctuation
+
+ - - test
+|^ punctuation.definition.list_item
+|  ^^^^^^^ markup.list.unnumbered meta.paragraph.list - punctuation
+- - - - test
+| <- punctuation.definition.list_item
+| ^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - punctuation


### PR DESCRIPTION
Previously, for example, `- - test` would have both `-`s scoped as punctuation