### PR TITLE
[C#] more stray brace detection

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1316,6 +1316,7 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.cs
       pop: true
+    - include: stray_close_bracket
     - match: '(?=\S)'
       push: line_of_code_in
 

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1098,3 +1098,15 @@ namespace TestNamespace.Test
 ///<- punctuation.section.block.end
 }
 /// <- invalid.illegal.stray.brace
+
+class Test
+{
+    void Abc()
+    {
+        Something.SomeMethod(];
+///                         ^ meta.function-call meta.group punctuation.section.group.begin
+///                          ^ invalid.illegal.stray.brace
+///                           ^ invalid.illegal.expected-close-paren
+    }
+/// ^ - invalid.illegal.stray.brace
+}


### PR DESCRIPTION
https://github.com/sublimehq/Packages/pull/1038 missed a case of stray braces in function calls. This corrects that, while limiting the amount of invalid highlighting, to help developers find the bug quickly without any extra distractions.