### PR TITLE
[Lua] Fix auto-indenting for functions

### DIFF
--- a/Lua/Indent.tmPreferences
+++ b/Lua/Indent.tmPreferences
@@ -10,7 +10,7 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*(elseif|else|end|\})\s*$</string>
 		<key>increaseIndentPattern</key>
-		<string>^\s*(else|elseif|for|(local\s+)?function|if|repeat|until|while)\b((?!end).)*$|\{\s*$</string>
+		<string>^\s*(else|elseif|for|(local[\s\w=]+)?function|if|repeat|until|while)\b((?!end).)*$|\{\s*$</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26496/32571244-0d77a326-c4c7-11e7-88ce-cae6f5f3658b.png)

In the first and the third case in that image, the content of the function is auto-indented, but not for the second variant (which is commonly used for recursion).

This commit fixes that.