### PR TITLE
[R] fix bug in detecting function parameters

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -137,7 +137,7 @@ contexts:
         - include: main
 
   function-declarations:
-    - match: ^\s*({{var}})\s*(<<?-|=)\s*(?=function\s*\()
+    - match: ({{var}})\s*(<<?-|=)\s*(?=function\s*\()
       scope: meta.function.r
       captures:
         1: entity.name.function.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -216,3 +216,12 @@ function(
 #        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign
   y = 2
 )
+
+foo(abc = function() {})
+#   ^^^ variable.parameter
+
+foo(
+  NULL,
+  bar = function() {}
+# ^^^ variable.parameter
+)


### PR DESCRIPTION
In some cases, parameters are wrongly detected as `entity.name`