### PR TITLE
[ShellScript] Add scopes to #!/usr/bin/env snippet

### DIFF
--- a/ShellScript/Snippets/#!-usr-bin-env-(!env).sublime-snippet
+++ b/ShellScript/Snippets/#!-usr-bin-env-(!env).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[#!/usr/bin/env ${1:${TM_SCOPE/(?:source|.*)\.(?:(shell)|(\w+)).*/(?1:bash:$2)/}}
 ]]></content>
 	<tabTrigger>!env</tabTrigger>
-	<scope></scope>
+	<scope>source.actionscript.2, source.applescript, source.clojure, source.cs, source.d, source.dart, source.fsharp, source.groovy, source.haskell, source.java, source.js, source.julia, source.lisp, source.lua, source.makefile, source.ocaml, source.perl, source.php, source.python, source.r, source.ruby, source.rust, source.scala, source.shell, source.swift, source.tcl, source.ts</scope>
 	<description>#!/usr/bin/env</description>
 </snippet>


### PR DESCRIPTION
Fix #1118. The `#!/usr/bin/env` snippet didn't have a scope, so it would always be offered, even if the current syntax wasn't `Shell Script (Bash)`.