### PR TITLE
[Python] Exclude string type from string scope

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1121,9 +1121,9 @@ contexts:
     - match: '([uU]?R)(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1132,9 +1132,9 @@ contexts:
     - match: '([bB]R|R[bB])(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1142,9 +1142,9 @@ contexts:
     - match: '([uU]?r)(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: meta.string.python string.quoted.double.block.python
@@ -1174,9 +1174,9 @@ contexts:
     - match: '([bB]r|r[bB])(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1189,9 +1189,9 @@ contexts:
     - match: ((?i)fr|rf)(""")
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.begin.python
           set: after-expression
@@ -1200,9 +1200,9 @@ contexts:
     - match: ((?i)f|f)(""")
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.begin.python
           set: after-expression
@@ -1213,9 +1213,9 @@ contexts:
     - match: '([uU]?)(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: meta.string.python string.quoted.double.block.python
@@ -1243,9 +1243,9 @@ contexts:
     - match: '([bB])(""")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.block.python
+        - meta_content_scope: meta.string.python string.quoted.double.block.python
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1257,9 +1257,9 @@ contexts:
     - match: '([uU]?R)(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1268,9 +1268,9 @@ contexts:
     - match: '([bB]R|R[bB])(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1279,9 +1279,9 @@ contexts:
     - match: '([uU]?r)(")(?={{sql_indicator}})'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1297,9 +1297,9 @@ contexts:
     - match: '([uU]?r)(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1314,9 +1314,9 @@ contexts:
     - match: '([bB]r|r[bB])(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1330,9 +1330,9 @@ contexts:
     - match: ((?i)fr|rf)(")
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.double.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1342,9 +1342,9 @@ contexts:
     - match: ((?i)f|f)(")
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.double.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1356,9 +1356,9 @@ contexts:
     - match: '([uU]?)(")(?={{sql_indicator}})'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1376,9 +1376,9 @@ contexts:
     - match: '([uU]?)(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1390,9 +1390,9 @@ contexts:
     - match: '([bB])(")'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.double.python
+        - meta_content_scope: meta.string.python string.quoted.double.python
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1405,9 +1405,9 @@ contexts:
     - match: ([uU]?R)(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1415,9 +1415,9 @@ contexts:
     - match: ([bB]R|R[bB])(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1425,9 +1425,9 @@ contexts:
     - match: ([uU]?r)(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: meta.string.python string.quoted.single.block.python
@@ -1458,9 +1458,9 @@ contexts:
     - match: ([bB]r|r[bB])(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1473,20 +1473,20 @@ contexts:
     - match: ((?i)fr|rf)(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.begin.python
           set: after-expression
         - include: f-string-content
     # Triple-quoted f-string
-    - match: ((?i)f|f)(''')
+    - match: ([fF])(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.begin.python
           set: after-expression
@@ -1497,9 +1497,9 @@ contexts:
     - match: ([uU]?)(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: '(?={{sql_indicator}})'
           set:
             - meta_scope: meta.string.python string.quoted.single.block.python
@@ -1527,9 +1527,9 @@ contexts:
     - match: ([bB])(''')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.block.python
+        - meta_content_scope: meta.string.python string.quoted.single.block.python
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1541,9 +1541,9 @@ contexts:
     - match: '([uU]?R)('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1552,9 +1552,9 @@ contexts:
     - match: '([bB]R|R[bB])('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1563,9 +1563,9 @@ contexts:
     - match: '([uU]?r)('')(?={{sql_indicator}})'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1581,9 +1581,9 @@ contexts:
     - match: '([uU]?r)('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1598,9 +1598,9 @@ contexts:
     - match: '([bB]r|r[bB])('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1615,9 +1615,9 @@ contexts:
     - match: ((?i)fr|rf)(')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.single.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1627,9 +1627,9 @@ contexts:
     - match: ((?i)f|f)(')
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.interpolated.python string.quoted.single.python
+        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1641,9 +1641,9 @@ contexts:
     - match: '([uU]?)('')(?={{sql_indicator}})'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1661,9 +1661,9 @@ contexts:
     - match: '([uU]?)('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
@@ -1675,9 +1675,9 @@ contexts:
     - match: '([bB])('')'
       captures:
         1: storage.type.string.python
-        2: punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push:
-        - meta_scope: meta.string.python string.quoted.single.python
+        - meta_content_scope: meta.string.python string.quoted.single.python
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -416,7 +416,7 @@ sql = Ur"SELECT `name` FROM `users` \
 #                              ^ punctuation.definition.string.end.python
 
 sql = b'just some \
-#     ^^^^^^^^^^^^^^ string.quoted.single.python - invalid.illegal.unclosed-string.python, \
+#      ^^^^^^^^^^^^^ string.quoted.single.python - invalid.illegal.unclosed-string.python, \
 #                 ^ punctuation.separator.continuation.line.python, \
     string'
 #^^^^^^^^^^ string.quoted.single
@@ -498,16 +498,16 @@ f"string"
 #^^^^^^^^ string.quoted.double
 
  RF"""string"""
-#^^ storage.type.string
-#^^^^^^^^^^^^^^ meta.string.interpolated string.quoted.double.block
+#^^ storage.type.string - string
+#  ^^^^^^^^^^^^ meta.string.interpolated string.quoted.double.block
 
 F'''string'''
 # <- storage.type.string
 #^^^^^^^^^^^^ meta.string.interpolated string.quoted.single.block
 
  rf'string'
-#^^ storage.type.string
-#^^^^^^^^^^ meta.string.interpolated string.quoted.single
+#^^ storage.type.string - string
+#  ^^^^^^^^ meta.string.interpolated string.quoted.single
 
 rf'\r\n' f'\r\n'
 #  ^^^^ - constant
@@ -558,7 +558,8 @@ f"result: {value:{width}.{precision}}\n"
 #                        ^^^^^^^^^^^ meta.interpolation.python meta.interpolation.python
 #                                   ^^^ - meta.interpolation.python meta.interpolation.python
 rf"{value:{width!s:d}}"
-#^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+# <- storage.type.string.python - string
+# ^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
 #          ^^^^^ source source.python.embedded
 #               ^^ storage.modifier.conversion
 #                 ^^ constant.other.format-spec


### PR DESCRIPTION
The string prefixes are not part of the actual string, so they shouldn't be scoped as such. Should ease the life of BracketHighlighter, for example (cc @facelessuser).