### PR TITLE
[XML] Add support for Document Type Definition (DTD)

### DIFF
--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -250,8 +250,9 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.dtd
           pop: true
-        - include: constant-entity
-        - include: should-be-entity
+        - match: "'(?:[^'\"]+')?"
+          scope: constant.character.escape.string.dtd
+        - include: string-body
 
   single-quoted-string:
     - match: "'"
@@ -261,8 +262,17 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.dtd
           pop: true
-        - include: constant-entity
-        - include: should-be-entity
+        - match: "\"(?:[^'\"]+\")?"
+          scope: constant.character.escape.string.dtd
+        - include: string-body
+
+  string-body:
+    - match: '[\(\)\|,]'
+      scope: constant.character.escape.punctuation.dtd
+    - match: '[*?+]'
+      scope: keyword.operator.dtd
+    - include: constant-entity
+    - include: should-be-entity
 
   unquoted-string:
     - match: '{{name}}'
@@ -287,7 +297,7 @@ contexts:
       scope: punctuation.definition.group.begin.dtd
       push:
         - meta_scope: meta.group.sequence.dtd
-        - match: (\))([*?+])?
+        - match: (\))\s*([*?+])?
           captures:
             1: punctuation.definition.group.end.dtd
             2: keyword.operator.dtd

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -222,7 +222,7 @@ contexts:
       set:
         - meta_content_scope: meta.tag.subset.body.dtd
         - match: \[
-          scope: punctuation.definition.internal-subset.begin.xml
+          scope: punctuation.definition.internal-subset.begin.dtd
           set: decl-subset-body
     - include: parameter-entity
     - match: '{{name}}'
@@ -231,11 +231,11 @@ contexts:
   decl-subset-body:
     - meta_content_scope: meta.tag.subset.body.dtd
     - match: \]
-      scope: punctuation.definition.internal-subset.end.xml
+      scope: punctuation.definition.internal-subset.end.dtd
       set:
         - meta_content_scope: meta.tag.subset.dtd
         - match: \]>
-          scope: meta.tag.subset.dtd punctuation.definition.tag.end.xml
+          scope: meta.tag.subset.dtd punctuation.definition.tag.end.dtd
           pop: true
     - include: main
 

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -14,6 +14,9 @@ variables:
 
 contexts:
   main:
+    # NOTE: prototype is ignored if the file is included by another one.
+    #       Including it explicitly fixes the issue.
+    - include: prototype
     - include: decl-attlist
     - include: decl-element
     - include: decl-entity

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -217,27 +217,30 @@ contexts:
       push: decl-subset-name
 
   decl-subset-name:
