### PR TITLE
[Python] Format strings don't extend past strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1034,7 +1034,7 @@ contexts:
         2: storage.modifier.conversion.python
         3: constant.other.format-spec.python
         4: punctuation.definition.placeholder.end.python
-    - match: \{(?=[^\}]+\{) # complex (nested) form
+    - match: \{(?=[^\}"']+\{) # complex (nested) form
       scope: punctuation.definition.placeholder.begin.python
       push:
         - meta_scope: constant.other.placeholder.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -482,6 +482,10 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 #                       ^^^^^^^^^^^ constant.other.placeholder constant.other.placeholder
 #                                 ^^ punctuation.definition.placeholder.end
 
+a=["aaaa{", "bbbb{"]
+#       ^ - constant.other.placeholder
+#        ^ punctuation.definition.string.end.python
+
 f"string"
 # <- storage.type.string
 #^^^^^^^^ string.quoted.double


### PR DESCRIPTION
The complex format string look-ahead disregarded string boundaries.

Fixes #1022.