### PR TITLE
[JavaScript] Added new.target construct.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -729,13 +729,22 @@ contexts:
           - include: scope:source.regexp.js
 
   constructor:
+    - match: \bnew\b(?=\s*\.)
+      scope: keyword.operator.word.new.js
+      set: new-target
+
     - match: '\bnew\b'
       scope: keyword.operator.word.new.js
       set:
-        - constructor-meta
-        - constructor-body-expect-arguments
-        - constructor-body-expect-class-end
-        - constructor-body-expect-class-begin
+        - meta_scope: meta.instance.constructor.js meta.function-call.constructor.js
+        - match: (?=\s*\.)
+          set: new-target
+        - match: (?=\s*\S)
+          set:
+            - constructor-meta
+            - constructor-body-expect-arguments
+            - constructor-body-expect-class-end
+            - constructor-body-expect-class-begin
 
   constructor-meta:
     - meta_scope: meta.instance.constructor.js meta.function-call.constructor.js
@@ -770,6 +779,17 @@ contexts:
 
     - include: expression-begin
 
+  new-target:
+    - match: \.
+      scope: punctuation.accessor.dot.js
+      set:
+        - match: \btarget\b
+          scope: variable.language.target.js
+          pop: true
+        - include: else-pop
+
+    - include: else-pop
+
   prefix-operators:
     - match: '~'
       scope: keyword.operator.bitwise.js
@@ -783,9 +803,6 @@ contexts:
       scope: keyword.operator.spread.js
     - match: \+|\-
       scope: keyword.operator.arithmetic.js
-
-    - match: \bnew\b
-      scope: keyword.operator.word.new.js
     - match: \b(?:delete|typeof|void)\b
       scope: keyword.operator.js
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -989,6 +989,19 @@ var abc = new ABC(
     })
 );
 
+function f() {
+    new.target;
+//  ^^^ keyword.operator.word.new
+//     ^ punctuation.accessor.dot.js
+//      ^^^^^^ variable.language.target
+
+    new
+//  ^^^ keyword.operator.word.new
+    .target;
+//  ^ punctuation.accessor.dot.js
+//   ^^^^^^ variable.language.target
+}
+
 new Date().getTime()
 // ^^^^^^^ meta.instance.constructor
 //  ^^^^^^ meta.function-call.constructor


### PR DESCRIPTION
See documentation at [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target).

The `meta.instance.constructor.js` scope complicates this. When we see `new`, we can't reliably tell whether it's followed by `.target` or an expression. In order to apply that meta scope, we have to guess anyway; then, we have to recover from a wrong guess. No independent syntax appears to use the `meta.instance` scope, so it might be a good candidate for removal.