### PR TITLE
[Makefile] Big refactor

### DIFF
--- a/Makefile/Comments.tmPreferences
+++ b/Makefile/Comments.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.makefile</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string># </string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/Makefile/Makefile.sublime-settings
+++ b/Makefile/Makefile.sublime-settings
@@ -1,0 +1,4 @@
+{
+	"translate_tabs_to_spaces": false,
+	"detect_indentation": false
+}

--- a/Makefile/Makefile.sublime-settings
+++ b/Makefile/Makefile.sublime-settings
@@ -1,4 +1,0 @@
-{
-	"translate_tabs_to_spaces": false,
-	"detect_indentation": false
-}

--- a/Makefile/Makefile.sublime-settings
+++ b/Makefile/Makefile.sublime-settings
@@ -1,4 +1,4 @@
 {
 	"translate_tabs_to_spaces": false,
-	"detect_indentation": false
+	"detect_indentation": true
 }

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -124,6 +124,7 @@ contexts:
       captures:
         1: keyword.control.conditional.makefile
       push:
+        - include: control-flow
         - include: comments
         - include: pop-on-line-end
     - match: ^\s*(endif)\b
@@ -281,6 +282,22 @@ contexts:
       scope: constant.character.escape.makefile
 
   comments:
+    # This hack is here in order to circumvent false-positives for the big
+    # rule lookahead. For example, if this match is not present, then things
+    # like
+    # 
+    #     # A comment with a : colon
+    #     
+    # will match the rule-lookahead.
+    - match: (?=^\s*\#)
+      push:
+        - match: \#
+          scope: punctuation.definition.comment.makefile
+          set:
+            - meta_scope: comment.line.number-sign.makefile
+            - include: pop-on-line-end
+    # This is the "normal" comment parsing logic, but not sufficient in every
+    # case (see above).
     - match: \#
       scope: punctuation.definition.comment.makefile
       push:

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -5,6 +5,9 @@
 # Includes a few improvement like special-target, a bit more shell command,
 # better variable recognition, fix ifeq/ifneq missing highlight ...
 # Rewritten by Raoul Wols on May 2017.
+# 
+# All number references refer to the "Make manual" located at
+# https://www.gnu.org/software/make/manual/make.html
 name: Makefile
 file_extensions:
   - make
@@ -196,7 +199,7 @@ contexts:
 
   recipe-inline:
     - include: recipe-junction-between-spaces-or-tabs
-    - include: recipe-common-includes
+    - include: control-flow
 
   recipe-with-spaces:
     - meta_content_scope: meta.function.body.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -474,7 +474,7 @@ contexts:
     - match: \$\$?\(
       scope: keyword.other.block.begin.makefile
       push:
-        - meta_scope: variable.other.makefile
+        - meta_scope: variable.parameter.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
           pop: true
@@ -482,7 +482,7 @@ contexts:
     - match: \$\$?{
       scope: keyword.other.block.begin.makefile
       push:
-        - meta_scope: variable.other.makefile
+        - meta_scope: variable.parameter.makefile
         - match: \}
           scope: keyword.other.block.end.makefile
           pop: true
@@ -493,5 +493,5 @@ contexts:
       scope: constant.character.escape.makefile
     - match: (\$)[[:alpha:]]
       captures:
-        0: variable.other.makefile
+        0: variable.parameter.makefile
         1: keyword.other.single-character-variable.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -112,7 +112,7 @@ contexts:
         - include: pop-on-line-end
     - match: ^\s*(vpath)$
       captures: keyword.control.vpath.makefile
-    - match: ^\s*({{include}})\b
+    - match: ^\s*({{include}})\s+
       captures:
         1: keyword.control.import.makefile
       push:
@@ -161,7 +161,7 @@ contexts:
             - include: continuation-or-pop-on-line-end
     - match: (?= *::?)
       set:
-        - match: ::?
+        - match: ::?\s*
           scope: keyword.operator.assignment.makefile
           set:
             - meta_content_scope: meta.function.arguments.makefile string.unquoted.makefile
@@ -387,7 +387,7 @@ contexts:
         - include: variable-substitutions
         - match: (\?|\+|::?)?=
           scope: keyword.operator.assignment.makefile
-          set: value-to-be-defined
+          set: [value-to-be-defined, eat-whitespace-then-pop]
     - match: (?={{var_lookahead}}|{{first_assign_then_colon}})
       push:
         - meta_content_scope: variable.other.makefile
@@ -403,10 +403,15 @@ contexts:
           set:
             - match: (!|\?|\+|::?)?=
               scope: keyword.operator.assignment.makefile
-              set: value-to-be-defined
+              set: [value-to-be-defined, eat-whitespace-then-pop]
             - include: variable-substitutions
             - include: continuation-or-pop-on-line-end
         - include: variable-substitutions
+
+  eat-whitespace-then-pop:
+    - clear_scopes: 1
+    - match: \s*
+      pop: true
 
   value-to-be-defined:
     - meta_content_scope: string.unquoted.makefile
@@ -423,17 +428,20 @@ contexts:
 
   inside-define-directive-context:
     - meta_content_scope: variable.other.makefile
-    - match: \s*(?=(!|\?|\+|::?)?=)
+    - match: \s*(?=(!|\?|\+|::?)?=\s*$\n)
       set:
-        - match: (!|\?|\+|::?)?=
-          scope: keyword.operator.assignment.makefile
+        - match: ((!|\?|\+|::?)?=)\s*$\n
+          captures:
+            1: keyword.operator.assignment.makefile
           set:
             - meta_content_scope: string.unquoted.makefile
             - match: ^\s*(endef)
               captures:
                 1: keyword.control.makefile
               pop: true
-    - match: $
+    # Need to eat the actual newline character in order to start the
+    # string.unquoted scope on the next line.
+    - match: $\n
       set:
         - meta_content_scope: string.unquoted.makefile
         - match: ^\s*(endef)

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -21,11 +21,11 @@ first_line_match: ^#!\s*/usr/bin/make\b
 scope: source.makefile
 variables:
   
-  VarAssign: (\?|\+|::?)?=
-  ShellAssign: '!='
-  StartDirective: ifn?(def|eq)
-  Include: '[s-]?include'
-  RuleAssign: :(?!=)
+  varassign: (\?|\+|::?)?=
+  shellassign: '!='
+  startdirective: ifn?(def|eq)
+  include: '[s-]?include'
+  ruleassign: :(?!=)
 
   # The big "rule lookahead". What we want to do is here is detect if the
   # line that we are parsing is going to define a rule. So we need to check
@@ -34,20 +34,20 @@ variables:
   # variable substitutions anywhere. We try to remedy this by hacking in a
   # regex that matches up to four levels of nested parentheses, and ignores
   # whatever's inside the parentheses.
-  NonParenChar: '[^()]'
-  NPS: '{{NonParenChar}}*'
+  nonparenchar: '[^()]'
+  nps: '{{nonparenchar}}*'
   # Eats up to 4 nested parens
-  ParenEater: (?:\({{NPS}}*(?:\({{NPS}}*(?:\({{NPS}}*(?:\({{NPS}}*\))?{{NPS}}*\))?{{NPS}}*\))?{{NPS}}\))?
-  JustEat: '{{NPS}}{{ParenEater}}{{NPS}}'
-  IsThisARule: '{{JustEat}}{{RuleAssign}}{{JustEat}}'
+  paren_eater: (?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*\))?{{nps}}*\))?{{nps}}*\))?{{nps}}\))?
+  just_eat: '{{nps}}{{paren_eater}}{{nps}}'
+  rule_lookahead: '{{just_eat}}{{ruleassign}}{{just_eat}}'
 
-  VarLookaheadBase: '{{JustEat}}({{VarAssign}}|{{ShellAssign}}){{JustEat}}'
+  var_lookahead_base: '{{just_eat}}({{varassign}}|{{shellassign}}){{just_eat}}'
   # Just as with rules we want to look ahead if we are going to define a var.
   # However, due to the possibility of "target-specific" variables (see 6.11),
-  # we want to NOT match if there's a {{RuleAssign}} before a {{VarAssign}}.
-  IsThisAVariable: (?!{{IsThisARule}}){{VarLookaheadBase}}
+  # we want to NOT match if there's a {{ruleassign}} before a {{varassign}}.
+  var_lookahead: (?!{{rule_lookahead}}){{var_lookahead_base}}
 
-  FirstAssignThenColon: '{{JustEat}}{{VarAssign}}{{JustEat}}{{RuleAssign}}{{JustEat}}'
+  first_assign_then_colon: '{{just_eat}}{{varassign}}{{just_eat}}{{ruleassign}}{{just_eat}}'
 contexts:
 
   # 3.1 What Makefiles Contain
@@ -56,7 +56,7 @@ contexts:
   main:
     - include: comments
     - include: variable-definitions
-    - match: (?={{IsThisARule}})
+    - match: (?={{rule_lookahead}})
       push: expect-rule
     - include: function-invocations
     - include: control-flow
@@ -112,7 +112,7 @@ contexts:
         - include: pop-on-line-end
     - match: ^\s*(vpath)$
       captures: keyword.control.vpath.makefile
-    - match: ^\s*({{Include}})\b
+    - match: ^\s*({{include}})\b
       captures:
         1: keyword.control.import.makefile
       push:
@@ -120,7 +120,7 @@ contexts:
         - include: continuation-or-pop-on-line-end
         - include: variable-substitutions
         - include: comments
-    - match: \b{{StartDirective}}\b
+    - match: \b{{startdirective}}\b
       scope: keyword.control.conditional.makefile
       push: inside-control-flow
     - match: ^\s*(else)\b
@@ -185,7 +185,7 @@ contexts:
   recipe-junction-between-spaces-or-tabs:
     - meta_content_scope: meta.function.body.makefile
     - include: comments
-    - match: ^\s*({{StartDirective}})
+    - match: ^\s*({{startdirective}})
       captures:
         1: keyword.control.conditional.makefile
       push:
@@ -388,7 +388,7 @@ contexts:
         - match: (\?|\+|::?)?=
           scope: keyword.operator.assignment.makefile
           set: value-to-be-defined
-    - match: (?={{IsThisAVariable}}|{{FirstAssignThenColon}})
+    - match: (?={{var_lookahead}}|{{first_assign_then_colon}})
       push:
         - meta_content_scope: variable.other.makefile
         - match: (?=\s*!=)

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -468,3 +468,7 @@ contexts:
       scope: variable.language.automatic.makefile
     - match: \$\$
       scope: constant.character.escape.makefile
+    - match: (\$)[[:alpha:]]
+      captures:
+        0: variable.other.makefile
+        1: punctuation.definition.variable.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -278,8 +278,6 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
-        - include: textual-parenthesis-balancer
-        - include: quoted-string
 
   recipe-with-spaces:
     - meta_content_scope: meta.function.body.makefile
@@ -291,8 +289,6 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
-        - include: textual-parenthesis-balancer
-        - include: quoted-string
     - match: ^(\t)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.spaces.makefile
@@ -311,8 +307,6 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
-        - include: textual-parenthesis-balancer
-        - include: quoted-string
     - match: ^([ ]+)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.tab.makefile
@@ -503,8 +497,9 @@ contexts:
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-substitutions
-        - include: textual-parenthesis-balancer
         - include: quoted-string
+        - match: \(
+          push: textual-parenthesis-balancer
 
   variable-definitions:
     - match: \s*(override)\b
@@ -542,7 +537,6 @@ contexts:
                 - include: variable-substitutions
                 - include: pop-on-line-end
                 - include: textual-parenthesis-balancer
-                - include: quoted-string
         - match: (?=\s*(!|\?|\+|::?)?=)
           set:
             - match: (!|\?|\+|::?)?=

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -335,7 +335,7 @@ contexts:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
         2: constant.language.call.makefile
-        3: support.function.makefile
+        3: variable.function.makefile
         4: punctuation.separator.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
@@ -344,7 +344,7 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: support.function.makefile
+        2: variable.function.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: highlight-percentage-sign
@@ -353,7 +353,7 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: support.function.makefile
+        2: variable.function.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: inside-function-call
@@ -362,12 +362,12 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: support.function.makefile
+        2: variable.function.makefile
       push: inside-function-call
     - match: (\$\()(shell)\s
       captures:
         1: keyword.other.block.begin.makefile
-        2: support.function.builtin.makefile
+        2: variable.function.makefile
       push: scope:source.shell
       with_prototype:
         - match: \)

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -311,7 +311,7 @@ contexts:
   inside-function-call:
     - meta_content_scope: meta.function-call.arguments.makefile
     - match: \)
-      scope: punctuation.definition.variable.end.makefile
+      scope: keyword.other.block.end.makefile
       pop: true
     - match: \,
       scope: punctuation.separator.makefile
@@ -322,7 +322,7 @@ contexts:
     - match: (\$\()(call)\s+([a-zA-Z0-9\-_]+)(,)
       captures:
         0: meta.function-call.makefile
-        1: punctuation.definition.variable.begin.makefile
+        1: keyword.other.block.begin.makefile
         2: constant.language.call.makefile
         3: support.function.makefile
         4: punctuation.separator.makefile
@@ -332,7 +332,7 @@ contexts:
     - match: (\$\()(patsubst|filter)\s
       captures:
         0: meta.function-call.makefile
-        1: punctuation.definition.variable.begin.makefile
+        1: keyword.other.block.begin.makefile
         2: support.function.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
@@ -341,7 +341,7 @@ contexts:
     - match: (\$\()(wildcard)\s
       captures:
         0: meta.function-call.makefile
-        1: punctuation.definition.variable.begin.makefile
+        1: keyword.other.block.begin.makefile
         2: support.function.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
@@ -350,17 +350,17 @@ contexts:
     - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|error|warning|info|guile) \s
       captures:
         0: meta.function-call.makefile
-        1: punctuation.definition.variable.begin.makefile
+        1: keyword.other.block.begin.makefile
         2: support.function.makefile
       push: inside-function-call
     - match: (\$\()(shell)\s
       captures:
-        1: punctuation.definition.variable.begin.makefile
+        1: keyword.other.block.begin.makefile
         2: support.function.builtin.makefile
       push: scope:source.shell
       with_prototype:
         - match: \)
-          scope: punctuation.definition.variable.end.makefile
+          scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-substitutions
 
@@ -453,19 +453,19 @@ contexts:
   variable-substitutions:
     - include: function-invocations
     - match: \$\$?\(
-      scope: punctuation.definition.variable.begin.makefile
+      scope: keyword.other.block.begin.makefile
       push:
         - meta_scope: variable.other.makefile
         - match: \)
-          scope: punctuation.definition.variable.end.makefile
+          scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
     - match: \$\$?{
-      scope: punctuation.definition.variable.end.makefile
+      scope: keyword.other.block.begin.makefile
       push:
         - meta_scope: variable.other.makefile
         - match: \}
-          scope: punctuation.definition.variable.end.makefile
+          scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
     - match: \$\$?[@%<?^+|*]

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -26,6 +26,7 @@ variables:
   startdirective: ifn?(def|eq)
   include: '[s-]?include'
   ruleassign: :(?!=)
+  function_call_token_begin: \$\$?\(
 
   # The big "rule lookahead". What we want to do is here is detect if the
   # line that we are parsing is going to define a rule. So we need to check
@@ -34,11 +35,64 @@ variables:
   # variable substitutions anywhere. We try to remedy this by hacking in a
   # regex that matches up to four levels of nested parentheses, and ignores
   # whatever's inside the parentheses.
-  nonparenchar: '[^()]'
-  nps: '{{nonparenchar}}*'
-  # Eats up to 4 nested parens
-  paren_eater: (?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*\))?{{nps}}*\))?{{nps}}*\))?{{nps}}\))?
-  just_eat: '{{nps}}{{paren_eater}}{{nps}}'
+  nps: '[^()]*'
+  open: '(?:\('
+  close: '\))?'       # ignore this invalid.illegal
+  just_eat: |         # WARNING: INSANITY FOLLOWS!
+    (?x)              # ignore whitespace in this regex
+      {{nps}}         #       level 0
+      {{open}}        # start level 1                      __
+        {{nps}}       #       level 1          _______    /*_>-<
+        {{open}}      # start level 2      ___/ _____ \__/ /
+          {{nps}}     #       level 2     <____/     \____/
+          {{open}}    # start level 3     is like snek... (by Valerie Haecky)
+            {{nps}}   #       level 3
+            {{open}}  # start level 4
+              {{nps}} #       level 4
+            {{close}} #   end level 4
+            {{nps}}   #       level 3
+          {{close}}   #   end level 3
+          {{nps}}     #       level 2
+          {{open}}    # start level 3
+            {{nps}}   #       level 3
+            {{open}}  # start level 4
+              {{nps}} #       level 4
+            {{close}} #   end level 4
+            {{nps}}   #       level 3
+          {{close}}   #   end level 3
+          {{nps}}     #       level 2
+        {{close}}     #   end level 2
+        {{nps}}       #       level 1
+        {{open}}      # start level 2
+          {{nps}}     #       level 2
+          {{open}}    # start level 3
+            {{nps}}   #       level 3
+            {{open}}  # start level 4
+              {{nps}} #       level 4
+            {{close}} #   end level 4
+            {{nps}}   #       level 3
+          {{close}}   #   end level 3
+          {{nps}}     #       level 2
+          {{open}}    # start level 3
+            {{nps}}   #       level 3
+            {{open}}  # start level 4
+              {{nps}} #       level 4
+            {{close}} #   end level 4
+            {{nps}}   #       level 3
+          {{close}}   #   end level 3
+          {{nps}}     #       level 2
+          {{open}}    # start level 3
+            {{nps}}   #       level 3
+            {{open}}  # start level 4
+              {{nps}} #       level 4
+            {{close}} #   end level 4
+            {{nps}}   #       level 3
+          {{close}}   #   end level 3
+          {{nps}}     #       level 2
+        {{close}}     #   end level 2
+        {{nps}}       #       level 1
+      {{close}}       #   end level 1
+      {{nps}}         #       level 0
   rule_lookahead: '{{just_eat}}{{ruleassign}}{{just_eat}}'
 
   var_lookahead_base: '{{just_eat}}({{varassign}}|{{shellassign}}){{just_eat}}'
