### PR TITLE
[C++] [Objective-C] Fix declspec highlighting

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -358,7 +358,7 @@ contexts:
         - match: '\)'
           scope: meta.group.c++ punctuation.section.group.end.c++
           pop: true
-        - match: '\b(align|allocate|code_seg|property|uuid)\b\s*(\()'
+        - match: '\b(align|allocate|code_seg|deprecated|property|uuid)\b\s*(\()'
           captures:
             1: storage.modifier.c++
             2: meta.group.c++ punctuation.section.group.begin.c++

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -585,7 +585,7 @@ contexts:
         - match: '\)'
           scope: meta.group.c punctuation.section.group.end.c
           pop: true
-        - match: '\b(align|allocate|code_seg|property|uuid)\b\s*(\()'
+        - match: '\b(align|allocate|code_seg|deprecated|property|uuid)\b\s*(\()'
           captures:
             1: storage.modifier.c
             2: meta.group.c punctuation.section.group.begin.c

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -429,6 +429,22 @@ int32
 /* <- - entity.name.function */
 () {}
 
+_declspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                ^ entity.name.function      */
+__declspec(deprecated("bla")) void func2(int) {}
+/* <- storage.modifier - variable.function                    */
+/*         ^ storage.modifier - variable.function             */
+/*                    ^ string.quoted.double punctuation      */
+/*                     ^ string.quoted.double - punctuation   */
+/*                       ^ string.quoted.double - punctuation */
+/*                        ^ string.quoted.double punctuation  */
+/*                         ^^ punctuation - invalid           */
+/*                                 ^ entity.name.function     */
+__notdeclspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                    ^ entity.name.function  */
+
 /////////////////////////////////////////////
 // Test function call in function parameters
 /////////////////////////////////////////////

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1666,6 +1666,22 @@ int32
 /* <- - entity.name.function */
 () {}
 
+_declspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                ^ entity.name.function      */
+__declspec(deprecated("bla")) void func2(int) {}
+/* <- storage.modifier - variable.function                    */
+/*         ^ storage.modifier - variable.function             */
+/*                    ^ string.quoted.double punctuation      */
+/*                     ^ string.quoted.double - punctuation   */
+/*                       ^ string.quoted.double - punctuation */
+/*                        ^ string.quoted.double punctuation  */
+/*                         ^^ punctuation - invalid           */
+/*                                 ^ entity.name.function     */
+__notdeclspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                    ^ entity.name.function  */
+
 /////////////////////////////////////////////
 // Paths/identifiers
 /////////////////////////////////////////////

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -444,7 +444,7 @@ contexts:
         - match: '\)'
           scope: meta.group.objc++ punctuation.section.group.end.objc++
           pop: true
-        - match: '\b(align|allocate|code_seg|property|uuid)\b\s*(\()'
+        - match: '\b(align|allocate|code_seg|deprecated|property|uuid)\b\s*(\()'
           captures:
             1: storage.modifier.objc++
             2: meta.group.objc++ punctuation.section.group.begin.objc++

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -792,6 +792,34 @@ contexts:
         - match: \)\)
           scope: meta.group.objc punctuation.section.group.end.objc
           pop: true
+    - match: \b(__declspec)(\()
+      captures:
+        1: storage.modifier.objc
+        2: meta.group.objc punctuation.section.group.begin.objc
+      push:
+        - meta_content_scope: meta.group.objc
+        - match: '\)'
+          scope: meta.group.objc punctuation.section.group.end.objc
+          pop: true
+        - match: '\b(align|allocate|code_seg|deprecated|property|uuid)\b\s*(\()'
+          captures:
+            1: storage.modifier.objc
+            2: meta.group.objc punctuation.section.group.begin.objc
+          push:
+            - meta_content_scope: meta.group.objc
+            - match: '\)'
+              scope: meta.group.objc punctuation.section.group.end.objc
+              pop: true
+            - include: numbers
+            - include: strings
+            - match: \b(get|put)\b
+              scope: variable.parameter.objc
+            - match: ','
+              scope: punctuation.separator.objc
+            - match: '='
+              scope: keyword.operator.assignment.objc
+        - match: '\b(appdomain|deprecated|dllimport|dllexport|jintrinsic|naked|noalias|noinline|noreturn|nothrow|novtable|process|restrict|safebuffers|selectany|thread)\b'
+          scope: constant.other.objc
 
   keywords-parens:
     - match: '\b(sizeof)\b\s*(\()'

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1666,6 +1666,22 @@ int32
 /* <- - entity.name.function */
 () {}
 
+_declspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                ^ entity.name.function      */
+__declspec(deprecated("bla")) void func2(int) {}
+/* <- storage.modifier - variable.function                    */
+/*         ^ storage.modifier - variable.function             */
+/*                    ^ string.quoted.double punctuation      */
+/*                     ^ string.quoted.double - punctuation   */
+/*                       ^ string.quoted.double - punctuation */
+/*                        ^ string.quoted.double punctuation  */
+/*                         ^^ punctuation - invalid           */
+/*                                 ^ entity.name.function     */
+__notdeclspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                    ^ entity.name.function  */
+
 /////////////////////////////////////////////
 // Paths/identifiers
 /////////////////////////////////////////////

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -427,6 +427,22 @@ int32
 /* <- - entity.name.function */
 () {}
 
+_declspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                ^ entity.name.function      */
+__declspec(deprecated("bla")) void func2(int) {}
+/* <- storage.modifier - variable.function                    */
+/*         ^ storage.modifier - variable.function             */
+/*                    ^ string.quoted.double punctuation      */
+/*                     ^ string.quoted.double - punctuation   */
+/*                       ^ string.quoted.double - punctuation */
+/*                        ^ string.quoted.double punctuation  */
+/*                         ^^ punctuation - invalid           */
+/*                                 ^ entity.name.function     */
+__notdeclspec(deprecated("bla")) void func2(int) {}
+/* <- meta.function-call variable.function                    */
+/*                                    ^ entity.name.function  */
+
 /////////////////////////////////////////////
 // Test function call in function parameters
 /////////////////////////////////////////////


### PR DESCRIPTION
Fix for https://github.com/sublimehq/Packages/issues/1041.

Commit 3eabef5 is separate because Objective-C was missing a bunch of declspec handling. This made me wonder wether this was intentional or not. If it's intentional, then it's easy to revert that commit now.