### PR TITLE
[Python] Introduce meta.{mapping,sequence,set}

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -982,6 +982,7 @@ contexts:
     - include: comments
     - match: (?=\S)
       push:
+        - clear_scopes: 1
         - meta_scope: meta.mapping.key.python
         - match: \s*(?=\}|,|:)
           pop: true
@@ -989,8 +990,9 @@ contexts:
 
   inside-directory-value:
     - meta_content_scope: meta.mapping.python
-    - match: (?=\})
-      set: inside-dictionary
+    - match: \}
+      scope: punctuation.section.mapping.end.python
+      set: after-expression
     - match: (?=,)
       set:
         # clear meta scope from this match, because 'inside-directory' has it in meta_scope
@@ -999,7 +1001,6 @@ contexts:
           set: inside-dictionary
     - match: (?=for)
       push:
-        - meta_content_scope: meta.mapping.python
         - match: (?=\})
           pop: true
         - match: ','
@@ -1009,8 +1010,9 @@ contexts:
     - include: comments
     - match: (?=\S)
       push:
+        - clear_scopes: 1
         - meta_content_scope: meta.mapping.value.python
-        - match: \s*(?=\}|,|for)
+        - match: (?=\s*(\}|,|for))
           pop: true
         - include: expressions
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -328,6 +328,9 @@ contexts:
     - include: strings
     - include: function-calls
     - include: item-access
+    - include: lists
+    - include: dictionaries-and-sets
+    - include: tuples
     - include: groups
     - match: \)
       scope: invalid.illegal.stray.brace.round.python
@@ -335,8 +338,6 @@ contexts:
       scope: invalid.illegal.stray.brace.square.python
     - match: \}
       scope: invalid.illegal.stray.brace.curly.python
-    - include: lists
-    - include: dictionaries-and-sets
     - include: line-continuation
 
   line-expressions: # Always include this last!
@@ -877,9 +878,34 @@ contexts:
         - include: inline-for
         - include: expressions
 
+  tuples:
+    # We don't know for certain, whether a parenthesized expression is a tuple,
+    # so try looking ahead.
+    - match: (\()\s*(\))
+      scope: meta.sequence.tuple.python meta.empty-tuple.python
+      captures:
+        1: punctuation.section.sequence.begin.python
+        2: punctuation.section.sequence.end.python
+    - match: \((?={{simple_expression}},|\s*\*{{path}})
+      scope: punctuation.section.sequence.begin.python
+      push: inside-tuple
+    # TODO generator
+    # - match: \((?:{{simple_expression}}for)
+
+  inside-tuple:
+    - meta_scope: meta.sequence.tuple.python
+    - match: \)
+      scope: punctuation.section.sequence.end.python
+      set: after-expression
+    - match: ','
+      scope: punctuation.separator.sequence.python
+      push: allow-unpack-operators
+    - include: inline-for
+    - include: expressions
+
   lists:
     - match: (\[)\s*(\])
-      scope: meta.sequence.python meta.empty-list.python
+      scope: meta.sequence.list.python meta.empty-list.python
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
@@ -888,7 +914,7 @@ contexts:
       push: [inside-list, allow-unpack-operators]
 
   inside-list:
-    - meta_scope: meta.sequence.python
+    - meta_scope: meta.sequence.list.python
     - match: \]
       scope: punctuation.section.sequence.end.python
       set: after-expression

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -882,7 +882,7 @@ contexts:
     # We don't know for certain, whether a parenthesized expression is a tuple,
     # so try looking ahead.
     - match: (\()\s*(\))
-      scope: meta.sequence.tuple.python meta.empty-tuple.python
+      scope: meta.sequence.tuple.empty.python
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
@@ -905,7 +905,7 @@ contexts:
 
   lists:
     - match: (\[)\s*(\])
-      scope: meta.sequence.list.python meta.empty-list.python
+      scope: meta.sequence.list.empty.python
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
@@ -928,7 +928,7 @@ contexts:
     # Dictionaries and set literals use the same punctuation,
     # so we try looking ahead to determine whether we have a dict or a set.
     - match: '(\{)\s*(\})'
