### PR TITLE
[batch] Fixes comments last line character is not scoped

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -273,6 +273,7 @@ contexts:
         1: keyword.operator.conditional.dosbatch
       push:
         - match: '\n'
+          scope: comment.line.rem.dosbatch
           pop: true
         - match: '({{colon_comment_start}})'
           scope: punctuation.definition.comment.dosbatch
@@ -287,6 +288,7 @@ contexts:
       push:
         - meta_content_scope: comment.line.rem.dosbatch
         - match: \n
+          scope: comment.line.rem.dosbatch
           pop: true
         - match: '[(|)]'
           scope: invalid.illegal.unexpected-character.dosbatch

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -286,9 +286,8 @@ contexts:
     - match: \b(?i)rem\b
       scope: keyword.command.rem.dosbatch
       push:
-        - meta_content_scope: comment.line.rem.dosbatch
+        - meta_scope: comment.line.rem.dosbatch
         - match: \n
-          scope: comment.line.rem.dosbatch
           pop: true
         - match: '[(|)]'
           scope: invalid.illegal.unexpected-character.dosbatch

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -286,8 +286,11 @@ contexts:
     - match: \b(?i)rem\b
       scope: keyword.command.rem.dosbatch
       push:
-        - meta_scope: comment.line.rem.dosbatch
+        # REM is a command for creating comments
+        # https://github.com/sublimehq/Packages/pull/1091
+        - meta_content_scope: comment.line.rem.dosbatch
         - match: \n
+          scope: comment.line.rem.dosbatch
           pop: true
         - match: '[(|)]'
           scope: invalid.illegal.unexpected-character.dosbatch

--- a/Batch File/syntax_test_batch_file.bat
+++ b/Batch File/syntax_test_batch_file.bat
@@ -11,6 +11,10 @@ REM
    not a comment
 :: ^^^^^^^^^^^^^ - comment.line.rem.dosbatch
 
+REM This follows a REM command
+:: <- keyword.command - comment
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line
+
    :: Me too!
 :: ^^         punctuation.definition.comment.dosbatch
 :: ^^^^^^^^^^ comment.line.colon.dosbatch


### PR DESCRIPTION
Issue:

1. https://github.com/sublimehq/Packages/issues/1090