### PR TITLE
[Java] Annotation-related fixes

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -32,8 +32,8 @@ contexts:
     - include: prototype
     - include: package
     - include: import
-    - include: annotations
     - include: body
+    - include: annotations
     - include: code
   package:
     - match: '\bpackage\b'
@@ -190,8 +190,8 @@ contexts:
           scope: keyword.operator.assert.expression-separator.java
         - include: code
   body:
-    - include: annotations
     - include: class
+    - include: annotations
     # Get modifiers defined on a different line than the class
     - include: storage-modifiers
     - include: stray-braces
@@ -235,8 +235,8 @@ contexts:
 
   class-body:
     - include: storage-modifiers
-    - include: annotations
     - include: class
+    - include: annotations
     - include: static-assignment
     - include: enums
     - include: generic-declaration # for methods

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -89,14 +89,28 @@ contexts:
             - match: \)
               scope: punctuation.section.parens.end.java
               pop: true # pop: 2
-            - match: (\w*)\s*(?=\=)
+            - match: (\w*)\s*(=)
               captures:
                 1: variable.parameter.java
-            - include: array-construction-block
+                2: keyword.operator.assignment.java
+              push:
+                - match: (?=[,})])
+                  pop: true
+                - include: annotations
+                - include: code
+            - include: annotations-array-construction-block
+            - include: annotations
             - include: code
             - match: \,
               scope: punctuation.separator.java
         - include: any_POP
