### PR TITLE
[JavaScript] Improved function parameter bindings (and tests).

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -402,7 +402,6 @@ contexts:
         - match: '\]'
           scope: punctuation.section.brackets.end.js
           pop: true
-        - include: function-parameter-binding-spread
         - include: function-parameter-binding-list
 
   function-parameter-binding-object-destructuring:
@@ -443,6 +442,7 @@ contexts:
   function-parameter-binding-list:
     - match: ','
       scope: punctuation.separator.parameter.function.js
+    - include: function-parameter-binding-spread
     - match: (?={{binding_pattern_lookahead}})
       push:
         - initializer

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -384,6 +384,71 @@ contexts:
         - variable-binding-list-top
         - variable-binding-top
 
+  function-parameter-binding-pattern:
+    - include: function-parameter-binding-name
+    - include: function-parameter-binding-array-destructuring
+    - include: function-parameter-binding-object-destructuring
+    - include: else-pop
+
+  function-parameter-binding-name:
+    - match: '{{identifier}}'
+      scope: meta.binding.name.js variable.parameter.function.js
+
+  function-parameter-binding-array-destructuring:
+    - match: '\['
+      scope: punctuation.section.brackets.begin.js
+      set:
+        - meta_scope: meta.binding.destructuring.sequence.js
+        - match: '\]'
+          scope: punctuation.section.brackets.end.js
+          pop: true
+        - include: function-parameter-binding-spread
+        - include: function-parameter-binding-list
+
+  function-parameter-binding-object-destructuring:
+    - match: '\{'
+      scope: punctuation.section.block.begin.js
+      set:
+        - meta_scope: meta.binding.destructuring.mapping.js
+        - match: ','
+          scope: punctuation.separator.parameter.function.js
+        - match: '\}'
+          scope: punctuation.section.block.end.js
+          pop: true
+        - include: function-parameter-binding-spread
+        - match: (?={{identifier}})
+          push:
+            - initializer
+            - function-parameter-binding-object-alias
+            - object-literal-meta-key
+            - function-parameter-binding-object-key
+
+  function-parameter-binding-object-alias:
+    - match: ':'
+      scope: punctuation.separator.key-value.js
+      set: function-parameter-binding-pattern
+    - include: else-pop
+
+  function-parameter-binding-object-key:
+    - match: '{{identifier}}(?=\s*:)'
+      pop: true
+    - include: function-parameter-binding-name
+    - include: else-pop
+
+  function-parameter-binding-spread:
+    - match: '\.\.\.'
+      scope: keyword.operator.spread.js
+      push: function-parameter-binding-pattern
+
+  function-parameter-binding-list:
+    - match: ','
+      scope: punctuation.separator.parameter.function.js
+    - match: (?={{binding_pattern_lookahead}})
+      push:
+        - initializer
+        - function-parameter-binding-pattern
+    - include: else-pop
+
   function-or-class-declaration:
     - match: (?=\bclass\b)
       push: class
@@ -1224,40 +1289,7 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.js
           pop: true
-        # Destructuring
-        - match: \{
-          scope: punctuation.section.block.begin.js
-          push:
-            - meta_scope: meta.block.js
-            - match: \}
-              scope: punctuation.section.block.end.js
-              pop: true
-            - match: '{{identifier}}'
-              scope: variable.parameter.function.js
-            - match: ','
-              scope: punctuation.separator.parameter.function.js
-            - match: '='
-              scope: keyword.operator.assignment.js
-              push:
-                - meta_scope: meta.parameter.optional.js
-                - match: "(?=[,)}])"
-                  pop: true
-                - match: (?=\S)
-                  push: expression-no-comma
-        - match: \.\.\.
-          scope: keyword.operator.spread.js
-        - match: '{{identifier}}'
-          scope: variable.parameter.function.js
-        - match: ','
-          scope: punctuation.separator.parameter.function.js
-        - match: '='
-          scope: keyword.operator.assignment.js
-          push:
-            - meta_scope: meta.parameter.optional.js
-            - match: "(?=[,)])"
-              pop: true
-            - match: (?=\S)
-              push: expression-no-comma
+        - include: function-parameter-binding-list
 
   label:
     - match: '({{identifier}})\s*(:)'

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -836,7 +836,7 @@ class Foo extends getSomeClass() {}
 const test = ({a, b, c=()=>({active:false}) }) => {};
 //    ^ entity.name.function
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring
 //            ^ punctuation.section.block.begin
 //             ^ variable.parameter
 //                ^ variable.parameter
@@ -1263,7 +1263,7 @@ strayBracket = {}};
 
 function optionalParam(b=0) {};
 //                    ^ punctuation.section.group.begin
-//                      ^^ meta.parameter.optional
+//                      ^ keyword.operator.assignment
 //                        ^ punctuation.section.group.end
 
 var path = require('path');

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -32,7 +32,84 @@ const { a, b: c, ...d } = value;
 //    ^^^^^^^^^^^^^^^^^ meta.binding.destructuring.mapping
 //      ^ meta.object-literal.key meta.binding.name variable.other.readwrite
 //       ^ punctuation.separator.comma
