### PR TITLE
[HTML] Updated comment errors for HTML5.

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -38,16 +38,18 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: <!--
-      scope: punctuation.definition.comment.begin.html
+    - match: (<!--)(-?>)?
+      captures:
+        1: punctuation.definition.comment.begin.html
+        2: invalid.illegal.bad-comments-or-CDATA.html
       push:
         - meta_scope: comment.block.html
-        - match: '(-*)--\s*>'
-          scope: punctuation.definition.comment.end.html
+        - match: '(<!-)?(--\s*>)'
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
+            2: punctuation.definition.comment.end.html
           pop: true
-        - match: -{2,}
+        - match: '<!--(?!-?>)|--!>'
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -56,38 +56,19 @@
 ##          ^^^^^^^^^ - punctuation
 
         <!----- hyphens - -- --- -->
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
-        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##  ^^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                       ^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##                          ^ - comment.block.html
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block - invalid.illegal.bad-comments-or-CDATA
 
-        <!---   hyphens - -- --- -- >
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
-        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                       ^^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##                           ^ - comment.block.html
+        <!-->-- hyphens <!-- --!> <!--->
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block
+##          ^ invalid.illegal.bad-comments-or-CDATA
+##                      ^^^^ invalid.illegal.bad-comments-or-CDATA
+##                           ^^^^ invalid.illegal.bad-comments-or-CDATA
+##                                ^^^ invalid.illegal.bad-comments-or-CDATA
 
-        <!----- hyphens - -- --- ---->
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
-        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##  ^^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                ^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                   ^^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                       ^^ invalid.illegal.bad-comments-or-CDATA.html
-        ##                         ^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##                            ^ - comment.block.html
-
-        <!--- hyphens --- >
-        ## ^^^^^^^^^^^^^^^^ comment.block.html
-        ##^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##            ^ invalid.illegal.bad-comments-or-CDATA.html
-        ##             ^^^^ - invalid.illegal.bad-comments-or-CDATA.html
-        ##                 ^ - comment.block.html
+        <!--->- hyphens <!-   -!> <!-->
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block
+##          ^^ invalid.illegal.bad-comments-or-CDATA
+##                      ^^^^^^^^^^^^^^^ - invalid.illegal.bad-comments-or-CDATA
 
         <div title=description></div>
         ##  ^ - meta.attribute-with-value


### PR DESCRIPTION
As noted [on the forum](https://forum.sublimetext.com/t/html-comment-false-highlighting/34605), the HTML syntax definition currently marks strings of hyphens inside comments as errors. This is congruent with the [HTML4](https://www.w3.org/TR/html4/intro/sgmltut.html#h-3.2.4) spec. However, the [HTML5](https://www.w3.org/TR/html5/syntax.html#comments) spec is more lenient. This PR updates the HTML syntax definition and tests to use the HTML5 rules.