### PR TITLE
[ShellScript] Refactor redirection handling

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -50,7 +50,7 @@ variables:
   extension: \.sh
   identifier: '[[:alpha:]_][[:alnum:]_]*'
   identifier_non_posix: '[^{{metachar}}\d][^{{metachar}}]*'
-  is_command: \s*(?=\S)
+  is_command: (?=\S)
   is_end_of_interpolation: \)
   is_end_of_option: '[^\w$-]|$'
   is_function: \s*\b(function)\s+|(?=\s*{{identifier_non_posix}}\s*\(\s*\))
@@ -58,7 +58,12 @@ variables:
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
   keyword_boundary_end: (?!=)(?=[^\w_-])
-  metachar: '[/$`=|&;()<>\s]'
+
+  # A character that, when unquoted, separates words. A metacharacter is a
+  # space, tab, newline, or one of the following characters: ‘|’, ‘&’, ‘;’,
+  # ‘(’, ‘)’, ‘<’, or ‘>’.
+  metachar: '[\s\t\n|&;()<>]'
+
   nbc: '[^{}()=\s]*' # non bracket characters (and also non-whitespace, parens)
   reset_and: \s*(&&)
   reset_job: \s*(&)
@@ -121,6 +126,7 @@ contexts:
   main:
     - include: funcdef
     - include: vardef
+    - include: redirection
     - match: '{{is_command}}'
       push: cmd
 
@@ -137,6 +143,7 @@ contexts:
   main-bt:
     - include: funcdef-bt
     - include: vardef
+    - include: redirection
     - match: '{{is_command}}'
       push: cmd-bt
 
@@ -490,20 +497,32 @@ contexts:
         - include: main
 
   redirection-output:
-    - match: (\d*)(>>!?|>&?|&>|&?>(?:\||>))\s*(?:(\d+)|(-))?\s*
+    - match: (\d*)(>>!?|>&?|&>|&?>(?:\||>))
       captures:
         1: constant.numeric.integer.decimal.file-descriptor.shell
         2: keyword.operator.assignment.redirection.shell
-        3: constant.numeric.integer.decimal.file-descriptor.shell
-        4: punctuation.terminator.file-descriptor.shell
+      push: redirection-post
 
   redirection-input:
-    - match: (\d*)(<&?)((-)|(\d+))?\s*
+    - match: (\d*)(<&?)
       captures:
         1: constant.numeric.integer.decimal.file-descriptor.shell
         2: keyword.operator.assignment.redirection.shell
-        4: punctuation.terminator.shell
-        5: constant.numeric.integer.decimal.file-descriptor.shell
+      push: redirection-post
+
+  redirection-post:
+    - match: \s*(?:(\d+)|(-))
+      captures:
+        1: constant.numeric.integer.decimal.file-descriptor.shell
+        2: punctuation.terminator.file-descriptor.shell
+      pop: true
+    - match: \s*(?=\S)
+      set:
+        - match: (?={{metachar}}|`)
+          pop: true
+        - include: expansion-and-string
+    - match: \s*
+      pop: true
 
   redirection-inout:
     - match: (\d*)(<>)

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1734,6 +1734,20 @@ gzip | tee >(md5sum - | sed 's/-$/mydata.lz2/'>mydata-gz.md5) > mydata.gz
 #                                             ^ keyword.operator.assignment.redirection
 #                                                           ^ punctuation
 #                                                             ^ keyword.operator.assignment.redirection
+LC_ALL=C 2> /dev/null
+#        ^ constant.numeric.integer.decimal.file-descriptor
+#         ^ keyword.operator.assignment.redirection
+#           ^ - variable.function
+2>&1 echo foo
+# <- constant.numeric.integer.decimal.file-descriptor
+#^^ keyword.operator.assignment.redirection
+#  ^ constant.numeric.integer.decimal.file-descriptor
+#    ^^^^ meta.function-call support.function.echo
+#        ^^^^ meta.function-call.arguments
+touch file.txt
+foo=x <file.txt
+#     ^ keyword.operator.assignment.redirection
+#      ^ - variable.function
 
 ##################
 # Here documents #


### PR DESCRIPTION
- Redirections may occur *before* a command. For example: `2>&1 echo foo`.
- Redirections may occur *after* a variable assignment. For example: `LC_ALL=C 2> /dev/null`.

Related (but doesn't close): https://github.com/sublimehq/Packages/issues/1358