### PR TITLE
[HTML] Should handle all HTML5 attribute names.

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -13,7 +13,7 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
-  attribute_name: (?:[^ "'>/=]+)
+  attribute_name: (?:[^ "'>/=\x00-\x1f\x7f-\x9f]+)
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -13,6 +13,7 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
+  attribute_name: (?:[^ "'>/=]+)
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
 
@@ -268,14 +269,11 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: '[a-zA-Z0-9:\-_.]+'
+    - match: '{{attribute_name}}'
       scope: entity.other.attribute-name.html
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
-
-    - match: '[a-zA-Z0-9:\-_.]+'
-      scope: entity.other.attribute-name.html
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -305,6 +305,7 @@ contexts:
         - include: attribute-entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html
+      pop: true
     - include: else-pop
 
   tag-class-attribute:
@@ -346,6 +347,7 @@ contexts:
         - include: attribute-entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.class-name.html
+      pop: true
     - include: else-pop
 
   tag-id-attribute:
@@ -387,6 +389,7 @@ contexts:
         - include: attribute-entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.toc-list.id.html
+      pop: true
     - include: else-pop
 
   tag-style-attribute:

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -215,6 +215,11 @@ class="foo"></div>
         ##   ^^^^^ entity.other.attribute-name
         ##        ^ punctuation.separator.key-value
 
+        <tag    foo	bar></tag>Mind the tab character!
+        ##      ^^^ entity.other.attribute-name
+        ##         ^ - entity.other.attribute-name
+        ##          ^^^ entity.other.attribute-name
+
         <a disabled onclick="setTimeout(function(){}, 100)">Test</a>
         ##         ^ - meta.attribute-with-value.event
         ##          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -210,6 +210,11 @@ class="foo"></div>
         ##                                                         ^^^^^^^^^^^^^ entity.other.attribute-name.html
         ##                                                                       ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
 
+        <tag *([&\=></tag>
+        ##   ^^^^^^^ - invalid
+        ##   ^^^^^ entity.other.attribute-name
+        ##        ^ punctuation.separator.key-value
+
         <a disabled onclick="setTimeout(function(){}, 100)">Test</a>
         ##         ^ - meta.attribute-with-value.event
         ##          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -220,6 +220,12 @@ class="foo"></div>
         ##         ^ - entity.other.attribute-name
         ##          ^^^ entity.other.attribute-name
 
+        <tag foo=a bar=b></tag>
+        ##   ^^^ entity.other.attribute-name
+        ##       ^ string.unquoted
+        ##         ^^^ entity.other.attribute-name
+        ##             ^ string.unquoted
+
         <a disabled onclick="setTimeout(function(){}, 100)">Test</a>
         ##         ^ - meta.attribute-with-value.event
         ##          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event


### PR DESCRIPTION
Fixes #1419. Also removes an unreachable rule.

Spec: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2