### PR TITLE
[JavaScript] Added spread operator and made computed property names consistent.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1180,6 +1180,10 @@ contexts:
           scope: punctuation.section.block.js
           pop: true
 
+        - match: \.\.\.
+          scope: keyword.operator.spread.js
+          push: literal-variable
+
         - match: >-
             (?x)(?=
               {{property_name}}\s*:
@@ -1197,14 +1201,8 @@ contexts:
 
         - match: '{{identifier}}(?=\s*(?:[},]|$|//|/\*))'
           scope: variable.other.readwrite.js
-        - match: \[
-          scope: punctuation.section.brackets.js
-          push:
-            - match: \]
-              scope: punctuation.section.brackets.js
-              pop: true
-            - match: (?=\S)
-              push: expression
+        - match: (?=\[)
+          push: computed-property-name
         - match: "(?=\"|')"
           push:
             - object-literal-meta-key
@@ -1224,6 +1222,17 @@ contexts:
         - match: ':'
           scope: punctuation.separator.key-value.js
           push: expression-no-comma
+
+  computed-property-name:
+    - match: \[
+      scope: punctuation.section.brackets.begin.js
+      set:
+        - match: \]
+          scope: punctuation.section.brackets.end.js
+          pop: true
+        - match: (?=\S)
+          push: expression
+    - include: else-pop
 
   object-literal-meta-key:
     - meta_scope: meta.object-literal.key.js 
@@ -1268,12 +1277,8 @@ contexts:
           pop: true
         - include: string-content
 
-    - match: '(\[)({{identifier}}(?:\.{{identifier}}|\.)*)?(\])?'
-      captures:
-        1: punctuation.definition.symbol.begin.js
-        2: entity.name.function.js
-        3: punctuation.definition.symbol.end.js
-      pop: true
+    - match: (?=\[)
+      push: computed-property-name
 
     - include: else-pop
 
@@ -1315,12 +1320,8 @@ contexts:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
 
-    - match: '(\[)({{identifier}}(?:\.{{identifier}}|\.)*)?(\])?'
-      captures:
-        1: punctuation.definition.symbol.begin.js
-        2: variable.other.readwrite.js
-        3: punctuation.definition.symbol.end.js
-      pop: true
+    - match: (?=\[)
+      push: computed-property-name
 
     - include: else-pop
 

--- a/JavaScript/syntax_test_js.js
+++ b/JavaScript/syntax_test_js.js
@@ -669,9 +669,9 @@ class MyClass extends TheirClass {
 //        ^^ constant.numeric
 
     [w] = 42;
-//  ^ punctuation.definition.symbol.begin
+//  ^ punctuation.section.brackets.begin
 //   ^ variable.other.readwrite
-//    ^ punctuation.definition.symbol.end
+//    ^ punctuation.section.brackets.end
 //      ^ keyword.operator.assignment
 //        ^^ constant.numeric
 
@@ -703,9 +703,9 @@ class MyClass extends TheirClass {
 
     static [w] = 42;
 //  ^^^^^^ storage.modifier.js
-//         ^ punctuation.definition.symbol.begin
+//         ^ punctuation.section.brackets.begin
 //          ^ variable.other.readwrite
-//           ^ punctuation.definition.symbol.end
+//           ^ punctuation.section.brackets.end
 //             ^ keyword.operator.assignment
 //               ^^ constant.numeric
 
@@ -808,7 +808,8 @@ class Foo extends React.Component {
     {}
 
     [foo.bar](arg) {
-//   ^^^^^^^ entity.name.function
+//   ^^^ variable.other
+//       ^^^ meta.property
 //            ^^^ variable.parameter
         return this.a;
     }


### PR DESCRIPTION
Implemented object literal [spread properties](https://github.com/tc39/proposal-object-rest-spread). (Stage 3, widely used, very stable.)

Also fixed inconsistencies with computed property names:

The square brackets were sometimes `punctuation.section.brackets` and sometimes `punctuation.definition.symbol`. The latter seems clearly wrong, so I standardized on the former.

When the value of a property is a function expression (determined by lookahead), we generally try to scope the property name as `entity.name.function`. This works fine with literal property names, mostly fine with string and number property names, and not at all for computed property names. Consider the following:

```js
({
    [foo.bar]: function() {}
})
```

The string `foo.bar` was scoped `entity.name.function`. But this is incorrect; we have no way of knowing the name of the function (insofar as that's meaningful in this case), but it certainly isn't "foo.bar". Rather, `foo.bar` is an expression with an identifier `foo`, punctuation `.`, and a property name `bar`. Now, it is highlighted accordingly.

The same applies to computed method names and class field names. These have been fixed as well.