### PR TITLE
[CSS][Add] Scope for RGBA hexadecimal

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -110,6 +110,10 @@ contexts:
       # Hex Color
     - match: '(#)(\h{3}|\h{6})\b'
       scope: constant.other.color.rgb-value.css
+      # RGBA Hexadecimal Colors
+      # https://en.wikipedia.org/wiki/RGBA_color_space#RGBA_hexadecimal_.28word-order.29
+    - match: '(#)(\h{8})\b'
+      scope: constant.other.color.rgba-value.css
       captures:
         1: punctuation.definition.constant.css
 
@@ -135,7 +139,7 @@ contexts:
   # @counter-style
   # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
   at-counter-style:
-    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))\s*(?=\{|$)
+    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))\s*(?={)
       captures:
         1: keyword.control.at-rule.counter-style.css
         2: punctuation.definition.keyword.css
@@ -143,7 +147,6 @@ contexts:
         4: entity.other.counter-style-name.css
       push:
         - meta_scope: meta.at-rule.counter-style.css
-        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -192,13 +195,12 @@ contexts:
         - include: comma-delimiter
 
   at-font-face:
-    - match: '\s*((@)font-face)\s*(?=\{|$)'
+    - match: '\s*((@)font-face)\s*(?=\{)'
       captures:
         1: keyword.control.at-rule.font-face.css
         2: punctuation.definition.keyword.css
       push:
         - meta_scope: meta.at-rule.font-face.css
-        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -351,7 +353,7 @@ contexts:
   # @page
   # https://www.w3.org/TR/CSS2/page.html
   at-page:
-    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*(?=\{|$)'
+    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*(?=\{)'
       captures:
         1: keyword.control.at-rule.page.css
         2: punctuation.definition.keyword.css
@@ -359,7 +361,6 @@ contexts:
         4: entity.other.pseudo-class.css
       push:
         - meta_scope: meta.at-rule.page.css
-        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -522,7 +523,6 @@ contexts:
               | rtl|ruby|running|saturat(e|ion)|screen
               | scroll(-position|bar)?
               | separate|sepia
-              | scale-down
               | shape-(image-threshold|margin|outside)
               | show
               | sideways(-lr|-rl)?
@@ -570,7 +570,7 @@ contexts:
             )\b
       scope: support.constant.property-value.css
       # Generic Font Families: https://www.w3.org/TR/CSS2/fonts.html
-    - match: \b(?i:sans-serif|serif|monospace|fantasy|cursive)\b(?=\s*[;,\n}])
+    - match: \b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)\b
       scope: support.constant.font-name.css
 
   property-values:
@@ -614,26 +614,6 @@ contexts:
             1: keyword.other.custom-property.prefix.css
             2: support.type.custom-property.name.css
         - include: custom-property-name
-        - match: \bfont(-family)?(?!-)\b
-          scope: support.type.property-name.css
-          push:
-            - match: (:)([ \t]*)
-              captures:
-                1: punctuation.separator.key-value.css
-                2: meta.property-value.css
-              push:
-                - meta_content_scope: meta.property-value.css
-                - match: '\s*(;)|(?=[})])'
-                  captures:
-                    1: punctuation.terminator.rule.css
-                  pop: true
-                - include: property-values
-                - match: '{{ident}}(\s+{{ident}})*'
-                  scope: string.unquoted.css
-                - match: ','
-                  scope: punctuation.separator.css
-            - match: ''
-              pop: true
         # Property names are sorted by popularity in descending order.
         # Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
         - match: |-
@@ -662,7 +642,7 @@ contexts:
               | border-top|unicode-range|list-style-position|orphans|outline-width
               | line-clamp|order|flex-direction|box-pack|animation-fill-mode
               | outline-color|list-style-image|list-style|touch-action|flex-grow
-              | border-left-style|border-left|animation-iteration-count
+              | border-left-style|border-left|speak|animation-iteration-count
               | page-break-inside|box-flex|box-align|page-break-after|animation-delay
               | widows|border-right-style|border-right|flex-align|outline-style
               | outline|background-origin|animation-direction|fill-opacity
