### PR TITLE
[Regular Expressions] enable toggle block comment support

### DIFF
--- a/Regular Expressions/Comments.tmPreferences
+++ b/Regular Expressions/Comments.tmPreferences
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.regexp</string>
+	<key>settings</key>
+	<dict>
+	<key>shellVariables</key>
+	<array>
+		<dict>
+		<key>name</key>
+		<string>TM_COMMENT_START</string>
+		<key>value</key>
+		<string>(?# </string>
+		</dict>
+		<dict>
+		<key>name</key>
+		<string>TM_COMMENT_END</string>
+		<key>value</key>
+		<string>)</string>
+		</dict>
+	</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds the required `tmPreferences` metadata file to enable support for the "toggle block comment" functionality in ST. Maybe in future we will want to get fancy and allow line comments to be toggled when in extended mode, but this PR simply uses the `(?#...)` block style comments in all situations.