### PR TITLE
[JavaScript] Fix regex lookahead

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -495,7 +495,24 @@ contexts:
       scope: constant.character.escape.js
 
   regexp-complete:
-    - match: '/(?=(?:[^/\\\[]|\\.|\[([^\]\\]|\\.)+\])+/(?![/*])[gimyu]*(?!\s*[a-zA-Z0-9_$]))'
+    - match: >-
+        (?x)
+        /
+        (?=
+          (?:
+            [^ / \\ \[  ]
+            | \\.
+            | # Character class
+              \[ ( 
+                [^ \] \\ ]
+                | \\.
+              )+ \]
+          )+
+          /
+          [gimyu]*
+          (?! \s* [a-zA-Z0-9_$] )
+        )
+
       scope: punctuation.definition.string.begin.js
       push: regexp
 

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -765,6 +765,20 @@ var reg = /a+/gimy.exec('aabb')
 // <- string.regexp
 //  ^^ punctuation.definition.group.no-capture.regexp
 
+/test// 1;
+// <- string.regexp.js
+//    ^ keyword.operator.arithmetic.js
+
+/test/* 1;
+// <- string.regexp.js
+//    ^ keyword.operator.arithmetic.js
+// */
+
+/test/** 1;
+// <- string.regexp.js
+//    ^^ keyword.operator.arithmetic.js
+// */
+
 'foo'.bar() / baz
 //            ^ variable.other.readwrite
 


### PR DESCRIPTION
(This PR formerly known as #1004)

Fixes #874 and #894. Adds the test cases from #894; they seem to be comprehensive.