@@ -709,13 +689,12 @@ contexts:
               | nbsp-mode|color|image-resolution|grid-row|grid-column|blend-mode
               | azimuth|pause-after|pause-before|pause|pitch-range|pitch|text-height
               | system|negative|prefix|suffix|range|pad|fallback|additive-symbols
-              | symbols|speak-as|speak|grid-gap|grid-row-gap
+              | symbols|speak-as
             )\b
           scope: support.type.property-name.css
-    - match: (:)([ \t]*)
+    - match: (:)\s*
       captures:
         1: punctuation.separator.key-value.css
-        2: meta.property-value.css
       push:
         - meta_content_scope: meta.property-value.css
         - match: '\s*(;)|(?=[})])'

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -139,7 +139,7 @@ contexts:
   # @counter-style
   # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
   at-counter-style:
-    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))\s*(?={)
+    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))\s*(?=\{|$)
       captures:
         1: keyword.control.at-rule.counter-style.css
         2: punctuation.definition.keyword.css
@@ -147,6 +147,7 @@ contexts:
         4: entity.other.counter-style-name.css
       push:
         - meta_scope: meta.at-rule.counter-style.css
+        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -195,12 +196,13 @@ contexts:
         - include: comma-delimiter
 
   at-font-face:
-    - match: '\s*((@)font-face)\s*(?=\{)'
+    - match: '\s*((@)font-face)\s*(?=\{|$)'
       captures:
         1: keyword.control.at-rule.font-face.css
         2: punctuation.definition.keyword.css
       push:
         - meta_scope: meta.at-rule.font-face.css
+        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -353,7 +355,7 @@ contexts:
   # @page
   # https://www.w3.org/TR/CSS2/page.html
   at-page:
-    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*(?=\{)'
+    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*(?=\{|$)'
       captures:
         1: keyword.control.at-rule.page.css
         2: punctuation.definition.keyword.css
@@ -361,6 +363,7 @@ contexts:
         4: entity.other.pseudo-class.css
       push:
         - meta_scope: meta.at-rule.page.css
+        - include: comment-block
         - include: rule-list-terminator
         - include: rule-list
 
@@ -523,6 +526,7 @@ contexts:
               | rtl|ruby|running|saturat(e|ion)|screen
               | scroll(-position|bar)?
               | separate|sepia
+              | scale-down
               | shape-(image-threshold|margin|outside)
               | show
               | sideways(-lr|-rl)?
@@ -570,7 +574,7 @@ contexts:
             )\b
       scope: support.constant.property-value.css
       # Generic Font Families: https://www.w3.org/TR/CSS2/fonts.html
-    - match: \b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace|fantasy|cursive)\b
+    - match: \b(?i:sans-serif|serif|monospace|fantasy|cursive)\b(?=\s*[;,\n}])
       scope: support.constant.font-name.css
 
   property-values:
@@ -614,6 +618,26 @@ contexts:
             1: keyword.other.custom-property.prefix.css
             2: support.type.custom-property.name.css
         - include: custom-property-name
+        - match: \bfont(-family)?(?!-)\b
+          scope: support.type.property-name.css
+          push:
+            - match: (:)([ \t]*)
+              captures:
+                1: punctuation.separator.key-value.css
+                2: meta.property-value.css
+              push:
+                - meta_content_scope: meta.property-value.css
+                - match: '\s*(;)|(?=[})])'
+                  captures:
+                    1: punctuation.terminator.rule.css
+                  pop: true
+                - include: property-values
+                - match: '{{ident}}(\s+{{ident}})*'
+                  scope: string.unquoted.css
+                - match: ','
+                  scope: punctuation.separator.css
+            - match: ''
+              pop: true
         # Property names are sorted by popularity in descending order.
         # Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
         - match: |-
@@ -642,7 +666,7 @@ contexts:
               | border-top|unicode-range|list-style-position|orphans|outline-width
               | line-clamp|order|flex-direction|box-pack|animation-fill-mode
               | outline-color|list-style-image|list-style|touch-action|flex-grow
