### PR TITLE
[LaTeX] Disable prototype inside the verb command

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -591,6 +591,7 @@ contexts:
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.verb.latex
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.verb.latex
         - meta_content_scope: markup.raw.verb.latex
         - match: '\3'

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -205,6 +205,11 @@
 %      ^ markup.raw.verb.latex
 %      ^ meta.environment.verbatim.verb.latex
 %      ^ - support.function.general.latex
+\verb|foo % bar|
+% ^^^^^^^^^^^^^^ meta.environment.verbatim.verb.latex
+%         ^^^^^ - comment
+
+% <- - meta.environment.verbatim.verb.latex
 
 \begin{verbatim}
 % ^ support.function.begin.latex keyword.control.flow.begin.latex


### PR DESCRIPTION
Comments (and other potential prototypes) should be disabled inside `\verb`-commands as done in this PR.

Fix https://github.com/SublimeText/LaTeXTools/issues/1135