### PR TITLE
[HTML] support self-closing other/custom tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -61,7 +61,7 @@ contexts:
         2: entity.name.tag.custom.html
       push:
         - meta_scope: meta.tag.custom.html
-        - match: '>'
+        - match: '(?: ?/)?>'
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-stuff
@@ -205,7 +205,7 @@ contexts:
         2: invalid.illegal.uppercase-custom-tag-name.html
       push:
         - meta_scope: meta.tag.custom.html
-        - match: '>'
+        - match: '(?: ?/)?>'
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-stuff
@@ -215,7 +215,7 @@ contexts:
         2: entity.name.tag.other.html
       push:
         - meta_scope: meta.tag.other.html
-        - match: '>'
+        - match: '(?: ?/)?>'
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-stuff

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -163,10 +163,11 @@ class="foo"></div>
         ##                   ^ meta.function-call.js support.function.js
         ## ^^^^^^^^ entity.other.attribute-name
 
-        <article><span><othertag></othertag></span></article>
+        <article><span><othertag></othertag><othertag /></span></article>
         ## ^^^^^ entity.name.tag.block.any.html
         ##        ^^^^ entity.name.tag.inline.any.html
         ##              ^^^^^^^^ entity.name.tag.other.html
+        ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
 
         <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
         ##^^^^^^^^^^^^^^ entity.name.tag.custom.html
@@ -174,6 +175,10 @@ class="foo"></div>
         ##                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
         ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        
+        <test-custom-tag/>
+        ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
+        ##              ^^ punctuation.definition.tag.end.html
 
         <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
         ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html


### PR DESCRIPTION
fixes https://github.com/SublimeTextIssues/DefaultPackages/issues/176 (problems with autocompletion when typing `</` when a non-standard tag is used that is self-closing)