### PR TITLE
[Python] Augmented assignment for matrix multi

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -480,7 +480,7 @@ contexts:
         2: keyword.control.flow.yield-from.python
 
   assignments:
-    - match: \+=|-=|\*=|/=|//=|%=|&=|\|=|\^=|>>=|<<=|\*\*=
+    - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
     - match: '=(?!=)'
       scope: keyword.operator.assignment.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -985,6 +985,8 @@ foo <<= bar
 matrix @ multiplication
 #      ^ keyword.operator.matrix.python
 
+a @= b
+# ^^ keyword.operator.assignment.augmented.python
 
 
 ##################


### PR DESCRIPTION
Missed this when I added the normal matrix multiplication operator.