### PR TITLE
[HTML] Add the onauxclick event attribute

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -429,7 +429,7 @@ contexts:
   tag-event-attribute:
     - match: |-
         (?x)\bon(
-          abort|autocomplete|autocompleteerror|blur|cancel|canplay
+          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
           |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
           |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
           |durationchange|emptied|ended|error|focus|input|invalid|keydown

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -154,7 +154,7 @@ def get_tag_to_attributes():
 
     # Extend `global_attributes` by the event handler attributes
     global_attributes.extend([
-        'onabort', 'onautocomplete', 'onautocompleteerror', 'onblur',
+        'onabort', 'onautocomplete', 'onautocompleteerror', 'onauxclick', 'onblur',
         'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange', 'onclick',
         'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick', 'ondrag',
         'ondragend', 'ondragenter', 'ondragexit', 'ondragleave', 'ondragover',


### PR DESCRIPTION
auxclick is new event, equivalent to click but for non-primary mouse buttons. [Spec](https://w3c.github.io/uievents/#event-type-auxclick).
Implemented in at least Blink and Gecko.

I didn't add a syntax test for this on the basis that it wouldn't add anything over the [existing event attribute test](https://github.com/sublimehq/Packages/blob/e0759e08f54b51a436f589c51b836ac3ae5894b1/HTML/syntax_test_html.html#L213), but if you disagree I'm more than happy to write one.