-      scope: meta.mapping.python meta.empty-dictionary.python
+      scope: meta.mapping.empty.python
       captures:
         1: punctuation.section.mapping.begin.python
         2: punctuation.section.mapping.end.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -885,16 +885,18 @@ contexts:
         2: punctuation.section.sequence.end.python
     - match: \[
       scope: punctuation.section.sequence.begin.python
-      push:
-        - meta_scope: meta.sequence.python
-        - match: \]
-          scope: punctuation.section.sequence.end.python
-          set: after-expression
-        - match: ','
-          scope: punctuation.separator.sequence.python
-          push: allow-unpack-operators
-        - include: inline-for
-        - include: expressions
+      push: [inside-list, allow-unpack-operators]
+
+  inside-list:
+    - meta_scope: meta.sequence.python
+    - match: \]
+      scope: punctuation.section.sequence.end.python
+      set: after-expression
+    - match: ','
+      scope: punctuation.separator.sequence.python
+      push: allow-unpack-operators
+    - include: inline-for
+    - include: expressions
 
   dictionaries-and-sets:
     # Dictionaries and set literals use the same punctuation,

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -886,6 +886,7 @@ contexts:
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
+      push: after-expression
     - match: \((?={{simple_expression}},|\s*\*{{path}})
       scope: punctuation.section.sequence.begin.python
       push: inside-tuple
@@ -909,6 +910,7 @@ contexts:
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
+      push: after-expression
     - match: \[
       scope: punctuation.section.sequence.begin.python
       push: [inside-list, allow-unpack-operators]
@@ -932,6 +934,7 @@ contexts:
       captures:
         1: punctuation.section.mapping.begin.python
         2: punctuation.section.mapping.end.python
+      push: after-expression
     - match: \{(?={{simple_expression}}:|\s*\*\*{{path}})
       scope: punctuation.section.mapping.begin.python
       push: inside-dictionary

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -46,6 +46,20 @@ variables:
       [bcdeEfFgGnosxX%]? # type
     )
   strftime_spec: '(?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))'
+  # This can be used in look-aheads to parse simple expressions.
+  # Can't be recursive, because sregex doesn't support that,
+  # so we're skipping parentheses.
+  # Can't parse multiple lines as well, for obvious reasons
+  simple_expression: |-
+    (?x:
+      \s+                      # whitespace
+      | [urfb]*"(?:\\.|[^"])*" # strings
+      | [urfb]*'(?:\\.|[^'])*' # ^
+      | [\d.ej]+               # numerics
+      | [+*/%@-] | // | and | or # operators
+      | {{path}}               # a path
+    )*
+
 
 
 contexts:
@@ -864,45 +878,134 @@ contexts:
         - include: expressions
 
   lists:
-    - match: '(\[)(\s*(\]))\b'
+    - match: (\[)\s*(\])
+      scope: meta.sequence.python meta.empty-list.python
       captures:
-        1: punctuation.section.list.begin.python
-        2: meta.empty-list.python
-        3: punctuation.section.list.end.python
+        1: punctuation.section.sequence.begin.python
+        2: punctuation.section.sequence.end.python
     - match: \[
-      scope: punctuation.section.list.begin.python
+      scope: punctuation.section.sequence.begin.python
       push:
-        - meta_scope: meta.structure.list.python
+        - meta_scope: meta.sequence.python
         - match: \]
-          scope: punctuation.section.list.end.python
+          scope: punctuation.section.sequence.end.python
           set: after-expression
         - match: ','
-          scope: punctuation.separator.list.python
+          scope: punctuation.separator.sequence.python
           push: allow-unpack-operators
         - include: inline-for
         - include: expressions
 
   dictionaries-and-sets:
-    - match: '(\{)(\s*(\}))'
-      scope: meta.structure.dictionary.python
+    # Dictionaries and set literals use the same punctuation,
+    # so we try looking ahead to determine whether we have a dict or a set.
+    - match: '(\{)\s*(\})'
+      scope: meta.mapping.python meta.empty-dictionary.python
       captures:
-        1: punctuation.section.dictionary.begin.python
-        2: meta.empty-dictionary.python
-        3: punctuation.section.dictionary.end.python
+        1: punctuation.section.mapping.begin.python
+        2: punctuation.section.mapping.end.python
+    - match: \{(?={{simple_expression}}:|\s*\*\*{{path}})
+      scope: punctuation.section.mapping.begin.python
+      push: inside-dictionary
+    - match: \{(?={{simple_expression}}[,}]|\s*\*{{path}})
+      scope: punctuation.section.set.begin.python
+      push: inside-set
+    # If the expression is "more complex" or on the next line,
+    # fall back to default and determine later.
     - match: \{
-      scope: punctuation.section.dictionary-or-set.begin.python
+      scope: punctuation.section.mapping-or-set.begin.python
       push:
-        - meta_scope: meta.structure.dictionary-or-set.python
+        - meta_scope: meta.mapping-or-set.python
         - match: \}
-          scope: punctuation.section.dictionary-or-set.end.python
+          scope: punctuation.section.mapping-or-set.end.python
           set: after-expression
+        - match: (?={{simple_expression}}:|\s*\*\*{{path}})
+          set: inside-dictionary
+        - match: (?={{simple_expression}}[,}]|\s*\*{{path}})
+          set: inside-set
         - match: ','
