### PR TITLE
[CSS] support 0 lengths i.e. for translateZ function and var function in other transform functions

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1966,6 +1966,8 @@ contexts:
       scope: constant.numeric.css
       captures:
         1: keyword.other.unit.css
+    - match: '0\b(?!%)'
+      scope: constant.numeric.css
 
   time-type:
     - match: '{{number}}({{duration_units}})\b'

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1032,6 +1032,7 @@ contexts:
             pop: true
           - include: comma-delimiter
           - include: number-type
+          - include: var-function
 
       # transform functions with comma separated <number> or <length> types
       # translate(), translate3d()
@@ -1050,6 +1051,7 @@ contexts:
           - include: percentage-type
           - include: length-type
           - include: number-type
+          - include: var-function
 
       # transform functions with a single <number> or <length> type
       # translateX(), translateY()

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -631,7 +631,12 @@
 /*                  ^^^ constant.numeric.css           */
 
     top: translateX(1%);
+/*       ^^^^^^^^^^ support.function.transform */
 /*                  ^^ constant.numeric.css */
+
+    top: translateZ(0);
+/*       ^^^^^^^^^^ support.function.transform */
+/*                  ^ constant.numeric.css */
 
     top: skewY(1deg);
 /*       ^^^^^      support.function.transform.css */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -659,6 +659,13 @@
     top: skewY(1rad) rotate(1turn);
 /*                   ^^^^^^       support.function.transform.css */
 /*                          ^^^^^ constant.numeric.css           */
+
+    transform: translate(var(--center), 0) scale(var(--ripple-scale), 1);
+/*             ^^^^^^^^^ support.function.transform */
+/*                       ^^^ support.function.var */
+/*                           ^^^^^^^^ support.type.custom-property */
+/*                                      ^ constant.numeric */
+/*                                               ^^^ support.function.var */
 }
 
 .test-timing-functions {


### PR DESCRIPTION
fix #1066 and https://github.com/sublimehq/Packages/issues/1100