### PR TITLE
[C#] fix bug whereby == was being scoped as an assignment in a func call

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -802,7 +802,7 @@ contexts:
       set: [else_block, if_block, if_condition]
     - match: \b(switch)\b
       captures:
-        1: keyword.control.conditional.if.cs
+        1: keyword.control.flow.switch.cs
       set: [switch_block, if_condition]
     - match: \b(for)\s*(\()
       captures:

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1321,7 +1321,7 @@ contexts:
     - match: (ref)\s
       captures:
         1: storage.modifier.argument.cs
-    - match: '({{name}})\s*(=)'
+    - match: '({{name}})\s*(=)(?!=)'
       captures:
         1: variable.parameter.cs
         2: keyword.operator.assignment.cs

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1149,6 +1149,10 @@ namespace TestNamespace.Test
 ///                                 ^^^^^^^^^^^^^^^^^^^^^^ constant.other.placeholder - invalid
 ///                                            ^^^^ constant.character.escape
 ///                                                      ^ punctuation.definition.placeholder.end
+        formatted = string.Format(test, hello == true, world);
+///                                     ^^^^^ variable.other - variable.parameter
+///                                                    ^^^^^ variable.other - variable.parameter
+///                                           ^^ keyword.operator - keyword.operator.assignment
     }
 }
 ///<- punctuation.section.block.end

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -313,7 +313,7 @@ namespace TestNamespace.Test
 ///         ^ meta.method meta.block meta.block punctuation.section.block.end
 
             switch (foo) {
-///         ^ keyword.control
+///         ^^^^^^ keyword.control.flow.switch
 ///                ^^^^^ meta.group
 ///                ^ punctuation.section.group.begin
 ///                 ^^^ variable.other


### PR DESCRIPTION
`==` is an equality check, not an assignment, but prior to this PR, it was being scoped incorrectly in method calls. This also meant that some arguments to the method had different scopes and colors to other arguments, which was wrong.

i.e. `Console.WriteLine(hello == true, world);` - `hello` and `world` are both just normal variables and should be scoped the same, and the `==` is not an assignment but an equality check.