### PR TITLE
[LaTeX] Pop math environment on unmatched closing brace

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -486,6 +486,8 @@ contexts:
     - include: scope:text.tex#math-characters
     - include: scope:text.tex#math-numerics
     - include: general-constants
+    - match: (?=\})
+      pop: true
 
   inline-math:
     - match: \$

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -439,6 +439,22 @@ a & b
 \end{tabular}
 
 
+\AnyDeclarationCommand{\eq}{\begin{equation}}
+
+% <- - meta.environment.math
+
+\wrapcommand{$}
+
+% <- - meta.environment.math
+
+\wrapcommand{\[}
+
+% <- - meta.environment.math
+
+$f(x) = \} {} y$
+% ^^^^^^^^^^^^^ meta.environment.math.inline.dollar.latex
+
+
 \end{document}
 % ^ support.function.end.latex keyword.control.flow.end.latex
 %        ^ variable.parameter.function.latex


### PR DESCRIPTION
This is not directly LaTeX syntax, but a suggestion to improve the handling of not directly supported behaviors by keeping the error local.

There have been a lot of issues of people opening math environments inside commands and not closing them, because it is not required with that specific command (but this specific command is not supported by the syntax definition). https://github.com/sublimehq/Packages/issues/544 https://github.com/sublimehq/Packages/issues/937 https://github.com/sublimehq/Packages/issues/472 https://github.com/SublimeText/LaTeXTools/issues/1124 https://github.com/SublimeText/LaTeXTools/issues/1104 https://github.com/SublimeText/LaTeXTools/issues/921 [tex.stackexchange#371105](https://tex.stackexchange.com/questions/371105/sublime-thinks-my-whole-text-is-an-equation)

The idea of the PR is to pop the math environment if a unmatched closing brace `}` occurs. This will end the math environment and keep the error local instead of messing up the whole document. Since closing a brace inside a math environment would be invalid anyway it should not break on existing documents.

I am open to feedback
@ig0774 @randy3k