### PR TITLE
[YAML] Use non-ambiguous syntax for xdigit class

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -51,11 +51,11 @@ variables:
   c_indicator: '[-?:,\[\]{}#&*!|>''"%@`]'
   c_flow_indicator: '[\[\]{},]'
   ns_word_char: '[0-9A-Za-z\-]'
-  ns_uri_char: '(?x: %\p{XDigit}{2} | [0-9A-Za-z\-#;/?:@&=+$,_.!~*''()\[\]] )'
+  ns_uri_char: '(?x: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&=+$,_.!~*''()\[\]] )'
 
   # Tag stuff
   c_tag_handle: (?:!(?:{{ns_word_char}}*!)?)
-  ns_tag_char: '(?x: %\p{XDigit}{2} | [0-9A-Za-z\-#;/?:@&=+$_.~*''()] )' # ns-uri-char - "!" - c-flow-indicator
+  ns_tag_char: '(?x: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&=+$_.~*''()] )' # ns-uri-char - "!" - c-flow-indicator
   ns_tag_prefix: |- # "!" ns-uri-char*  | ns-tag-char ns-uri-char*
     (?x:
         !              {{ns_uri_char}}*


### PR DESCRIPTION
While `\p{XDigit}` works, alternate regex engines might interpret it
according to [UTS #18](http://www.unicode.org/reports/tr18/#Compatibility_Properties), which contains more than just the ASCII
characters, or not even implement it at all.

The YAML spec only contains the ASCII characters, see here:

http://yaml.org/spec/1.2/spec.html#id2775468