### PR TITLE
[Rails] fix snippet scope miss-matches

### DIFF
--- a/Rails/Snippets/Create-binary-column.sublime-snippet
+++ b/Rails/Snippets/Create-binary-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.binary :${1:title}${2:, :limit => ${3:2}.megabytes}
 $0]]></content>
 	<tabTrigger>tcbi</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column binary</description>
 </snippet>

--- a/Rails/Snippets/Create-boolean-column.sublime-snippet
+++ b/Rails/Snippets/Create-boolean-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.boolean :${1:title}
 $0]]></content>
 	<tabTrigger>tcb</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column boolean</description>
 </snippet>

--- a/Rails/Snippets/Create-date-column.sublime-snippet
+++ b/Rails/Snippets/Create-date-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.date :${1:title}
 $0]]></content>
 	<tabTrigger>tcda</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column date</description>
 </snippet>

--- a/Rails/Snippets/Create-datetime-column.sublime-snippet
+++ b/Rails/Snippets/Create-datetime-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.datetime :${1:title}
 $0]]></content>
 	<tabTrigger>tcdt</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column datetime</description>
 </snippet>

--- a/Rails/Snippets/Create-decimal-column.sublime-snippet
+++ b/Rails/Snippets/Create-decimal-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.decimal :${1:title}${2:${3:, :precision => ${4:10}}${5:, :scale => ${6:2}}}
 $0]]></content>
 	<tabTrigger>tcd</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column decimal</description>
 </snippet>

--- a/Rails/Snippets/Create-float-column.sublime-snippet
+++ b/Rails/Snippets/Create-float-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.float :${1:title}
 $0]]></content>
 	<tabTrigger>tcf</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column float</description>
 </snippet>

--- a/Rails/Snippets/Create-integer-column.sublime-snippet
+++ b/Rails/Snippets/Create-integer-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.integer :${1:title}
 $0]]></content>
 	<tabTrigger>tci</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column integer</description>
 </snippet>

--- a/Rails/Snippets/Create-lock_version-column.sublime-snippet
+++ b/Rails/Snippets/Create-lock_version-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.integer :lock_version, :null => false, :default => 0
 $0]]></content>
 	<tabTrigger>tcl</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column lock_version</description>
 </snippet>

--- a/Rails/Snippets/Create-references-column.sublime-snippet
+++ b/Rails/Snippets/Create-references-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.references :${1:taggable}${2:, :polymorphic => ${3:{ :default => '${4:Photo}' \}}}
 $0]]></content>
 	<tabTrigger>tcr</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column(s) references</description>
 </snippet>

--- a/Rails/Snippets/Create-string-column.sublime-snippet
+++ b/Rails/Snippets/Create-string-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.string :${1:title}
 $0]]></content>
 	<tabTrigger>tcs</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column string</description>
 </snippet>

--- a/Rails/Snippets/Create-text-column.sublime-snippet
+++ b/Rails/Snippets/Create-text-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.text :${1:title}
 $0]]></content>
 	<tabTrigger>tct</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column text</description>
 </snippet>

--- a/Rails/Snippets/Create-time-column.sublime-snippet
+++ b/Rails/Snippets/Create-time-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.time :${1:title}
 $0]]></content>
 	<tabTrigger>tcti</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column time</description>
 </snippet>

--- a/Rails/Snippets/Create-timestamp-column.sublime-snippet
+++ b/Rails/Snippets/Create-timestamp-column.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.timestamp :${1:title}
 $0]]></content>
 	<tabTrigger>tcts</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column timestamp</description>
 </snippet>

--- a/Rails/Snippets/Create-timestamps-columns.sublime-snippet
+++ b/Rails/Snippets/Create-timestamps-columns.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.timestamps
 $0]]></content>
 	<tabTrigger>tctss</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column timestamps</description>
 </snippet>

--- a/Rails/Snippets/Migration-Create-Column-(mcc).sublime-snippet
+++ b/Rails/Snippets/Migration-Create-Column-(mcc).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.column ${1:title}, :${2:string}
 $0]]></content>
 	<tabTrigger>mcol</tabTrigger>
-	<scope>meta.rails.migration.create_table</scope>
+	<scope>meta.migration.create_table.rails</scope>
 	<description>Create Column in Table</description>
 </snippet>

--- a/Rails/Snippets/Migration-Create-Column-Continue-(mccc).sublime-snippet
+++ b/Rails/Snippets/Migration-Create-Column-Continue-(mccc).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.column ${1:title}, :${2:string}
 mccc$0]]></content>
 	<tabTrigger>mccc</tabTrigger>
-	<scope>meta.rails.migration.create_table</scope>
+	<scope>meta.migration.create_table.rails</scope>
 	<description>Create Several Columns in Table</description>
 </snippet>

--- a/Rails/Snippets/Migration-Drop-Create-Table-(mdct).sublime-snippet
+++ b/Rails/Snippets/Migration-Drop-Create-Table-(mdct).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[drop_table :${1:table}${2: [press tab twice to generate create_table]}]]></content>
 	<tabTrigger>mtab</tabTrigger>
