### PR TITLE
[LaTeX] Correct scope for \citeyearpar cite command

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -634,7 +634,7 @@ contexts:
         (
           (\\)
           (?:
-            [cC]ite(?:author|title|year|date|url|t|p|alt|alp|text)?
+            [cC]ite(?:author|title|year|date|url|t|p|alt|alp|text|yearpar)?
           | (?:[pP]aren|foot|[tT]ext|[sS]mart|super|[aA]|no|full|footfull)cite|footcitetext
           )
           \*?


### PR DESCRIPTION
The LaTeX syntax does not assign the correct scope to the cite function `\citeyearpar`.` \citeyearpar` has the scope `support.function.general.latex` but should be `support.function.cite.latex` (like all other cite function).