### PR TITLE
[JavaScript] Fixed arrow function body block bug.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -651,6 +651,7 @@ contexts:
     # If an arrow function has the ( and ) on different lines, we won't have matched
     - match: =>
       scope: storage.type.function.arrow.js
+      push: arrow-function-expect-body
 
   literal-string:
     - match: "'"

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -853,6 +853,14 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 //    ^^ storage.type.function.arrow
 //         ^^^^^^ meta.block keyword.control.flow
 
+(
+    ()
+    => { return; }
+//  ^^ storage.type.function.arrow
+//     ^^^^^^^^^^^ meta.block - meta.object-literal
+//       ^^^^^^ keyword.control.flow
+);
+
 MyClass.foo = function() {}
 // ^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 // ^ support.class


### PR DESCRIPTION
```js
(
    ()
    => { return; }
//  ^^ storage.type.function.arrow
//     ^^^^^^^^^^^ meta.block - meta.object-literal
//       ^^^^^^ keyword.control.flow
);
```

Fixes the bug identified in #1430.