### PR TITLE
[Python] Fixed a couple of newline-related bugs.

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -515,7 +515,7 @@ contexts:
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
       pop: true
-    - match: (?!\s|#)
+    - match: (?=\S)
       pop: true
 
   classes:
@@ -1765,6 +1765,7 @@ contexts:
         1: storage.modifier.async.python
         2: keyword.control.flow.for.generator.python
       push:
+        - include: comments
         - meta_scope: meta.expression.generator.python
         - match: \b(in)\b
           scope: keyword.control.flow.for.in.python
@@ -1782,7 +1783,6 @@ contexts:
       scope: keyword.control.flow.else.inline.python
 
   target-list:
-    - include: line-continuation-or-pop
     - match: ','
       scope: punctuation.separator.target-list.python
     - match: \(

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -266,7 +266,7 @@ def _():
 #                       ^ invalid.illegal.expected-parameter.python
 #                            ^ invalid.illegal.expected-parameter.python
 
-    lambda
+    lambda x
 #   ^^^^^^ storage.type.function.inline
 
     ( 3 - 6 \
@@ -578,6 +578,16 @@ def func(*args, other_arg=2**10, **kwargs):
 #                                ^^ keyword.operator.unpacking.mapping.python
     pass
 
+def func(
+    *args,
+#   ^ keyword.operator.unpacking.sequence
+    other_arg=2**10,
+#              ^^ keyword.operator.arithmetic
+    **kwargs
+#   ^^ keyword.operator.unpacking.mapping
+):
+    pass
+
 
 ##################
 # Class definitions
@@ -848,6 +858,16 @@ l = [1 * 2, 2**10, *result]
 d = {1: 3**4, **dict_}
 #        ^^ keyword.operator.arithmetic.python
 #             ^^ keyword.operator.unpacking.mapping.python
+
+generator = (
+    i
+    for
+#   ^^^ keyword.control.flow.for.generator
+    i
+    in
+#   ^^ keyword.control.flow.for.in
+    range(100)
+)
 
 ##################
 # Exception handling


### PR DESCRIPTION
Should fix #1367 and #1377. Tests added.

The Python syntax should probably have comments in the prototype rather than including it manually. I ran into a comment bug while working on this, and there are probably more lurking. It's much easier to put `meta_include_prototype: false` in a handful of places than `include: comments` in dozens of places.

There was a bit of invalid Python in a test, and fixing this broke the following test. I changed the first test to avoid the problem. It's possible that there's some special error behavior that the first test is trying to trigger; someone more familiar with the Python syntax definition might take a look.