### PR TITLE
Revert broken change in StartDocBlock snippet.

### DIFF
--- a/PHP/Snippets/Start-Docblock.sublime-snippet
+++ b/PHP/Snippets/Start-Docblock.sublime-snippet
@@ -3,6 +3,6 @@
  * $0
  */]]></content>
 	<tabTrigger>/**</tabTrigger>
-	<scope>source.php</scope>
+	<scope>source.php comment</scope>
 	<description>Start Docblock</description>
 </snippet>

--- a/PHP/Snippets/Start-Docblock.sublime-snippet
+++ b/PHP/Snippets/Start-Docblock.sublime-snippet
@@ -3,6 +3,5 @@
  * $0
  */]]></content>
 	<tabTrigger>/**</tabTrigger>
-	<scope>source.php - string - comment</scope>
 	<description>Start Docblock</description>
 </snippet>

--- a/PHP/Snippets/Start-Docblock.sublime-snippet
+++ b/PHP/Snippets/Start-Docblock.sublime-snippet
@@ -3,5 +3,6 @@
  * $0
  */]]></content>
 	<tabTrigger>/**</tabTrigger>
+	<scope>source.php</scope>
 	<description>Start Docblock</description>
 </snippet>


### PR DESCRIPTION
Recently, a change was made to not trigger snippets in comments; however, this breaks the StartDocBlock snippet because it by-definition exists within a comment. Reverted that change on this snippet.