-    - meta_scope: meta.tag.subset.dtd
+    - meta_scope: meta.tag.declaration.internal-subset.dtd
     - match: (?=\[)
-      set:
-        - meta_content_scope: meta.tag.subset.body.dtd
-        - match: \[
-          scope: punctuation.definition.internal-subset.begin.dtd
-          set: decl-subset-body
+      set: decl-subset-content
     - include: parameter-entity
     - match: '{{name}}'
       scope: variable.entity.dtd
+    - include: decl-subset-end
 
-  decl-subset-body:
-    - meta_content_scope: meta.tag.subset.body.dtd
-    - match: \]
-      scope: punctuation.definition.internal-subset.end.dtd
+  decl-subset-content:
+    - match: \[
+      scope: punctuation.section.brackets.begin.dtd
       set:
-        - meta_content_scope: meta.tag.subset.dtd
-        - match: \]>
-          scope: meta.tag.subset.dtd punctuation.definition.tag.end.dtd
-          pop: true
-    - include: main
+        - meta_scope: meta.tag.declaration.internal-subset.content.dtd meta.brackets.dtd
+        - match: \]
+          scope: punctuation.section.brackets.end.dtd
+          set: decl-subset-end
+        - include: main
+    - include: decl-subset-end
+
+  decl-subset-end:
+    - meta_content_scope: meta.tag.declaration.internal-subset.dtd
+    - match: \]>
+      scope: meta.tag.declaration.internal-subset.dtd punctuation.definition.tag.end.dtd
+      pop: true
 
   double-quoted-string:
     - match: '"'

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -1,0 +1,325 @@
+%YAML 1.2
+---
+name: DTD
+file_extensions:
+  - dtd
+  - mod
+  - ent
+scope: text.xml.dtd
+variables:
+  # This is the full XML Name production, but should not be used where namespaces
+  # are possible. Those locations should use a qualified_name.
+  name: '[[:alpha:]:_][[:alnum:]:_.-]*'
+  param: (%){{name}}(;)
+
+contexts:
+  main:
+    - include: decl-attlist
+    - include: decl-element
+    - include: decl-entity
+    - include: decl-notation
+    - include: decl-subset
+    - include: parameter-entity
+
+  prototype:
+    - match: '<!--'
+      scope: punctuation.definition.comment.begin.dtd
+      push:
+        - meta_scope: comment.block.dtd
+        - match: '-->'
+          scope: punctuation.definition.comment.end.dtd
+          pop: true
+        - match: '-{2,}'
+          scope: invalid.illegal.double-hyphen-within-comment.dtd
+
+  # <!ENTITY name PUBLIC "CDATA">
+  # https://www.quackit.com/xml/tutorial/dtd_general_entities.cfm
+  # https://www.quackit.com/xml/tutorial/dtd_parameter_entities.cfm
+  decl-entity:
+    - match: (<!)(ENTITY)\b
+      scope: meta.tag.declaration.entity.dtd
+      captures:
+        1: punctuation.definition.tag.begin.dtd
+        2: entity.name.tag.entity.dtd
+      push: decl-entity-name
+
+  decl-entity-name:
+    - meta_content_scope: meta.tag.declaration.entity.name.dtd
+    # % indicates an parameter entity declaration
+    - match: '%'
+      scope: punctuation.definition.tag.separator.entity.dtd
+      set:
+        - meta_content_scope: meta.tag.declaration.entity.name.dtd
+        - match: '{{name}}'
+          scope: variable.entity.parameter-entity.dtd
+          set: decl-entity-type
+    - match: '{{name}}'
+      scope: variable.entity.general-entity.dtd
+      set: decl-entity-type
+    - include: decl-end
+
+  decl-entity-type:
+    - meta_content_scope: meta.tag.declaration.entity.type.dtd
+    - match: (?:PUBLIC|SYSTEM)\b
+      scope: keyword.content.external.dtd
+      set: decl-entity-content-external
+    - match: (?=\S)
+      set: decl-entity-content-internal
+    - include: decl-end
+
+  decl-entity-content-external:
+    # contains at most 2 strings with FPI and uri
+    - meta_content_scope: meta.tag.declaration.entity.content.external.dtd
+    - include: decl-entity-content-ndata
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - include: decl-end
+
+  decl-entity-content-internal:
+    # contains one string which contains the content
+    # of any other kind of declaration from this file
+    - meta_content_scope: meta.tag.declaration.entity.content.internal.dtd
+    - include: decl-entity-content-ndata
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - include: decl-end
+
+  # embedded images
+  # https://www.quackit.com/xml/tutorial/dtd_embedded_images.cfm
+  decl-entity-content-ndata:
+    - match: NDATA\b
+      scope: keyword.ndata.dtd
+      push:
+        # one of variable.notation
+        - include: unquoted-string
+        - match: (?=>)
+          pop: true
+
+  # <!ELEMENT name (values+)>
+  # https://www.quackit.com/xml/tutorial/dtd_elements.cfm
+  decl-element:
+    - match: (<!)(ELEMENT)\b
+      scope: meta.tag.declaration.element.dtd
+      captures:
+        1: punctuation.definition.tag.begin.dtd
+        2: entity.name.tag.element.dtd
+      push: decl-element-name
+
+  decl-element-name:
+    - meta_content_scope: meta.tag.declaration.element.name.dtd
+    - match: '{{param}}'
+      scope: variable.parameter.dtd
+      captures:
+        1: punctuation.definition.variable.begin.dtd
+        2: punctuation.definition.variable.end.dtd
+      set: decl-element-content
+    - match: '{{name}}'
+      scope: variable.element.dtd
+      set: decl-element-content
+    - include: decl-end
+
+  decl-element-content:
+    - meta_content_scope: meta.tag.declaration.element.content.dtd
+    - match: \bANY\b
+      scope: storage.type.content.any.dtd
+    - match: \bEMPTY\b
+      scope: storage.type.content.empty.dtd
+    - include: group
+    - include: parameter-entity
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - include: decl-end
+
+  # <!ATTLIST element-name attribute-name attribute-type attribute-value>
+  # https://www.w3schools.com/xml/xml_dtd_attributes.asp
+  decl-attlist:
+    - match: (<!)(ATTLIST)\b
+      scope: meta.tag.declaration.attlist.dtd
+      captures:
+        1: punctuation.definition.tag.begin.dtd
+        2: entity.name.tag.attlist.dtd
+      push: decl-attlist-name
+
+  decl-attlist-name:
+    - meta_content_scope: meta.tag.declaration.attlist.element.dtd
+    - match: '{{param}}'
+      scope: variable.parameter.dtd
+      captures:
+        1: punctuation.definition.variable.begin.dtd
+        2: punctuation.definition.variable.end.dtd
+      set: decl-attlist-content
+    - match: '{{name}}'
+      scope: variable.element.dtd
+      set: decl-attlist-content
+    - include: decl-end
+
+  decl-attlist-content:
+    - meta_content_scope: meta.tag.declaration.attlist.content.dtd
+    - include: enumerated
+    - include: parameter-entity
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - match: (?:CDATA|ENTITY|ENTITIES|IDREFS?|ID|NMTOKENS?|NOTATION)\b
+      scope: storage.type.attribute.dtd
+    - match: (#)(?:FIXED|IMPLIED|REQUIRED)
+      scope: constant.other.attribute-value.dtd
+      captures:
+        1: punctuation.definition.constant.attribute-value.dtd
+    - match: '{{name}}'
+      scope: entity.other.attribute-name.dtd
+    - include: decl-end
+
+  # <!-- W3C XML 1.0 Recommendation -->
+  # https://www.quackit.com/xml/tutorial/dtd_attribute_types_notation.cfm
+  # <!NOTATION w3c-xml PUBLIC "ISO 8879//NOTATION Extensible Markup Language (XML) 1.0//EN
+  decl-notation:
+    - match: (<!)(NOTATION)\b
+      scope: meta.tag.declaration.notation.dtd
+      captures:
+        1: punctuation.definition.tag.begin.dtd
+        2: entity.name.tag.notation.dtd
+      push: decl-notation-name
+
+  decl-notation-name:
+    - meta_content_scope: meta.tag.declaration.notation.name.dtd
+    - match: '{{name}}'
+      scope: variable.notation.dtd
+      set: decl-notation-type
+    - include: decl-end
+
+  decl-notation-type:
+    - meta_content_scope: meta.tag.declaration.notation.type.dtd
+    - match: (?:PUBLIC|SYSTEM)\b
+      scope: keyword.content.external.dtd
+      set: decl-notation-content
+    - include: decl-end
+
+  decl-notation-content:
+    - meta_content_scope: meta.tag.declaration.notation.content.dtd
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - include: decl-end
+
+  decl-end:
+    # don't pop off directly to include > into current meta_content_scope
+    - match: '>'
+      scope: punctuation.definition.tag.end.dtd
+      set:
+        - match: ''
+          pop: true
+    - match: <!
+      scope: invalid.illegal.unexpected.dtd
+
+  # <![%name[ ... ]]>
+  decl-subset:
+    - match: <!\[
+      scope: punctuation.definition.tag.begin.dtd
+      push: decl-subset-name
+
+  decl-subset-name:
+    - meta_scope: meta.tag.subset.dtd
+    - match: (?=\[)
+      set:
+        - meta_content_scope: meta.tag.subset.body.dtd
+        - match: \[
+          scope: punctuation.definition.internal-subset.begin.xml
+          set: decl-subset-body
+    - include: parameter-entity
+    - match: '{{name}}'
+      scope: variable.entity.dtd
+
+  decl-subset-body:
+    - meta_content_scope: meta.tag.subset.body.dtd
+    - match: \]
+      scope: punctuation.definition.internal-subset.end.xml
+      set:
+        - meta_content_scope: meta.tag.subset.dtd
+        - match: \]>
+          scope: meta.tag.subset.dtd punctuation.definition.tag.end.xml
+          pop: true
+    - include: main
+
+  double-quoted-string:
+    - match: '"'
+      scope: punctuation.definition.string.begin.dtd
+      push:
+        - meta_scope: string.quoted.double.dtd
+        - match: '"'
+          scope: punctuation.definition.string.end.dtd
+          pop: true
+        - include: constant-entity
+        - include: should-be-entity
+
+  single-quoted-string:
+    - match: "'"
+      scope: punctuation.definition.string.begin.dtd
+      push:
+        - meta_scope: string.quoted.single.dtd
+        - match: "'"
+          scope: punctuation.definition.string.end.dtd
+          pop: true
+        - include: constant-entity
+        - include: should-be-entity
+
+  unquoted-string:
+    - match: '{{name}}'
+      scope: string.unquoted.dtd
+
+  enumerated:
+    - match: \(
+      scope: punctuation.definition.group.begin.dtd
+      push:
+        - meta_scope: meta.group.enumerated.dtd
+        - match: \)
+          scope: punctuation.definition.group.end.dtd
+          pop: true
+        - match: \|
+          scope: punctuation.separator.logical.dtd
+        - include: constant-entity
+        - include: parameter-entity
+        - include: unquoted-string
+
+  group:
+    - match: \(
+      scope: punctuation.definition.group.begin.dtd
+      push:
+        - meta_scope: meta.group.sequence.dtd
+        - match: (\))([*?+])?
+          captures:
+            1: punctuation.definition.group.end.dtd
+            2: keyword.operator.dtd
+          pop: true
+        - match: '[*?+]'
+          scope: keyword.operator.dtd
+        - match: ','
+          scope: punctuation.separator.group.dtd
+        - match: \|
+          scope: punctuation.separator.logical.dtd
+        - include: group
+        - include: constant-entity
+        - include: parameter-entity
+        - include: unquoted-string
+
+  parameter-entity:
+    - match: '{{param}}'
+      scope: variable.parameter.dtd
+      captures:
+        1: punctuation.definition.variable.begin.dtd
+        2: punctuation.definition.variable.end.dtd
+
+  constant-entity:
+    - match: (#)PCDATA
+      scope: variable.language.parsed-character-data.dtd
+      captures:
+        1: punctuation.definition.variable.begin.dtd
+    - match: (&)(?:{{name}}|#[0-9]+|#x\h+)(;)
+      scope: constant.character.entity.dtd
+      captures:
+        1: punctuation.definition.constant.begin.dtd
+        2: punctuation.definition.constant.end.dtd
+
+  should-be-entity:
+    - match: '&'
+      scope: invalid.illegal.bad-ampersand.dtd
+    - match: '<'
+      scope: invalid.illegal.missing-entity.dtd

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -246,6 +246,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.dtd
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.dtd
         - match: '"'
           scope: punctuation.definition.string.end.dtd
@@ -258,6 +259,7 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.begin.dtd
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.dtd
         - match: "'"
           scope: punctuation.definition.string.end.dtd

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -95,8 +95,6 @@ contexts:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.doctype.xml
       push: doctype-root-name
-      with_prototype:
-        - include: comment
 
   doctype-root-name:
     - meta_scope: meta.tag.declaration.doctype.xml
@@ -128,6 +126,7 @@ contexts:
         - include: scope:text.xml.dtd
 
   doctype-end:
+    - include: comment
     - match: '>'
       scope: meta.tag.declaration.doctype.xml punctuation.definition.tag.end.xml
       pop: true

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -47,18 +47,7 @@ contexts:
             4: punctuation.separator.key-value.xml
         - include: double-quoted-string
         - include: single-quoted-string
-    - match: '(<!)(DOCTYPE)(?:\s+({{name}}))?'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: keyword.doctype.xml
-        3: variable.documentroot.xml
-      push:
-        - meta_scope: meta.tag.sgml.doctype.xml
-        - match: \s*(>)
-          captures:
-            1: punctuation.definition.tag.end.xml
-          pop: true
-        - include: internal-subset
+    - include: doctype
     - include: comment
     - match: '(</?){{qualified_name}}([^/>\s]*)'
       captures:
@@ -113,11 +102,13 @@ contexts:
     - match: ']]>'
       scope: invalid.illegal.missing-entity.xml
     - include: should-be-entity
+
   should-be-entity:
     - match: '&'
       scope: invalid.illegal.bad-ampersand.xml
     - match: '<'
       scope: invalid.illegal.missing-entity.xml
+
   double-quoted-string:
     - match: '"'
       scope: punctuation.definition.string.begin.xml
@@ -128,12 +119,14 @@ contexts:
           pop: true
         - include: entity
         - include: should-be-entity
+
   entity:
     - match: '(&)(?:{{name}}|#[0-9]+|#x\h+)(;)'
       scope: constant.character.entity.xml
       captures:
         1: punctuation.definition.constant.xml
         2: punctuation.definition.constant.xml
+
   comment:
     - match: '<!--'
       scope: punctuation.definition.comment.begin.xml
@@ -144,93 +137,54 @@ contexts:
           pop: true
         - match: '-{2,}'
           scope: invalid.illegal.double-hyphen-within-comment.xml
-  internal-subset:
-    - match: \[
-      scope: punctuation.definition.constant.xml
-      push:
-        - meta_scope: meta.internalsubset.xml
-        - match: \]
-          pop: true
+
+  # DOCTYPE declaration
+  # see: https://www.quackit.com/xml/tutorial/dtd_doctype.cfm
+  doctype:
+    - match: (<!)(DOCTYPE)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.doctype.xml
+      push: doctype-root-name
+      with_prototype:
         - include: comment
-        - include: entity-decl
-        - include: element-decl
-        - include: attlist-decl
-        - include: notation-decl
-        - include: parameter-entity
-  entity-decl:
-    - match: '(<!)(ENTITY)\s+(%\s+)?({{name}})(\s+(?:SYSTEM|PUBLIC)\s+)?'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: keyword.entity.xml
-        3: punctuation.definition.entity.xml
-        4: variable.entity.xml
-        5: keyword.entitytype.xml
-      push:
-        - match: '>'
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: double-quoted-string
-        - include: single-quoted-string
-  element-decl:
-    - match: '(<!)(ELEMENT)\s+({{name}})\s+'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: keyword.element.xml
-        3: variable.element.xml
-      push:
-        - match: '>'
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - match: '\b(EMPTY|ANY)\b'
-          scope: constant.other.xml
-        - include: element-parens
-  element-parens:
-    - match: \(
-      scope: punctuation.definition.group.xml
-      push:
-        - match: (\))([*?+])?
-          captures:
-            1: punctuation.definition.group.xml
-            2: keyword.operator.xml
-          pop: true
-        - match: '#PCDATA'
-          scope: constant.other.xml
-        - match: '[*?+]'
-          scope: keyword.operator.xml
-        - match: '[,|]'
-          scope: punctuation.separator.xml
-        - include: element-parens
-  attlist-decl:
-    - match: '(<!)(ATTLIST)\s+({{name}})\s+({{name}})'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: keyword.attlist.xml
-        3: variable.element.xml
-        4: variable.attribute-name.xml
-      push:
-        - match: '>'
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: double-quoted-string
-        - include: single-quoted-string
-  notation-decl:
-    - match: '(<!)(NOTATION)\s+({{name}})'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: keyword.notation.xml
-        3: variable.notation.xml
-      push:
-        - match: '>'
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: double-quoted-string
-        - include: single-quoted-string
-  parameter-entity:
-    - match: '(%){{name}}(;)'
-      scope: constant.character.parameter-entity.xml
-      captures:
-        1: punctuation.definition.constant.xml
-        2: punctuation.definition.constant.xml
+
+  doctype-root-name:
+    - meta_scope: meta.tag.declaration.doctype.xml
+    - match: '{{name}}'
+      scope: variable.documentroot.xml
+      set: doctype-content
+    - include: tag-end
+
+  doctype-content:
+    - meta_content_scope: meta.tag.declaration.doctype.xml
+    - match: \b(PUBLIC|SYSTEM)\b
+      scope: keyword.content.external.xml
+    - include: double-quoted-string
+    - include: single-quoted-string
+    - include: doctype-internal-subset
+    - include: tag-end
+
+  doctype-internal-subset:
+    - match: \[
+      scope: punctuation.definition.internal-subset.begin.xml
+      set:
+        - meta_scope: meta.internal-subset.xml
+        - meta_content_scope: meta.tag.declaration.doctype.xml
+        - match: \]
+          scope: punctuation.definition.internal-subset.end.xml
+          set:
+            - meta_content_scope: meta.tag.declaration.doctype.xml
+            - include: tag-end
+        - include: scope:text.xml.dtd
+
+  tag-end:
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      pop: true
+    - match: '<'
+      scope: invalid.illegal.unexpected.dtd
+
   single-quoted-string:
     - match: "'"
       scope: punctuation.definition.string.begin.xml
@@ -241,6 +195,7 @@ contexts:
           pop: true
         - include: entity
         - include: should-be-entity
+
   tag-stuff:
     - match: '(?:\s+|^){{qualified_name}}\s*(=)'
       captures:

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -158,25 +158,26 @@ contexts:
 
   doctype-content:
     - meta_content_scope: meta.tag.declaration.doctype.xml
+    - match: (?=\[)
+      set: doctype-internal-subset
     - match: \b(PUBLIC|SYSTEM)\b
       scope: keyword.content.external.xml
     - include: double-quoted-string
     - include: single-quoted-string
-    - include: doctype-internal-subset
     - include: tag-end
 
   doctype-internal-subset:
     - match: \[
-      scope: punctuation.definition.internal-subset.begin.xml
+      scope: punctuation.section.brackets.begin.xml
       set:
-        - meta_scope: meta.internal-subset.xml
-        - meta_content_scope: meta.tag.declaration.doctype.xml
+        - meta_scope: meta.tag.declaration.doctype.internal-subset.xml meta.brackets.xml
         - match: \]
-          scope: punctuation.definition.internal-subset.end.xml
+          scope: punctuation.section.brackets.end.xml
           set:
             - meta_content_scope: meta.tag.declaration.doctype.xml
             - include: tag-end
         - include: scope:text.xml.dtd
+    - include: tag-end
 
   tag-end:
     - match: '>'

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -154,7 +154,7 @@ contexts:
     - match: '{{name}}'
       scope: variable.documentroot.xml
       set: doctype-content
-    - include: tag-end
+    - include: doctype-end
 
   doctype-content:
     - meta_content_scope: meta.tag.declaration.doctype.xml
@@ -164,7 +164,7 @@ contexts:
       scope: keyword.content.external.xml
     - include: double-quoted-string
     - include: single-quoted-string
-    - include: tag-end
+    - include: doctype-end
 
   doctype-internal-subset:
     - match: \[
@@ -175,16 +175,15 @@ contexts:
           scope: punctuation.section.brackets.end.xml
           set:
             - meta_content_scope: meta.tag.declaration.doctype.xml
-            - include: tag-end
+            - include: doctype-end
         - include: scope:text.xml.dtd
-    - include: tag-end
 
-  tag-end:
+  doctype-end:
     - match: '>'
-      scope: punctuation.definition.tag.end.xml
+      scope: meta.tag.declaration.doctype.xml punctuation.definition.tag.end.xml
       pop: true
-    - match: '<'
-      scope: invalid.illegal.unexpected.dtd
+    - match: '[^>\s]'
+      scope: invalid.illegal.unexpected.xml
 
   single-quoted-string:
     - match: "'"

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -94,17 +94,20 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.doctype.xml
-      push: doctype-root-name
+      push: [doctype-meta, doctype-root-name]
+
+  doctype-meta:
+    - meta_scope: meta.tag.declaration.doctype.xml
+    - match: ''
+      pop: true
 
   doctype-root-name:
-    - meta_scope: meta.tag.declaration.doctype.xml
     - match: '{{name}}'
       scope: variable.documentroot.xml
       set: doctype-content
     - include: doctype-end
 
   doctype-content:
-    - meta_content_scope: meta.tag.declaration.doctype.xml
     - match: (?=\[)
       set: doctype-internal-subset
     - match: \b(PUBLIC|SYSTEM)\b
@@ -117,18 +120,16 @@ contexts:
     - match: \[
       scope: punctuation.section.brackets.begin.xml
       set:
-        - meta_scope: meta.tag.declaration.doctype.internal-subset.xml meta.brackets.xml
+        - meta_scope: meta.brackets.xml meta.internal-subset.xml.dtd
         - match: \]
           scope: punctuation.section.brackets.end.xml
-          set:
-            - meta_content_scope: meta.tag.declaration.doctype.xml
-            - include: doctype-end
+          set: doctype-end
         - include: scope:text.xml.dtd
 
   doctype-end:
     - include: comment
     - match: '>'
-      scope: meta.tag.declaration.doctype.xml punctuation.definition.tag.end.xml
+      scope: punctuation.definition.tag.end.xml
       pop: true
     - match: '[^>\s]'
       scope: invalid.illegal.unexpected.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -68,6 +68,7 @@ contexts:
     - match: '<!--'
       scope: punctuation.definition.comment.begin.xml
       push:
+        - meta_include_prototype: false
         - meta_scope: comment.block.xml
         - match: '-->'
           scope: punctuation.definition.comment.end.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -77,12 +77,16 @@ contexts:
           scope: invalid.illegal.double-hyphen-within-comment.xml
 
   cdata:
-    - match: '<!\[CDATA\['
-      scope: punctuation.definition.string.begin.xml
+    - match: (<!\[)(CDATA)(\[)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.cdata.xml
+        3: punctuation.definition.tag.begin.xml
       push:
-        - meta_scope: string.unquoted.cdata.xml
+        - meta_scope: meta.tag.cdata.xml
+        - meta_content_scope: string.unquoted.cdata.xml
         - match: ']]>'
-          scope: punctuation.definition.string.end.xml
+          scope: punctuation.definition.tag.end.xml
           pop: true
     - match: ']]>'
       scope: invalid.illegal.missing-entity.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -94,20 +94,20 @@ contexts:
   # DOCTYPE declaration
   # see: https://www.quackit.com/xml/tutorial/dtd_doctype.cfm
   doctype:
-    - match: (<!)(DOCTYPE)
+    - match: (<!)(?i)(DOCTYPE)
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.doctype.xml
       push: [doctype-meta, doctype-root-name]
 
   doctype-meta:
-    - meta_scope: meta.tag.declaration.doctype.xml
+    - meta_scope: meta.tag.doctype.xml
     - match: ''
       pop: true
 
   doctype-root-name:
     - match: '{{name}}'
-      scope: variable.documentroot.xml
+      scope: constant.language.doctype.xml
       set: doctype-content
     - include: doctype-end
 

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -21,13 +21,13 @@ scope: text.xml
 variables:
   # This is the full XML Name production, but should not be used where namespaces
   # are possible. Those locations should use a qualified_name.
-  name: '[[:alpha:]:_][[:alnum:]:_.-]*'
+  name: '(?i)[[:alpha:]:_][[:alnum:]:_.-]*'
   # This is the form that allows a namespace prefix (ns:) followed by a local
   # name. The captures are:
   #  1: namespace prefix name
   #  2: namespace prefix colon
   #  3: local tag name
-  qualified_name: '(?:([[:alpha:]_][[:alnum:]_.-]*)(:))?([[:alpha:]_][[:alnum:]_.-]*)'
+  qualified_name: '(?i)(?:([[:alpha:]_][[:alnum:]_.-]*)(:))?([[:alpha:]_][[:alnum:]_.-]*)'
 
 contexts:
   main:
@@ -45,7 +45,7 @@ contexts:
     #   <?xml version="1.0" ?>
     #   <?xml-model href='freb.xsl'?>
     #   <?xml-stylesheet type='text/xsl' href='freb.xsl'?>
-    - match: '(<\?)(xml(?:-{{name}})?)(?=\s|\?>)'
+    - match: '(?i)(<\?)(xml(?:-{{name}})?)(?=\s|\?>)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.preprocessor.xml
@@ -57,7 +57,7 @@ contexts:
         - include: tag-attributes
     # All tags like <?...?>
     # meta tag without internal highlighting
-    - match: '(<\?)((?![xX][mM][lL]){{name}}).*(\?>)'
+    - match: '(?i)(<\?)((?!xml){{name}}).*(\?>)'
       captures:
         0: meta.tag.preprocessor.xml
         1: punctuation.definition.tag.begin.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -108,12 +108,11 @@ contexts:
     - include: doctype-end
 
   doctype-content:
-    - match: (?=\[)
-      set: doctype-internal-subset
     - match: \b(PUBLIC|SYSTEM)\b
       scope: keyword.content.external.xml
     - include: double-quoted-string
     - include: single-quoted-string
+    - include: doctype-internal-subset
     - include: doctype-end
 
   doctype-internal-subset:

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -113,6 +113,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.xml
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.xml
         - match: '"'
           scope: punctuation.definition.string.end.xml
@@ -189,6 +190,7 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.begin.xml
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.xml
         - match: "'"
           scope: punctuation.definition.string.end.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -4,6 +4,7 @@ name: XML
 file_extensions:
   - xml
   - xsd
+  - xsl
   - xslt
   - tld
   - dtml
@@ -30,78 +31,38 @@ variables:
 
 contexts:
   main:
-    - match: '(<\?)(xml)(?=\s)'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.xml
-      push:
-        - meta_scope: meta.tag.preprocessor.xml
-        - match: \?>
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - match: '\s+{{qualified_name}}(=)?'
-          captures:
-            1: entity.other.attribute-name.namespace.xml
-            2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
-            3: entity.other.attribute-name.localname.xml
-            4: punctuation.separator.key-value.xml
-        - include: double-quoted-string
-        - include: single-quoted-string
-    - include: doctype
     - include: comment
-    - match: '(</?){{qualified_name}}([^/>\s]*)'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.namespace.xml
-        3: entity.name.tag.xml punctuation.separator.namespace.xml
-        4: entity.name.tag.localname.xml
-        5: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.xml
-        - match: /?>
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: tag-stuff
-    - match: '(</?)([[:digit:].-][[:alnum:]:_.-]*)'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.xml
-        - match: /?>
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: tag-stuff
-    - match: '(<\?)(xml-stylesheet|xml-model)(?=\s|\?>)'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.xml
-      push:
-        - meta_scope: meta.tag.preprocessor.xml
-        - match: \?>
-          scope: punctuation.definition.tag.end.xml
-          pop: true
-        - include: tag-stuff
-    - match: '(<\?)((?![xX][mM][lL]){{qualified_name}})(?=\s|\?>)'
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.xml
-      push:
-        - meta_scope: meta.tag.preprocessor.xml
-        - match: \?>
-          scope: punctuation.definition.tag.end.xml
-          pop: true
+    - include: preprocessor
+    - include: doctype
+    - include: tags
+    - include: cdata
     - include: entity
-    - match: '<!\[CDATA\['
-      scope: punctuation.definition.string.begin.xml
-      push:
-        - meta_scope: string.unquoted.cdata.xml
-        - match: ']]>'
-          scope: punctuation.definition.string.end.xml
-          pop: true
-    - match: ']]>'
-      scope: invalid.illegal.missing-entity.xml
     - include: should-be-entity
+
+  preprocessor:
+    # All tags like <?xml...?> without respect of details
+    # Examples:
+    #   <?xml version="1.0" ?>
+    #   <?xml-model href='freb.xsl'?>
+    #   <?xml-stylesheet type='text/xsl' href='freb.xsl'?>
+    - match: '(<\?)(xml(?:-{{name}})?)(?=\s|\?>)'
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.preprocessor.xml
+      push:
+        - meta_scope: meta.tag.preprocessor.xml
+        - match: '\?>'
+          scope: punctuation.definition.tag.end.xml
+          pop: true
+        - include: tag-attributes
+    # All tags like <?...?>
+    # meta tag without internal highlighting
+    - match: '(<\?)((?![xX][mM][lL]){{name}}).*(\?>)'
+      captures:
+        0: meta.tag.preprocessor.xml
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.xml
+        3: punctuation.definition.tag.end.xml
 
   comment:
     - match: '<!--'
@@ -113,6 +74,17 @@ contexts:
           pop: true
         - match: '-{2,}'
           scope: invalid.illegal.double-hyphen-within-comment.xml
+
+  cdata:
+    - match: '<!\[CDATA\['
+      scope: punctuation.definition.string.begin.xml
+      push:
+        - meta_scope: string.unquoted.cdata.xml
+        - match: ']]>'
+          scope: punctuation.definition.string.end.xml
+          pop: true
+    - match: ']]>'
+      scope: invalid.illegal.missing-entity.xml
 
   # DOCTYPE declaration
   # see: https://www.quackit.com/xml/tutorial/dtd_doctype.cfm
@@ -161,19 +133,56 @@ contexts:
     - match: '[^>\s]'
       scope: invalid.illegal.unexpected.xml
 
-  tag-stuff:
-    - match: '(?:\s+|^){{qualified_name}}\s*(=)'
+  tags:
+    # closing tags
+    # (?=<) improves overall performance by 8%
+    - match: '(?=<)(</)(?:{{qualified_name}})?([^/>\s]*)'
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.namespace.xml
+        3: entity.name.tag.xml punctuation.separator.namespace.xml
+        4: entity.name.tag.localname.xml
+        5: invalid.illegal.bad-tag-name.xml
+      push:
+        - meta_scope: meta.tag.xml
+        - match: '>'
+          scope: punctuation.definition.tag.end.xml
+          pop: true
+        - match: '[^>\s]+'
+          scope: invalid.illegal.unexpected.xml
+    # opening maybe self-closing tag
+    - match: '(<(?=\w))(?:{{qualified_name}})?([^/>\s]*)'
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.namespace.xml
+        3: entity.name.tag.xml punctuation.separator.namespace.xml
+        4: entity.name.tag.localname.xml
+        5: invalid.illegal.bad-tag-name.xml
+      push:
+        - meta_scope: meta.tag.xml
+        - match: '/?>'
+          scope: punctuation.definition.tag.end.xml
+          pop: true
+        - include: tag-attributes
+
+  tag-attributes:
+    - include: double-quoted-string
+    - include: single-quoted-string
+    # valid attribute name followed by '='
+    - match: '\b{{qualified_name}}\s*(=)'
       captures:
         1: entity.other.attribute-name.namespace.xml
         2: entity.other.attribute-name.xml punctuation.separator.namespace.xml
         3: entity.other.attribute-name.localname.xml
         4: punctuation.separator.key-value.xml
-    - match: '(?:\s+|^)([[:alnum:]:_.-]+)\s*(=)'
+    # everything before '=' not matched by previous pattern
+    - match: '(\S+)\s*(=)'
       captures:
         1: invalid.illegal.bad-attribute-name.xml
         2: punctuation.separator.key-value.xml
-    - include: double-quoted-string
-    - include: single-quoted-string
+    # everything unquoted is illegal
+    - match: '[^\s=]'
+      scope: invalid.illegal.bad-attribute-value.xml
 
   double-quoted-string:
     - match: '"'

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -21,13 +21,13 @@ scope: text.xml
 variables:
   # This is the full XML Name production, but should not be used where namespaces
   # are possible. Those locations should use a qualified_name.
-  name: '(?i)[[:alpha:]:_][[:alnum:]:_.-]*'
+  name: '[[:alpha:]:_][[:alnum:]:_.-]*'
   # This is the form that allows a namespace prefix (ns:) followed by a local
   # name. The captures are:
   #  1: namespace prefix name
   #  2: namespace prefix colon
   #  3: local tag name
-  qualified_name: '(?i)(?:([[:alpha:]_][[:alnum:]_.-]*)(:))?([[:alpha:]_][[:alnum:]_.-]*)'
+  qualified_name: '(?:([[:alpha:]_][[:alnum:]_.-]*)(:))?([[:alpha:]_][[:alnum:]_.-]*)'
 
 contexts:
   main:
@@ -45,7 +45,7 @@ contexts:
     #   <?xml version="1.0" ?>
     #   <?xml-model href='freb.xsl'?>
     #   <?xml-stylesheet type='text/xsl' href='freb.xsl'?>
-    - match: '(?i)(<\?)(xml(?:-{{name}})?)(?=\s|\?>)'
+    - match: '(<\?)(xml|(?:[xX][mM][lL]-{{name}}))(?=\s|\?>)'
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.preprocessor.xml
@@ -57,7 +57,7 @@ contexts:
         - include: tag-attributes
     # All tags like <?...?>
     # meta tag without internal highlighting
-    - match: '(?i)(<\?)((?!xml){{name}}).*(\?>)'
+    - match: '(<\?)((?![xX][mM][lL]){{name}}).*(\?>)'
       captures:
         0: meta.tag.preprocessor.xml
         1: punctuation.definition.tag.begin.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -114,8 +114,8 @@ contexts:
   doctype-content:
     - match: \b(PUBLIC|SYSTEM)\b
       scope: keyword.content.external.xml
-    - include: double-quoted-string
-    - include: single-quoted-string
+    - include: string-douple-quoted
+    - include: string-single-quoted
     - include: doctype-internal-subset
     - include: doctype-end
 
@@ -170,8 +170,8 @@ contexts:
         - include: tag-attributes
 
   tag-attributes:
-    - include: double-quoted-string
-    - include: single-quoted-string
+    - include: string-douple-quoted
+    - include: string-single-quoted
     # valid attribute name followed by '='
     - match: '\b{{qualified_name}}\s*(=)'
       captures:
@@ -188,7 +188,7 @@ contexts:
     - match: '[^\s=]'
       scope: invalid.illegal.bad-attribute-value.xml
 
-  double-quoted-string:
+  string-douple-quoted:
     - match: '"'
       scope: punctuation.definition.string.begin.xml
       push:
@@ -200,7 +200,7 @@ contexts:
         - include: entity
         - include: should-be-entity
 
-  single-quoted-string:
+  string-single-quoted:
     - match: "'"
       scope: punctuation.definition.string.begin.xml
       push:
@@ -213,11 +213,21 @@ contexts:
         - include: should-be-entity
 
   entity:
-    - match: '(&)(?:{{name}}|#[0-9]+|#x\h+)(;)'
-      scope: constant.character.entity.xml
+    - match: (&#[xX])(\h+)(;)
+      scope: constant.character.entity.hexadecimal.xml
       captures:
-        1: punctuation.definition.constant.xml
-        2: punctuation.definition.constant.xml
+        1: punctuation.definition.entity.xml
+        3: punctuation.definition.entity.xml
+    - match: (&#)([0-9]+)(;)
+      scope: constant.character.entity.decimal.xml
+      captures:
+        1: punctuation.definition.entity.xml
+        3: punctuation.definition.entity.xml
+    - match: (&)([a-zA-Z0-9]+)(;)
+      scope: constant.character.entity.named.xml
+      captures:
+        1: punctuation.definition.entity.xml
+        3: punctuation.definition.entity.xml
 
   should-be-entity:
     - match: '&'

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -103,31 +103,6 @@ contexts:
       scope: invalid.illegal.missing-entity.xml
     - include: should-be-entity
 
-  should-be-entity:
-    - match: '&'
-      scope: invalid.illegal.bad-ampersand.xml
-    - match: '<'
-      scope: invalid.illegal.missing-entity.xml
-
-  double-quoted-string:
-    - match: '"'
-      scope: punctuation.definition.string.begin.xml
-      push:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.double.xml
-        - match: '"'
-          scope: punctuation.definition.string.end.xml
-          pop: true
-        - include: entity
-        - include: should-be-entity
-
-  entity:
-    - match: '(&)(?:{{name}}|#[0-9]+|#x\h+)(;)'
-      scope: constant.character.entity.xml
-      captures:
-        1: punctuation.definition.constant.xml
-        2: punctuation.definition.constant.xml
-
   comment:
     - match: '<!--'
       scope: punctuation.definition.comment.begin.xml
@@ -186,18 +161,6 @@ contexts:
     - match: '[^>\s]'
       scope: invalid.illegal.unexpected.xml
 
-  single-quoted-string:
-    - match: "'"
-      scope: punctuation.definition.string.begin.xml
-      push:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.single.xml
-        - match: "'"
-          scope: punctuation.definition.string.end.xml
-          pop: true
-        - include: entity
-        - include: should-be-entity
-
   tag-stuff:
     - match: '(?:\s+|^){{qualified_name}}\s*(=)'
       captures:
@@ -211,3 +174,40 @@ contexts:
         2: punctuation.separator.key-value.xml
     - include: double-quoted-string
     - include: single-quoted-string
+
+  double-quoted-string:
+    - match: '"'
+      scope: punctuation.definition.string.begin.xml
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.xml
+        - match: '"'
+          scope: punctuation.definition.string.end.xml
+          pop: true
+        - include: entity
+        - include: should-be-entity
+
+  single-quoted-string:
+    - match: "'"
+      scope: punctuation.definition.string.begin.xml
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.single.xml
+        - match: "'"
+          scope: punctuation.definition.string.end.xml
+          pop: true
+        - include: entity
+        - include: should-be-entity
+
+  entity:
+    - match: '(&)(?:{{name}}|#[0-9]+|#x\h+)(;)'
+      scope: constant.character.entity.xml
+      captures:
+        1: punctuation.definition.constant.xml
+        2: punctuation.definition.constant.xml
+
+  should-be-entity:
+    - match: '&'
+      scope: invalid.illegal.bad-ampersand.xml
+    - match: '<'
+      scope: invalid.illegal.missing-entity.xml

--- a/XML/syntax_test_dtd.dtd
+++ b/XML/syntax_test_dtd.dtd
@@ -1,0 +1,440 @@
+<!--SYNTAX TEST "Packages/XML/DTD.sublime-syntax" -->
+
+<!--
+  =============
+  DTD Parameter
+  =============
+ -->
+
+      %SVG.font.qname;
+<!--  ^ punctuation.definition.variable.begin -->
+<!--  ^^^^^^^^^^^^^^^^  variable.parameter -->
+<!--                 ^ punctuation.definition.variable.end -->
+
+<!--
+  ============
+  DTD Entities
+  ============
+ -->
+
+    <!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' NDATA JPG>
+<!--^^^^^^^^ meta.tag.declaration.entity -->
+<!--        ^^^^^^^^^^^^^^^ meta.tag.declaration.entity.name -->
+<!--                       ^^^^^^^ meta.tag.declaration.entity.type -->
+<!--                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.entity.content.external -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^ entity.name.tag.entity -->
+<!--         ^ punctuation.definition.tag.separator -->
+<!--           ^^^^^^^^^^^^ variable.entity -->
+<!--                        ^^^^^^ keyword.content.external -->
+<!--                               ^ punctuation.definition.string.begin -->
+<!--                               ^^^^^^^^^^^ string.quoted.single -->
+<!--                                         ^ punctuation.definition.string.end -->
+<!--                                           ^ punctuation.definition.string.begin -->
+<!--                                           ^^^^^^^^^^^^^^^ string.quoted.single -->
+<!--                                                         ^ punctuation.definition.string.end -->
+<!--                                                           ^^^^^ keyword.ndata -->
+<!--                                                                 ^^^ string.unquoted -->
+<!--                                                                    ^ punctuation.definition.tag.end -->
+    <!ENTITY
+<!--^^^^^^^^ meta.tag.declaration.entity -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^ entity.name.tag.entity -->
+      % xs-datatypes
+<!--^^^^^^^^^^^^^^^^ meta.tag.declaration.entity.name -->
+<!--  ^ punctuation.definition.tag.separator -->
+<!--    ^^^^^^^^^^^^ variable.entity -->
+      PUBLIC
+<!--^^^^^^^^ meta.tag.declaration.entity.type -->
+<!--  ^^^^^^ keyword.content.external -->
+      'datatypes' 'datatypes.dtd'
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.entity.content.external -->
+<!--  ^ punctuation.definition.string.begin -->
+<!--  ^^^^^^^^^^^ string.quoted.single -->
+<!--            ^ punctuation.definition.string.end -->
+<!--              ^ punctuation.definition.string.begin -->
+<!--              ^^^^^^^^^^^^^^^ string.quoted.single -->
+<!--                            ^ punctuation.definition.string.end -->
+      NDATA JPG
+<!--^^^^^^^^^^^ meta.tag.declaration.entity.content -->
+<!--  ^^^^^ keyword.ndata -->
+<!--        ^^^ string.unquoted -->
+    >
+<!--^ meta.tag.declaration.entity -->
+<!--^ punctuation.definition.tag.end -->
+
+<!--
+  ============
+  DTD Elements
+  ============
+ -->
+
+<!-- Empty value -->
+    <!ELEMENT element-name EMPTY >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                      ^^^^^^^ meta.tag.declaration.element.content -->
+<!--                             ^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^ variable.element -->
+<!--                       ^^^^^ storage.type.content.empty -->
+<!--                             ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+      element-name
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--  ^^^^^^^^^^^^ variable.element -->
+      EMPTY
+<!--^^^^^^^ meta.tag.declaration.element.content -->
+<!--  ^^^^^ storage.type.content.empty -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+<!-- Any value -->
+    <!ELEMENT element-name ANY >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                      ^^^^^ meta.tag.declaration.element.content -->
+<!--                           ^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^ variable.element -->
+<!--                       ^^^ storage.type.content.any -->
+<!--                           ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+      element-name
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--  ^^^^^^^^^^^^ variable.element -->
+      ANY
+<!--^^^^^ meta.tag.declaration.element.content -->
+<!--  ^^^ storage.type.content.any -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+<!-- String values -->
+    <!ELEMENT element-name 'value' >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                      ^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--                               ^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^ variable.element -->
+<!--                       ^ punctuation.definition.string.begin -->
+<!--                       ^^^^^^^ string.quoted.single -->
+<!--                             ^ punctuation.definition.string.end -->
+<!--                               ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+      element-name
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--  ^^^^^^^^^^^^ variable.element -->
+      'value'
+<!--^^^^^ meta.tag.declaration.element.content -->
+<!--^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--  ^ punctuation.definition.string.begin -->
+<!--  ^^^^^^^ string.quoted.single -->
+<!--        ^ punctuation.definition.string.end -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+    <!ELEMENT element-name "value" >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                      ^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^ variable.element -->
+<!--                       ^ punctuation.definition.string.begin -->
+<!--                       ^^^^^^^ string.quoted.double -->
+<!--                             ^ punctuation.definition.string.end -->
+<!--                               ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+      element-name
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--  ^^^^^^^^^^^^ variable.element -->
+      "value"
+<!--^^^^^ meta.tag.declaration.element.content -->
+<!--^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--  ^ punctuation.definition.string.begin -->
+<!--  ^^^^^^^ string.quoted.double -->
+<!--        ^ punctuation.definition.string.end -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+
+<!-- Sequence values -->
+    <!ELEMENT element-name (#PCDATA,value1*,value2+,(%param;|value32)?) >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--                                                                   ^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^ variable.element -->
+<!--                       ^ punctuation.definition.group.begin -->
+<!--                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.sequence -->
+<!--                        ^ punctuation.definition.variable.begin -->
+<!--                        ^^^^^^^ variable.language.parsed-character-data -->
+<!--                               ^ punctuation.separator.group -->
+<!--                                ^^^^^^ string.unquoted -->
+<!--                                      ^ keyword.operator -->
+<!--                                       ^ punctuation.separator.group -->
+<!--                                        ^^^^^^ string.unquoted -->
+<!--                                              ^ keyword.operator -->
+<!--                                               ^ punctuation.separator.group -->
+<!--                                                ^ punctuation.definition.group.begin -->
+<!--                                                 ^ punctuation.definition.variable.begin -->
+<!--                                                 ^^^^^^^  variable.parameter -->
+<!--                                                       ^ punctuation.definition.variable.end -->
+<!--                                                        ^ punctuation.separator.logical -->
+<!--                                                                ^ punctuation.definition.group.end -->
+<!--                                                                 ^ keyword.operator -->
+<!--                                                                  ^ punctuation.definition.group.end -->
+<!--                                                         ^^^^^^^ string.unquoted -->
+<!--                                                                    ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+        element-name
+<!--^^^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--    ^^^^^^^^^^^^ variable.element -->
+        (
+<!--^^^^^ meta.tag.declaration.element.content -->
+<!--    ^ meta.group.sequence -->
+<!--    ^ punctuation.definition.group.begin -->
+          #PCDATA ,
+<!--^^^^^^^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--      ^ punctuation.definition.variable.begin -->
+<!--      ^^^^^^^ variable.language.parsed-character-data -->
+<!--              ^ punctuation.separator.group -->
+          value1*,
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--      ^^^^^^ string.unquoted -->
+<!--            ^ keyword.operator -->
+<!--             ^ punctuation.separator.group -->
+          value2 + ,
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--      ^^^^^^ string.unquoted -->
+<!--             ^ keyword.operator -->
+<!--               ^ punctuation.separator.group -->
+          (
+<!--^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--      ^ punctuation.definition.group.begin -->
+            %param;
+<!--^^^^^^^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--        ^ punctuation.definition.variable.begin -->
+<!--        ^^^^^^^  variable.parameter -->
+<!--              ^ punctuation.definition.variable.end -->
+            |
+<!--^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--        ^ punctuation.separator.logical -->
+            value32
+<!--^^^^^^^^^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--        ^^^^^^^ string.unquoted -->
+          ) ?
+<!--^^^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--      ^ punctuation.definition.group.end -->
+<!--        ^ keyword.operator -->
+        )
+<!--^^^^^ meta.tag.declaration.element.content meta.group.sequence -->
+<!--    ^ punctuation.definition.group.end -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+
+<!-- Parameter values -->
+    <!ELEMENT %SVG.font.qname; %SVG.font.content; >
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--         ^^^^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                          ^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+<!--          ^^^^^^^^^^^^^^^^  variable.parameter -->
+<!--          ^ punctuation.definition.variable.begin -->
+<!--                         ^ punctuation.definition.variable.end -->
+<!--                           ^^^^^^^^^^^^^^^^^^  variable.parameter -->
+<!--                           ^ punctuation.definition.variable.begin -->
+<!--                                            ^ punctuation.definition.variable.end -->
+<!--                                              ^ punctuation.definition.tag.end -->
+
+    <!ELEMENT
+<!--^^^^^^^^^ meta.tag.declaration.element -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.element -->
+      %SVG.font.qname;
+<!--^^^^^^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--  ^ punctuation.definition.variable.begin -->
+<!--  ^^^^^^^^^^^^^^^^ variable.parameter -->
+<!--                 ^ punctuation.definition.variable.end -->
+      %SVG.font.content;
+<!--^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.element.content -->
+<!--  ^ punctuation.definition.variable.begin -->
+<!--  ^^^^^^^^^^^^^^^^^^ variable.parameter -->
+<!--                   ^ punctuation.definition.variable.end -->
+    >
+<!--^ meta.tag.declaration.element -->
+<!--^ punctuation.definition.tag.end -->
+
+<!--
+  ==================
+  DTD Attribute list
+  ==================
+ -->
+
+    <!ATTLIST %element-name;
+<!--^^^^^^^^^ meta.tag.declaration.attlist -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^ entity.name.tag.attlist -->
+<!--         ^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.element -->
+<!--          ^ punctuation.definition.variable.begin -->
+<!--          ^^^^^^^^^^^^^^ variable.parameter -->
+<!--                       ^ punctuation.definition.variable.end -->
+          id            ID                     #IMPLIED
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.content -->
+<!--      ^^ entity.other.attribute-name -->
+<!--                    ^^ storage.type.attribute -->
+<!--                                           ^ punctuation.definition.constant.attribute-value -->
+<!--                                           ^^^^^^^^ constant.other.attribute-value -->
+          %nds;         %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.content -->
+<!--      ^ punctuation.definition.variable.begin -->
+<!--      ^^^^^ variable.parameter -->
+<!--          ^ punctuation.definition.variable.end -->
+<!--                    ^ punctuation.definition.variable.begin -->
+<!--                    ^^^^^^^^ variable.parameter -->
+<!--                           ^ punctuation.definition.variable.end -->
+<!--                                           ^ punctuation.definition.constant.attribute-value -->
+<!--                                           ^^^^^^ constant.other.attribute-value -->
+<!--                                                  ^ punctuation.definition.string.begin -->
+<!--                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single -->
+<!--                                                                                   ^ punctuation.definition.string.end -->
+          enum          (value1|value2|value3) 'value1'
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.content -->
+<!--      ^^^^ entity.other.attribute-name -->
+<!--                    ^ punctuation.definition.group.begin -->
+<!--                    ^^^^^^^^^^^^^^^^^^^^^^ meta.group.enumerated -->
+<!--                     ^^^^^^ string.unquoted -->
+<!--                           ^ punctuation.separator.logical -->
+<!--                            ^^^^^^ string.unquoted -->
+<!--                                  ^ punctuation.separator.logical -->
+<!--                                   ^^^^^^ string.unquoted -->
+<!--                                         ^ punctuation.definition.group.end -->
+<!--                                           ^ punctuation.definition.string.begin -->
+<!--                                           ^^^^^^^^ string.quoted.single -->
+<!--                                                  ^ punctuation.definition.string.end -->
+          finalDefault  %complexDerivationSet; ''
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.content -->
+<!--      ^^^^^^^^^^^^ entity.other.attribute-name -->
+<!--                    ^ punctuation.definition.variable.begin -->
+<!--                    ^^^^^^^^^^^^^^^^^^^^^^ variable.parameter -->
+<!--                                         ^ punctuation.definition.variable.end -->
+<!--                                           ^ punctuation.definition.string.begin -->
+<!--                                           ^^ string.quoted.single -->
+<!--                                            ^ punctuation.definition.string.end -->
+          %sequenceAttrs;
+<!--^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.attlist.content -->
+<!--      ^ punctuation.definition.variable.begin -->
+<!--      ^^^^^^^^^^^^^^^ variable.parameter -->
+<!--                    ^ punctuation.definition.variable.end -->
+    >
+<!--^ meta.tag.declaration.attlist -->
+<!--^ punctuation.definition.tag.end -->
+
+<!--
+  ============
+  DTD Notation
+  ============
+ -->
+
+    <!NOTATION XMLSchemaStructures PUBLIC 'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!--^^^^^^^^^^ meta.tag.declaration.notation -->
+<!--          ^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.notation.name -->
+<!--                              ^^^^^^^ meta.tag.declaration.notation.type -->
+<!--                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.notation.content -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^^ entity.name.tag.notation -->
+<!--           ^^^^^^^^^^^^^^^^^^^ variable.notation -->
+<!--                               ^^^^^^ keyword.content.external -->
+<!--                                      ^ punctuation.definition.string.begin -->
+<!--                                      ^^^^^^^^^^^^ string.quoted.single -->
+<!--                                                 ^ punctuation.definition.string.end -->
+<!--                                                   ^ punctuation.definition.string.begin -->
+<!--                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single -->
+<!--                                                                                        ^ punctuation.definition.string.end -->
+<!--                                                                                          ^ punctuation.definition.tag.end -->
+    <!NOTATION
+<!--^^^^^^^^^^ meta.tag.declaration.notation -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^^^ entity.name.tag.notation -->
+      XMLSchemaStructures
+<!--^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.notation.name -->
+<!--  ^^^^^^^^^^^^^^^^^^^ variable.notation -->
+      PUBLIC
+<!--^^^^^^^^ meta.tag.declaration.notation.type -->
+<!--  ^^^^^^ keyword.content.external -->
+      'structures'
+<!--^^^^^^^^^^^^^^ meta.tag.declaration.notation.content -->
+<!--  ^ punctuation.definition.string.begin -->
+<!--  ^^^^^^^^^^^^ string.quoted.single -->
+<!--             ^ punctuation.definition.string.end -->
+      'http://www.w3.org/2001/XMLSchema.xsd'
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.notation.content -->
+<!--  ^ punctuation.definition.string.begin -->
+<!--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single -->
+<!--                                       ^ punctuation.definition.string.end -->
+    >
+<!--^ meta.tag.declaration.notation -->
+<!--^ punctuation.definition.tag.end -->
+
+
+ <!--
+  ============
+  DTD Subsets
+  ============
+ -->
+
+    <![%subset-name;[<!ELEMENT element-name 'value'><!-- comment -->]]>
+<!--^^^^^^^^^^^^^^^^ meta.tag.subset -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.subset.body -->
+<!--                 ^^^^^^^^^ meta.tag.declaration.element -->
+<!--                          ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
+<!--                                       ^^^^^^^ meta.tag.declaration.element.content -->
+<!--                                                                 ^^ meta.tag.subset -->
+<!--^^^ punctuation.definition.tag.begin -->
+<!--   ^ punctuation.definition.variable.begin -->
+<!--   ^^^^^^^^^^^^^ variable.parameter -->
+<!--               ^ punctuation.definition.variable.end -->
+<!--                ^ punctuation.definition.internal-subset.begin -->
+<!--                 ^^ punctuation.definition.tag.begin -->
+<!--                   ^^^^^^^ entity.name.tag.element -->
+<!--                           ^^^^^^^^^^^^ variable.element -->
+<!--                                        ^ punctuation.definition.string.begin -->
+<!--                                        ^^^^^^ string.quoted.single -->
+<!--                                              ^ punctuation.definition.string.end -->
+<!--                                               ^ punctuation.definition.tag.end -->
+<!--                                                ^^^^^^^^^^^^^^^^ comment.block -->
+<!--                                                                ^ punctuation.definition.internal-subset.end -->
+<!--                                                                 ^^ punctuation.definition.tag.end -->

--- a/XML/syntax_test_dtd.dtd
+++ b/XML/syntax_test_dtd.dtd
@@ -63,6 +63,36 @@
 <!--^ meta.tag.declaration.entity -->
 <!--^ punctuation.definition.tag.end -->
 
+    <!ENTITY nbsp "&#160;">
+<!--^^^^^^^^ meta.tag.declaration.entity -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^ entity.name.tag.entity -->
+<!--         ^^^^ variable.entity -->
+<!--              ^^^^^^^^ string.quoted.double -->
+<!--               ^^^^^^ constant.character.entity -->
+
+    <!ENTITY
+<!--^^^^^^^^ meta.tag.declaration.entity -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^ entity.name.tag.entity -->
+      nbsp
+<!--  ^^^^ variable.entity -->
+      "&#160;"
+<!--  ^^^^^^^^ string.quoted.double -->
+<!--   ^^^^^^ constant.character.entity -->
+    >
+<!--^ meta.tag.declaration.entity -->
+<!--^ punctuation.definition.tag.end -->
+
+    <!ENTITY nbsp "&#A60;">
+<!--^^^^^^^^ meta.tag.declaration.entity -->
+<!--^^ punctuation.definition.tag.begin -->
+<!--  ^^^^^^ entity.name.tag.entity -->
+<!--         ^^^^ variable.entity -->
+<!--              ^^^^^^^^ string.quoted.double -->
+<!--               ^^^^^^ - constant.character.entity -->
+<!--               ^ invalid.illegal.bad-ampersand -->
+
 <!--
   ============
   DTD Elements

--- a/XML/syntax_test_dtd.dtd
+++ b/XML/syntax_test_dtd.dtd
@@ -417,17 +417,17 @@
  -->
 
     <![%subset-name;[<!ELEMENT element-name 'value'><!-- comment -->]]>
-<!--^^^^^^^^^^^^^^^^ meta.tag.subset -->
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.subset.body -->
+<!--^^^^^^^^^^^^^^^^ meta.tag.declaration.internal-subset -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.internal-subset.content meta.brackets -->
 <!--                 ^^^^^^^^^ meta.tag.declaration.element -->
 <!--                          ^^^^^^^^^^^^^ meta.tag.declaration.element.name -->
 <!--                                       ^^^^^^^ meta.tag.declaration.element.content -->
-<!--                                                                 ^^ meta.tag.subset -->
+<!--                                                                 ^^ meta.tag.declaration.internal-subset -->
 <!--^^^ punctuation.definition.tag.begin -->
 <!--   ^ punctuation.definition.variable.begin -->
 <!--   ^^^^^^^^^^^^^ variable.parameter -->
 <!--               ^ punctuation.definition.variable.end -->
-<!--                ^ punctuation.definition.internal-subset.begin -->
+<!--                ^ punctuation.section.brackets.begin -->
 <!--                 ^^ punctuation.definition.tag.begin -->
 <!--                   ^^^^^^^ entity.name.tag.element -->
 <!--                           ^^^^^^^^^^^^ variable.element -->
@@ -436,5 +436,5 @@
 <!--                                              ^ punctuation.definition.string.end -->
 <!--                                               ^ punctuation.definition.tag.end -->
 <!--                                                ^^^^^^^^^^^^^^^^ comment.block -->
-<!--                                                                ^ punctuation.definition.internal-subset.end -->
+<!--                                                                ^ punctuation.section.brackets.end -->
 <!--                                                                 ^^ punctuation.definition.tag.end -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -87,18 +87,17 @@
         [
 <!--    ^ punctuation.section.brackets.begin -->
             <!ELEMENT p "">
-<!--    <- meta.tag.declaration.doctype.internal-subset meta.brackets -->
+<!--    <- meta.brackets meta.internal-subset.xml.dtd -->
         ]
-<!--    <- meta.tag.declaration.doctype.internal-subset meta.brackets -->
+<!--    <- meta.brackets meta.internal-subset.xml.dtd -->
 <!--    ^ punctuation.section.brackets.end -->
      >
 <!-- ^ meta.tag.declaration.doctype -->
 <!-- ^ punctuation.definition.tag.end -->
 
      <!DOCTYPE root [<!ENTITY br "\n" <!-- comment --> > %name; <!-- comment --> ]>
-<!-- ^^^^^^^^^^^^^^^ meta.tag.declaration.doctype - meta.tag.declaration.doctype.internal-subset - meta.brackets  -->
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype.internal-subset meta.brackets -->
-<!--                                                                              ^ meta.tag.declaration.doctype -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype  -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.brackets meta.internal-subset.xml.dtd -->
 <!--                   ^^^^^^ meta.tag.declaration.entity -->
 <!--                         ^^^ meta.tag.declaration.entity.name -->
 <!--                            ^ meta.tag.declaration.entity.type.dtd -->
@@ -170,7 +169,7 @@
 <!--                   ^ string.quoted.double -->
 
 ]>
-<!-- <- meta.tag.declaration.doctype.internal-subset meta.brackets punctuation.section.brackets.end -->
+<!-- <- meta.brackets meta.internal-subset.xml.dtd punctuation.section.brackets.end -->
 
 <!--
   Comments

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -335,21 +335,21 @@ foo="bar" />
  -->
 
      &amp;
-<!-- ^ punctuation.definition.constant -->
-<!--  ^^^ - punctuation.definition.constant -->
+<!-- ^ punctuation.definition.entity -->
+<!--  ^^^ - punctuation.definition.entity -->
 <!-- ^^^^^ constant.character.entity -->
-<!--     ^ punctuation.definition.constant -->
-<!--      ^ - constant.character.entity - punctuation.definition.constant -->
+<!--     ^ punctuation.definition.entity -->
+<!--      ^ - constant.character.entity - punctuation.definition.entity -->
 
      &#160;
-<!-- ^ punctuation.definition.constant -->
-<!--  ^^^^ -punctuation.definition.constant -->
+<!-- ^ punctuation.definition.entity -->
+<!--   ^^^ - punctuation.definition.entity -->
 <!-- ^^^^^^ constant.character.entity -->
-<!--      ^ punctuation.definition.constant -->
+<!--      ^ punctuation.definition.entity -->
 <!--       ^ - constant.character.entity -->
 
      <!-- &amp; -->
-<!--      ^ -punctuation.definition.constant -->
+<!--      ^ -punctuation.definition.entity -->
 
      <example attr="&quot;test&quot;" />
 <!--               ^^^^^^^^^^^^^^^^^^ string.quoted.double -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -59,30 +59,30 @@
  -->
 
      <!DOCTYPE root PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/1999/xhtml">
- <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.tag.declaration.doctype -->
+ <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.tag.doctype -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
-<!--           ^^^^ variable.documentroot -->
+<!--           ^^^^ constant.language.doctype.xml -->
 <!--                ^^^^^^ keyword.content.external -->
 <!--                       ^ string.quoted.double -->
 <!--                                                   ^ string.quoted.double -->
 <!--                                                                                 ^ punctuation.definition.tag.end     -->
 
      <!DOCTYPE
-     <!-- <- meta.tag.declaration.doctype -->
+     <!-- <- meta.tag.doctype -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
         root
-<!-- <- meta.tag.declaration.doctype -->
-<!--    ^^^^ variable.documentroot -->
+<!-- <- meta.tag.doctype -->
+<!--    ^^^^ constant.language.doctype.xml -->
         PUBLIC
-<!-- <- meta.tag.declaration.doctype -->
+<!-- <- meta.tag.doctype -->
 <!--    ^^^^^^ keyword.content.external -->
         "-//W3C//DTD XHTML 1.1//EN"
-<!-- <- meta.tag.declaration.doctype -->
+<!-- <- meta.tag.doctype -->
 <!--    ^ string.quoted.double -->
         "http://www.w3.org/1999/xhtml"
-<!-- <- meta.tag.declaration.doctype -->
+<!-- <- meta.tag.doctype -->
 <!--    ^ string.quoted.double -->
         [
 <!--    ^ punctuation.section.brackets.begin -->
@@ -92,11 +92,11 @@
 <!--    <- meta.brackets meta.internal-subset.xml.dtd -->
 <!--    ^ punctuation.section.brackets.end -->
      >
-<!-- ^ meta.tag.declaration.doctype -->
+<!-- ^ meta.tag.doctype -->
 <!-- ^ punctuation.definition.tag.end -->
 
      <!DOCTYPE root [<!ENTITY br "\n" <!-- comment --> > %name; <!-- comment --> ]>
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype  -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.doctype  -->
 <!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.brackets meta.internal-subset.xml.dtd -->
 <!--                   ^^^^^^ meta.tag.declaration.entity -->
 <!--                         ^^^ meta.tag.declaration.entity.name -->
@@ -104,7 +104,7 @@
 <!--                             ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.entity.content.internal -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
-<!--           ^^^^ variable.documentroot -->
+<!--           ^^^^ constant.language.doctype.xml -->
 <!--                ^ punctuation.section.brackets.begin -->
 <!--                 ^^ punctuation.definition.tag.begin -->
 <!--                   ^^^^^^ entity.name.tag.entity -->
@@ -125,7 +125,7 @@
 
 <!DOCTYPE data [
 <!-- ^ entity.name.tag.doctype -->
-<!--      ^ variable.documentroot -->
+<!--      ^ constant.language.doctype.xml -->
 <!--           ^ punctuation.section.brackets.begin -->
 
 <!ENTITY name PUBLIC "content" <!-- comment --> >

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -46,44 +46,83 @@
   DOCTYPE Declaration
  -->
 
-     <!DOCTYPE root [<!ENTITY br "\n"> %name; <!-- comment --> ]>
-     <!-- <- meta.tag.sgml.doctype -->
+     <!DOCTYPE root PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/1999/xhtml">
+     <!-- <- meta.tag.declaration.doctype -->
 <!-- ^^ punctuation.definition.tag.begin -->
-<!--   ^^^^^^^ keyword.doctype -->
+<!--   ^^^^^^^ entity.name.tag.doctype -->
 <!--           ^^^^ variable.documentroot -->
-<!--                ^ meta.internalsubset -->
+<!--                ^^^^^^ keyword.content.external -->
+<!--                       ^ string.quoted.double -->
+<!--                                                   ^ string.quoted.double -->
+<!--                                                                                 ^ punctuation.definition.tag.end     -->
+
+     <!DOCTYPE
+     <!-- <- meta.tag.declaration.doctype -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^^^^^ entity.name.tag.doctype -->
+        root
+<!-- <- meta.tag.declaration.doctype -->
+<!--    ^^^^ variable.documentroot -->
+        PUBLIC
+<!-- <- meta.tag.declaration.doctype -->
+<!--    ^^^^^^ keyword.content.external -->
+        "-//W3C//DTD XHTML 1.1//EN"
+<!-- <- meta.tag.declaration.doctype -->
+<!--    ^ string.quoted.double -->
+        "http://www.w3.org/1999/xhtml"
+<!-- <- meta.tag.declaration.doctype -->
+<!--    ^ string.quoted.double -->
+        [
+<!--    ^ punctuation.definition.internal-subset.begin -->
+            <!ELEMENT p "">
+<!--    <- meta.internal-subset -->
+        ]
+<!--    <- meta.internal-subset -->
+<!--    ^ punctuation.definition.internal-subset.end -->
+     >
+<!-- <- meta.tag.declaration.doctype -->
+<!-- ^ punctuation.definition.tag.end     -->
+
+     <!DOCTYPE root [<!ENTITY br "\n"> %name; <!-- comment --> ]>
+     <!-- <- meta.tag.declaration.doctype -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^^^^^ entity.name.tag.doctype -->
+<!--           ^^^^ variable.documentroot -->
+<!--                ^ punctuation.definition.internal-subset.begin -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.internal-subset -->
+<!--                                                           ^ punctuation.definition.internal-subset.end -->
 <!--                 ^^ punctuation.definition.tag.begin -->
-<!--                   ^^^^^^ keyword.entity -->
+<!--                   ^^^^^^ entity.name.tag.entity -->
 <!--                          ^^ variable.entity -->
-<!--                                   ^ punctuation.definition.constant -->
-<!--                                    ^^^^ constant.character.parameter-entity -->
-<!--                                        ^ punctuation.definition.constant -->
-<!--                                          ^^^^^^^^^^^^^^^^ comment.block.xml -->
-<!--                                          ^^^^ punctuation.definition.comment.begin.xml -->
-<!--                                                       ^^^ punctuation.definition.comment.end.xml -->
+<!--                                   ^ punctuation.definition.variable.begin -->
+<!--                                    ^^^^ variable.parameter -->
+<!--                                        ^ punctuation.definition.variable.end -->
+<!--                                          ^^^^^^^^^^^^^^^^ comment.block -->
+<!--                                          ^^^^ punctuation.definition.comment.begin -->
+<!--                                                       ^^^ punctuation.definition.comment.end -->
 <!--                                                            ^ punctuation.definition.tag.end -->
 
 <!DOCTYPE data [
-<!-- ^ keyword.doctype -->
+<!-- ^ entity.name.tag.doctype -->
 <!--      ^ variable.documentroot -->
 
 <!ENTITY auml  "&#228;">
-<!-- ^ keyword.entity -->
+<!-- ^ entity.name.tag.entity -->
 <!--      ^ variable.entity -->
 <!--           ^ string.quoted.double -->
 <!--            ^ constant.character.entity -->
 
 <!ELEMENT ArticleTitle (#PCDATA)>
-<!-- ^ keyword.element -->
+<!-- ^ entity.name.tag.element -->
 <!--      ^ variable.element -->
 <!--                   ^ punctuation.definition.group -->
-<!--                    ^ constant.other -->
+<!--                    ^ variable.language.parsed-character-data -->
 <!--                           ^ punctuation.definition.group -->
 
 <!ELEMENT AbstractText (#PCDATA)>
 
 <!ELEMENT info (ArticleTitle,AbstractText)+>
-<!-- ^ keyword.element -->
+<!-- ^ entity.name.tag.element -->
 <!--      ^ variable.element -->
 <!--           ^ punctuation.definition.group -->
 <!--                        ^ punctuation.separator -->
@@ -91,16 +130,17 @@
 <!--                                      ^ keyword.operator -->
 
 <!ATTLIST image width CDATA #REQUIRED>
-<!-- ^ keyword.attlist -->
+<!-- ^ entity.name.tag.attlist -->
 <!--      ^ variable.element -->
-<!--            ^ variable.attribute-name -->
+<!--            ^ entity.other.attribute-name -->
 
 <!NOTATION name PUBLIC "public_ID" "URI">
-<!-- ^ keyword.notation -->
+<!-- ^ entity.name.tag.notation -->
 <!--       ^ variable.notation -->
 <!--                   ^ string.quoted.double -->
 
 ]>
+<!-- <- meta.internal-subset.xml meta.tag.declaration.doctype.xml punctuation.definition.internal-subset.end.xml -->
 
 <!--
   Comments

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -250,8 +250,12 @@
 <!-- ^ text - punctuation - illegal -->
 
      <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata - meta.tag - keyword -->
-<!--                                           ^ - string.unquoted.cdata -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.cdata.xml -->
+<!-- ^^^ punctuation.definition.tag.begin.xml -->
+<!--    ^^^^^ entity.name.tag.cdata.xml -->
+<!--         ^ punctuation.definition.tag.begin.xml - string.unquoted.cdata -->
+<!--          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata -->
+<!--                                        ^^^ punctuation.definition.tag.end.xml - string.unquoted.cdata -->
 
      <?pi "markup" is <ignored>?>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -17,11 +17,32 @@
 <!--                     ^^ punctuation.definition.tag.end -->
 <!--                       ^ - meta.tag.preprocessor -->
 
-
-     <?XML version="1.0" ?>
-<!-- ^ invalid.illegal.missing-entity - meta.tag.preprocessor -->
+     <?XML VERSION="1.0" ?>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^ entity.name.tag -->
+<!--       ^^^^^^^ entity.other.attribute-name -->
+<!--              ^ punctuation.separator.key-value -->
+<!--               ^ punctuation.definition.string.begin -->
+<!--               ^^^^^ string.quoted -->
+<!--                   ^ punctuation.definition.string.end -->
+<!--                     ^^ punctuation.definition.tag.end -->
+<!--                       ^ - meta.tag.preprocessor -->
 
      <?xml-stylesheet type='text/xsl' href='freb.xsl'?>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
+<!--                                                   ^ - meta.tag.preprocessor -->
+<!-- ^^ punctuation.definition.tag.begin -->
+<!--   ^^^^^^^^^^^^^^ entity.name.tag -->
+<!--                 ^ - entity -->
+<!--                  ^^^^ entity.other.attribute-name.localname -->
+<!--                      ^ punctuation.separator.key-value -->
+<!--                       ^ punctuation.definition.string.begin -->
+<!--                       ^^^^^^^^^^ string.quoted.single -->
+<!--                                ^ punctuation.definition.string.end -->
+<!--                                 ^ - string -->
+
+     <?XML-STYLESHEET TYPE='TEXT/XSL' HREF='FREB.XSL'?>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
 <!--                                                   ^ - meta.tag.preprocessor -->
 <!-- ^^ punctuation.definition.tag.begin -->
@@ -182,6 +203,26 @@
  -->
 
      <ns:tagname xmlns:ns="uri">
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!--                            ^ - meta.tag -->
+<!-- ^ punctuation.definition.tag.begin -->
+<!--  ^^ entity.name.tag.namespace -->
+<!--    ^ punctuation.separator.namespace -->
+<!--     ^^^^^^^ entity.name.tag.localname -->
+<!--            ^ - entity -->
+<!--             ^^^^^ entity.other.attribute-name.namespace -->
+<!--                  ^ punctuation.separator.namespace -->
+<!--                   ^^ entity.other.attribute-name.localname -->
+<!--                      ^ punctuation.definition.string.begin -->
+<!--                      ^^^^^ string.quoted -->
+<!--                          ^ punctuation.definition.string.end -->
+<!--                           ^ punctuation.definition.tag.end -->
+     text
+<!-- ^^^^ text -->
+     >
+<!-- ^ text - punctuation - illegal -->
+
+     <NS:TAGNAME XMLNS:NS="URI">
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
 <!--                            ^ - meta.tag -->
 <!-- ^ punctuation.definition.tag.begin -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -95,29 +95,46 @@
 <!-- ^ meta.tag.declaration.doctype -->
 <!-- ^ punctuation.definition.tag.end -->
 
-     <!DOCTYPE root [<!ENTITY br "\n"> %name; <!-- comment --> ]>
-     <!-- <- meta.tag.declaration.doctype -->
+     <!DOCTYPE root [<!ENTITY br "\n" <!-- comment --> > %name; <!-- comment --> ]>
+<!-- ^^^^^^^^^^^^^^^ meta.tag.declaration.doctype - meta.tag.declaration.doctype.internal-subset - meta.brackets  -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype.internal-subset meta.brackets -->
+<!--                                                                              ^ meta.tag.declaration.doctype -->
+<!--                   ^^^^^^ meta.tag.declaration.entity -->
+<!--                         ^^^ meta.tag.declaration.entity.name -->
+<!--                            ^ meta.tag.declaration.entity.type.dtd -->
+<!--                             ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.entity.content.internal -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
 <!--           ^^^^ variable.documentroot -->
 <!--                ^ punctuation.section.brackets.begin -->
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype.internal-subset meta.brackets -->
-<!--                                                           ^ punctuation.section.brackets.end -->
 <!--                 ^^ punctuation.definition.tag.begin -->
 <!--                   ^^^^^^ entity.name.tag.entity -->
 <!--                          ^^ variable.entity -->
-<!--                                   ^ punctuation.definition.variable.begin -->
-<!--                                    ^^^^ variable.parameter -->
-<!--                                        ^ punctuation.definition.variable.end -->
-<!--                                          ^^^^^^^^^^^^^^^^ comment.block -->
-<!--                                          ^^^^ punctuation.definition.comment.begin -->
-<!--                                                       ^^^ punctuation.definition.comment.end -->
-<!--                                                            ^ punctuation.definition.tag.end -->
+<!--                             ^ punctuation.definition.string.begin -->
+<!--                             ^^^^ string.quoted.double -->
+<!--                                ^ punctuation.definition.string.end -->
+<!--                                  ^^^^^^^^^^^^^^^^ comment.block -->
+<!--                                                   ^ punctuation.definition.tag.end -->
+<!--                                                     ^ punctuation.definition.variable.begin -->
+<!--                                                      ^^^^ variable.parameter -->
+<!--                                                          ^ punctuation.definition.variable.end -->
+<!--                                                            ^^^^^^^^^^^^^^^^ comment.block -->
+<!--                                                            ^^^^ punctuation.definition.comment.begin -->
+<!--                                                                         ^^^ punctuation.definition.comment.end -->
+<!--                                                                             ^ punctuation.section.brackets.end -->
+<!--                                                                              ^ punctuation.definition.tag.end -->
 
 <!DOCTYPE data [
 <!-- ^ entity.name.tag.doctype -->
 <!--      ^ variable.documentroot -->
 <!--           ^ punctuation.section.brackets.begin -->
+
+<!ENTITY name PUBLIC "content" <!-- comment --> >
+<!-- ^ entity.name.tag.entity -->
+<!--     ^^^^ variable.entity -->
+<!--          ^^^^^^ keyword.content.external -->
+<!--                 ^^^^^^^^^ string.quoted.double -->
+<!--                           ^^^^^^^^^^^^^^^^ comment.block -->
 
 <!ENTITY auml  "&#228;">
 <!-- ^ entity.name.tag.entity -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -73,12 +73,12 @@
 <!-- <- meta.tag.declaration.doctype -->
 <!--    ^ string.quoted.double -->
         [
-<!--    ^ punctuation.definition.internal-subset.begin -->
+<!--    ^ punctuation.section.brackets.begin -->
             <!ELEMENT p "">
-<!--    <- meta.internal-subset -->
+<!--    <- meta.tag.declaration.doctype.internal-subset meta.brackets -->
         ]
-<!--    <- meta.internal-subset -->
-<!--    ^ punctuation.definition.internal-subset.end -->
+<!--    <- meta.tag.declaration.doctype.internal-subset meta.brackets -->
+<!--    ^ punctuation.section.brackets.end -->
      >
 <!-- <- meta.tag.declaration.doctype -->
 <!-- ^ punctuation.definition.tag.end     -->
@@ -88,9 +88,9 @@
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
 <!--           ^^^^ variable.documentroot -->
-<!--                ^ punctuation.definition.internal-subset.begin -->
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.internal-subset -->
-<!--                                                           ^ punctuation.definition.internal-subset.end -->
+<!--                ^ punctuation.section.brackets.begin -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.declaration.doctype.internal-subset meta.brackets -->
+<!--                                                           ^ punctuation.section.brackets.end -->
 <!--                 ^^ punctuation.definition.tag.begin -->
 <!--                   ^^^^^^ entity.name.tag.entity -->
 <!--                          ^^ variable.entity -->
@@ -105,6 +105,7 @@
 <!DOCTYPE data [
 <!-- ^ entity.name.tag.doctype -->
 <!--      ^ variable.documentroot -->
+<!--           ^ punctuation.section.brackets.begin -->
 
 <!ENTITY auml  "&#228;">
 <!-- ^ entity.name.tag.entity -->
@@ -140,7 +141,7 @@
 <!--                   ^ string.quoted.double -->
 
 ]>
-<!-- <- meta.internal-subset.xml meta.tag.declaration.doctype.xml punctuation.definition.internal-subset.end.xml -->
+<!-- <- meta.tag.declaration.doctype.internal-subset meta.brackets punctuation.section.brackets.end -->
 
 <!--
   Comments

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -47,7 +47,7 @@
  -->
 
      <!DOCTYPE root PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/1999/xhtml">
-     <!-- <- meta.tag.declaration.doctype -->
+ <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.tag.declaration.doctype -->
 <!-- ^^ punctuation.definition.tag.begin -->
 <!--   ^^^^^^^ entity.name.tag.doctype -->
 <!--           ^^^^ variable.documentroot -->
@@ -80,8 +80,8 @@
 <!--    <- meta.tag.declaration.doctype.internal-subset meta.brackets -->
 <!--    ^ punctuation.section.brackets.end -->
      >
-<!-- <- meta.tag.declaration.doctype -->
-<!-- ^ punctuation.definition.tag.end     -->
+<!-- ^ meta.tag.declaration.doctype -->
+<!-- ^ punctuation.definition.tag.end -->
 
      <!DOCTYPE root [<!ENTITY br "\n"> %name; <!-- comment --> ]>
      <!-- <- meta.tag.declaration.doctype -->

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -17,17 +17,8 @@
 <!--                     ^^ punctuation.definition.tag.end -->
 <!--                       ^ - meta.tag.preprocessor -->
 
-     <?XML VERSION="1.0" ?>
-<!-- ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->
-<!-- ^^ punctuation.definition.tag.begin -->
-<!--   ^^^ entity.name.tag -->
-<!--       ^^^^^^^ entity.other.attribute-name -->
-<!--              ^ punctuation.separator.key-value -->
-<!--               ^ punctuation.definition.string.begin -->
-<!--               ^^^^^ string.quoted -->
-<!--                   ^ punctuation.definition.string.end -->
-<!--                     ^^ punctuation.definition.tag.end -->
-<!--                       ^ - meta.tag.preprocessor -->
+     <?XML version="1.0" ?>
+<!-- ^ invalid.illegal.missing-entity - meta.tag.preprocessor -->
 
      <?xml-stylesheet type='text/xsl' href='freb.xsl'?>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor -->


### PR DESCRIPTION
Hello Devs

The current _XML.sublime-syntax_ provides only basic support of internal DOCTYPE subsets.
The declarations don't highlight well if rules span multiple lines.

Reading some official DTD files from DITA/DOCBOOK etc. revealed support for external DTD files is missing at all.

Suggestion:

This PR intends to solve the highlighting issues related with all the declaration tags and adds support for DTD-files.

A _DTD.sublime-syntax_ is created which is imported by the XML.sublime-syntax. DTD is understood as part of XML and thus placed into the XML package. We may or may not create a dedicated package folder for it.

If you like this idea, the DOCTYPE definitions of HTML package could be updated the same way, too.

_Note: This PR includes #978 for technical reasons._