### PR TITLE
[JavaScript] Remove Mustache templating from JavaScript syntax.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -233,7 +233,7 @@ contexts:
 
   statements:
     - include: conditional
-    - match: '\{(?!\{)'
+    - match: '\{'
       scope: punctuation.definition.block.js
       push:
         - meta_scope: meta.block.js
@@ -382,7 +382,6 @@ contexts:
     - include: literal-prototype
     - include: named-function
     - include: anonymous-function
-    - include: mustache
     - include: object-literal
     - include: brackets
     - include: literal-number
@@ -1013,13 +1012,6 @@ contexts:
       captures:
         1: entity.name.label.js
         2: punctuation.separator.js
-
-  mustache:
-    - match: '\{\{'
-      push:
-        - meta_scope: meta.tag.mustache.js
-        - match: '\}\}'
-          pop: true
 
   object-literal:
     - match: '\{'

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -205,10 +205,7 @@ a = test ? a + b : c;
 //             ^ variable.other.readwrite
 
 {{foo}}
-// ^ meta.tag.mustache.js
-{{#bar}}{{/bar}}
-// ^ meta.tag.mustache.js
-//         ^ meta.tag.mustache.js
+// ^ meta.block meta.block variable.other.readwrite
 
 var obj = {
 //        ^ meta.object-literal - meta.block


### PR DESCRIPTION
For #889. Fixes the following test:

```js
{{foo}}
// ^ meta.block meta.block variable.other.readwrite
```