### PR TITLE
[JavaScript] String template snippet adapted from existing implementation for Ruby

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -1,0 +1,14 @@
+[
+	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${1:$SELECTION}}$0"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{
+				"operand": "(string.template.js) - string source",
+				"operator": "equal",
+				"match_all": true,
+				"key": "selector"
+			}
+		]
+	}
+
+]


### PR DESCRIPTION
Changes:
* Adds a snippet for `${}` when entering `$` in a JavaScript template literal context- adapted from the existing Ruby handling.