### PR TITLE
[Java] Add scopes for all operators

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -609,7 +609,7 @@ contexts:
     - match: ;
       scope: punctuation.terminator.java
   assignment:
-    - match: \=(?!=)
+    - match: ([|&^*/+-]\=|\=(?!=))
       scope: keyword.operator.assignment.java
       push:
         - meta_scope: meta.assignment.rhs.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -346,7 +346,9 @@ contexts:
     - match: '\?|:'
       scope: keyword.operator.ternary.java
     - match: \b(instanceof)\b
-      scope: keyword.operator.java
+      scope: keyword.operator.word.instanceof.java
+    - match: (<<|>>>?)
+      scope: keyword.operator.bitshift.java
     - match: (==|!=|<=|>=|<>|<|>)
       scope: keyword.operator.comparison.java
     - match: (\-\-|\+\+)
@@ -355,6 +357,8 @@ contexts:
       scope: keyword.operator.arithmetic.java
     - match: (!|&&|\|\|)
       scope: keyword.operator.logical.java
+    - match: (~|\^|&|\|)
+      scope: keyword.operator.bitwise.java
     - match: (\.)(class\b)?
       captures:
         1: punctuation.accessor.dot.java
@@ -605,7 +609,7 @@ contexts:
     - match: ;
       scope: punctuation.terminator.java
   assignment:
-    - match: \=
+    - match: \=(?!=)
       scope: keyword.operator.assignment.java
       push:
         - meta_scope: meta.assignment.rhs.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -705,7 +705,7 @@ public class Foo {
 //                   ^ - meta.parens.java
       return foo<<32;
 //    ^^^^^^ keyword.control.java
-//              ^^ keyword.operator.comparison.java
+//              ^^ keyword.operator.bitshift.java
 //                ^^ constant.numeric.java
 //                  ^ punctuation.terminator.java
     }
@@ -720,6 +720,23 @@ public class Foo {
 //                        ^ punctuation.terminator.java
 
     return foo<bar;
+
+    if (a == false) {
+//        ^^ keyword.operator.comparison
+
+        x = (e & 1) << c^2;
+//             ^ keyword.operator.bitwise
+//                  ^^ keyword.operator.bitshift
+//                      ^ keyword.operator.bitwise
+
+        y = ~e >>> (c | 2);
+//          ^ keyword.operator.bitwise
+//             ^^^ keyword.operator.bitshift
+//                    ^ keyword.operator.bitwise
+    }
+
+    boolean inst = a instanceof Object;
+//                   ^^^^^^^^^^ keyword.operator.word.instanceof
   }
 //^ meta.method.java meta.method.body.java punctuation.section.block.end.java
 

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -90,8 +90,7 @@ public class SyntaxTest {
 //                        ^ keyword.operator.comparison.java
 //                          ^^ constant.numeric.java
 //                            ^ punctuation.terminator.java
-//                               ^ keyword.operator.arithmetic.java
-//                                ^ keyword.operator.assignment.java
+//                               ^^ keyword.operator.assignment.java
 //                                 ^^ meta.assignment.rhs.java
 //                                   ^ - meta.assignment.rhs.java
             System.out.println(i);
@@ -733,6 +732,13 @@ public class Foo {
 //          ^ keyword.operator.bitwise
 //             ^^^ keyword.operator.bitshift
 //                    ^ keyword.operator.bitwise
+
+        z &= x; z ^= x; z *= x; z /= x;
+//        ^^ keyword.operator.assignment
+//                ^^ keyword.operator.assignment
+//                        ^^ keyword.operator.assignment
+//                                ^^ keyword.operator.assignment
+
     }
 
     boolean inst = a instanceof Object;


### PR DESCRIPTION
Fixes:

1. `==`, `<<`,  `>>`, `*=` and similar not being drawn with ligature.
2. `|`, `&`, `^` and `~` not being treated as operators.

Before:
<img width="210" alt="screen shot 2017-10-18 at 14 35 59" src="https://user-images.githubusercontent.com/6729879/31717677-94a2b0ec-b415-11e7-92d4-f037bb3ec8b1.png">

After:
<img width="199" alt="screen shot 2017-10-18 at 14 36 34" src="https://user-images.githubusercontent.com/6729879/31717678-94cdd114-b415-11e7-8f2a-f8a1d0e885d3.png">
  