### PR TITLE
[JavaScript] Add BigInt suffix and Numeric Separators

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1268,24 +1268,50 @@ contexts:
     - match: '(?:\B[-+]|\b)0[0-9_]+\.(\B|\b[0-9_]+)'
       scope: invalid.illegal.numeric.octal.js
       pop: true
+
+    - match: '[+-]?0[0-9]+'
+      scope: constant.numeric.octal.js invalid.deprecated.octal.js
+      pop: true
+
+    - match: '[+-]?(0[Xx])[0-9a-fA-F_]*(n)?'
+      scope: constant.numeric.hexadecimal.js
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.js
+        2: storage.type.numeric.bigint.js
+      pop: true
+
+    - match: '[+-]?(0[Oo])[0-7_]*(n)?'
+      scope: constant.numeric.octal.js
+      captures:
+        1: punctuation.definition.numeric.octal.js
+        2: storage.type.numeric.bigint.js
+      pop: true
+
+    - match: '[+-]?(0[Bb])[0-1_]*(n)?'
+      scope: constant.numeric.binary.js
+      captures:
+        1: punctuation.definition.numeric.binary.js
+        2: storage.type.numeric.bigint.js
+      pop: true
+
+    - match: '[+-]?[0-9][0-9_]*(n)'
+      scope: constant.numeric.decimal.js
+      captures:
+        1: storage.type.numeric.bigint.js
+      pop: true
+
     - match: |-
         (?x)
         (?:\B[-+])?
-        (?:
-          (?i:
+        (?i:
+          (
             \B\.[0-9][0-9_]*|         # e.g. .999
             \b[0-9][0-9_]*(\.[0-9_]*)?# e.g. 999.999, 999. or 999
-          )(e[-+]?[0-9_]+)?           # e.g. e+123, E-123
-          |
-          \b(?i:
-            [0-9][0-9_]*              # decimal
-            | 0b[0-1_]*               # binary
-            | 0o[0-7_]*               # octal
-            | 0x[0-9a-f_]*            # hex
-          )n?
+          )(e[-+]?[0-9_]*)?           # e.g. e+123, E-123
         )
-      scope: constant.numeric.js
+      scope: constant.numeric.decimal.js
       pop: true
+
     - match: '(?:\B[-+]|\b)(Infinity)\b'
       scope: constant.language.infinity.js
       pop: true

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1262,23 +1262,27 @@ contexts:
         - include: object-property
 
   literal-number:
-    - match: '(?i)(?:\B[-+]|\b)0x[0-9a-f]*\.(\B|\b[0-9]+)'
+    - match: '(?i)(?:\B[-+]|\b)0x[0-9a-f_]*\.(\B|\b[0-9_]+)'
       scope: invalid.illegal.numeric.hex.js
       pop: true
-    - match: '(?:\B[-+]|\b)0[0-9]+\.(\B|\b[0-9]+)'
+    - match: '(?:\B[-+]|\b)0[0-9_]+\.(\B|\b[0-9_]+)'
       scope: invalid.illegal.numeric.octal.js
       pop: true
     - match: |-
-        (?xi)
+        (?x)
         (?:\B[-+])?
         (?:
-          \b0b[0-1]*|                 # binary
-          \b0o[0-7]*|                 # octal
-          \b0x[0-9a-f]*|              # hex
-          (
-            \B\.[0-9]+|               # e.g. .999
-            \b[0-9]+(\.[0-9]*)?       # e.g. 999.999, 999. or 999
-          )(e[-+]?[0-9]+)?            # e.g. e+123, E-123
+          (?i:
+            \B\.[0-9][0-9_]*|         # e.g. .999
+            \b[0-9][0-9_]*(\.[0-9_]*)?# e.g. 999.999, 999. or 999
+          )(e[-+]?[0-9_]+)?           # e.g. e+123, E-123
+          |
+          \b(?i:
+            [0-9][0-9_]*              # decimal
+            | 0b[0-1_]*               # binary
+            | 0o[0-7_]*               # octal
+            | 0x[0-9a-f_]*            # hex
+          )n?
         )
       scope: constant.numeric.js
       pop: true

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -1145,3 +1145,55 @@ function yy (a, b) {
 //               ^ punctuation.section.group.end
 //                 ^ meta.block punctuation.section.block - meta.function
 }
+
+// Integers
+
+    123_456_789_0n;
+//  ^^^^^^^^^^^^^^ constant.numeric.decimal
+//               ^ storage.type.numeric.bigint
+
+    0;
+//  ^ constant.numeric.decimal
+
+    0123456789;
+//  ^^^^^^^^^^ constant.numeric.octal invalid.deprecated.octal
+
+    0b0110_1001_1001_0110n;
+//  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.binary
+//  ^^ punctuation.definition.numeric.binary
+//                       ^ storage.type.numeric.bigint
+
+    0o0123_4567n;
+//  ^^^^^^^^^^^^ constant.numeric.octal
+//  ^^ punctuation.definition.numeric.octal
+//             ^ storage.type.numeric.bigint
+
+    0x01_23_45_67_89_ab_CD_efn;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hexadecimal
+//  ^^ punctuation.definition.numeric.hexadecimal
+//                           ^ storage.type.numeric.bigint
+
+    0B0; 0O0; 0X0;
+//  ^^^ constant.numeric.binary
+//       ^^^ constant.numeric.octal
+//            ^^^ constant.numeric.hexadecimal
+
+// Floats
+
+    1_234_567_890.123_456_789_0;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.decimal
+
+    .123_456_789_0;
+//  ^^^^^^^^^^^^^^ constant.numeric.decimal
+
+    0123.45;
+//  ^^^^^^^ invalid.illegal.numeric.octal
+
+    12345e6_7_8;
+//  ^^^^^^^^^^^ constant.numeric.decimal
+    
+    123.456e+789;
+//  ^^^^^^^^^^^^ constant.numeric.decimal
+
+    .123E-7_8_9;
+//  ^^^^^^^^^^^ constant.numeric.decimal


### PR DESCRIPTION
Implements the [BigInt](https://github.com/tc39/proposal-bigint) and [Numeric Separators](https://github.com/tc39/proposal-numeric-separator) proposals. See #1269.