-              | border-left-style|border-left|speak|animation-iteration-count
+              | border-left-style|border-left|animation-iteration-count
               | page-break-inside|box-flex|box-align|page-break-after|animation-delay
               | widows|border-right-style|border-right|flex-align|outline-style
               | outline|background-origin|animation-direction|fill-opacity
@@ -689,12 +713,13 @@ contexts:
               | nbsp-mode|color|image-resolution|grid-row|grid-column|blend-mode
               | azimuth|pause-after|pause-before|pause|pitch-range|pitch|text-height
               | system|negative|prefix|suffix|range|pad|fallback|additive-symbols
-              | symbols|speak-as
+              | symbols|speak-as|speak|grid-gap|grid-row-gap
             )\b
           scope: support.type.property-name.css
-    - match: (:)\s*
+    - match: (:)([ \t]*)
       captures:
         1: punctuation.separator.key-value.css
+        2: meta.property-value.css
       push:
         - meta_content_scope: meta.property-value.css
         - match: '\s*(;)|(?=[})])'

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -110,6 +110,8 @@ contexts:
       # Hex Color
     - match: '(#)(\h{3}|\h{6})\b'
       scope: constant.other.color.rgb-value.css
+      captures:
+        1: punctuation.definition.constant.css
       # RGBA Hexadecimal Colors
       # https://en.wikipedia.org/wiki/RGBA_color_space#RGBA_hexadecimal_.28word-order.29
     - match: '(#)(\h{8})\b'

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -147,18 +147,6 @@
 /*      ^^^^^ comment.block.css */
 }
 
-    @font-face
-/*  ^^^^^^^^^^^ meta.at-rule.font-face.css */
-/*  ^          punctuation.definition.keyword.css    */
-/*   ^^^^^^^^^ keyword.control.at-rule.font-face.css */
-{
-    font-family: monospace,
-/*  ^^^^^^^^^^^ support.type.property-name.css */
-/*               ^^^^^^^^^ support.constant.font-name.css */
-        /* */
-/*      ^^^^^ comment.block.css */
-}
-
     @supports not ( and ( top: 2px ) ) { }
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css */
 /*  ^          punctuation.definition.keyword.css  */
@@ -200,20 +188,6 @@
     suffix: " ";
 /*  ^^^^^^ meta.at-rule.counter-style.css support.type.property-name.css */
 /*          ^^^ string.quoted.double.css */
-}
-
-    @counter-style blacknwhite
-/*  ^^^^^^^^^^^^^^ meta.at-rule.counter-style.css keyword.control.at-rule.counter-style.css */
-/*                 ^^^^^^^^^^^ entity.other.counter-style-name.css */
-{
-  system: cyclic;
-  negative: "(" ")";
-  prefix: "/";
-  symbols: ◆ ◇;
-  suffix: "/ ";
-  range: 2 4;
-  speak-as: "bullets";
-/*^^^^^^^^ support.type.property-name.css */
 }
 
 .test-var { --test-var: arial; }
@@ -400,31 +374,6 @@
 /*        ^^^^^^^^^  support.constant.font-name.css */
 }
 
-.test-unquoted-font-name {
-    font: m700, aria;
-/*        ^^^^ string.unquoted */
-/*            ^ punctuation.separator */
-/*            ^^ - string */
-/*              ^^^^ string.unquoted */
-    font: inherit;
-/*        ^ - string */
-    font: initial;
-/*        ^ - string */
-    font: unset;
-/*        ^ - string */
-    font: italic;
-/*        ^ - string */
-    font: small-caps;
-/*        ^ - string */
-    font: 2em m700, sans-serif;
-/*        ^ - string */
-/*            ^^^^ string.unquoted */
-/*                ^ punctuation.separator */
-/*                  ^ - string */
-    font-weight: bold;
-/*  ^^^^^^^^^^^ meta.property-name support.type.property-name */
-}
-
 .test-color-values {
     color: aqua;
 /*         ^^^^ support.constant.color.w3c-standard-color-name.css */
@@ -439,11 +388,17 @@
 /*         ^^^^^^^^^^^ support.constant.color.w3c-special-color-keyword.css */
 
     color: #b4da55;
-/*         ^ punctuation.definition.constant.css */
 /*         ^^^^^^^ constant.other.color.rgb-value.css */
 
     color: #137;
 /*         ^^^^ constant.other.color.rgb-value.css */
+
+    color: #a1b2c3d4;
+/*         ^^^^^^^^^ constant.other.color.rgba-value.css */
+
+    color: #E5F6A7B8;
+/*         ^^^^^^^^^ constant.other.color.rgba-value.css */
+
 }
 
 .test-function-meta {
@@ -809,12 +764,6 @@
 /*           ^^^^^^^^^^^^ string.unquoted.css            */
 }
 
