### PR TITLE
[Python] Fix `from . import` relative imports

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -160,11 +160,11 @@ contexts:
     - match: (?={{path}})
       push:
         - meta_scope: meta.import-path.python
-        - match: '{{illegal_names}}'
+        - match: '{{illegal_names}}\b'
           scope: invalid.illegal.name.python
         - match: '{{identifier}}'
           scope: meta.import-name.python
-        - match: \s*(\.) *(?:({{illegal_names}})|({{identifier}}))
+        - match: \s*(\.) *(?:({{illegal_names}}\b)|({{identifier}}))
           captures:
             1: punctuation.accessor.dot.python
             2: invalid.illegal.name.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -160,6 +160,8 @@ contexts:
     - match: (?={{path}})
       push:
         - meta_scope: meta.import-path.python
+        - match: '{{illegal_names}}'
+          scope: invalid.illegal.name.python
         - match: '{{identifier}}'
           scope: meta.import-name.python
         - match: \s*(\.) *(?:({{illegal_names}})|({{identifier}}))

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -155,15 +155,18 @@ contexts:
       scope: keyword.control.import.as.python
 
   import-from-name:
-    - match: (?=(\. *)?{{path}})
+    - match: \.+
+      scope: meta.import-path.python keyword.control.import.relative.python
+    - match: (?={{path}})
       push:
         - meta_scope: meta.import-path.python
         - match: '{{identifier}}'
           scope: meta.import-name.python
-        - match: \s*(\.) *({{identifier}})
+        - match: \s*(\.) *(?:({{illegal_names}})|({{identifier}}))
           captures:
             1: punctuation.accessor.dot.python
-            2: meta.import-name.python
+            2: invalid.illegal.name.python
+            3: meta.import-name.python
         - match: \ *(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
           captures:
             1: invalid.illegal.name.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -52,6 +52,8 @@ from a.b.c.else import module
 from .while import module
 #     ^^^^^ invalid.illegal.name.python
 #           ^^^^^^ keyword.control.import
+from .index import module
+#     ^^^^^ - invalid
 from \
     os \
     import \

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -49,6 +49,9 @@ from collections.abc import Iterable
 from a.b.c.else import module
 #          ^^^^ invalid.illegal.name.python
 #               ^^^^^^ keyword.control.import
+from .while import module
+#     ^^^^^ invalid.illegal.name.python
+#           ^^^^^^ keyword.control.import
 from \
     os \
     import \

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -38,8 +38,17 @@ from os import path, chdir # comment
 #       ^^^^^^ keyword.control.import
 #                  ^ punctuation.separator.import-list
 #                          ^ comment
+from . import module
+#    ^ keyword.control.import.relative.python
+#      ^^^^^^ keyword.control.import
+from .import module  # yes, this is actually legit
+#    ^ keyword.control.import.relative.python
+#     ^^^^^^ keyword.control.import.python
 from collections.abc import Iterable
 #                    ^^^^^^ keyword.control.import
+from a.b.c.else import module
+#          ^^^^ invalid.illegal.name.python
+#               ^^^^^^ keyword.control.import
 from \
     os \
     import \
@@ -85,6 +94,7 @@ import .str
 
 import str
 #      ^^^ support.type.python
+
 
 ##################
 # Identifiers


### PR DESCRIPTION
Also highlight invalid names in the `from` section.

Fixes #1300.