### PR TITLE
[C#] fix for delegates with spaces between the name and paren bug

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -329,10 +329,11 @@ contexts:
   delegate_name:
     - match: '\s+'
       scope: meta.delegate.cs
-    - match: '({{name}})(<)'
+    - match: '({{name}})(\s*)(<)'
       captures:
         1: meta.delegate.cs variable.other.member.delegate.cs
-        2: meta.delegate.cs meta.generic.cs punctuation.definition.generic.begin.cs
+        2: meta.delegate.cs
+        3: meta.delegate.cs meta.generic.cs punctuation.definition.generic.begin.cs
       set:
         - meta_content_scope: meta.delegate.cs meta.generic.cs
         - match: '>'
@@ -344,11 +345,14 @@ contexts:
               scope: meta.delegate.parameters.cs punctuation.section.parameters.begin.cs
               set: delegate_params
         - include: type_parameter
-    - match: '({{name}})(\()'
+    - match: '({{name}})(\s*)(\()'
       captures:
         1: meta.delegate.cs variable.other.member.delegate.cs
-        2: meta.delegate.parameters.cs punctuation.section.parameters.begin.cs
+        2: meta.delegate.cs
+        3: meta.delegate.parameters.cs punctuation.section.parameters.begin.cs
       set: delegate_params
+    - match: '(?=\S)'
+      pop: true
 
   delegate_params:
     - meta_content_scope: meta.delegate.parameters.cs

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -148,6 +148,18 @@ namespace YourNamespace
 ///                                  ^ variable.parameter
 ///                                    ^ punctuation.terminator
 
+    public delegate FooBar YourDelegate (int a);
+///        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.delegate
+///        ^^^^^^^^ storage.type.delegate
+///                 ^^^^^^ support.type
+///                        ^^^^^^^^^^^^ variable.other.member.delegate
+///                                     ^^^^^^^ meta.delegate.parameters
+///                                     ^ punctuation.section.parameters.begin
+///                                      ^^^ storage.type
+///                                          ^ variable.parameter
+///                                           ^ punctuation.section.parameters.end
+///                                            ^ punctuation.terminator
+
     enum YourEnum
 /// ^^^^^^^^^^^^^ meta.enum
 /// ^ storage.type.enum


### PR DESCRIPTION
fixes #1144