### PR TITLE
[C#] support namespace aliases in using directives

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -217,7 +217,15 @@ contexts:
         3: meta.path.cs
       push: using_namespace
 
+  namespace_alias:
+    - match: '(?:(global)|({{name}}))\s*(::)'
+      captures:
+        1: support.namespace.cs
+        2: variable.other.namespace.cs
+        3: punctuation.accessor.double-colon.namespace.cs
+
   using_namespace:
+    - include: namespace_alias
     - match: '{{name}}'
       scope: meta.path.cs
     - match: '='
@@ -230,7 +238,7 @@ contexts:
     - match: ';'
       scope: punctuation.terminator.cs
       pop: true
-    - match: '\S+'
+    - match: '[^\s;]+'
       scope: invalid.illegal.expected-namespace.cs
     - match: '$'
       pop: true
@@ -923,11 +931,7 @@ contexts:
         1: entity.name.label.cs
         2: punctuation.separator.cs
       pop: true
-    - match: '(?:(global)|({{name}}))\s*(::)'
-      captures:
-        1: support.namespace.cs
-        2: variable.other.namespace.cs
-        3: punctuation.accessor.double-colon.namespace.cs
+    - include: namespace_alias
     - match: '({{name}})\s+({{name}})'
       captures:
         1: support.type.cs
@@ -1365,11 +1369,7 @@ contexts:
       scope: support.type.cs
 
   type_common:
-    - match: '(?:(global)|({{name}}))\s*(::)'
-      captures:
-        1: support.namespace.cs
-        2: variable.other.namespace.cs
-        3: punctuation.accessor.double-colon.namespace.cs
+    - include: namespace_alias
     - match: '(class|struct|enum)'
       scope: storage.type.other.cs
     - match: 'new\s*\(\s*\)'

--- a/C#/tests/syntax_test_Using.cs
+++ b/C#/tests/syntax_test_Using.cs
@@ -18,6 +18,30 @@ using Wrapped = PC.MyCompany.Project.Wrapper<float>;
 ///    ^ meta.path
 ///           ^ keyword.operator.assignment
 ///                                            ^ storage.type
+using col = global::System.Collections;
+///^^ keyword.control.import
+///   ^^^ meta.path
+///       ^ keyword.operator.assignment
+///         ^^^^^^ support.namespace
+///               ^^ punctuation.accessor.double-colon.namespace
+///                 ^^^^^^ meta.path
+///                       ^ punctuation.separator.namespace
+///                        ^^^^^^^^^^^ meta.path
+///                                   ^ punctuation.terminator
+using sys = global::System;
+///^^ keyword.control.import
+///   ^^^ meta.path
+///       ^ keyword.operator.assignment
+///         ^^^^^^ support.namespace
+///               ^^ punctuation.accessor.double-colon.namespace
+///                 ^^^^^^ meta.path
+///                       ^ punctuation.terminator
+using abc = global:test;
+///   ^^^ meta.path
+///       ^ keyword.operator.assignment
+///         ^^^^^^ meta.path
+///               ^^^^^ invalid.illegal.expected-namespace
+///                    ^ punctuation.terminator
 
 class Foo {
 
@@ -38,8 +62,12 @@ class Foo {
 ///     ^ meta.method meta.block meta.block punctuation.section.block.begin
             // Use font3
             global::System.Console.WriteLine("foo");
-///         ^ support.namespace
-///               ^ punctuation.accessor.double-colon
+///         ^^^^^^ support.namespace
+///               ^^ punctuation.accessor.double-colon
+///                       ^ punctuation.accessor.dot
+///                        ^^^^^^^ variable.other
+///                               ^ punctuation.accessor.dot
+///                                ^^^^^^^^^ variable.function
         }
 ///     ^ meta.method meta.block meta.block punctuation.section.block.end
 
@@ -92,13 +120,21 @@ class Foo {
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
 ///  ^ support.namespace
 ///    ^^ punctuation.accessor.double-colon
-internal sealed partial class Test : global::System.Configuration.ApplicationSettingsBase {
-///                                    ^ support.namespace
-///                                        ^^ punctuation.accessor.double-colon
+///      ^^^^^^ variable.other.namespace
+///            ^ punctuation.accessor.dot.namespace
+///             ^^^^^^^ variable.other.namespace
+internal sealed partial class Test : sys::Configuration.ApplicationSettingsBase {
+///                                  ^^^ meta.path
+///                                     ^^ punctuation.accessor.double-colon
+///                                       ^^^^^^^^^^^^^ meta.path
+///                                                    ^ punctuation.accessor.dot.namespace
+///                                                     ^^^^^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
 
     private static Test defaultInstance = ((Test)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Test())));
-///                                                ^ support.namespace
+///                                               ^^^^^^ support.namespace
 ///                                                     ^^ punctuation.accessor.double-colon
+///                                                       ^^^^^^ variable.other
+///                                                             ^ punctuation.accessor.dot
 
     public static Test Default {
         [Tag]


### PR DESCRIPTION
some support for namespace aliases already existed in the C# syntax definition, but it was missing for `using` directives. This PR adds that, and thus fixes #1283. It also marks the `;` as a terminator instead of invalid when namespaces are expected but missing.