### PR TITLE
[ShellScript] Split up compound statement into backticks and non-backticks version

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -250,7 +250,7 @@ contexts:
       set:
         - meta_scope: meta.group.for.shell
         - include: cmd-args-boilerplate
-        - include: compound
+        - include: arithmetic
         - match: \bin\b
           scope: keyword.control.in.shell
 
@@ -769,6 +769,13 @@ contexts:
 
   cmd:
     - include: cmd-common
+    - match: \(
+      scope: punctuation.definition.compound.begin.shell
+      push:
+        - match: \)
+          scope: punctuation.definition.compound.end.shell
+          set: [cmd-post, cmd-args]
+        - include: main
     - include: scope:commands.builtin.shell.bash#main
     - match: \blet\b
       scope: support.function.let.bash
@@ -798,6 +805,13 @@ contexts:
 
   cmd-bt:
     - include: cmd-common
+    - match: \(
+      scope: punctuation.definition.compound.begin.shell
+      push:
+        - match: \)
+          scope: punctuation.definition.compound.end.shell
+          set: [cmd-post, cmd-args-bt]
+        - include: main
     - include: scope:commands.builtin.shell.bash#main-bt
     - match: \blet\b
       scope: support.function.let.bash
@@ -884,12 +898,12 @@ contexts:
 
   cmd-common:
     - include: control
-    - include: compound
+    - include: arithmetic
     - match: (?=\)|})
       pop: true
     - include: line-continuation-or-pop-at-end
 
-  compound:
+  arithmetic:
     - match: \(\((?=.+\)\))
       scope: punctuation.section.arithmetic.begin.shell
       push:
@@ -898,13 +912,6 @@ contexts:
           scope: punctuation.section.arithmetic.end.shell
           pop: true
         - include: expression
-    - match: \(
-      scope: punctuation.definition.compound.begin.shell
-      push:
-        - match: \)
-          scope: punctuation.definition.compound.end.shell
-          set: [cmd-post, cmd-args]
-        - include: main
 
   expansion-tilde:
     - match: '~'

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1225,6 +1225,15 @@ echo "`dirname -- foo/bar`"
 #              ^^ keyword.operator.end-of-options
 #                        ^ punctuation.section.group.end
 
+foo=`(uname -r) 2>/dev/null`
+#                          ^ punctuation.section.group.end - punctuation.section.group.begin
+UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
+#                                    ^ punctuation.section.group.end
+UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
+#                                   ^ punctuation.section.group.end
+UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+#                                    ^ punctuation.section.group.end
+
 commits=($(git rev-list --reverse --abbrev-commit "$latest".. -- "$prefix"))
 
 # <- - variable.other.readwrite


### PR DESCRIPTION
fix #1220 

After merging this PR and https://github.com/sublimehq/Packages/pull/1225, [this file](https://github.com/llvm-mirror/llvm/blob/master/cmake/config.guess) should highlight correctly. The problematic regions are [here](https://github.com/llvm-mirror/llvm/blob/0446db2b0e822bb1abb094bf3ff3eda824ddc457/cmake/config.guess#L138-L141) and [here](https://github.com/llvm-mirror/llvm/blob/0446db2b0e822bb1abb094bf3ff3eda824ddc457/cmake/config.guess#L438-L458).