### PR TITLE
[Diff] Handle non-existant files

### DIFF
--- a/Diff/diff.py
+++ b/Diff/diff.py
@@ -38,7 +38,11 @@ class DiffFilesCommand(sublime_plugin.WindowCommand):
 class DiffChangesCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
-        fname = self.view.file_name();
+        fname = self.view.file_name()
+
+        if not fname or not os.path.exists(fname):
+            sublime.status_message("Unable to diff changes because the file does not exist")
+            return
 
         try:
             a = codecs.open(fname, "r", "utf-8").read().splitlines()

--- a/Diff/diff.py
+++ b/Diff/diff.py
@@ -45,7 +45,8 @@ class DiffChangesCommand(sublime_plugin.TextCommand):
             return
 
         try:
-            a = codecs.open(fname, "r", "utf-8").read().splitlines()
+            with codecs.open(fname, "r", "utf-8") as f:
+                a = f.read().splitlines()
             b = self.view.substr(sublime.Region(0, self.view.size())).splitlines()
         except UnicodeDecodeError:
             sublime.status_message("Diff only works with UTF-8 files")


### PR DESCRIPTION
Pretty self-explanatory. Happens a lot when opening resource files that don't exist on the file system at the location that ST maps them to.

Closes https://github.com/SublimeTextIssues/DefaultPackages/issues/96.