### PR TITLE
[Python] strftime in format() strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -44,6 +44,7 @@ variables:
       (?:\.\d+)?         # precision
       [bcdeEfFgGnosxX%]? # type
     )
+  strftime_spec: '(?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))'
 contexts:
   main:
     - include: statements
@@ -1034,7 +1035,7 @@ contexts:
       scope: constant.other.placeholder.python
       captures:
         2: variable.other.placeholder.python
-    - match: '%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj])'
+    - match: '{{strftime_spec}}'
       scope: constant.other.placeholder.python
     - match: '\{\{|\}\}'
       scope: constant.character.escape.python
@@ -1045,9 +1046,11 @@ contexts:
     - match: |- # simple form
         (?x)
         (\{)
-          (?: [\w.\[\]]+)?         # field_name
-          (   ! [ars])?            # conversion
-          (   : {{format_spec}} )? # format_spec
+          (?: [\w.\[\]]+)?             # field_name
+          (   ! [ars])?                # conversion
+          (   : (?:{{format_spec}}|    # format_spec OR
+                   {{strftime_spec}}+) # strftime_spec
+          )?
         (\})
       scope: constant.other.placeholder.python
       captures:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1049,7 +1049,7 @@ contexts:
           (?: [\w.\[\]]+)?             # field_name
           (   ! [ars])?                # conversion
           (   : (?:{{format_spec}}|    # format_spec OR
-                   {{strftime_spec}}+) # strftime_spec
+                   [^}%]*%.[^}]*)      # any format-like string
           )?
         (\})
       scope: constant.other.placeholder.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -385,6 +385,21 @@ datetime.strptime('2011227', '%Y%V%u')
 #                            ^^^^^^^^ string.quoted.single.python
 #                             ^^^^^^ constant.other.placeholder.python
 
+'{0:%Y%m%d}'.format(datetime.date.today())
+# ^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^ constant.other.placeholder.python
+#   ^^^^^^ constant.other.format-spec.python
+'{0:%Y}-{0:%m}-{0:%d}'.format(datetime.date.today())
+# ^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^ constant.other.placeholder.python
+#  ^^^ constant.other.format-spec.python
+#      ^ - constant.other.placeholder.python
+#       ^^^^^^ constant.other.placeholder.python
+#          ^^ constant.other.format-spec.python
+#             ^ - constant.other.placeholder.python
+#              ^^^^^^ constant.other.placeholder.python
+#                 ^^ constant.other.format-spec.python
+
 x = "hello \
 #   ^^^^^^^^^ string.quoted.double.python - invalid.illegal.unclosed-string.python, \
 #          ^ punctuation.separator.continuation.line.python, \

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -384,11 +384,25 @@ rB'''This is a \n (test|with), %s no unicode \uDEAD'''
 datetime.strptime('2011227', '%Y%V%u')
 #                            ^^^^^^^^ string.quoted.single.python
 #                             ^^^^^^ constant.other.placeholder.python
+datetime.strftime(datetime.now(), '%Y%V%uT')
+#                                 ^^^^^^^^^ string.quoted.single.python
+#                                  ^^^^^^ constant.other.placeholder.python
+#                                        ^ - constant.other.placeholder.python
 
 '{0:%Y%m%d}'.format(datetime.date.today())
 # ^^^^^^^^^^ string.quoted.single.python
 # ^^^^^^^^ constant.other.placeholder.python
 #   ^^^^^^ constant.other.format-spec.python
+'{0:%Y-%m-%d}'.format(datetime.date.today())
+# ^^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^^^ constant.other.placeholder.python
+#   ^^^^^^^^ constant.other.format-spec.python
+'{0:%Y-%m-%dT}'.format(datetime.date.today())
+# ^^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^^^^ constant.other.placeholder.python
+#   ^^^^^^^^^ constant.other.format-spec.python
+'{0:T}'.format(datetime.date.today())  # This is legal but uninteresting
+# ^^^^^ string.quoted.single.python
 '{0:%Y}-{0:%m}-{0:%d}'.format(datetime.date.today())
 # ^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
@@ -399,6 +413,18 @@ datetime.strptime('2011227', '%Y%V%u')
 #             ^ - constant.other.placeholder.python
 #              ^^^^^^ constant.other.placeholder.python
 #                 ^^ constant.other.format-spec.python
+'{0:%Y}-{0:%m
+# ^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^ constant.other.placeholder.python
+#  ^^^ constant.other.format-spec.python
+#      ^^^^ - constant.other.placeholder.python
+#            ^ invalid.illegal.unclosed-string.python
+'{0:%Y}-{0:%
+# ^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^ constant.other.placeholder.python
+#  ^^^ constant.other.format-spec.python
+#      ^^^^^ - constant.other.placeholder.python
+#           ^ invalid.illegal.unclosed-string.python
 
 x = "hello \
 #   ^^^^^^^^^ string.quoted.double.python - invalid.illegal.unclosed-string.python, \


### PR DESCRIPTION
Fixes #1209 

Note that this doesn't allow arbitrary strings as `strftime` formats. We can't tell the difference between a `datetime` argument and something else.

```python
'{0:%Y%m%d}'.format(datetime.date.today()) # legal, newly highlighted
'{0:%Y-%m-%d}'.format(datetime.date.today()) # legal, not highlighted

'{0:%Y%m%d}'.format('foo') # not legal, newly highlighted
'{0:%Y-%m-%d}'.format('foo') # not legal, not highlighted
```