### PR TITLE
[CSS] Fix @counter-style not scoped correctly if name is missing

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -141,7 +141,7 @@ contexts:
   # @counter-style
   # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
   at-counter-style:
-    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))\s*(?=\{|$)
+    - match: \s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))?\s*(?=\{|$)
       captures:
         1: keyword.control.at-rule.counter-style.css
         2: punctuation.definition.keyword.css

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -247,6 +247,10 @@
     }
 }
 
+    @counter-style {}
+/*  ^          punctuation.definition.keyword.css  */
+/*  ^^^^^^^^^^^^^^ keyword.control.at-rule.counter-style.css */
+
 @counter-style none {}
 /*             ^^^^ invalid.illegal.counter-style-name.css */
 


### PR DESCRIPTION
Prior to this commit the globally valid keyword @counter-style was highlighted as `entity.name.tag.custom` if no style-name is provided between it and the next `{`.

Even though the style-name is required the keyword must/should be scoped correctly if it is missing in order to avoid confusion.

Therefore this commit marks the style-name as optional to fix scoping of incomplete counter-style rules.