### PR TITLE
[YAML] Update of YAML boolean keywords

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -113,9 +113,7 @@ variables:
   _type_null: (?:null|Null|NULL|~) # http://yaml.org/type/null.html
   _type_bool: |- # http://yaml.org/type/bool.html
     (?x:
-       y|Y|yes|Yes|YES|n|N|no|No|NO
-      |true|True|TRUE|false|False|FALSE
-      |on|On|ON|off|Off|OFF
+       true|True|TRUE|false|False|FALSE
     )
   _type_int: |- # http://yaml.org/type/int.html
     (?x:


### PR DESCRIPTION
If my understanding is correct then `yes`, `no`, `on`, `off` and their various aliases were valid boolean keywords in YAML 1.1, but not anymore in the current YAML 1.2.

Relevant spec: [http://www.yaml.org/spec/1.2/spec.html#id2805071](http://www.yaml.org/spec/1.2/spec.html#id2805071)