### PR TITLE
[XML] add csproj as a hidden extension

### DIFF
--- a/XML/XML.sublime-settings
+++ b/XML/XML.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"hidden_extensions": ["rss", "sublime-snippet", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae"]
+	"hidden_extensions": ["rss", "sublime-snippet", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae", "csproj"]
 }


### PR DESCRIPTION
I've found myself working with .NET Core 2 a bit recently, and I noticed that the [`csproj` format](https://docs.microsoft.com/en-us/dotnet/core/tools/csproj) is XML but never includes a the XML declaration prolog. Therefore, the first line match regex pattern never matches, and one has to assign the XML syntax highlighting manually. 

I figured other people would also benefit from ST recognizing `.csproj` files as XML, so I've added it to the `hidden_extensions` in the `XML.sublime-settings` file (which already caters for`vcproj` files this way).