### PR TITLE
[Scala] Fixed incorrect class decl state management

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -283,7 +283,7 @@ contexts:
         1: storage.type.class.scala
         2: storage.type.class.scala
         3: entity.name.class.scala
-      set: class-type-parameter-list
+      push: class-type-parameter-list
     - match: '\b(type)\s+({{id}})'
       captures:
         1: storage.type.scala


### PR DESCRIPTION
I legit have no idea how this ever worked.  My only guess is that if you `pop: true` when there is only a single context on the stack, Sublime will treat it as a `set: main`.

This fixes https://github.com/SublimeText-Markdown/MarkdownEditing/issues/430, and probably some other issues that I didn't know about.  Wasn't quite sure how to write a test for it, unfortunately.