### PR TITLE
[Python] Parse line continuations in more places

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -253,14 +253,15 @@ contexts:
       scope: invalid.illegal.stray.brace.curly.python
     - include: lists
     - include: dictionaries-and-sets
+    - include: line-continuation
 
   line-expressions: # Always include this last!
     - include: expressions-common
-    - include: line-continuation
     - include: qualified-name
 
   expressions: # Always include this last!
     # Differs from the line scope in that invalid-name matches will pop the current context
+    # and matches accessors continued on a different line
     - include: expressions-common
     - include: illegal-names-pop
     - include: qualified-name
@@ -546,6 +547,7 @@ contexts:
     - include: illegal-names
     - match: '{{identifier}}'
       scope: variable.parameter.python
+    - include: line-continuation
 
   function-after-parameters:
     - meta_content_scope: meta.function.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -113,11 +113,13 @@ dotted.identifier(12, True)
 #     ^ punctuation.accessor.dot
 #      ^^^^^^^^^^ variable.function
 
-open.__new__(12, True)
+open.__new__(12, \
 #^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 #^^^ support.function.builtin
 #   ^ punctuation.accessor.dot
 #    ^^^^^^^ support.function.magic
+#                ^ punctuation.separator.continuation.line.python
+             True)
 
 TypeError()
 #^^^^^^^^ support.type.exception
@@ -204,6 +206,15 @@ def _():
     lambda
 #   ^^^^^^ storage.type.function.inline
 
+    ( 3 - 6 \
+#   ^^^^^^^^^ meta.group.python
+#   ^ punctuation.section.group.begin.python
+#     ^ constant.numeric.integer.decimal.python
+#       ^ keyword.operator.arithmetic.python
+#         ^ constant.numeric.integer.decimal.python
+#           ^ punctuation.separator.continuation.line.python
+     )
+#^^^^^ meta.group.python
 
 ##################
 # Compound expressions
@@ -377,8 +388,10 @@ def my_func(param1, # Multi-line function definition
 #                   ^ comment.line.number-sign
     # This is defaulted
 #   ^ comment.line.number-sign
-    param2='#1'):
-#              ^ punctuation.section.parameters.end
+    param2='#1' \
+#               ^ punctuation.separator.continuation.line.python
+):
+# <- punctuation.section.parameters.end
     print('Hi!')
 
 
@@ -469,10 +482,11 @@ class UnicødeIdentifier():
 #             ^^^^ keyword.control.flow
 
 
-class MyClass(Inherited,
+class MyClass(Inherited, \
 #     ^^^^^^^ entity.name.class
 #             ^^^^^^^^^ entity.other.inherited-class
 #                      ^ punctuation.separator.inheritance
+#                        ^ punctuation.separator.continuation.line.python
               module . Inherited2, metaclass=ABCMeta):
 #             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
 #                    ^ punctuation.accessor.dot


### PR DESCRIPTION
Notably: groups, function calls and function/class definitions.

Fixes #1018.