### PR TITLE
[Ruby] unindent on closing curly brace or square bracket at bol

### DIFF
--- a/Ruby/Miscellaneous.tmPreferences
+++ b/Ruby/Miscellaneous.tmPreferences
@@ -8,7 +8,7 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*([}\]]\s*$|(end|rescue|ensure|else|elsif|when)\b)</string>
+		<string>^\s*([}\]]|(end|rescue|ensure|else|elsif|when)\b)</string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)^
 		(\s*


### PR DESCRIPTION
fixes #1123

the biggest problem with indentation and unindentation rules are that they need to mirror/complement each other, otherwise you end up in exactly this situation where for e.g. `{` indents the line, but the corresponding `}` doesn't unindent it, or more rarely that a line gets unindented when nothing triggered an indentation previously. (Tweaks were also made to HTML to this effect a while ago: https://github.com/sublimehq/Packages/issues/915)

So for Ruby, a `{` or `[` anywhere on the line not followed by the respective closing token would cause indentation to be increased, but it would only then be decreased again for `}` or `]` if it was the only non-whitespace token on the line - this PR changes that to decrease the indentation when it is the first non-whitespace token on the line, regardless of what comes afterwards, so that the rules align with each other better.