### PR TITLE
[C#] support value tuples in generic types

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -544,7 +544,7 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.cs
       push:
-        - meta_scope: meta.group.cs
+        - meta_scope: meta.group.tuple.cs
         - match: \)
           scope: punctuation.section.group.end.cs
           set: method_name
@@ -1398,7 +1398,20 @@ contexts:
     - match: '<'
       scope: meta.generic.cs punctuation.definition.generic.begin.cs
       push: type_argument
-    - match: '(\(|\{|:)'
+    - match: \(
+      scope: punctuation.section.group.begin.cs
+      push:
+        - meta_scope: meta.group.tuple.cs
+        - match: (\))\s*([^,>\s/])? # expect a comma, close generic or a comment afterwards
+          captures:
+            1: punctuation.section.group.end.cs
+            2: invalid.illegal.expected-type-separator.cs
+          pop: true
+        - match: ','
+          scope: punctuation.separator.cs
+        - match: (?=\S)
+          push: var_declaration_explicit
+    - match: '[{:]'
       scope: invalid.illegal
       pop: true
     - match: (?=\}|\)|>|\]|,|;|>|=>)

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -406,6 +406,33 @@ class Foo {
 ///                  ^^^ variable.other
 ///                     ^ punctuation.section.group.end
 ///                      ^ punctuation.terminator.statement
+        
+        Func<string, (string example1, int Example2)> test = s => (example1: "hello", Example2: "world");
+///     ^^^^ support.type
+///         ^ punctuation.definition.generic.begin
+///         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+///                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
+///                  ^ punctuation.section.group.begin
+///                   ^^^^^^ storage.type
+///                          ^^^^^^^^ variable.other
+///                                  ^ punctuation.separator
+///                                    ^^^ storage.type
+///                                        ^^^^^^^^ variable.other
+///                                                ^ punctuation.section.group.end
+///                                                 ^ punctuation.definition.generic.end
+///                                                   ^^^^ variable.other
+///                                                        ^ keyword.operator.assignment.variable
+///                                                          ^ variable.parameter
+///                                                            ^^ storage.type.function.lambda
+///                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+///                                                               ^ punctuation.section.group.begin
+///                                                                ^^^^^^^^ variable.other
+///                                                                        ^ punctuation.separator.assignment
+///                                                                                 ^ punctuation.separator
+///                                                                                   ^^^^^^^^ variable.other
+///                                                                                           ^ punctuation.separator.assignment
+///                                                                                                    ^ punctuation.section.group.end
+///                                                                                                     ^ punctuation.terminator.statement
     }
 }
 /// <- meta.class.body punctuation.section.block.end


### PR DESCRIPTION
this PR adds support for `ValueTuples` in generic type declarations - prior to this, tuples were scoped correctly as part of normal method declarations but not when the method is declared as a generic `Func`.
More info on ValueTuples can be found at https://blogs.msdn.microsoft.com/mazhou/2017/05/26/c-7-series-part-1-value-tuples/.