### PR TITLE
[C#] make lambda parameter separator scope more specific

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -948,13 +948,15 @@ contexts:
         - match: '{{name}}(?=\s*[\),/])'
           scope: variable.parameter.cs
         - match: ','
-          scope: punctuation.separator.cs
+          scope: punctuation.separator.parameter.function.cs
         - match: (\))\s*(=>)
           captures:
             1: meta.group.cs punctuation.section.group.end.cs
             2: storage.type.function.lambda.cs
           set:
             - meta_content_scope: meta.function.anonymous.cs
+            - match: '(?=;)'
+              pop: true
             - include: line_of_code_in
 
   member_variables_declaration:

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -931,6 +931,16 @@ namespace TestNamespace.Test
         {
         }
         
+        Func<string, bool, int> test = (a, b) => a.len();
+///                                    ^^^^^^^^^^^^^^^^^ meta.function.anonymous
+///                                    ^^^^^^ meta.group
+///                                     ^ variable.parameter
+///                                      ^ punctuation.separator.parameter.function
+///                                        ^ variable.parameter
+///                                           ^^ storage.type.function.lambda
+///                                                     ^ punctuation.terminator.statement
+///                                                      ^ - meta.function.anonymous
+
         goto abc;
 ///     ^^^^ keyword.control.flow.goto
 ///          ^^^ constant.other.label


### PR DESCRIPTION
use the same scope for parameter separators in lambdas as for normal methods, for consistent highlighting.
Fix bug with lambdas with multiple parameters and no curly braces, similar to https://github.com/sublimehq/Packages/pull/788