### PR TITLE
[Python] Don't highlight types in `from` lists

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -96,21 +96,24 @@ contexts:
       push:
         - meta_scope: meta.statement.import.python
         - include: line-continuation-or-pop
-        - include: import-alias
-        - include: qualified-name
         - match: ','
           scope: punctuation.separator.import-list.python
+        - match: \.
+          scope: invalid.illegal.unexpected-relative-import.python
+        - include: import-alias
+        - include: qualified-name
         - match: (?=\S)
           pop: true
     - match: \b(from)\b
       scope: keyword.control.import.from.python
       push:
         - meta_scope: meta.statement.import.python
-          meta_content_scope: meta.import-source.python
+        - meta_content_scope: meta.import-source.python
         - include: line-continuation-or-pop
         - match: \b(import)\b
           scope: keyword.control.import.python
           set:
+            - meta_scope: meta.statement.import.python
             - include: line-continuation-or-pop
             - match: ' *(\()'
               captures:
@@ -133,9 +136,7 @@ contexts:
                   pop: true
             - match: (?=\S)
               pop: true
-        - include: qualified-name
-        - match: (\.)
-          scope: punctuation.accessor.dot.python
+        - include: import-from-name
         - match: (?=\S)
           pop: true
 
@@ -152,6 +153,23 @@ contexts:
   import-alias:
     - match: \b(as)\b
       scope: keyword.control.import.as.python
+
+  import-from-name:
+    - match: (?=(\. *)?{{path}})
+      push:
+        - meta_scope: meta.import-path.python
+        - match: '{{identifier}}'
+          scope: meta.import-name.python
+        - match: \s*(\.) *({{identifier}})
+          captures:
+            1: punctuation.accessor.dot.python
+            2: meta.import-name.python
+        - match: \ *(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
+          captures:
+            1: invalid.illegal.name.python
+          pop: true
+        - match: ''
+          pop: true
 
   block-statements:
     # async for ... in ...:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -70,6 +70,21 @@ import re; re.compile(r'')
 #        ^^^^^^^^^^^^^^^^^ - meta.statement.import
 #        ^ punctuation.terminator.statement
 
+from unicode.__init__ . 123 import unicode as unicode
+#    ^^^^^^^^^^^^^^^^^^^^^^ meta.import-source.python meta.import-path.python
+#    ^^^^^^^ meta.import-name.python - support
+#           ^ punctuation.accessor.dot.python
+#            ^^^^^^^^ meta.import-name.python - support
+#                     ^^^^^ invalid.illegal.name.python
+#                                  ^^^^^^^ support.type.python
+#                                             ^^^^^^^ support.type.python
+
+import .str
+#      ^ invalid.illegal.unexpected-relative-import.python
+#       ^^^ support.type.python
+
+import str
+#      ^^^ support.type.python
 
 ##################
 # Identifiers


### PR DESCRIPTION
However, still do highlight them for `import str` to indicate potential naming collisions with built-in types.

Also highlight invalid relative imports (i.e. `import .anything`).

Fixes #1250.