### PR TITLE
[Go] Remove snake_case from placeholder text in Go func snippets

### DIFF
--- a/Go/Snippets/Type Function.sublime-snippet
+++ b/Go/Snippets/Type Function.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[func (${1:varname typename}) ${2:func_name}($3)$4 {
+	<content><![CDATA[func (${1:varname typename}) ${2:name}($3)$4 {
 	$0
 }]]></content>
 	<tabTrigger>tfunc</tabTrigger>

--- a/Go/Snippets/func.sublime-snippet
+++ b/Go/Snippets/func.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[func ${1:func_name}($2)$3 {
+	<content><![CDATA[func ${1:name}($2)$3 {
 	$0
 }]]></content>
 	<tabTrigger>func</tabTrigger>


### PR DESCRIPTION
[Go uses camelCase, not snake_case](https://golang.org/doc/effective_go.html#mixed-caps). In the `func` and `tfunc` snippets, the placeholder text for the function name was `func_name`. I replaced this with just `name`. The fact that it's a function name is implied.