### PR TITLE
Add build-system for ActionScript

### DIFF
--- a/ActionScript/ActionScript.sublime-build
+++ b/ActionScript/ActionScript.sublime-build
@@ -1,0 +1,12 @@
+{
+	"selector": "source.actionscript",
+	"cmd": [
+		"mxmlc", 
+		"${file}",
+		"-library-path+=${project_path}/libs",
+		"-output", "${project_path}/bin/${project_base_name}.swf",
+		"-debug=false",
+		"-static-link-runtime-shared-libraries=true"
+	],
+	"file_regex": "^(.+?)\\(([0-9]+)\\): col: (([0-9]+))(.*)$"
+}


### PR DESCRIPTION
While ActionScript might no longer have much of an significance in 2017, I thought it should at least come with a build-system.