### PR TITLE
[Rust] OSX: don't override loaded path and build & run a single file

### DIFF
--- a/Rust/Rust.sublime-build
+++ b/Rust/Rust.sublime-build
@@ -2,10 +2,6 @@
     "cmd": ["rustc", "$file"],
     "selector": "source.rust",
     "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
-    "osx":
-    {
-        "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
-    },
 
     "variants": [
         {

--- a/Rust/Rust.sublime-build
+++ b/Rust/Rust.sublime-build
@@ -11,7 +11,13 @@
             "windows":
             {
                 "cmd": ["$file_base_name.exe"]
-            }
-        }
+            }, 
+        },
+        {
+            "selector": "source.rust",
+            "cmd": ["rustc $file && ./${file_base_name}"],
+            "shell": true,
+            "name": "Build & Run",
+        },
     ]
 }

--- a/Rust/Rust.sublime-build
+++ b/Rust/Rust.sublime-build
@@ -15,8 +15,7 @@
         },
         {
             "selector": "source.rust",
-            "cmd": ["rustc $file && ./${file_base_name}"],
-            "shell": true,
+            "shell_cmd": "rustc \"$file\" && \"./$file_base_name\"",
             "name": "Build & Run",
         },
     ]


### PR DESCRIPTION
5b29174: Sublime Text loads environment variables on startup (`zsh -l`, in case of zsh), so the hardcoded path in Rust.sublime-build file overrides the loaded path. On top of that, the hardcoded path doesn't include `~/.cargo/bin` anyway, so the build does not work.

2552ed0: I didn't initially intend to pull-request it, but I did not know GitHub would tack it onto the pull request on push. In any case, it adds a build variant to build and run the Rust file. It's been convenient while learning Rust to just have one-off files here and there to play with. I won't be at all surprised if you don't accept this one, though.