### PR TITLE
[CSS] Avoid calling find

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -496,7 +496,7 @@ class CSSCompletions(sublime_plugin.EventListener):
                         if add_semi_colon:
                             snippet += ";"
 
-                        if snippet.find("$1") != -1:
+                        if "$1" in snippet:
                             desc = desc.replace("$1", "")
 
                         l.append((desc, snippet))


### PR DESCRIPTION
The `find` seems a bit more expensive than using `x in list`. After this commit collecting completions for "padding" values was reduced from 70ms to 50ms on each first run. The time savings vary very much but seem smaller in most cases.