### PR TITLE
[PHP] Fix the static accessor (::) is not scoped

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1005,6 +1005,11 @@ contexts:
         2: variable.other.member.php
         3: punctuation.definition.variable.php
       push: after-identifier
+    - match: '(::)({{identifier}})?'
+      captures:
+        1: punctuation.accessor.php
+        2: constant.other.class.php
+      push: after-identifier
   parameter-default-types:
     - include: strings
     - include: numbers

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -156,7 +156,7 @@ contexts:
         - match: (::)({{identifier}})(?=\s*\()
           scope: meta.function-call.static.php
           captures:
-            1: punctuation.accessor.php
+            1: punctuation.accessor.double-colon.php
             2: variable.function.php
           set: function-call-parameters
         - match: |-
@@ -169,7 +169,7 @@ contexts:
                 ({{identifier}})
             )?
           captures:
-            1: punctuation.accessor.php
+            1: punctuation.accessor.double-colon.php
             2: constant.class.php
             3: variable.other.class.php
             4: punctuation.definition.variable.php
@@ -508,7 +508,7 @@ contexts:
               scope: keyword.other.insteadof.php
             - include: class-builtin
             - match: '::'
-              scope: punctuation.accessor.php
+              scope: punctuation.accessor.double-colon.php
             - match: (?={{path}})
               push:
                 - meta_scope: meta.path.php
@@ -951,7 +951,7 @@ contexts:
       push:
         - match: (->)({{identifier}})
           captures:
-            1: punctuation.accessor.php
+            1: punctuation.accessor.arrow.php
             2: variable.other.member.php
           pop: true
         - match: '\['
@@ -985,7 +985,7 @@ contexts:
   object:
     - match: '(->)(\$?\{)'
       captures:
-        1: punctuation.accessor.php
+        1: punctuation.accessor.arrow.php
         2: punctuation.definition.variable.php
       push:
         - match: '(\})'
@@ -996,18 +996,18 @@ contexts:
     - match: (->)({{identifier}})(?=\s*\()
       scope: meta.function-call.method.php
       captures:
-        1: punctuation.accessor.php
+        1: punctuation.accessor.arrow.php
         2: variable.function.php
       push: function-call-parameters
     - match: (->)((\$+)?{{identifier}})?
       captures:
-        1: punctuation.accessor.php
+        1: punctuation.accessor.arrow.php
         2: variable.other.member.php
         3: punctuation.definition.variable.php
       push: after-identifier
     - match: '(::)({{identifier}})?'
       captures:
-        1: punctuation.accessor.php
+        1: punctuation.accessor.double-colon.php
         2: constant.other.class.php
       push: after-identifier
   parameter-default-types:
@@ -1036,7 +1036,7 @@ contexts:
       push:
         - match: '(::)({{identifier}})?'
           captures:
-            1: punctuation.accessor.php
+            1: punctuation.accessor.double-colon.php
             2: constant.other.class.php
           pop: true
         - include: class-name

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -570,6 +570,13 @@ class B
         echo B::class;
 //              ^ constant.class
 
+        echo $this->pro1::FOO;
+//           ^^^^^ variable.language
+//                ^^ punctuation.accessor
+//                  ^^^^ variable.other.member
+//                      ^^ punctuation.accessor
+//                        ^^^ constant.other.class
+
         parent::abc($var, $var2, $var3);
 //      ^^^^^^ variable.language
 //            ^^ punctuation.accessor


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6594915/32046329-54ebefe8-ba75-11e7-9551-7e21c0d33125.png)

```php
<?php

$foo::BAZ;
$foo->bar::BAZ;
$foo->bar['x']::BAZ;
```

It look like GitHub's code highlight doesn't highlight it well either.