### PR TITLE
[ShellScript] Fix: regex set handling

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -985,7 +985,7 @@ contexts:
     - match: \[
       scope: keyword.control.regexp.set.begin.shell
       push:
-        - match: \]
+        - match: (?=])
           set: expansion-pattern-post-first-char
         - match: '[!^]'
           scope: keyword.operator.logical.not.shell
@@ -1014,6 +1014,11 @@ contexts:
       captures:
         1: punctuation.separator.character-class.begin.shell
         2: punctuation.separator.character-class.end.shell
+    # You cannot have a regex set inside a regex set, so just consume this
+    # character in order to not push into another regex set.
+    # Except when writing a character class like [:lower:], so negative look
+    # ahead for that possibility.
+    - match: \[(?![\.=:])
     - include: expansion-and-string
 
   expansion-arithmetic:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -998,6 +998,40 @@ echo +(bar|qux)
 #     ^ punctuation.section.parens.begin
 #         ^ keyword.operator.logical.or
 #             ^ punctuation.section.parens.end
+[[ a == [abc[]* ]]
+#           ^ - keyword.control
+#               ^^ support.function
+: ${foo//[abc[]/x}
+#            ^ - keyword.control
+#                ^ punctuation.section.expansion.parameter.end
+if [[ ' foobar' == [\ ]foo* ]]; then
+  #                ^ keyword.control.regexp.set.begin
+  #                 ^^ constant.character.escape
+  #                   ^ keyword.control.regexp.set.end
+  #                         ^^ support.function.double-brace.end
+  :
+fi
+case $_G_unquoted_arg in
+*[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")
+#^ keyword.control.regexp.set.begin
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape
+#                                 ^ keyword.control.regexp.set.end
+#                                     ^ - keyword.control
+  _G_quoted_arg=\"$_G_unquoted_arg\"
+  ;;
+*)
+  _G_quoted_arg=$_G_unquoted_arg
+;;
+esac
+case $1 in
+*[\\\`\"\$]*)
+#^ keyword.control.regexp.set.begin
+# ^^^^^^^^ constant.character.escape
+#         ^ keyword.control.regexp.set.end
+  _G_unquoted_arg=`printf '%s\n' "$1" |$SED "$sed_quote_subst"` ;;
+*)
+  _G_unquoted_arg=$1 ;;
+esac
 
 ###################
 # Misc. operators #


### PR DESCRIPTION
Related: https://github.com/sublimehq/Packages/issues/1358

These constructs should not break highlighting anymore:
```bash
[[ a == [abc[]* ]]
: ${foo//[abc[]/x}

if [[ ' foobar' == [\ ]foo* ]]; then
  :
fi
```