### PR TITLE
[Python] Fix New-Property snippet not being suggested

### DIFF
--- a/Python/Snippets/New-Property.sublime-snippet
+++ b/Python/Snippets/New-Property.sublime-snippet
@@ -4,6 +4,6 @@ def ${1:foo}(self):
 	return self.${2:_$1}
 $0]]></content>
 	<tabTrigger>property</tabTrigger>
-	<scope>source.python meta.function.decorator</scope>
+	<scope>source.python meta.annotation</scope>
 	<description>New Property</description>
 </snippet>


### PR DESCRIPTION
fixes #1264

Due to scope changes the "New-Property" snippet was no longer available to end users.

Therefore the snippet scope needs to be changed to `meta.annotation`, too.