### PR TITLE
[C++/Python/ShellScript] Flow control keywords - more specific scopes for "jumping" keywords.

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -87,6 +87,16 @@ contexts:
   unique-keywords:
     - match: \busing\b
       scope: keyword.control.c++
+    - match: \bbreak\b
+      scope: keyword.control.flow.break.c++
+    - match: \bcontinue\b
+      scope: keyword.control.flow.continue.c++
+    - match: \bgoto\b
+      scope: keyword.control.flow.goto.c++
+    - match: \breturn\b
+      scope: keyword.control.flow.return.c++
+    - match: \bthrow\b
+      scope: keyword.control.flow.throw.c++
     - match: \b({{control_keywords}})\b
       scope: keyword.control.c++
     - match: '\bdelete\b(\s*\[\])?|\bnew\b(?!])'

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -111,6 +111,14 @@ contexts:
       scope: constant.other.placeholder.c
 
   keywords:
+    - match: \bbreak\b
+      scope: keyword.control.flow.break.c
+    - match: \bcontinue\b
+      scope: keyword.control.flow.continue.c
+    - match: \bgoto\b
+      scope: keyword.control.flow.goto.c
+    - match: \breturn\b
+      scope: keyword.control.flow.return.c
     - match: \b({{control_keywords}})\b
       scope: keyword.control.c
     - match: \bsizeof\b

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -584,46 +584,51 @@ scanf("%ms %as %*[, ]", &buf);
 // Control Keywords
 /////////////////////////////////////////////
 
-if (x < 5)
-/* <- keyword.control */
-{}
-else
-/* <- keyword.control */
-{}
-
-switch (x)
-/* <- keyword.control */
+int control_keywords()
 {
-case 1:
-/* <- keyword.control */
-    break;
-    /* <- keyword.control.flow.break */
-default:
-/* <- keyword.control */
-    break;
-    /* <- keyword.control.flow.break */
+  if (x < 5)
+  /* <- keyword.control */
+  {}
+  else
+  /* <- keyword.control */
+  {}
+
+  switch (x)
+  /* <- keyword.control */
+  {
+  case 1:
+  /* <- keyword.control */
+      break;
+      /* <- keyword.control.flow.break */
+  default:
+  /* <- keyword.control */
+      break;
+      /* <- keyword.control.flow.break */
+  }
+
+  do
+  /* <- keyword.control */
+  {
+      if (y == 3)
+          continue;
+          /* <- keyword.control.flow.continue */
+  } while (y < x);
+  /*^ keyword.control */
+
+  switch (a) {
+      case 1: break;
+  /*        ^ punctuation.separator */
+      case 100 - 10: break;
+  /*               ^ punctuation.separator */
+      default: break;
+  /*         ^ punctuation.separator */
+  }
+
+  goto label;
+  /* <- keyword.control.flow.goto */
+
+label:
+
+  return 123;
+  /* <- keyword.control.flow.return */
 }
-
-do
-/* <- keyword.control */
-{
-    if (y == 3)
-        continue;
-        /* <- keyword.control.flow.continue */
-} while (y < x);
-/*^ keyword.control */
-
-switch (a) {
-    case 1: break;
-/*        ^ punctuation.separator */
-    case 100 - 10: break;
-/*               ^ punctuation.separator */
-    default: break;
-/*         ^ punctuation.separator */
-}
-
-goto label;
-/* <- keyword.control.flow.goto */
-
-return 123;
-/* <- keyword.control.flow.return */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -578,3 +578,52 @@ scanf("%ms %as %*[, ]", &buf);
 
 "foo % baz"
 /*   ^ - invalid */
+
+
+/////////////////////////////////////////////
+// Control Keywords
+/////////////////////////////////////////////
+
+if (x < 5)
+/* <- keyword.control */
+{}
+else
+/* <- keyword.control */
+{}
+
+switch (x)
+/* <- keyword.control */
+{
+case 1:
+/* <- keyword.control */
+    break;
+    /* <- keyword.control.flow.break */
+default:
+/* <- keyword.control */
+    break;
+    /* <- keyword.control.flow.break */
+}
+
+do
+/* <- keyword.control */
+{
+    if (y == 3)
+        continue;
+        /* <- keyword.control.flow.continue */
+} while (y < x);
+/*^ keyword.control */
+
+switch (a) {
+    case 1: break;
+/*        ^ punctuation.separator */
+    case 100 - 10: break;
+/*               ^ punctuation.separator */
+    default: break;
+/*         ^ punctuation.separator */
+}
+
+goto label;
+/* <- keyword.control.flow.goto */
+
+return 123;
+/* <- keyword.control.flow.return */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -643,11 +643,11 @@ switch (x)
 case 1:
 /* <- keyword.control */
     break;
