### PR TITLE
[HTML] correctly scope comment punctuation

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -26,10 +26,11 @@ contexts:
         - include: string-double-quoted
         - include: string-single-quoted
     - match: <!--
-      scope: punctuation.definition.comment.html
+      scope: punctuation.definition.comment.begin.html
       push:
         - meta_scope: comment.block.html
         - match: '(-*)--\s*>'
+          scope: punctuation.definition.comment.end.html
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
           pop: true

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -50,7 +50,10 @@
     </head>
     <body>
         <!-- Comment -->
-        ## ^ comment.block.html
+##      ^^^^^^^^^^^^^^^^ comment.block.html
+##      ^^^^ punctuation.definition.comment.begin.html
+##                   ^^^ punctuation.definition.comment.end.html
+##          ^^^^^^^^^ - punctuation
 
         <!----- hyphens - -- --- -->
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html


### PR DESCRIPTION
Prior to this PR, the HTML comment blocks had no scope at all applied to the closing comment punctuation (`-->`), and the opening comment punctuation (`<!--`) was missing the `.begin` that is common to all comment blocks. This PR fixes that, and brings it in line with all the other packages, which will allow color schemes to color said punctuation properly, and plugins to make proper use of it too.