### PR TITLE
[C++] [ObjC++] Fix uniform init in constructor init list

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1297,18 +1297,28 @@ contexts:
           scope: punctuation.separator.initializer-list.c++
           set:
             - meta_scope: meta.method.constructor.initializer-list.c++
-            - match: '(?=\{|;)'
-              set: method-definition-continue
-            - match: '({{identifier}})\s*(\()'
-              captures:
-                1: variable.other.readwrite.member.c++
-                2: meta.group.c++ punctuation.section.group.begin.c++
+            - match: '{{identifier}}'
+              scope: variable.other.readwrite.member.c++
               push:
-                - meta_content_scope: meta.group.c++
-                - match: \)
-                  scope: meta.group.c++ punctuation.section.group.end.c++
-                  pop: true
-                - include: expressions
+                - match: \(
+                  scope: meta.group.c++ punctuation.section.group.begin.c++
+                  set:
+                    - meta_content_scope: meta.group.c++
+                    - match: \)
+                      scope: meta.group.c++ punctuation.section.group.end.c++
+                      pop: true
+                    - include: expressions
+                - match: \{
+                  scope: meta.group.c++ punctuation.section.group.begin.c++
+                  set:
+                    - meta_content_scope: meta.group.c++
+                    - match: \}
+                      scope: meta.group.c++ punctuation.section.group.end.c++
+                      pop: true
+                    - include: expressions
+                - include: comments
+            - match: (?=\{|;)
+              set: method-definition-continue
             - include: expressions
     - match: '(?=\{)'
       set: method-definition-body

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1227,6 +1227,42 @@ class Adapter : public Abstraction
 
 }
 
+/* C++11 "uniform initialization" in initializer lists */
+class Foo {
+public:
+    Foo() : var1(1), var(2), var3{3}, var4(4) {}
+                                 /* ^ meta.method.constructor.initializer-list   */
+                                 /*   ^ - meta.function-call - variable.function */
+private:
+    int var1, var2, var3, var4;    
+};
+
+class X {
+    int a, b, i, j;
+public:
+    const int& r;
+    X(int i)
+      : r(a) // initializes X::r to refer to X::a
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , b{i} // initializes X::b to the value of the parameter i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , i(i) // initializes X::i to the value of the parameter i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , j(this->i) // initializes X::j to the value of X::i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*         ^ meta.method.constructor.initializer-list punctuation */
+      , j
+      /*^ variable */
+      (this->i)
+      /* <- meta.method.constructor.initializer-list punctuation */
+    { }
+/*  ^ punctuation - meta.method.constructor.initializer-list   */
+/*    ^ punctuation - meta.method.constructor.initializer-list */
+};
+
 struct bar {
 /*^^^^^^^^^^ meta.struct */
 /*^^^^ storage.type */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1385,18 +1385,28 @@ contexts:
           scope: punctuation.separator.initializer-list.objc++
           set:
             - meta_scope: meta.method.constructor.initializer-list.objc++
-            - match: '(?=\{|;)'
-              set: method-definition-continue
-            - match: '({{identifier}})\s*(\()'
-              captures:
-                1: variable.other.readwrite.member.objc++
-                2: meta.group.objc++ punctuation.section.group.begin.objc++
+            - match: '{{identifier}}'
+              scope: variable.other.readwrite.member.objc++
               push:
-                - meta_content_scope: meta.group.objc++
-                - match: \)
-                  scope: meta.group.objc++ punctuation.section.group.end.objc++
-                  pop: true
-                - include: expressions
+                - match: \(
+                  scope: meta.group.objc++ punctuation.section.group.begin.objc++
+                  set:
+                    - meta_content_scope: meta.group.objc++
+                    - match: \)
+                      scope: meta.group.objc++ punctuation.section.group.end.objc++
+                      pop: true
+                    - include: expressions
+                - match: \{
+                  scope: meta.group.objc++ punctuation.section.group.begin.objc++
+                  set:
+                    - meta_content_scope: meta.group.objc++
+                    - match: \}
+                      scope: meta.group.objc++ punctuation.section.group.end.objc++
+                      pop: true
+                    - include: expressions
+                - include: comments
+            - match: (?=\{|;)
+              set: method-definition-continue
             - include: expressions
     - match: '(?=\{)'
       set: method-definition-body

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1227,6 +1227,42 @@ class Adapter : public Abstraction
 
 }
 
+/* C++11 "uniform initialization" in initializer lists */
+class Foo {
+public:
+    Foo() : var1(1), var(2), var3{3}, var(4) {}
+                                 /* ^ meta.method.constructor.initializer-list */
+                                 /*   ^ - meta.function-call - variable.function */
+private:
+    int var1, var2, var3, var4;    
+};
+
+class X {
+    int a, b, i, j;
+public:
+    const int& r;
+    X(int i)
+      : r(a) // initializes X::r to refer to X::a
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , b{i} // initializes X::b to the value of the parameter i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , i(i) // initializes X::i to the value of the parameter i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*   ^ meta.method.constructor.initializer-list punctuation       */
+      , j(this->i) // initializes X::j to the value of X::i
+      /* ^ meta.method.constructor.initializer-list punctuation         */
+      /*         ^ meta.method.constructor.initializer-list punctuation */
+      , j
+      /*^ variable */
+      (this->i)
+      /* <- meta.method.constructor.initializer-list punctuation */
+    { }
+/*  ^ punctuation - meta.method.constructor.initializer-list   */
+/*    ^ punctuation - meta.method.constructor.initializer-list */
+};
+
 struct bar {
 /*^^^^^^^^^^ meta.struct */
 /*^^^^ storage.type */


### PR DESCRIPTION
When initializing the members of a class in the initializer list of
the constructor, it may happen that variables are initialized with
an opening brace. This confused the syntax. This commit fixes that.

In response to https://github.com/sublimehq/Packages/issues/979.