### PR TITLE
[C#] describe indentation rules and fix when a comma comes after a `}`

### DIFF
--- a/C#/Indentation.tmPreferences
+++ b/C#/Indentation.tmPreferences
@@ -9,20 +9,34 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string>(?x)
-		^ (.*\*/)? \s* \} ( [^}{"']* \{ | \s* while \s* \( .* )? [;\s]* (//.*|/\*.*\*/\s*)? $
+			^                                    # the beginning of the line
+			(.*\*/)?                             # optionally followed by the end of a block comment
+			\s*                                  # followed by any amount of whitespace
+			\}                                   # followed by a closing brace
+			(                                    # followed by
+			    [^}{"']* \{                      # - anything thats not a brace or a string (or nothing), followed by an opening brace
+			|   \s* while \s* \( .*              # - or any whitespace followed by `while` followed by any whitespace followed by an opening paren
+			|   ,                                # - or a comma
+			)?                                   # optional
+			[;\s]*                               # followed by any number of semi-colons or whitespace characters
+			(//.*|/\*.*\*/\s*)?                  # optionally followed by a comment
+			$                                    # the end of the line
 		</string>
 		<key>increaseIndentPattern</key>
 		<string>(?x)
-		^ .* \{ [^}"']* $
-		|   ^ \s* \{ \} $
+		^                                        # the beginning of the line
+		.*                                       # followed by anything
+		\{                                       # followed by an open brace
+		[^}"']*                                  # followed by any number of characters that isn't a close brace or a string
+		$                                        # the end of the line
 		</string>
 		<key>indentNextLinePattern</key>
 		<string>(?x)^
 		(?! .* [;:{}]                   # do not indent when line ends with ;, :, {, or }
-			\s* (//|/[*] .* [*]/ \s* $) #  …account for potential trailing comment
+		    \s* (//|/[*] .* [*]/ \s* $) #  …account for potential trailing comment
 		)
 		.* [^\s;:{}] \s* $              # indent next if this one isn’t
-										#  terminated with ;, :, {, or }
+		                                #  terminated with ;, :, {, or }
 		</string>
 		<key>unIndentedLinePattern</key>
 		<string>^\s*((/\*|\*/|//|#).*)?$</string>


### PR DESCRIPTION
This PR describes (with comments) the indentation rules used for the C# syntax, and fixes it so that the following gets reindented properly:

```cs
new [] {
    new Point {
        X = 5,
        Y = 10
    },
    new Point {
        X = 7,
        Y = 9
    },
}
```

(previously, the `},` wouldn't have it's indentation decreased...

I also removed a rule that said to decrease indentation on lines that only contain whitespace followed by `{}` because it doesn't make any sense.