### PR TITLE
[PHP] Add a scope to the nullable types symbol

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -586,6 +586,8 @@ contexts:
     # Class name type hint
     - match: '{{identifier}}'
       scope: meta.path.php support.class.php
+    - match: '\?'
+      scope: storage.type.nullable.php
     - match: '&'
       scope: storage.modifier.reference.php
     - match: (\$+){{identifier}}
@@ -634,6 +636,8 @@ contexts:
       set: function-body
     - match: ':'
       scope: punctuation.separator.php
+    - match: '\?'
+      scope: storage.type.nullable.php
     - match: \b(array|bool|int|float|string)\b
       scope: storage.type.php
     - include: class-builtin

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -425,6 +425,16 @@ $anon = new class extends Test1 implements Countable {};
 //                                     ^ support.other.namespace.php
 //                                                 ^ support.class.php
 
+    function nullableReturnType(?int $param1): ?bool {}
+//  ^ storage.type.function.php
+//           ^ entity.name.function.php
+//                             ^ punctuation.section.group.begin.php
+//                              ^ storage.type.nullable.php
+//                               ^ meta.function.parameters
+//                                          ^ punctuation.section.group.end.php
+//                                             ^ storage.type.nullable.php
+//                                              ^ storage.type.php
+
 $test = "\0 \12 \345g \x0f \u{a} \u{9999} \u{999}";
 //       ^^ constant.character.escape.octal.php
 //          ^^^ constant.character.escape.octal.php


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6594915/31102562-3950aa9e-a805-11e7-94f4-956015f9c34c.png)

Add a scope (`storage.type.nullable.php`) to `question marks` in `function parameters` and the `return type hinting`.

```php
<?php

function testReturn(?string $str): ?string
{
    return $str;
}
```

Ref: http://php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types