-          scope: punctuation.separator.dictionary-or-set.python
-          push: allow-unpack-operators
+          scope: punctuation.separator.set.python
+          set: inside-set
         - match: ':'
-          scope: punctuation.separator.key-value.python
+          scope: punctuation.separator.mapping.python
+          set: inside-directory-value
         - include: inline-for
         - include: expressions
+
+  inside-dictionary:
+    - meta_scope: meta.mapping.python
+    - match: \}
+      scope: punctuation.section.mapping.end.python
+      set: after-expression
+    - match: ':'
+      scope: punctuation.separator.mapping.python
+      set: inside-directory-value
+    - match: ','
+      scope: invalid.illegal.expected-colon.python
+    - match: \*\*
+      scope: keyword.operator.unpacking.mapping.python
+      push:
+        - match: (?=\})
+          pop: true
+        - match: ','
+          scope: punctuation.separator.mapping.python
+          pop: true
+        - include: expressions
+    - include: comments
+    - match: (?=\S)
+      push:
+        - meta_scope: meta.mapping.key.python
+        - match: \s*(?=\}|,|:)
+          pop: true
+        - include: expressions
+
+  inside-directory-value:
+    - meta_content_scope: meta.mapping.python
+    - match: (?=\})
+      set: inside-dictionary
+    - match: (?=,)
+      set:
+        # clear meta scope from this match, because 'inside-directory' has it in meta_scope
+        - match: ','
+          scope: punctuation.separator.mapping.python
+          set: inside-dictionary
+    - match: (?=for)
+      push:
+        - meta_content_scope: meta.mapping.python
+        - match: (?=\})
+          pop: true
+        - match: ','
+          scope: invalid.illegal.unexpected-comma.python
+        - include: inline-for
+        - include: expressions
+    - include: comments
+    - match: (?=\S)
+      push:
+        - meta_content_scope: meta.mapping.value.python
+        - match: \s*(?=\}|,|for)
+          pop: true
+        - include: expressions
+
+  inside-set:
+    - meta_scope: meta.set.python
+    - match: \}
+      scope: punctuation.section.set.end.python
+      set: after-expression
+    - match: ':'
+      scope: invalid.illegal.colon-inside-set.python
+    - match: ','
+      scope: punctuation.separator.set.python
+    - match: \*
+      scope: keyword.operator.unpacking.sequence.python
+      push:
+        - match: (?=\})
+          pop: true
+        - match: ','
+          scope: punctuation.separator.set.python
+          pop: true
+        - include: expressions
+    - include: inline-for
+    - include: expressions
 
   builtin-exceptions:
     - match: |-

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -927,7 +927,7 @@ contexts:
           scope: punctuation.separator.set.python
           set: inside-set
         - match: ':'
-          scope: punctuation.separator.mapping.python
+          scope: punctuation.separator.mapping.key-value.python
           set: inside-directory-value
         - include: inline-for
         - include: expressions
@@ -938,7 +938,7 @@ contexts:
       scope: punctuation.section.mapping.end.python
       set: after-expression
     - match: ':'
-      scope: punctuation.separator.mapping.python
+      scope: punctuation.separator.mapping.key-value.python
       set: inside-directory-value
     - match: ','
       scope: invalid.illegal.expected-colon.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -891,8 +891,10 @@ mytuple = ("this", 'is', 4, tuple)
 #                         ^ punctuation.separator.sequence
 #                           ^^^^^ support.type
 #                                ^ punctuation.section.sequence.end
-also_a_tuple = ()
+
+also_a_tuple = ()[-1]
 #              ^^ meta.sequence.tuple.empty.python
+#                ^^^^ meta.item-access
 
 not_a_tuple = (a = 2, b += 3)
 #             ^^^^^^^^^^^^^^^ - meta.sequence

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -364,7 +364,7 @@ range(20)[10:2:-2]
 #                     ^^^ meta.item-access - meta.structure
 
 [1, 2, 3][2]
-#^^^^^^^^ meta.structure.list
+#^^^^^^^^ meta.sequence
 #        ^^^ meta.item-access - meta.structure
 
 {True: False}.get(True)
