### PR TITLE
[ShellScript] Fix: lookahead for (more) metachars in variable assignments

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -466,7 +466,7 @@ contexts:
         - include: expansion-and-string
         - include: line-continuation-or-pop-at-end
         - include: any-escape
-        - match: (?=[\s;])
+        - match: (?={{metachar}})
           pop: true
 
   redirection:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -432,6 +432,12 @@ done=hello
 # <- - keyword.control
 #   ^ keyword.operator
 
+(foo=bar)
+# <- punctuation.definition.compound.begin
+#   ^ keyword.operator.assignment
+#    ^^^ string.unquoted
+#       ^ punctuation.definition.compound.end - string-unquoted
+
 foo= pwd
 local pid="$(cat "$PIDFILE" 2>/dev/null)"
 #     ^ - variable.parameter


### PR DESCRIPTION
You can define variables inside sub shells, e.g.

```
#!/bin/bash
(foo=bar)
```
Related to, but doesn't close, https://github.com/sublimehq/Packages/issues/1358