### PR TITLE
[Java] 'invalid.illegal' for strings without closing quote

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -712,8 +712,10 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.java
-        - match: '"'
-          scope: punctuation.definition.string.end.java
+        - match: (")|(\n)
+          captures:
+            1: punctuation.definition.string.end.java
+            2: invalid.illegal.newline.java
           pop: true
         - match: \\.
           scope: constant.character.escape.java
@@ -722,8 +724,10 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.single.java
-        - match: "'"
-          scope: punctuation.definition.string.end.java
+        - match: (')|(\n)
+          captures:
+            1: punctuation.definition.string.end.java
+            2: invalid.illegal.newline.java
           pop: true
         - match: \\.
           scope: constant.character.escape.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -910,6 +910,45 @@ public class Foo {
 //                                  ^ storage.type.numeric
   }
 
+  String stringAndChars() {
+    String doubleQuotes = "String with double quotes";
+//                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+//                        ^ punctuation.definition.string.begin
+//                                                  ^ punctuation.definition.string.end
+
+    char singleQuotes = 'x';
+//                      ^^^ string.quoted.single
+//                      ^ punctuation.definition.string.begin
+//                        ^ punctuation.definition.string.end
+
+    String escapes = "Here \2 are \n some \t escaped \'\\' characters \"";
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+//                         ^^ constant.character.escape
+//                                ^^ constant.character.escape
+//                                                   ^^^^ constant.character.escape
+//                                                                    ^^ constant.character.escape
+
+    char escape = '\t' + '\1' + '\'' + '\\';
+//                ^^^^ string.quoted.single
+//                 ^^ constant.character.escape
+//                       ^^^^ string.quoted.single
+//                        ^^ constant.character.escape
+//                              ^^^^ string.quoted.single
+//                               ^^ constant.character.escape
+//                                     ^^^^ string.quoted.single
+//                                      ^^ constant.character.escape
+
+    String text = "String without closing quote
+//                                             ^ invalid.illegal.newline
+    System.out.println(text);
+//  ^^^^^^ support.class
+
+    char letter = 'z
+//                  ^ invalid.illegal.newline
+    System.out.println(letter);
+//  ^^^^^^ support.class
+  }
+
   @Test
 //^ punctuation.definition.annotation.java
   public void someMethod(WithParam foo) throws Exception {


### PR DESCRIPTION
Other syntax files already have this, why not add it to Java.

Match rules are copied from js syntax.