@@ -47,7 +101,14 @@ variables:
   # we want to NOT match if there's a {{ruleassign}} before a {{varassign}}.
   var_lookahead: (?!{{rule_lookahead}}){{var_lookahead_base}}
 
-  first_assign_then_colon: '{{just_eat}}{{varassign}}{{just_eat}}{{ruleassign}}{{just_eat}}'
+  first_assign_then_colon: |
+    (?x)
+      {{just_eat}}
+        {{varassign}}
+      {{just_eat}}
+        {{ruleassign}}
+      {{just_eat}}
+
 contexts:
 
   # 3.1 What Makefiles Contain
@@ -161,10 +222,12 @@ contexts:
             - include: continuation-or-pop-on-line-end
     - match: (?= *::?)
       set:
-        - match: ::?\s*
-          scope: keyword.operator.assignment.makefile
+        - match: (::?)\s*
+          captures:
+            1: keyword.operator.assignment.makefile
           set:
-            - meta_content_scope: meta.function.arguments.makefile string.unquoted.makefile
+            - meta_content_scope: >-
+                meta.function.arguments.makefile string.unquoted.makefile
             - include: line-continuation
             - include: variable-substitutions
             - include: highlight-percentage-sign
@@ -332,17 +395,22 @@ contexts:
     - include: quoted-string
 
   function-invocations:
-    - match: (\$\()(call)\s+([a-zA-Z0-9\-_]+)(,)
+    - match: ({{function_call_token_begin}})(call)\s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
         2: constant.language.call.makefile
-        3: variable.function.makefile
-        4: punctuation.separator.makefile
       push:
-        - meta_content_scope: meta.function-call.arguments.makefile
-        - include: inside-function-call
-    - match: (\$\()(patsubst|filter)\s
+        - meta_content_scope: >-
+            meta.function-call.makefile variable.function.makefile
+        - match: (?=,)
+          set:
+            - meta_content_scope: meta.function-call.makefile
+            - match: \,
+              scope: punctuation.separator.makefile
+              set: inside-function-call
+        - include: variable-substitutions
+    - match: ({{function_call_token_begin}})(patsubst|filter)\s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
@@ -351,7 +419,7 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: highlight-percentage-sign
         - include: inside-function-call
-    - match: (\$\()(wildcard)\s
+    - match: ({{function_call_token_begin}})(wildcard)\s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
@@ -360,7 +428,7 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: inside-function-call
         - include: highlight-wildcard-sign
-    - match: (\$\()(info|warning|error)\s
+    - match: ({{function_call_token_begin}})(info|warning|error)\s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
@@ -375,13 +443,47 @@ contexts:
         - match: \,
           scope: punctuation.separator.makefile
         - include: variable-substitutions
-    - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|guile) \s
+    - match: | # multiline string
+        (?x)   # ignore whitespace
+        ({{function_call_token_begin}})
+          (
+            subst|
+            strip|
+            findstring|
+            filter-out|
+            sort|
+            word|
+            wordlist|
+            words|
+            firstword|
+            lastword|
+            dir|
+            notdir|
+            suffix|
+            basename|
+            addsuffix|
+            addprefix|
+            join|
+            realpath|
+            abspath|
+            if|
+            or|
+            and|
+            foreach|
+            file|
+            value|
+            eval|
+            origin|
+            flavor|
+            guile
+          )
+          \s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
         2: support.function.builtin.makefile
       push: inside-function-call
-    - match: (\$\()(shell)\s
+    - match: ({{function_call_token_begin}})(shell)\s
       captures:
         1: keyword.other.block.begin.makefile
         2: support.function.builtin.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -475,4 +475,4 @@ contexts:
     - match: (\$)[[:alpha:]]
       captures:
         0: variable.other.makefile
-        1: punctuation.definition.variable.makefile
+        1: keyword.other.single-character-variable.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -111,9 +111,15 @@ contexts:
     - match: ^\s*(else)\b
       captures:
         1: keyword.control.conditional.makefile
+      push:
+        - include: comments
+        - include: pop-on-line-end
     - match: ^\s*(endif)\b
       captures:
         1: keyword.control.conditional.makefile
+      push:
+        - include: comments
+        - include: pop-on-line-end
 
   highlight-percentage-sign:
     - match: \%
@@ -259,9 +265,8 @@ contexts:
       scope: constant.character.escape.makefile
 
   comments:
-    - match: \s*(\#)
-      captures:
-        1: punctuation.definition.comment.makefile
+    - match: \#
+      scope: punctuation.definition.comment.makefile
       push:
         - meta_scope: comment.line.number-sign.makefile
         - include: pop-on-line-end

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -346,7 +346,7 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: variable.function.makefile
+        2: support.function.builtin.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: highlight-percentage-sign
@@ -355,7 +355,7 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: variable.function.makefile
+        2: support.function.builtin.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: inside-function-call
@@ -364,7 +364,7 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: variable.function.makefile
+        2: support.function.builtin.makefile
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - match: \)
@@ -379,12 +379,12 @@ contexts:
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
-        2: variable.function.makefile
+        2: support.function.builtin.makefile
       push: inside-function-call
     - match: (\$\()(shell)\s
       captures:
         1: keyword.other.block.begin.makefile
-        2: variable.function.makefile
+        2: support.function.builtin.makefile
       push: scope:source.shell
       with_prototype:
         - match: \)

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -106,6 +106,9 @@ contexts:
           set:
             - meta_content_scope: string.unquoted.makefile
             - include: pop-on-line-end
+        - include: pop-on-line-end
+    - match: ^\s*(vpath)$
+      captures: keyword.control.vpath.makefile
     - match: ^\s*({{include}})\b
       captures:
         1: keyword.control.import.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -324,6 +324,8 @@ contexts:
     - match: \)
       scope: keyword.other.block.end.makefile
       pop: true
+    - match: \(
+      push: textual-parenthesis-balancer
     - match: \,
       scope: punctuation.separator.makefile
     - include: variable-substitutions
@@ -358,7 +360,22 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: inside-function-call
         - include: highlight-wildcard-sign
-    - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|error|warning|info|guile) \s
+    - match: (\$\()(info|warning|error)\s
+      captures:
+        0: meta.function-call.makefile
+        1: keyword.other.block.begin.makefile
+        2: variable.function.makefile
+      push:
+        - meta_content_scope: meta.function-call.arguments.makefile
+        - match: \)
+          scope: keyword.other.block.end.makefile
+          pop: true
+        - match: \(
+          push: textual-parenthesis-balancer
+        - match: \,
+          scope: punctuation.separator.makefile
+        - include: variable-substitutions
+    - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|guile) \s
       captures:
         0: meta.function-call.makefile
         1: keyword.other.block.begin.makefile
@@ -418,6 +435,11 @@ contexts:
             - include: variable-substitutions
             - include: continuation-or-pop-on-line-end
         - include: variable-substitutions
+
+  textual-parenthesis-balancer:
+    - match: \)
+      pop: true
+    - include: variable-substitutions
 
   eat-whitespace-then-pop:
     - clear_scopes: 1

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -228,8 +228,9 @@ contexts:
           captures:
             1: keyword.operator.assignment.makefile
           set:
-            - meta_content_scope: >
-                meta.function.arguments.makefile string.unquoted.makefile
+            - meta_content_scope:
+                meta.function.arguments.makefile 
+                string.unquoted.makefile
             - include: line-continuation
             - include: variable-substitutions
             - include: highlight-percentage-sign
@@ -403,8 +404,9 @@ contexts:
         1: keyword.other.block.begin.makefile
         2: constant.language.call.makefile
       push:
-        - meta_content_scope: >
-            meta.function-call.makefile variable.function.makefile
+        - meta_content_scope:
+            meta.function-call.makefile 
+            variable.function.makefile
         - match: (?=,)
           set:
             - meta_content_scope: meta.function-call.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -17,7 +17,7 @@ file_extensions:
   - OCamlMakefile
   - mak
   - mk
-first_line_match: '^#!\s*/usr/bin/make\b'
+first_line_match: ^#!\s*/usr/bin/make\b
 scope: source.makefile
 variables:
   

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -293,7 +293,7 @@ contexts:
     #     # A comment with a : colon
     #     
     # will match the rule-lookahead.
-    - match: (?=^\s*\#)
+    - match: (?=^\s*#)
       push:
         - match: \#
           scope: punctuation.definition.comment.makefile
@@ -411,7 +411,7 @@ contexts:
   value-to-be-defined:
     - meta_content_scope: string.unquoted.makefile
     - include: escape-literals
-    - match: (?=\#)
+    - match: (?=#)
       set:
         - match: \#
           scope: punctuation.definition.comment.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -121,7 +121,7 @@ contexts:
     - include: variable-definitions
     - match: (?={{rule_lookahead}})
       push: expect-rule
-    - include: function-invocations
+    - include: variable-substitutions
     - include: control-flow
     - match: ^\s*(endef)
       captures:

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -97,6 +97,15 @@ contexts:
     - include: continuation-or-pop-on-line-end
 
   control-flow:
+    - match: ^\s*(vpath)\s
+      captures:
+        1: keyword.control.vpath.makefile
+      push:
+        - include: highlight-wildcard-sign
+        - match: \s
+          set:
+            - meta_content_scope: string.unquoted.makefile
+            - include: pop-on-line-end
     - match: ^\s*({{include}})\b
       captures:
         1: keyword.control.import.makefile
@@ -124,6 +133,10 @@ contexts:
   highlight-percentage-sign:
     - match: \%
       scope: variable.language.makefile
+
+  highlight-wildcard-sign:
+    - match: \*
+      scope: variable.language.wildcard.makefile
 
   expect-rule:
     # Anything before the colon is part of the rule's name.
@@ -309,8 +322,7 @@ contexts:
       push:
         - meta_content_scope: meta.function-call.arguments.makefile
         - include: inside-function-call
-        - match: \*
-          scope: variable.language.wildcard.makefile
+        - include: highlight-wildcard-sign
     - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|error|warning|info|guile) \s
       captures:
         0: meta.function-call.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -168,13 +168,14 @@ contexts:
             - include: line-continuation
             - include: variable-substitutions
             - include: highlight-percentage-sign
-            - match: \#
-              scope: punctuation.definition.comment.makefile
+            - match: (?=#)
               set:
-                - clear_scopes: true
-                - meta_scope: comment.line.number-sign.makefile
-                - match: $
-                  set: recipe-junction-between-spaces-or-tabs
+                - match: \#
+                  scope: punctuation.definition.comment.makefile
+                  set:
+                    - meta_scope: comment.line.number-sign.makefile
+                    - match: $
+                      set: recipe-junction-between-spaces-or-tabs
             - match: $
               set: recipe-junction-between-spaces-or-tabs
             - match: ;

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -1,13 +1,13 @@
 %YAML 1.2
----
 # http://www.sublimetext.com/docs/3/syntax.html
+# https://www.gnu.org/software/make/manual/make.html
+--- #---------------------------------------------------------------------------
 # Converted from Makefile Improved by Kay-Uwe (Kiwi) Lorenz
 # Includes a few improvement like special-target, a bit more shell command,
 # better variable recognition, fix ifeq/ifneq missing highlight ...
 # Rewritten by Raoul Wols on May 2017.
 # 
-# All number references refer to the "Make manual" located at
-# https://www.gnu.org/software/make/manual/make.html
+# All number references refer to the "Make manual" (see link above).
 name: Makefile
 file_extensions:
   - make
@@ -19,6 +19,7 @@ file_extensions:
   - mk
 first_line_match: ^#!\s*/usr/bin/make\b
 scope: source.makefile
+#-------------------------------------------------------------------------------
 variables:
   
   varassign: (\?|\+|::?)?=
@@ -109,6 +110,7 @@ variables:
         {{ruleassign}}
       {{just_eat}}
 
+#-------------------------------------------------------------------------------
 contexts:
 
   # 3.1 What Makefiles Contain
@@ -226,7 +228,7 @@ contexts:
           captures:
             1: keyword.operator.assignment.makefile
           set:
-            - meta_content_scope: >-
+            - meta_content_scope: >
                 meta.function.arguments.makefile string.unquoted.makefile
             - include: line-continuation
             - include: variable-substitutions
@@ -401,7 +403,7 @@ contexts:
         1: keyword.other.block.begin.makefile
         2: constant.language.call.makefile
       push:
-        - meta_content_scope: >-
+        - meta_content_scope: >
             meta.function-call.makefile variable.function.makefile
         - match: (?=,)
           set:

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -278,6 +278,8 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
+        - include: textual-parenthesis-balancer
+        - include: quoted-string
 
   recipe-with-spaces:
     - meta_content_scope: meta.function.body.makefile
@@ -289,6 +291,8 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
+        - include: textual-parenthesis-balancer
+        - include: quoted-string
     - match: ^(\t)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.spaces.makefile
@@ -307,6 +311,8 @@ contexts:
         - include: line-continuation
         - include: variable-substitutions
         - include: pop-on-line-end
+        - include: textual-parenthesis-balancer
+        - include: quoted-string
     - match: ^([ ]+)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.tab.makefile
@@ -497,6 +503,8 @@ contexts:
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-substitutions
+        - include: textual-parenthesis-balancer
+        - include: quoted-string
 
   variable-definitions:
     - match: \s*(override)\b
@@ -533,6 +541,8 @@ contexts:
               with_prototype:
                 - include: variable-substitutions
                 - include: pop-on-line-end
+                - include: textual-parenthesis-balancer
+                - include: quoted-string
         - match: (?=\s*(!|\?|\+|::?)?=)
           set:
             - match: (!|\?|\+|::?)?=

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -2,7 +2,9 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 # Converted from Makefile Improved by Kay-Uwe (Kiwi) Lorenz
-# Includes a few improvement like special-target, a bit more shell command, better variable recognition, fix ifeq/ifneq missing highlight ...
+# Includes a few improvement like special-target, a bit more shell command,
+# better variable recognition, fix ifeq/ifneq missing highlight ...
+# Rewritten by Raoul Wols on May 2017.
 name: Makefile
 file_extensions:
   - make
@@ -14,182 +16,418 @@ file_extensions:
   - mk
 first_line_match: '^#!\s*/usr/bin/make\b'
 scope: source.makefile
+variables:
+  
+  varassign: (\?|\+|::?)?=
+  shellassign: '!='
+  startdirective: ifn?(def|eq)
+  include: '[s-]?include'
+  ruleassign: :(?!=)
+
+  # The big "rule lookahead". What we want to do is here is detect if the
+  # line that we are parsing is going to define a rule. So we need to check
+  # if we have something of the form <rule-name> : <rule-prerequisites>
+  # However matters become complicated by the fact that we can have arbitrary
+  # variable substitutions anywhere. We try to remedy this by hacking in a
+  # regex that matches up to four levels of nested parentheses, and ignores
+  # whatever's inside the parentheses.
+  nonparenchar: '[^()]'
+  nps: '{{nonparenchar}}*'
+  # Eats up to 4 nested parens
+  paren_eater: (?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*\))?{{nps}}*\))?{{nps}}*\))?{{nps}}\))?
+  just_eat: '{{nps}}{{paren_eater}}{{nps}}'
+  rule_lookahead: '{{just_eat}}{{ruleassign}}{{just_eat}}'
+
+  var_lookahead_base: '{{just_eat}}({{varassign}}|{{shellassign}}){{just_eat}}'
+  # Just as with rules we want to look ahead if we are going to define a var.
+  # However, due to the possibility of "target-specific" variables (see 6.11),
+  # we want to NOT match if there's a {{ruleassign}} before a {{varassign}}.
+  var_lookahead: (?!{{rule_lookahead}}){{var_lookahead_base}}
+
+  first_assign_then_colon: '{{just_eat}}{{varassign}}{{just_eat}}{{ruleassign}}{{just_eat}}'
 contexts:
