### PR TITLE
[C] [C++] Greedily scope the "dot" as punctuation.accessor

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -613,10 +613,10 @@ contexts:
       captures:
         1: punctuation.accessor.c++
         2: variable.other.readwrite.member.c++
-    - match: (?<!\.)\.(?!\.)
-      scope: punctuation.accessor.c++
     - match: \.\.(?!\.)
       scope: invalid.illegal.syntax.c++
+    - match: \.(?!\.)
+      scope: punctuation.accessor.c++
 
   typedef:
     - match: \btypedef\b

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -609,10 +609,11 @@ contexts:
               scope: meta.method-call.c++ meta.group.c++ punctuation.section.group.end.c++
               pop: true
             - include: expressions
-    - match: '(\.|->)({{identifier}})(?!\s*\()'
+    - match: '(\.|->)({{identifier}})(::)?(?!\s*\()'
       captures:
         1: punctuation.accessor.c++
         2: variable.other.readwrite.member.c++
+        3: punctuation.accessor.c++
     - match: \.\.(?!\.)
       scope: invalid.illegal.syntax.c++
     - match: \.(?!\.)

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -613,6 +613,10 @@ contexts:
       captures:
         1: punctuation.accessor.c++
         2: variable.other.readwrite.member.c++
+    - match: (?<!\.)\.(?!\.)
+      scope: punctuation.accessor.c++
+    - match: \.\.(?!\.)
+      scope: invalid.illegal.syntax.c++
 
   typedef:
     - match: \btypedef\b

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -185,10 +185,10 @@ contexts:
       captures:
         1: punctuation.accessor.c
         2: variable.other.member.c
-    - match: (?<!\.)\.(?!\.)
-      scope: punctuation.accessor.c
     - match: \.\.(?!\.)
       scope: invalid.illegal.syntax.c
+    - match: \.(?!\.)
+      scope: punctuation.accessor.c
 
   label:
     - match: '^\s*((?!default){{identifier}})(:)(?!:)'

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -185,6 +185,10 @@ contexts:
       captures:
         1: punctuation.accessor.c
         2: variable.other.member.c
+    - match: (?<!\.)\.(?!\.)
+      scope: punctuation.accessor.c
+    - match: \.\.(?!\.)
+      scope: invalid.illegal.syntax.c
 
   label:
     - match: '^\s*((?!default){{identifier}})(:)(?!:)'

--- a/C++/syntax_test_accessor.c
+++ b/C++/syntax_test_accessor.c
@@ -1,0 +1,35 @@
+// SYNTAX TEST "Packages/C++/C.sublime-syntax"
+
+typedef struct _X
+{
+    int a;
+    int b;
+} X;
+
+int main()
+{
+    X x;
+    x.
+//   ^ punctuation.accessor
+}
+
+int main()
+{
+    X x;
+    x..
+//   ^^ invalid.illegal - punctuation.accessor
+}
+
+int main()
+{
+    X x;
+    x...
+//   ^^^ keyword - punctuation.accessor
+}
+
+int main()
+{
+    X* x = malloc(sizeof(X));
+    x->
+//   ^^ punctuation.accessor
+}

--- a/C++/syntax_test_accessor.cpp
+++ b/C++/syntax_test_accessor.cpp
@@ -9,6 +9,12 @@ class X
     int b;
 };
 
+class Y : public X
+{
+  public:
+    int c;
+}
+
 } // namespace N
 
 int main()
@@ -43,4 +49,20 @@ int main()
     N::X* x = new X();
     x->
 //   ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::Y y;
+    y.X::
+//   ^ punctuation.accessor
+//     ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::Y* y = new Y();
+    y->X::
+//   ^^ punctuation.accessor
+//      ^^ punctuation.accessor
 }

