### PR TITLE
[XML] support xml-model preprocessor instructions

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -91,7 +91,7 @@ contexts:
           scope: punctuation.definition.tag.end.xml
           pop: true
         - include: tag-stuff
-    - match: '(<\?)(xml-stylesheet)(?=\s|\?>)'
+    - match: '(<\?)(xml-stylesheet|xml-model)(?=\s|\?>)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.xml

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -34,6 +34,14 @@
 <!--                                ^ punctuation.definition.string.end -->
 <!--                                 ^ - string -->
 
+     <?xml-model href="http://www.oxygenxml.com/docbook/xml/5.0/rng/dbmathmlsvg.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
+<!--   ^^^^^^^^^ entity.name.tag -->
+<!--             ^^^^ entity.other.attribute-name.localname -->
+<!--                 ^ punctuation.separator.key-value -->
+<!--                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double -->
+<!--                                                                                                                                   ^^ punctuation.definition.tag.end -->
+
 <!--
   DOCTYPE Declaration
  -->


### PR DESCRIPTION
this adds support for the `xml-model` preprocessor instruction, just like we added for `xml-stylesheet`: https://github.com/sublimehq/Packages/issues/882

https://www.w3.org/TR/xml-model/#the-xml-model-processing-instruction