-    /* <- keyword.control */
+    /* <- keyword.control.flow.break */
 default:
 /* <- keyword.control */
     break;
-    /* <- keyword.control */
+    /* <- keyword.control.flow.break */
 }
 
 do
@@ -655,7 +655,7 @@ do
 {
     if (y == 3)
         continue;
-        /* <- keyword.control */
+        /* <- keyword.control.flow.continue */
 } while (y < x);
 /*^ keyword.control */
 
@@ -669,13 +669,13 @@ switch (a) {
 }
 
 goto label;
-/* <- keyword.control */
+/* <- keyword.control.flow.goto */
 
 try
 /* <- keyword.control */
 {
     throw std :: string("xyz");
-    /* <- keyword.control */
+    /* <- keyword.control.flow.throw */
     /*    ^^^^^^^^^^^^^ variable.function */
     /*        ^^ punctuation.accessor */
 }
@@ -691,7 +691,7 @@ delete ptr;
 /* <- keyword.control */
 
 return 123;
-/* <- keyword.control */
+/* <- keyword.control.flow.return */
 
 
 /////////////////////////////////////////////

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -332,7 +332,7 @@ def my_function():
 % <- meta.environment.verbatim.lstlisting.latex
 % <- meta.environment.embedded.python.latex
 % <- source.python.embedded
