### PR TITLE
[RST] Support multi-line comments

### DIFF
--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -196,5 +196,5 @@ contexts:
         1: punctuation.definition.comment.restructuredtext
       push:
         - meta_scope: comment.line.double-dot.restructuredtext
-        - match: $\n?
+        - match: '^(?=\S)'
           pop: true

--- a/RestructuredText/syntax_test_restructuredtext.rst
+++ b/RestructuredText/syntax_test_restructuredtext.rst
@@ -1,0 +1,62 @@
+.. SYNTAX TEST "Packages/RestructuredText/reStructuredText.sublime-syntax"
+
+.. a comment
+.. <- punctuation.definition.comment.restructuredtext
+.. ^^^^^^^^^ comment.line.double-dot.restructuredtext
+
+
+..
+  a multi-line comment is indented after initial ..
+..^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dot.restructuredtext
+
+
+..
+  a multi-line comment ends at the first character in the
+  first column
+
+Some text
+.. <- meta.paragraph.restructuredtext
+
+
+Paragraph of text
+.. <- meta.paragraph.restructuredtext
+
+A heading
+=========
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+---------
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+~~~~~~~~~
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+#########
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+"""""""""
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+^^^^^^^^^
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
++++++++++
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+A heading
+*********
+.. <- meta.paragraph.restructuredtext markup.heading.restructuredtext punctuation.definition.heading.restructuredtext
+
+
+This is *italic*.
+..      ^^^^^^^^ markup.italic.restructuredtext
+..      ^        punctuation.definition.italic.restructuredtext
+
+this is **bold**.
+..      ^^^^^^^^ markup.bold.restructuredtext


### PR DESCRIPTION
In reStructured Text, comments are multiline if they are indented after the initial `..`. Hence we need to capture up to, but not including the first non-whitespace character on a subsequent line.

See http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#comments.