### PR TITLE
[C#] better C#7 support

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -527,6 +527,17 @@ contexts:
         6: punctuation.section.brackets.end.cs
         7: keyword.operator.pointer.cs
       push: method_name
+    - match: \(
+      scope: punctuation.section.group.begin.cs
+      push:
+        - meta_scope: meta.group.cs
+        - match: \)
+          scope: punctuation.section.group.end.cs
+          set: method_name
+        - match: ','
+          scope: punctuation.separator.cs
+        - match: (?=\S)
+          push: var_declaration_explicit
 
   method_name:
     - match: '\.'
@@ -1263,7 +1274,11 @@ contexts:
           pop: true
         - match: ','
           scope: punctuation.separator.expression.cs
-        - include: line_of_code_in
+        - match: ':'
+          scope: punctuation.separator.assignment.cs
+        - match: (?!{{reserved}})(?={{name}}{{generic_declaration}}{{type_suffix}}\s+{{name}}\s*[:,])
+          push: var_declaration_explicit
+        - include: line_of_code_in_no_semicolon
     - match: \{
       scope: punctuation.section.block.begin.cs
       set:

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -789,7 +789,10 @@ contexts:
 
   code_block_in:
     - match: (?=\S)
-      push: line_of_code
+      push:
+        - match: (?={{reserved}})
+          pop: true
+        - include: line_of_code
 
   line_of_code:
     # language keywords

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -637,8 +637,9 @@ contexts:
     - include: attribute
     - match: (?=[^\s\[])
       set:
-      - match: '\s*(out|ref|this|params)\s+'
-        scope: storage.modifier.parameter.cs
+      - match: '\s*\b(out|ref|this|params)\s+'
+        captures:
+          1: storage.modifier.parameter.cs
       - match: \s
         pop: true
       - include: type
@@ -1299,8 +1300,19 @@ contexts:
       pop: true
 
   arguments:
-    - match: (out|ref)\s
-      scope: storage.modifier.argument.cs
+    - match: (out)\s
+      captures:
+        1: storage.modifier.argument.cs
+      push:
+        - match: (ref)\s
+          captures:
+            1: storage.modifier.argument.cs
+        - include: var_declaration
+        - match: ''
+          pop: true
+    - match: (ref)\s
+      captures:
+        1: storage.modifier.argument.cs
     - match: '({{name}})\s*(=)'
       captures:
         1: variable.parameter.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -474,11 +474,11 @@ contexts:
       scope: punctuation.separator.inherited-class.cs
 
   method_declaration:
-    - match: '\b(abstract|async|const|event|extern|new|override|readonly|sealed|static|unsafe|virtual|volatile)\b'
+    - match: '\b(abstract|async|const|event|extern|new|override|readonly|ref|sealed|static|unsafe|virtual|volatile)\b'
       scope: storage.modifier.cs
     - match: \bdelegate\b
       scope: storage.type.delegate.cs
-    - match: '\b(dynamic)\b'
+    - match: '\bdynamic\b'
       scope: storage.modifier.cs
     - match: '\b(implicit|explicit)\b'
       scope: storage.modifier.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -925,9 +925,6 @@ contexts:
         1: support.namespace.cs
         2: variable.other.namespace.cs
         3: punctuation.accessor.double-colon.namespace.cs
-    - match: '{{name}}(\.)'
-      captures:
-        1: punctuation.accessor.dot.cs
     - match: '({{name}})\s+({{name}})'
       captures:
         1: support.type.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -844,19 +844,12 @@ contexts:
         3: punctuation.terminator.statement.cs
       pop: true
     - include: keywords
-    # TODO: use the same code for method detection
     # C#7, nested method
-    - match: '(?:({{base_type}})|({{name}})){{type_suffix_capture}}\s+(?={{name}}{{generic_declaration}}\()'
-      captures:
-        1: storage.type.cs
-        2: support.type.cs
-        3: storage.type.nullable.cs
-        4: meta.brackets.cs
-        5: punctuation.section.brackets.begin.cs
-        6: punctuation.separator.cs
-        7: punctuation.section.brackets.end.cs
-        8: keyword.operator.pointer.cs
-      push: method_name
+    - match: '(?=(?:\basync\s+)?({{base_type}}|{{name}}){{type_suffix_capture}}({{generic_declaration}})?\s+{{name}}{{generic_declaration}}\()'
+      push:
+        - include: method_declaration
+        - match: ''
+          pop: true
     - match: '({{name}})(<)(?=([^(={};]*>){{type_suffix}}\s+{{name}}{{generic_declaration}}\()'
       captures:
         1: support.type.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -262,6 +262,111 @@ class Foo {
 ///                                        ^ punctuation.terminator.statement
         throw new InvalidOperationException("Not found");
     }
+    
+    // https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#tuples
+    public void TupleTest () {
+        var letters = ("a", "b");
+///                   ^ punctuation.section.group.begin
+///                       ^ punctuation.separator.expression
+///                            ^ punctuation.section.group.end
+///                             ^ punctuation.terminator.statement
+        (string Alpha, string Beta) namedLetters = ("a", "b");
+///     ^ punctuation.section.group.begin
+///      ^^^^^^ storage.type
+///             ^^^^^ variable.other
+///                  ^ punctuation.separator.expression
+///                    ^^^^^^ storage.type
+///                           ^^^^ variable.other
+///                               ^ punctuation.section.group.end
+///                                 ^^^^^^^^^^^^ variable.other
+///                                              ^ keyword.operator.assignment
+///                                                ^ punctuation.section.group.begin
+///                                                    ^ punctuation.separator.expression
+///                                                         ^ punctuation.section.group.end
+///                                                          ^ punctuation.terminator.statement
+
+        (SomeType[] Alpha, SomeType<int> Beta) example = (a, b);
+///     ^ punctuation.section.group.begin
+///      ^^^^^^^^ support.type
+///              ^ punctuation.section.brackets.begin
+///               ^ punctuation.section.brackets.end
+///                 ^^^^^ variable.other
+///                      ^ punctuation.separator.expression
+///                        ^^^^^^^^ support.type
+///                                ^ punctuation.definition.generic.begin
+///                                 ^^^ storage.type
+///                                    ^ punctuation.definition.generic.end
+///                                      ^^^^ variable.other
+///                                          ^ punctuation.section.group.end
+///                                            ^^^^^^^ variable.other
+///                                                    ^ keyword.operator.assignment
+///                                                      ^ punctuation.section.group.begin
+///                                                        ^ punctuation.separator.expression
+///                                                           ^ punctuation.section.group.end
+///                                                            ^ punctuation.terminator.statement
+        var alphabetStart = (Alpha: "a", Beta: "b");
+///                         ^ punctuation.section.group.begin
+///                          ^^^^^ variable.other
+///                               ^ punctuation.separator.assignment
+///                                    ^ punctuation.separator.expression
+///                                      ^^^^ variable.other
+///                                          ^ punctuation.separator.assignment
+///                                               ^ punctuation.section.group.end
+///                                                ^ punctuation.terminator.statement
+        var abc = (this as object, input);
+///               ^ punctuation.section.group.begin
+///                ^^^^ variable.language
+///                     ^^ keyword.operator.reflection
+///                        ^^^^^^ storage.type
+///                              ^ punctuation.separator.expression
+///                                ^^^^^ variable.other
+///                                     ^ punctuation.section.group.end
+///                                      ^ punctuation.terminator.statement
+        var abc = (example.Alpha as SomeType);
+///               ^ punctuation.section.group.begin
+///                ^^^^^^^ variable.other
+///                       ^ punctuation.accessor.dot
+///                        ^^^^^ variable.other
+///                              ^^ keyword.operator.reflection
+///                                 ^^^^^^^^ support.type
+///                                         ^ punctuation.section.group.end
+///                                          ^ punctuation.terminator.statement
+    }
+
+    private static (int Max, int Min) Range(IEnumerable<int> numbers)
+/// ^^^^^^^ storage.modifier.access
+///         ^^^^^^ storage.modifier
+///                ^ punctuation.section.group.begin
+///                 ^^^ storage.type
+///                     ^^^ variable.other
+///                        ^ punctuation.separator
+///                          ^^^ storage.type
+///                              ^^^ variable.other
+///                                 ^ punctuation.section.group.end
+///                                   ^^^^^ entity.name.function - entity.name.function.constructor
+///                                        ^ punctuation.section.parameters.begin
+///                                         ^^^^^^^^^^^ support.type
+///                                                    ^ punctuation.definition.generic.begin
+///                                                     ^^^ storage.type
+///                                                        ^ punctuation.definition.generic.end
+///                                                          ^^^^^^^ variable.parameter
+///                                                                 ^ punctuation.section.parameters.end
+    {
+        int min = int.MaxValue;
+        int max = int.MinValue;
+        foreach(var n in numbers)
+        {
+            min = (n < min) ? n : min;
+            max = (n > max) ? n : max;
+        }
+        return (max, min);
+///     ^^^^^^ keyword.control.flow.return
+///            ^ punctuation.section.group.begin
+///             ^^^ variable.other
+///                ^ punctuation.separator.expression
+///                  ^^^ variable.other
+///                     ^ punctuation.section.group.end
+///                      ^ punctuation.terminator.statement
     }
 }
 /// <- meta.class.body punctuation.section.block.end

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -233,5 +233,35 @@ class Foo {
 ///     ^ punctuation.section.block.end
 ///      ^ meta.class.body meta.method.body - meta.method.body meta.method.body
     }
+    
+    // https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#ref-locals-and-returns
+    public static ref int Find3(int[,] matrix, Func<int, bool> predicate) {
+/// ^^^^^^ storage.modifier.access
+///        ^^^^^^ storage.modifier
+///               ^^^ storage.modifier
+///                   ^^^ storage.type
+///                       ^^^^^ entity.name.function
+///                            ^ punctuation.section.parameters.begin
+///                             ^^^ storage.type
+///                                ^ punctuation.section.brackets.begin
+///                                 ^ punctuation.separator
+///                                  ^ punctuation.section.brackets.end
+///                                    ^^^^^^ variable.parameter
+        for (int i = 0; i < matrix.GetLength(0); i++)
+            for (int j = 0; j < matrix.GetLength(1); j++)
+                if (predicate(matrix[i, j]))
+                    return ref matrix[i, j];
+///                 ^^^^^^ keyword.control.flow.return
+///                        ^^^ keyword.other
+///                            ^^^^^^ variable.other
+///                                  ^ punctuation.section.brackets.begin
+///                                   ^ variable.other
+///                                    ^ punctuation.separator.accessor
+///                                      ^ variable.other
+///                                       ^ punctuation.section.brackets.end
+///                                        ^ punctuation.terminator.statement
+        throw new InvalidOperationException("Not found");
+    }
+    }
 }
 /// <- meta.class.body punctuation.section.block.end

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -193,13 +193,22 @@ class Foo {
         else
             WriteLine("Quantity is not a valid integer!");
 
-        WriteLine($"{nameof(quantity)}: {quantity}"); // still valid
+        Console.WriteLine($"{nameof(quantity)}: {quantity}"); // still valid
+///     ^^^^^^^ variable.other
+///            ^ punctuation.accessor.dot
+///             ^^^^^^^^^ variable.function
 
         int.TryParse(input, out ref int quantity);
+///     ^^^ storage.type
+///        ^ punctuation.accessor.dot
+///         ^^^^^^^^ variable.function
+///         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+///                 ^ punctuation.section.group.begin
 ///                         ^^^ storage.modifier.argument
 ///                             ^^^ storage.modifier.argument
 ///                                 ^^^ storage.type
 ///                                     ^^^^^^^^ variable.other
+///                                             ^ punctuation.section.group.end
     }
 /// ^ meta.class.body meta.method.body punctuation.section.block.end
 

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -202,5 +202,36 @@ class Foo {
 ///                                     ^^^^^^^^ variable.other
     }
 /// ^ meta.class.body meta.method.body punctuation.section.block.end