@@ -491,23 +491,23 @@ def _():
 #                ^ punctuation.section.arguments.begin
 #                 ^ punctuation.section.arguments.end
 #                   ^^ keyword.control.flow.with.as
-#                      ^ punctuation.section.list.begin
+#                      ^ punctuation.section.sequence.begin
 #                       ^^^ meta.generic-name
-#                          ^ punctuation.separator.list
+#                          ^ punctuation.separator.sequence
 #                            ^^^ meta.generic-name
-#                               ^ punctuation.section.list.end
+#                               ^ punctuation.section.sequence.end
 #                                ^ punctuation.section.block.with
 
     with captured() \
     as [
-#      ^ punctuation.section.list.begin
+#      ^ punctuation.section.sequence.begin
         out,
 #       ^^^ meta.generic-name
-#          ^ punctuation.separator.list
+#          ^ punctuation.separator.sequence
         err
 #       ^^^ meta.generic-name
     ]:
-#   ^ punctuation.section.list.end
+#   ^ punctuation.section.sequence.end
 #    ^ punctuation.section.block.with
 
     async with context_manager() as c:
@@ -896,59 +896,77 @@ not_a_tuple = (a = 2, b += 3)
 #                        ^ - keyword
 
 mylist = []
-#        ^^ meta.structure.list.python
-#        ^ punctuation.section.list.begin
-#         ^ punctuation.section.list.end
+#        ^^ meta.sequence.python
+#        ^ punctuation.section.sequence.begin
+#         ^ punctuation.section.sequence.end
 
 mylist = [1, "testing", ["sublist", True]]
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
-#        ^ punctuation.section.list.begin
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
+#        ^ punctuation.section.sequence.begin
 #         ^ constant.numeric
-#          ^ punctuation.separator.list
+#          ^ punctuation.separator.sequence
 #            ^^^^^^^^^ string.quoted.double
 #                     ^ punctuation.separator
-#                       ^^^^^^^^^^^^^^^^^ meta.structure.list meta.structure.list
-#                       ^ punctuation.section.list.begin
+#                       ^^^^^^^^^^^^^^^^^ meta.sequence meta.sequence
+#                       ^ punctuation.section.sequence.begin
 #                        ^^^^^^^^^ string.quoted.double
-#                                 ^ punctuation.separator.list
+#                                 ^ punctuation.separator.sequence
 #                                   ^^^^ constant.language
-#                                       ^ punctuation.section.list.end
-#                                        ^ punctuation.section.list.end
+#                                       ^ punctuation.section.sequence.end
+#                                        ^ punctuation.section.sequence.end
 
 mydict = {}
-#        ^^ meta.structure.dictionary
-#        ^ punctuation.section.dictionary.begin
-#         ^ punctuation.section.dictionary.end
+#        ^^ meta.mapping meta.empty-dictionary
+#        ^ punctuation.section.mapping.begin
+#         ^ punctuation.section.mapping.end
 
 key2 = "my_key"
-mydict = {"key": True, key2: (1, 2, [-1, -2])}
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
-#         ^^^^^ string.quoted.double
-#              ^ punctuation.separator.key-value
-#                ^^^^ constant.language
-#                    ^ punctuation.separator.dictionary-or-set
-#                          ^ punctuation.separator.key-value
+mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping.python meta.mapping.python
+#        ^ punctuation.section.mapping.begin
+#         ^^^^^ meta.mapping.key.python string.quoted.double
+#              ^ punctuation.separator.mapping
+#                ^^^^ meta.mapping.value.python constant.language
+#                    ^ punctuation.separator.mapping
+#                      ^^^^ meta.mapping.key.python meta.qualified-name
+#                          ^ punctuation.separator.mapping
 #                            ^^^^^^^^^^^^^^^^ meta.group
 #                            ^ punctuation.section.group.begin
 #                             ^ constant.numeric
 #                                ^ constant.numeric
-#                                   ^^^^^^^ meta.structure.list
-#                                      ^ punctuation.separator.list
+#                                   ^^^^^^^^ meta.sequence
+#                                      ^ punctuation.separator.sequence
 #                                           ^ punctuation.section.group.end
-#        ^ punctuation.section.dictionary-or-set.begin
-#                                            ^ punctuation.section.dictionary-or-set.end
+#                                            ^ punctuation.separator.mapping.python
+#                                              ^ invalid.illegal.expected-colon.python
+#                                               ^ punctuation.section.mapping.end - meta.mapping.key
 
