### PR TITLE
Add .clisp file extension for 'lisp' syntax

### DIFF
--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -9,6 +9,7 @@ name: Lisp
 file_extensions:
   - lisp
   - cl
+  - clisp
   - l
   - mud
   - el


### PR DESCRIPTION
`.clisp` is a common file extension for common-lisp files.