+  annotations-array-construction-block:
+    - match: \{
+      scope: punctuation.definition.array-constructor.begin.java
+      push:
+        - meta_scope: meta.block.java
+        - include: array-construction-block-end
+        - include: annotations
 
   anonymous-classes-and-new:
     - match: \bnew\b
@@ -143,17 +157,19 @@ contexts:
     - include: array-construction-block
     - include: any_POP
   array-construction-block:
-    - match: "{"
+    - match: \{
       scope: punctuation.definition.array-constructor.begin.java
       push:
         - meta_scope: meta.block.java
-        - match: "}"
-          scope: punctuation.definition.array-constructor.end.java
-          pop: true
-        - include: array-construction-block
-        - include: code
-        - match: \,
-          scope: punctuation.separator.java
+        - include: array-construction-block-end
+  array-construction-block-end:
+    - match: \}
+      scope: punctuation.definition.array-constructor.end.java
+      pop: true
+    - include: array-construction-block
+    - include: code
+    - match: \,
+      scope: punctuation.separator.java
   generic-declaration:
     - match: <
       comment: Generic parameter declaration scopes

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -512,13 +512,14 @@ contexts:
               scope: invalid.illegal.missing-parameter-end
               pop: true
         - include: throws
+        - include: annotation-default
         - match: "{"
           scope: punctuation.section.block.begin.java
-          push:
-            - meta_scope: meta.method.body.java
+          set:
+            - meta_scope: meta.method.java meta.method.body.java
             - match: "}"
               scope: punctuation.section.block.end.java
-              pop: true # pop: 2 would be nice here
+              pop: true
             - include: code-block
         - include: any_POP
   invalid-generic-tags:
@@ -592,6 +593,14 @@ contexts:
         - match: '(?=\s*{|;)'
           pop: true
         - include: object-types
+  annotation-default:
+    - match: \bdefault\b
+      scope: keyword.declaration.default.java
+      push:
+        - meta_scope: meta.annotation.default.java
+        - match: (?=;)
+          pop: true
+        - include: code
   parameters:
     - match: \bfinal\b
       scope: storage.modifier.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -626,6 +626,51 @@ class Bàr {
 //^^^ entity.name.function.constructor.java
 }
 
+@AnnotationAsParameterSingle(
+    @Parameter(name = "foo")
+//  ^ punctuation.definition.annotation.java
+//   ^^^^^^^^^ variable.annotation.java
+//             ^^^^ variable.parameter.java
+)
+
+@AnnotationAsParameterSingleNamed(
+  value = @Parameter(name = "foo")
+//^^^^^ variable.parameter.java
+//        ^ punctuation.definition.annotation.java
+//         ^^^^^^^^ variable.annotation.java
+//                   ^^^^ variable.parameter.java
+)
+
+@AnnotationAsParameterMultiple({
+//                             ^ punctuation.definition.array-constructor.begin.java
+    @Parameter(name = "foo"),
+//  ^ punctuation.definition.annotation.java
+//   ^^^^^^^^^ variable.annotation.java
+//             ^^^^ variable.parameter.java
+
+    @Parameter(name = "bar")
+//  ^ punctuation.definition.annotation.java
+//   ^^^^^^^^^ variable.annotation.java
+//             ^^^^ variable.parameter.java
+})
+// <- punctuation.definition.array-constructor.end.java
+
+@AnnotationAsParameterMultipleNamed(
+  first  = {@Parameter(name = "foo"), @Parameter(name = "bar")},
+//^^^^^ variable.parameter.java
+//          ^ punctuation.definition.annotation.java
+//           ^^^^^^^^^ variable.annotation.java
+//                     ^^^^ variable.parameter.java
+//                                    ^ punctuation.definition.annotation.java
+//                                     ^^^^^^^^^ variable.annotation.java
+//                                               ^^^^ variable.parameter.java
+  second = {@Parameter(name = "foo"), @Parameter(name = "bar")},
+//^^^^^^ variable.parameter.java
+  third = @Parameter(name = "foo")
+//^^^^^ variable.parameter.java
+//         ^^^^^^^^^ variable.annotation.java
+)
+
 @SomeInterface
 // <- punctuation.definition.annotation.java
 public class Foo {

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -582,6 +582,9 @@ public @interface PublicAnnotation {
 //                                           ^ punctuation.section.block.end
 }
 
+@interface PackageAnnotation {}
+//^^^^^^^^ storage.type.java
+
 @MultiLineAnnotation(
 // <- meta.annotation.java
 // <- punctuation.definition.annotation.java

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -555,6 +555,33 @@ public final class SomeClass<V extends OtherClass, T> extends BaseClass<V> {
 //                                     ^ support.class.java
 //                                                                         ^ punctuation.section.block.begin.java
 }
+
+public @interface PublicAnnotation {
+//     ^^^^^^^^^^ storage.type.java
+  int numericValue() default 42;
+//                   ^^^^^^^ keyword.declaration.default.java
+//                           ^^ constant.numeric
+  boolean booleanValue() default true;
+//                       ^^^^^^^ keyword.declaration.default.java
+//                               ^^^^ constant.language
+  char charValue() default 'S';
+//                 ^^^^^^^ keyword.declaration.default.java
+//                         ^^^ string.quoted.single.java
+  String value() default "Default value";
+//               ^^^^^^^ keyword.declaration.default.java
+//                       ^^^^^^^^^^^^^^^ string.quoted.double.java
+  Class<?> classValue() default String.class;
+//                      ^^^^^^^ keyword.declaration.default.java
+//                              ^^^^^^ support.class.java
+//                                     ^^^^^ variable.language.java
+  String[] arrayValue() default {"Foo", "Bar"};
+//                      ^^^^^^^ keyword.declaration.default.java
+//                              ^ punctuation.section.block.begin
+//                               ^^^^^ string.quoted.double.java
+//                                      ^^^^^ string.quoted.double.java
+//                                           ^ punctuation.section.block.end
+}
+
 @MultiLineAnnotation(
 // <- meta.annotation.java
 // <- punctuation.definition.annotation.java


### PR DESCRIPTION
1. If a default value in annotation's definition is a string it is not highlighted:
<img src="https://user-images.githubusercontent.com/6729879/33020675-2449d978-ce10-11e7-85ed-6f0fc0f5d925.png" width=514 height=84/>

2. Annotation's definition only works after an access modifier:
<img src="https://user-images.githubusercontent.com/6729879/33020676-24742d7c-ce10-11e7-90fb-82565d2bb840.png" width=417 height=71/>

3. Annotations are not highlighted when used as parameters to other annotations:
<img src="https://user-images.githubusercontent.com/6729879/33020678-250fb5da-ce10-11e7-8246-3ae7add9f914.png" width=499 height=183/>