-myset = {"key", True, key2, [-1], {}}
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+myset = {"key", True, key2, [-1], {}:1}
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set
+#       ^ punctuation.section.set.begin.python
 #        ^^^^^ string.quoted.double
-#             ^ punctuation.separator.dictionary-or-set
+#             ^ punctuation.separator.set
 #               ^^^^ constant.language
-#                   ^ punctuation.separator.dictionary-or-set
-#                         ^ punctuation.separator.dictionary-or-set
-#                           ^^^^ meta.structure.list
+#                   ^ punctuation.separator.set
+#                         ^ punctuation.separator.set
+#                           ^^^^ meta.sequence
 #                             ^ constant.numeric
-#                               ^ punctuation.separator.dictionary-or-set
-#                                 ^^ meta.structure.dictionary
+#                               ^ punctuation.separator.set
+#                                 ^^ meta.mapping meta.empty-dictionary
+#                                   ^ invalid.illegal.colon-inside-set.python
+#                                     ^ punctuation.section.set.end.python
+
+mapping_or_set = {
+#                ^ meta.mapping-or-set.python punctuation.section.mapping-or-set.begin.python
+    1: True
+#   ^ meta.mapping.python meta.mapping.key.python constant.numeric.integer.decimal.python
+#    ^ punctuation.separator.mapping.python
+}
+# <- meta.mapping.python punctuation.section.mapping.end.python
+
+complex_mapping = {(): "value"}
+#                 ^^^ meta.mapping-or-set.python
+#                    ^^^^^^^^^^ meta.mapping.python - meta.mapping-or-set
 
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
@@ -956,22 +974,26 @@ generator = (i for i in range(100))
 #              ^^^ keyword.control.flow.for.generator
 #                    ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100)]
-#       ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
+#       ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
 #          ^^^ keyword.control.flow.for.generator
 #                ^^ keyword.control.flow.for.in
 set_ = {i for i in range(100)}
-#      ^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+#      ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping-or-set
 #         ^^^^^^^^ meta.expression.generator
 #         ^^^ keyword.control.flow.for.generator
 #               ^^ keyword.control.flow.for.in
 dict_ = {i: i for i in range(100)}
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
+#        ^ meta.mapping.key.python
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.key.python
+#           ^ meta.mapping.value.python
+#            ^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.value
 #             ^^^^^^^^ meta.expression.generator
 #             ^^^ keyword.control.flow.for.generator
 #                   ^^ keyword.control.flow.for.in
 list_ = [i for i in range(100) if i > 0 else -1]
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
 #                              ^^ keyword.control.flow.if.inline
 #                                       ^^^^ keyword.control.flow.else.inline
@@ -993,27 +1015,27 @@ generator = ((k1, k2, v) for ((k1, k2), v) in xs)
 #                                               ^ punctuation.section.group.end.python
 
 list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list.python
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.python
 #        ^^^^^^^^^^^ meta.group.python
 #                   ^ - meta.group.python - meta.expression.generator.python
-#       ^ punctuation.section.list.begin.python
+#       ^ punctuation.section.sequence.begin.python
 #        ^ punctuation.section.group.begin.python
 #                  ^ punctuation.section.group.end.python
 #                        ^^ punctuation.section.target-list.begin.python
 #                                ^ punctuation.section.target-list.end.python
 #                                    ^ punctuation.section.target-list.end.python
-#                                           ^ punctuation.section.list.end.python
+#                                           ^ punctuation.section.sequence.end.python
 
 dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set.python
-#       ^ punctuation.section.dictionary-or-set.begin.python
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
+#       ^ punctuation.section.mapping.begin.python
 #            ^^^^^^^ meta.group.python
 #            ^ punctuation.section.group.begin.python
 #                  ^ punctuation.section.group.end.python
 #                        ^^ punctuation.section.target-list.begin.python
 #                                ^ punctuation.section.target-list.end.python
 #                                    ^ punctuation.section.target-list.end.python
-#                                           ^ punctuation.section.dictionary-or-set.end.python
+#                                           ^ punctuation.section.mapping.end.python
 
 list(i for i in generator)
 #      ^^^^^^^^ meta.expression.generator
@@ -1045,6 +1067,24 @@ d = {1: 3**4, **dict_}
 #        ^^ keyword.operator.arithmetic.python
 #             ^^ keyword.operator.unpacking.mapping.python
 
