### PR TITLE
[JavaScript][HTML] Removed HTML comments from JavaScript.

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -98,7 +98,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push:
-        - match: (?i)(-->)?(</)(script)(>)
+        - match: (?i)(-->)?\s*(</)(script)(>)
           captures:
             0: meta.tag.script.end.html
             1: comment.block.html punctuation.definition.comment.html
@@ -106,7 +106,7 @@ contexts:
             3: entity.name.tag.script.html
             4: punctuation.definition.tag.end.html
           pop: true
-        - match: '(>)(<!--)?'
+        - match: '(>)\s*(<!--)?'
           captures:
             1: meta.tag.script.begin.html punctuation.definition.tag.end.html
             2: comment.block.html punctuation.definition.comment.html
@@ -114,7 +114,7 @@ contexts:
             - meta_content_scope: source.js.embedded.html
             - include: 'scope:source.js'
           with_prototype:
-             - match: (?i)(?=(-->)?</script)
+             - match: (?i)(?=(-->)?\s*</script)
                pop: true
         - match: ''
           push:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -98,20 +98,23 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push:
-        - match: (?i)(</)(script)(>)
+        - match: (?i)(-->)?(</)(script)(>)
           captures:
             0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
+            1: comment.block.html punctuation.definition.comment.html
+            2: punctuation.definition.tag.begin.html
+            3: entity.name.tag.script.html
+            4: punctuation.definition.tag.end.html
           pop: true
-        - match: '>'
-          scope: meta.tag.script.begin.html punctuation.definition.tag.end.html
+        - match: '(>)(<!--)?'
+          captures:
+            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
+            2: comment.block.html punctuation.definition.comment.html
           push:
             - meta_content_scope: source.js.embedded.html
             - include: 'scope:source.js'
           with_prototype:
-             - match: (?i)(?=</script)
+             - match: (?i)(?=(-->)?</script)
                pop: true
         - match: ''
           push:

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -11,16 +11,19 @@
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
-        ##                             ^ - meta.tag
+        ##                             ^^^^ comment.block.html punctuation.definition.comment.html
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
             }
-        //--></script>
-        ## ^ source.js.embedded.html
-        ##     ^^^^^^ entity.name.tag.script.html
-        ##   ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
-        ##            ^ - meta.tag
+
+            (a --> b);
+            ## ^^^ source.js.embedded.html meta.group.js keyword.operator
+        --></script>
+        ## <- comment.block.html punctuation.definition.comment.html
+        ##   ^^^^^^ entity.name.tag.script.html
+        ## ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##          ^ - meta.tag
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -7,11 +7,11 @@
 <html>
     <head>
         <title>Test HTML</title>
-        <script type="text/javascript"><!--
+        <script type="text/javascript"> <!--
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
-        ##                             ^^^^ comment.block.html punctuation.definition.comment.html
+        ##                              ^^^^ comment.block.html punctuation.definition.comment.html
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
@@ -19,11 +19,11 @@
 
             (a --> b);
             ## ^^^ source.js.embedded.html meta.group.js keyword.operator
-        --></script>
+        --> </script>
         ## <- comment.block.html punctuation.definition.comment.html
-        ##   ^^^^^^ entity.name.tag.script.html
-        ## ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
-        ##          ^ - meta.tag
+        ##    ^^^^^^ entity.name.tag.script.html
+        ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##           ^ - meta.tag
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -224,8 +224,6 @@ contexts:
       pop: true
 
   comments-top-level:
-    - match: (<!--|-->)
-      scope: comment.block.html.js punctuation.definition.comment.js
     - match: ^(#!).*$\n?
       scope: comment.line.shebang.js
       captures:

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -154,8 +154,9 @@ if (true)
 // <- comment.block punctuation.definition.comment
 */
 
-<!-- -->
-// <- comment.block.html punctuation.definition.comment
+x --> y;
+//^^ keyword.operator.arithmetic.js
+//  ^ keyword.operator.relational.js
 
 #! /usr/bin/env node
 // <- comment.line.shebang punctuation.definition.comment


### PR DESCRIPTION
For #889. Removes support for HTML comments in JavaScript, removes old tests, and adds new one.

#### Background

When JavaScript was first introduced, not all browsers supported `<script>` tags. If such a browser encountered a `<script>` tag, it would usually display its contents on the page. In order to avoid this, an accepted practice was to wrap the interior of the `<script>` tag with HTML comment markers `<!--` and `-->`.

Now, `<script>` tags cannot contain HTML comments -- anything inside them will be interpreted as JavaScript code. In browsers that support JavaScript (i.e. every browser today), these HTML comments are interpreted as either valid syntax (e.g. `a --> b`) or a syntax error (`<!--`). Fortunately (or unfortunately), browsers are lenient, so this workaround didn't break pages in practice.

There is no reason to use this old workaround anymore, because essentially every browser in use supports `<script>` tags. Supporting JavaScript itself isn't necessary, just correct parsing of HTML script tags. Of course, there's a lot of old code in the universe, and surely someone is using Sublime to view it.

#### Current state

Currently, JavaScript.sublime-syntax highlights these constructs as HTML comments even in pure JavaScript. This may sometimes result in the desired behavior, but it will also cause valid JavaScript to be highlighted incorrectly, as in the following failing test:

```js
x --> y;
//^^ keyword.operator.arithmetic.js
//  ^ keyword.operator.relational.js
```

It seems to be that correctly highlighting valid syntax wherever possible should be prioritized over highlighting invalid or variant syntax. If so, then the current implementation must be modified.

#### Options

The simplest fix -- implemented in this PR -- is to remove the HTML comment support from the syntax entirely. This should not affect any valid JavaScript code that is currently highlighted correctly. It will, however, affect the highlighting of invalid code and (by fixing the above bug) on valid code that is not currently highlighted correctly.

What then remains is ensuring that the highlighting of legacy HTML/JavaScript code is acceptable. After this PR, legacy code will be highlighted as follows:

```html
<script><!--
//      ^^^^ text.html.basic source.js.embedded.html keyword.operator.relational
   console.log("Hello, World!");
--></script>
```

This is invalid JavaScript, so there isn't a "correct" way to highlight it. This result doesn't bother me, and it shouldn't disrupt the surrounding HTML or JavaScript highlighting.

Alternatively, we could introduce special styling for this legacy workaround. I don't think it's necessary, but it wouldn't be particularly intrusive. The simplest option here would be to modify the HTML syntax so that an opening `<script>` tag will look for the characters `<!--` immediately afterward and highlight them as an HTML comment. Similarly, the closing tag could handle a preceding `-->`. This should not affect any valid JavaScript code, nor would it put any burden on the JavaScript.sublime-syntax. If there is a strong feeling in favor of this approach, I can implement it promptly.