### PR TITLE
[Scala] Minor symbolic id bugs

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -20,7 +20,7 @@ variables:
   op: |-
     (?x:
       [[^:=<@\x{2190}\x{21D2}#]&&{{operator_character}}]{{operator_character}}*|
-      =[[^>]&&{{operator_character}}]+|
+      =[[^>]&&{{operator_character}}]{{operator_character}}*|
       =>{{operator_character}}+|
       <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-]&&{{operator_character}}]+|
@@ -32,7 +32,7 @@ variables:
   typeop: |-
     (?x:
       [[^:=<@\x{2190}\x{21D2}#+\-]&&{{operator_character}}]{{operator_character}}*|
-      =[[^>]&&{{operator_character}}]+|
+      =[[^>]&&{{operator_character}}]{{operator_character}}*|
       =>{{operator_character}}+|
       <(?!{{operator_character}}|[[:alpha:]])|
       <[[^\-%:]&&{{operator_character}}]+|

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -46,7 +46,8 @@ variables:
   # an id that starts with lower-case OR underscore
   varid: '(?:(?:\p{Ll}|_+(?={{idcont}})){{idrest}})'
   boundvarid: '(?:`{{varid}}`|{{varid}})'
-  plainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{op}})'
+  alphaplainid: '(?:{{upper}}{{idrest}}|{{varid}})'
+  plainid: '(?:{{alphaplainid}}|{{op}})'
   typeplainid: '(?:{{upper}}{{idrest}}|{{varid}}|{{typeop}})'
   id: '(?:{{plainid}}|`[^`\n]+`)'
   idorunder: '(?:{{id}}|_)'
@@ -147,20 +148,20 @@ contexts:
       push: single-type-expression
 
   annotation:
-    - match: '(@)({{plainid}})(\.)'
+    - match: '(@)({{alphaplainid}})(\.)'
       captures:
         1: meta.annotation.scala punctuation.definition.annotation.scala
         2: meta.annotation.identifier.scala
         3: meta.annotation.identifier.scala punctuation.accessor.scala
       push:
         - meta_content_scope: meta.annotation.identifier.scala
-        - match: '({{plainid}})(\.)'
+        - match: '({{alphaplainid}})(\.)'
           captures:
             2: punctuation.accessor.scala
-        - match: '{{plainid}}'
+        - match: '{{alphaplainid}}'
           scope: variable.annotation.scala
           set: annotation-parameters
-    - match: '(@)({{plainid}})'
+    - match: '(@)({{alphaplainid}})'
       captures:
         1: meta.annotation.scala punctuation.definition.annotation.scala
         2: meta.annotation.identifier.scala variable.annotation.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1634,3 +1634,6 @@ new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
 
 type =?>[A] = Any
 //   ^^^ entity.name.type.scala
+
+  val x: Foo @> Bar
+//           ^^ support.type.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1631,3 +1631,6 @@ new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
    type Bar = Unit
 //      ^^^ entity.name.type.scala
 //          ^ keyword.operator.assignment.scala
+
+type =?>[A] = Any
+//   ^^^ entity.name.type.scala


### PR DESCRIPTION
- Annotations can only contain alphabetical ids
- Tricky over-disambiguation issues on ids starting with `=` and containing a `>`