--- a/C++/syntax_test_accessor.cpp
+++ b/C++/syntax_test_accessor.cpp
@@ -1,0 +1,46 @@
+// SYNTAX TEST "Packages/C++/C++.sublime-syntax"
+
+namespace N {
+
+class X
+{
+  public:
+    int a;
+    int b;
+};
+
+} // namespace N
+
+int main()
+{
+    N::
+//   ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x.
+//   ^ punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x..
+//   ^^ - punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x...
+//   ^^^ keyword - punctuation.accessor
+}
+
+int main()
+{
+    N::X* x = new X();
+    x->
+//   ^^ punctuation.accessor
+}

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -696,10 +696,15 @@ contexts:
               scope: meta.method-call.objc++ meta.group.objc++ punctuation.section.group.end.objc++
               pop: true
             - include: expressions
-    - match: '(\.|->)({{identifier}})(?!\s*\()'
+    - match: '(\.|->)({{identifier}})(::)?(?!\s*\()'
       captures:
         1: punctuation.accessor.objc++
         2: variable.other.readwrite.member.objc++
+        3: punctuation.accessor.objc++
+    - match: \.\.(?!\.)
+      scope: invalid.illegal.syntax.objc++
+    - match: \.(?!\.)
+      scope: punctuation.accessor.objc++
 
   typedef:
     - match: \btypedef\b

--- a/Objective-C/syntax_test_accessor.m
+++ b/Objective-C/syntax_test_accessor.m
@@ -1,0 +1,35 @@
+// SYNTAX TEST "Packages/Objective-C/Objective-C.sublime-syntax"
+
+typedef struct _X
+{
+    int a;
+    int b;
+} X;
+
+int main()
+{
+    X x;
+    x.
+//   ^ punctuation.accessor
+}
+
+int main()
+{
+    X x;
+    x..
+//   ^^ invalid.illegal - punctuation.accessor
+}
+
+int main()
+{
+    X x;
+    x...
+//   ^^^ keyword - punctuation.accessor
+}
+
+int main()
+{
+    X* x = malloc(sizeof(X));
+    x->
+//   ^^ punctuation.accessor
+}

--- a/Objective-C/syntax_test_accessor.mm
+++ b/Objective-C/syntax_test_accessor.mm
@@ -1,0 +1,68 @@
+// SYNTAX TEST "Packages/Objective-C/Objective-C++.sublime-syntax"
+
+namespace N {
+
+class X
+{
+  public:
+    int a;
+    int b;
+};
+
+class Y : public X
+{
+  public:
+    int c;
+}
+
+} // namespace N
+
+int main()
+{
+    N::
+//   ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x.
+//   ^ punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x..
+//   ^^ - punctuation.accessor
+}
+
+int main()
+{
+    N::X x;
+    x...
+//   ^^^ keyword - punctuation.accessor
+}
+
+int main()
+{
+    N::X* x = new X();
+    x->
+//   ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::Y y;
+    y.X::
+//   ^ punctuation.accessor
+//     ^^ punctuation.accessor
+}
+
+int main()
+{
+    N::Y* y = new Y();
+    y->X::
+//   ^^ punctuation.accessor
+//      ^^ punctuation.accessor
+}


### PR DESCRIPTION
## Problem & Current Situation
For implementations of `on_query_completions` in event listeners, it'd be nice to check if the user wants to get completions for a member variable or member function. I think the most aesthetic way would be to do
```python
def on_query_completions(self, prefix, locations):
    point = locations[0]
    if self.view.match_selector(point - 1, 'punctuation.accessor'):
        # OK: user wants members of a namespace/struct/class
```
Now observe that:
* `->` is scoped greedily as an accessor, even when there's no identifier after it. 💯 
* `::` in C++ is scoped greedily as an accessor, even when there's no identifier after it. 💯 
* `.` in C and C++ is not scoped as an accessor when there's no identifier after it. 👎 

This forces plugin writers to use hacks:
```python
def on_query_completions(self, prefix, locations):
    point = locations[0]
    if self.view.match_selector(point - 1, 'punctuation.accessor'):
        # OK: user wants members of a namespace or pointer-to-struct/class
    elif is_dot_present_and_is_not_ellipsis_operator(point - 1): # hacky :-(
        # OK: user typed a single dot
```
## Solution
Scope the dot as `punctuation.accessor` even when there's not an identifier following it yet.