### PR TITLE
[HTML] indentation rule improvements

### DIFF
--- a/HTML/Miscellaneous.tmPreferences
+++ b/HTML/Miscellaneous.tmPreferences
@@ -9,27 +9,27 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                                    # the beginning of the line followed by any amount of whitespace
+			^\s*+                                                                                   # the beginning of the line followed by any amount of whitespace
 			(
 			    <\?(php)?\s+(else(if)?|end(if|for(each)?|while))\b                                  # ending PHP control keywords
-			|   </(?!html)[A-Za-z0-9-]+\b[^>]*>                                                     # any valid HTML close tag except "html"
+			|   [^<>]*+</(?!html)[A-Za-z0-9-]+\b[^>]*>                                              # optionally, anything that's not an angle bracket, followed by any valid HTML close tag except "html"
 			|   (<!\[endif\])?-->                                                                   # closing comment punctuation, optionally preceded by an end "comment selector"
 			|   \}                                                                                  # a closing curly brace
 			)
 		]]></string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)
-			^\s*                                                                                    # the beginning of the line followed by any amount of whitespace
+			^\s*+                                                                                   # the beginning of the line followed by any amount of whitespace
 			(
 			    <\?(php)?\s*\b                                                                      # an open PHP tag
 			    (
 			        (if|else|elseif)\b.*:(?!.*?endif\b)                                             # PHP if related statements not followed by an endif
-			    |   (?<php_control_word>for|foreach|while)\b.*:(?!.*?end\g<php_control_word>\b)     # PHP control keywords that don't end themselves on the same line
+			    |   (?<php_control_word>for|foreach|while)\b.*:(?!.*?end\k<php_control_word>\b)     # PHP control keywords that don't end themselves on the same line
 			    )
 			|   \{[^}"']*$                                                                          # open curly braces that don't have close braces or string punctuation after them
 			|   <!--(?!.*-->)                                                                       # comments that don't close themselves on the same line
-			|   <(?!\?|(?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*/>)     # skip self closing tags (tags that end with />, as well as known self closing tags)
-			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\g<html_tag>\s*>)              # valid HTML tags that don't close themselves on the same line
+			|   .*<(?!\?|(?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*/>)   # skip self closing tags (tags that end with />, as well as known self closing tags)
+			        (?<html_tag>[A-Za-z0-9-]+)(?=\s|>)\b[^>]*>(?!.*</\k<html_tag>\s*>)              # a valid non-self-closing HTML tag that doesn't close itself on the same line
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -28,7 +28,7 @@
 			| # OR
 			^\s*                                                                                # the beginning of the line followed by any amount of whitespace
 			(   (if|else|elseif)\b.*:(?!.*?endif\b)                                             # PHP "if" related statements not followed by an "endif"
-			|   (?<php_control_word>for|foreach|while)\b.*:(?!.*?end\g<php_control_word>\b)     # PHP control keywords that don't end themselves on the same line
+			|   (?<php_control_word>for|foreach|while)\b.*:(?!.*?end\k<php_control_word>\b)     # PHP control keywords that don't end themselves on the same line
 			)
 		]]></string>
 		


### PR DESCRIPTION
fixes #915

- allow text (i.e. excluding angle brackets) preceding the close tag for unindent rule. (note: it won't unindent when there are more closing tags than opening tags on the line e.g. `<span>example</span>test</div>`, but it is better than the current implementation.)
- indent the next line if there is an unclosed open tag on the line. (note: it can be fooled by nested tags that are the same i.e. `<div>test<div>example</div>` won't create a new line, despite the unclosed `div`, but it is better than the current implementation.)
- use `\k` rather than `\g` to reference the previously captured named group because (in Oniguruma,) the latter recurses the expression and not the match.