### PR TITLE
[Groovy] Improve string syntax highlighting

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -6,6 +6,23 @@ file_extensions:
   - groovy
   - gvy
   - gradle
+variables:
+  unicode_letter: |-
+    (?:(?xi)
+      # Valid unicode letters according to:
+      # http://groovy-lang.org/syntax.html#_normal_identifiers
+      #   Literal Unicode         Escaped Unicode
+          [\x{00C0}-\x{00D6}]  |  \\u00C[0-9A-F] | \\u00D[0-6]
+        | [\x{00D8}-\x{00F6}]  |  \\u00D[89A-F]  | \\u00E[0-9A-F] | \\u00F[0-6]
+        | [\x{00F8}-\x{00FF}]  |  \\u00F[89A-F]
+        | [\x{0100}-\x{FFFE}]  |  \\u0[1-9A-F][0-9A-F]{2} | \\u(?!FFFF)[1-9A-F][0-9A-F]{3}
+    )
+
+  # dollars aren't allowed in the single dollar interpolated identifiers
+  # (dotted expressions), but they are supposed to be valid characters
+  # in identifiers in other contexts
+  # e.g. `"$$a"` is invalid, but `"${$a}"` is fine.
+  single_dollar_interpolation_identifier: (?:{{unicode_letter}}|[a-zA-Z_])(?:{{unicode_letter}}|[a-zA-Z0-9_])*
 scope: source.groovy
 contexts:
   main:
@@ -107,6 +124,7 @@ contexts:
   groovy-code:
     - include: groovy-code-minus-map-keys
     - include: map-keys
+    - include: block
   groovy-code-minus-map-keys:
     - include: comments
     - include: support-functions
@@ -328,16 +346,15 @@ contexts:
         - match: '{|$\n?'
           pop: true
         - include: method-declaration-remainder
-  nest_curly:
+  block:
     - match: '\{'
-      captures:
-        0: punctuation.section.scope.groovy
+      scope: punctuation.section.block.begin.groovy
       push:
+        - meta_scope: meta.block.groovy
         - match: '\}'
-          captures:
-            0: punctuation.section.scope.groovy
+          scope: punctuation.section.block.end.groovy
           pop: true
-        - include: nest_curly
+        - include: groovy-code
   numbers:
     - match: '((0(x|X)[0-9a-fA-F]*)|(\+|-)?\b(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
       scope: constant.numeric.groovy
@@ -351,8 +368,26 @@ contexts:
           captures:
             0: punctuation.definition.string.regexp.end.groovy
           pop: true
-        - match: \\.
+        # backslashes only escape forward slashes and newlines (and unicode)
+        - match: \\/
           scope: constant.character.escape.groovy
+        - include: escaped-end-of-line
+        - include: unicode-escape-sequence
+        - include: single-dollar-string-interpolation
+        - match: '\$\{'
+          scope: punctuation.section.embedded.groovy
+          push:
+            - meta_scope: source.groovy.embedded.source
+            - match: '\}'
+              scope: punctuation.section.embedded.groovy
+              pop: true
+            - include: escaped-end-of-line
+            # newlines are invalid inside the interpolation
+            # but outside of a nested multiline string
+            - match: '\n'
+              scope: invalid.illegal.newline.groovy
+              pop: true
+            - include: groovy-code
   storage-modifiers:
     - match: \b(private|protected|public)\b
       scope: storage.modifier.access-control.groovy
@@ -386,6 +421,32 @@ contexts:
       scope: storage.type.def.groovy
     - match: '\b(boolean|byte|char|short|int|float|long|double)(?:\[\s*\])*\b'
       scope: storage.type.primitive.groovy
