### PR TITLE
[C#] fix label scoping

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -823,10 +823,10 @@ contexts:
         1: keyword.control.flow.goto.cs
         2: keyword.control.switch.case.cs
       push: line_of_code_in
-    - match: '\b(goto)\s+{{name}}\s*(;)'
+    - match: '\b(goto)\s+({{name}})\s*(;)'
       captures:
         1: keyword.control.flow.goto.cs
-        2: entity.name.tag.cs
+        2: constant.other.label.cs
         3: punctuation.terminator.statement.cs
       pop: true
     - include: keywords
@@ -904,8 +904,10 @@ contexts:
       captures:
         1: support.type.cs
       set: [variables_declaration, type_no_space]
-    - match: '{{name}}\s*(:)(?!:)'
-      scope: entity.name.tag.cs
+    - match: '({{name}})\s*(:)(?!:)'
+      captures:
+        1: entity.name.label.cs
+        2: punctuation.separator.cs
       pop: true
     - match: '(?:(global)|({{name}}))\s*(::)'
       captures:

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -894,6 +894,13 @@ namespace TestNamespace.Test
 ///     ^^^^^^^ keyword.control.trycatch.finally
         {
         }
+        
+        goto abc;
+///     ^^^^ keyword.control.flow.goto
+///          ^^^ constant.other.label
+    abc:
+/// ^^^ entity.name.label
+///    ^ punctuation.separator
     }
 }
 ///<- punctuation.section.block.end


### PR DESCRIPTION
this updates the scope used for labels in C# to the same as that used in e.g. the Batch File syntax, `entity.name.label`.