### PR TITLE
[PHP] don't unindent on else or elseif unless a colon is at the end of the line

### DIFF
--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -10,10 +10,10 @@
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
 			(
-			    ^                                                         # start of the line
-			    (.*\*/)?                                                  # optionally with an end block comment somewhere on the line
-			    \s* [}\])]                                                # optionally followed by whitespace, followed by a closing curly brace, square bracket or paren
-			|   \s* (<\?(php)?\s+)? end(if|for(each)?|while)\b            # or an optional PHP open tag followed by an keyword that ends a control flow block
+			    ^                                                                             # start of the line
+			    (.*\*/)?                                                                      # optionally with an end block comment somewhere on the line
+			    \s* [}\])]                                                                    # optionally followed by whitespace, followed by a closing curly brace, square bracket or paren
+			|   \s* (<\?(php)?\s+)?(else(if)?\b.*:\s*($|//|/\*)|(end(if|for(each)?|while))\b) # or an optional PHP open tag followed by an keyword that ends a control flow block
 			)
 		]]></string>
 		

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -13,7 +13,7 @@
 			    ^                                                         # start of the line
 			    (.*\*/)?                                                  # optionally with an end block comment somewhere on the line
 			    \s* [}\])]                                                # optionally followed by whitespace, followed by a closing curly brace, square bracket or paren
-			|   \s* (<\?(php)?\s+)?(else(if)?|end(if|for(each)?|while))\b # or an optional PHP open tag followed by an keyword that ends a control flow block
+			|   \s* (<\?(php)?\s+)? end(if|for(each)?|while)\b            # or an optional PHP open tag followed by an keyword that ends a control flow block
 			)
 		]]></string>
 		


### PR DESCRIPTION
don't unindent on `else` or `elseif` [unless a colon is at the end of the line](http://php.net/manual/en/control-structures.alternative-syntax.php) (optionally followed by whitespace or a comment) - leave it for the closing brace rules to match instead. This fixes #901