### PR TITLE
[ShellScript] Fix: func defs in command substitutions are allowed

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1039,8 +1039,7 @@ contexts:
           captures:
             1: punctuation.section.parens.end.shell
           pop: true
-        - match: ""
-          push: cmd
+        - include: main
     - match: \`
       scope: punctuation.section.group.begin.shell
       push:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2075,6 +2075,23 @@ function foo {
 
 # <- - meta.function
 
+foo=$(
+  #  ^ punctuation.section
+  func() {
+    # <- meta.function entity.name.function
+    #    ^ punctuation.section
+    echo bar
+  }
+  # <- punctuation.section
+  func
+  
+  # <- meta.group.expansion.command
+)
+# <- punctuation.section
+echo $foo # prints "bar"
+
+# <- - meta.function - meta.group.expansion
+
 foo:foo () {
   # <- meta.function entity.name.function
     echo "this foo:foo"


### PR DESCRIPTION
You can have functions defined *inside* command substitutions. e.g.

```bash
foo=$(
  func() {
    echo bar
  }
  func
)
echo $foo # prints "bar"
```
Related to, but doesn't close, https://github.com/sublimehq/Packages/issues/1358