### PR TITLE
[CSS] Update missing values/properties

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -428,7 +428,7 @@ contexts:
               | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
               | border-(bottom|top)-(left|right)-radius
               | border-image(-outset|-repeat|-slice|-source|-width)?
-              | border(-bottom|-left|-right|-top|-collapse|-spacing)?
+              | border(-bottom|-left|-right|-top|-collapse|-spacing|-box)?
               | both|bottom
               | box(-shadow)?
               | break-(all|word)
@@ -519,7 +519,9 @@ contexts:
               | replaced|reset-size|reverse|ridge|right
               | round
               | row(-resize|-reverse)?
-              | rtl|ruby|running|saturat(e|ion)|screen
+              | run-in
+              | ruby(-base|-text)?(-container)?
+              | rtl|running|saturat(e|ion)|screen
               | scroll(-position|bar)?
               | separate|sepia
               | scale-down
@@ -546,7 +548,7 @@ contexts:
               | super|swash
               | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
               | tabular-nums|tb-rl
-              | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under)-edge|-shadow|-size(-adjust)?|-top)|field)?
+              | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under|after|before)-edge|-shadow|-size(-adjust)?|-top)|field)?
               | thi(ck|n)
               | titling-ca(ps|se)
               | to[p]?

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -398,6 +398,7 @@ PROPERTY_DICT = {
     'transition-timing-function': ['<timing_function>'],
     'unicode-bidi': ['normal', 'embed', 'bidi-override'],
     'unicode-range': [],
+    'user-select': ['auto', 'text', 'none', 'contain'],
     'vertical-align': [
         'baseline', 'sub', 'super', 'text-top', 'text-bottom', 'middle', 'top',
         'bottom', '<percentage>', '<length>'
@@ -474,7 +475,7 @@ class CSSCompletions(sublime_plugin.EventListener):
         if (view.match_selector(loc, prop_value_scope) or
             # This will catch scenarios like:
             # - .foo {font-style: |}
-            # - <style type="text/css">.foo { font-weight: b|</style> 
+            # - <style type="text/css">.foo { font-weight: b|</style>
             view.match_selector(loc - 1, prop_value_scope)):
 
             alt_loc = loc - len(prefix)


### PR DESCRIPTION
- Add `border-box`, `text-before-edge`, `text-after-edge`, `ruby-base`, `ruby-text`, `run-in`, `ruby-base-container`, and `ruby-text-container` to CSS syntax for correct highlighting, these already exist in _css_completions.py_
- Add `user-select` to completions. Although this still needs a prefix in most browsers (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) and [Caniuse](http://caniuse.com/#search=user-select)), having this part of the completions would be great as most users are probably using Autoprefixer