### PR TITLE
[Rails] Drop legacy snippets

### DIFF
--- a/Rails/Snippets/assert_rjs.sublime-snippet
+++ b/Rails/Snippets/assert_rjs.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[assert_rjs :${1:replace}, ${2:"${3:dom id}"}]]></content>
-	<tabTrigger>asrj</tabTrigger>
-	<scope>source.ruby.rails</scope>
-	<description>assert_rjs</description>
-</snippet>

--- a/Rails/Snippets/find(%3Aall).sublime-snippet
+++ b/Rails/Snippets/find(%3Aall).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[find(:all${1:, :conditions => ['${2:${3:field} = ?}', ${5:true}]})]]></content>
-	<tabTrigger>fina</tabTrigger>
-	<scope>source.ruby.rails</scope>
-	<description>find(:all)</description>
-</snippet>

--- a/Rails/Snippets/find(%3Afirst).sublime-snippet
+++ b/Rails/Snippets/find(%3Afirst).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[find(:first${1:, :conditions => ['${2:${3:field} = ?}', ${5:true}]})]]></content>
-	<tabTrigger>finf</tabTrigger>
-	<scope>source.ruby.rails</scope>
-	<description>find(:first)</description>
-</snippet>

--- a/Rails/Snippets/page_hide-(%2Aids).sublime-snippet
+++ b/Rails/Snippets/page_hide-(%2Aids).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.hide ${1:"${2:id(s)}"}]]></content>
-	<tabTrigger>hide</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.hide (*ids)</description>
-</snippet>

--- a/Rails/Snippets/page_insert_html-(position-id-partial).sublime-snippet
+++ b/Rails/Snippets/page_insert_html-(position-id-partial).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.insert_html :${1:top}, ${2:"${3:id}"}, :${4:partial => "${5:template}"}]]></content>
-	<tabTrigger>ins</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.insert_html (position, id, partial)</description>
-</snippet>

--- a/Rails/Snippets/page_replace-(id-partial).sublime-snippet
+++ b/Rails/Snippets/page_replace-(id-partial).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.replace ${1:"${2:id}"}, :${3:partial => "${4:template}"}]]></content>
-	<tabTrigger>rep</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.replace (id, partial)</description>
-</snippet>

--- a/Rails/Snippets/page_replace_html-(id-partial).sublime-snippet
+++ b/Rails/Snippets/page_replace_html-(id-partial).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.replace_html ${1:"${2:id}"}, :${3:partial => "${4:template}"}]]></content>
-	<tabTrigger>reph</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.replace_html (id, partial)</description>
-</snippet>

--- a/Rails/Snippets/page_show-(%2Aids).sublime-snippet
+++ b/Rails/Snippets/page_show-(%2Aids).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.show ${1:"${2:id(s)}"}]]></content>
-	<tabTrigger>show</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.show (*ids)</description>
-</snippet>

--- a/Rails/Snippets/page_toggle-(%2Aids).sublime-snippet
+++ b/Rails/Snippets/page_toggle-(%2Aids).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.toggle ${1:"${2:id(s)}"}]]></content>
-	<tabTrigger>tog</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.toggle (*ids)</description>
-</snippet>

--- a/Rails/Snippets/page_visual_effect-(effect-id).sublime-snippet
+++ b/Rails/Snippets/page_visual_effect-(effect-id).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[page.visual_effect :${1:toggle_slide}, ${2:"${3:DOM ID}"}]]></content>
-	<tabTrigger>vis</tabTrigger>
-	<scope>source.ruby.rails.rjs</scope>
-	<description>page.visual_effect (effect, id)</description>
-</snippet>


### PR DESCRIPTION
Delete RJS-related snippets – not a thing since Rails 3.1

Delete `find(:all)` and `find(:first)` – dropped in Rails 3.? in favour of .all and .first