### PR TITLE
[JavaScript] `yield` and `await` expressions

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -272,7 +272,7 @@ contexts:
     - match: \b(break|continue|goto)\b
       scope: keyword.control.loop.js
 
-    - match: \b(await|return)\b
+    - match: \breturn\b
       scope: keyword.control.flow.js
       push: restricted-production
 
@@ -509,6 +509,7 @@ contexts:
     - include: constructor
     - include: prefix-operators
     - include: yield-expression
+    - include: await-expression
 
     - include: class
     - include: constants
@@ -786,6 +787,10 @@ contexts:
           set: expression-begin
         - match: (?=\S)
           set: expression-begin
+
+  await-expression:
+    - match: \bawait\b
+      scope: keyword.control.flow.js
 
   class:
     - match: \bclass\b

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -272,12 +272,6 @@ contexts:
     - match: \b(break|continue|goto)\b
       scope: keyword.control.loop.js
 
-    - match: \b(yield)\b(?:\s*(\*))?
-      captures:
-        1: keyword.control.flow.js
-        2: keyword.generator.asterisk.js
-      push: restricted-production
-
     - match: \b(await|return)\b
       scope: keyword.control.flow.js
       push: restricted-production
@@ -514,6 +508,7 @@ contexts:
     - include: literal-string-template
     - include: constructor
     - include: prefix-operators
+    - include: yield-expression
 
     - include: class
     - include: constants
@@ -779,6 +774,18 @@ contexts:
       scope: keyword.operator.arithmetic.js
     - match: '\+\+'
       scope: keyword.operator.arithmetic.js
+
+  yield-expression:
+    - match: \byield\b
+      scope: keyword.control.flow.js
+      set:
+        - match: $
+          pop: true
+        - match: \*
+          scope: keyword.generator.asterisk.js
+          set: expression-begin
+        - match: (?=\S)
+          set: expression-begin
 
   class:
     - match: \bclass\b

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -556,8 +556,24 @@ while (true)
 //     ^^^^ meta.group
 {
 // <- meta.block
-    yield;
-//  ^^^^^ keyword.control.flow
+    x = yield;
+//      ^^^^^ keyword.control.flow
+
+    x = yield * 42;
+//      ^^^^^ keyword.control.flow
+//            ^ keyword.generator.asterisk
+
+    x = yield
+    function f() {}
+    [];
+//  ^^ meta.sequence - meta.brackets
+
+
+    x = yield*
+    function f() {}
+    [];
+//  ^^ meta.brackets - meta.sequence
+
     break;
 //  ^^^^^^ meta.while meta.block
 }

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -574,6 +574,9 @@ while (true)
     [];
 //  ^^ meta.brackets - meta.sequence
 
+    y = await 42;
+//      ^^^^^ keyword.control.flow
+
     break;
 //  ^^^^^^ meta.while meta.block
 }

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -577,6 +577,10 @@ while (true)
     y = await 42;
 //      ^^^^^ keyword.control.flow
 
+    y = yield await 42;
+//      ^^^^^ keyword.control.flow
+//            ^^^^^ keyword.control.flow
+
     break;
 //  ^^^^^^ meta.while meta.block
 }


### PR DESCRIPTION
`yield` and `await` now work inside expressions:

```js
    x = yield;
//      ^^^^^ keyword.control.flow

    x = yield * 42;
//      ^^^^^ keyword.control.flow
//            ^ keyword.generator.asterisk

    x = yield
    function f() {}
    [];
//  ^^ meta.sequence - meta.brackets


    x = yield*
    function f() {}
    [];
//  ^^ meta.brackets - meta.sequence

    y = await 42;
//      ^^^^^ keyword.control.flow
```

This does introduce a bug in that `yield` and `await` should be valid identifiers outside generator and async functions, respectively. The ECMAScript formal syntax represents this by using weird EBNF with parameterized productions. The equivalent implementation for JavaScript would be to have four near-complete copies of the syntax, one for async generators, one for non-async generators, one for async non-generators, and one for everything else. Alternatively, people could not use `yield` and `await` as identifiers, and that would be cool too.