### PR TITLE
[C#] more stray brace handling

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -181,8 +181,7 @@ contexts:
       scope: invalid.illegal.cs
 
   main:
-    - match: '\}'
-      scope: invalid.illegal.unexpected.closing-bracket.cs
+    - include: stray_close_bracket
     - match: '\{'
       scope: punctuation.section.block.begin.cs
       push:
@@ -199,6 +198,10 @@ contexts:
     - include: delegate_declaration
     # allows coloration of code outside a class
     - include: code_block_in
+
+  stray_close_bracket:
+    - match: '[})\]]'
+      scope: invalid.illegal.stray.brace.cs
 
   using:
     - match: '\b(using)\s+(?={{name}}\s*=\s*)'
@@ -414,6 +417,7 @@ contexts:
               scope: punctuation.section.block.end.cs
               pop: true
             - include: data_type_body
+        - include: stray_close_bracket
     - match: \S*
       scope: invalid.illegal
       pop: true
@@ -688,6 +692,7 @@ contexts:
             - match: \}
               scope: punctuation.section.block.end.cs
               pop: true
+            - include: stray_close_bracket
             - include: code_block_in
     - match: ;
       scope: punctuation.terminator.cs

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1017,6 +1017,9 @@ namespace TestNamespace.Test
     abc:
 /// ^^^ entity.name.label
 ///    ^ punctuation.separator
+    
+        "hello".OfType<char>().Where(c => c == 'l').Count());
+///                                                        ^ invalid.illegal.stray.brace
 
         // https://msdn.microsoft.com/en-us/library/txafckwd(v=vs.110).aspx
 ///        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
@@ -1093,3 +1096,5 @@ namespace TestNamespace.Test
     }
 }
 ///<- punctuation.section.block.end
+}
+/// <- invalid.illegal.stray.brace


### PR DESCRIPTION
this makes it easier to find syntax errors in C# files by scoping stray closing braces as illegal, just like Python does. Previously the C# syntax did this, but only for curly braces and only at root level - i.e. when not inside a class or method etc.