### PR TITLE
[C#] Fix character escape sequences and add tests

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -25,8 +25,8 @@ variables:
   floating_point: '([0-9]+(?:\.[0-9]+)?(?:{{exponent}})?)([fFdDmM]?)'
 
   # characters
-  unicode_char: '\\u[0-9a-fA-F]{,4}'
-  escaped_char: '(?:\\[btnfr"''\\]|{{unicode_char}}|\\x[0-9a-fA-F]{,4}||\\[0-9]{,3})'
+  unicode_char: '(?:\\u\h{4}|\\U\h{8})'
+  escaped_char: '(?:\\[abfnrtv"''\\]|{{unicode_char}}|\\x[0-9a-fA-F]{1,4}||\\[0-9]{1,3})'
 
   visibility: \b(?:public|private|protected|internal|protected\s+internal)\b
   base_type: (?:bool|byte|sbyte|char|decimal|double|float|int|uint|long|ulong|short|ushort|object|string|void)

--- a/C#/tests/syntax_test_Strings.cs
+++ b/C#/tests/syntax_test_Strings.cs
@@ -1,0 +1,27 @@
+/// SYNTAX TEST "Packages/C#/C#.sublime-syntax"
+
+"short unicode \u1234";
+///<- string.quoted.double.cs
+///            ^^^^^^ constant.character.escape.cs
+
+"long unicode \U12345678";
+///<- string.quoted.double.cs
+///           ^^^^^^^^^^ constant.character.escape.cs
+
+"invalid escape \u12";
+///<- string.quoted.double.cs
+///             ^ invalid.illegal.lone-escape.cs
+
+"simple escapes \' \" \\ \0 \a \b \f \n \r \t \v";
+///<- string.quoted.double.cs
+///             ^^ constant.character.escape.cs
+///                ^^ constant.character.escape.cs
+///                   ^^ constant.character.escape.cs
+///                      ^^ constant.character.escape.cs
+///                         ^^ constant.character.escape.cs
+///                            ^^ constant.character.escape.cs
+///                               ^^ constant.character.escape.cs
+///                                  ^^ constant.character.escape.cs
+///                                     ^^ constant.character.escape.cs
+///                                        ^^ constant.character.escape.cs
+///                                           ^^ constant.character.escape.cs


### PR DESCRIPTION
* `\u` needs to be followed by 4 hex digits, `\U` by 8
* `\x` needs at least one hex digit
* Add missing escapes `\a` and `\v`

See spec: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#character-literals

(CC @trishume and @keith-hall)