### PR TITLE
[HTML] fix invalid comment syntax highlighting bug

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -29,9 +29,11 @@ contexts:
       scope: punctuation.definition.comment.html
       push:
         - meta_scope: comment.block.html
-        - match: '--\s*>'
+        - match: '(-*)--\s*>'
+          captures:
+            1: invalid.illegal.bad-comments-or-CDATA.html
           pop: true
-        - match: '-{2,}(?!-?\s*>)'
+        - match: -{2,}
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
         - meta_scope: comment.block.html
         - match: '--\s*>'
           pop: true
-        - match: '--(?!(>|->))'
+        - match: '-{2,}(?!-?\s*>)'
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
         - meta_scope: comment.block.html
         - match: '--\s*>'
           pop: true
-        - match: "--"
+        - match: '--(?!(>|->))'
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -51,6 +51,33 @@
         <!-- Comment -->
         ## ^ comment.block.html
 
+        <!----- hyphens - -- --- -->
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
+        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##  ^^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                       ^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##                          ^ - comment.block.html
+
+        <!---   hyphens - -- --- -- >
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
+        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                       ^^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##                           ^ - comment.block.html
+
+        <!----- hyphens - -- --- ---->
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
+        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##  ^^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                       ^^ invalid.illegal.bad-comments-or-CDATA.html
+        ##                         ^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##                            ^ - comment.block.html
+
         <div title=description></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -78,6 +78,13 @@
         ##                         ^^ - invalid.illegal.bad-comments-or-CDATA.html
         ##                            ^ - comment.block.html
 
+        <!--- hyphens --- >
+        ## ^^^^^^^^^^^^^^^^ comment.block.html
+        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##            ^ invalid.illegal.bad-comments-or-CDATA.html
+        ##             ^^^^ - invalid.illegal.bad-comments-or-CDATA.html
+        ##                 ^ - comment.block.html
+
         <div title=description></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name


### PR DESCRIPTION
For comments with an odd number of hyphens on the closing tag such as `<!-- test ----->`, the hyphens are marked invalid but everything in the entire file after the closing tag becomes highlighted as a comment.

This update fixes that bug, and also improves how invalid comments are marked, to match exactly in accordance with the W3 validator.

Preview of bug and invalid comment marks before this fix:
![image](https://user-images.githubusercontent.com/17580512/30397994-52bbac20-9894-11e7-81b8-9fd14fd0a8b3.png)
