### PR TITLE
[C#] individually scoped chars are not included in autocompletion

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1930,5 +1930,5 @@ contexts:
     - match: '^\s*(?!///)'
       pop: true
     - include: comments_in
-    - match: .
+    - match: '[\w\s]+|.'
       scope: text.documentation.cs

--- a/C#/tests/syntax_test_Comments.cs
+++ b/C#/tests/syntax_test_Comments.cs
@@ -7,25 +7,34 @@ using System;
 namespace HelloWorld
 {
     /// <summary>
-//*  ^ punctuation.definition.comment.documentation.cs
-//*    ^ comment.block.documentation
+//* ^^^ punctuation.definition.comment.documentation.cs
+//* ^^^^^^^^^^^^^^ comment.block.documentation
 //*     ^ punctuation.definition.tag.begin
-//*      ^ entity.name.tag.begin
+//*      ^^^^^^^ entity.name.tag.begin
 //*             ^ punctuation.definition.tag.end
+//*    ^ text.documentation
+//*     ^^^^^^^^^ - text.documentation
+//*              ^ text.documentation
     /// This class is testing comments
-//*  ^ comment.block.documentation
+//* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
+//*    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.documentation
     /// </summary>
-//*       ^ entity.name.tag.end
+//*     ^^ punctuation.definition.tag.begin
+//*       ^^^^^^^ entity.name.tag.end
+//*              ^ punctuation.definition.tag.end
     /// <see href="http://foo.com">Reference</see>
+//*     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - text.documentation
 //*     ^ punctuation.definition.tag.begin
-//*       ^ entity.name.tag
-//*           ^ entity.other.attribute-name
+//*      ^^^ entity.name.tag
+//*          ^^^^ entity.other.attribute-name
 //*              ^ punctuation.separator.argument.value
 //*                               ^ punctuation.definition.tag.end
+//*                                ^^^^^^^^^ text.documentation
     class Hello
     {
         /// <summary>
         /// Computes matrix-matrix product of a sparse matrix stored in the CSC format.
+//*         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.documentation
         /// </summary>
         void dcscmm(Transpose TransA, int m, int n, int k,
             double alpha,


### PR DESCRIPTION
...so scope the whole word at a time instead to workaround it

originally reported/discovered at https://forum.sublimetext.com/t/gwenzek-all-autocomplete-broken-in-st3-dev-for-c-mode/29925