### PR TITLE
[ShellScript] Allow functions in functions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -53,7 +53,7 @@ variables:
   is_command: \s*(?=\S)
   is_end_of_interpolation: \)
   is_end_of_option: '[^\w$-]|$'
-  is_function: \b(function)\s+|(?=\s*{{identifier_non_posix}}\s*\(\s*\))
+  is_function: \s*\b(function)\s+|(?=\s*{{identifier_non_posix}}\s*\(\s*\))
   is_path_component: (?=[^\s/]*/)
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
@@ -274,7 +274,7 @@ contexts:
     - match: \s*
       set:
         - meta_content_scope: entity.name.function.shell
-        - match: (?=\s*[({])
+        - match: (?=\s*[({]|$)
           pop: true
 
   funcdef-parens:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2013,6 +2013,68 @@ typeset -f _init_completion > /dev/null && complete -F _upto upto
 #                           ^ keyword.operator.assignment.redirection
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 
+function foo
+# <- meta.function
+#^^^^^^^^^^^ meta.function
+#       ^ - entity.name.function
+#        ^^^ entity.name.function
+#           ^ - entity.name.function
+{
+# <- punctuation.section
+    foo bar
+    # <- variable.function
+    # <- meta.function meta.function-call
+}
+# <- punctuation.section
+
+# <- - meta.function
+
+function foo (     ) {
+# <- meta.function
+#^^^^^^^^^^^ meta.function
+#       ^ - entity.name.function
+#        ^^^ entity.name.function
+#           ^ - entity.name.function
+#            ^ punctuation.section
+#                  ^ punctuation.section
+#                    ^ punctuation.section
+    echo 'hello from foo'
+    # <- support.function
+    # <- meta.function meta.function-call
+}
+# <- punctuation.section
+
+# <- - meta.function
+
+function foo {
+    # <- meta.function
+    function bar {
+        # <- meta.function meta.function
+        echo "baz"
+    }
+    bar
+    # <- meta.function meta.function-call
+
+    bar () {
+        # <- meta.function meta.function
+        echo "baz"
+    }
+    bar
+    # <- meta.function meta.function-call
+    function function
+    # <- meta.function meta.function
+    #       ^ - entity.name.function
+    #        ^^^^^^^^ entity.name.function
+    #                ^ - entity.name.function
+    {
+        echo "Hello! From 'function'!"
+    }
+    "function"
+    # <- meta.function meta.function-call
+}
+
+# <- - meta.function
+
 foo:foo () {
   # <- meta.function entity.name.function
     echo "this foo:foo"


### PR DESCRIPTION
and prevent the newline from getting scoped as entity.name.function.

For example, before this commit we got this
```
function foo
#           ^ entity.name.function, whoops
{
    echo 'hello from foo'
}
```
but this is now corrected:
```
function foo
#           ^ - entity.name.function
{
    echo 'hello from foo'
}
```
Moreover, functions in functions are correctly recognized now:

```
function foo {
    function bar {
        echo 'hello from bar'
    }
    bar
}
foo
```

closes https://github.com/SublimeTextIssues/DefaultPackages/issues/178