### PR TITLE
[JavaScript] Use prototype for comments

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -21,6 +21,9 @@ contexts:
     - include: keywords-top-level
     - include: statements
 
+  prototype:
+    - include: comments
+
   keywords-top-level:
     - match: \bimport\b
       scope: meta.import.js keyword.control.import-export.js
@@ -40,7 +43,6 @@ contexts:
   import-extended:
     - meta_content_scope: meta.import.js
     - include: import-escape
-    - include: comments
     - match: '\{'
       scope: meta.block.js punctuation.section.block.js
       set: import-brace
@@ -66,7 +68,6 @@ contexts:
   import-extended-continue:
     - meta_scope: meta.import.js
     - include: import-escape
-    - include: comments
     - match: ','
       scope: punctuation.separator.comma.js
       set: import-extended
@@ -76,7 +77,6 @@ contexts:
   import-brace:
     - meta_content_scope: meta.import.js meta.block.js
     - include: import-escape
-    - include: comments
     - match: '\}'
       scope: punctuation.section.block.js
       set: import-extended-as
@@ -102,7 +102,6 @@ contexts:
   import-brace-continue:
     - meta_scope: meta.import.js meta.block.js
     - include: import-escape
-    - include: comments
     - match: '(?=\})'
       set: import-brace
     - match: ','
@@ -113,7 +112,6 @@ contexts:
 
   import-final:
     - meta_scope: meta.import.js
-    - include: comments
     - match: '\bfrom\b'
       scope: keyword.control.import-export.js
     - include: literal-string
@@ -135,7 +133,6 @@ contexts:
           pop: true
         - include: expressions
     - include: export-escape
-    - include: comments
     - match: '\bdefault\b'
       scope: keyword.control.import-export.js
       set:
@@ -165,7 +162,6 @@ contexts:
   export-extended-continue:
     - meta_scope: meta.export.js
     - include: export-escape
-    - include: comments
     - match: ','
       scope: punctuation.separator.comma.js
       set: export-extended
@@ -175,7 +171,6 @@ contexts:
   export-brace:
     - meta_content_scope: meta.export.js meta.block.js
     - include: export-escape
-    - include: comments
     - match: '\}'
       scope: punctuation.section.block.js
       set: export-extended-as
@@ -205,7 +200,6 @@ contexts:
   export-brace-continue:
     - meta_scope: meta.export.js meta.block.js
     - include: export-escape
-    - include: comments
     - match: '(?=\})'
       set: export-brace
     - match: ','
@@ -216,7 +210,6 @@ contexts:
 
   export-final:
     - meta_scope: meta.export.js
-    - include: comments
     - match: '\bfrom\b'
       scope: keyword.control.import-export.js
     - include: literal-string
@@ -270,7 +263,6 @@ contexts:
       scope: keyword.control.loop.js
       push:
         - meta_scope: meta.do-while.js
-        - include: comments
         - match: '\{'
           scope: punctuation.section.block.js
           push:
@@ -352,7 +344,6 @@ contexts:
     - include: block-scope
 
   block-scope:
-    - include: comments
     - match: '\}'
       scope: meta.block.js punctuation.section.block.js
       pop: true
@@ -367,7 +358,6 @@ contexts:
       pop: true
 
   expressions:
-    - include: comments
     - include: regexp-complete
     - include: literal-string
     - include: literal-string-template
@@ -424,6 +414,7 @@ contexts:
     - match: /\*\*(?!/)
       scope: punctuation.definition.comment.js
       push:
+        - meta_include_prototype: false
         - meta_scope: comment.block.documentation.js
         - match: \*/
           scope: punctuation.definition.comment.js
@@ -431,6 +422,7 @@ contexts:
     - match: /\*
       scope: punctuation.definition.comment.js
       push:
+        - meta_include_prototype: false
         - meta_scope: comment.block.js
         - match: \*/
           scope: punctuation.definition.comment.js
@@ -438,6 +430,7 @@ contexts:
     - match: //
       scope: punctuation.definition.comment.js
       push:
+        - meta_include_prototype: false
         - meta_scope: comment.line.double-slash.js
         - match: \n
           pop: true
@@ -446,6 +439,7 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.begin.js
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.js
         - match: (')|(\n)
           captures:
@@ -457,6 +451,7 @@ contexts:
       captures:
         0: punctuation.definition.string.begin.js
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.js
         - match: (")|(\n)
           captures:
@@ -471,6 +466,7 @@ contexts:
         1: variable.function.tagged-template.js
         2: punctuation.definition.string.template.begin.js
       push:
+        - meta_include_prototype: false
         - meta_scope: string.template.js
         - match: "`"
           scope: punctuation.definition.string.template.end.js
@@ -500,6 +496,7 @@ contexts:
       push: regexp
 
   regexp:
+      - meta_include_prototype: false
       - meta_scope: string.regexp.js
       - match: "(/)([gimyu]*)"
         captures:
@@ -508,6 +505,7 @@ contexts:
         set: after-identifier
       - match: '(?=.|\n)'
         push:
+          - meta_include_prototype: false
           - match: '(?=/)'
             pop: true
           - include: scope:source.regexp.js
@@ -677,11 +675,9 @@ contexts:
               pop: true
         - match: '{{identifier}}'
           scope: entity.name.class.js
-        - include: comments
 
   class-body:
     - meta_scope: meta.class.js meta.block.js
-    - include: comments
     - match: '\}'
       scope: punctuation.section.block.js
       pop: true
@@ -856,7 +852,6 @@ contexts:
       push: arrow-function-declaration
 
   function-declaration:
-    - include: comments
     - match: '\b(async)\b\s*'
       scope: meta.function.declaration.js
       captures:
@@ -898,7 +893,6 @@ contexts:
 
   arrow-function-declaration-continuation:
     - meta_content_scope: meta.function.declaration.js
-    - include: comments
     - match: '(?=\{)'
       set: function-block
     - match: '(?=\S)'
@@ -982,7 +976,6 @@ contexts:
             - match: "(?=[,)])"
               pop: true
             - include: expressions
-        - include: comments
 
   label:
     - match: '^\s*((?!default){{identifier}})\s*(:)'
@@ -998,7 +991,6 @@ contexts:
         - match: '\}'
           scope: punctuation.section.block.js
           set: after-identifier
-        - include: comments
         - match: \[
           scope: punctuation.section.brackets.js
           push:
@@ -1036,6 +1028,7 @@ contexts:
             - match: "'"
               scope: punctuation.definition.string.begin.js
               push:
+                - meta_include_prototype: false
                 - meta_scope: string.quoted.single.js
                 - meta_content_scope: entity.name.function.js
                 - match: (')|(\n)
@@ -1047,6 +1040,7 @@ contexts:
             - match: '"'
               scope: punctuation.definition.string.begin.js
               push:
+                - meta_include_prototype: false
                 - meta_scope: string.quoted.double.js
                 - meta_content_scope: entity.name.function.js
                 - match: (")|(\n)
@@ -1091,7 +1085,6 @@ contexts:
             - match: "(?=\\}|,|('[^']*'|\"[^\"]*\"|{{identifier}})\\s*:)"
               pop: true
             - include: expressions
-        - include: comments
 
   method-declaration:
     - match: \b(get|set)\b(?!\s*\()\s*
@@ -1122,7 +1115,6 @@ contexts:
               scope: punctuation.section.block.js
               pop: true
             - include: statements
-        - include: comments
         - match: '(?=\S)'
           pop: true
     - match: (?=('[^\\]*'|"[^\\]*")\s*\()
@@ -1131,6 +1123,7 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.begin.js
           push:
+            - meta_include_prototype: false
             - meta_scope: string.quoted.single.js
             - meta_content_scope: entity.name.function.js
             - match: (')|(\n)
@@ -1142,6 +1135,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.begin.js
           push:
+            - meta_include_prototype: false
             - meta_scope: string.quoted.double.js
             - meta_content_scope: entity.name.function.js
             - match: (")|(\n)
@@ -1160,7 +1154,6 @@ contexts:
               scope: punctuation.section.block.js
               pop: true
             - include: statements
-        - include: comments
         - match: '(?=\S)'
           pop: true
     - match: '({{identifier}})\s*(?=\()'
@@ -1177,7 +1170,6 @@ contexts:
               scope: punctuation.section.block.js
               pop: true
             - include: statements
-        - include: comments
         - match: '(?=\S)'
           pop: true
 

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -167,6 +167,41 @@ x --> y;
 /*@if /*/
 //     ^^ punctuation.definition.comment.js
 
+// /*
+not_a_comment;
+// <- -comment
+
+/* // */
+not_a_comment;
+// <- -comment
+
+/* /* */
+not_a_comment;
+// <- -comment
+
+'// /* not a comment';
+// ^^^^^^^^^^^^^^^^^^^ -comment
+
+"// /* not a comment";
+// ^^^^^^^^^^^^^^^^^^^ -comment
+
+`// /* not a comment`;
+// ^^^^^^^^^^^^^^^^^^^ -comment
+
+({
+    '// /* not a comment': x => x,
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -comment
+
+    "// /* not a comment": x => x,
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -comment
+
+    '// /* not a comment'() {},
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ -comment() {}
+
+    "// /* not a comment"() {},
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ -comment() {}
+});
+
 var str = '\':';
 var str2 = NaN;
 // <- storage.type
@@ -809,6 +844,11 @@ a = /\//u + 0;
 //      ^ keyword.other
 //        ^ keyword.operator
 //          ^ constant.numeric
+
+1 /**/ / 2 / /**/ 3;
+//     ^ keyword.operator
+//       ^ constant.numeric
+//         ^ keyword.operator
 
 var π = 3.141592653
 //  ^ variable.other.readwrite


### PR DESCRIPTION
(This PR formerly known as #1003)

### Background

The default JavaScript syntax definition is descended from an old `.tmLanguage`. Since its transition to a `.sublime-syntax`, it has largely modernized, but signs remain of its history.

One such sign is that the syntax definition does not use the new `prototype` feature for comments. Instead, the `comments` context is included manually. There are many dozens of contexts in the definition and somewhere between many and most of them should have manually included `comments`. An unknown number of those did not, resulting in at least one bug (#885, first test case).

In addition, the tests did not include any negative tests to ensure that comments were *not* included where they should not have been. No related bugs are known.

### This commit

I have moved the `comments` include to the prototype and removed it from all other contexts. I added `meta_include_prototype: false` as appropriate to remove it from the few contexts that should not include it. Finally, I have added negative tests to verify that comments should not appear in those contexts and a test for the known bug that was fixed in the process.

### Discussion

The known bug could have been fixed by adding another manual `include`. So why make a larger change?

The primary reason is simplicity. Comments are a pervasive feature that applies to nearly every part of the language. Each `- include: comments` is a separate implementation of this feature. While not every context would need that include, it is necessary for every context to *consider* whether it is needed. In at least one known case, the include was mistakenly omitted (and there are probably more such cases).

Conversely, the parts of the language that do *not* need to support comments are few: strings, regexps, and comments themselves. These parts all stand out as special cases with their own unique microsyntaxes. Additionally, this enumeration is likely to be relatively stable as the language evolves. Every piece of new syntax may require a new context and explicit consideration of comments, whereas new types of strings don't come along very often.

Prototypes also lessen the testing requirements. In this commit, I added a test for each `meta_include_prototype: false` that covers all comment types. Without prototypes, there really ought to be such a test for every single context that *does* allow comments. Many, many tests would be required to catch bugs such as the example from #885. Such tests do not yet exist.

In short, I believe that it makes the most sense to mark each exception rather than each non-exception. Doing so will result in less code and require fewer tests.

### Remarks

- There seem to be three separate copies of single- and double-quoted strings. These could perhaps be consolidated.

- This change is one of the steps on the program of improvement I outlined in #885. I consider this PR to be an important part of the foundation for this program.