### PR TITLE
[Graphviz] use new embed action for embedded HTML and tidy up comments

### DIFF
--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -56,15 +56,12 @@ contexts:
         - match: '((>)?\s*)(>)'
           captures:
             1: source.dot.embedded.html
-            2: punctuation.definition.tag.end.html
+            2: meta.tag punctuation.definition.tag.end.html
             3: punctuation.section.embedded.end.dot
           pop: true
         - match: ''
-          push:
-            - include: 'scope:text.html.basic'
-          with_prototype:
-            - match: '(?=>\s*>)'
-              pop: true
+          embed: scope:text.html.basic
+          escape: (?=>\s*>)
 
   braces:
     - match: \{
@@ -74,7 +71,7 @@ contexts:
         - match: \}
           scope: punctuation.definition.group.end.dot
           pop: true
-        - match: ',|;'
+        - match: '[,;]'
           scope: punctuation.separator.dot
         - include: expressions
 
@@ -86,19 +83,23 @@ contexts:
         - match: \]
           scope: punctuation.definition.attributes.end.dot
           pop: true
-        - match: ',|;'
+        - match: '[,;]'
           scope: punctuation.separator.dot
         - include: expressions
 
   comments:
-    - match: (//).*$\n?
-      scope: comment.line.double-slash.dot
-      captures:
-        1: punctuation.definition.comment.dot
-    - match: (#).*$\n?
-      scope: comment.line.number-sign.dot
-      captures:
-        1: punctuation.definition.comment.dot
+    - match: //
+      scope: punctuation.definition.comment.dot
+      push:
+        - meta_scope: comment.line.double-slash.dot
+        - match: $\n?
+          pop: true
+    - match: '#'
+      scope: punctuation.definition.comment.dot
+      push:
+        - meta_scope: comment.line.number-sign.dot
+        - match: $\n?
+          pop: true
     - match: /\*
       scope: punctuation.definition.comment.dot
       push:

--- a/Graphviz/syntax_test_dot.dot
+++ b/Graphviz/syntax_test_dot.dot
@@ -67,8 +67,9 @@ digraph structs {
 //                                              ^ punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
   <TR><TD PORT="f0">one</TD><TD>two</TD></TR>
 </TABLE> >];
-// ^^^^       source.dot.embedded.html
 // ^^^^^^     source.dot.embedded.html
+//^^^^^^ meta.tag
+//      ^ - meta.tag
 //     ^      punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
 //       ^    punctuation.section.embedded.end.dot - source.dot.embedded.html
     struct1:f1 -> struct2:f0;


### PR DESCRIPTION
This PR updates the Graphviz syntax to use the new `embed`/`escape` action for embedded HTML and updates the `comments` context to use the preferred style of pushing into a context and pushing at the end of the line (instead of matching the comment start token and the rest of the line in one pattern).