### PR TITLE
[CSS] reorder some property matches to fix bugs

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -708,16 +708,16 @@ contexts:
               | font-variant|font-size-adjust|font-size|font-language-override
               | font-display|font-synthesis|font|line-box-contain|text-justify
               | text-decoration-color|text-decoration-style|text-decoration-line
-              | text-decoration|text-underline-position|grid-template|rotate
-              | scale|translate|grid-template-columns|grid-template-rows
-              | scroll-behavior|grid-column-start|grid-column-end|grid-column-gap
-              | grid-row-start|grid-row-end|grid-auto-rows|grid-template-areas
+              | text-decoration|text-underline-position|grid-template-rows
+              | grid-template-columns|grid-template-areas|grid-template|rotate|scale
+              | translate|scroll-behavior|grid-column-start|grid-column-end
+              | grid-column-gap|grid-row-start|grid-row-end|grid-auto-rows
               | grid-area|grid-auto-flow|grid-auto-columns|image-orientation
               | hyphens|overflow-scrolling|overflow|color-profile|kerning
-              | nbsp-mode|color|image-resolution|grid-row|grid-column|blend-mode
-              | azimuth|pause-after|pause-before|pause|pitch-range|pitch|text-height
-              | system|negative|prefix|suffix|range|pad|fallback|additive-symbols
-              | symbols|speak-as|speak|grid-gap|grid-row-gap
+              | nbsp-mode|color|image-resolution|grid-row-gap|grid-row|grid-column
+              | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
+              | text-height|system|negative|prefix|suffix|range|pad|fallback
+              | additive-symbols|symbols|speak-as|speak|grid-gap
             )\b
           scope: support.type.property-name.css
     - match: (:)([ \t]*)

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -892,6 +892,27 @@
 /*                                                                                       ^^^^^^^^^^ -entity.name.tag.custom.css */
 /*                                                                                                  ^^^^^ -entity.name.tag.custom.css */
 
+.test-property-name-order-doesnt-prevent-full-matches {
+    grid-template-rows: none;
+/*  ^^^^^^^^^^^^^^^^^^ support.type.property-name */
+/*                    ^ punctuation.separator.key-value */
+    grid-template-columns: none;
+/*  ^^^^^^^^^^^^^^^^^^^^^ support.type.property-name */
+/*                       ^ punctuation.separator.key-value */
+    grid-template-areas: auto;
+/*  ^^^^^^^^^^^^^^^^^^^ support.type.property-name */
+/*                     ^ punctuation.separator.key-value */
+    grid-template: initial;
+/*  ^^^^^^^^^^^^^ support.type.property-name */
+/*               ^ punctuation.separator.key-value */
+    grid-row-gap: 3vmin;
+/*  ^^^^^^^^^^^^ support.type.property-name */
+/*              ^ punctuation.separator.key-value */
+    grid-row: auto;
+/*  ^^^^^^^^ support.type.property-name */
+/*          ^ punctuation.separator.key-value */
+}
+
 .test-meta-scopes-for-completions {
     top: 5px;
 /*^^^^^^^^^^^ meta.property-list */


### PR DESCRIPTION
fixes https://github.com/sublimehq/Packages/issues/992 - some property names are shorter versions of other valid property names, and were being matched first - thus preventing the longer names from matching. These have now been reordered to fix this.