### PR TITLE
[HTML] fix reindentation of style tag

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -80,8 +80,9 @@ contexts:
             2: entity.name.tag.style.html
             3: punctuation.definition.tag.end.html
           pop: true
-        - match: '>'
-          scope: meta.tag.style.begin.html punctuation.definition.tag.end.html
+        - match: '(>)\s*'
+          captures:
+            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
           push:
             - meta_content_scope: source.css.embedded.html
             - include: 'scope:source.css'

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -27,11 +27,12 @@
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html
-        ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
+        ## ^^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
         ##                     ^ - meta.tag
             h2 {
             ## <- entity.name.tag.css
+## <- source.css.embedded.html
                 font-family: "Arial";
                 ##             ^ string.quoted.double.css
             }


### PR DESCRIPTION
Prior to this PR, the following HTML gets reindented incorrectly:

- new tab
- set syntax to HTML
- `html` <kbd>Tab</kbd>
- type `<sty` <kbd>Tab</kbd><kbd>Enter</kbd>
- looks fine, but reindent it =

```html
<!DOCTYPE html>
<html>
<head>
    <title></title>
    <style type="text/css">
    
</style>
</head>
<body>

</body>
</html>
```

this PR fixes that by capturing the whitespace (specifically the newline) after the `<style>` tag, so that it doesn't get a CSS (`source.css`) scope, which was causing the CSS indentation rules take over, and thus not indenting after `<style>\n`. Which was a problem, because it unindents after `</style>` (due to the newline after that having the html scope), and thus the indentation was getting out of kilter.