-	<scope>meta.rails.migration - meta.rails.migration.create_table - meta.rails.migration.change_table</scope>
+	<scope>meta.migration.rails - meta.migration.create_table.rails - meta.migration.change_table.rails</scope>
 	<description>Drop / Create Table</description>
 </snippet>

--- a/Rails/Snippets/Migration-Remove-and-Add-Column-(mrac).sublime-snippet
+++ b/Rails/Snippets/Migration-Remove-and-Add-Column-(mrac).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[remove_column :${1:table}, :${2:column}${3: [press tab twice to generate add_column]}]]></content>
 	<tabTrigger>mcol</tabTrigger>
-	<scope>meta.rails.migration - meta.rails.migration.create_table - meta.rails.migration.change_table</scope>
+	<scope>meta.migration.rails - meta.migration.create_table.rails - meta.migration.change_table.rails</scope>
 	<description>Remove / Add Column</description>
 </snippet>

--- a/Rails/Snippets/Table-column(s)-rename.sublime-snippet
+++ b/Rails/Snippets/Table-column(s)-rename.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.rename(:${1:old_column_name}, :${2:new_column_name})
 $0]]></content>
 	<tabTrigger>tre</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>Table column(s) rename</description>
 </snippet>

--- a/Rails/Snippets/def-create-resource.sublime-snippet
+++ b/Rails/Snippets/def-create-resource.sublime-snippet
@@ -15,6 +15,6 @@
 end
 ]]></content>
 	<tabTrigger>defcreate</tabTrigger>
-	<scope>meta.rails.controller</scope>
+	<scope>meta.controller.rails</scope>
 	<description>def create - resource</description>
 </snippet>

--- a/Rails/Snippets/def-get-request.sublime-snippet
+++ b/Rails/Snippets/def-get-request.sublime-snippet
@@ -6,6 +6,6 @@
 	$0
 end]]></content>
 	<tabTrigger>deftg</tabTrigger>
-	<scope>meta.rails.functional_test</scope>
+	<scope>meta.functional_test.rails</scope>
 	<description>def test_should_get_action</description>
 </snippet>

--- a/Rails/Snippets/def-post-request.sublime-snippet
+++ b/Rails/Snippets/def-post-request.sublime-snippet
@@ -6,6 +6,6 @@
 
 end]]></content>
 	<tabTrigger>deftp</tabTrigger>
-	<scope>meta.rails.functional_test</scope>
+	<scope>meta.functional_test.rails</scope>
 	<description>def test_should_post_action</description>
 </snippet>

--- a/Rails/Snippets/map_catch_all.sublime-snippet
+++ b/Rails/Snippets/map_catch_all.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[${1:map}.catch_all "*${2:anything}", :controller => "${3:default}", :action => "${4:error}"
 ]]></content>
 	<tabTrigger>mapca</tabTrigger>
-	<scope>meta.rails.routes</scope>
+	<scope>meta.routes.rails</scope>
 	<description>map.catch_all</description>
 </snippet>

--- a/Rails/Snippets/map_named_route.sublime-snippet
+++ b/Rails/Snippets/map_named_route.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[${1:map}.${2:connect} '${3::controller/:action/:id}']]></content>
 	<tabTrigger>map</tabTrigger>
-	<scope>meta.rails.routes</scope>
+	<scope>meta.routes.rails</scope>
 	<description>map.named_route</description>
 </snippet>

--- a/Rails/Snippets/map_resource.sublime-snippet
+++ b/Rails/Snippets/map_resource.sublime-snippet
@@ -3,6 +3,6 @@
 	$0
 end}]]></content>
 	<tabTrigger>mapr</tabTrigger>
-	<scope>meta.rails.routes</scope>
+	<scope>meta.routes.rails</scope>
 	<description>map.resource</description>
 </snippet>

--- a/Rails/Snippets/map_resources.sublime-snippet
+++ b/Rails/Snippets/map_resources.sublime-snippet
@@ -3,6 +3,6 @@
 	$0
 end}]]></content>
 	<tabTrigger>maprs</tabTrigger>
-	<scope>meta.rails.routes</scope>
+	<scope>meta.routes.rails</scope>
 	<description>map.resources</description>
 </snippet>

--- a/Rails/Snippets/map_with_options.sublime-snippet
+++ b/Rails/Snippets/map_with_options.sublime-snippet
@@ -4,6 +4,6 @@
 end
 ]]></content>
 	<tabTrigger>mapwo</tabTrigger>
-	<scope>meta.rails.routes</scope>
+	<scope>meta.routes.rails</scope>
 	<description>map.with_options</description>
 </snippet>

--- a/Rails/Snippets/respond_to.sublime-snippet
+++ b/Rails/Snippets/respond_to.sublime-snippet
@@ -3,6 +3,6 @@
 	wants.${1:html}${2: { $0 \}}
 end]]></content>
 	<tabTrigger>rest</tabTrigger>
