### PR TITLE
[Python] Highlight `_` as language variable

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -881,6 +881,8 @@ contexts:
   language-variables:
     - match: \b(self|cls)\b
       scope: variable.language.python
+    - match: _(?!{{identifier_continue}})
+      scope: variable.language.python
 
   line-continuation:
     - match: (\\)(.*)$\n?

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -110,6 +110,11 @@ open.open.open
 #            ^^^^^^^^^ constant.language.python
 
 
+_ self
+# <- variable.language.python
+# ^^^^ variable.language.python
+
+
 ##################
 # Function Calls
 ##################


### PR DESCRIPTION
`_` in itself does not have a special meaning, but it is a
conventionally used identifier much like `self` and `cls` for when you
don't want to store a value into a variable but are required to do so
syntactically.

This is usually the case for unpacking/pattern matching tuples or lists,
or in for loops.

Additionally, `_` has a special meaning in an interactive session where
it refers to the value returned by the last expression executed.