-%   ^ keyword.control.flow.python
+%   ^ keyword.control.flow.pass.python
 \end{lstlisting}
 
 \begin{lstlisting}[frame=single,
@@ -342,7 +342,7 @@ def my_function():
 % <- meta.environment.verbatim.lstlisting.latex
 % <- meta.environment.embedded.python.latex
 % <- source.python.embedded
-%   ^ keyword.control.flow.python
+%   ^ keyword.control.flow.pass.python
 \end{lstlisting}
 
 \begin{lstlisting} %java
@@ -378,7 +378,7 @@ def my_function():
 % <- meta.environment.verbatim.minted.latex
 % <- meta.environment.embedded.python.latex
 % <- source.python.embedded
-%   ^ keyword.control.flow.python
+%   ^ keyword.control.flow.pass.python
 \end{minted}
 
 

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1892,7 +1892,7 @@ FROM TableName
 |  ^^^^^^ constant.other.language-name
 def function():
     pass
-|   ^^^^ keyword.control.flow.python
+|   ^^^^ keyword.control.flow.pass.python
 unclosed_paren = (
 |                ^ meta.group.python punctuation.section.group.begin.python
 ```

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -613,11 +613,11 @@ switch (x)
 case 1:
 /* <- keyword.control */
     break;
-    /* <- keyword.control */
+    /* <- keyword.control.flow.break */
 default:
 /* <- keyword.control */
     break;
-    /* <- keyword.control */
+    /* <- keyword.control.flow.break */
 }
 
 do
@@ -625,7 +625,7 @@ do
 {
     if (y == 3)
         continue;
-        /* <- keyword.control */
+        /* <- keyword.control.flow.continue */
 } while (y < x);
 /*^ keyword.control */
 
@@ -639,13 +639,13 @@ switch (a) {
 }
 
 goto label;
-/* <- keyword.control */
+/* <- keyword.control.flow.goto */
 
 try
 /* <- keyword.control */
 {
     throw std :: string("xyz");
-    /* <- keyword.control */
+    /* <- keyword.control.flow.throw */
     /*    ^^^^^^^^^^^^^ variable.function */
     /*        ^^ punctuation.accessor */
 }
@@ -661,7 +661,7 @@ delete ptr;
 /* <- keyword.control */
 
 return 123;
-/* <- keyword.control */
+/* <- keyword.control.flow.return */
 
 
 /////////////////////////////////////////////

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -298,6 +298,7 @@ int foo(int val, float val2[])
 /*        ^^ punctuation.accessor */
     if (result == 0) {
         return 0;
+/*      ^^^^^^ keyword.control.flow.return */
 #if CROSS_SCOPE_MACRO
  /* <- keyword.control.import */
     } else if (result > 0) {
@@ -401,6 +402,7 @@ MACRO1 void * MACRO2 myfuncname () {
 /*       ^ punctuation.separator */
         do {
             break;
+/*          ^^^^^ keyword.control.flow.break */
         } while(true);
 
     switch (a) {

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -86,8 +86,12 @@ contexts:
       scope: keyword.other.exec.python
     - match: \b(return)\b
       scope: keyword.control.flow.return.python
-    - match: \b(break|continue|pass)\b
-      scope: keyword.control.flow.python
+    - match: \b(break)\b
+      scope: keyword.control.flow.break.python
+    - match: \b(continue)\b
+      scope: keyword.control.flow.continue.python
+    - match: \b(pass)\b
+      scope: keyword.control.flow.pass.python
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -85,13 +85,13 @@ contexts:
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
     - match: \b(return)\b
-      scope: keyword.control.flow.python keyword.control.flow.return.python
+      scope: keyword.control.flow.return.python
     - match: \b(break)\b
-      scope: keyword.control.flow.python keyword.control.flow.break.python
+      scope: keyword.control.flow.break.python
     - match: \b(continue)\b
-      scope: keyword.control.flow.python keyword.control.flow.continue.python
+      scope: keyword.control.flow.continue.python
     - match: \b(pass)\b
-      scope: keyword.control.flow.python keyword.control.flow.pass.python
+      scope: keyword.control.flow.pass.python
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -85,13 +85,13 @@ contexts:
     - match: \b(exec)\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
     - match: \b(return)\b
-      scope: keyword.control.flow.return.python
+      scope: keyword.control.flow.python keyword.control.flow.return.python
     - match: \b(break)\b
-      scope: keyword.control.flow.break.python
+      scope: keyword.control.flow.python keyword.control.flow.break.python
     - match: \b(continue)\b
-      scope: keyword.control.flow.continue.python
+      scope: keyword.control.flow.python keyword.control.flow.continue.python
     - match: \b(pass)\b
-      scope: keyword.control.flow.pass.python
+      scope: keyword.control.flow.python keyword.control.flow.pass.python
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -514,6 +514,12 @@ def _():
     ):
 #    ^ meta.statement.while.python punctuation.section.block.while.python
         sleep()
+        if a:
+            break
+#           ^^^^^ keyword.control.flow.break.python
+        elif b:
+            continue
+#           ^^^^^^^^ keyword.control.flow.continue.python
 
     if 213 is 231:
 #   ^^^^^^^^^^^^^^ meta.statement.if.python
@@ -551,6 +557,10 @@ def _():
 #   ^^^^ keyword.control.flow.conditional.python
     while
 #   ^^^^^ keyword.control.flow.while.python
+    return
+#   ^^^^^^ keyword.control.flow.return.python
+    raise
+#   ^^^^^ keyword.control.flow.raise.python
 
 
 ##################

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -182,9 +182,9 @@ contexts:
       scope: keyword.control.case.begin.shell
       set: [case-body, case-item, case-item-first-character, case-preamble]
     - match: \bcontinue{{keyword_boundary_end}}
-      scope: keyword.control.continue.shell keyword.control.flow.continue.shell
+      scope: keyword.control.flow.continue.shell
     - match: \bbreak{{keyword_boundary_end}}
-      scope: keyword.control.break.shell keyword.control.flow.break.shell
+      scope: keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]
 
   case-preamble:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -182,9 +182,9 @@ contexts:
       scope: keyword.control.case.begin.shell
       set: [case-body, case-item, case-item-first-character, case-preamble]
     - match: \bcontinue{{keyword_boundary_end}}
-      scope: keyword.control.continue.shell
+      scope: keyword.control.continue.shell keyword.control.flow.continue.shell
     - match: \bbreak{{keyword_boundary_end}}
-      scope: keyword.control.break.shell
+      scope: keyword.control.break.shell keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]
 
   case-preamble:

--- a/ShellScript/commands-builtin-shell-bash.sublime-syntax
+++ b/ShellScript/commands-builtin-shell-bash.sublime-syntax
@@ -894,7 +894,7 @@ contexts:
     - scope:source.shell.bash#cmd-post
     - cmd-args-bg
   - match: '{{boundary_begin}}return{{boundary_end}}'
-    scope: meta.function-call.shell keyword.control.return.shell keyword.control.flow.return.shell
+    scope: meta.function-call.shell keyword.control.flow.return.shell
     set:
     - scope:source.shell.bash#cmd-post
     - cmd-args-return
@@ -1095,7 +1095,7 @@ contexts:
     - scope:source.shell.bash#cmd-post
     - cmd-args-bg-bt
   - match: '{{boundary_begin}}return{{boundary_end}}'
-    scope: meta.function-call.shell keyword.control.return.shell keyword.control.flow.return.shell
+    scope: meta.function-call.shell keyword.control.flow.return.shell
     set:
     - scope:source.shell.bash#cmd-post
     - cmd-args-return-bt

--- a/ShellScript/commands-builtin-shell-bash.sublime-syntax
+++ b/ShellScript/commands-builtin-shell-bash.sublime-syntax
@@ -894,7 +894,7 @@ contexts:
     - scope:source.shell.bash#cmd-post
     - cmd-args-bg
   - match: '{{boundary_begin}}return{{boundary_end}}'
-    scope: meta.function-call.shell keyword.control.return.shell
+    scope: meta.function-call.shell keyword.control.return.shell keyword.control.flow.return.shell
     set:
     - scope:source.shell.bash#cmd-post
     - cmd-args-return
@@ -1095,7 +1095,7 @@ contexts:
     - scope:source.shell.bash#cmd-post
     - cmd-args-bg-bt
   - match: '{{boundary_begin}}return{{boundary_end}}'
-    scope: meta.function-call.shell keyword.control.return.shell
+    scope: meta.function-call.shell keyword.control.return.shell keyword.control.flow.return.shell
     set:
     - scope:source.shell.bash#cmd-post
     - cmd-args-return-bt

--- a/ShellScript/commands-builtin-shell-bash.yml
+++ b/ShellScript/commands-builtin-shell-bash.yml
@@ -91,8 +91,7 @@ pwd:
 
 return:
   allow-end-of-options-token: false
-  scope: keyword.control.return.shell
-         keyword.control.flow.return.shell
+  scope: keyword.control.flow.return.shell
 
 shift:
   allow-end-of-options-token: false

--- a/ShellScript/commands-builtin-shell-bash.yml
+++ b/ShellScript/commands-builtin-shell-bash.yml
@@ -92,6 +92,7 @@ pwd:
 return:
   allow-end-of-options-token: false
   scope: keyword.control.return.shell
+         keyword.control.flow.return.shell
 
 shift:
   allow-end-of-options-token: false

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1323,10 +1323,10 @@ while true; do
 #         ^ keyword.operator
 #            ^ keyword.control
     break
-    # <- keyword.control.break.shell keyword.control.flow.break.shell
+    # <- keyword.control.flow.break.shell
 
     continue
-    # <- keyword.control.continue.shell keyword.control.flow.continue.shell
+    # <- keyword.control.flow.continue.shell
 
 done
 # <- keyword.control
@@ -2113,7 +2113,7 @@ function foo
     # <- meta.function meta.function-call
 
     return 0
-    # <- keyword.control.return.shell keyword.control.flow.return.shell
+    # <- keyword.control.flow.return.shell
 }
 # <- punctuation.section
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1323,7 +1323,11 @@ while true; do
 #         ^ keyword.operator
 #            ^ keyword.control
     break
-    # <- keyword.control
+    # <- keyword.control.break.shell keyword.control.flow.break.shell
+
+    continue
+    # <- keyword.control.continue.shell keyword.control.flow.continue.shell
+
 done
 # <- keyword.control
 
@@ -2107,6 +2111,9 @@ function foo
     foo bar
     # <- variable.function
     # <- meta.function meta.function-call
+
+    return 0
+    # <- keyword.control.return.shell keyword.control.flow.return.shell
 }
 # <- punctuation.section
 


### PR DESCRIPTION
Relating to RFC #1228, this adds/refines scopes for jumping type flow control keywords. In this context jumping refers to more arbitrary changes in flow than the branch from an `if` or such.

This only covers **C, C++, Python and Bash** and does not attempt to do any standardization across languages and does not replace existing scopes. It also does not change anything for support functions like `exit` or `assert`, but this can be reviewed in future if necessary and most of these already have fairly specific scopes.