### PR TITLE
[PHP] always keep the closing heredoc keyword unindented

### DIFF
--- a/PHP/Indentation Rules - heredoc end.tmPreferences
+++ b/PHP/Indentation Rules - heredoc end.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Indentation Rules - HEREDOC end</string>
+	<key>scope</key>
+	<string>source.php meta.heredoc-end.php</string>
+	<key>settings</key>
+	<dict>
+		<key>unIndentedLinePattern</key>
+		<string>.</string>
+		<key>preserveIndent</key>
+		<true />
+	</dict>
+</dict>
+</plist>

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Indentation Rules</string>
 	<key>scope</key>
-	<string>source.php - comment, meta.html-newline-after-php</string>
+	<string>source.php - comment - meta.embedded.html - string - meta.heredoc-end, meta.html-newline-after-php</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -800,9 +800,11 @@ contexts:
   heredoc:
     - match: '(?=<<<\s*''?({{identifier}})''?\s*$)'
       push:
-        - match: ^(\1)\b
+        - match: ^(\1)\b(?:(;)(\s*$\n?))?
           captures:
             1: punctuation.section.embedded.end.php keyword.operator.heredoc.php
+            2: punctuation.terminator.expression.php
+            3: meta.heredoc-end.php
           pop: true
         - match: <<<\s*(HTML)\s*$\n?
           scope: punctuation.section.embedded.begin.php punctuation.definition.string.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -784,6 +784,8 @@ This is a test!
 //         ^^^^^^^^^ string.quoted.double
 HTML;
 // <- punctuation.section.embedded.end keyword.operator.heredoc
+//  ^ punctuation.terminator.expression
+//   ^ meta.heredoc-end
 
 echo <<< JAVASCRIPT
 //   ^^^^^^^^^^^^^^ punctuation.section.embedded.begin punctuation.definition.string


### PR DESCRIPTION
Previously, having code like

```php
<?php
function test () {
    echo <<<HTML
    <table class="table table-bordered table-striped sup1em" id="tableResponsive">
        <thead>
            <tr>
                <th class="text-center linhaStatus">ID Pedido</th>
                <th class="text-center">Cliente / Destino</th>
                <th class="text-center">Pedido</th>
                <th class="text-center linhaStatus">Gerenciar</th>
            </tr>
        </thead>
    </table>
HTML;
}
?>
```

and then doing a full "Reindent" would cause the `HTML;` to be indented and thus no longer close the HEREDOC. This PR fixes that by:

- scoping the semi-colon and newline after the heredoc (if present) with a meta scope
- targeting that meta scope with some indentation rules (this required the specificity of the main PHP indentation rules to be tweaked slightly) to:
  - ignore lines ending with this meta scope when calculating indentation
  - preserve the indentation (i.e. none) of lines ending with this meta scope