### PR TITLE
Support #1152

### DIFF
--- a/Ruby/Miscellaneous.tmPreferences
+++ b/Ruby/Miscellaneous.tmPreferences
@@ -13,7 +13,7 @@
 		<string><![CDATA[(?x)^
 		(\s*
 			(
-				module|class|(private(_class_method)?\s*)?def
+				module|class|((private|public|protected)(_class_method)?\s*)?def
 				|unless|if|else|elsif
 				|case|when
 				|begin|rescue|ensure

--- a/Ruby/Miscellaneous.tmPreferences
+++ b/Ruby/Miscellaneous.tmPreferences
@@ -13,7 +13,7 @@
 		<string><![CDATA[(?x)^
 		(\s*
 			(
-				module|class|def
+				module|class|(private(_class_method)?\s*)?def
 				|unless|if|else|elsif
 				|case|when
 				|begin|rescue|ensure


### PR DESCRIPTION
Expand method matching to match visibility modifiers before `def` statements to resolve #1152

This matches all 6 combinations of `private/public/protected` `_class_method`(/instance method).

Technically `protected_class_method` isn't a valid keyword, so I can modify this to not support that indentation if you prefer.