+
+  # 3.1 What Makefiles Contain
+  # Makefiles contain five kinds of things: explicit rules, implicit rules, 
+  # variable definitions, directives, and comments.
   main:
-    - include: comment
-    - include: directive
-    - match: '^ *((export)\s+)?((?:\w|[-_])+)\s*((\?|\+|::|:)?=)'
+    - include: comments
+    - include: variable-definitions
+    - match: (?={{rule_lookahead}})
+      push: expect-rule
+    - include: function-invocations
+    - include: control-flow
+    - match: ^\s*(endef)
       captures:
-        2: keyword.control.makefile
-        3: variable.other.makefile
-        4: keyword.operator.assignment.makefile
+        1: invalid.illegal.stray.endef.makefile
+
+  inside-control-flow:
+    - meta_scope: meta.group.makefile
+    - match: "'"
+      scope: punctuation.definition.string.begin.makefile
+      push:
+        - meta_scope: string.quoted.single.makefile
+        - match: "'"
+          scope: punctuation.definition.string.end.makefile
+          pop: true
+        - include: escape-literals
+        - include: line-continuation
+        - include: variable-substitutions
+    - match: '"'
+      scope: punctuation.definition.string.begin.makefile
+      push:
+        - meta_scope: string.quoted.double.makefile
+        - match: '"'
+          scope: punctuation.definition.string.end.makefile
+          pop: true
+        - include: escape-literals
+        - include: line-continuation
+        - include: variable-substitutions
+    - match: \(
+      scope: punctuation.section.group.begin.makefile
+      push:
+        - match: \)
+          scope: punctuation.section.group.end.makefile
+          pop: true
+        - include: variable-substitutions
+        - match: \,
+          scope: punctuation.separator.makefile
+    - match: \)
+      scope: invalid.illegal.stray.paren.makefile
+    - include: continuation-or-pop-on-line-end
+
+  control-flow:
+    - match: ^\s*({{include}})\b
+      captures:
+        1: keyword.control.import.makefile
       push:
         - meta_content_scope: string.unquoted.makefile
-        - include: variable
-        - include: line_continuation
-        - match: (?<!\\)$(?=\n)
-          pop: true
-    - match: '^(?=\S[^:]+::?(?!\=))'
-      push:
-        - meta_scope: entity.name.function.makefile
-        - include: target
-        - match: (::?)(?!\=)
-          pop: true
-        - include: variable
-    - match: (?<=:)\s*
-      push:
-        - meta_scope: meta.function.prerequisites.makefile
-        - match: (?=^\t)|(?<!\\)$(?=\n)
-          pop: true
-        - include: variable
-        - include: directive
-        - include: target
-        - include: comment
-        - match: '\s*(\w+)\s*((\?|\+|::|:)?=)'
-          captures:
-            1: variable.other.makefile
-            2: keyword.operator.assignment.makefile
-          push:
-            - meta_content_scope: string.unquoted.makefile
-            - include: variable
-            - include: line_continuation
-            - match: (?<!\\)$(?=\n)
-              pop: true
-        - include: line_continuation
-    - match: ^\s*((?:-|s)?include|ifeq|ifneq|ifdef|ifndef|else|endif|vpath|export|unexport|define|endef|override)\b
-      scope: meta.keyword.control.makefile
+        - include: continuation-or-pop-on-line-end
+        - include: variable-substitutions
+        - include: comments
+    - match: \b{{startdirective}}\b
+      scope: keyword.control.conditional.makefile
+      push: inside-control-flow
+    - match: ^\s*(else)\b
       captures:
-        1: keyword.control.makefile
-      push:
-        - meta_scope: meta.directive.include.makefile
-        - include: variable
-        - match: \n
-          pop: true
-    - match: ^(?=\t)
-      push:
-        - meta_scope: meta.function.body.makefile
-        - match: ^(?!\t)
-          pop: true
-        - include: at
-        - include: string
-        - include: variable
-        - include: comment
-        - include: backtick
-        - include: shell
-        - include: line_continuation
-  directive:
-    - match: ^\s*(ifeq|ifneq)\s*\(
+        1: keyword.control.conditional.makefile
+    - match: ^\s*(endif)\b
       captures:
-        1: keyword.control.makefile
+        1: keyword.control.conditional.makefile
+
+  highlight-percentage-sign:
+    - match: \%
+      scope: variable.language.makefile
+
+  expect-rule:
+    # Anything before the colon is part of the rule's name.
+    - meta_scope: meta.function.makefile entity.name.function.makefile
+    - include: line-continuation
+    - include: variable-substitutions
+    - include: highlight-percentage-sign
+    - match: (?= *::?[^=]+[!:?]?=)
+      set:
+        - match: ::?
+          scope: keyword.operator.assignment.makefile
+          set:
+            - include: variable-definitions
+            - include: variable-substitutions
+            - include: continuation-or-pop-on-line-end
+    - match: (?= *::?)
+      set:
+        - match: ::?
+          scope: keyword.operator.assignment.makefile
+          set:
+            - meta_content_scope: meta.function.arguments.makefile string.unquoted.makefile
+            - include: line-continuation
+            - include: variable-substitutions
+            - include: highlight-percentage-sign
+            - match: \#
+              scope: punctuation.definition.comment.makefile
+              set:
+                - clear_scopes: true
+                - meta_scope: comment.line.number-sign.makefile
+                - match: $
+                  set: recipe-junction-between-spaces-or-tabs
+            - match: $
+              set: recipe-junction-between-spaces-or-tabs
+            - match: ;
+              scope: punctuation.separator.end.makefile
+              set: recipe-inline
+
+  recipe-junction-between-spaces-or-tabs:
+    - meta_content_scope: meta.function.body.makefile
+    - include: comments
+    - match: ^\s*({{startdirective}})
+      captures:
+        1: keyword.control.conditional.makefile
       push:
-        - meta_scope: meta.directive.condition.makefile
-        - include: string
-        - include: variable
-        - include: shell
-        - match: \)
+        - include: inside-control-flow
+        - include: recipe-junction-between-spaces-or-tabs
+    - match: ^(?=[ ]+([-@]{1,2})?)
+      set: recipe-with-spaces
+    - match: ^(?=\t([-@]{1,2})?)
+      set: recipe-with-tabs
+    - match: ^
+      pop: true
+
+  recipe-inline:
+    - include: recipe-junction-between-spaces-or-tabs
+    - include: recipe-common-includes
+
+  recipe-with-spaces:
+    - meta_content_scope: meta.function.body.makefile
+    - match: ^([ ]+)([-@]{1,2})?
+      captures:
+        2: constant.language.makefile
+      push: scope:source.shell
+      with_prototype:
+        - include: line-continuation
+        - include: variable-substitutions
+        - include: pop-on-line-end
+    - match: ^(\t)([-@]{1,2})?
+      captures:
+        1: invalid.illegal.inconsistent.expected.spaces.makefile
+        2: constant.language.makefile
+    - include: recipe-common
+    - match: ^(?![ ]+)
+      pop: true
+
+  recipe-with-tabs:
+    - meta_content_scope: meta.function.body.makefile
+    - match: ^\t([-@]{1,2})?
+      captures:
+        1: constant.language.makefile
+      push: scope:source.shell
+      with_prototype:
+        - include: line-continuation
+        - include: variable-substitutions
+        - include: pop-on-line-end
+    - match: ^([ ]+)([-@]{1,2})?
+      captures:
+        1: invalid.illegal.inconsistent.expected.tab.makefile
+        2: constant.language.makefile
+    - include: recipe-common
+    - match: ^(?!\t)
+      pop: true
+
+  recipe-common:
+    - include: control-flow
+    - match: ^\n
+
+  line-continuation:
+    - match: (\\)([ ]*)$\n?
+      captures:
+        1: punctuation.separator.continuation.line.makefile
+      # make sure to resume parsing at next line
+      push:
+        - match: (?=\S|^\s*$)
           pop: true
