### PR TITLE
[ruby] need to pop the context earlier to match regex

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -282,7 +282,7 @@ contexts:
     - match: \|
       scope: meta.block.parameters.ruby punctuation.definition.parameters.begin.ruby
       set: block-parameters
-    - match: (?=\S)
+    - match: (?=\s*[^\s\|])
       pop: true
 
   block-parameters:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -458,3 +458,8 @@ a = b / "c"
 foo / "bar/bla"
 #   ^ keyword.operator.arithmetic.ruby
 #     ^^^^^^^^^ string.quoted.double.ruby
+
+{
+  /foo/ => :foo
+# ^^^^^ string.regexp.classic.ruby
+}


### PR DESCRIPTION
fix the issue mentioned in https://github.com/sublimehq/Packages/pull/1142#issuecomment-335493118