### PR TITLE
[JavaScript] Debugger statement is no longer an expression. Improved scope.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -276,6 +276,9 @@ contexts:
       scope: keyword.control.flow.js
       push: restricted-production
 
+    - match: \bdebugger\b
+      scope: keyword.other.debugger.js
+
     - include: function-or-class-declaration
 
     - match: (?=\S)
@@ -1619,9 +1622,6 @@ contexts:
         2: variable.other.readwrite.js
 
   support:
-    - match: \bdebugger\b
-      scope: keyword.other.js
-      pop: true
     - match: |-
         (?x)
         \b(

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -1386,6 +1386,3 @@ debugger;
 debugger
 []
 // <- meta.sequence
-
-    +debugger;
-//   ^^^^^^^^ variable.other.readwrite - keyword

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -1386,3 +1386,6 @@ debugger;
 debugger
 []
 // <- meta.sequence
+
+    +debugger;
+//   ^^^^^^^^ variable.other.readwrite - keyword

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -1379,3 +1379,10 @@ function yy (a, b) {
 
     .123E-7_8_9;
 //  ^^^^^^^^^^^ constant.numeric.decimal
+
+debugger;
+// <- keyword.other.debugger
+
+debugger
+[]
+// <- meta.sequence


### PR DESCRIPTION
```js
debugger;
// <- keyword.other.debugger

debugger
[]
// <- meta.sequence
```