### PR TITLE
[C++] [Objective-C] Auto-pair "<" and ">" inside meta.preprocessor.include

### DIFF
--- a/C++/Default.sublime-keymap
+++ b/C++/Default.sublime-keymap
@@ -1,0 +1,41 @@
+[
+    // Auto-pair less-than and greater-than symbols in include statements
+    { "keys": ["<"], "command": "insert_snippet", "args": {"contents": "<$0>"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.c | source.c++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": ["<"], "command": "insert_snippet", "args": {"contents": "<${0:$SELECTION}>"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.c | source.c++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": [">"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^>", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.c | source.c++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "<$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^>", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.c | source.c++) & meta.preprocessor.include" }
+        ]
+    },
+]

--- a/Objective-C/Default.sublime-keymap
+++ b/Objective-C/Default.sublime-keymap
@@ -1,0 +1,41 @@
+[
+    // Auto-pair less-than and greater-than symbols in include statements
+    { "keys": ["<"], "command": "insert_snippet", "args": {"contents": "<$0>"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.objc | source.objc++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": ["<"], "command": "insert_snippet", "args": {"contents": "<${0:$SELECTION}>"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.objc | source.objc++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": [">"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^>", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.objc | source.objc++) & meta.preprocessor.include" }
+        ]
+    },
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "<$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^>", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.other - punctuation.definition.string.end", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "(source.objc | source.objc++) & meta.preprocessor.include" }
+        ]
+    },
+]


### PR DESCRIPTION
This has annoyed me for several years, but I never got around to fixing it. I also assumed someone else would do this :-). Anyway, this does what it says on the tin: auto-pairing of "<>" inside meta.preprocessor.include scopes.

For instance, if you type this now:
```c
#include <|
```
(the `|` represents the cursor), Then it'll insert the `>` automatically now:
```c
#include <|>
```
When you then type `>`, the cursor will just move over the existing `>`:
```c
#include <>|
```
This functionality is already present in the default keybindings and well-known by everyone for e.g. double-quotes. I just copied that and adjusted it accordingly.