### PR TITLE
[ShellScript] Fix not popping backtick after end-of-options token

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -673,15 +673,6 @@ contexts:
       pop: true
     - include: expansion-and-string
     - include: line-continuation-or-pop-at-end
-    - match: (?:\s+|^)--(?=\s|$)
-      scope: keyword.operator.end-of-options.shell
-      set:
-        - meta_content_scope: meta.function-call.arguments.shell
-        - include: redirection
-        - match: (?=[)};&|])
-          pop: true
-        - include: expansion-and-string
-        - include: line-continuation-or-pop-at-end
 
   cmd-post: # looks like [main, cmd-post] at this point
     - match: ""
@@ -714,11 +705,30 @@ contexts:
     - match: (?={{is_end_of_interpolation}})
       pop: true
     - include: cmd-args-common
+    - match: (?:\s+|^)--(?=\s|$)
+      scope: keyword.operator.end-of-options.shell
+      set:
+        - meta_content_scope: meta.function-call.arguments.shell
+        - include: end-of-options-common
 
   cmd-args-boilerplate-bt:
     - match: (?={{is_end_of_interpolation}}|`) # <-------------- extra backtick
       pop: true
     - include: cmd-args-common
+    - match: (?:\s+|^)--(?=\s|$)
+      scope: keyword.operator.end-of-options.shell
+      set:
+        - meta_content_scope: meta.function-call.arguments.shell
+        - match: (?=`) # <-------------------------------------- extra backtick
+          pop: true
+        - include: end-of-options-common
+
+  end-of-options-common:
+    - include: redirection
+    - match: (?=[)};&|])
+      pop: true
+    - include: expansion-and-string
+    - include: line-continuation-or-pop-at-end
 
   cmd-args:
     - match: ""

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1220,6 +1220,11 @@ foo=`cd -L`
 #        ^ meta.function-call.arguments variable.parameter
 #         ^ punctuation.section.group.end
 
+echo "`dirname -- foo/bar`"
+#     ^ punctuation.section.group.begin
+#              ^^ keyword.operator.end-of-options
+#                        ^ punctuation.section.group.end
+
 commits=($(git rev-list --reverse --abbrev-commit "$latest".. -- "$prefix"))
 
 # <- - variable.other.readwrite


### PR DESCRIPTION
If we're inside backticks, we should look ahead for a backtick and then pop. Forgot to account for this after an end-of-options token. [See this forum post for reference](https://forum.sublimetext.com/t/bug-broken-highlighting-with-bash/32402).