-@font-face {
-    font-family: m700, aria;
-/*               ^^^^ string.unquoted.css */
-/*                     ^^^^ string.unquoted.css */
-}
-
 .test-var-function {
     top: var(--name);
 /*       ^^^         support.function.var.css                   */
@@ -834,33 +783,3 @@
 /*                                                                             ^^^^^^^^^ entity.other.attribute-name.class.css */
 /*                                                                                       ^^^^^^^^^^ -entity.name.tag.custom.css */
 /*                                                                                                  ^^^^^ -entity.name.tag.custom.css */
-
-.test-meta-scopes-for-completions {
-    top: 5px;
-/*^^^^^^^^^^^ meta.property-list */
-/*  ^^^ meta.property-name */
-/*      ^^^^ meta.property-value */
-    top: ;
-/*^^^^^^^^^^^ meta.property-list */
-/*  ^^^ meta.property-name */
-/*      ^ meta.property-value */
-    top: 
-/*^^^^^^^ meta.property-list */
-/*  ^^^ meta.property-name */
-}/*     ^ meta.property-value */
-
-.generic-font-family { font-family: my-serif, serif }
-/*                                  ^^^^^^^^ string.unquoted */
-/*                                          ^ - string */
-/*                                            ^^^^^ support.constant.font-name */
-.generic-font-family2 { font-family: sans-serif , fantasy ; }
-/*                                   ^^^^^^^^^^ support.constant.font-name */
-/*                                                ^^^^^^^ support.constant.font-name */
-.generic-font-family3 {
-    font-family: cursive
-/*               ^^^^^^^ support.constant.font-name */
-}
-.generic-font-family4 {
-    font-family: droid serif;
-/*               ^^^^^^^^^^^ string.unquoted */
-}

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -439,6 +439,7 @@
 /*         ^^^^^^^^^^^ support.constant.color.w3c-special-color-keyword.css */
 
     color: #b4da55;
+/*         ^ punctuation.definition.constant.css */
 /*         ^^^^^^^ constant.other.color.rgb-value.css */
 
     color: #137;
@@ -448,6 +449,7 @@
 /*         ^^^^^^^^^ constant.other.color.rgba-value.css */
 
     color: #E5F6A7B8;
+/*         ^ punctuation.definition.constant.css */
 /*         ^^^^^^^^^ constant.other.color.rgba-value.css */
 }
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -147,6 +147,18 @@
 /*      ^^^^^ comment.block.css */
 }
 
+    @font-face
+/*  ^^^^^^^^^^^ meta.at-rule.font-face.css */
+/*  ^          punctuation.definition.keyword.css    */
+/*   ^^^^^^^^^ keyword.control.at-rule.font-face.css */
+{
+    font-family: monospace,
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*               ^^^^^^^^^ support.constant.font-name.css */
+        /* */
+/*      ^^^^^ comment.block.css */
+}
+
     @supports not ( and ( top: 2px ) ) { }
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css */
 /*  ^          punctuation.definition.keyword.css  */
@@ -188,6 +200,20 @@
     suffix: " ";
 /*  ^^^^^^ meta.at-rule.counter-style.css support.type.property-name.css */
 /*          ^^^ string.quoted.double.css */
