### PR TITLE
[C#] fix symbol index

### DIFF
--- a/C#/Symbol List Classes.tmPreferences
+++ b/C#/Symbol List Classes.tmPreferences
@@ -15,10 +15,6 @@
 		<string>
 		s/^/class /;
 		</string>
-		<key>symbolIndexTransformation</key>
-		<string>
-		s/^/class /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Constructors.tmPreferences
+++ b/C#/Symbol List Constructors.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List: Constructor</string>
 	<key>scope</key>
-	<string><![CDATA[source.cs meta.method.constructor - meta.method.constructor.prebody]]></string>
+	<string>source.cs meta.method.constructor - meta.method.constructor.prebody</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/C#/Symbol List Enums.tmPreferences
+++ b/C#/Symbol List Enums.tmPreferences
@@ -15,10 +15,6 @@
 		<string>
 		s/^/enum /;
 		</string>
-		<key>symbolIndexTransformation</key>
-		<string>
-		s/^/enum /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Index Constructors.tmPreferences
+++ b/C#/Symbol List Index Constructors.tmPreferences
@@ -9,10 +9,6 @@
 	<dict>
 		<key>showInIndexedSymbolList</key>
 		<integer>1</integer>
-		<key>symbolIndexTransformation</key>
-		<string>
-			s/^\s*/constructor /;   # prepend "constructor " to the method name, to make them easier to find
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Inner Function.tmPreferences
+++ b/C#/Symbol List Inner Function.tmPreferences
@@ -16,11 +16,6 @@
 			s/\s{2,}/ /g; # collapse whitespace
 			s/^\s*/  /;   # indent by two spaces
 		</string>
-		<key>symbolIndexTransformation</key>
-		<string>
-			s/\s{2,}/ /g;      # collapse whitespace
-			s/^\s*/method /;   # prepend "method " to the method name, to make them easier to find
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Interfaces.tmPreferences
+++ b/C#/Symbol List Interfaces.tmPreferences
@@ -15,10 +15,6 @@
 		<string>
 		s/^/interface /;
 		</string>
-		<key>symbolIndexTransformation</key>
-		<string>
-		s/^/interface /;
-		</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
removed usages of `symbolIndexTransformation` because it prevents Goto Definition from working properly

re: https://github.com/sublimehq/Packages/pull/910#discussion_r112312960