### PR TITLE
[Python] Allow generators inside f-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1092,6 +1092,7 @@ contexts:
               pop: true
             - match: \\
               scope: invalid.illegal.backslash-in-fstring.python
+            - include: inline-for
             - include: expressions
 
   string-quoted-double-block:

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -570,6 +570,9 @@ f'   \
 #^^^^^^^^^^^^^^ meta.string.interpolated
 # ^^^^^ source source.python.embedded
 
+f"{d for d in range(10)}"  # yes, this doesn't make sense
+#    ^^^ keyword.control.flow.for.generator.python
+
 f'
 # ^ invalid.illegal.unclosed-string
 


### PR DESCRIPTION
They really don't make sense semantically, since the result will be a stringified generator, but they are valid syntax.