### PR TITLE
[Markdown] following headers appear incorrect in goto

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -412,7 +412,7 @@ contexts:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
   atx-heading-terminator:
-    - match: '[ ]*(#*)[ ]*(?=$)($\n?)' # \n is optional so ## is matched as end punctuation in new document (at eof)
+    - match: '[ ]*(#*)[ ]*($\n?)' # \n is optional so ## is matched as end punctuation in new document (at eof)
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -418,9 +418,10 @@ contexts:
       push:
         - meta_scope: markup.heading.1.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$\n?
+        - match: \s*(#*)$(\n)
           captures:
             1: punctuation.definition.heading.end.markdown
+            2: meta.whitespace.newline.markdown
           pop: true
         - include: inline-bold-italic
     - match: '(##)(?!#)\s*(?=\S)'
@@ -429,9 +430,10 @@ contexts:
       push:
         - meta_scope: markup.heading.2.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$\n?
+        - match: \s*(#*)$(\n)
           captures:
             1: punctuation.definition.heading.end.markdown
+            2: meta.whitespace.newline.markdown
           pop: true
         - include: inline-bold-italic
     - match: '(#{3,6})(?!#)\s*(?=\S)'
@@ -440,9 +442,10 @@ contexts:
       push:
         - meta_scope: markup.heading.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$\n?
+        - match: \s*(#*)$(\n)
           captures:
             1: punctuation.definition.heading.end.markdown
+            2: meta.whitespace.newline.markdown
           pop: true
         - include: inline-bold-italic
   image-inline:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -411,6 +411,12 @@ contexts:
   escape:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
+  atx-heading-terminator:
+    - match: '[ ]*(#*)[ ]*(?=$)($\n?)'
+      captures:
+        1: punctuation.definition.heading.end.markdown
+        2: meta.whitespace.newline.markdown
+      pop: true
   atx-heading:
     - match: '(#)(?!#)\s*(?=\S)'
       captures:
@@ -418,11 +424,7 @@ contexts:
       push:
         - meta_scope: markup.heading.1.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$(\n)
-          captures:
-            1: punctuation.definition.heading.end.markdown
-            2: meta.whitespace.newline.markdown
-          pop: true
+        - include: atx-heading-terminator
         - include: inline-bold-italic
     - match: '(##)(?!#)\s*(?=\S)'
       captures:
@@ -430,11 +432,7 @@ contexts:
       push:
         - meta_scope: markup.heading.2.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$(\n)
-          captures:
-            1: punctuation.definition.heading.end.markdown
-            2: meta.whitespace.newline.markdown
-          pop: true
+        - include: atx-heading-terminator
         - include: inline-bold-italic
     - match: '(#{3,6})(?!#)\s*(?=\S)'
       captures:
@@ -442,11 +440,7 @@ contexts:
       push:
         - meta_scope: markup.heading.markdown
         - meta_content_scope: entity.name.section.markdown
-        - match: \s*(#*)$(\n)
-          captures:
-            1: punctuation.definition.heading.end.markdown
-            2: meta.whitespace.newline.markdown
-          pop: true
+        - include: atx-heading-terminator
         - include: inline-bold-italic
   image-inline:
     - match: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -412,7 +412,7 @@ contexts:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
   atx-heading-terminator:
-    - match: '[ ]*(#*)[ ]*(?=$)($\n?)'
+    - match: '[ ]*(#*)[ ]*(?=$)($\n?)' # \n is optional so ## is matched as end punctuation in new document (at eof)
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown

--- a/Markdown/Symbol List - Heading.tmPreferences
+++ b/Markdown/Symbol List - Heading.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List: Heading</string>
 	<key>scope</key>
-	<string>text.html.markdown markup.heading</string>
+	<string>text.html.markdown markup.heading - (meta.whitespace.newline.markdown)</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Markdown/Symbol List - Heading.tmPreferences
+++ b/Markdown/Symbol List - Heading.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List: Heading</string>
 	<key>scope</key>
-	<string>text.html.markdown markup.heading - (meta.whitespace.newline.markdown)</string>
+	<string>text.html.markdown markup.heading - meta.whitespace.newline.markdown</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -5,13 +5,30 @@
 |^^^^^^^^ markup.heading
 |        ^ meta.whitespace.newline.markdown
 
-## Second Heading
+## Second Heading #
 | <- markup.heading.2 punctuation.definition.heading
 |^^^^^^^^^^^^^^^^ markup.heading
+|  ^^^^^^^^^^^^^^ entity.name.section
+|                ^ - entity.name.section
+|                 ^ punctuation.definition.heading.end.markdown
 
 Alternate Heading
 =================
 |^^^^^^^^^^^^^^^^ markup.heading.1 punctuation.definition
+
+heading underlined with dashes
+------------------------------
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2 punctuation.definition.heading
+
+underlined heading followed by a separator
+-------------------
+------
+| <- meta.block-level meta.separator - markup.heading
+
+underlined heading followed by another one that should be treated as a normal paragraph
+==================
+=====
+| <- - markup.heading
 
 Paragraph of text that should be scoped as meta.paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
@@ -315,20 +332,6 @@ this is a raw ampersand & does not require HTML escaping
 |                                                  ^ punctuation.definition.string.begin
 |                                                                          ^ punctuation.definition.string.end
 
-heading underlined with dashes
-------------------------------
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2 punctuation.definition.heading
-
-underlined heading followed by a separator
--------------------
-------
-| <- meta.block-level meta.separator - markup.heading
-
-underlined heading followed by another one that should be treated as a normal paragraph
-==================
-=====
-| <- - markup.heading
-
 Paragraph followed immediately by a list, no blank line in between
 - list item 1
 | <- markup.list.unnumbered punctuation.definition.list_item
@@ -443,12 +446,6 @@ because it doesn't begin with the number one:
 
   <!-- HTML comment -->
 | ^^^^^^^^^^^^^^^^^^^^^ comment.block.html
-
-## Heading with ending hashes ##
-| <- punctuation.definition.heading
-|  ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.section
-|                            ^ - entity.name.section
-|                             ^^ punctuation.definition.heading
 
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -3,6 +3,7 @@
 # Heading
 | <- markup.heading.1 punctuation.definition.heading
 |^^^^^^^^ markup.heading
+|        ^ meta.whitespace.newline.markdown
 
 ## Second Heading
 | <- markup.heading.2 punctuation.definition.heading

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -11,6 +11,12 @@
 |  ^^^^^^^^^^^^^^ entity.name.section
 |                ^ - entity.name.section
 |                 ^ punctuation.definition.heading.end.markdown
+## Example 43 (trailing spaces!) #####    
+|                                    ^ punctuation.definition.heading.end.markdown
+|                                         ^ meta.whitespace.newline.markdown
+## Example 44 ####    >
+|^^^^^^^^^^^^^^^^^^^^^^ markup.heading
+|             ^ - punctuation.definition.heading.end.markdown
 
 Alternate Heading
 =================


### PR DESCRIPTION
This follows from a report on the forum. If two headers appear directly after each other, the first will eat the next and it will appear incorrectly in the symbols list:

https://forum.sublimetext.com/t/a-bug-of-markdowns-ctrl-r-panel/30872

![af57522df708ca08ded63dfa55b2ee2f7b584120](https://user-images.githubusercontent.com/2543659/29781608-08149c76-8c1a-11e7-96ad-39eb87b4a9ac.png)


This solves that by capturing the newline character and removing it from the symbol.

Questions:

- Originally the match was for `\n?`but I can't seem to get Sublime to capture the `\n` if I also use the `?`quantifier. Perhaps I'm missing something?
- Is `meta.whitespace.newline.markdown` a good scope? I couldn't find any examples.

Possible future improvements:
- Change it to lookahead for the newline and not capture it. I think it's a bit odd to capture it, but ¯\_(ツ)_/¯ . It would simplify things, but perhaps it breaks something somewhere. (something always breaks).
