### PR TITLE
[PHP] Fix ligature not working on comparison operators

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -218,13 +218,13 @@ contexts:
       scope: keyword.operator.increment-decrement.php
     - match: (\-|\+|\*|/|%)
       scope: keyword.operator.arithmetic.php
-    - match: (?i)(!|&&|\|\|)|\b(and|or|xor|as)\b
-      scope: keyword.operator.logical.php
-    - include: function-call
     - match: '<<|>>|~|\^|&|\|'
       scope: keyword.operator.bitwise.php
     - match: (===|==|!==|!=|<=|>=|<>|<|>)
       scope: keyword.operator.comparison.php
+    - match: (?i)(!|&&|\|\|)|\b(and|or|xor|as)\b
+      scope: keyword.operator.logical.php
+    - include: function-call
     - match: "="
       scope: keyword.operator.assignment.php
     - match: '(?i)\b(instanceof)\b\s+(?=[[:alpha:]\\$_])'

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -640,6 +640,9 @@ $var4 = 0b0111;
   foo_bar:
 //^^^^^^^ entity.name.label.php - keyword.control.php
 
+if ($a !== $b);
+//     ^^^ keyword.operator.comparison.php
+
 if ():
 else:
 // <- keyword.control - entity.name.label


### PR DESCRIPTION
https://forum.sublimetext.com/t/dev-build-3145/32340/27

`!` operator has a higher priority than `!==` hence `!==` is cut into `!` and `==` causing ligature not working.


