### PR TITLE
[C#] fix case expression scoping

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1698,11 +1698,12 @@ contexts:
           scope: keyword.control.switch.case.cs
           push:
             - include: literals
-            - match: '({{name}})(\.)*({{name}})'
+            - match: '({{name}})(\.)'
               captures:
                 1: variable.other.namespace.cs
                 2: punctuation.accessor.dot.cs
-                3: constant.other.cs
+            - match: '{{name}}'
+              scope: constant.other.cs
             - match: ':'
               scope: punctuation.separator.case-statement.cs
               pop: true

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1697,16 +1697,12 @@ contexts:
         - match: '\b(case)\b'
           scope: keyword.control.switch.case.cs
           push:
-            - include: literals
-            - match: '({{name}})(\.)'
-              captures:
-                1: variable.other.namespace.cs
-                2: punctuation.accessor.dot.cs
-            - match: '{{name}}'
+            - match: '{{name}}(?=\s*:)'
               scope: constant.other.cs
             - match: ':'
               scope: punctuation.separator.case-statement.cs
               pop: true
+            - include: line_of_code_in
             - match: $
               pop: true
         - include: code_block_in

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -315,6 +315,15 @@ namespace TestNamespace.Test
 ///                 ^ variable.function
                     break;
 ///                 ^ keyword.control
+                case BLBodyBattleLibrary.ContextType.TapUp:
+///             ^^^^ keyword.control.switch.case
+///                  ^^^^^^^^^^^^^^^^^^^ variable.other.namespace
+///                                     ^ punctuation.accessor.dot
+///                                      ^^^^^^^^^^^ variable.other.namespace
+///                                                 ^ punctuation.accessor.dot
+///                                                  ^^^^^ constant.other
+///                                                       ^ punctuation.separator
+                    break;
                 default:
 ///             ^ keyword.control
 ///                    ^ punctuation.separator

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -317,12 +317,32 @@ namespace TestNamespace.Test
 ///                 ^ keyword.control
                 case BLBodyBattleLibrary.ContextType.TapUp:
 ///             ^^^^ keyword.control.switch.case
-///                  ^^^^^^^^^^^^^^^^^^^ variable.other.namespace
+///                  ^^^^^^^^^^^^^^^^^^^ variable.other
 ///                                     ^ punctuation.accessor.dot
-///                                      ^^^^^^^^^^^ variable.other.namespace
+///                                      ^^^^^^^^^^^ variable.other
 ///                                                 ^ punctuation.accessor.dot
 ///                                                  ^^^^^ constant.other
-///                                                       ^ punctuation.separator
+///                                                       ^ punctuation.separator.case-statement
+                case BindingFlags.Static:
+///             ^^^^ keyword.control.switch.case
+///                  ^^^^^^^^^^^^ variable.other
+///                              ^ punctuation.accessor.dot
+///                               ^^^^^^ constant.other
+///                                     ^ punctuation.separator.case-statement
+                case test:
+///             ^^^^ keyword.control.switch.case
+///                  ^^^^ constant.other
+///                      ^ punctuation.separator.case-statement
+                case this.test;
+///             ^^^^ keyword.control.switch.case
+///                  ^^^^ variable.language
+///                      ^ punctuation.accessor.dot
+                case 1*2:
+///             ^^^^ keyword.control.switch.case
+///                  ^ constant.numeric
+///                   ^ keyword.operator
+///                    ^ constant.numeric
+///                     ^ punctuation.separator.case-statement
                     break;
                 default:
 ///             ^ keyword.control

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -343,6 +343,13 @@ namespace TestNamespace.Test
 ///                   ^ keyword.operator
 ///                    ^ constant.numeric
 ///                     ^ punctuation.separator.case-statement
+                case bar("hello"):
+///             ^^^^ keyword.control.switch.case
+///                  ^^^ variable.function
+///                     ^ punctuation.section.group.begin
+///                      ^^^^^^^ string.quoted.double
+///                             ^ punctuation.section.group.end
+///                              ^ punctuation.separator.case-statement
                     break;
                 default:
 ///             ^ keyword.control


### PR DESCRIPTION
fixes #902 
prior to this, the syntax only coped with 2 part identifiers following the `case` keyword - now it supports everything, including expressions, casts, etc.