### PR TITLE
[Rust] support raw pointers

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -94,6 +94,9 @@ contexts:
     - match: \b(let|const|static)\b
       scope: storage.type.rust
 
+    - match: \*const\b
+      scope: storage.type.rust
+
     - match: \bfn\b
       scope: storage.type.function.rust
 
@@ -116,6 +119,9 @@ contexts:
       scope: storage.type.trait.rust
 
     - match: \b(mut|pub|unsafe|move|ref)\b
+      scope: storage.modifier.rust
+
+    - match: \*mut\b
       scope: storage.modifier.rust
 
     - match: \b(crate|extern|use|where)\b
@@ -451,7 +457,7 @@ contexts:
         - include: strings
         - match: '(?=\S)'
           pop: true
-    - match: '(?=>|[^ \t\n\$=<_+''(),&:\[\][:alnum:]])'
+    - match: '(?=>|[^ \t\n\$=<_+''(),&:\[\]*[:alnum:]])'
       pop: true
     - match: '<'
       scope: punctuation.definition.generic.begin.rust
@@ -503,7 +509,9 @@ contexts:
   type-any-identifier:
     - match: '&'
       scope: keyword.operator.rust
-    - match: \b(mut|ref)\b
+    - match: \bref\b
+      scope: storage.modifier.rust
+    - match: (?:\b|\*)(?:mut|const)\b
       scope: storage.modifier.rust
     - match: \b(fn)\b(\()
       captures:

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -1074,3 +1074,20 @@ let _: Box<[[bool; (FOO + 1) / 2]; FOO * 3 % 12 - 1]>;
 //                                                 ^ punctuation.section.group.end
 //                                                  ^ punctuation.definition.generic.end
 //                                                   ^ punctuation.terminator
+
+let x = 5;
+let raw = &x as *const i32;
+//              ^^^^^^ storage.type
+
+let mut y = 10;
+let raw_mut = &mut y as *mut i32;
+//                      ^^^^ storage.modifier
+
+let i: u32 = 1;
+let p_imm: *const u32 = &i as *const u32;
+//         ^^^^^^ storage.type
+//                            ^^^^^^ storage.type
+
+type ExampleRawPointer = HashMap<*const i32, Option<i32>, BuildHasherDefault<FnvHasher>>;
+//                               ^^^^^^ storage.modifier - invalid
+//                                      ^^^ storage.type


### PR DESCRIPTION
This PR adds support for [Rust's raw pointers](https://doc.rust-lang.org/book/first-edition/raw-pointers.html), and fixes #1279.