### PR TITLE
[JavaScript] Support `export function|class` form

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -175,16 +175,23 @@ contexts:
   export-extended:
     - include: variable-declaration
 
+    - match: (?=\bclass\b)
+      set: class
+
+    - match: (?={{func_lookahead}})
+      set: function-declaration
+
     - match: '\bdefault\b'
       scope: keyword.control.import-export.js
       set:
         - match: (?=\bclass\b)
           set: class
 
-        - match: (?=\bfunction\b)
+        - match: (?={{func_lookahead}})
           set: function-declaration
 
-        - include: expression
+        - match: (?=\S)
+          set: expression-statement
 
     - match: (?=\S)
       set:
@@ -276,7 +283,7 @@ contexts:
     - match: (?=\bclass\b)
       push: class
 
-    - match: (?=\bfunction\b)
+    - match: (?={{func_lookahead}})
       push: function-declaration
 
   expression-statement:
@@ -936,6 +943,7 @@ contexts:
         - function-declaration-meta
         - function-declaration-expect-parameters
         - function-declaration-expect-name
+        - function-declaration-expect-generator-star
         - function-declaration-expect-function-keyword
         - function-declaration-expect-async
 
@@ -957,11 +965,15 @@ contexts:
       pop: true
     - include: else-pop
 
+  function-declaration-expect-generator-star:
+    - match: \*
+      scope: keyword.generator.asterisk.js
+      pop: true
+    - include: else-pop
+
   function-declaration-expect-function-keyword:
-    - match: \b(function)\b\s*(\*)?
-      captures:
-        1: storage.type.function.js
-        2: keyword.generator.asterisk.js
+    - match: \bfunction\b
+      scope: storage.type.function.js
       pop: true
     - include: else-pop
 

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -46,6 +46,38 @@ export const name1 = 5;
 //     ^^^^^ storage.type
 //                 ^ keyword.operator.assignment
 
+export function foo() {}
+//^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^^^^^^^^  meta.function.declaration
+
+[];
+// <- meta.sequence
+
+export function* foo() {}
+//^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^^^^^^^^^  meta.function.declaration
+
+[];
+// <- meta.sequence
+
+export async function foo() {}
+//^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+
+[];
+// <- meta.sequence
+
+export class Foo {}
+//^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^^^^^^ meta.class
+
+[];
+// <- meta.sequence
+
 export default expression;
 //^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^ keyword.control.import-export
@@ -53,10 +85,23 @@ export default expression;
 
 export default function (a) { }
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
-//^ keyword.control.import-export
-//     ^ keyword.control.import-export
-//             ^ storage.type
+//^^^^ keyword.control.import-export
+//     ^^^^^^^ keyword.control.import-export
+//             ^^^^^^^^^^^^ meta.function.declaration.js
 //                             ^ - meta.export
+
+[];
+// <- meta.sequence
+
+export default function* (a) { }
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^ keyword.control.import-export
+//             ^^^^^^^^^^^^^ meta.function.declaration.js
+//                              ^ - meta.export
+
+[];
+// <- meta.sequence
 
 export default function name1(b) { }
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
@@ -64,6 +109,25 @@ export default function name1(b) { }
 //     ^ keyword.control.import-export
 //             ^ storage.type
 //                      ^ entity.name.function
+
+export default class Foo {}
+//^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^ keyword.control.import-export
+//             ^^^^^^^^^^^^ meta.class
+
+[];
+// <- meta.sequence
+
+export default +function (a) { }
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^^^^^^ keyword.control.import-export
+//              ^^^^^^^^^^^^ meta.function.declaration.js
+
+[];
+// <- meta.export
+// <- meta.brackets
 
 export { name1 as default };
 //^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export


### PR DESCRIPTION
You should now be able to directly export function and class declarations. Added tests to verify.

Fixes #1322.