### PR TITLE
[Java] support multi-catch exception parameters

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -374,8 +374,14 @@ contexts:
           pop: true
     - match: \b(goto|const)\b
       scope: invalid.illegal.java
-    - match: \b(try|catch|finally|throw)\b
+    - match: \b(try|finally|throw)\b
       scope: keyword.control.catch-exception.java
+    - match: \b(catch)\b
+      scope: keyword.control.catch-exception.java
+      push:
+        - match: (?=[){}])
+          pop: true
+        - include: exception-parameter-declaration
     - match: '\?|:'
       scope: keyword.control.java
     - match: \b(return|break|case|continue|default|do|while|for|switch|if|else)\b
@@ -403,6 +409,49 @@ contexts:
         2: support.variable.magic.java
     - match: ;
       scope: punctuation.terminator.java
+
+  # https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20
+  exception-parameter-declaration:
+    - match: \(
+      push:
+        - meta_content_scope: meta.catch.parameters.java
+        - include: annotations
+        # Stop the catch-clause early in case the user has left it
+        # incompletely mistyped; although { and } can be used in
+        # annotations, the annotations section should account for that.
+        - match: (?=[){}])
+          pop: true
+        # TODO: It is a compile-time error if final appears more than once
+        # as a modifier for an exception parameter declaration.
+        - match: \bfinal\b
+          scope: storage.modifier.java
+        - match: '{{qualified_id}}'
+          scope: support.class.java
+          push:
+            - match: (?=[){}])
+              pop: true
+            - match: ','
+              scope: invalid.illegal.java
+            - match: \|
+              scope: keyword.operator.logical.java
+              push:
+                - match: '[,|]'
+                  scope: invalid.illegal.java
+                - match: '{{qualified_id}}'
+                  scope: support.class.java
+                  pop: true
+                - match: (?=[){}])
+                  pop: true
+            - match: '{{id}}'
+              scope: variable.parameter.java
+              push:
+                - match: (?=[){}])
+                  pop: true
+                - match: '[,|]'
+                  scope: invalid.illegal.java
+        # Only a single | can separate the alternatives. Might detect typos.
+        - match: '[,|]'
+          scope: invalid.illegal.java
 
   methods:
     - match: '(?=\w.*\s+)(?=[^=;]+\()'

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -70,7 +70,22 @@ public class SyntaxTest {
 //                                                   ^ meta.method.body.java - meta.assignment.rhs.java
             lines.forEach(System.out::println);
 //                                    ^^^^^^^ variable.function.reference.java
-        }
+        } catch (IOException ignore) {
+//        ^^^^^ keyword.control.catch-exception.java
+//               ^^^^^^^^^^^ support.class.java
+//                           ^^^^^^ variable.parameter
+        } catch (final MyException | com.net.org.Foo.Bar |
+//               ^ meta.catch.parameters storage.modifier.java
+//                     ^ support.class
+//                                 ^ keyword.operator
+//                                   ^ support.class
+//                                                       ^ keyword.operator
+                YourException ignore) {}
+//              ^ support.class
+//                            ^ variable.parameter
+//                                 ^ meta.catch.parameters
+//                                  ^ - meta.catch.parameters
+
         for (int i = 0; i < 10; i+= 2) {
 //      ^^^ keyword.control
 //           ^^^ storage.type


### PR DESCRIPTION
Supports syntax highlighting with Java's multi-catch statements.

This change does not seem to introduce any regressions in
functionality or performance, aside from the fact that there is more code in the test itself now:

> HEAD^ (de4eaaa) without new test: 1.9ms
HEAD without new test: 2.0ms
HEAD^ (de4eaaa) with new test: 2.0ms
HEAD with new test: 2.0ms

---


I have a hunch that there's a way of making this implementation more elegant. 
Maybe it's possible to do something similar to how `method-parameters`
invokes `method-parameter-after`; and I bet a lot of the repeated matches,
such as `[,|] -> illegal` and `(?=[){}]) -> pop` could also be DRYed.