+
+    // https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#local-functions
+    public Task<string> PerformLongRunningWork(string address, int index, string name)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+            throw new ArgumentException(message: "An address is required", paramName: nameof(address));
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(paramName: nameof(index), message: "The index must be non-negative");
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException(message: "You must supply a name", paramName: nameof(name));
+
+        return longRunningWorkImplementation();
+
+        async Task<string> longRunningWorkImplementation ()
+///     ^^^^^ storage.modifier
+///           ^^^^ support.type
+///               ^ punctuation.definition.generic.begin
+///                ^^^^^^ storage.type
+///                      ^ punctuation.definition.generic.end
+///                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.function
+///                                                      ^^ meta.method.parameters
+        {
+///     ^ punctuation.section.block.begin
+///      ^ meta.class.body meta.method.body meta.method.body
+            var interimResult = await FirstWork(address);
+            var secondResult = await SecondStep(index, name);
+            return $"The results are {interimResult} and {secondResult}. Enjoy.";
+        }
+///     ^ punctuation.section.block.end
+///      ^ meta.class.body meta.method.body - meta.method.body meta.method.body
+    }
 }
 /// <- meta.class.body punctuation.section.block.end

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -181,6 +181,25 @@ class Foo {
 ///                                                   ^ constant.numeric
 ///                                                    ^ punctuation.separator.case-statement
         }
