### PR TITLE
[Java] Refactor Java Properties

### DIFF
--- a/Java/Comments - Properties.tmPreferences
+++ b/Java/Comments - Properties.tmPreferences
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments - Properties</string>
+    <key>scope</key>
+    <string>source.java-props</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string># </string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START_2</string>
+                <key>value</key>
+                <string>! </string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/Java/JavaProperties.sublime-syntax
+++ b/Java/JavaProperties.sublime-syntax
@@ -5,23 +5,46 @@ name: Java Properties
 file_extensions:
   - properties
 scope: source.java-props
+
+# https://en.wikipedia.org/wiki/.properties
 contexts:
   main:
-    - match: '([#!])(.+)?$\n?'
-      scope: comment.line.number-sign.java-props
+    - match: ^\s*([#!]).*
+      scope: comment.line.java-props
       captures:
         1: punctuation.definition.comment.java-props
-    - match: /\*
-      captures:
-        0: punctuation.definition.comment.java-props
+
+    - match: (?=\S)
       push:
-        - meta_scope: comment.block.java-props
-        - match: \*/
-          captures:
-            0: punctuation.definition.comment.java-props
+        - - meta_scope: meta.property.java-props
+          - match: ''
+            pop: true
+        - property
+
+  property:
+    - meta_content_scope: entity.name.key.java-props
+    - include: backslash
+    - match: (?=[:=\s])
+      set:
+        - match: '[:=]'
+          scope: punctuation.separator.java-props
+          set: property-value
+        - include: property-value
+      with_prototype:
+        - match: (?=\n)
           pop: true
-    - match: "^([^:=]+)([:=])(.*)$"
-      comment: Not compliant with the properties file spec, but this works for me, and I'm the one who counts around here.
+
+  property-value:
+    - match: (?=\S)
+      set:
+        - meta_content_scope: string.unquoted.java-props
+        - include: backslash
+
+  backslash:
+    - match: (\\)\n
       captures:
-        1: keyword.other.java-props
-        2: punctuation.separator.key-value.java-props
+        1: punctuation.separator.continuation.java-props
+    - match: \\u[[:xdigit:]]{4}
+      scope: constant.character.escape.unicode.java-props
+    - match: \\[^u]
+      scope: constant.character.escape.java-props

--- a/Java/Symbol List - Properties.tmPreferences
+++ b/Java/Symbol List - Properties.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Symbol List - Properties</string>
+    <key>scope</key>
+    <string>entity.name.key.java-props</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>s/\\(?!u)//g;</string>
+    </dict>
+</dict>
+</plist>

--- a/Java/syntax_test_java_properties.properties
+++ b/Java/syntax_test_java_properties.properties
@@ -1,0 +1,109 @@
+# SYNTAX TEST "Packages/Java/JavaProperties.sublime-syntax"
+
+# Comment line 1
+# <- comment.line.java-props punctuation.definition.comment.java-props
+#^^^^^^^^^^^^^^^ comment.line.java-props
+
+  # Comment line 2
+# ^ comment.line.java-props punctuation.definition.comment.java-props
+# ^^^^^^^^^^^^^^^^ comment.line.java-props
+
+! Comment line 3
+# <- comment.line.java-props punctuation.definition.comment.java-props
+#^^^^^^^^^^^^^^^ comment.line.java-props
+
+  ! Comment line 4
+# ^ comment.line.java-props punctuation.definition.comment.java-props
+# ^^^^^^^^^^^^^^^^ comment.line.java-props
+
+property_name=Value of Property
+#^^^^^^^^^^^^ entity.name.key.java-props
+#            ^ punctuation.separator.java-props
+#             ^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+
+property_name = Value of Property
+#^^^^^^^^^^^^ entity.name.key.java-props
+#            ^ -entity.name.key.java-props
+#             ^ punctuation.separator.java-props
+#              ^ -entity.name.key.java-props
+#               ^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+
+property_name:Value of Property
+#^^^^^^^^^^^^ entity.name.key.java-props
+#            ^ punctuation.separator.java-props
+#             ^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+
+property_name     :     Value of Property
+#^^^^^^^^^^^^ entity.name.key.java-props
+#            ^^^^^ -entity.name.key.java-props
+#                 ^ punctuation.separator.java-props
+#                  ^^^^^ -entity.name.key.java-props
+#                       ^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+
+property_name Value of Property
+#^^^^^^^^^^^^ entity.name.key.java-props
+#            ^ -entity.name.key.java-props -string.unquoted.java-props
+#             ^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+
+
+name=
+#^^^ entity.name.key.java-props
+#   ^ punctuation.separator.java-props
+value
+#^^^^ entity.name.key.java-props -string.unquoted.java-props
+
+=value
+# <- punctuation.separator.java-props
+#^^^^^ string.unquoted.java-props
+
+:value
+# <- punctuation.separator.java-props
+#^^^^^ string.unquoted.java-props
+
+name===value
+#   ^ punctuation.separator.java-props
+#    ^^ -punctuation.separator.java-props string.unquoted.java-props
+
+name\ with\=escap\es\:=Value \ with \nescap\es
+#^^^^^^^^^^^^^^^^^^^^^ entity.name.key.java-props
+#   ^^ constant.character.escape.java-props
+#         ^^ constant.character.escape.java-props
+#                ^^ constant.character.escape.java-props
+#                   ^^ constant.character.escape.java-props
+#                     ^ punctuation.separator.java-props
+#                      ^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+#                            ^^ constant.character.escape.java-props
+#                                   ^^ constant.character.escape.java-props
+#                                          ^^ constant.character.escape.java-props
+
+
+unicode_\u263A = \u263B unicode \u263c
+#^^^^^^^^^^^^^ entity.name.key.java-props
+#       ^^^^^^ constant.character.escape.unicode.java-props
+#                ^^^^^^^^^^^^^^^^^^^^^ string.unquoted.java-props
+#                ^^^^^^ constant.character.escape.unicode.java-props
+#                               ^^^^^^ constant.character.escape.unicode.java-props
+
+name = First Line \
+#      ^^^^^^^^^^^^ string.unquoted.java-props
+#                 ^ punctuation.separator.continuation.java-props
+
+name = First Line \
+       Second Line \
+       Third Line
+#      ^^^^^^^^^^ string.unquoted.java-props
+
+name=value
+#^^^ -string.unquoted.java-props
+
+name = \
+value
+#^^^^ string.unquoted.java-props
+
+name = \
+# Not a comment
+#^^^^^^^^^^^^^^ string.unquoted.java-props
+
+property_\
+name = value
+#^^^ entity.name.key.java-props


### PR DESCRIPTION
Another remnant of the TextMate era. The format is really simple but has its own 'hidden features'.

Changes:

1. Property key and value are now scoped as `entity.name.key` and `string.unquoted` respectively. Key's scope is added to symbols' list.
2. Line continuation and escapes are recognized.
3. `tmPreferences` with settings for line comments.
4. Block comments were removed as there is no such thing.