### PR TITLE
[PHP] Add highlight support for multiple phpdoc tags with tests

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource))\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|method)\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final)\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource))\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|property|method)\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|property|method|source)\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|method)\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|property|method)\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource))\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource))\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -246,6 +246,146 @@ $var->meth()[10];
 //   ^ comment.block - keyword.other.phpdoc
  */
 
+/**
+ * @api Methods: declares that elements are suitable for consumption by third parties.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @author Any: documents the author of the associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @category File, Class: groups a series of packages together.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @copyright Any: documents the copyright information for the associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @deprecated Any: indicates that the associated element is deprecated and can be removed in a future version.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @example Any: shows the code of a specified example file or, optionally, just a portion of it.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @filesource File: includes the source of the current file for use in the output.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @global Variable: informs phpDocumentor of a global variable or its usage.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @ignore Any: tells phpDocumentor that the associated element is not to be included in the documentation.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @internal Any: denotes that the associated elements is internal to this application or library and hides it by default.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @license File, Class: indicates which license is applicable for the associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @link Any: indicates a relation between the associated element and a page of a website.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @method Class: allows a class to know which ‘magic’ methods are callable.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @package File, Class: categorizes the associated element into a logical grouping or subdivision.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @param Method, Function: documents a single argument of a function or method.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @property Class: allows a class to know which ‘magic’ properties are present.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @property-read Class: allows a class to know which ‘magic’ properties are present that are read-only.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @property-write Class: allows a class to know which ‘magic’ properties are present that are write-only.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @return Method, Function: documents the return value of functions or methods.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @see Any: indicates a reference from the associated element to a website or other elements.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @since Any: indicates at which version the associated element became available.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @source Any, except File: shows the source code of the associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @subpackage File, Class: categorizes the associated element into a logical grouping or subdivision.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @throws Method, Function: indicates whether the associated element could throw a specific type of exception.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @todo Any: indicates whether any development activity should still be executed on the associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @uses Any: indicates a reference to (and from) a single associated element.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @var Properties: class properties.
+//  ^ keyword.other.phpdoc
+ */
+
+/**
+ * @version Any: indicates the current version of Structural Elements.
+//  ^ keyword.other.phpdoc
+ */
+
     class Test1 extends stdClass implements Countable {}
 //  ^ storage.type.class.php
 //        ^ entity.name.class.php


### PR DESCRIPTION
[PHPDoc Tags](https://docs.phpdoc.org/guides/docblocks.html#tags) are a type of specialized information (meta-data) about the associated element.

A tag always starts on a new line with an at-sign (@) followed by the name of the tag. Between the start of the line and the tag’s name (including at-sign) there may be one or more spaces or tabs. The following is an example of a simple tag:

```
/**
 * @source
 */
```

In addition to their name each tag may have arguments that can provide additional context specific for that tag. The most common example of this is the @param tag, with which the argument of a method or function is documented:

```
/**
 * @param string $argument1 This is the description.
 */
```

In the example above we can see that the @param tag features an argument that tells you that the argument with name $argument1 is of type string and has a description This is the description. that, in real life, will tell you the function of that argument.

The best way to discover which options a tag supports is by reading the documentation for that specific tag.

Most tags are associated with a specific element type. So some tags only apply to classes, some only to methods, etc. The easiest way to see to which element a tag applies is to check the documentation for each tag, or consult the table in the next chapter.

TAG            | Element          | Description
---------------|------------------|------------
api            | Methods          | Declares that elements are suitable for consumption by third parties.
author         | Any              | Documents the author of the associated element.
category       | File, Class      | Groups a series of packages together.
copyright      | Any              | Documents the copyright information for the associated element.
deprecated     | Any              | Indicates that the associated element is deprecated and can be removed in a future version.
example        | Any              | Shows the code of a specified example file or, optionally, just a portion of it.
filesource     | File             | Includes the source of the current file for use in the output.
global         | Variable         | Informs phpDocumentor of a global variable or its usage.
ignore         | Any              | Tells phpDocumentor that the associated element is not to be included in the documentation.
internal       | Any              | Denotes that the associated elements is internal to this application or library and hides it by default.
license        | File, Class      | Indicates which license is applicable for the associated element.
link           | Any              | Indicates a relation between the associated element and a page of a website.
method         | Class            | Allows a class to know which "magic" methods are callable.
package        | File, Class      | Categorizes the associated element into a logical grouping or subdivision.
param          | Method, Function | Documents a single argument of a function or method.
property       | Class            | Allows a class to know which "magic" properties are present.
return         | Method, Function | Documents the return value of functions or methods.
see            | Any              | Indicates a reference from the associated element to a website or other elements.
since          | Any              | Indicates at which version the associated element became available.
source         | Any, except File | Shows the source code of the associated element.
subpackage     | File, Class      | Categorizes the associated element into a logical grouping or subdivision.
throws         | Method, Function | Indicates whether the associated element could throw a specific type of exception.
todo           | Any              | Indicates whether any development activity should still be executed on the associated element.
uses           | Any              | Indicates a reference to (and from) a single associated element.
var            | Properties       | Class properties.
version        | Any              | Indicates the current version of Structural Elements.

Please see the [tag reference](https://docs.phpdoc.org/references/phpdoc/tags/index.html) for the canonical list of tags and their complete descriptions.