### PR TITLE
[JavaScript] Add CSS inspired keybindings

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -1,0 +1,40 @@
+[
+    // Avoid double adding ,
+    { "keys": [","], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.json - comment - string", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^,", "match_all": true }
+        ]
+    },
+    // Avoid double adding :
+    { "keys": [":"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.json - comment - string", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^:", "match_all": true }
+        ]
+    },
+    // Auto-add : ,
+    { "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0,"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.json - comment - string", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:[ \t]*$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\"[ \t]*$", "match_all": true }
+        ]
+    },
+    // Auto-remove :,
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.json - comment - string", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^,", "match_all": true }
+        ]
+    }
+]


### PR DESCRIPTION
The CSS package contains some nice key bindings to avoid double adding `;` or `,` and adds some tiny snippets.

This PR adds those helpers to the JSON file format as well.