### PR TITLE
[Rust] Fix handling of `#[attribute = "value"]` attributes

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -233,14 +233,14 @@ contexts:
 
   attributes:
     - match: '(#!?)(\[)'
-      scope: meta.annotation.rust
       captures:
         1: punctuation.definition.annotation.rust
         2: punctuation.section.group.begin.rust
       push:
+        - meta_scope: meta.annotation.rust
         - match: '({{identifier}})(\()'
           captures:
-            1: meta.annotation.rust variable.annotation.rust
+            1: variable.annotation.rust
             2: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.begin.rust
           push:
             - meta_content_scope: meta.annotation.parameters.rust meta.group.rust
@@ -249,12 +249,14 @@ contexts:
               pop: true
             - include: attribute-call
         - match: '({{identifier}})'
-          scope: meta.annotation.rust variable.annotation.rust
+          scope: variable.annotation.rust
+        - match: '='
+          scope: keyword.operator.rust
         - match: '\]'
-          scope: meta.annotation.rust punctuation.section.group.end.rust
+          scope: punctuation.section.group.end.rust
           pop: true
         - match: '[ \t]+'
-          scope: meta.annotation.rust
+        - include: strings
 
   attribute-call:
     - match: \)

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -1016,3 +1016,12 @@ fn abc() {
 impl ApplicationPreferenceseeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee {
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.impl.rust
 }
+
+#[test = "foo ] bar"]
+// <- meta.annotation punctuation.definition.annotation
+//^^^^^^^^^^^^^^^^^^^ meta.annotation
+//^^^^ variable.annotation
+//     ^ keyword.operator
+//       ^^^^^^^^^^^ string.quoted.double
+pub trait Foo {
+}


### PR DESCRIPTION
The string was not recognized before, so with something like:

    #[test = "foo ] bar"]

The first `]` would close the annotation, and the code/lines following
the second " would be recognized as a string.

Screenshot of the problem from Sublime Text 3:

<img width="170" alt="screen shot 2017-08-23 at 16 42 14" src="https://user-images.githubusercontent.com/16778/29602114-1459483e-8822-11e7-8321-131042ea47d6.png">

Here's the documentation about attributes in Rust: https://doc.rust-lang.org/reference/attributes.html

CC @keith-hall and @trishume 