+}
+
+    @counter-style blacknwhite
+/*  ^^^^^^^^^^^^^^ meta.at-rule.counter-style.css keyword.control.at-rule.counter-style.css */
+/*                 ^^^^^^^^^^^ entity.other.counter-style-name.css */
+{
+  system: cyclic;
+  negative: "(" ")";
+  prefix: "/";
+  symbols: ◆ ◇;
+  suffix: "/ ";
+  range: 2 4;
+  speak-as: "bullets";
+/*^^^^^^^^ support.type.property-name.css */
 }
 
 .test-var { --test-var: arial; }
@@ -374,6 +400,31 @@
 /*        ^^^^^^^^^  support.constant.font-name.css */
 }
 
+.test-unquoted-font-name {
+    font: m700, aria;
+/*        ^^^^ string.unquoted */
+/*            ^ punctuation.separator */
+/*            ^^ - string */
+/*              ^^^^ string.unquoted */
+    font: inherit;
+/*        ^ - string */
+    font: initial;
+/*        ^ - string */
+    font: unset;
+/*        ^ - string */
+    font: italic;
+/*        ^ - string */
+    font: small-caps;
+/*        ^ - string */
+    font: 2em m700, sans-serif;
+/*        ^ - string */
+/*            ^^^^ string.unquoted */
+/*                ^ punctuation.separator */
+/*                  ^ - string */
+    font-weight: bold;
+/*  ^^^^^^^^^^^ meta.property-name support.type.property-name */
+}
+
 .test-color-values {
     color: aqua;
 /*         ^^^^ support.constant.color.w3c-standard-color-name.css */
@@ -398,7 +449,6 @@
 
     color: #E5F6A7B8;
 /*         ^^^^^^^^^ constant.other.color.rgba-value.css */
-
 }
 
 .test-function-meta {
@@ -764,6 +814,12 @@
 /*           ^^^^^^^^^^^^ string.unquoted.css            */
 }
 
+@font-face {
+    font-family: m700, aria;
+/*               ^^^^ string.unquoted.css */
+/*                     ^^^^ string.unquoted.css */
+}
+
 .test-var-function {
     top: var(--name);
 /*       ^^^         support.function.var.css                   */
@@ -783,3 +839,33 @@
 /*                                                                             ^^^^^^^^^ entity.other.attribute-name.class.css */
 /*                                                                                       ^^^^^^^^^^ -entity.name.tag.custom.css */
 /*                                                                                                  ^^^^^ -entity.name.tag.custom.css */
+
+.test-meta-scopes-for-completions {
+    top: 5px;
+/*^^^^^^^^^^^ meta.property-list */
+/*  ^^^ meta.property-name */
+/*      ^^^^ meta.property-value */
+    top: ;
+/*^^^^^^^^^^^ meta.property-list */
+/*  ^^^ meta.property-name */
+/*      ^ meta.property-value */
+    top:
+/*^^^^^^^ meta.property-list */
+/*  ^^^ meta.property-name */
+}/*     ^ meta.property-value */
+
+.generic-font-family { font-family: my-serif, serif }
+/*                                  ^^^^^^^^ string.unquoted */
+/*                                          ^ - string */
+/*                                            ^^^^^ support.constant.font-name */
+.generic-font-family2 { font-family: sans-serif , fantasy ; }
+/*                                   ^^^^^^^^^^ support.constant.font-name */
+/*                                                ^^^^^^^ support.constant.font-name */
+.generic-font-family3 {
+    font-family: cursive
+/*               ^^^^^^^ support.constant.font-name */
+}
+.generic-font-family4 {
+    font-family: droid serif;
+/*               ^^^^^^^^^^^ string.unquoted */
+}


### PR DESCRIPTION
### 1. Settings

Part of my `SashaClassy.css` file:

```css
.SashaClass {
    color: #a1b2c3d4;
}

.SashaClass {
    color: #E5F6A7B8;
}
```

### 2. Behavior before pull request

![Before](http://i.imgur.com/w0tK9pI.png)

### 3. Behavior after pull request

![After](http://i.imgur.com/fNJYYnk.png)

### 4. Argumentation

[**RGBA Hexadecimal**](https://en.wikipedia.org/wiki/RGBA_color_space#RGBA_hexadecimal_.28word-order.29) support.

### 5. Tests

```python
Success: 2266 assertions in 1 files passed
[Finished]
```

Thanks.