### PR TITLE
Java: Add constant entities to symbol list

### DIFF
--- a/Java/Symbol List%3A Constants.tmPreferences
+++ b/Java/Symbol List%3A Constants.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List: Constants</string>
+  <key>scope</key>
+  <string>source.java entity.name.constant.java</string>
+  <key>settings</key>
+  <dict>
+    <key>showInIndexedSymbolList</key>
+    <integer>1</integer>
+
+    <key>showInSymbolList</key>
+    <integer>1</integer>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Now that the java syntax has been updated we can add the constants to the symbol list.