### PR TITLE
[Markdown] improve backtracking on non-sregex engines like Oniguruma

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -89,7 +89,7 @@ variables:
         )
     table_first_row: |-
         (?x:
-            (?:{{balance_square_brackets_and_pipes}}*\|){2}           # at least 2 non-escaped pipe chars on the line
+            (?:{{balance_square_brackets_and_pipes}}?\|){2}           # at least 2 non-escaped pipe chars on the line
         |   (?!\s+\|){{balance_square_brackets_and_pipes}}\|(?!\s+$)  # something other than whitespace followed by a pipe char, followed by something other than whitespace and the end of the line
         )
     fenced_code_block_start: |-


### PR DESCRIPTION
...by correcting `((example)+)*` style patterns to `((example)+)?`

(originally discovered at https://github.com/google/fancy-regex/issues/14)