### PR TITLE
[Python] Add highlighting for "variable" constants

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -782,6 +782,8 @@ contexts:
     - match: '(?={{identifier}})'
       push:
         - include: name-specials
+        - match: '\b_*\p{Lu}{3,}[\p{Lu}_]*\b' # require 3 upper-case letters for undotted names
+          scope: variable.other.constant.python
         - include: generic-names
         - match: ''
           pop: true
@@ -792,6 +794,8 @@ contexts:
         1: punctuation.accessor.dot.python
       push:
         - include: dotted-name-specials
+        - match: '\b_*\p{Lu}+[\p{Lu}_]*\b'
+          scope: variable.other.constant.python
         - include: generic-names
         - match: ''
           pop: true

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -109,6 +109,16 @@ open.open.open
 #   ^^^^^^^^ constant.language.python
 #            ^^^^^^^^^ constant.language.python
 
+CONSTANT.__
+#^^^^^^^ meta.qualified-name.python variable.other.constant.python
+#        ^^ - variable.other.constant
+
+NO _A_B
+#^ - variable.other.constant
+#  ^^^^ - variable.other.constant
+
+some.NO
+#    ^^ meta.qualified-name.python variable.other.constant.python
 
 ##################
 # Function Calls
@@ -119,6 +129,9 @@ identifier()
 #^^^^^^^^^ meta.qualified-name variable.function
 #         ^ punctuation.section.arguments.begin
 #          ^ punctuation.section.arguments.end
+
+IDENTIFIER()
+#^^^^^^^^^ meta.qualified-name variable.function - variable.other.constant
 
 dotted.identifier(12, True)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call


### PR DESCRIPTION
As raised in https://github.com/sublimehq/Packages/issues/458, this PR adds highlighting of "constant variables" in SCREAM_CASE. I tried to add a little heuristic in requiring at least 3 upper case characters for normal names to be recognized as a constant, in case people were using smaller ones such as `A` or `B` for class names. Dotted names only need one upper case letter because of enums and the like.

Function calls and decorators are not covered by this, since those already have `variable.function`.

I chose `variable.other.constant` based on its usage in other syntaxes, notably JavaScript, Ruby and OCaml.
https://github.com/sublimehq/Packages/search?utf8=%E2%9C%93&q=%22variable.other.constant%22&type=

`entity.name.constant` and indexing for assignments will be added at a later time when I add proper matching for assignments in general (including type annotations).