### PR TITLE
[JavaScript] Object literal rest spread handles complex expressions.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1280,7 +1280,7 @@ contexts:
 
         - match: \.\.\.
           scope: keyword.operator.spread.js
-          push: literal-variable
+          push: expression-no-comma
 
         - match: >-
             (?x)(?=

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -464,6 +464,17 @@ var obj = {
     // <- keyword.generator.asterisk
     // ^ entity.name.function
     }
+
+    ...foo,
+//  ^^^ keyword.operator.spread
+//     ^^^ variable.other.readwrite
+//        ^ punctuation.separator.comma
+
+    ...bar(baz),
+//  ^^^ keyword.operator.spread
+//     ^^^^^^^^ meta.function-call
+//     ^^^ variable.function
+//             ^ punctuation.separator.comma
 }
 // <- meta.object-literal - meta.block
 


### PR DESCRIPTION
[TC39 proposal](https://github.com/tc39/proposal-object-rest-spread) (Stage 4, implemented and widely used in Babel).

Also added tests for object rest spread.

Reported [here](https://github.com/Thom1729/Sublime-JS-Custom/issues/19).

Looks like the bug was introduced in #1344.