### PR TITLE
[Ruby] match /<regex>/ syntax explictly

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1055,9 +1055,7 @@ contexts:
   try-regex:
     # Generally for multiline regexes, one of the %r forms below will be used,
     # so we bail out if we can't find a second / on the current line
-    - match: '(?=\s*/[^/]*$)'
-      pop: true
-    - match: '\s*(/)(?![*+{}?])'
+    - match: '\s*(/)(?![*+{}?])(?=.*/)'
       captures:
         1: string.regexp.classic.ruby punctuation.definition.string.ruby
       push:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -442,3 +442,13 @@ end
 
 p huh?("H", 1) + huh?("u") + huh?("gs")
 )
+
+
+# issue #923
+foo = 2 / @d
+#         ^^ - string.regexp.classic
+#         ^ variable.other.readwrite.instance punctuation.definition.variable
+
+# issue #933
+a = b / "c"
+#       ^^^ string.quoted.double.ruby - string.regexp.classic.ruby


### PR DESCRIPTION
close #923 
close #933 
close #1006 
close #1136 

The issue was looking ahead pattern cannot be popped immediately, see https://github.com/SublimeTextIssues/Core/issues/1906#issuecomment-329536967