### PR TITLE
[Python] Fix line continuation not popping properly

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -891,7 +891,7 @@ contexts:
       push:
         # This prevents strings after a continuation from being a docstring
         - include: strings
-        - match: (?=\S|^\s*$)
+        - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
           pop: true
 
   line-continuation-or-pop:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -589,6 +589,15 @@ class Class():
 #   ^^^ storage.type.function - meta.decorator
 
 
+class AClass:
+    # `def` immediately after a line-continued string within a class
+    x =  "Type help() for interactive help, " \
+         "or help(object) for help about object."
+    def __call__(self, *args, **kwds):
+#   ^^^ - invalid.illegal
+        pass
+
+
 ##################
 # Collection literals and generators
 ##################


### PR DESCRIPTION
Discovered randomly while investigating some code base a few weeks ago.

A string on the continued line would cause the pop pattern not being
matched, which in return meant the line continuation context wasn't
exited and whitespaces until the first non-string character were
consumed, which in return caused def and class statements to match as
invalid, since those require to be written on their own line.

(What a nice sentence.)

Previously failing test:

![2017-10-18_00-01-34](https://user-images.githubusercontent.com/931051/31692305-7da5232e-b399-11e7-8545-7476350bd645.png)
