### PR TITLE
[ShellScript] Fix: Unescaped hash inside parameter expansion breaks file

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1073,6 +1073,7 @@ contexts:
     - include: expansion-command
     - include: expansion-tilde
     # no pattern expansion
+    - include: any-escape
 
   array:
     - match: \[
@@ -1137,6 +1138,7 @@ contexts:
         1: variable.language.shell
         2: keyword.operator.expansion.shell
       set:
+        - meta_include_prototype: false
         - meta_content_scope: meta.group.expansion.parameter.shell
         - include: expansion-parameter-common
         - include: expansion-pattern

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -741,6 +741,12 @@ ${var###Pattern}
 #      ^ - keyword.operator
 #              ^ punctuation
 
+: ${foo# #} # hello
+#      ^ keyword.operator.expansion
+#        ^ meta.group.expansion - comment-line
+#         ^ punctuation
+#           ^ comment.line punctuation
+
 ${var%Pattern}
 # <- punctuation.definition.variable
 #    ^ keyword.operator
@@ -757,6 +763,25 @@ ${var%%%Pattern}
 #      ^ - keyword.operator
 #              ^ punctuation
 
+: ${foo% #} # hello
+#      ^ keyword.operator.expansion
+#        ^ meta.group.expansion - comment-line
+#         ^ punctuation
+#           ^ comment.line punctuation
+
+: ${foo#\ \#} # hello
+#      ^ keyword.operator.expansion
+#       ^^^^ constant.character.escape
+#          ^ meta.group.expansion - comment-line
+#           ^ punctuation
+#             ^ comment.line punctuation
+
+: ${foo%\ \#} # hello
+#      ^ keyword.operator.expansion
+#       ^^^^ constant.character.escape
+#          ^ meta.group.expansion - comment-line
+#           ^ punctuation
+#             ^ comment.line punctuation
 
 ####################################################################
 # Parameter-expansion operators                                    #


### PR DESCRIPTION
For example:

```bash
#!/bin/bash
foo=" #bar"
echo ${foo# #} # prints "bar"
```

Related to https://github.com/sublimehq/Packages/issues/1358.