### PR TITLE
[PHP] Fix comments scope inside "catch" parentheses

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -125,6 +125,7 @@ contexts:
         1: keyword.control.exception.catch.php
       push:
         - meta_scope: meta.catch.php
+        - include: comments
         - include: identifier-parts-as-path
         - match: '(\\)'
           scope: meta.path.php punctuation.separator.namespace.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -616,6 +616,9 @@ try {
 //             ^^^^^^ support.other.namespace.php
 //                   ^ punctuation.separator.namespace.php
 //                    ^^^^^^^^^ support.class
+} catch (/* comment */ ExceptionExample $e) {
+//       ^^^^^^^^^^^^^ comment.block
+    echo 'Caught exception: ', $e->getMessage(), "\n";
 } catch (Exception $e) {
 //^ keyword.control.exception
 //       ^^^^^^^^^ meta.path.php


### PR DESCRIPTION
```php
try {
    // ...
} catch (/* comment */ Exception $e) {
//       ^^^^^^^^^^^^^ comment.block
}
```