### PR TITLE
Git merge conflicts syntax mixin for other syntaxes

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -72,6 +72,9 @@ variables:
     )
 
 contexts:
+  prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
+
   main:
     - include: comment-block
     - include: selector

--- a/CSS/syntax_test_css_git_conflicts.css
+++ b/CSS/syntax_test_css_git_conflicts.css
@@ -1,0 +1,10 @@
+/* SYNTAX TEST "Packages/CSS/CSS.sublime-syntax" */
+
+<<<<<<< HEAD
+.conflicted_style1 {
+  color: #123;
+=======
+.conflicted_style2 {
+  color: #456;
+>>>>>>> master
+}

--- a/Git Conflicts/git-conflicts.sublime-syntax
+++ b/Git Conflicts/git-conflicts.sublime-syntax
@@ -1,0 +1,17 @@
+%YAML 1.2
+---
+name: Git conflicts
+scope: source.git
+
+contexts:
+  main:
+    - match: '^<<<<<<<.*\n'
+      scope: invalid.illegal
+      push: git-conflict-head
+    - match: '^>>>>>>>.*\n'
+      scope: invalid.illegal
+
+  git-conflict-head:
+    - match: '^=======.*\n'
+      scope: invalid.illegal
+      pop: true

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -12,6 +12,9 @@ file_extensions:
 first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 contexts:
+  prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
+
   main:
     - match: (<\?)(xml)
       captures:

--- a/HTML/syntax_test_html_git_conflicts.html
+++ b/HTML/syntax_test_html_git_conflicts.html
@@ -1,0 +1,7 @@
+## SYNTAX TEST "Packages/HTML/HTML.sublime-syntax"
+
+<<<<<<< HEAD
+<div>conflicted value1</div>
+=======
+<div>conflicted value1</div>
+>>>>>>> master

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -15,6 +15,9 @@ file_extensions:
   - sublime-macro
 scope: source.json
 contexts:
+  prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
+
   main:
     - include: value
   array:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -23,6 +23,7 @@ contexts:
     - include: statements
 
   prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
     - include: comments
 
   keywords-top-level:

--- a/JavaScript/syntax_test_js_git_conflicts.js
+++ b/JavaScript/syntax_test_js_git_conflicts.js
@@ -1,0 +1,7 @@
+// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
+
+<<<<<<< HEAD
+var conflicted_value1 = 'value1';
+=======
+var conflicted_value2 = 'value2';
+>>>>>>> master

--- a/JavaScript/syntax_test_json_git_conflicts.json
+++ b/JavaScript/syntax_test_json_git_conflicts.json
@@ -1,0 +1,9 @@
+// SYNTAX TEST "Packages/JavaScript/JSON.sublime-syntax"
+
+{
+<<<<<<< HEAD
+  "conflicted_value1": "value1"
+=======
+  "conflicted_value2": "value2"
+>>>>>>> master
+}

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -82,6 +82,9 @@ variables:
   path_lookahead: '(::)?({{identifier}}(\.|::))*{{identifier}}'
 
 contexts:
+  prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
+
   main:
     - include: expressions
 

--- a/Ruby/syntax_test_ruby_git_conflicts.rb
+++ b/Ruby/syntax_test_ruby_git_conflicts.rb
@@ -1,0 +1,7 @@
+# SYNTAX TEST "Packages/Ruby/Ruby.sublime-syntax"
+
+<<<<<<< HEAD
+conflicted_value1 = 'value1'
+=======
+conflicted_value2 = 'value2'
+>>>>>>> master

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -165,6 +165,7 @@ variables:
 
 contexts:
   prototype:
+    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
     - include: comment
     - include: property
 

--- a/YAML/tests/syntax_test_git_conflicts.yaml
+++ b/YAML/tests/syntax_test_git_conflicts.yaml
@@ -1,0 +1,7 @@
+# SYNTAX TEST "Packages/YAML/YAML.sublime-syntax"
+
+<<<<<<< HEAD
+conflicted_key1: conflicted_value1
+=======
+conflicted_key2: conflicted_value2
+>>>>>>> master


### PR DESCRIPTION
Introduce a mixin for git conflicts which can be included to other syntaxes via:

```yaml
contexts:
  prototype:
    - include: Packages/Git Conflicts/git-conflicts.sublime-syntax
```

This syntax makes git conflicts more noticeable in the code.

In this PR I also fixed CSS, HTML, JavaScript, Ruby, YAML syntaxes to enable highlighting of git conflicts.