### PR TITLE
[Regular Expressions] add GNU word bounaries \< and \>

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -291,7 +291,7 @@ contexts:
       scope: constant.character.escape.regexp
 
   backslashes:
-    - match: '\\[bBAZzG]|[\^$]'
+    - match: '\\[bBAZzG><]|[\^$]'
       scope: keyword.control.anchors.regexp
       push: unexpected-quantifier-pop
     - match: '\\[QEK]'

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -5,10 +5,12 @@
 ## Anchors and escapes
 ###################
 
-^foo \bbar$
+^foo \bbar$ \<test\>
 # <- keyword.control.anchors
 #    ^^ keyword.control.anchors
 #         ^ keyword.control.anchors
+#           ^^ keyword.control.anchors
+#                 ^^ keyword.control.anchors
 
 \^foo \\bbar\$
  # <- constant.character.escape


### PR DESCRIPTION
add GNU word bounaries `\<` and `\>` as these are used by Boost, which ST uses in the Find panel, which is highlighted using this syntax.

see also http://www.regular-expressions.info/wordboundaries.html#gnu