+  single-dollar-string-interpolation:
+    - match: \${{single_dollar_interpolation_identifier}}
+      scope: variable.other.interpolated.groovy
+      push:
+        - match: \.(?={{single_dollar_interpolation_identifier}})
+          scope: keyword.operator.navigation.groovy
+        - match: '{{single_dollar_interpolation_identifier}}'
+          scope: variable.other.interpolated.groovy
+        - match: \b
+          pop: true
+  unicode-escape-sequence:
+    - match: \\u\h{4}
+      scope: constant.character.escape.groovy
+    - match: \\u(?!\h{4}).{4}
+      scope: invalid.illegal.escape.groovy
+  escaped-end-of-line:
+    - match: \\\n
+      scope: constant.character.escape.groovy
+  string-escape-sequences:
+    - include: unicode-escape-sequence
+    - include: escaped-end-of-line
+    - match: |-
+        \\[nrtbf\$\\'"]
+      scope: constant.character.escape.groovy
+    - match: \\.
+      scope: invalid.illegal.escape.groovy
   string-quoted-double:
     - match: '"'
       captures:
@@ -396,20 +457,29 @@ contexts:
           captures:
             0: punctuation.definition.string.end.groovy
           pop: true
-        - match: \\.
-          scope: constant.character.escape.groovy
-        - match: \$\w+
-          scope: variable.other.interpolated.groovy
+        - match: '\n'
+          scope: invalid.illegal.unclosed-string.groovy
+          pop: true
+        - include: string-escape-sequences
+        - include: single-dollar-string-interpolation
         - match: '\$\{'
-          captures:
-            0: punctuation.section.embedded.groovy
+          scope: punctuation.section.embedded.groovy
           push:
             - meta_scope: source.groovy.embedded.source
             - match: '\}'
-              captures:
-                0: punctuation.section.embedded.groovy
+              scope: punctuation.section.embedded.groovy
               pop: true
-            - include: nest_curly
+            - include: escaped-end-of-line
+            # we don't consume the newline here, so that
+            # the outer scope handles it and pops correctly
+            - match: '(?=\n)'
+              pop: true
+            - include: groovy-code
+        # anything else following a dollar sign is not a valid interpolation
+        - match: \$(?=")
+          scope: invalid.illegal.identifier.groovy
+        - match: \$[^"]+
+          scope: invalid.illegal.identifier.groovy
   string-quoted-single:
     - match: "'"
       captures:
@@ -420,12 +490,83 @@ contexts:
           captures:
             0: punctuation.definition.string.end.groovy
           pop: true
-        - match: \\.
+        - match: '\n'
+          scope: invalid.illegal.unclosed-string.groovy
+          pop: true
+        - include: string-escape-sequences
+  string-quoted-triple-single:
+    - match: "'''"
+      captures:
+        0: punctuation.definition.string.begin.groovy
+      push:
+        - meta_scope: string.quoted.single.block.groovy
+        - match: "'''"
+          captures:
+            0: punctuation.definition.string.end.groovy
+          pop: true
+        - include: string-escape-sequences
+  string-quoted-triple-double:
+    - match: '"""'
+      captures:
+        0: punctuation.definition.string.begin.groovy
+      push:
+        - meta_scope: string.quoted.double.block.groovy
+        - match: '""""'
+          captures:
+            0: invalid.illegal
+          pop: true
+        - match: '"""'
+          captures:
+            0: punctuation.definition.string.end.groovy
+          pop: true
+        - include: string-escape-sequences
+        - include: single-dollar-string-interpolation
+        - match: '\$\{'
+          scope: punctuation.section.embedded.groovy
+          push:
+            - meta_scope: source.groovy.embedded.source
+            - match: '\}'
+              scope: punctuation.section.embedded.groovy
+              pop: true
+            - include: escaped-end-of-line
+            - include: groovy-code
+        # anything else following a dollar sign is not a valid interpolation
+        - match: \$(?=")
+          scope: invalid.illegal.groovy
+        - match: \$[^"]+
+          scope: invalid.illegal.groovy
+  string-dollar-slashy:
+    - match: '\$/'
+      captures:
+        0: punctuation.definition.string.begin.groovy
+      push:
+        - meta_scope: string.quoted.other.dollar-slashy.groovy
+        - match: '/\$'
+          captures:
+            0: punctuation.definition.string.end.groovy
+          pop: true
+        - match: '\$/|\$\$'
           scope: constant.character.escape.groovy
+        # backslashes only escape newlines (and unicode)
+        - include: escaped-end-of-line
+        - include: unicode-escape-sequence
+        - include: single-dollar-string-interpolation
+        - match: '\$\{'
+          scope: punctuation.section.embedded.groovy
+          push:
+            - meta_scope: source.groovy.embedded.source
+            - match: '\}'
+              scope: punctuation.section.embedded.groovy
+              pop: true
+            - include: escaped-end-of-line
+            - include: groovy-code
   strings:
+    - include: string-quoted-triple-double
+    - include: string-quoted-triple-single
     - include: string-quoted-double
     - include: string-quoted-single
     - include: regexp
+    - include: string-dollar-slashy
   structures:
     - match: '\['
       captures:

--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -179,9 +179,9 @@ contexts:
     - match: "<<"
       scope: keyword.operator.leftshift.groovy
     - match: (?<=\S)\.(?=\S)
-      scope: keyword.operator.navigation.groovy
+      scope: punctuation.accessor.dot.groovy
     - match: (?<=\S)\?\.(?=\S)
-      scope: keyword.operator.safe-navigation.groovy
+      scope: punctuation.accessor.groovy
     - match: \?
       captures:
         0: keyword.operator.ternary.groovy
@@ -426,7 +426,7 @@ contexts:
       scope: variable.other.interpolated.groovy
       push:
         - match: \.(?={{single_dollar_interpolation_identifier}})
-          scope: keyword.operator.navigation.groovy
+          scope: punctuation.accessor.dot.groovy
         - match: '{{single_dollar_interpolation_identifier}}'
           scope: variable.other.interpolated.groovy
         - match: \b

--- a/Groovy/tests/syntax_test_Strings.groovy
+++ b/Groovy/tests/syntax_test_Strings.groovy
@@ -91,7 +91,7 @@ interpolation3 = "Hello $name"
 
 interpolation4 = "Hello $person.name"
 //                      ^^^^^^^ variable.other.interpolated.groovy
-//                             ^ keyword.operator.navigation.groovy
+//                             ^ punctuation.accessor.dot.groovy
 //                              ^^^^ string.quoted.double.groovy variable.other.interpolated.groovy
 //                                  ^ punctuation.definition.string.end.groovy
 
@@ -126,13 +126,13 @@ unicodeInterpolation1 = "$À"
 
 unicodeInterpolation2 = "$À.ö"
 //                       ^^ variable.other.interpolated.groovy
-//                         ^ keyword.operator.navigation.groovy
+//                         ^ punctuation.accessor.dot.groovy
 //                          ^ variable.other.interpolated.groovy
 //                           ^ punctuation.definition.string.end.groovy
 
 unicodeInterpolation3 = "$\u00c0.\u00F6"
 //                       ^^^^^^^ variable.other.interpolated.groovy
-//                              ^ keyword.operator.navigation.groovy
+//                              ^ punctuation.accessor.dot.groovy
 //                               ^^^^^^ variable.other.interpolated.groovy
 //                                     ^ punctuation.definition.string.end.groovy
 
@@ -148,44 +148,44 @@ invalidInterpolation3 = "$$"
 //                       ^^ invalid.illegal - variable.other.interpolated.groovy
 //                         ^ punctuation.definition.string.end.groovy
 
-notANavigation1 = "$obj."
-//                 ^^^^^ string.quoted.double.groovy
-//                 ^^^^ variable.other.interpolated.groovy
-//                     ^ - keyword.operator.navigation.groovy
-//                      ^ punctuation.definition.string.end.groovy - variable.other.interpolated.groovy
+notAnAccessorDot1 = "$obj."
+//                   ^^^^^ string.quoted.double.groovy
+//                   ^^^^ variable.other.interpolated.groovy
+//                       ^ - punctuation.accessor.dot.groovy
+//                        ^ punctuation.definition.string.end.groovy - variable.other.interpolated.groovy
 
-notANavigation2 = "$obj.2"
-//                 ^^^^^^ string.quoted.double.groovy
-//                 ^^^^ variable.other.interpolated.groovy
-//                     ^ - keyword.operator.navigation.groovy
-//                      ^ - variable.other.interpolated.groovy
-//                       ^ punctuation.definition.string.end.groovy
+notAnAccessorDot2 = "$obj.2"
+//                   ^^^^^^ string.quoted.double.groovy
+//                   ^^^^ variable.other.interpolated.groovy
+//                       ^ - punctuation.accessor.dot.groovy
+//                        ^ - variable.other.interpolated.groovy
+//                         ^ punctuation.definition.string.end.groovy
 
-notANavigation3 = "$obj.×"
-//                 ^^^^^^ string.quoted.double.groovy
-//                 ^^^^ variable.other.interpolated.groovy
-//                     ^ - keyword.operator.navigation.groovy
-//                      ^ - variable.other.interpolated.groovy
-//                       ^ punctuation.definition.string.end.groovy
+notAnAccessorDot3 = "$obj.×"
+//                   ^^^^^^ string.quoted.double.groovy
+//                   ^^^^ variable.other.interpolated.groovy
+//                       ^ - punctuation.accessor.dot.groovy
+//                        ^ - variable.other.interpolated.groovy
+//                         ^ punctuation.definition.string.end.groovy
 
-notANavigation4 = "$obj.\u00D7"
-//                 ^^^^^^^^^^^ string.quoted.double.groovy
-//                 ^^^^ variable.other.interpolated.groovy
-//                     ^ - keyword.operator.navigation.groovy
-//                      ^^^^^^ constant.character.escape.groovy - variable.other.interpolated.groovy
-//                            ^ punctuation.definition.string.end.groovy
+notAnAccessorDot4 = "$obj.\u00D7"
+//                   ^^^^^^^^^^^ string.quoted.double.groovy
+//                   ^^^^ variable.other.interpolated.groovy
+//                       ^ - punctuation.accessor.dot.groovy
+//                        ^^^^^^ constant.character.escape.groovy - variable.other.interpolated.groovy
+//                              ^ punctuation.definition.string.end.groovy
 
 notASafeNavigation = "$obj?.nope"
 //                    ^^^^^^^^^^ string.quoted.double.groovy
 //                    ^^^^ variable.other.interpolated.groovy
-//                        ^^ - keyword.operator.safe-navigation.groovy
+//                        ^^ - punctuation.accessor.groovy
 //                          ^^^^ - variable.other.interpolated.groovy
 //                              ^ punctuation.definition.string.end.groovy
 
 notAMethodCall = "$obj.nope()"
 //                ^^^^^^^^^^^ string.quoted.double.groovy
 //                ^^^^ variable.other.interpolated.groovy
-//                    ^ keyword.operator.navigation.groovy
+//                    ^ punctuation.accessor.dot.groovy
 //                     ^^^^ variable.other.interpolated.groovy
 //                     ^^^^^^ - meta.method-call.groovy
 //                           ^ punctuation.definition.string.end.groovy
@@ -249,7 +249,7 @@ embeddedNonInterpolation = "${'$nope'}"
 
 dollarSlashy01 = $/Hello $person.name/$
 //                       ^^^^^^^ string.quoted.other.dollar-slashy.groovy variable.other.interpolated.groovy
-//                              ^ keyword.operator.navigation.groovy
+//                              ^ punctuation.accessor.dot.groovy
 //                               ^^^^ string.quoted.other.dollar-slashy.groovy variable.other.interpolated.groovy
 //                                   ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
 

--- a/Groovy/tests/syntax_test_Strings.groovy
+++ b/Groovy/tests/syntax_test_Strings.groovy
@@ -1,0 +1,298 @@
+// SYNTAX TEST "Packages/Groovy/Groovy.sublime-syntax"
+
+multilineSingle = '''
+//                ^^^ string.quoted.single.block.groovy punctuation.definition.string.begin.groovy
+  '''
+//^^^ string.quoted.single.block.groovy punctuation.definition.string.end.groovy
+
+multilineDouble = """
+//                ^^^ string.quoted.double.block.groovy punctuation.definition.string.begin.groovy
+  """
+//^^^ string.quoted.double.block.groovy punctuation.definition.string.end.groovy
+
+multilineDollarSlashy = $/
+//                      ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.begin.groovy
+  /$
+//^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+escapedNewlineSingle = '\
+//                     ^ string.quoted.single.groovy punctuation.definition.string.begin.groovy
+//                      ^^ string.quoted.single.groovy constant.character.escape.groovy - invalid.illegal.unclosed-string.groovy
+
+escapedNewlineDouble = "\
+//                     ^ string.quoted.double.groovy punctuation.definition.string.begin.groovy
+//                      ^^ string.quoted.double.groovy constant.character.escape.groovy - invalid.illegal.unclosed-string.groovy
+
+escapeNewlineTripleSingle = '''\
+//                          ^^^ string.quoted.single.block.groovy punctuation.definition.string.begin.groovy
+//                             ^^ string.quoted.single.block.groovy constant.character.escape.groovy - invalid.illegal.unclosed-string.groovy
+  '''
+//^^^ string.quoted.single.block.groovy punctuation.definition.string.end.groovy
+
+escapeNewlineTripleDouble = """\
+//                          ^^^ string.quoted.double.block.groovy punctuation.definition.string.begin.groovy
+//                             ^^ string.quoted.double.block.groovy constant.character.escape.groovy - invalid.illegal.unclosed-string.groovy
+  """
+//^^^ string.quoted.double.block.groovy punctuation.definition.string.end.groovy
+
+escapedNewlineInterpolated = "${\
+//                              ^^ string.quoted.double.groovy source.groovy.embedded.source constant.character.escape.groovy
+}";
+
+escapeInterpolation = "\${notInterpolated}"
+//                     ^^ constant.character.escape.groovy - punctuation.section.embedded.groovy
+//                       ^^^^^^^^^^^^^^^^^ string.quoted.double.groovy - source.groovy.embedded.source
+
+validEscapesSingle = '\$\'\"\t\n\r\t\f\b\u00D7\\'
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.groovy constant.character.escape.groovy
+
+validEscapesDouble = "\$\'\"\t\n\r\t\f\b\u00D7\\"
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.groovy constant.character.escape.groovy
+
+validEscapesTripleSingle = '''\$\'\"\t\n\r\t\f\b\u00D7\\'''
+//                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.block.groovy constant.character.escape.groovy
+
+validEscapesTripleDouble = """\$\'\"\t\n\r\t\f\b\u00D7\\"""
+//                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.block.groovy constant.character.escape.groovy
+
+validEscapesSlashy= /\/\u00D7/
+//                   ^^^^^^^^ string.regexp.groovy constant.character.escape.groovy
+
+invalidEscapesSingle = '\y \1 \+ \{'
+//                      ^^^^^^^^^^^ string.quoted.single.groovy - constant.character.escape.groovy
+
+invalidEscapesDouble = "\y \1 \+ \{"
+//                      ^^^^^^^^^^^ string.quoted.double.groovy - constant.character.escape.groovy
+
+invalidEscapesTripleSingle = '''\y \1 \+ \{'''
+//                              ^^^^^^^^^^^ string.quoted.single.block.groovy - constant.character.escape.groovy
+
+invalidEscapesTripleDouble = """\y \1 \+ \{"""
+//                              ^^^^^^^^^^^ string.quoted.double.block.groovy - constant.character.escape.groovy
+
+regularCharactersSlashy = /\$\'\"\t\n\r\t\f\b\y\1\+\{/
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.groovy - constant.character.escape.groovy
+
+regularCharactersDollarSlashy = $/\$\'\"\t\n\r\t\f\b\y\1\+\{/$
+//                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.dollar-slashy.groovy - constant.character.escape.groovy
+
+interpolation1 = "2 + 3 = ${2 + 3}"
+//                        ^^ punctuation.section.embedded.groovy
+//                          ^^^^^ source.groovy.embedded.source
+//                          ^ constant.numeric.groovy
+//                            ^ keyword.operator.arithmetic.groovy
+//                              ^ constant.numeric.groovy
+//                               ^ punctuation.section.embedded.groovy
+//                                ^ punctuation.definition.string.end.groovy
+
+interpolation3 = "Hello $name"
+//                      ^^^^^ variable.other.interpolated.groovy
+//                           ^ punctuation.definition.string.end.groovy
+
+interpolation4 = "Hello $person.name"
+//                      ^^^^^^^ variable.other.interpolated.groovy
+//                             ^ keyword.operator.navigation.groovy
+//                              ^^^^ string.quoted.double.groovy variable.other.interpolated.groovy
+//                                  ^ punctuation.definition.string.end.groovy
+
+interpolation5 = "$a2_3"
+//                ^^^^^ string.quoted.double.groovy variable.other.interpolated.groovy
+//                     ^ punctuation.definition.string.end.groovy
+
+interpolation6 = "The sum of 1 and 2 is equal to ${def a = 1; a + 2}"
+//                                                 ^^^^^^^^^^^^^^^^ string.quoted.double.groovy source.groovy.embedded.source
+//                                                 ^^^ storage.type.def.groovy
+//                                                         ^ constant.numeric.groovy
+//                                                              ^ keyword.operator.arithmetic.groovy
+//                                                                ^ constant.numeric.groovy
+//                                                                  ^ punctuation.definition.string.end.groovy
+
+interpolation7 = "foo { ${if (x) { y } else { z } } }"
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.groovy
+//                    ^ - punctuation.section.block.begin.groovy
+//                        ^^ keyword.control.groovy
+//                               ^ punctuation.section.block.begin.groovy
+//                                   ^ punctuation.section.block.end.groovy - punctuation.section.embedded.groovy
+//                                     ^^^^ keyword.control.groovy
+//                                          ^ punctuation.section.block.begin.groovy
+//                                              ^ punctuation.section.block.end.groovy - punctuation.section.embedded.groovy
+//                                                ^ punctuation.section.embedded.groovy
+//                                                  ^ - punctuation.section.block.end.groovy
+//                                                   ^ punctuation.definition.string.end.groovy
+
+unicodeInterpolation1 = "$À"
+//                       ^^ variable.other.interpolated.groovy
+//                         ^ punctuation.definition.string.end.groovy
+
+unicodeInterpolation2 = "$À.ö"
+//                       ^^ variable.other.interpolated.groovy
+//                         ^ keyword.operator.navigation.groovy
+//                          ^ variable.other.interpolated.groovy
+//                           ^ punctuation.definition.string.end.groovy
+
+unicodeInterpolation3 = "$\u00c0.\u00F6"
+//                       ^^^^^^^ variable.other.interpolated.groovy
+//                              ^ keyword.operator.navigation.groovy
+//                               ^^^^^^ variable.other.interpolated.groovy
+//                                     ^ punctuation.definition.string.end.groovy
+
+invalidInterpolation1 = "$"
+//                       ^ invalid.illegal
+//                        ^ punctuation.definition.string.end.groovy
+
+invalidInterpolation2 = "$21"
+//                       ^^^ invalid.illegal - variable.other.interpolated.groovy
+//                          ^ punctuation.definition.string.end.groovy
+
+invalidInterpolation3 = "$$"
+//                       ^^ invalid.illegal - variable.other.interpolated.groovy
+//                         ^ punctuation.definition.string.end.groovy
+
+notANavigation1 = "$obj."
+//                 ^^^^^ string.quoted.double.groovy
+//                 ^^^^ variable.other.interpolated.groovy
+//                     ^ - keyword.operator.navigation.groovy
+//                      ^ punctuation.definition.string.end.groovy - variable.other.interpolated.groovy
+
+notANavigation2 = "$obj.2"
+//                 ^^^^^^ string.quoted.double.groovy
+//                 ^^^^ variable.other.interpolated.groovy
+//                     ^ - keyword.operator.navigation.groovy
+//                      ^ - variable.other.interpolated.groovy
+//                       ^ punctuation.definition.string.end.groovy
+
+notANavigation3 = "$obj.×"
+//                 ^^^^^^ string.quoted.double.groovy
+//                 ^^^^ variable.other.interpolated.groovy
+//                     ^ - keyword.operator.navigation.groovy
+//                      ^ - variable.other.interpolated.groovy
+//                       ^ punctuation.definition.string.end.groovy
+
+notANavigation4 = "$obj.\u00D7"
+//                 ^^^^^^^^^^^ string.quoted.double.groovy
+//                 ^^^^ variable.other.interpolated.groovy
+//                     ^ - keyword.operator.navigation.groovy
+//                      ^^^^^^ constant.character.escape.groovy - variable.other.interpolated.groovy
+//                            ^ punctuation.definition.string.end.groovy
+
+notASafeNavigation = "$obj?.nope"
+//                    ^^^^^^^^^^ string.quoted.double.groovy
+//                    ^^^^ variable.other.interpolated.groovy
+//                        ^^ - keyword.operator.safe-navigation.groovy
+//                          ^^^^ - variable.other.interpolated.groovy
+//                              ^ punctuation.definition.string.end.groovy
+
+notAMethodCall = "$obj.nope()"
+//                ^^^^^^^^^^^ string.quoted.double.groovy
+//                ^^^^ variable.other.interpolated.groovy
+//                    ^ keyword.operator.navigation.groovy
+//                     ^^^^ variable.other.interpolated.groovy
+//                     ^^^^^^ - meta.method-call.groovy
+//                           ^ punctuation.definition.string.end.groovy
+
+lazyInterpolation = "lazy ${-> someVariable}"
+//                   ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.groovy
+//                          ^^ keyword.operator.arrow.groovy
+//                                          ^ punctuation.definition.string.end.groovy
+
+invalidStringClose = """""""
+//                      ^^^^ invalid.illegal
+
+unclosedStr1 = "
+//              ^ invalid.illegal.unclosed-string.groovy
+
+unclosedStr2 = '
+//              ^ invalid.illegal.unclosed-string.groovy
+
+unclosedStr3 = "newlines ${'''
+    aren't valid inside the interpolation but outside of the
+    multiline string
+'''}
+//  ^ invalid.illegal.unclosed-string.groovy
+
+unclosedStr4 = "newlines ${'''
+    aren't valid inside the interpolation but outside of the
+    multiline string'''
+//                     ^ invalid.illegal.unclosed-string.groovy
+
+// multiline string embedded in a single line string
+embed1 = "embed ${'''
+//       ^ string.quoted.double.groovy punctuation.definition.string.begin.groovy
+//        ^^^^^^ string.quoted.double.groovy
+//              ^^ punctuation.section.embedded.groovy
+//                ^^^ source.groovy.embedded.source
+  Some text
+//^^^^^^^^^ string.quoted.double.groovy source.groovy.embedded.source string.quoted.single.block.groovy
+'''}"
+// ^ punctuation.section.embedded.groovy
+//  ^ string.quoted.double.groovy punctuation.definition.string.end.groovy
+
+// multiline > singleline > multiline
+embed2 = """I hope
+    ${
+        " people ${'''don't
+//        ^^^^^^^ string.quoted.double.block.groovy source.groovy.embedded.source string.quoted.double.groovy
+//                    ^^^^^ string.quoted.single.block.groovy
+        actually'''}"
+//                 ^ string.quoted.double.block.groovy source.groovy.embedded.source string.quoted.double.groovy punctuation.section.embedded.groovy
+    }
+//  ^ punctuation.section.embedded.groovy
+              do this
+  """
+//^^^ string.quoted.double.block.groovy punctuation.definition.string.end.groovy
+
+embeddedInterpolation1 = "${"$yep"}"
+//                           ^^^^ string.quoted.double.groovy source.groovy.embedded.source string.quoted.double.groovy variable.other.interpolated.groovy
+
+embeddedNonInterpolation = "${'$nope'}"
+//                             ^^^^^ string.quoted.double.groovy source.groovy.embedded.source string.quoted.single.groovy - variable.other.interpolated.groovy
+
+dollarSlashy01 = $/Hello $person.name/$
+//                       ^^^^^^^ string.quoted.other.dollar-slashy.groovy variable.other.interpolated.groovy
+//                              ^ keyword.operator.navigation.groovy
+//                               ^^^^ string.quoted.other.dollar-slashy.groovy variable.other.interpolated.groovy
+//                                   ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy02 = $/today is ${new Date().format( 'yyyy-MM-dd' )}./$
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.groovy.embedded.source
+//                          ^^ punctuation.section.embedded.groovy
+//                            ^^^ keyword.other.new.groovy
+//                                       ^^^^^^^^^^^^^^^^^^^^^^ meta.method-call.groovy
+//                                                               ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy03 = $/$ dollar sign/$
+//                 ^^^^^^^^^^^^^ string.quoted.other.dollar-slashy.groovy - invalid.illegal
+//                              ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy04 = $/$$ escaped dollar sign/$
+//                 ^^ string.quoted.other.dollar-slashy.groovy constant.character.escape.groovy - invalid.illegal - variable.other.interpolated.groovy
+//                                       ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy05 = $/\ backslash/$
+//                 ^^^^^^^^^^^ string.quoted.other.dollar-slashy.groovy - invalid.illegal - constant.character.escape.groovy
+//                            ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy06 = $// forward slash/$
+//                 ^^^^^^^^^^^^^^^ string.quoted.other.dollar-slashy.groovy - invalid.illegal - constant.character.escape.groovy
+//                                ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy07 = $/$/ escaped forward slash/$
+//                 ^^ string.quoted.other.dollar-slashy.groovy constant.character.escape.groovy
+//                                         ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy08 = $/$$$/ escaped opening dollar slashy/$
+//                 ^^^^ string.quoted.other.dollar-slashy.groovy constant.character.escape.groovy
+//                                                   ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy09 = $/$/$$ escaped closing dollar slashy/$
+//                 ^^^^ string.quoted.other.dollar-slashy.groovy constant.character.escape.groovy
+//                                                   ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+dollarSlashy10 = $/${$$}/$
+//                   ^^ string.quoted.other.dollar-slashy.groovy source.groovy.embedded.source - constant.character.escape.groovy
+//                      ^^ string.quoted.other.dollar-slashy.groovy punctuation.definition.string.end.groovy
+
+interpolatedSlashy = /a ${color} $obj$/
+//                        ^^^^^ string.regexp.groovy source.groovy.embedded.source
+//                               ^^^^ string.regexp.groovy variable.other.interpolated.groovy
+//                                   ^ string.regexp.groovy - variable.other.interpolated.groovy


### PR DESCRIPTION
- Highlight triple quoted strings
- Highlight "dollar slashy strings"
- Highlight unclosed strings
- Highlight erroneous newlines in single line strings
- Highlight invalid identifiers in interpolated strings
- Highlight interpolation in slashy strings ("regexp")
- Enable full language highlighting inside interpolation
- Only include the proper unicode ranges in identifiers (variables)
  inside string interpolation.
- Only match valid escape sequences (instead of any character at all);
  note that the different kinds of strings don't share all of the same
  escape sequences.
- Add a whole bunch of tests for strings

Note: Technically "slashy strings" (scoped as "regexp" here) allow
newlines as well, but I think more work needs to be done before
removing the lookahead expression on the opening '/'.

For instance, the following is already highlighted incorrectly and it
would probably lead to even more troubles if these were set free from
their current single line containment (without additional work).

```groovy
// Current (incorrect) highlighting
def a = 1 / 2 + / 3 /
//      ^ constant.numeric.groovy
//        ^^^^^^^ string.regexp.groovy
//                ^ constant.numeric.groovy
//                  ^ keyword.operator.arithmetic.groovy

// Correct highlighting
def a = 1 / 2 + / 3 /
//      ^ constant.numeric.groovy
//        ^ keyword.operator.arithmetic.groovy
//          ^ constant.numeric.groovy
//            ^ keyword.operator.arithmetic.groovy
//              ^^^^^ string.regexp.groovy
```