### PR TITLE
[C++] [Objective-C] Fix too greedy template bracket matchings

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -228,6 +228,10 @@ contexts:
     - include: keywords-parens
     - include: keywords
     - include: numbers
+    # Prevent a '<' from getting scoped as the start of another template
+    # parameter list, if in reality a less-than-or-equals sign is meant.
+    - match: <=
+      scope: keyword.operator.comparison.c
 
   early-expressions-after-generic-type:
     - include: members-arrow
@@ -625,23 +629,26 @@ contexts:
         2: meta.group.c++ punctuation.section.group.begin.c++
       set: members-inside-function-call
     # Templated member function call
-    - match: (~?{{identifier}})\s*(<)
+    - match: (~?{{identifier}})\s*(?={{generic_lookahead}})
       captures:
         1: variable.function.member.c++
-        2: punctuation.section.generic.begin.c++
       set:
         - meta_scope: meta.method-call.c++
-        - match: '>'
-          scope: punctuation.section.generic.end.c++
+        - match: <
+          scope: punctuation.section.generic.begin.c++
           set:
             - meta_content_scope: meta.method-call.c++
-            - include: comments
-            - match: \(
-              scope: punctuation.section.group.begin.c++
-              set: members-inside-function-call
-            - match: (?=\S) # safety pop
-              pop: true
-        - include: expressions
+            - match: '>'
+              scope: punctuation.section.generic.end.c++
+              set:
+                - meta_content_scope: meta.method-call.c++
+                - include: comments
+                - match: \(
+                  scope: punctuation.section.group.begin.c++
+                  set: members-inside-function-call
+                - match: (?=\S) # safety pop
+                  pop: true
+            - include: expressions
     # Explicit base-class access
     - match: ({{identifier}})\s*(::)
       captures:

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -536,6 +536,20 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+struct A { int foo; };
+int main() {
+    A a;
+    a.foo = a.foo < 0 ? 1 : 2;
+    /*            ^ - punctuation.section.generic */
+}
+/* <- - invalid.illegal */
+
+template <typename T>
+struct A<T, enable_if_t<std::is_arithmetic<T>::value && !is_std_char_type<T>::value>> {
+    using x = conditional_t<sizeof(T) <= sizeof(long), long, long long>;
+    /*                                ^^ keyword.operator */
+};
+/* <- - invalid.illegal */
 
 
 /////////////////////////////////////////////

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -103,6 +103,10 @@ contexts:
     - include: keywords-parens
     - include: keywords
     - include: numbers
+    # Prevent a '<' from getting scoped as the start of another template
+    # parameter list, if in reality a less-than-or-equals sign is meant.
+    - match: <=
+      scope: keyword.operator.comparison.c
 
   early-expressions-after-generic-type:
     - include: members-arrow
@@ -712,23 +716,26 @@ contexts:
         2: meta.group.objc++ punctuation.section.group.begin.objc++
       set: members-inside-function-call
     # Templated member function call
-    - match: (~?{{identifier}})\s*(?={{generic_lookahead}})(<)
+    - match: (~?{{identifier}})\s*(?={{generic_lookahead}})
       captures:
         1: variable.function.member.objc++
-        2: punctuation.section.generic.begin.objc++
       set:
         - meta_scope: meta.method-call.objc++
-        - match: '>'
-          scope: punctuation.section.generic.end.objc++
+        - match: <
+          scope: punctuation.section.generic.begin.objc++
           set:
             - meta_content_scope: meta.method-call.objc++
-            - include: comments
-            - match: \(
-              scope: punctuation.section.group.begin.objc++
-              set: members-inside-function-call
-            - match: (?=\S) # safety pop
-              pop: true
-        - include: expressions
+            - match: '>'
+              scope: punctuation.section.generic.end.objc++
+              set:
+                - meta_content_scope: meta.method-call.objc++
+                - include: comments
+                - match: \(
+                  scope: punctuation.section.group.begin.objc++
+                  set: members-inside-function-call
+                - match: (?=\S) # safety pop
+                  pop: true
+            - include: expressions
     # Explicit base-class access
     - match: ({{identifier}})\s*(::)
       captures:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -534,6 +534,22 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+struct A { int foo; };
+int main() {
+    A a;
+    a.foo = a.foo < 0 ? 1 : 2;
+    /*            ^ - punctuation.section.generic */
+}
+/* <- - invalid.illegal */
+
+template <typename T>
+struct A<T, enable_if_t<std::is_arithmetic<T>::value && !is_std_char_type<T>::value>> {
+    using x = conditional_t<sizeof(T) <= sizeof(long), long, long long>;
+    /*                                ^^ keyword.operator */
+};
+/* <- - invalid.illegal */
+
+
 /////////////////////////////////////////////
 // Storage Modifiers
 /////////////////////////////////////////////


### PR DESCRIPTION
- Use the generic_lookahead variable to scout ahead for a closing ">" when
  encountering an opening "<" for member variables/methods. [From here](https://github.com/pybind/pybind11/blob/1e6172d4055d654df466f32b8327de7145bc9ea3/include/pybind11/cast.h#L292).
- Inside of a template parameter list, make sure we match "<=" first, before
  we push another template scope. [From here](https://github.com/pybind/pybind11/blob/1e6172d4055d654df466f32b8327de7145bc9ea3/include/pybind11/cast.h#L928).