### PR TITLE
[PHP] Fix scopes for scientific number notation

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1031,7 +1031,12 @@ contexts:
       scope: constant.numeric.integer.hexadecimal.php
       captures:
         1: punctuation.definition.numeric.hexadecimal.php
-    - match: '(?:(\b\d+|\B)\.\d+|\b\d+\.\d*)(?:[eE][+-]?\d+)?\b'
+    - match: |-
+        (?x:
+          (?:(\b\d+|\B)\.\d+|\b\d+\.\d*)(?:[eE][+-]?\d+)?\b
+          |
+          \b\d+(?:[eE][+-]?\d+)\b
+        )
       scope: constant.numeric.float.decimal.php
     - match: '\b\d+\b'
       scope: constant.numeric.integer.decimal.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -670,6 +670,15 @@ $var = 0;
 $var2 = -123.456e10;
 //       ^^^^^^^^^^ constant.numeric.float.decimal
 
+$var2 = -123.e10;
+//       ^^^^^^^ constant.numeric.float.decimal
+
+$var2 = -.123e10;
+//       ^^^^^^^ constant.numeric.float.decimal
+
+$var2 = -123e10;
+//       ^^^^^^ constant.numeric.float.decimal
+
 $var3 = 0x0f;
 //      ^^^^ constant.numeric.integer.hexadecimal
 //      ^^ punctuation.definition.numeric.hexadecimal


### PR DESCRIPTION
```php
$var2 = -123e10;
//       ^^^^^^ constant.numeric.float.decimal
```