### PR TITLE
[ShellScript] Fix: empty array assignment regression

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -49,7 +49,7 @@ variables:
   cmd_boundary: (?=\s|;|$|>|<)
   extension: \.sh
   identifier: '[[:alpha:]_][[:alnum:]_]*'
-  identifier_non_posix: '[^{{metachar}}\d][^{{metachar}}]*'
+  identifier_non_posix: '[^{{metachar}}\d][^{{metachar}}=]*'
   is_command: (?=\S)
   is_end_of_interpolation: \)
   is_end_of_option: '[^\w$-]|$'

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1392,6 +1392,10 @@ array=([foo]== ["bar"]='what' [5+10]=qux)
 #                                  ^ punctuation.section.brackets.end
 #                                   ^ keyword.operator.assignment
 #                                       ^ punctuation.section.parens.end
+array=()  # an empty array
+#    ^ keyword.operator.assignment
+#     ^ punctuation.section.parens.begin
+#      ^ punctuation.section.parens.end
 for (( i = 0; i < 10; i++ )); do
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.arithmetic
 # <- keyword.control


### PR DESCRIPTION
Some interplay between the last few merges caused a regression where an empty array assignment is incorrectly scoped as the start of a function definition. The fix is one extra byte in the `is_function` lookahead.

```bash
#!/bin/bash
my_array=()
```
