### PR TITLE
[Go] Improve func snippet

### DIFF
--- a/Go/Snippets/func.sublime-snippet
+++ b/Go/Snippets/func.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[func ${1:func_name}($2)$3 {
-	$0
+	<content><![CDATA[func ${1:name}($2) $3{
+	$4
 }]]></content>
 	<tabTrigger>func</tabTrigger>
 	<scope>source.go</scope>


### PR DESCRIPTION
* replace `func_name` placeholder text with `name`
  * should not be snake_case. [Go uses camelCase](https://golang.org/doc/effective_go.html#mixed-caps))
* additional tab press can jump over the closing curly