### PR TITLE
[PHP] Add new type hinting "object" for PHP 7.2

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -586,7 +586,7 @@ contexts:
         - match: (?=\S)
           pop: true
     - include: comments
-    - match: \b(array|callable|int|string|bool|float)\b
+    - match: \b(array|callable|int|string|bool|float|object)\b
       scope: storage.type.php
     # Class name type hint
     - match: '{{identifier}}'
@@ -643,7 +643,7 @@ contexts:
       scope: punctuation.separator.php
     - match: '\?'
       scope: storage.type.nullable.php
-    - match: \b(array|bool|int|float|string)\b
+    - match: \b(array|bool|int|float|string|object)\b
       scope: storage.type.php
     - include: class-builtin
     - include: identifier-parts-as-path

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -643,7 +643,7 @@ contexts:
       scope: punctuation.separator.php
     - match: '\?'
       scope: storage.type.nullable.php
-    - match: \b(array|bool|int|float|string|object)\b
+    - match: \b(array|callable|int|string|bool|float|object)\b
       scope: storage.type.php
     - include: class-builtin
     - include: identifier-parts-as-path

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -435,6 +435,16 @@ $anon = new class extends Test1 implements Countable {};
 //                                             ^ storage.type.nullable.php
 //                                              ^ storage.type.php
 
+    function nullableObjectReturnType(?int $param1): ?object {}
+//  ^ storage.type.function.php
+//           ^ entity.name.function.php
+//                                   ^ punctuation.section.group.begin.php
+//                                    ^ storage.type.nullable.php
+//                                     ^ meta.function.parameters
+//                                                ^ punctuation.section.group.end.php
+//                                                   ^ storage.type.nullable.php
+//                                                    ^ storage.type.php
+
 $test = "\0 \12 \345g \x0f \u{a} \u{9999} \u{999}";
 //       ^^ constant.character.escape.octal.php
 //          ^^^ constant.character.escape.octal.php


### PR DESCRIPTION
PHP 7.2 introduces the "object" type hint: https://wiki.php.net/rfc/object-typehint

Without this modification, it looks actually like this:

![capture d ecran 2017-12-05 a 13 47 36](https://user-images.githubusercontent.com/623763/33608033-64c5b6ca-d9c3-11e7-9fd3-4188a124c900.png)

After this PR, it will correctly use the same colors of the other type hints:

![capture d ecran 2017-12-05 a 13 46 58](https://user-images.githubusercontent.com/623763/33608055-85c05402-d9c3-11e7-9052-27f4910f9301.png)
 