### PR TITLE
[Python] scope numeric punctuation that marks which base to use

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -333,28 +333,39 @@ contexts:
   numbers:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
     # hexadecimal
-    - match: \b(?i)(?:0x\h*)(L) # py2
+    - match: \b(?i)(0x)\h*(L) # py2
       scope: constant.numeric.integer.long.hexadecimal.python
       captures:
-        1: storage.type.numeric.long.python
-    - match: \b(?i)(0x(_?\h)+)
+        1: punctuation.definition.numeric.hexadecimal.python
+        2: storage.type.numeric.long.python
+    - match: \b(?i)(0x)(_?\h)+
       scope: constant.numeric.integer.hexadecimal.python
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.python
     # octal
-    - match: \b(?i)0(?:o|[0-7])[0-7]*(L) # py2
+    - match: \b(?i)(0o?)(?=o|[0-7])[0-7]*(L) # py2
       scope: constant.numeric.integer.long.octal.python
       captures:
-        1: storage.type.numeric.long.python
-    - match: \b(?i)0[0-7]+ # py2
+        1: constant.numeric.integer.octal.python
+        2: storage.type.numeric.long.python
+    - match: \b(?i)(0)[0-7]+ # py2
       scope: constant.numeric.integer.octal.python
-    - match: \b(?i)0o(_?[0-7])+
+      captures:
+        1: punctuation.definition.numeric.octal.python
+    - match: \b(?i)(0o)(_?[0-7])+
       scope: constant.numeric.integer.octal.python
+      captures:
+        1: punctuation.definition.numeric.octal.python
     # binary
-    - match: \b(?i)0b[01]*(L) # py2
+    - match: \b(?i)(0b)[01]*(L) # py2
       scope: constant.numeric.integer.long.binary.python
       captures:
-        1: storage.type.numeric.long.python
-    - match: \b(?i)0b(_?[01])*
+        1: punctuation.definition.numeric.binary.python
+        2: storage.type.numeric.long.python
+    - match: \b(?i)(0b)(_?[01])*
       scope: constant.numeric.integer.binary.python
+      captures:
+        1: punctuation.definition.numeric.binary.python
     # complex
     - match: (?i){{digitpart}}?(\.){{digitpart}}(?:e[\-\+]?{{digitpart}})?(j) # mandatory fraction
       scope: constant.numeric.complex.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -346,7 +346,7 @@ contexts:
     - match: \b(?i)(0o?)(?=o|[0-7])[0-7]*(L) # py2
       scope: constant.numeric.integer.long.octal.python
       captures:
-        1: constant.numeric.integer.octal.python
+        1: punctuation.definition.integer.octal.python
         2: storage.type.numeric.long.python
     - match: \b(?i)(0)[0-7]+ # py2
       scope: constant.numeric.integer.octal.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -799,28 +799,39 @@ not_floating = abc.123
 
 binary = 0b1010011 | 0b0110110L
 #        ^^^^^^^^^ constant.numeric.integer.binary.python
+#        ^^ punctuation.definition.numeric.binary.python
 #                    ^^^^^^^^^^ constant.numeric.integer.long.binary.python
+#                    ^^ punctuation.definition.numeric.binary.python
 #                             ^ storage.type.numeric.long.python
 
 octal = 0o755 ^ 0o644L
 #       ^^^^^ constant.numeric.integer.octal.python
+#       ^^ punctuation.definition.numeric.octal.python
 #                    ^ storage.type.numeric.long.python
 #               ^^^^^^ constant.numeric.integer.long.octal.python
+#               ^^ constant.numeric.integer.octal.python
 
 old_style_octal = 010 + 007 - 012345670L
 #                 ^^^ constant.numeric.integer.octal.python
+#                 ^ punctuation.definition.numeric.octal.python
 #                       ^^^ constant.numeric.integer.octal.python
+#                       ^ punctuation.definition.numeric.octal.python
 #                             ^^^^^^^^^^ constant.numeric.integer.long.octal.python
+#                             ^ constant.numeric.integer.octal.python
 #                                      ^ storage.type.numeric.long.python
 
 hexadecimal = 0x100af - 0XDEADF00L
 #             ^^^^^^^ constant.numeric.integer.hexadecimal.python
+#             ^^ punctuation.definition.numeric.hexadecimal.python
 #                       ^^^^^^^^^^ constant.numeric.integer.long.hexadecimal.python
+#                       ^^ punctuation.definition.numeric.hexadecimal.python
 #                                ^ storage.type.numeric.long.python
 
 unintuitive = 0B101 + 0O101 + 10l
 #             ^^^^^ constant.numeric.integer.binary.python
+#             ^^ punctuation.definition.numeric.binary.python
 #                     ^^^^^ constant.numeric.integer.octal.python
+#                     ^^ punctuation.definition.numeric.octal.python
 #                             ^^^ constant.numeric.integer.long.decimal.python
 #                               ^ storage.type.numeric.long.python
 
@@ -845,9 +856,11 @@ very_complex = 23_2.2e2_0J + 2_1j
 
 addr = 0xCAFE_F00D
 #      ^^^^^^^^^^^ constant.numeric
+#      ^^ punctuation.definition.numeric.hexadecimal.python
 
 flags = 0b_0011_1111_0100_1110 | 0b_1 & 0b_0_
 #       ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric
+#       ^^ punctuation.definition.numeric.binary.python
 #                                ^^^^ constant.numeric.integer.binary.python
 #                                           ^ - constant
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -809,7 +809,7 @@ octal = 0o755 ^ 0o644L
 #       ^^ punctuation.definition.numeric.octal.python
 #                    ^ storage.type.numeric.long.python
 #               ^^^^^^ constant.numeric.integer.long.octal.python
-#               ^^ constant.numeric.integer.octal.python
+#               ^^ punctuation.definition.integer.octal.python
 
 old_style_octal = 010 + 007 - 012345670L
 #                 ^^^ constant.numeric.integer.octal.python
@@ -817,7 +817,7 @@ old_style_octal = 010 + 007 - 012345670L
 #                       ^^^ constant.numeric.integer.octal.python
 #                       ^ punctuation.definition.numeric.octal.python
 #                             ^^^^^^^^^^ constant.numeric.integer.long.octal.python
-#                             ^ constant.numeric.integer.octal.python
+#                             ^ punctuation.definition.integer.octal.python
 #                                      ^ storage.type.numeric.long.python
 
 hexadecimal = 0x100af - 0XDEADF00L


### PR DESCRIPTION
based on a discussion on Discord, this allows plugins (and color schemes, if so desired) to tell where the number begins and ends, compared to the punctuation that isn't part of the number, but specifies what base the number is in.

(There is also a PR for C# that does the same: https://github.com/sublimehq/Packages/pull/1047)