-  comment:
-    - match: ^\s*(\#)
+
+  pop-on-line-end:
+    - match: $
+      pop: true
+
+  continuation-or-pop-on-line-end:
+    - include: line-continuation
+    - include: pop-on-line-end
+
+  quoted-string:
+    - match: "'"
+      scope: punctuation.definition.string.begin.makefile
+      push:
+        - meta_scope: string.quoted.single.makefile
+        - match: "'"
+          scope: punctuation.definition.string.end.makefile
+          pop: true
+        - include: escape-literals
+        - include: line-continuation
+        - include: variable-substitutions
+    - match: '"'
+      scope: punctuation.definition.string.begin.makefile
+      push:
+        - meta_scope: string.quoted.double.makefile
+        - match: '"'
+          scope: punctuation.definition.string.end.makefile
+          pop: true
+        - include: escape-literals
+        - include: line-continuation
+        - include: variable-substitutions
+
+  escape-literals:
+    - match: \\.
+      scope: constant.character.escape.makefile
+
+  comments:
+    - match: \s*(\#)
       captures:
         1: punctuation.definition.comment.makefile
       push:
         - meta_scope: comment.line.number-sign.makefile
-        - match: $\n
-          pop: true
-        - match: (?<!\\)\\$\n
-          scope: punctuation.separator.continuation.makefile
-    - match: '\#'
+        - include: pop-on-line-end
+
+  inside-function-call:
+    - meta_content_scope: meta.function-call.arguments.makefile
+    - match: \)
+      scope: punctuation.definition.variable.end.makefile
+      pop: true
+    - match: \,
+      scope: punctuation.separator.makefile
+    - include: variable-substitutions
+    - include: quoted-string
+
+  function-invocations:
+    - match: (\$\()(call)\s+([a-zA-Z0-9\-_]+)(,)
       captures:
-        0: punctuation.definition.comment.makefile
+        0: meta.function-call.makefile
+        1: punctuation.definition.variable.begin.makefile
+        2: constant.language.call.makefile
+        3: support.function.makefile
+        4: punctuation.separator.makefile
       push:
-        - meta_scope: comment.line.number-sign.makefile
-        - match: $\n
-          pop: true
-        - match: (?<!\\)\\$\n
-          scope: punctuation.separator.continuation.makefile
-  at:
-    - match: ^\t+\@
-      scope: support.variable.makefile
-  backtick:
-    - match: "`"
+        - meta_content_scope: meta.function-call.arguments.makefile
+        - include: inside-function-call
+    - match: (\$\()(patsubst|filter)\s
+      captures:
+        0: meta.function-call.makefile
+        1: punctuation.definition.variable.begin.makefile
+        2: support.function.makefile
       push:
-        - meta_scope: string.interpolated.backtick.makefile
-        - match: "`"
-          pop: true
-        - include: scope:source.shell
-  shell:
-    - match: '(?x) (?<=[\s\(])\b(?:for|in|do|done|while|if|then|fi|elif|read|echo|case|esac|exit|die|printf)\b'
-      scope: support.function.builtin.makefile
-    - match: '(?x) (?: \;\; | \; | \[\[ | \]\] | \&\& | \|\| | \! | = | > | < | & | \| )'
-      scope: keyword.operator.makefile
-    - match: '(?x) \b(?:cp|mv|rm|cat|ls|\[|\]|find|grep|awk|perl|mkdir|rmdir|cd|cwd|pwd|svn|git|hg|scp|make|ps|sed|python|ruby|setenv|export|echo|test|source|ln|touch)\b'
-      scope: support.function.makefile
-    - include: line_continuation
-    - match: \b(true|false)\b
-      scope: constant.other.makefile
-    - include: variable
-  string:
-    - match: '(?<!\\)(["''])'
+        - meta_content_scope: meta.function-call.arguments.makefile
+        - include: highlight-percentage-sign
+        - include: inside-function-call
+    - match: (\$\()(wildcard)\s
+      captures:
+        0: meta.function-call.makefile
+        1: punctuation.definition.variable.begin.makefile
+        2: support.function.makefile
       push:
-        - meta_scope: string.source.makefile
-        - match: (?<!\\)\1
+        - meta_content_scope: meta.function-call.arguments.makefile
+        - include: inside-function-call
+        - match: \*
+          scope: variable.language.wildcard.makefile
+    - match: (?x) (\$\() (subst|strip|findstring|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|error|warning|info|guile) \s
+      captures:
+        0: meta.function-call.makefile
+        1: punctuation.definition.variable.begin.makefile
+        2: support.function.makefile
+      push: inside-function-call
+    - match: (\$\()(shell)\s
+      captures:
+        1: punctuation.definition.variable.begin.makefile
+        2: support.function.builtin.makefile
+      push: scope:source.shell
+      with_prototype:
+        - match: \)
+          scope: punctuation.definition.variable.end.makefile
           pop: true
-        - include: string_escapes
-        - include: variable
-  string_escapes:
-    - match: \\.
+        - include: variable-substitutions
+
+  variable-definitions:
+    - match: \s*(override)\b
+      captures:
+        1: keyword.control.makefile
+      set:
+        - match: \bdefine\b
+          scope: keyword.control.makefile
+          push: inside-define-directive-context
+        - include: variable-definitions
+        - include: continuation-or-pop-on-line-end
+    - match: \s*(define)\b
+      captures:
+        1: keyword.control.makefile
+      push: inside-define-directive-context
+    - match: ^\s*(export)\b
+      captures:
+        1: keyword.control.makefile
+      push:
+        - meta_content_scope: variable.other.makefile 
+        - include: continuation-or-pop-on-line-end
+        - include: variable-substitutions
+        - match: (\?|\+|::?)?=
+          scope: keyword.operator.assignment.makefile
+          set: value-to-be-defined
+    - match: (?={{var_lookahead}}|{{first_assign_then_colon}})
+      push:
+        - meta_content_scope: variable.other.makefile
+        - match: (?=\s*!=)
+          set:
+            - match: '!='
+              scope: keyword.operator.assignment.makefile
+              set: scope:source.shell
+              with_prototype:
+                - include: variable-substitutions
+                - include: pop-on-line-end
+        - match: (?=\s*(!|\?|\+|::?)?=)
+          set:
+            - match: (!|\?|\+|::?)?=
+              scope: keyword.operator.assignment.makefile
+              set: value-to-be-defined
+            - include: variable-substitutions
+            - include: continuation-or-pop-on-line-end
+        - include: variable-substitutions
+
+  value-to-be-defined:
+    - meta_content_scope: string.unquoted.makefile
+    - include: escape-literals
+    - match: (?=\#)
+      set:
+        - match: \#
+          scope: punctuation.definition.comment.makefile
+          set:
+            - meta_scope: comment.line.number-sign.makefile
+            - include: pop-on-line-end
+    - include: variable-substitutions
+    - include: continuation-or-pop-on-line-end
+
+  inside-define-directive-context:
+    - meta_content_scope: variable.other.makefile
+    - match: \s*(?=(!|\?|\+|::?)?=)
+      set:
+        - match: (!|\?|\+|::?)?=
+          scope: keyword.operator.assignment.makefile
+          set:
+            - meta_content_scope: string.unquoted.makefile
+            - match: ^\s*(endef)
+              captures:
+                1: keyword.control.makefile
+              pop: true
+    - match: $
+      set:
+        - meta_content_scope: string.unquoted.makefile
+        - match: ^\s*(endef)
+          captures:
+            1: keyword.control.makefile
+          pop: true  
+    - include: variable-substitutions
+
+  variable-sub-common:
+    - match: ':'
+      scope: punctuation.definition.substitution.makefile
+    - match: =
+      scope: punctuation.definition.assignment.makefile
+    - include: highlight-percentage-sign
+    - include: variable-substitutions
+
+  variable-substitutions:
+    - include: function-invocations
+    - match: \$\$?\(
+      scope: punctuation.definition.variable.begin.makefile
+      push:
+        - meta_scope: variable.other.makefile
+        - match: \)
+          scope: punctuation.definition.variable.end.makefile
+          pop: true
+        - include: variable-sub-common
+    - match: \$\$?{
+      scope: punctuation.definition.variable.end.makefile
+      push:
+        - meta_scope: variable.other.makefile
+        - match: \}
+          scope: punctuation.definition.variable.end.makefile
+          pop: true
+        - include: variable-sub-common
+    - match: \$\$?[@%<?^+|*]
+      scope: variable.language.automatic.makefile
+    - match: \$\$
       scope: constant.character.escape.makefile
-  line_continuation:
-    - match: \\\n
-      scope: punctuation.separator.continuation.makefile
-  variable:
-    - match: (?x) (\$\() (subst|patsubst|strip|findstring|filter|filter-out|sort|word|wordlist|words|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|wildcard|realpath|abspath|if|or|and|foreach|file|call|value|eval|origin|flavor|error|warning|info|guile) \s
-      captures:
-        1: punctuation.definition.variable.begin.makefile
-        2: support.function.builtin.makefile
-      push:
-        - meta_scope: meta.support.function.makefile
-        - match: (\))
-          captures:
-            1: punctuation.definition.variable.end.makefile
-          pop: true
-        - include: variable
-        - include: string
-    - match: (?x) (\$\() (shell) \s
-      captures:
-        1: punctuation.definition.variable.begin.makefile
-        2: support.function.builtin.makefile
-      push:
-        - meta_scope: meta.support.function.makefile
-        - match: (\))
-          captures:
-            1: punctuation.definition.variable.end.makefile
-          pop: true
-        - include: shell
-    - match: '(\$?\$\{)'
-      captures:
-        1: punctuation.definition.variable.begin.makefile
-      push:
-        - meta_scope: variable.source.makefile
-        - match: '(\})'
-          captures:
-            1: punctuation.definition.variable.end.makefile
-          pop: true
-        - include: variable
-    - match: (\$?\$\()
-      captures:
-        1: punctuation.definition.variable.begin.makefile
-      push:
-        - meta_scope: variable.source.makefile
-        - match: (\))
-          captures:
-            1: punctuation.definition.variable.end.makefile
-          pop: true
-        - include: variable
-    - match: '\$?\$[$<*^@+?]'
-      scope: support.variable.makefile
-    - match: \%
-      scope: keyword.operator.percent.makefile
-  target:
-    - match: (\.PHONY|\.SUFFIXES|\.DEFAULT|\.PRECIOUS|\.INTERMEDIATE|\.SECONDARY|\.SECONDARY|\.SECONDEXPANSION|\.DELETE_ON_ERROR|\.IGNORE|\.LOW_RESOLUTION_TIME|\.LOW_RESOLUTION_TIME|\.SILENT|\.EXPORT_ALL_VARIABLES|\.NOTPARALLEL|\.ONESHELL|\.POSIX|\bFORCE)\b
-      scope: constant.other.target.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -178,9 +178,11 @@ contexts:
                       set: recipe-junction-between-spaces-or-tabs
             - match: $
               set: recipe-junction-between-spaces-or-tabs
-            - match: ;
-              scope: punctuation.separator.end.makefile
-              set: recipe-inline
+            - match: (?=\s*;)
+              set:
+                - match: ;
+                  scope: punctuation.terminator.makefile
+                  set: recipe-inline
 
   recipe-junction-between-spaces-or-tabs:
     - meta_content_scope: meta.function.body.makefile
@@ -199,8 +201,17 @@ contexts:
       pop: true
 
   recipe-inline:
+    - meta_content_scope: meta.function.body.makefile
     - include: recipe-junction-between-spaces-or-tabs
     - include: control-flow
+    - match: $
+      set: recipe-junction-between-spaces-or-tabs
+    - match: ""
+      push: scope:source.shell
+      with_prototype:
+        - include: line-continuation
+        - include: variable-substitutions
+        - include: pop-on-line-end
 
   recipe-with-spaces:
     - meta_content_scope: meta.function.body.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -21,11 +21,11 @@ first_line_match: '^#!\s*/usr/bin/make\b'
 scope: source.makefile
 variables:
   
-  varassign: (\?|\+|::?)?=
-  shellassign: '!='
-  startdirective: ifn?(def|eq)
-  include: '[s-]?include'
-  ruleassign: :(?!=)
+  VarAssign: (\?|\+|::?)?=
+  ShellAssign: '!='
+  StartDirective: ifn?(def|eq)
+  Include: '[s-]?include'
+  RuleAssign: :(?!=)
 
   # The big "rule lookahead". What we want to do is here is detect if the
   # line that we are parsing is going to define a rule. So we need to check
@@ -34,20 +34,20 @@ variables:
   # variable substitutions anywhere. We try to remedy this by hacking in a
   # regex that matches up to four levels of nested parentheses, and ignores
   # whatever's inside the parentheses.
-  nonparenchar: '[^()]'
-  nps: '{{nonparenchar}}*'
+  NonParenChar: '[^()]'
+  NPS: '{{NonParenChar}}*'
   # Eats up to 4 nested parens
-  paren_eater: (?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*(?:\({{nps}}*\))?{{nps}}*\))?{{nps}}*\))?{{nps}}\))?
-  just_eat: '{{nps}}{{paren_eater}}{{nps}}'
-  rule_lookahead: '{{just_eat}}{{ruleassign}}{{just_eat}}'
+  ParenEater: (?:\({{NPS}}*(?:\({{NPS}}*(?:\({{NPS}}*(?:\({{NPS}}*\))?{{NPS}}*\))?{{NPS}}*\))?{{NPS}}\))?
+  JustEat: '{{NPS}}{{ParenEater}}{{NPS}}'
+  IsThisARule: '{{JustEat}}{{RuleAssign}}{{JustEat}}'
 
-  var_lookahead_base: '{{just_eat}}({{varassign}}|{{shellassign}}){{just_eat}}'
+  VarLookaheadBase: '{{JustEat}}({{VarAssign}}|{{ShellAssign}}){{JustEat}}'
   # Just as with rules we want to look ahead if we are going to define a var.
   # However, due to the possibility of "target-specific" variables (see 6.11),
-  # we want to NOT match if there's a {{ruleassign}} before a {{varassign}}.
-  var_lookahead: (?!{{rule_lookahead}}){{var_lookahead_base}}
+  # we want to NOT match if there's a {{RuleAssign}} before a {{VarAssign}}.
+  IsThisAVariable: (?!{{IsThisARule}}){{VarLookaheadBase}}
 
-  first_assign_then_colon: '{{just_eat}}{{varassign}}{{just_eat}}{{ruleassign}}{{just_eat}}'
+  FirstAssignThenColon: '{{JustEat}}{{VarAssign}}{{JustEat}}{{RuleAssign}}{{JustEat}}'
 contexts:
 
   # 3.1 What Makefiles Contain
@@ -56,7 +56,7 @@ contexts:
   main:
     - include: comments
     - include: variable-definitions
-    - match: (?={{rule_lookahead}})
+    - match: (?={{IsThisARule}})
       push: expect-rule
     - include: function-invocations
     - include: control-flow
@@ -112,7 +112,7 @@ contexts:
         - include: pop-on-line-end
     - match: ^\s*(vpath)$
       captures: keyword.control.vpath.makefile
-    - match: ^\s*({{include}})\b
+    - match: ^\s*({{Include}})\b
       captures:
         1: keyword.control.import.makefile
       push:
@@ -120,7 +120,7 @@ contexts:
         - include: continuation-or-pop-on-line-end
         - include: variable-substitutions
         - include: comments
-    - match: \b{{startdirective}}\b
+    - match: \b{{StartDirective}}\b
       scope: keyword.control.conditional.makefile
       push: inside-control-flow
     - match: ^\s*(else)\b
@@ -184,7 +184,7 @@ contexts:
   recipe-junction-between-spaces-or-tabs:
     - meta_content_scope: meta.function.body.makefile
     - include: comments
-    - match: ^\s*({{startdirective}})
+    - match: ^\s*({{StartDirective}})
       captures:
         1: keyword.control.conditional.makefile
       push:
@@ -387,7 +387,7 @@ contexts:
         - match: (\?|\+|::?)?=
           scope: keyword.operator.assignment.makefile
           set: value-to-be-defined
-    - match: (?={{var_lookahead}}|{{first_assign_then_colon}})
+    - match: (?={{IsThisAVariable}}|{{FirstAssignThenColon}})
       push:
         - meta_content_scope: variable.other.makefile
         - match: (?=\s*!=)

--- a/Makefile/Miscellaneous.tmPreferences
+++ b/Makefile/Miscellaneous.tmPreferences
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Miscellaneous</string>
 	<key>scope</key>
-	<string>source.makefile</string>
+	<string>source.makefile - string - comment</string>
 	<key>settings</key>
 	<dict>
 		<key>increaseIndentPattern</key>
-		<string>^[^\t ]+:</string>
+		<string>^[^:]+:(?!=)|^\s*(else\s+)?ifn?(eq|def)\b|^\s*else\b</string>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*(else|endif)\b</string>
 		<key>shellVariables</key>
 		<array>
 			<dict>

--- a/Makefile/Miscellaneous.tmPreferences
+++ b/Makefile/Miscellaneous.tmPreferences
@@ -9,15 +9,6 @@
 		<string>^[^:]+:(?!=)|^\s*(else\s+)?ifn?(eq|def)\b|^\s*else\b</string>
 		<key>decreaseIndentPattern</key>
 		<string>^\s*(else|endif)\b</string>
-		<key>shellVariables</key>
-		<array>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_START</string>
-				<key>value</key>
-				<string># </string>
-			</dict>
-		</array>
 	</dict>
 </dict>
 </plist>

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -27,29 +27,29 @@ foo := a.o b.o c.o
 bar := $(foo:.o=.c)
 # <- variable
 #   ^^ keyword
-#      ^^ punctuation
+#      ^^ keyword.other.block.begin
 #           ^ punctuation
 #              ^ punctuation
-#                 ^ punctuation
+#                 ^ keyword.other.block.end
 bar := $(foo:%.o=%.c)
 # <- variable
 #   ^^ keyword
-#      ^^ punctuation
+#      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
 #               ^ punctuation
 #                ^ variable.language
-#                   ^ punctuation
+#                   ^ keyword.other.block.end
 
 bar := ${foo:%.o=%.c}
 # <- variable
 #   ^^ keyword
-#      ^^ punctuation
+#      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
 #               ^ punctuation
 #                ^ variable.language
-#                   ^ punctuation
+#                   ^ keyword.other.block.end
 
 foo = bar # a comment
 #         ^ comment.line punctuation - string.unquoted
@@ -65,18 +65,18 @@ a := $($(x))
 sources := $($(a1)_objects:.o=.c)
 dir = foo
 $(dir)_sources := $(wildcard $(dir)/*.c)
-# <- punctuation
-#^ punctuation
+# <- keyword.other.block.begin
+#^ keyword.other.block.begin
 #              ^^ keyword.operator.assignment
-#                 ^^ punctuation
-#                            ^^ punctuation
-#                                 ^ punctuation
+#                 ^^ keyword.other.block.begin
+#                            ^^ keyword.other.block.begin
+#                                 ^ keyword.other.block.end
 #                                   ^ variable.language.wildcard
-#                                      ^ punctuation
+#                                      ^ keyword.other.block.end
 define $(dir)_print =
 # ^ keyword.control.makefile
-#      ^^ punctuation
-#           ^ punctuation
+#      ^^ keyword.other.block.begin
+#           ^ keyword.other.block.end
 #                   ^ keyword.operator.assignment
 lpr $($(dir)_sources)
 endef
@@ -163,9 +163,9 @@ lib/%.o: CFLAGS := -fPIC -g
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 # <- keyword.control
 #       ^ support.function.builtin
-#                     ^^variable.other punctuation.definition.variable.begin
-#                       ^^^^^^^^^^^^^variable.other
-#                                    ^variable.other punctuation.definition.variable.end
+#                     ^^ variable.other keyword.other.block.begin
+#                       ^^^^^^^^^^^^^ variable.other
+#                                    ^ variable.other keyword.other.block.end
 #                                                         ^^^ variable.language.automatic
     include $(MAKEFILE_PATH)Makefile.Defs
     # <- keyword.control
@@ -219,16 +219,16 @@ all: foo.o # a comment
 sources := $($(a1)_objects:.o=.c)
 # ^ variable
 #       ^^ keyword.operator
-#          ^^ string variable punctuation.definition
-#            ^^ string variable variable punctuation.definition
+#          ^^ string variable keyword.other.block.begin
+#            ^^ string variable variable keyword.other.block.begin
 #              ^^ string variable variable
-#                ^ string variable variable punctuation.definition
+#                ^ string variable variable keyword.other.block.end
 #                 ^^^^^^^^ string variable
 #                         ^ string variable punctuation.definition
 #                          ^^ string variable
 #                            ^ string variable punctuation.definition
 #                             ^^ string variable
-#                               ^ string variable punctuation.definition
+#                               ^ string variable keyword.other.block.end
 
 CC=g++
 #<- variable.other
@@ -242,10 +242,10 @@ SOURCES=main.cpp hello.cpp factorial.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 #<- variable.other
 #      ^ keyword.operator.assignment
-#       ^^ string.unquoted punctuation.definition.variable.begin
+#       ^^ string.unquoted keyword.other.block.begin
 #                ^ string.unquoted variable.other punctuation.definition.substitution
 #                     ^ string.unquoted variable.other punctuation.definition
-#                        ^ string.unquoted punctuation.definition.variable.end
+#                        ^ string.unquoted keyword.other.block.end
 EXECUTABLE=hello
 
 lib: foo.o bar.o lose.o win.o
@@ -261,12 +261,12 @@ lib: foo.o bar.o lose.o win.o
 all: $(SOURCES) $(EXECUTABLE)
 #<- entity.name.function
 #  ^ keyword.operator.assignment
-#    ^^ variable.other punctuation.definition.variable.begin
+#    ^^ variable.other keyword.other.block.begin
 #      ^^^^^^^ variable.other
-#             ^ variable.other punctuation.definition.variable.end
-#               ^^ variable.other punctuation.definition.variable.begin
+#             ^ variable.other keyword.other.block.end
+#               ^^ variable.other keyword.other.block.begin
 #                 ^^^^^^^^^^ variable.other
-#                           ^ variable.other punctuation.definition.variable.end
+#                           ^ variable.other keyword.other.block.end
 
 export FOO=foo
 # ^ keyword.control
@@ -295,12 +295,12 @@ FOO = some \
 reverse = $(2) $(1)
 # <- variable.other
 #       ^ keyword.operator.assignment
-#         ^^ punctuation.definition.variable.begin
+#         ^^ keyword.other.block.begin
 #           ^ string.unquoted variable.other
 #             ^ string.unquoted
-#              ^^ punctuation.definition.variable.begin
+#              ^^ keyword.other.block.begin
 #                ^ string.unquoted variable.other
-#                 ^ punctuation.definition.variable.end
+#                 ^ keyword.other.block.end
 
 foo = $(call reverse,a,b)
 #       ^ constant.language.call
@@ -309,30 +309,30 @@ foo = $(call reverse,a,b)
 #                    ^ string.unquoted meta.function-call.arguments
 #                     ^ string.unquoted meta.function-call.arguments punctuation.separator
 #                      ^ string.unquoted meta.function-call.arguments
-#                       ^ string.unquoted punctuation.definition.variable.end
+#                       ^ string.unquoted keyword.other.block.end
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 #              ^^^^^^^^^ meta.function-call support.function
 #                          ^^^^^^^^ meta.function-call.arguments meta.function-call support.function
 #                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
 #                                               ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments
-#                                                ^^ punctuation
+#                                                ^^ keyword.other.block.begin
 #                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
-#                                                   ^ punctuation
+#                                                   ^ keyword.other.block.end
 #                                                    ^ punctuation.separator
-#                                                     ^^ punctuation
+#                                                     ^^ keyword.other.block.begin
 #                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
 #                                                             ^ string.unquoted
 #                                                              ^ punctuation.separator
 #                                                               ^ string.unquoted
 #                                                                ^ punctuation.separator
-#                                                                 ^^ punctuation.definition
+#                                                                 ^^ keyword.other.block.begin
 #                                                                   ^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
-#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other punctuation
-#                                                                        ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments punctuation
-#                                                                         ^ meta.function-call.arguments meta.function-call.arguments punctuation
-#                                                                          ^ meta.function-call.arguments punctuation
-#                                                                           ^ punctuation
+#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other keyword.other.block.end
+#                                                                        ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
+#                                                                         ^ meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
+#                                                                          ^ meta.function-call.arguments keyword.other.block.end
+#                                                                           ^ keyword.other.block.end
 
 LS := $(call pathsearch,ls)
 
@@ -341,9 +341,9 @@ LS := $(call pathsearch,ls)
 
 sinclude $(MAKEFILE_PATH)Makefile.Defs
 # <- keyword.control.import
-#        ^ string.unquoted variable.other punctuation
+#        ^ string.unquoted variable.other keyword.other.block.begin
 #          ^ string.unquoted variable.other
-#                       ^ string.unquoted variable.other punctuation
+#                       ^ string.unquoted variable.other keyword.other.block.end
 
 
 CC=g++
@@ -363,13 +363,13 @@ OBJECTS=$(SOURCES:.cpp=.o)
 
 all: $(SOURCES) hello.o
 # <- entity.name.function.makefile
-#    ^ punctuation.definition.variable.begin.makefile
+#    ^ keyword.other.block.begin
 #      ^ variable.other.makefile
 
 $(EXECUTABLE): $(OBJECTS)
-# <- punctuation.definition.variable.begin.makefile
+# <- keyword.other.block.begin
 # ^ variable.other.makefile
-#              ^ punctuation.definition.variable.begin.makefile
+#              ^ keyword.other.block.begin
 #                ^ variable.other.makefile
 	@$(CC) $(LDFLAGS) $(OBJECTS) -o $@
 	# <- constant.language
@@ -401,18 +401,18 @@ help::
 $(warning he:llo)
 # ^ meta.function-call support.function
 #         ^^^ meta.function-call.arguments.makefile - punctuation
-#               ^ punctuation
+#               ^ keyword.other.block.end
 
 all: deps
 	$(warning he:llo)
 	# ^ meta.function-call support.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
-	#               ^ punctuation
+	#               ^ keyword.other.block.end
 deps:
 	$(warning he:llo)
 	# ^ meta.function-call support.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
-	#               ^ punctuation
+	#               ^ keyword.other.block.end
 all: 
 # ^ meta.function entity.name.function
 #  ^ keyword.operator.assignment
@@ -504,14 +504,14 @@ a : b ;
 #     ^ punctuation
 
 a-$(b) := c
-# ^ punctuation
-#    ^ punctuation
+# ^ keyword.other.block.begin
+#    ^ keyword.other.block.end
 #      ^^ keyword.operator
 #         ^ string.unquoted
 
 $(a): b
-# <- punctuation
-#  ^ meta.function entity.name.function punctuation
+# <- keyword.other.block.begin
+#  ^ meta.function entity.name.function keyword.other.block.end
 #   ^ keyword.operator
 #     ^ meta.function.arguments string.unquoted
 	$(Q)$(MAKE) $(build)=$@
@@ -527,7 +527,7 @@ $(a:b=c) : d
 	#                    ^^ meta.function.body variable.language.automatic
 
 $(X:a=b) : w ;
-# <- meta.function entity.name.function variable.other punctuation
+# <- meta.function entity.name.function variable.other keyword.other.block.begin
 #        ^ keyword.operator
 #          ^^ meta.function.arguments string.unquoted
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -105,10 +105,10 @@ file_list != find . -name '*.c'
 #            ^ source.shell
 
 hash := $(shell printf '\043')
-#         ^variable.function
+#         ^ support.function
 #               ^ source.shell
 var := $(shell find . -name "*.c")
-#        ^variable.function
+#        ^ support.function
 #              ^ source.shell
 
 ########################################
@@ -192,7 +192,7 @@ lib/%.o: CFLAGS := -fPIC -g
 
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 # <- keyword.control
-#       ^ variable.function
+#       ^ support.function
 #                     ^^ variable.parameter keyword.other.block.begin
 #                       ^^^^^^^^^^^^^ variable.parameter
 #                                    ^ variable.parameter keyword.other.block.end
@@ -350,16 +350,16 @@ foo = $(call reverse,a,b)
 #                       ^ string.unquoted keyword.other.block.end
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
-#              ^^^^^^^^^ meta.function-call variable.function
-#                          ^^^^^^^^ meta.function-call.arguments meta.function-call variable.function
-#                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call variable.function
+#              ^^^^^^^^^ meta.function-call support.function
+#                          ^^^^^^^^ meta.function-call.arguments meta.function-call support.function
+#                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
 #                                               ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments
 #                                                ^^ keyword.other.block.begin
 #                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter
 #                                                   ^ keyword.other.block.end
 #                                                    ^ punctuation.separator
 #                                                     ^^ keyword.other.block.begin
-#                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call variable.function
+#                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
 #                                                             ^ string.unquoted
 #                                                              ^ punctuation.separator
 #                                                               ^ string.unquoted
@@ -437,18 +437,18 @@ help::
 	# <- constant.language
 
 $(warning he:llo)
-# ^ meta.function-call variable.function
+# ^ meta.function-call support.function
 #         ^^^ meta.function-call.arguments.makefile - punctuation
 #               ^ keyword.other.block.end
 
 all: deps
 	$(warning he:llo)
-	# ^ meta.function-call variable.function
+	# ^ meta.function-call support.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
 	#               ^ keyword.other.block.end
 deps:
 	$(warning he:llo)
-	# ^ meta.function-call variable.function
+	# ^ meta.function-call support.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
 	#               ^ keyword.other.block.end
 all: 
@@ -686,7 +686,7 @@ else # some comment
 endif
 # <- keyword
 
-# Another case where the lookahead for the colon used to fails:
+# Another case where the lookahead for the colon used to fail:
 ifneq ($(words $(subst :, ,$(CURDIR))), 1)
 #                      ^ meta.function-call.arguments meta.function-call.arguments - keyword.operator
   $(error main directory cannot contain spaces nor colons)
@@ -745,10 +745,15 @@ else
 endif
 ifndef ARDMK_DIR_MSG
     $(call show_config_variable,ARDMK_DIR,[COMPUTED],(relative to $(notdir $(lastword $(MAKEFILE_LIST)))))
+    #      ^ variable.function
+    #                                                               ^ support.function
+    #                                                                        ^ support.function
     #                                                                                                   ^ - keyword.other.block.end
     #                                                                                                    ^ keyword.other.block.end
 else
     $(call show_config_variable,ARDMK_DIR,[USER])
+    #    ^ constant.language
+    #      ^ variable.function
 endif
 
 kselftest-merge:
@@ -765,6 +770,12 @@ search:
     #                                                   ^ variable.language.wildcard
         search
 
+CC_VERSION := $(shell $(CC) -dumpversion)
+$(call show_config_variable,CC_VERSION,[COMPUTED],($(CC_NAME)))
+#                                                           ^ keyword.other.block.end
+#                                                            ^ - keyword.other.block.end
+#                                                             ^ keyword.other.block.end
+
 # A recipe may contain empty lines like below
 help:
     @echo  'Cleaning targets:'
@@ -778,4 +789,10 @@ help:
     #                ^ - keyword.operator.assignment
     @echo  '        2: warnings which occur quite often but may still be relevant'
     # <- meta.function.body constant.language
+
+CC_VERSION := $(shell $(CC) -dumpversion)
+$(call show_config_variable,CC_VERSION,[COMPUTED],($(CC_NAME)))
+#                                                           ^ keyword.other.block.end
+#                                                            ^ - keyword.other.block.end
+#                                                             ^ keyword.other.block.end
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -1,23 +1,308 @@
 # SYNTAX TEST "Packages/Makefile/Makefile.sublime-syntax"
 
+#################################
+# 6.3.1 substitution references #
+#################################
+
+foo := a.o b.o c.o
+# <- variable
+#   ^^ keyword
+#      ^^^^^^^^^^^ string
+bar := $(foo:.o=.c)
+# <- variable
+#   ^^ keyword
+#      ^^ punctuation
+#           ^ punctuation
+#              ^ punctuation
+#                 ^ punctuation
+bar := $(foo:%.o=%.c)
+# <- variable
+#   ^^ keyword
+#      ^^ punctuation
+#           ^ punctuation
+#            ^ variable.language
+#               ^ punctuation
+#                ^ variable.language
+#                   ^ punctuation
+
+#################################
+# 6.3.2 computed variable names #
+#################################
+
+x = $(y)
+y = z
+z = Hello
+a := $($(x))
+sources := $($(a1)_objects:.o=.c)
+dir = foo
+$(dir)_sources := $(wildcard $(dir)/*.c)
+# <- punctuation
+#^ punctuation
+#              ^^ keyword.operator.assignment
+#                 ^^ punctuation
+#                            ^^ punctuation
+#                                 ^ punctuation
+#                                   ^ variable.language.wildcard
+#                                      ^ punctuation
+define $(dir)_print =
+# ^ keyword.control.makefile
+#      ^^ punctuation
+#           ^ punctuation
+#                   ^ keyword.operator.assignment
+lpr $($(dir)_sources)
+endef
+
+#########################
+# 6.5 setting variables #
+#########################
+
+FOO ?= bar
+
+ifeq ($(origin FOO), undefined)
+FOO = bar
+endif
+
+hash != printf '\043'
+#       ^ source.shell
+file_list != find . -name '*.c'
+#            ^ source.shell
+
+hash := $(shell printf '\043')
+#         ^support.function.builtin
+#               ^ source.shell
+var := $(shell find . -name "*.c")
+#        ^support.function.builtin
+#              ^ source.shell
+
+########################################
+# 6.6 appending more text to variables #
+########################################
+
+objects = main.o foo.o bar.o utils.o
+objects += another.o
+CFLAGS = $(includes) -O
+CFLAGS += -pg # enable profiling
+
+##############################
+# 6.7 the override directive #
+##############################
+
+override variable = value
+# ^ keyword.control
+override variable := value
+override variable += more text
+override CFLAGS += -g
+override define foo =
+#                   ^ keyword.operator.assignment
+bar
+endef
+override define foo ?=
+#                   ^^ keyword.operator.assignment
+bar
+endef
+override define foo :=
+#                   ^^ keyword.operator.assignment
+bar
+endef
+# ^ keyword.control
+
+endef
+# <- invalid.illegal.stray
+
+########################################
+# 6.11 target-specific variable values #
+########################################
+
+prog : CFLAGS = -g
+#    ^ keyword.operator
+#      ^ variable - string
+#             ^ keyword
+#               ^^ string - meta.function.arguments
+
+#########################################
+# 6.12 pattern-specific variable values #
+#########################################
+
+lib/%.o: CFLAGS := -fPIC -g
+#      ^ keyword.operator
+%.o: CFLAGS := -g
+#  ^ keyword.operator
+
 # Line comment
 # <- comment
 
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
-# <- keyword.control.makefile
-#       ^ support.function.builtin.makefile
-#                                                  ^ keyword.operator.makefile
-#                                                           ^ support.variable.makefile
-	include $(MAKEFILE_PATH)Makefile.Defs
-	# <- keyword.control.makefile
+# <- keyword.control
+#       ^ support.function.builtin
+#                     ^^variable.other punctuation.definition.variable.begin
+#                       ^^^^^^^^^^^^^variable.other
+#                                    ^variable.other punctuation.definition.variable.end
+#                                                         ^^^ variable.language.automatic
+    include $(MAKEFILE_PATH)Makefile.Defs
+    # <- keyword.control
+    # IMPORTANT NOTE: Extra spaces are allowed and ignored at the beginning of 
+    # the line, but the first character must not be a tab (or the value of 
+    # .RECIPEPREFIX) — if the line begins with a tab, it will be considered a 
+    # recipe line.
 endif
-# <- keyword.control.makefile
+# <- keyword.control
+
+a_objects := a.o b.o c.o
+# ^ variable.other.makefile
+#         ^^ keyword.operator.assignment
+#           ^^^^^^^^^^^^ string
+1_objects := 1.o 2.o 3.o
+# ^^^^^^^ variable.other
+#         ^^ keyword.operator.assignment
+#           ^^^^^^^^^^^^ string.unquoted
+
+all: foo.o
+    ld a
+    ar b
+    asdf
+    @echo "that's, like, your opinion man!" # some movie?
+	asdf
+# <- invalid.illegal.inconsistent.expected.spaces
+
+all: foo.o
+    ld a
+    ar b
+    asdf
+    @echo "that's, like, your opinion man!" # some movie?
+    # <- constant.language
+	asdf
+# <- invalid.illegal.inconsistent.expected.spaces
+
+
+sources := $($(a1)_objects:.o=.c)
+# ^ variable
+#       ^^ keyword.operator
+#          ^^ string variable punctuation.definition
+#            ^^ string variable variable punctuation.definition
+#              ^^ string variable variable
+#                ^ string variable variable punctuation.definition
+#                 ^^^^^^^^ string variable
+#                         ^ string variable punctuation.definition
+#                          ^^ string variable
+#                            ^ string variable punctuation.definition
+#                             ^^ string variable
+#                               ^ string variable punctuation.definition
+
+CC=g++
+#<- variable.other
+# ^ keyword.operator.assignment
+#  ^^^ string.unquoted
+CFLAGS=-c -Wall
+LDFLAGS=
+#<- variable.other
+#      ^ keyword.operator.assignment
+SOURCES=main.cpp hello.cpp factorial.cpp
+OBJECTS=$(SOURCES:.cpp=.o)
+#<- variable.other
+#      ^ keyword.operator.assignment
+#       ^^ string.unquoted punctuation.definition.variable.begin
+#                ^ string.unquoted variable.other punctuation.definition.substitution
+#                     ^ string.unquoted variable.other punctuation.definition
+#                        ^ string.unquoted punctuation.definition.variable.end
+EXECUTABLE=hello
+
+lib: foo.o bar.o lose.o win.o
+	ar r lib $@
+	ar whatevs
+# <- meta.function.body
+	# <- meta.function.body
+	# BIG NOTE: This comment is actually a shell comment, not a makefile
+	# comment. Everything on a recipe line is passed to the shell; even lines
+	# starting with a numbrer sign! It depends on the particular shell if it 
+	# gets treated as comments, but for all intents and purposes it should.
+
+all: $(SOURCES) $(EXECUTABLE)
+#<- entity.name.function
+#  ^ keyword.operator.assignment
+#    ^^ variable.other punctuation.definition.variable.begin
+#      ^^^^^^^ variable.other
+#             ^ variable.other punctuation.definition.variable.end
+#               ^^ variable.other punctuation.definition.variable.begin
+#                 ^^^^^^^^^^ variable.other
+#                           ^ variable.other punctuation.definition.variable.end
+
+export FOO=foo
+# ^ keyword.control
+#      ^ variable.other
+#         ^ keyword.operator.assignment
+#          ^ string.unquoted
+
+$(EXECUTABLE): $(OBJECTS)
+# <- meta.function entity.name.function
+	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+
+
+.cpp.o: a.c b.c
+# <- meta.function entity.name.function
+	$(CC) $(CFLAGS) $< -o $@
+	#               ^^ meta.function.body variable.language.automatic
+	#                     ^^ meta.function.body variable.language.automatic
+
+FOO = some \
+      line \
+      continuation \
+      in \
+      here
+#        ^ string.unquoted
+
+reverse = $(2) $(1)
+# <- variable.other
+#       ^ keyword.operator.assignment
+#         ^^ punctuation.definition.variable.begin
+#           ^ string.unquoted variable.other
+#             ^ string.unquoted
+#              ^^ punctuation.definition.variable.begin
+#                ^ string.unquoted variable.other
+#                 ^ punctuation.definition.variable.end
+
+foo = $(call reverse,a,b)
+#       ^ constant.language.call
+#            ^ string.unquoted - meta.function-call.arguments
+#                   ^ string.unquoted punctuation.separator - meta.function-call.arguments
+#                    ^ string.unquoted meta.function-call.arguments
+#                     ^ string.unquoted meta.function-call.arguments punctuation.separator
+#                      ^ string.unquoted meta.function-call.arguments
+#                       ^ string.unquoted punctuation.definition.variable.end
+
+pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
+#              ^^^^^^^^^ meta.function-call support.function
+#                          ^^^^^^^^ meta.function-call.arguments meta.function-call support.function
+#                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
+#                                               ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments
+#                                                ^^ punctuation
+#                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
+#                                                   ^ punctuation
+#                                                    ^ punctuation.separator
+#                                                     ^^ punctuation
+#                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
+#                                                             ^ string.unquoted
+#                                                              ^ punctuation.separator
+#                                                               ^ string.unquoted
+#                                                                ^ punctuation.separator
+#                                                                 ^^ punctuation.definition
+#                                                                   ^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
+#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other punctuation
+#                                                                        ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments punctuation
+#                                                                         ^ meta.function-call.arguments meta.function-call.arguments punctuation
+#                                                                          ^ meta.function-call.arguments punctuation
+#                                                                           ^ punctuation
+
+LS := $(call pathsearch,ls)
 
 -include $(MAKEFILE_PATH)Makefile.Defs
-# <- keyword.control.makefile
+# <- keyword.control.import
 
 sinclude $(MAKEFILE_PATH)Makefile.Defs
-# <- keyword.control.makefile
+# <- keyword.control.import
+#        ^ string.unquoted variable.other punctuation
+#          ^ string.unquoted variable.other
+#                       ^ string.unquoted variable.other punctuation
+
 
 CC=g++
 # <- variable.other.makefile
@@ -32,29 +317,336 @@ SOURCES+=hello.cpp
 EXECUTABLE=hello
 
 OBJECTS=$(SOURCES:.cpp=.o)
-#         ^ string.unquoted.makefile variable.source.makefile
+#         ^ string.unquoted.makefile variable.other.makefile
 
 all: $(SOURCES) hello.o
 # <- entity.name.function.makefile
 #    ^ punctuation.definition.variable.begin.makefile
-#      ^ variable.source.makefile
+#      ^ variable.other.makefile
 
 $(EXECUTABLE): $(OBJECTS)
 # <- punctuation.definition.variable.begin.makefile
-# ^ variable.source.makefile
+# ^ variable.other.makefile
 #              ^ punctuation.definition.variable.begin.makefile
-#                ^ variable.source.makefile
+#                ^ variable.other.makefile
 	@$(CC) $(LDFLAGS) $(OBJECTS) -o $@
-	#   <- support.variable.makefile
-	#                               ^ support.variable.makefile
+	# <- constant.language
+	#                               ^^ variable.language.automatic
 
-.PHONY: help
-# <- constant.other.target.makefile
+
+all: whatevs
+	@asdf
+	# <- constant.language
+
+all: whatevs
+	@asdf
+	@echo "Heyo!"
+	# <- constant.language
+
+export RCS_FIND_IGNORE := \( -name SCCS -o -name BitKeeper -o -name .svn -o    \
+              -name CVS -o -name .pc -o -name .hg -o -name .git \) \
+              -prune -o
+export RCS_TAR_IGNORE := --exclude SCCS --exclude BitKeeper --exclude .svn \
+             --exclude CVS --exclude .pc --exclude .hg --exclude .git
+
+# Use spaces instead of tabs... This complicates matters.
+.RECIPEPREFIX += 
 
 help::
-	@echo 'Excutable is $$(EXECUTABLE)'
-	# <- support.variable.makefile
-	 # <- support.function.makefile
-	#     ^ string.source.makefile
-	#                   ^ punctuation.definition.variable.begin.makefile
-	#                      ^ string.source.makefile variable.source.makefile
+	@echo "Excutable is $(EXECUTABLE)"
+	# <- constant.language
+
+$(warning he:llo)
+# ^ meta.function-call support.function
+#         ^^^ meta.function-call.arguments.makefile - punctuation
+#               ^ punctuation
+
+all: deps
+	$(warning he:llo)
+	# ^ meta.function-call support.function
+	#         ^^^ meta.function-call.arguments.makefile - punctuation
+	#               ^ punctuation
+deps:
+	$(warning he:llo)
+	# ^ meta.function-call support.function
+	#         ^^^ meta.function-call.arguments.makefile - punctuation
+	#               ^ punctuation
+all: 
+# ^ meta.function entity.name.function
+#  ^ keyword.operator.assignment
+	asdf
+# <- meta.function.body
+
+# OS detecting makefile
+# http://stackoverflow.com/questions/714100/os-detecting-makefile
+#
+ifeq ($(OS),Windows_NT)
+# ^ keyword.control
+    SEPARATOR = ;
+#           ^ variable.other
+#            ^ - variable.other
+#             ^ keyword.operator.assignment
+#               ^ string.unquoted
+
+else
+# ^ keyword.control
+    SEPARATOR = :
+#           ^ variable.other
+#            ^ - variable.other
+#             ^ keyword.operator.assignment
+#               ^ string.unquoted
+endif
+# ^ keyword.control
+
+a_percentage_%_sign := $(SOME_C%MPLEX:SUBSTITUTI%N)
+#            ^variable.other - variable.language
+#                              ^ string.unquoted variable.other variable.language
+#                                    ^ punctuation
+#                                               ^ string.unquoted variable.other variable.language
+
+%.cpp: %.o
+# <- meta.function entity.name.function variable.language
+#    ^ keyword.operator
+#      ^ meta.function.arguments string.unquoted variable.language
+	@rm -rf /
+	@rm -rf /
+	# <- meta.function.body constant.language
+	#^ meta.function.body - constant.language
+
+a = b # c
+#<- variable.other
+# ^ keyword.operator.assignment
+#   ^ string.unquoted
+#     ^ comment.line.number-sign punctuation.definition.comment
+#       ^ comment.line.number-sign
+
+a = b # c
+#<- variable.other
+# ^ keyword.operator.assignment
+#   ^ string.unquoted
+#     ^ comment.line.number-sign punctuation.definition.comment
+#       ^ comment.line.number-sign
+
+_modinst_:
+    @rm -rf $(MODLIB)/kernel
+    # <- constant.language
+    @rm -f $(MODLIB)/source
+    # <- constant.language
+    @mkdir -p $(MODLIB)/kernel
+    # <- constant.language
+    @ln -s `cd $(srctree) && /bin/pwd` $(MODLIB)/source
+    # <- constant.language
+    @if [ ! $(objtree) -ef  $(MODLIB)/build ]; then \
+        rm -f $(MODLIB)/build ; \
+        ln -s $(CURDIR) $(MODLIB)/build ; \
+    fi
+    @cp -f $(objtree)/modules.order $(MODLIB)/
+    # <- constant.language
+    @cp -f $(objtree)/modules.builtin $(MODLIB)/
+    # <- constant.language
+    $(Q)$(MAKE) -f $(srctree)/scripts/Makefile.modinst
+
+
+$(sort $(a)): $(b) ;
+#           ^ keyword.operator
+
+%:x
+# <- meta.function entity.name.function variable.language
+#^ keyword.operator
+	rm -rf /
+
+a : b ;
+# <- meta.function entity.name.function
+# ^ keyword.operator - entity.name.function
+#   ^ meta.function.arguments string.unquoted
+#     ^ punctuation
+
+a-$(b) := c
+# ^ punctuation
+#    ^ punctuation
+#      ^^ keyword.operator
+#         ^ string.unquoted
+
+$(a): b
+# <- punctuation
+#  ^ meta.function entity.name.function punctuation
+#   ^ keyword.operator
+#     ^ meta.function.arguments string.unquoted
+	$(Q)$(MAKE) $(build)=$@
+	# <- meta.function.body
+	#                    ^^ meta.function.body variable.language.automatic
+
+$(a:b=c) : d
+# <- meta.function entity.name.function
+#   ^ - meta.function.arguments
+#          ^ meta.function.arguments
+	$(Q)$(MAKE) $(build)=$@
+	# <- meta.function.body
+	#                    ^^ meta.function.body variable.language.automatic
+
+$(X:a=b) : w ;
+# <- meta.function entity.name.function variable.other punctuation
+#        ^ keyword.operator
+#          ^^ meta.function.arguments string.unquoted
+
+$(Y:%.cpp=%.o) := $(Z)
+# <- - meta.function
+#              ^^ keyword.operator.assignment
+
+include $(c)
+ifneq ($(a),)
+$(b): ; 
+	@git clone asdf
+	# ^ meta.function.body
+endif
+
+define filechk_utsrelease.h
+    if [ `echo -n "$(KERNELRELEASE)" | wc -c ` -gt $(uts_len) ]; then \
+      echo '"$(KERNELRELEASE)" exceeds $(uts_len) characters' >&2;    \
+      exit 1;                                                         \
+    fi;                                                               \
+    (echo \#define UTS_RELEASE \"$(KERNELRELEASE)\";)
+endef
+# <- keyword.control
+
+endef
+# <- invalid.illegal.stray
+
+# meta.group.conditional balancing
+ifeq ($(shell git status >/dev/null 2>&1 && echo USING_GIT),USING_GIT)
+  ifeq ($(shell git svn info >/dev/null 2>&1 && echo USING_GIT_SVN),USING_GIT_SVN)
+    # git-svn
+    ifeq ($(REVISION),)
+      REVISION := $(shell git svn find-rev git-svn)
+    endif
+    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/refs/remotes/git-svn)
+  else
+    # plain git
+    ifeq ($(REVISION),)
+      REVISION := $(shell git describe --always HEAD)
+    endif
+    GIT_BRANCH := $(shell git symbolic-ref HEAD 2>/dev/null)
+    VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/$(GIT_BRANCH))
+  endif
+else ifeq ($(shell hg root >/dev/null 2>&1 && echo USING_HG),USING_HG)
+  # mercurial
+  ifeq ($(REVISION),)
+    REVISION := $(shell hg id -i)
+  endif
+  VCSTURD := $(subst $(SPACE),\ ,$(shell hg root)/.hg/dirstate)
+else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
+  # subversion
+  ifeq ($(REVISION),)
+    REVISION := $(subst :,-,$(shell svnversion -n))
+  endif
+  # This breaks the Makefile syntax currently, because for some reason the
+  # embedded shell syntax doesn't end the single quoted string (the troubling
+  # part is the argument to sed).
+  VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
+endif
+
+ifeq (0,1)
+	$(info zero is one)
+else ifneq (1,2)
+	$(info one is not equal to two)
+else ifeq ("asf",asdf")
+	$(info foo)
+else ifeq (2,3)
+	$(info one is equal to three)
+else ifeq "2" "3"
+	$(info asdf)
+else ifeq '2' "3"
+	$(info asdf)
+else ifeq "2" '3'
+	$(info asdf)
+else ifeq '2' '3'
+	$(info asdf)
+else ifdef X
+	$(info X is defined)
+else ifndef Y
+	$(info Y is not defined)
+endif
+# <- keyword
+
+ifeq (0,1)
+	$(info asdf)
+else
+ifeq (0,1)
+	$(info asdf)
+endif
+# <- keyword
+
+a:b
+ifeq (0,1)
+	$(info asdf)
+else
+	$(info asdf)
+endif
+# <- keyword
+
+# Another case where the lookahead for the colon used to fails:
+ifneq ($(words $(subst :, ,$(CURDIR))), 1)
+#                      ^ meta.function-call.arguments meta.function-call.arguments - keyword.operator
+  $(error main directory cannot contain spaces nor colons)
+endif
+
+ifeq ($(shell which inkscape >/dev/null 2>&1 && echo USING_INKSCAPE),USING_INKSCAPE)
+# <- keyword.control.conditional
+$(FIGS)/%.pdf: $(FIGS)/%.svg  ## Figures for the manuscript
+# <- meta.function entity.name.function
+#            ^ keyword.operator.assignment
+#              ^ meta.function.arguments string.unquoted
+    #                         ^ comment.line - string.unquoted
+    inkscape -C -z --file=$< --export-pdf=$@ 2> /dev/null
+    # <- meta.function.body
+endif
+# <- keyword.control.conditional
+
+ifneq ($(REVISION),)
+REVDEPS += revision.tex
+revision.tex: $(VCSTURD)
+    /bin/echo '\newcommand{\Revision}'"{$(subst _,\_,$(REVISION))}" > $@
+    #           ^ - invalid.illegal
+    #                                     ^ meta.function-call.makefile
+    #                                                ^^ meta.function.body meta.function-call.arguments variable.other
+AUXFILES += revision.aux
+endif
+
+build_target:
+    @echo "${INFO_CLR}>> Building $(TARGET)...${RESTORE_CLR}${RESULT_CLR}"
+    # <- constant.language
+ifdef WORKSPACE
+    @xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -target "$(TARGET)" -configuration "$(CONFIG)" SYMROOT="$(BUILD_PATH)/Products" -jobs 6 build 2>/dev/null | tail -n 2 | cat && printf "${RESET_CLR}"
+    # <- constant.language
+else
+    @xcodebuild -sdk iphoneos -project "$(PROJECT).xcodeproj" -target "$(TARGET)" -configuration "$(CONFIG)" CONFIGURATION_BUILD_DIR="$(BUILD_PATH)/Products" -jobs 6 build 2>/dev/null | tail -n 2 | cat && printf "${RESET_CLR}"
+    # <- constant.language
+endif
+
+kselftest-merge:
+    $(if $(wildcard $(objtree)/.config),, $(error No .config exists, config your kernel first!))
+    $(Q)$(CONFIG_SHELL) $(srctree)/scripts/kconfig/merge_config.sh \
+        -m $(objtree)/.config \
+    #   ^ - constant.language.makefile
+        $(srctree)/tools/testing/selftests/*/config
+    +$(Q)$(MAKE) -f $(srctree)/Makefile olddefconfig
+
+search:
+    @$(MAKE) --no-print-directory \
+        -f core/core.mk $(addprefix -f,$(wildcard index/*.mk)) -f core/index.mk \
+    #                                                   ^ variable.language.wildcard
+        search
+
+# A recipe may contain empty lines like below
+help:
+    @echo  'Cleaning targets:'
+    # <- meta.function.body constant.language
+
+    @echo  '  make V=0|1 [targets] 0 => quiet build (default), 1 => verbose build'
+    # <- meta.function.body constant.language
+    #               ^ - keyword.operator.assignment
+    @echo  '        1: warnings which may be relevant and do not occur too often'
+    # <- meta.function.body constant.language
+    #                ^ - keyword.operator.assignment
+    @echo  '        2: warnings which occur quite often but may still be relevant'
+    # <- meta.function.body constant.language

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -808,6 +808,7 @@ help:
     @echo  '  make V=0|1 [targets] 0 => quiet build (default), 1 => verbose build'
     # <- meta.function.body constant.language
     #               ^ - keyword.operator.assignment
+    #                                                        ^ string.quoted.single.shell
     @echo  '        1: warnings which may be relevant and do not occur too often'
     # <- meta.function.body constant.language
     #                ^ - keyword.operator.assignment

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -6,9 +6,12 @@
 
 P = Hello
 # <- variable.other
-#  ^ - string.unquoted
 # ^ keyword.operator.assignment
-#   ^^^^^ string
+#  ^ - string.unquoted
+#   ^ string.unquoted
+#       ^ string.unquoted
+#        ^ - string.unquoted
+
 FOO = $P
 # <- variable.other
 #   ^ keyword.operator.assignment
@@ -535,8 +538,21 @@ $(sort $(a)): $(b) ;
 a : b ;
 # <- meta.function entity.name.function
 # ^ keyword.operator - entity.name.function
+#  ^ - string.unquoted
 #   ^ meta.function.arguments string.unquoted
-#     ^ punctuation
+#    ^ - string.unquoted
+#     ^ punctuation.terminator
+
+a : b \
+    more prerequisites \
+    on a third line even
+    #                  ^ meta.function.arguments string.unquoted
+    @rm -rf /
+    # <- meta.function.body constant.language
+
+a : b ; rm -rf /
+#     ^ punctuation.terminator
+#       ^ source.shell
 
 a-$(b) := c
 # ^ keyword.other.block.begin
@@ -564,7 +580,9 @@ $(a:b=c) : d
 $(X:a=b) : w ;
 # <- meta.function entity.name.function variable.other keyword.other.block.begin
 #        ^ keyword.operator
-#          ^^ meta.function.arguments string.unquoted
+#          ^ meta.function.arguments string.unquoted
+#           ^ - string.unquoted
+#            ^ punctuation.terminator
 
 $(Y:%.cpp=%.o) := $(Z)
 # <- - meta.function
@@ -572,8 +590,10 @@ $(Y:%.cpp=%.o) := $(Z)
 
 include $(c)
 ifneq ($(a),)
-$(b): ; 
+$(b): ; rm -rf /
+#       ^ meta.function.body source.shell
 	@git clone asdf
+	# <- meta.function.body constant.language
 	# ^ meta.function.body
 endif
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -51,6 +51,9 @@ bar := ${foo:%.o=%.c}
 #                ^ variable.language
 #                   ^ punctuation
 
+foo = bar # a comment
+#         ^ comment.line punctuation - string.unquoted
+
 #################################
 # 6.3.2 computed variable names #
 #################################
@@ -202,6 +205,16 @@ all: foo.o
 	# <- constant.language
     asdf
 # <- invalid.illegal.inconsistent.expected.tab
+
+all: foo.o # a comment
+# <- meta.function entity.name.function
+#  ^ keyword.operator.assignment
+#        ^ meta.function.arguments string.unquoted
+#          ^ comment.line. punctuation - meta.function.arguments - string.unquoted 
+#           ^ comment.line - punctuation - meta.function.arguments - string.unquoted
+	rm -rf /
+# <- meta.function.body
+
 
 sources := $($(a1)_objects:.o=.c)
 # ^ variable

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -660,11 +660,15 @@ else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
   ifeq ($(REVISION),)
     REVISION := $(subst :,-,$(shell svnversion -n))
   endif
-  # This breaks the Makefile syntax currently, because for some reason the
-  # embedded shell syntax doesn't end the single quoted string (the troubling
-  # part is the argument to sed).
-  # VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
+  # This used to break the makefile syntax because we didn't properly account
+  # for closing parentheses in shell-strings. We now use our own quoted string
+  # context in the with_prototype override so that we can account for this.
+  # This does mean that the shell syntax looks a tiny bit different.
+  VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
+  #                                                                                  ^ string.quoted.single.makefile punctuation.definition.string.begin.makefile
+  #                                                                                                        ^ string.quoted.single.makefile punctuation.definition.string.end.makefile
 endif
+# <- keyword.control
 
 ifeq (0,1)
 	$(info zero is one)

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -643,7 +643,7 @@ else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
   # This breaks the Makefile syntax currently, because for some reason the
   # embedded shell syntax doesn't end the single quoted string (the troubling
   # part is the argument to sed).
-  VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
+  # VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
 endif
 
 ifeq (0,1)
@@ -743,6 +743,13 @@ else
     @xcodebuild -sdk iphoneos -project "$(PROJECT).xcodeproj" -target "$(TARGET)" -configuration "$(CONFIG)" CONFIGURATION_BUILD_DIR="$(BUILD_PATH)/Products" -jobs 6 build 2>/dev/null | tail -n 2 | cat && printf "${RESET_CLR}"
     # <- constant.language
 endif
+ifndef ARDMK_DIR_MSG
+    $(call show_config_variable,ARDMK_DIR,[COMPUTED],(relative to $(notdir $(lastword $(MAKEFILE_LIST)))))
+    #                                                                                                   ^ - keyword.other.block.end
+    #                                                                                                    ^ keyword.other.block.end
+else
+    $(call show_config_variable,ARDMK_DIR,[USER])
+endif
 
 kselftest-merge:
     $(if $(wildcard $(objtree)/.config),, $(error No .config exists, config your kernel first!))
@@ -771,3 +778,4 @@ help:
     #                ^ - keyword.operator.assignment
     @echo  '        2: warnings which occur quite often but may still be relevant'
     # <- meta.function.body constant.language
+

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -579,7 +579,8 @@ endif
 a:b
 ifeq (0,1)
 	$(info asdf)
-else
+else # some comment
+#    ^ comment.line
 	$(info asdf)
 endif
 # <- keyword

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -6,6 +6,7 @@
 
 P = Hello
 # <- variable.other
+#  ^ - string.unquoted
 # ^ keyword.operator.assignment
 #   ^^^^^ string
 FOO = $P
@@ -34,6 +35,7 @@ bar := $(foo:.o=.c)
 bar := $(foo:%.o=%.c)
 # <- variable
 #   ^^ keyword
+#     ^ - string.unquoted
 #      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
@@ -44,6 +46,7 @@ bar := $(foo:%.o=%.c)
 bar := ${foo:%.o=%.c}
 # <- variable
 #   ^^ keyword
+#     ^ - string.unquoted
 #      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
@@ -52,6 +55,8 @@ bar := ${foo:%.o=%.c}
 #                   ^ keyword.other.block.end
 
 foo = bar # a comment
+#    ^ - string.unquoted
+#        ^ string.unquoted
 #         ^ comment.line punctuation - string.unquoted
 
 #################################
@@ -74,7 +79,7 @@ $(dir)_sources := $(wildcard $(dir)/*.c)
 #                                   ^ variable.language.wildcard
 #                                      ^ keyword.other.block.end
 define $(dir)_print =
-# ^ keyword.control.makefile
+# ^ keyword.control
 #      ^^ keyword.other.block.begin
 #           ^ keyword.other.block.end
 #                   ^ keyword.operator.assignment
@@ -121,16 +126,31 @@ override variable = value
 override variable := value
 override variable += more text
 override CFLAGS += -g
+override define foo
+# <-keyword
+#        ^ keyword
+#               ^ variable.other
+#                  ^ - string.unquoted
+asdf
+# <- string.unquoted
+endef
+# <- keyword
 override define foo =
+# <- keyword
+#        ^ keyword
+#               ^ variable.other
 #                   ^ keyword.operator.assignment
+#                    ^ - string
 bar
 endef
 override define foo ?=
 #                   ^^ keyword.operator.assignment
+#                     ^ - string
 bar
 endef
 override define foo :=
 #                   ^^ keyword.operator.assignment
+#                     ^ - string
 bar
 endef
 # ^ keyword.control
@@ -146,6 +166,7 @@ prog : CFLAGS = -g
 #    ^ keyword.operator
 #      ^ variable - string
 #             ^ keyword
+#              ^ - string
 #               ^^ string - meta.function.arguments
 
 #########################################
@@ -154,8 +175,14 @@ prog : CFLAGS = -g
 
 lib/%.o: CFLAGS := -fPIC -g
 #      ^ keyword.operator
+#                 ^ - string
+#                  ^ string
+#                          ^ - string
 %.o: CFLAGS := -g
 #  ^ keyword.operator
+#             ^ - string
+#              ^^ string
+#                ^ - string
 
 # Line comment
 # <- comment
@@ -169,6 +196,8 @@ ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 #                                                         ^^^ variable.language.automatic
     include $(MAKEFILE_PATH)Makefile.Defs
     # <- keyword.control
+    #      ^ - string
+    #       ^ string
     # IMPORTANT NOTE: Extra spaces are allowed and ignored at the beginning of 
     # the line, but the first character must not be a tab (or the value of 
     # .RECIPEPREFIX) — if the line begins with a tab, it will be considered a 
@@ -179,17 +208,20 @@ endif
 a_objects := a.o b.o c.o
 # ^ variable.other.makefile
 #         ^^ keyword.operator.assignment
-#           ^^^^^^^^^^^^ string
+#            ^^^^^^^^^^^ string
 1_objects := 1.o 2.o 3.o
 # ^^^^^^^ variable.other
 #         ^^ keyword.operator.assignment
-#           ^^^^^^^^^^^^ string.unquoted
+#            ^^^^^^^^^^^ string.unquoted
 
 # This is NOT the start of a rule...
 	# A comment with a tab and with a : colon
 	# <- comment.line - meta.function - entity.name.function
 
 all: foo.o
+#   ^ - string
+#    ^ string
+#         ^ - string
     ld a
     ar b
     asdf
@@ -209,7 +241,10 @@ all: foo.o
 all: foo.o # a comment
 # <- meta.function entity.name.function
 #  ^ keyword.operator.assignment
+#   ^ - string
+#    ^ string
 #        ^ meta.function.arguments string.unquoted
+#         ^ string
 #          ^ comment.line. punctuation - meta.function.arguments - string.unquoted 
 #           ^ comment.line - punctuation - meta.function.arguments - string.unquoted
 	rm -rf /

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -193,9 +193,9 @@ lib/%.o: CFLAGS := -fPIC -g
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 # <- keyword.control
 #       ^ variable.function
-#                     ^^ variable.other keyword.other.block.begin
-#                       ^^^^^^^^^^^^^ variable.other
-#                                    ^ variable.other keyword.other.block.end
+#                     ^^ variable.parameter keyword.other.block.begin
+#                       ^^^^^^^^^^^^^ variable.parameter
+#                                    ^ variable.parameter keyword.other.block.end
 #                                                         ^^^ variable.language.automatic
     include $(MAKEFILE_PATH)Makefile.Defs
     # <- keyword.control
@@ -209,7 +209,7 @@ endif
 # <- keyword.control
 
 a_objects := a.o b.o c.o
-# ^ variable.other.makefile
+# ^ variable.other
 #         ^^ keyword.operator.assignment
 #            ^^^^^^^^^^^ string
 1_objects := 1.o 2.o 3.o
@@ -281,8 +281,8 @@ OBJECTS=$(SOURCES:.cpp=.o)
 #<- variable.other
 #      ^ keyword.operator.assignment
 #       ^^ string.unquoted keyword.other.block.begin
-#                ^ string.unquoted variable.other punctuation.definition.substitution
-#                     ^ string.unquoted variable.other punctuation.definition
+#                ^ string.unquoted variable.parameter punctuation.definition.substitution
+#                     ^ string.unquoted variable.parameter punctuation.definition
 #                        ^ string.unquoted keyword.other.block.end
 EXECUTABLE=hello
 
@@ -299,12 +299,12 @@ lib: foo.o bar.o lose.o win.o
 all: $(SOURCES) $(EXECUTABLE)
 #<- entity.name.function
 #  ^ keyword.operator.assignment
-#    ^^ variable.other keyword.other.block.begin
-#      ^^^^^^^ variable.other
-#             ^ variable.other keyword.other.block.end
-#               ^^ variable.other keyword.other.block.begin
-#                 ^^^^^^^^^^ variable.other
-#                           ^ variable.other keyword.other.block.end
+#    ^^ variable.parameter keyword.other.block.begin
+#      ^^^^^^^ variable.parameter
+#             ^ variable.parameter keyword.other.block.end
+#               ^^ variable.parameter keyword.other.block.begin
+#                 ^^^^^^^^^^ variable.parameter
+#                           ^ variable.parameter keyword.other.block.end
 
 export FOO=foo
 # ^ keyword.control
@@ -334,10 +334,10 @@ reverse = $(2) $(1)
 # <- variable.other
 #       ^ keyword.operator.assignment
 #         ^^ keyword.other.block.begin
-#           ^ string.unquoted variable.other
+#           ^ string.unquoted variable.parameter
 #             ^ string.unquoted
 #              ^^ keyword.other.block.begin
-#                ^ string.unquoted variable.other
+#                ^ string.unquoted variable.parameter
 #                 ^ keyword.other.block.end
 
 foo = $(call reverse,a,b)
@@ -355,7 +355,7 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 #                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call variable.function
 #                                               ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments
 #                                                ^^ keyword.other.block.begin
-#                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
+#                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter
 #                                                   ^ keyword.other.block.end
 #                                                    ^ punctuation.separator
 #                                                     ^^ keyword.other.block.begin
@@ -365,8 +365,8 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 #                                                               ^ string.unquoted
 #                                                                ^ punctuation.separator
 #                                                                 ^^ keyword.other.block.begin
-#                                                                   ^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
-#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other keyword.other.block.end
+#                                                                   ^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter
+#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter keyword.other.block.end
 #                                                                        ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
 #                                                                         ^ meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
 #                                                                          ^ meta.function-call.arguments keyword.other.block.end
@@ -379,36 +379,36 @@ LS := $(call pathsearch,ls)
 
 sinclude $(MAKEFILE_PATH)Makefile.Defs
 # <- keyword.control.import
-#        ^ string.unquoted variable.other keyword.other.block.begin
-#          ^ string.unquoted variable.other
-#                       ^ string.unquoted variable.other keyword.other.block.end
+#        ^ string.unquoted variable.parameter keyword.other.block.begin
+#          ^ string.unquoted variable.parameter
+#                       ^ string.unquoted variable.parameter keyword.other.block.end
 
 
 CC=g++
-# <- variable.other.makefile
-# ^ keyword.operator.assignment.makefile
-#  ^ string.unquoted.makefile
+# <- variable.other
+# ^ keyword.operator.assignment
+#  ^ string.unquoted
 SOURCES=main.cpp
 SOURCES+=hello.cpp
-# <- variable.other.makefile
-#      ^ keyword.operator.assignment.makefile
-#        ^ string.unquoted.makefile
+# <- variable.other
+#      ^ keyword.operator.assignment
+#        ^ string.unquoted
 
 EXECUTABLE=hello
 
 OBJECTS=$(SOURCES:.cpp=.o)
-#         ^ string.unquoted.makefile variable.other.makefile
+#         ^ string.unquoted.makefile variable.parameter.makefile
 
 all: $(SOURCES) hello.o
 # <- entity.name.function.makefile
 #    ^ keyword.other.block.begin
-#      ^ variable.other.makefile
+#      ^ variable.parameter.makefile
 
 $(EXECUTABLE): $(OBJECTS)
 # <- keyword.other.block.begin
-# ^ variable.other.makefile
+# ^ variable.parameter.makefile
 #              ^ keyword.other.block.begin
-#                ^ variable.other.makefile
+#                ^ variable.parameter.makefile
 	@$(CC) $(LDFLAGS) $(OBJECTS) -o $@
 	# <- constant.language
 	#                               ^^ variable.language.automatic
@@ -479,10 +479,10 @@ endif
 # ^ keyword.control
 
 a_percentage_%_sign := $(SOME_C%MPLEX:SUBSTITUTI%N)
-#            ^variable.other - variable.language
-#                              ^ string.unquoted variable.other variable.language
+#            ^ variable.other - variable.language
+#                              ^ string.unquoted variable.parameter variable.language
 #                                    ^ punctuation
-#                                               ^ string.unquoted variable.other variable.language
+#                                               ^ string.unquoted variable.parameter variable.language
 
 %.cpp: %.o
 # <- meta.function entity.name.function variable.language
@@ -578,7 +578,7 @@ $(a:b=c) : d
 	#                    ^^ meta.function.body variable.language.automatic
 
 $(X:a=b) : w ;
-# <- meta.function entity.name.function variable.other keyword.other.block.begin
+# <- meta.function entity.name.function variable.parameter keyword.other.block.begin
 #        ^ keyword.operator
 #          ^ meta.function.arguments string.unquoted
 #           ^ - string.unquoted
@@ -729,7 +729,7 @@ revision.tex: $(VCSTURD)
     /bin/echo '\newcommand{\Revision}'"{$(subst _,\_,$(REVISION))}" > $@
     #           ^ - invalid.illegal
     #                                     ^ meta.function-call.makefile
-    #                                                ^^ meta.function.body meta.function-call.arguments variable.other
+    #                                                ^^ meta.function.body meta.function-call.arguments variable.parameter
 AUXFILES += revision.aux
 endif
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -156,6 +156,10 @@ a_objects := a.o b.o c.o
 #         ^^ keyword.operator.assignment
 #           ^^^^^^^^^^^^ string.unquoted
 
+# This is NOT the start of a rule...
+	# A comment with a tab and with a : colon
+	# <- comment.line - meta.function - entity.name.function
+
 all: foo.o
     ld a
     ar b
@@ -529,12 +533,16 @@ ifeq ($(shell git status >/dev/null 2>&1 && echo USING_GIT),USING_GIT)
     VCSTURD := $(subst $(SPACE),\ ,$(shell git rev-parse --git-dir)/$(GIT_BRANCH))
   endif
 else ifeq ($(shell hg root >/dev/null 2>&1 && echo USING_HG),USING_HG)
+# ^ keyword.control
+#    ^ keyword.control
   # mercurial
   ifeq ($(REVISION),)
     REVISION := $(shell hg id -i)
   endif
   VCSTURD := $(subst $(SPACE),\ ,$(shell hg root)/.hg/dirstate)
 else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
+# ^ keyword.control
+#    ^ keyword.control
   # subversion
   ifeq ($(REVISION),)
     REVISION := $(subst :,-,$(shell svnversion -n))

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -105,10 +105,10 @@ file_list != find . -name '*.c'
 #            ^ source.shell
 
 hash := $(shell printf '\043')
-#         ^support.function.builtin
+#         ^variable.function
 #               ^ source.shell
 var := $(shell find . -name "*.c")
-#        ^support.function.builtin
+#        ^variable.function
 #              ^ source.shell
 
 ########################################
@@ -192,7 +192,7 @@ lib/%.o: CFLAGS := -fPIC -g
 
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 # <- keyword.control
-#       ^ support.function.builtin
+#       ^ variable.function
 #                     ^^ variable.other keyword.other.block.begin
 #                       ^^^^^^^^^^^^^ variable.other
 #                                    ^ variable.other keyword.other.block.end
@@ -350,16 +350,16 @@ foo = $(call reverse,a,b)
 #                       ^ string.unquoted keyword.other.block.end
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
-#              ^^^^^^^^^ meta.function-call support.function
-#                          ^^^^^^^^ meta.function-call.arguments meta.function-call support.function
-#                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
+#              ^^^^^^^^^ meta.function-call variable.function
+#                          ^^^^^^^^ meta.function-call.arguments meta.function-call variable.function
+#                                     ^^^^^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call variable.function
 #                                               ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments
 #                                                ^^ keyword.other.block.begin
 #                                                  ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.other
 #                                                   ^ keyword.other.block.end
 #                                                    ^ punctuation.separator
 #                                                     ^^ keyword.other.block.begin
-#                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call support.function
+#                                                       ^^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call variable.function
 #                                                             ^ string.unquoted
 #                                                              ^ punctuation.separator
 #                                                               ^ string.unquoted
@@ -437,18 +437,18 @@ help::
 	# <- constant.language
 
 $(warning he:llo)
-# ^ meta.function-call support.function
+# ^ meta.function-call variable.function
 #         ^^^ meta.function-call.arguments.makefile - punctuation
 #               ^ keyword.other.block.end
 
 all: deps
 	$(warning he:llo)
-	# ^ meta.function-call support.function
+	# ^ meta.function-call variable.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
 	#               ^ keyword.other.block.end
 deps:
 	$(warning he:llo)
-	# ^ meta.function-call support.function
+	# ^ meta.function-call variable.function
 	#         ^^^ meta.function-call.arguments.makefile - punctuation
 	#               ^ keyword.other.block.end
 all: 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -608,6 +608,19 @@ vpath dir/*/whatevs whatevs
 #         ^ variable.language.wildcard
 #                   ^ string.unquoted.makefile
 
+vpath asdf/*
+# ^ keyword.control.vpath
+#          ^ variable.language.wildcard
+vpath
+# ^ keyword.control.vpath.makefile
+
+# a comment check
+# <- comment.line
+
+rule: asdf
+	@rm -rf /
+# <- meta.function.body
+
 ifneq ($(REVISION),)
 # ^ keyword.control.conditional
 REVDEPS += revision.tex

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -820,6 +820,11 @@ $(call show_config_variable,CC_VERSION,[COMPUTED],($(CC_NAME)))
 #                                                            ^ - keyword.other.block.end
 #                                                             ^ keyword.other.block.end
 
+LIBRARIES := $(filter $(notdir $(wildcard $(HOME)/energia_sketchbook/libraries/*)), \
+    $(shell sed -ne "s/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p" $(SOURCES)))
+    #               ^ string.quoted.double.makefile punctuation.definition.string.begin.makefile
+    #                                                          ^ string.quoted.double.makefile punctuation.definition.string.end.makefile
+
 .SECONDEXPANSION:
 # <- meta.function entity.name.function
 #               ^ keyword.operator.assignment - entity.name.function

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -4,6 +4,22 @@
 # 6.3.1 substitution references #
 #################################
 
+P = Hello
+# <- variable.other
+# ^ keyword.operator.assignment
+#   ^^^^^ string
+FOO = $P
+# <- variable.other
+#   ^ keyword.operator.assignment
+#     ^ punctuation
+#      ^ string variable
+BAR = $PATH
+# <- variable.other
+#   ^ keyword.operator.assignment
+#     ^ punctuation
+#      ^ string variable
+#       ^ string - variable
+
 foo := a.o b.o c.o
 # <- variable
 #   ^^ keyword
@@ -169,14 +185,13 @@ all: foo.o
 # <- invalid.illegal.inconsistent.expected.spaces
 
 all: foo.o
-    ld a
-    ar b
-    asdf
-    @echo "that's, like, your opinion man!" # some movie?
-    # <- constant.language
+	ld a
+	ar b
 	asdf
-# <- invalid.illegal.inconsistent.expected.spaces
-
+	@echo "that's, like, your opinion man!" # some movie?
+	# <- constant.language
+    asdf
+# <- invalid.illegal.inconsistent.expected.tab
 
 sources := $($(a1)_objects:.o=.c)
 # ^ variable

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -11,12 +11,12 @@ P = Hello
 FOO = $P
 # <- variable.other
 #   ^ keyword.operator.assignment
-#     ^ punctuation
+#     ^ keyword.other
 #      ^ string variable
 BAR = $PATH
 # <- variable.other
 #   ^ keyword.operator.assignment
-#     ^ punctuation
+#     ^ keyword.other
 #      ^ string variable
 #       ^ string - variable
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -588,6 +588,26 @@ $(Y:%.cpp=%.o) := $(Z)
 # <- - meta.function
 #              ^^ keyword.operator.assignment
 
+$(call my_func,my_arg): deps
+# <- meta.function entity.name.function
+#                     ^ keyword.operator.assignment
+#                      ^ - keyword.operator.assignment
+	rm -rf /
+
+$(foreach i,j,k): deps
+# <- meta.function entity.name.function
+#               ^ keyword.operator.assignment
+#                ^ - keyword.operator.assignment
+	rm -rf /
+	# <- meta.function.body
+
+$(foreach i,$(a),$(foreach j,$(b),x)): deps
+# <- meta.function entity.name.function
+#                                    ^ keyword.operator.assignment
+#                                     ^ - keyword.operator.assignment
+	rm -rf /
+	# <- meta.function.body
+
 include $(c)
 ifneq ($(a),)
 $(b): ; rm -rf /
@@ -796,3 +816,22 @@ $(call show_config_variable,CC_VERSION,[COMPUTED],($(CC_NAME)))
 #                                                            ^ - keyword.other.block.end
 #                                                             ^ keyword.other.block.end
 
+.SECONDEXPANSION:
+# <- meta.function entity.name.function
+#               ^ keyword.operator.assignment - entity.name.function
+#                ^ - keyword.operator.assignment - entity.name.function
+$(DO_IMPLS): $$(foreach s,$$(STEPS),$$(call $$(@)_STEP_TO_PROG,$$(s)))
+# <- meta.function entity.name.function
+#          ^ keyword.operator.assignment - entity.name.function
+#           ^ - keyword.operator.assignment - entity.name.function
+#               ^ meta.function.arguments support.function
+#                                           ^^^^^^^^^^^^^^^^^^ variable.function
+#                                                             ^ punctuation.separator
+
+.SECONDEXPANSION:
+$(foreach i,$(DO_IMPLS),$(foreach s,$(STEPS),$(i)^$(s))): $$(call $$(word 1,$$(subst ^, ,$$(@)))_STEP_TO_PROG,$$(word 2,$$(subst ^, ,$$(@))))
+# <- meta.function entity.name.function
+#                                                       ^ keyword.operator.assignment
+#                                                        ^ - keyword.operator.assignment
+#                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.function
+#                                                                                                            ^ punctuation.separator

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -603,7 +603,13 @@ $(FIGS)/%.pdf: $(FIGS)/%.svg  ## Figures for the manuscript
 endif
 # <- keyword.control.conditional
 
+vpath dir/*/whatevs whatevs
+# ^ keyword.control.vpath
+#         ^ variable.language.wildcard
+#                   ^ string.unquoted.makefile
+
 ifneq ($(REVISION),)
+# ^ keyword.control.conditional
 REVDEPS += revision.tex
 revision.tex: $(VCSTURD)
     /bin/echo '\newcommand{\Revision}'"{$(subst _,\_,$(REVISION))}" > $@

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -41,6 +41,16 @@ bar := $(foo:%.o=%.c)
 #                ^ variable.language
 #                   ^ punctuation
 
+bar := ${foo:%.o=%.c}
+# <- variable
+#   ^^ keyword
+#      ^^ punctuation
+#           ^ punctuation
+#            ^ variable.language
+#               ^ punctuation
+#                ^ variable.language
+#                   ^ punctuation
+
 #################################
 # 6.3.2 computed variable names #
 #################################


### PR DESCRIPTION
# TL;DR
Fixes both https://github.com/sublimehq/Packages/issues/968 as well as https://github.com/sublimehq/Packages/issues/903. Also see https://github.com/sublimehq/Packages/issues/481.

# The Problem
The current syntax has a collection of problems:
1. It has various positive lookbehinds. This caused problems (https://github.com/sublimehq/Packages/issues/903).
2. It forces you to use tabs for indenting recipes.
3. It cannot detect wether something is the body of a recipe, or just regular indentation for an `ifeq/else/endif` block.
4. It has its own little subset of a shell-like syntax. This is used for highlighting recipe lines.

# Solutions
1. This refactoring has **zero look behinds**. Everything is done with look aheads.
2. You can use tabs or spaces for indenting recipe lines. It can detect recipes with mixed tabs/spaces and will scope the unexpected tabs or spaces as `invalid.illegal.expected.spaces.makefile` or `invalid.illegal.expected.tabs.makefile`.
3. I've done my best to try to detect wether a line in the file is the start of a new rule definition. If so, the syntax will push the `expect-rule` context onto the stack. After that, it'll go into the `recipe-junction-between-spaces-or-tabs` context. This context will detect wether you're starting a recipe with spaces or tabs. The rest should be straightforward. The nice result is that recipe lines are now scoped with `meta.function.body.makefile`.
4. The body of a recipe line is scoped with `scope:source.shell`, enabling the full power of the shell syntax.

# Other Improvements
- [Automatic variables](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html) are scoped as `variable.language.makefile`. This makes these important variables stand out.
- The wildcard symbol `*` inside a `$(wildcard ...)` function call is scoped as `variable.language.wildcard.makefile`.
- The percentage-symbol `%` is also scoped as `variable.language.makefile` in places where this is appropriate.
- The first argument of the `$(call ...)` function is actually scoped as `support.function` (like all other functions), instead of a first argument of a function. The word `call` is scoped as `constant.language`. This is because the `call` function is special in the sense that it's the only function that allows you to call your own written functions, and the word `call` is more of a keyword than an actual function name.
- The `source.shell` syntax is also pushed inside a `$(shell ...)` function call.
- The `source.shell` syntax is also pushed after a variable definition with the `!=` keyword.
- This PR has about ~400 syntax tests (the current one has about ~100).

I'll be pushing some more minor commits but the bulk of the work has been done I think.