+d = {**d, **dict()}
+#   ^^^^^^^^^^^^^^^ meta.mapping.python
+#    ^^^ - meta.mapping.key
+#    ^^ keyword.operator.unpacking.mapping.python
+#      ^ meta.qualified-name.python
+#       ^ punctuation.separator.mapping.python
+#         ^^^^^^^^ - meta.mapping.key
+#         ^^ keyword.operator.unpacking.mapping.python
+#           ^^^^ support.type.python
+
+s = {*d, *set()}
+#   ^^^^^^^^^^^^ meta.set.python
+#    ^ keyword.operator.unpacking.sequence.python
+#     ^ meta.qualified-name.python
+#      ^ punctuation.separator.set.python
+#        ^ keyword.operator.unpacking.sequence.python
+#         ^^^ support.type.python
+
 generator = (
     i
     for
@@ -1054,6 +1094,7 @@ generator = (
 #   ^^ keyword.control.flow.for.in
     range(100)
 )
+
 
 ##################
 # Exception handling
@@ -1247,7 +1288,7 @@ x = [
 for x in y:
     break
 #   ^^^^^ invalid.illegal.name
-#        ^ - meta.structure.list
+#        ^ - meta.sequence
 
 
 with open(x) as y:
@@ -1285,3 +1326,7 @@ class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python
 #                                   ^ keyword.operator.assignment
+
+
+# <- - meta
+# ensure we're not leaking a context

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1063,6 +1063,9 @@ l = [1 * 2, 2**10, *result]
 #            ^^ keyword.operator.arithmetic.python
 #                  ^ keyword.operator.unpacking.sequence.python
 
+l = [*l]
+#    ^ keyword.operator.unpacking.sequence.python
+
 d = {1: 3**4, **dict_}
 #        ^^ keyword.operator.arithmetic.python
 #             ^^ keyword.operator.unpacking.mapping.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -929,7 +929,7 @@ mydict = {}
 
 key2 = "my_key"
 mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping.python meta.mapping.python
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #        ^ punctuation.section.mapping.begin
 #         ^^^^^ meta.mapping.key.python string.quoted.double
 #              ^ punctuation.separator.mapping.key-value
@@ -966,14 +966,14 @@ myset = {"key", True, key2, [-1], {}:1}
 mapping_or_set = {
 #                ^ meta.mapping-or-set.python punctuation.section.mapping-or-set.begin.python
     1: True
-#   ^ meta.mapping.python meta.mapping.key.python constant.numeric.integer.decimal.python
+#   ^ meta.mapping.key.python constant.numeric.integer.decimal.python
 #    ^ punctuation.separator.mapping.key-value.python
 }
 # <- meta.mapping.python punctuation.section.mapping.end.python
 
 complex_mapping = {(): "value"}
 #                 ^^^ meta.mapping-or-set.python
-#                    ^^^^^^^^^^ meta.mapping.python - meta.mapping-or-set
+#                    ^^^^^^^^^^ meta.mapping - meta.mapping-or-set
 
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
@@ -991,7 +991,7 @@ set_ = {i for i in range(100)}
 #         ^^^ keyword.control.flow.for.generator
 #               ^^ keyword.control.flow.for.in
 dict_ = {i: i for i in range(100)}
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #        ^ meta.mapping.key.python
 #         ^^^^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.key.python
 #           ^ meta.mapping.value.python
@@ -1034,7 +1034,7 @@ list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
 #                                           ^ punctuation.section.sequence.end.python
 
 dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #       ^ punctuation.section.mapping.begin.python
 #            ^^^^^^^ meta.sequence.tuple.python
 #            ^ punctuation.section.sequence.begin.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -892,7 +892,7 @@ mytuple = ("this", 'is', 4, tuple)
 #                           ^^^^^ support.type
 #                                ^ punctuation.section.sequence.end
 also_a_tuple = ()
-#              ^^ meta.sequence.tuple.python
+#              ^^ meta.sequence.tuple.empty.python
 
 not_a_tuple = (a = 2, b += 3)
 #             ^^^^^^^^^^^^^^^ - meta.sequence
@@ -903,7 +903,7 @@ just_a_group = (1)
 #              ^^^ meta.group.python
 
 mylist = []
-#        ^^ meta.sequence.list.python
+#        ^^ meta.sequence.list.empty.python
 #        ^ punctuation.section.sequence.begin
 #         ^ punctuation.section.sequence.end
 
@@ -923,7 +923,7 @@ mylist = [1, "testing", ["sublist", True]]
 #                                        ^ punctuation.section.sequence.end
 
 mydict = {}
-#        ^^ meta.mapping meta.empty-dictionary
+#        ^^ meta.mapping.empty.python
 #        ^ punctuation.section.mapping.begin
 #         ^ punctuation.section.mapping.end
 
@@ -959,7 +959,7 @@ myset = {"key", True, key2, [-1], {}:1}
 #                           ^^^^ meta.sequence
 #                             ^ constant.numeric
 #                               ^ punctuation.separator.set
-#                                 ^^ meta.mapping meta.empty-dictionary
+#                                 ^^ meta.mapping.empty.python
 #                                   ^ invalid.illegal.colon-inside-set.python
 #                                     ^ punctuation.section.set.end.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -695,7 +695,7 @@ def func(args, (x, y)=(0,0)):
 #                          ^ meta.function.parameters.python
 #              ^^^^^^ meta.group.python
 #                    ^ - meta.group.python
-#                     ^^^^^ meta.group.python
+#                     ^^^^^ meta.sequence.tuple.python
 #                          ^ - meta.group.python
 #       ^ punctuation.section.parameters.begin.python
 #            ^ punctuation.separator.parameters.python
@@ -705,18 +705,18 @@ def func(args, (x, y)=(0,0)):
 #                  ^ variable.parameter.python
 #                   ^ punctuation.section.group.end.python
 #                    ^ keyword.operator.assignment.python
-#                     ^ punctuation.section.group.begin.python
+#                     ^ punctuation.section.sequence.begin.python
 #                      ^ constant.numeric.integer.decimal.python
-#                       ^ punctuation.separator.tuple.python
+#                       ^ punctuation.separator.sequence.python
 #                        ^ constant.numeric.integer.decimal.python
-#                         ^ punctuation.section.group.end.python
+#                         ^ punctuation.section.sequence.end.python
 #                          ^ punctuation.section.parameters.end.python
     pass
 
 def foo(arg: int = 0, (x: float, y=20) = (0.0, "default")):
 #                     ^^^^^^^^^^^^^^^^ meta.group.python
 #                                     ^^^ - meta.group.python
-#                                        ^^^^^^^^^^^^^^^^ meta.group.python
+#                                        ^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
 #                     ^ punctuation.section.group.begin.python
 #                      ^ variable.parameter.python
 #                       ^^^^^^^ invalid.illegal.annotation.python
@@ -725,8 +725,8 @@ def foo(arg: int = 0, (x: float, y=20) = (0.0, "default")):
 #                                 ^^^ invalid.illegal.default-value.python
 #                                    ^ punctuation.section.group.end.python
 #                                      ^ keyword.operator.assignment.python
-#                                        ^ punctuation.section.group.begin.python
-#                                                       ^ punctuation.section.group.end.python
+#                                        ^ punctuation.section.sequence.begin.python
+#                                                       ^ punctuation.section.sequence.end.python
     pass
 
 ##################
@@ -881,22 +881,29 @@ class AClass:
 ##################
 
 mytuple = ("this", 'is', 4, tuple)
-#         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
-#         ^ punctuation.section.group.begin
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
+#         ^ punctuation.section.sequence.begin
 #          ^^^^^^ string.quoted.double
-#                ^ punctuation.separator.tuple
+#                ^ punctuation.separator.sequence
 #                  ^^^^ string.quoted.single
-#                      ^ punctuation.separator.tuple
+#                      ^ punctuation.separator.sequence
 #                        ^ constant.numeric
-#                         ^ punctuation.separator.tuple
+#                         ^ punctuation.separator.sequence
 #                           ^^^^^ support.type
-#                                ^ punctuation.section.group.end
+#                                ^ punctuation.section.sequence.end
+also_a_tuple = ()
+#              ^^ meta.sequence.tuple.python
+
 not_a_tuple = (a = 2, b += 3)
+#             ^^^^^^^^^^^^^^^ - meta.sequence
 #                ^ - keyword
 #                        ^ - keyword
 
+just_a_group = (1)
+#              ^^^ meta.group.python
+
 mylist = []
-#        ^^ meta.sequence.python
+#        ^^ meta.sequence.list.python
 #        ^ punctuation.section.sequence.begin
 #         ^ punctuation.section.sequence.end
 
@@ -930,13 +937,13 @@ mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
 #                    ^ punctuation.separator.mapping
 #                      ^^^^ meta.mapping.key.python meta.qualified-name
 #                          ^ punctuation.separator.mapping
-#                            ^^^^^^^^^^^^^^^^ meta.group
-#                            ^ punctuation.section.group.begin
+#                            ^^^^^^^^^^^^^^^^ meta.sequence.tuple
+#                            ^ punctuation.section.sequence.begin
 #                             ^ constant.numeric
 #                                ^ constant.numeric
-#                                   ^^^^^^^^ meta.sequence
+#                                   ^^^^^^^^ meta.sequence.list
 #                                      ^ punctuation.separator.sequence
-#                                           ^ punctuation.section.group.end
+#                                           ^ punctuation.section.sequence.end
 #                                            ^ punctuation.separator.mapping.python
 #                                              ^ invalid.illegal.expected-colon.python
 #                                               ^ punctuation.section.mapping.end - meta.mapping.key
@@ -1004,23 +1011,23 @@ list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #                                                 ^^ keyword.operator.logical
 
 generator = ((k1, k2, v) for ((k1, k2), v) in xs)
-#           ^ meta.group.python
-#            ^^^^^^^^^^^ meta.group.python meta.group.python
-#                       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.python
-#           ^^ punctuation.section.group.begin.python
-#                      ^ punctuation.section.group.end.python
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.python
+#            ^^^^^^^^^^^ meta.sequence.tuple.python
+#           ^ punctuation.section.group.begin.python
+#            ^ punctuation.section.sequence.begin.python
+#                      ^ punctuation.section.sequence.end.python
 #                            ^^ punctuation.section.target-list.begin.python
 #                                    ^ punctuation.section.target-list.end.python
 #                                        ^ punctuation.section.target-list.end.python
 #                                               ^ punctuation.section.group.end.python
 
 list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.python
-#        ^^^^^^^^^^^ meta.group.python
-#                   ^ - meta.group.python - meta.expression.generator.python
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.python
+#        ^^^^^^^^^^^ meta.sequence.tuple.python
+#                   ^ - meta.sequence.tuple.python - meta.expression.generator.python
 #       ^ punctuation.section.sequence.begin.python
-#        ^ punctuation.section.group.begin.python
-#                  ^ punctuation.section.group.end.python
+#        ^ punctuation.section.sequence.begin.python
+#                  ^ punctuation.section.sequence.end.python
 #                        ^^ punctuation.section.target-list.begin.python
 #                                ^ punctuation.section.target-list.end.python
 #                                    ^ punctuation.section.target-list.end.python
@@ -1029,9 +1036,9 @@ list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
 dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
 #       ^ punctuation.section.mapping.begin.python
-#            ^^^^^^^ meta.group.python
-#            ^ punctuation.section.group.begin.python
-#                  ^ punctuation.section.group.end.python
+#            ^^^^^^^ meta.sequence.tuple.python
+#            ^ punctuation.section.sequence.begin.python
+#                  ^ punctuation.section.sequence.end.python
 #                        ^^ punctuation.section.target-list.begin.python
 #                                ^ punctuation.section.target-list.end.python
 #                                    ^ punctuation.section.target-list.end.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -925,7 +925,7 @@ mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping.python meta.mapping.python
 #        ^ punctuation.section.mapping.begin
 #         ^^^^^ meta.mapping.key.python string.quoted.double
-#              ^ punctuation.separator.mapping
+#              ^ punctuation.separator.mapping.key-value
 #                ^^^^ meta.mapping.value.python constant.language
 #                    ^ punctuation.separator.mapping
 #                      ^^^^ meta.mapping.key.python meta.qualified-name
@@ -960,7 +960,7 @@ mapping_or_set = {
 #                ^ meta.mapping-or-set.python punctuation.section.mapping-or-set.begin.python
     1: True
 #   ^ meta.mapping.python meta.mapping.key.python constant.numeric.integer.decimal.python
-#    ^ punctuation.separator.mapping.python
+#    ^ punctuation.separator.mapping.key-value.python
 }
 # <- meta.mapping.python punctuation.section.mapping.end.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1065,6 +1065,13 @@ result = [await fun() for fun in funcs]
 #         ^^^^^ keyword.other.await.python
 
 
+t = (*tuple(), *[1, 2], 3*1)
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
+#    ^ keyword.operator.arithmetic.python
+#     ^^^^^ support.type.python
+#              ^ keyword.operator.unpacking.sequence.python
+#                        ^ keyword.operator.arithmetic.python
+
 l = [1 * 2, 2**10, *result]
 #      ^ keyword.operator.arithmetic.python
 #            ^^ keyword.operator.arithmetic.python


### PR DESCRIPTION
Now distinguishes between mappings and sets, allowing more fine-grained matching and meta scopes.

Also add meta.mapping.{key,value} scope to the appropriate sections of a dict literal.

This is in line with the proposed changes to JSON in https://github.com/sublimehq/Packages/pull/862.