### PR TITLE
[HTML] Improved language detection in `<script>` and `<style>` tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -83,11 +83,13 @@ contexts:
         - include: tag-attributes
     - match: (<)((?i:style))\b
       captures:
+        0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push: style-css
     - match: '(<)((?i:script))\b'
       captures:
+        0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push: script-javascript
@@ -196,7 +198,7 @@ contexts:
       scope: invalid.illegal.incomplete.html
 
   style-css:
-    - meta_scope: meta.tag.style.begin.html
+    - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
@@ -208,7 +210,7 @@ contexts:
           escape: (?i)(?=(?:-->\s*)?</style)
 
   style-other:
-    - meta_scope: meta.tag.style.begin.html
+    - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
@@ -233,13 +235,13 @@ contexts:
 
   style-type-attribute:
     - match: (?i)\btype\b
-      scope: entity.other.attribute-name.html
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
-        - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
             - include: style-type-decider
         - match: (?=\S)
           set: style-css
@@ -248,30 +250,33 @@ contexts:
     - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
       set:
         - style-css
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=>|''|"")
       set:
         - style-css
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
         - style-other
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
 
   script-javascript:
-    - meta_scope: meta.tag.script.begin.html
+    - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
-        - match: ''
+        - match: (?=\S)
           embed: scope:source.js
           embed_scope: source.js.embedded.html
           escape: (?i)(?=(?:-->\s*)?</script)
 
   script-other:
-    - meta_scope: meta.tag.script.begin.html
+    - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
@@ -300,13 +305,13 @@ contexts:
 
   script-type-attribute:
     - match: (?i)\btype\b
-      scope: entity.other.attribute-name.html
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
-        - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
             - include: script-type-decider
         - match: (?=\S)
           set: script-javascript
@@ -315,18 +320,22 @@ contexts:
     - match: (?i)(?=text/javascript(?!{{unquoted_attribute_value}})|'text/javascript'|"text/javascript")
       set:
         - script-javascript
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
       set:
         - script-javascript
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=>|''|"")
       set:
         - script-javascript
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
         - script-other
+        - tag-generic-attribute-meta
         - tag-generic-attribute-value
 
   entities-common:
@@ -400,6 +409,7 @@ contexts:
         - include: attribute-entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html
+      pop: true
     - include: else-pop
 
   tag-class-attribute:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -245,11 +245,7 @@ contexts:
           set: style-css
 
   style-type-decider:
-    - match: (?i)(?=text/css|'text/css'|"text/css")
-      set:
-        - style-css
-        - tag-generic-attribute-value
-    - match: (?i)(?=module|'module'|"module")
+    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
       set:
         - style-css
         - tag-generic-attribute-value
@@ -316,11 +312,11 @@ contexts:
           set: script-javascript
 
   script-type-decider:
-    - match: (?i)(?=text/javascript|'text/javascript'|"text/javascript")
+    - match: (?i)(?=text/javascript(?!{{unquoted_attribute_value}})|'text/javascript'|"text/javascript")
       set:
         - script-javascript
         - tag-generic-attribute-value
-    - match: (?i)(?=module|'module'|"module")
+    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
       set:
         - script-javascript
         - tag-generic-attribute-value

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -106,33 +106,11 @@ contexts:
             - match: '(?=>)'
               pop: true
             - include: tag-attributes
-    - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))'
+    - match: '(<)((?i:script))\b'
       captures:
-        0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
-      push:
-        - match: (?i)(-->)?\s*(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: comment.block.html punctuation.definition.comment.html
-            2: punctuation.definition.tag.begin.html
-            3: entity.name.tag.script.html
-            4: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)\s*(<!--)?'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-            2: comment.block.html punctuation.definition.comment.html
-          embed: scope:source.js
-          embed_scope: source.js.embedded.html
-          escape: (?i)(?=(-->)?\s*</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
+      push: script-javascript
     - match: (</?)((?i:body|head|html)\b)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -236,6 +214,78 @@ contexts:
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
+
+  script-javascript:
+    - meta_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+        - match: ''
+          embed: scope:source.js
+          embed_scope: source.js.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</script)
+
+  script-other:
+    - meta_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+
+  script-close-tag:
+    - match: \s*(<!--)
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+    - match: (?i)(?:(-->)\s*)?(</)(script)(>)
+      scope: meta.tag.script.end.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.end.html
+        2: punctuation.definition.tag.begin.html
+        3: entity.name.tag.script.html
+        4: punctuation.definition.tag.end.html
+      pop: true
+
+  script-common:
+    - include: script-type-attribute
+    - include: tag-attributes
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  script-type-attribute:
+    - match: (?i)\btype\b
+      scope: entity.other.attribute-name.html
+      set:
+        - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-type-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  script-type-decider:
+    - match: (?i)(?=text/javascript|'text/javascript'|"text/javascript")
+      set:
+        - script-javascript
+        - tag-generic-attribute-value
+    - match: (?i)(?=module|'module'|"module")
+      set:
+        - script-javascript
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - script-javascript
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - script-other
+        - tag-generic-attribute-value
+
   entities-common:
     - match: (&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)
       scope: constant.character.entity.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -81,31 +81,11 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
