### PR TITLE
[JavaScript] Improved handling of unexpected close punctuation.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -252,6 +252,10 @@ contexts:
     - include: else-pop
 
   statements:
+    - match: '\)|\}|\]'
+      scope: invalid.illegal.stray-bracket-end.js
+      pop: true
+
     - match: \;
       scope: punctuation.terminator.statement.js
 
@@ -603,10 +607,6 @@ contexts:
     - include: expression-end
 
   expression-begin:
-    - match: \)
-      scope: invalid.illegal.stray-bracket-end.js
-      pop: true
-
     - include: expression-break
 
     - include: literal-prototype
@@ -1437,9 +1437,6 @@ contexts:
           pop: true
         - match: (?=\S)
           push: expression
-    - match: \)
-      scope: invalid.illegal.stray-bracket-end.js
-      pop: true
 
   function-call:
     - match: \(

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1257,6 +1257,18 @@ octal = 079.0;
 strayBracket = ());
 //               ^ invalid.illegal.stray-bracket-end
 
+strayBracket = []];
+//               ^ invalid.illegal.stray-bracket-end
+
+strayBracket = {}};
+//               ^ invalid.illegal.stray-bracket-end
+
+(a +) + c;
+//   ^^^^ - meta.group
+
+(a =>) + c;
+//    ^^^^ - meta.group
+
 function optionalParam(b=0) {};
 //                    ^ punctuation.section.group.begin
 //                      ^^ meta.parameter.optional


### PR DESCRIPTION
Currently, when the JavaScript syntax sees an unexpected close paren mid-expression, it marks it as invalid in a very eager fashion. This can disrupt highlighting when typing a line. For instance, the following test fails:

```js
myArray.map(element => /* typing here */)

{}
// <- meta.block - meta.object-literal
```

Because this syntax is invalid, we can choose to highlight it whatever way is convenient. In this case, I would prefer that the invalid close paren be interpreted as ending the arrow function and the `map` function call. This will preserve highlighting of subsequent code; it won't "flicker" while you're typing.

All tests pass. New tests have been added for error cases that were not present in the original tests.