### PR TITLE
[CSS] Add a hint to each completion item

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -490,7 +490,7 @@ class CSSCompletions(sublime_plugin.EventListener):
                     add_semi_colon = view.substr(sublime.Region(loc, loc + 1)) != ';'
 
                     for value in values:
-                        desc = value
+                        desc = value + "\t" + prop_name
                         snippet = value
 
                         if add_semi_colon:
@@ -509,8 +509,8 @@ class CSSCompletions(sublime_plugin.EventListener):
 
             for prop in self.props:
                 if add_colon:
-                    l.append((prop, prop + ": "))
+                    l.append((prop + "\tcss", prop + ": "))
                 else:
-                    l.append((prop, prop))
+                    l.append((prop + "\tcss", prop))
 
             return (l, sublime.INHIBIT_WORD_COMPLETIONS)

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -509,8 +509,8 @@ class CSSCompletions(sublime_plugin.EventListener):
 
             for prop in self.props:
                 if add_colon:
-                    l.append((prop + "\tcss", prop + ": "))
+                    l.append((prop + "\tproperty", prop + ": "))
                 else:
-                    l.append((prop + "\tcss", prop))
+                    l.append((prop + "\tproperty", prop))
 
             return (l, sublime.INHIBIT_WORD_COMPLETIONS)


### PR DESCRIPTION
Most auto-completion packages provide basic information about their suggestions as hints right next to each item, which distinguishes auto-completion items very clearly from word-completions.

CSS disables word-completions, but it is not obvious to the end user.

Therefore this commit adds a hint to each returned completion item to allow the end user to clearly see it is a valid value from a database but not something ST might have caught from anywhere in the text.