### PR TITLE
[Ruby] inline comments in multiline parameter list

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -745,12 +745,12 @@ contexts:
 
   method-parameters:
     - meta_content_scope: meta.function.parameters.ruby
-    - include: comments
     - match: '\)'
       scope: meta.function.parameters.ruby punctuation.definition.group.end.ruby
       pop: true
     - match: '{{identifier}}'
       scope: variable.parameter.ruby
+    - include: comments
     - match: ','
       scope: punctuation.separator.ruby
     - match: '\*'

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -748,6 +748,12 @@ contexts:
     - match: '\)'
       scope: meta.function.parameters.ruby punctuation.definition.group.end.ruby
       pop: true
+    - match: '(?=#)'
+      scope: comment.line.number-sign.ruby
+      push: comments
+      with_prototype:
+        - match: '(?=$)'
+          pop: true
     - match: '{{identifier}}'
       scope: variable.parameter.ruby
     - match: ','

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -745,15 +745,10 @@ contexts:
 
   method-parameters:
     - meta_content_scope: meta.function.parameters.ruby
+    - include: comments
     - match: '\)'
       scope: meta.function.parameters.ruby punctuation.definition.group.end.ruby
       pop: true
-    - match: '(?=#)'
-      scope: comment.line.number-sign.ruby
-      push: comments
-      with_prototype:
-        - match: '(?=$)'
-          pop: true
     - match: '{{identifier}}'
       scope: variable.parameter.ruby
     - match: ','

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -249,6 +249,15 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 #                           ^ punctuation.separator
 #                             ^^^^ constant.language
   end
+
+  def multiline_args(a,
+# ^^^^^^^^^^^^^^^^^^^^^ meta.function
+#                    ^^ meta.function.parameters
+#                     ^ punctuation.separator
+                     b)
+# ^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
+#                     ^ punctuation.definition.group.end
+  end
 end
 
 def MyModule::module_method

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -250,10 +250,11 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 #                             ^^^^ constant.language
   end
 
-  def multiline_args(a,
+  def multiline_args(a, # a comment
 # ^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                    ^^ meta.function.parameters
 #                     ^ punctuation.separator
+#                       ^^^^^^^^^^^ comment.line.number-sign
                      b)
 # ^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #                     ^ punctuation.definition.group.end


### PR DESCRIPTION
Occasionally, there are method definitions like these:

```ruby
def bar(arg1,         # some comment
        arg2,         # some other comment
        opt1: 'foo',  # some other comment
        opt2: 'bar')
```

This PR prevents sublime from confusing inline comments with method arguments/values.