### PR TITLE
[ShellScript] Fix if/then indentation

### DIFF
--- a/ShellScript/Indentation.tmPreferences
+++ b/ShellScript/Indentation.tmPreferences
@@ -11,11 +11,16 @@
 		<string>^\s*(\}|(elif|else|fi|esac|done)\b)</string>
 		<key>increaseIndentPattern</key>
 		<string>(?x)
-			^\s*(if|elif|else|case)\b
+			^\s*(elif|else|case)\b
 		|	^.*(\{|\b(do)\b)\s*$
+		|	^.*\bthen\b\s*$
 		</string>
 		<key>indentNextLinePattern</key>
 		<string>^.*[^\\]\\$</string>
+		<key>disableIndentNextLinePattern</key>
+		<string>^\s*then\s*$</string>
+		<key>bracketIndentNextLinePattern</key>
+		<string>^\s*if\b.*(?!\bthen\b)$</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This makes `then` keyword to have the same indentation level as the corresponding `if` and also makes the code following `then` be indented one level deeper.

See this topic: https://forum.sublimetext.com/t/incorrect-auto-indentation-for-bash-if-then/
