### PR TITLE
[Rails] Update before/after validation on create/update

### DIFF
--- a/Rails/Snippets/after_validation_on_create.sublime-snippet
+++ b/Rails/Snippets/after_validation_on_create.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[after_validation_on_create ]]></content>
+	<content><![CDATA[after_validation :${1:attr}, :on => :create]]></content>
 	<tabTrigger>aftvoc</tabTrigger>
 	<scope>source.ruby.rails</scope>
-	<description>after_validation_on_create</description>
+	<description>after_validation on create</description>
 </snippet>

--- a/Rails/Snippets/after_validation_on_update.sublime-snippet
+++ b/Rails/Snippets/after_validation_on_update.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[after_validation_on_update ]]></content>
+	<content><![CDATA[after_validation :${1:attr}, :on => :update]]></content>
 	<tabTrigger>aftvou</tabTrigger>
 	<scope>source.ruby.rails</scope>
 	<description>after_validation_on_update</description>

--- a/Rails/Snippets/before_validation_on_create.sublime-snippet
+++ b/Rails/Snippets/before_validation_on_create.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[before_validation_on_create ]]></content>
+	<content><![CDATA[before_validation :${1:attr}, :on => :create]]></content>
 	<tabTrigger>befvoc</tabTrigger>
 	<scope>source.ruby.rails</scope>
-	<description>before_validation_on_create</description>
+	<description>before_validation on create</description>
 </snippet>

--- a/Rails/Snippets/before_validation_on_update.sublime-snippet
+++ b/Rails/Snippets/before_validation_on_update.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[before_validation_on_update]]></content>
+	<content><![CDATA[before_validation :${1:attr}, :on => :update]]></content>
 	<tabTrigger>befvou</tabTrigger>
 	<scope>source.ruby.rails</scope>
-	<description>before_validation_on_update</description>
+	<description>before_validation on update</description>
 </snippet>


### PR DESCRIPTION
This syntax has been dropped in Rails 3 (2010) and replaced by the one
suggested in this commit.

~~Removes these four methods from the `support.function.activerecord.rails` match as well.~~

https://apidock.com/rails/ActiveRecord/Callbacks/before_validation_on_create
https://apidock.com/rails/ActiveRecord/Callbacks/before_validation_on_update
https://apidock.com/rails/ActiveRecord/Callbacks/after_validation_on_update
https://apidock.com/rails/ActiveRecord/Callbacks/after_validation_on_create

~~Note: the suggested changes in snippets use the "new" hash syntax `on: :create` instead of `:on => :create`. The "new" syntax was introduced in ruby 1.9, [as of now the oldest supported version of ruby is 2.2](https://www.ruby-lang.org/en/).~~

Question to the maintainers: I could open another PR converting all the existing snippets to the new syntax if you'd like that.

Edits: I kept the matches unchanged for backwards-compatibility and didn't enforce the new ruby hash syntax in this change. Crossed out irrelevant parts of the PR description.