-//         ^ meta.object-literal.key - variable.other.readwrite
+//         ^ meta.object-literal.key - variable
 //          ^ punctuation.separator.key-value
 //               ^^^ keyword.operator.spread
 //                  ^ meta.binding.name variable.other.readwrite
+
+const x;
+//    ^ meta.binding.name variable.other.readwrite
+
+
+function f ([ x, y, ...z, ]) {}
+//          ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//            ^ meta.binding.name variable.parameter.function
+//             ^ punctuation.separator.parameter
+//               ^ meta.binding.name variable.parameter.function
+//                ^ punctuation.separator.parameter
+//                  ^^^ keyword.operator.spread
+//                     ^ meta.binding.name variable.parameter.function
+//                      ^ punctuation.separator.parameter
+
+function f ([ x, [a, b], z]) {}
+//          ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//               ^^^^^^ meta.binding.destructuring.sequence meta.binding.destructuring.sequence
+//                ^ meta.binding.name variable.parameter.function
+//                   ^ meta.binding.name variable.parameter.function
+
+function f ([ x = 42, y = [a, b, c] ]) {}
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//              ^ keyword.operator.assignment
+//                ^^ meta.binding.destructuring.sequence.js constant.numeric.decimal.js
+//                      ^ keyword.operator.assignment
+//                        ^^^^^^^^^ meta.sequence
+//                         ^ variable.other.readwrite - meta.binding.name
+
+function f ({ a, b: c, ...d }) {}
+//          ^^^^^^^^^^^^^^^^^ meta.binding.destructuring.mapping
+//            ^ meta.object-literal.key meta.binding.name variable.parameter.function
+//             ^ punctuation.separator.parameter
+//               ^ meta.object-literal.key - variable
+//                ^ punctuation.separator.key-value
+//                     ^^^ keyword.operator.spread
+//                        ^ meta.binding.name variable.parameter.function
+
+let f = ([ x, y, ...z, ]) => {};
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//         ^ meta.binding.name variable.parameter.function
+//          ^ punctuation.separator.parameter
+//            ^ meta.binding.name variable.parameter.function
+//             ^ punctuation.separator.parameter
+//               ^^^ keyword.operator.spread
+//                  ^ meta.binding.name variable.parameter.function
+//                   ^ punctuation.separator.parameter
+
+let f = ([ x, [a, b], z]) => {};
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^ variable.other.readwrite entity.name.function
+//       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//            ^^^^^^ meta.binding.destructuring.sequence meta.binding.destructuring.sequence
+//             ^ meta.binding.name variable.parameter.function
+//                ^ meta.binding.name variable.parameter.function
+
+let f = ([ x = 42, y = [a, b, c] ]) => {};
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^ variable.other.readwrite entity.name.function
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//           ^ keyword.operator.assignment
+//             ^^ meta.binding.destructuring.sequence.js constant.numeric.decimal.js
+//                   ^ keyword.operator.assignment
+//                     ^^^^^^^^^ meta.sequence
+//                      ^ variable.other.readwrite - meta.binding.name
+
+let f = ({ a, b: c, ...d }) => {};
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^ variable.other.readwrite entity.name.function
+//       ^^^^^^^^^^^^^^^^^ meta.binding.destructuring.mapping
+//         ^ meta.object-literal.key meta.binding.name variable.parameter.function
+//          ^ punctuation.separator.parameter
+//            ^ meta.object-literal.key - variable
+//             ^ punctuation.separator.key-value
+//                  ^^^ keyword.operator.spread
+//                     ^ meta.binding.name variable.parameter.function

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -74,6 +74,11 @@ function f ({ a, b: c, ...d }) {}
 //                     ^^^ keyword.operator.spread
 //                        ^ meta.binding.name variable.parameter.function
 
+function f (a, ...rest) {}
+//          ^ meta.binding.name variable.parameter.function
+//             ^^^ keyword.operator.spread
+//                ^^^^ variable.parameter.function
+
 let f = ([ x, y, ...z, ]) => {};
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
@@ -113,3 +118,10 @@ let f = ({ a, b: c, ...d }) => {};
 //             ^ punctuation.separator.key-value
 //                  ^^^ keyword.operator.spread
 //                     ^ meta.binding.name variable.parameter.function
+
+let f = (a, ...rest) => {};
+//  ^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^ variable.other.readwrite entity.name.function
+//       ^ meta.binding.name variable.parameter.function
+//          ^^^ keyword.operator.spread
+//             ^^^^ meta.binding.name variable.parameter.function


### PR DESCRIPTION
Adapted variable binding pattern logic from #1338 to handle function parameters, finishing #1102. Should now cover all corner cases. Added comprehensive tests.

Notes:

- Commas in function parameter lists are scoped `punctuation.separator.parameter` rather than `punctuation.separator.comma`. I preserve the old behavior here. I'm not sure what the reason is for the distinction.
- Function parameter initializers were formerly scoped `meta.parameter.optional`. This is not a standard scope, and I'm not sure what its purpose would be. (No other syntaxes appear to use this scope, excepting syntaxes derived directly from this one.) If we do want to differentiate parameters with initializers, I'm open to suggestions on how to do it.
- Object destructuring patterns were formerly scoped `meta.block`. I have replaced that scope with `meta.binding.destructuring.mapping`.