+    - match: (<)((?i:style))\b
       captures:
-        0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)\s*'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css
-          embed_scope: source.css.embedded.html
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
+      push: style-css
     - match: '(<)((?i:script))\b'
       captures:
         1: punctuation.definition.tag.begin.html
@@ -214,6 +194,73 @@ contexts:
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
+
+  style-css:
+    - meta_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+        - match: ''
+          embed: scope:source.css
+          embed_scope: source.css.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</style)
+
+  style-other:
+    - meta_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+
+  style-close-tag:
+    - match: (?i)(</)(style)(>)
+      scope: meta.tag.style.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  style-common:
+    - include: style-type-attribute
+    - include: tag-attributes
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  style-type-attribute:
+    - match: (?i)\btype\b
+      scope: entity.other.attribute-name.html
+      set:
+        - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-type-decider
+        - match: (?=\S)
+          set: style-css
+
+  style-type-decider:
+    - match: (?i)(?=text/css|'text/css'|"text/css")
+      set:
+        - style-css
+        - tag-generic-attribute-value
+    - match: (?i)(?=module|'module'|"module")
+      set:
+        - style-css
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - style-css
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - style-other
+        - tag-generic-attribute-value
 
   script-javascript:
     - meta_scope: meta.tag.script.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -27,7 +27,7 @@
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html
-        ## ^^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
+        ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
         ##                     ^ - meta.tag
             h2 {
@@ -43,7 +43,7 @@
         ##      ^ - meta.tag
         <style />
         ##       ^ - source.css.embedded.html
-        ## ^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+        ## ^ meta.tag.style entity.name.tag.style
         <script />
         ##        ^ - source.js.embedded.html
         ## ^ meta.tag.script entity.name.tag.script

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -24,6 +24,24 @@
         ##    ^^^^^^ entity.name.tag.script.html
         ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
         ##           ^ - meta.tag
+
+        <script
+        type
+        =
+        text/javascript>
+            var foo = 100;
+        ##  ^^^^^^^^^^^^^^^ source.js.embedded
+        </script>
+
+        <script
+        type
+        =
+        'other'
+        >
+            var foo = 100;
+        ##  ^^^^^^^^^^^^^^^ - source.js
+        </script>
+
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html
@@ -41,6 +59,23 @@
         ##<- meta.tag.style.end.html - source.css.embedded.html
         ##^^^^^^ meta.tag.style.end.html - source.css.embedded.html
         ##      ^ - meta.tag
+
+        <style
+        type
+        =
+        text/css>
+            div {}
+        ##  ^^^^^^ source.css.embedded
+        </style>
+
+        <style
+        type
+        =
+        text/csss>
+            div {}
+        ##  ^^^^^^ - source.css
+        </style>
+
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.style entity.name.tag.style

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -11,7 +11,7 @@
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
-        ##                              ^^^^ comment.block.html punctuation.definition.comment.html
+        ##                              ^^^^ comment.block.html punctuation.definition.comment.begin.html
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
@@ -20,7 +20,7 @@
             (a --> b);
             ## ^^^ source.js.embedded.html meta.group.js keyword.operator
         --> </script>
-        ## <- comment.block.html punctuation.definition.comment.html
+        ## <- comment.block.html punctuation.definition.comment.end.html
         ##    ^^^^^^ entity.name.tag.script.html
         ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
         ##           ^ - meta.tag
@@ -46,7 +46,7 @@
         ## ^ meta.tag.inline.any.html entity.name.tag.inline.any.html
         <script />
         ##        ^ - source.js.embedded.html
-        ## ^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+        ## ^ meta.tag.script entity.name.tag.script
     </head>
     <body>
         <!-- Comment -->


### PR DESCRIPTION
In HTML, `<script>` tags usually contain JavaScript code and `<style>` tags usually contain CSS. However, if the tag's `type` attribute is set to a value other than `text/javascript` or `text/css` (respectively), the tag's contents will not be processed. The default HTML syntax handles this with a lookahead. However, there are several cases where this lookahead will fail:

```html
<script type='other'>
    var x = 0;
</script>

<script
type='text/other'>
    var x = 0;
</script>

<script type=text/javascriptFOO>
    var x = 0;
</script>
```

This PR adds a robust system for detecting attributes that determine the language. As implemented, this should handle all of the corner cases for JavaScript and CSS. In addition, third parties could use a system like YAML Macros to easily extend the core syntax with support for new languages. For instance (#1376), you could add support for [LESS](http://lesscss.org/) with the following YAML Macros patch:

```yaml
!merge
contexts:

  style-type-decider: !prepend
    - match: (?i)(?=text/x-less(?!{{unquoted_attribute_value}})|'text/x-less'|"text/x-less")
      set:
        - style-less
        - tag-generic-attribute-meta
        - tag-generic-attribute-value

  style-less:
    - meta_content_scope: meta.tag.style.begin.html
    - include: style-common
    - match: '>'
      scope: punctuation.definition.tag.end.html
      set:
        - include: style-close-tag
        - match: ''
          embed: scope:source.less
          embed_scope: source.less.embedded.html
          escape: (?i)(?=</style)
```