### PR TITLE
[JavaScript] Add support for class fields

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -785,6 +785,23 @@ contexts:
     - match: '\}'
       scope: punctuation.section.block.js
       pop: true
+
+    - match: \bconstructor\b
+      scope: entity.name.function.constructor.js
+      push:
+        - function-declaration-expect-body
+        - function-declaration-meta
+        - function-declaration-expect-parameters
+
+    - match: \bstatic\b
+      scope: storage.modifier.js
+      push:
+        - include: class-field
+        - include: else-pop
+
+    - include: class-field
+
+  class-field:
     - include: method-declaration
 
   constants:
@@ -1172,7 +1189,7 @@ contexts:
   method-declaration:
     - match: |-
         (?x)(?=
-          \b(?: get|set|async|static )\b
+          \b(?: get|set|async )\b
           | \*
           | {{method_name}} \s* \(
         )
@@ -1188,8 +1205,6 @@ contexts:
       scope: keyword.generator.asterisk.js
     - match: \b(get|set)\b(?!\s*\()
       scope: storage.type.accessor.js
-    - match: \bstatic\b
-      scope: storage.type.js
     - include: else-pop
 
   parenthesized-expression:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -806,25 +806,46 @@ contexts:
 
     - match: \bstatic\b
       scope: storage.modifier.js
-      push:
-        - include: class-field
-        - include: else-pop
-
-    - include: class-field
-
-  class-field:
-    - include: method-declaration
+      push: class-field
 
     - match: (?={{property_name}})
+      push: class-field
+
+  class-field:
+    - match: '{{method_lookahead}}'
+      set: method-declaration
+      
+    - match: (?={{property_name}})
+      set:
+        - field-initializer-or-method-declaration
+        - field-name
+
+    - include: else-pop
+
+  class-field-rest:
+    - match: ','
+      scope: punctuation.separator.js
       push:
         - field-initializer
         - field-name
+    - include: else-pop
 
   field-initializer:
     - match: =
       scope: keyword.operator.assignment.js
-      set: expression-statement
+      set: expression-no-comma
     - include: else-pop
+
+  field-initializer-or-method-declaration:
+    - match: (?=\()
+      set:
+        - function-declaration-expect-body
+        - function-declaration-meta
+        - function-declaration-expect-parameters
+    - match: (?=\S)
+      set:
+        - class-field-rest
+        - field-initializer
 
   constants:
     - match: \btrue\b
@@ -1124,7 +1145,8 @@ contexts:
             - object-literal-meta-key
             - method-name
 
-        - include: method-declaration
+        - match: '{{method_lookahead}}'
+          push: method-declaration
 
         - match: '{{identifier}}(?=\s*(?:[},]|$|//|/\*))'
           scope: variable.other.readwrite.js
@@ -1252,8 +1274,8 @@ contexts:
     - include: else-pop
 
   method-declaration:
-    - match: '{{method_lookahead}}'
-      push:
+    - match: ''
+      set:
         - function-declaration-expect-body
         - function-declaration-meta
         - function-declaration-expect-parameters

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -23,6 +23,12 @@ variables:
       | \[ {{identifier}} (?:\.{{identifier}})* \]
     )
 
+  class_element_name: |-
+    (?x)(?:
+      {{property_name}}
+      | \#{{identifier}}
+    )
+
   method_lookahead: |-
     (?x)(?=
       \b(?: get|set|async )\b
@@ -808,7 +814,7 @@ contexts:
       scope: storage.modifier.js
       push: class-field
 
-    - match: (?={{property_name}})
+    - match: (?={{class_element_name}})
       push: class-field
 
   class-field:
@@ -818,6 +824,12 @@ contexts:
     - match: (?={{property_name}})
       set:
         - field-initializer-or-method-declaration
+        - field-name
+
+    - match: (?=#{{identifier}})
+      set:
+        - class-field-rest
+        - field-initializer
         - field-name
 
     - include: else-pop
@@ -1263,6 +1275,10 @@ contexts:
             2: invalid.illegal.newline.js
           pop: true
         - include: string-content
+    - match: (#)({{identifier}})
+      captures:
+        1: punctuation.definition.variable.js
+        2: variable.other.readwrite.js
 
     - match: '(\[)({{identifier}}(?:\.{{identifier}}|\.)*)?(\])?'
       captures:
@@ -1532,6 +1548,10 @@ contexts:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.js
       pop: true
+    - match: (#)({{identifier}})
+      captures:
+        1: punctuation.definition.variable.js
+        2: variable.other.readwrite.js
 
   support:
     - match: \bdebugger\b

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -15,12 +15,19 @@ variables:
   func_lookahead: '\s*\b(async\s+)?function\b'
   arrow_func_lookahead: '\s*(\basync\s*)?([_$[:alpha:]][_$[:alnum:]]*|\(([^()]|\([^()]*\))*\))\s*=>'
 
-  method_name: >-
+  property_name: >-
     (?x)(?:
       {{identifier}}
       | '(?:[^\\']|\\.)*'
       | "(?:[^\\"]|\\.)*"
       | \[ {{identifier}} (?:\.{{identifier}})* \]
+    )
+
+  method_lookahead: |-
+    (?x)(?=
+      \b(?: get|set|async )\b
+      | \*
+      | {{property_name}} \s* \(
     )
 
   line_continuation_lookahead: >-
@@ -782,9 +789,13 @@ contexts:
 
   class-body:
     - meta_scope: meta.class.js meta.block.js
+
     - match: '\}'
       scope: punctuation.section.block.js
       pop: true
+
+    - match: \;
+      scope: punctuation.terminator.statement.js
 
     - match: \bconstructor\b
       scope: entity.name.function.constructor.js
@@ -803,6 +814,17 @@ contexts:
 
   class-field:
     - include: method-declaration
+
+    - match: (?={{property_name}})
+      push:
+        - field-initializer
+        - field-name
+
+  field-initializer:
+    - match: =
+      scope: keyword.operator.assignment.js
+      set: expression-statement
+    - include: else-pop
 
   constants:
     - match: \btrue\b
@@ -1092,7 +1114,7 @@ contexts:
 
         - match: >-
             (?x)(?=
-              {{method_name}}\s*:
+              {{property_name}}\s*:
               (?: {{func_lookahead}} | {{arrow_func_lookahead}} )
             )
           push:
@@ -1186,13 +1208,51 @@ contexts:
 
     - include: else-pop
 
+  field-name:
+    - match: '(\$)[_$[:alnum:]]*'
+      scope: meta.object-literal.key.dollar.js variable.other.readwrite.js
+      captures:
+        1: punctuation.dollar.js
+      pop: true
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.js
+      pop: true
+    - match: "'"
+      scope: punctuation.definition.string.begin.js
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.single.js
+        - meta_content_scope: variable.other.readwrite.js
+        - match: (')|(\n)
+          captures:
+            1: punctuation.definition.string.end.js
+            2: invalid.illegal.newline.js
+          pop: true
+        - include: string-content
+    - match: '"'
+      scope: punctuation.definition.string.begin.js
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.js
+        - meta_content_scope: variable.other.readwrite.js
+        - match: (")|(\n)
+          captures:
+            1: punctuation.definition.string.end.js
+            2: invalid.illegal.newline.js
+          pop: true
+        - include: string-content
+
+    - match: '(\[)({{identifier}}(?:\.{{identifier}}|\.)*)?(\])?'
+      captures:
+        1: punctuation.definition.symbol.begin.js
+        2: variable.other.readwrite.js
+        3: punctuation.definition.symbol.end.js
+      pop: true
+
+    - include: else-pop
+
   method-declaration:
-    - match: |-
-        (?x)(?=
-          \b(?: get|set|async )\b
-          | \*
-          | {{method_name}} \s* \(
-        )
+    - match: '{{method_lookahead}}'
       push:
         - function-declaration-expect-body
         - function-declaration-meta

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -609,6 +609,23 @@ class MyClass extends TheirClass {
 //             ^ keyword.operator.assignment
 //               ^^ constant.numeric
 
+    a, 'b' = 50, "c", [d] = 100;
+//  ^ variable.other.readwrite
+//      ^ variable.other.readwrite
+//                ^ variable.other.readwrite
+//                     ^ variable.other.readwrite
+
+    static a, 'b' = 50, "c", [d] = 100;
+//  ^^^^^^ storage.modifier.js
+//         ^ variable.other.readwrite
+//             ^ variable.other.readwrite
+//                       ^ variable.other.readwrite
+//                            ^ variable.other.readwrite
+
+    foo // You thought I was a field...
+    () { return '...but was a method all along!'; }
+//  ^^^ meta.class.js meta.block.js meta.function.declaration.js
+
     constructor(el)
 //  ^^^^^^^^^^^^^^^ meta.function.declaration
     // ^ entity.name.function.constructor

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -556,6 +556,59 @@ class MyClass extends TheirClass {
 //    ^^^^^^^ entity.name.class
 //            ^^^^^^^ storage.modifier.extends
 //                               ^ meta.block
+
+    x = 42;
+//  ^ variable.other.readwrite
+//    ^ keyword.operator.assignment
+//      ^^ constant.numeric
+
+    'y' = 42;
+//  ^^^ string.quoted.single
+//   ^ variable.other.readwrite
+//      ^ keyword.operator.assignment
+//        ^^ constant.numeric
+
+    "z" = 42;
+//  ^^^ string.quoted.double
+//   ^ variable.other.readwrite
+//      ^ keyword.operator.assignment
+//        ^^ constant.numeric
+
+    [w] = 42;
+//  ^ punctuation.definition.symbol.begin
+//   ^ variable.other.readwrite
+//    ^ punctuation.definition.symbol.end
+//      ^ keyword.operator.assignment
+//        ^^ constant.numeric
+
+    static x = 42;
+//  ^^^^^^ storage.modifier.js
+//         ^ variable.other.readwrite
+//           ^ keyword.operator.assignment
+//             ^^ constant.numeric
+
+    static 'y' = 42;
+//  ^^^^^^ storage.modifier.js
+//         ^^^ string.quoted.single
+//          ^ variable.other.readwrite
+//             ^ keyword.operator.assignment
+//               ^^ constant.numeric
+
+    static "z" = 42;
+//  ^^^^^^ storage.modifier.js
+//         ^^^ string.quoted.double
+//          ^ variable.other.readwrite
+//             ^ keyword.operator.assignment
+//               ^^ constant.numeric
+
+    static [w] = 42;
+//  ^^^^^^ storage.modifier.js
+//         ^ punctuation.definition.symbol.begin
+//          ^ variable.other.readwrite
+//           ^ punctuation.definition.symbol.end
+//             ^ keyword.operator.assignment
+//               ^^ constant.numeric
+
     constructor(el)
 //  ^^^^^^^^^^^^^^^ meta.function.declaration
     // ^ entity.name.function.constructor

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -581,6 +581,12 @@ class MyClass extends TheirClass {
 //      ^ keyword.operator.assignment
 //        ^^ constant.numeric
 
+    #v = 42;
+//  ^ punctuation.definition.variable
+//   ^ variable.other.readwrite
+//     ^ keyword.operator.assignment
+//       ^^ constant.numeric
+
     static x = 42;
 //  ^^^^^^ storage.modifier.js
 //         ^ variable.other.readwrite
@@ -609,22 +615,37 @@ class MyClass extends TheirClass {
 //             ^ keyword.operator.assignment
 //               ^^ constant.numeric
 
-    a, 'b' = 50, "c", [d] = 100;
+    static #v = 42;
+//         ^ punctuation.definition.variable
+//          ^ variable.other.readwrite
+//            ^ keyword.operator.assignment
+//              ^^ constant.numeric
+
+    a, 'b' = 50, "c", [d] = 100, #e;
 //  ^ variable.other.readwrite
 //      ^ variable.other.readwrite
 //                ^ variable.other.readwrite
 //                     ^ variable.other.readwrite
+//                                ^ variable.other.readwrite
 
-    static a, 'b' = 50, "c", [d] = 100;
+    static a, 'b' = 50, "c", [d] = 100, #e;
 //  ^^^^^^ storage.modifier.js
 //         ^ variable.other.readwrite
 //             ^ variable.other.readwrite
 //                       ^ variable.other.readwrite
 //                            ^ variable.other.readwrite
+//                                       ^ variable.other.readwrite
 
     foo // You thought I was a field...
     () { return '...but was a method all along!'; }
 //  ^^^ meta.class.js meta.block.js meta.function.declaration.js
+
+    someMethod() {
+        return #e * 2;
+//             ^ punctuation.definition.variable
+//              ^ variable.other.readwrite
+//                ^ keyword.operator.arithmetic
+    }
 
     constructor(el)
 //  ^^^^^^^^^^^^^^^ meta.function.declaration

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -387,11 +387,8 @@ var obj = {
     "key '(": true,
     // <- meta.object-literal.key
 
-    static foo(bar) {
-//  ^^^^^^^^^^^^^^^ meta.function.declaration
-    // ^ storage.type
-    //      ^entity.name.function
-    },
+    static,
+//  ^^^^^^ variable.other.readwrite
 
     *baz(){
 //  ^^^^^^ meta.function.declaration
@@ -561,7 +558,7 @@ class MyClass extends TheirClass {
 //                               ^ meta.block
     constructor(el)
 //  ^^^^^^^^^^^^^^^ meta.function.declaration
-    // ^ entity.name.function
+    // ^ entity.name.function.constructor
     {
 //  ^ meta.class meta.block meta.block punctuation.section.block
         $.foo = "";
@@ -578,9 +575,9 @@ class MyClass extends TheirClass {
     }
 
     static foo(baz) {
-//  ^^^^^^^^^^^^^^^ meta.function.declaration
-    // ^ storage.type
-    //       ^ entity.name.function
+//  ^^^^^^ storage.modifier
+//         ^^^^^^^^ meta.function.declaration
+    //     ^^^ entity.name.function
 
     }
 


### PR DESCRIPTION
Implements the [class fields proposal](https://github.com/tc39/proposal-class-fields). See #1269 for more discussion. Also resolves #1238 and partially resolves #876.

Outline of changes:

- No longer recognize the `static` keyword in object literals. It should be interpreted as an identifier.
- In classes, rescope `static` as `storage.modifier`. It was previously scoped as `storage.type`.
- Recognize class property declarations and initializers in class bodies.
- Recognize private class properties in expressions.

Relevant to https://github.com/tc39/proposal-class-fields/issues/57.