-	<scope>meta.rails.controller</scope>
+	<scope>meta.controller.rails</scope>
 	<description>respond_to</description>
 </snippet>

--- a/Rails/Snippets/t_binary-(tcbi).sublime-snippet
+++ b/Rails/Snippets/t_binary-(tcbi).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.binary :${1:title}${2:, :limit => ${3:2}.megabytes}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.binary (tcbi)</description>
 </snippet>

--- a/Rails/Snippets/t_boolean-(tcb).sublime-snippet
+++ b/Rails/Snippets/t_boolean-(tcb).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.boolean :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.boolean (tcb)</description>
 </snippet>

--- a/Rails/Snippets/t_date-(tcda).sublime-snippet
+++ b/Rails/Snippets/t_date-(tcda).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.date :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.date (tcda)</description>
 </snippet>

--- a/Rails/Snippets/t_datetime-(tcdt).sublime-snippet
+++ b/Rails/Snippets/t_datetime-(tcdt).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.datetime :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.datetime (tcdt)</description>
 </snippet>

--- a/Rails/Snippets/t_decimal-(tcd).sublime-snippet
+++ b/Rails/Snippets/t_decimal-(tcd).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.decimal :${1:title}${2:${3:, :precision => ${4:10}}${5:, :scale => ${6:2}}}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.decimal (tcd)</description>
 </snippet>

--- a/Rails/Snippets/t_float-(tcf).sublime-snippet
+++ b/Rails/Snippets/t_float-(tcf).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.float :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.float (tcf)</description>
 </snippet>

--- a/Rails/Snippets/t_integer-(tci).sublime-snippet
+++ b/Rails/Snippets/t_integer-(tci).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.integer :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.integer (tci)</description>
 </snippet>

--- a/Rails/Snippets/t_lock_version-(tcl).sublime-snippet
+++ b/Rails/Snippets/t_lock_version-(tcl).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.integer :lock_version, :null => false, :default => 0
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.lock_version (tcl)</description>
 </snippet>

--- a/Rails/Snippets/t_references-(tcr).sublime-snippet
+++ b/Rails/Snippets/t_references-(tcr).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.references :${1:taggable}${2:, :polymorphic => ${3:{ :default => '${4:Photo}' \}}}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.references (tcr)</description>
 </snippet>

--- a/Rails/Snippets/t_rename-(tre).sublime-snippet
+++ b/Rails/Snippets/t_rename-(tre).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.rename(:${1:old_column_name}, :${2:new_column_name})
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.rename (tre)</description>
 </snippet>

--- a/Rails/Snippets/t_string-(tcs).sublime-snippet
+++ b/Rails/Snippets/t_string-(tcs).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.string :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.string (tcs)</description>
 </snippet>

--- a/Rails/Snippets/t_text-(tct).sublime-snippet
+++ b/Rails/Snippets/t_text-(tct).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.text :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.text (tct)</description>
 </snippet>

--- a/Rails/Snippets/t_time-(tcti).sublime-snippet
+++ b/Rails/Snippets/t_time-(tcti).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.time :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.time (tcti)</description>
 </snippet>

--- a/Rails/Snippets/t_timestamp-(tcts).sublime-snippet
+++ b/Rails/Snippets/t_timestamp-(tcts).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.timestamp :${1:title}
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.timestamp (tcts)</description>
 </snippet>

--- a/Rails/Snippets/t_timestamps-(tctss).sublime-snippet
+++ b/Rails/Snippets/t_timestamps-(tctss).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[t.timestamps
 t.$0]]></content>
 	<tabTrigger>t.</tabTrigger>
-	<scope>meta.rails.migration.create_table, meta.rails.migration.change_table</scope>
+	<scope>meta.migration.create_table.rails, meta.migration.change_table.rails</scope>
 	<description>t.timestamps (tctss)</description>
 </snippet>

--- a/Rails/Snippets/wants_format.sublime-snippet
+++ b/Rails/Snippets/wants_format.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[wants.${1:js|xml|html}${2: { $0 \}}]]></content>
 	<tabTrigger>wants</tabTrigger>
-	<scope>meta.rails.controller</scope>
+	<scope>meta.controller.rails</scope>
 	<description>wants.format</description>
 </snippet>


### PR DESCRIPTION
Looks like the [Ruby on Rails.sublime-syntax file](https://github.com/sublimehq/Packages/blob/6ed5bc862b5b12c628bfeb4b9a98c7535b91dc18/Rails/Ruby%20on%20Rails.sublime-syntax) defines scopes in the format of
`meta.<scope1>.<scope2>.rails` whereas most of the snippets were following
`meta.rails.<scope1>.<scope2>`, making them essentially useless as they would
never trigger.

PS.: I have a repo (and a package) with more up-to date Rails snippets https://github.com/tadast/sublime-rails-snippets. I'll try to port over the changes via small PRs when I have time. If anyone looking at this feels like helping, please do. 