### PR TITLE
[Java] Better handling of numbers

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -302,7 +302,31 @@ contexts:
       scope: constant.language.java
     - match: \b(this|super)\b
       scope: variable.language.java
-    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
+    # Trailing underscores are allowed to prevent numbers from flickering while typing
+    - match: |-
+        (?x)
+        (?:
+          \b0(?:
+            [xX](?!_)[[:xdigit:]_]*[[:xdigit:]]
+            |
+            [bB](?!_)[01_]*[01]
+            |
+            [0-7_]*[0-7]+
+          )?(?:_*|[Ll]?)\b
+        |
+          \b[1-9](?:[\d_]*\d)?
+          (?:
+            _*
+            |
+            [LlFfDd]
+            |
+            \.(?!_)[\d_]*\d(?:[eE][+-]?(?!_)[\d_]*\d)?(?:_*|[FfDd]?)
+            |
+            [eE][+-]?(?!_)[\d_]*\d(?:_*|[FfDd]?)
+          )?\b
+        |
+          \.(?!_)[\d_]*\d(?:[eE][+-]?(?!_)[\d_]*\d)?(?:_*|[FfDd]?)\b
+        )
       scope: constant.numeric.java
   constant-reference:
     - match: '(\.)?(?!{{classes_named_as_constants}})\b([A-Z][A-Z0-9_]+)(?!<|\.class|\s*\w+\s*=)\b'

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -746,6 +746,81 @@ public class Foo {
   }
 //^ meta.method.java meta.method.body.java punctuation.section.block.end.java
 
+  int numbers() {
+    a = 0 + 0L;
+//      ^ constant.numeric
+//        ^ keyword.operator
+//          ^^ constant.numeric
+
+    a = 0xABCD + 0xAB_CD;
+//      ^^^^^^ constant.numeric
+//             ^ keyword.operator
+//               ^^^^^^ constant.numeric
+
+    a = 0xAB_CD_ - 0x_AB_CD - 0_xAB_CD;
+//      ^^^^^^^^ constant.numeric
+//                 ^^^^^^^^ -constant.numeric
+//                            ^^^^^^^^ -constant.numeric
+
+    a = 07 + 0_7;
+//      ^^ constant.numeric
+//         ^ keyword.operator
+//           ^^^ constant.numeric
+
+    a = 07_ - 09;
+//      ^^^ constant.numeric
+//            ^^ -constant.numeric
+
+    a = 0b101101 + 0b10_11_01;
+//      ^^^^^^^^ constant.numeric
+//               ^ keyword.operator
+//                 ^^^^^^^^^^ constant.numeric
+
+    a = 0b_101101;
+//      ^^^^^^^^^ -constant.numeric
+
+    a = 12345 + 12_34_5 + 1_____5;
+//      ^^^^^ constant.numeric
+//              ^^^^^^^ constant.numeric
+//                        ^^^^^^^ constant.numeric
+
+    a = 12345l + 12345L + 123_45d + 12_3245F
+//      ^^^^^^ constant.numeric
+//               ^^^^^^ constant.numeric
+//                        ^^^^^^^ constant.numeric
+//                                  ^^^^^^^^ constant.numeric
+
+    a = 12_34_5_ - _12_34_5 - 12_D - 12_L;
+//      ^^^^^^^^ constant.numeric
+//                 ^^^^^^^^ -constant.numeric
+//                            ^^^^ -constant.numeric
+//                                   ^^^^ -constant.numeric
+
+    a = 123_-_456;
+//      ^^^^ constant.numeric
+//          ^ keyword.operator
+//           ^^^^ -constant.numeric
+
+    a = 23.45 + 23.45F + 23.45d
+//      ^^^^^ constant.numeric
+//              ^^^^^^ constant.numeric
+//                       ^^^^^^ constant.numeric
+
+    a = .01 + .02e3+.02e3F
+//      ^^^ constant.numeric
+//          ^ keyword.operator
+//            ^^^^^ constant.numeric
+//                 ^ keyword.operator
+//                   ^^^^^ constant.numeric
+
+    a = 23.45e67+23.45e+6F+23.45e-67D
+//      ^^^^^^^^ constant.numeric
+//              ^ keyword.operator
+//               ^^^^^^^^^ constant.numeric
+//                        ^ keyword.operator
+//                         ^^^^^^^^^^ constant.numeric
+  }
+
   @Test
 //^ punctuation.definition.annotation.java
   public void someMethod(WithParam foo) throws Exception {


### PR DESCRIPTION
New regex for numbers. Old one was definitely C-inspired as Java doesn't have `U` modifier.

New one handles underscores in numbers (like `123_45_6`) and binary numbers (`0b00110101`).