### PR TITLE
[JavaScript] scope whitespace between function name and parameters

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -955,6 +955,8 @@ contexts:
         - include: statements
 
   function-declaration-parameters:
+    - match: \s+
+      scope: meta.function.declaration.js
     - match: \(
       scope: punctuation.section.group.begin.js
       push:

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -1080,3 +1080,14 @@ var str = `Hello, ${name}!`;
 
 let str = navigator.userAgent.toLowerCase();
 //        ^^^^^^^^^ support.type.object
+
+function yy (a, b) {
+// ^^^^^^^^^^^^^^^ meta.function.declaration
+//       ^^ entity.name.function
+//          ^ punctuation.section.group.begin
+//           ^ variable.parameter.function
+//            ^ punctuation.separator.parameter.function
+//              ^ variable.parameter.function
+//               ^ punctuation.section.group.end
+//                 ^ meta.block punctuation.section.block - meta.function
+}


### PR DESCRIPTION
...so that the function declaration scope is continuous. Fixes #1230