+
+        // https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#out-variables
+        if (int.TryParse(input, out var quantity))
+///                             ^^^ storage.modifier.argument
+///                                ^ - storage.modifier.argument
+///                                 ^^^ storage.type.variable
+///                                     ^^^^^^^^ variable.other
+///                                             ^^ punctuation.section.group.end
+            WriteLine(quantity);
+        else
+            WriteLine("Quantity is not a valid integer!");
+
+        WriteLine($"{nameof(quantity)}: {quantity}"); // still valid
+
+        int.TryParse(input, out ref int quantity);
+///                         ^^^ storage.modifier.argument
+///                             ^^^ storage.modifier.argument
+///                                 ^^^ storage.type
+///                                     ^^^^^^^^ variable.other
     }
 /// ^ meta.class.body meta.method.body punctuation.section.block.end
 }

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1166,3 +1166,15 @@ class Test
     }
 /// ^ - invalid.illegal.stray.brace
 }
+
+void Main () { // method outside a class, i.e. a LINQPad script
+///^ storage.type
+///  ^^^^ entity.name.function
+}
+/// <- punctuation.section.block.end
+
+public class AfterTopLevelMethod {
+///^^^ storage.modifier.access
+///    ^^^^^ storage.type.class
+///          ^^^^^^^^^^^^^^^^^^^ entity.name.class
+}


### PR DESCRIPTION
This PR adds much better C#7 support:

- [`out` variables](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#out-variables)
- [Tuples](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#tuples)
- [`ref` locals and returns](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#ref-locals-and-returns)
- [local functions](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#local-functions) (prior to this PR, it worked for functions that didn't return generic types)

NOTE: [numeric literal improvements](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#numeric-literal-syntax-improvements) remain in https://github.com/sublimehq/Packages/pull/1047