### PR TITLE
[JavaScript] Simplified function arguments.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -608,7 +608,9 @@ contexts:
     - include: ternary-operator
 
     - include: property-access
-    - include: function-call
+
+    - match: (?=\()
+      push: function-call-arguments
 
     - include: fallthrough
 
@@ -746,8 +748,7 @@ contexts:
     - include: immediately-pop
 
   constructor-body-expect-arguments:
-    - match: '(?=\()'
-      set: function-call-params
+    - include: function-call-arguments
     - include: else-pop
 
   constructor-body-expect-class-end:
@@ -1450,16 +1451,15 @@ contexts:
         - match: (?=\S)
           push: expression
 
-  function-call:
+  function-call-arguments:
     - match: \(
-      scope: punctuation.section.group.js
-      push:
+      scope: punctuation.section.group.begin.js
+      set:
         - meta_scope: meta.group.js
         - match: \)
-          scope: punctuation.section.group.js
+          scope: punctuation.section.group.end.js
           pop: true
-        - match: (?=\S)
-          push: expression
+        - include: expression-list
 
   array-literal:
     - match: '\['
@@ -1559,7 +1559,7 @@ contexts:
     - match: '(?={{identifier}}\s*\()'
       set:
         - call-expression-meta
-        - function-call-params
+        - function-call-arguments
         - call-expression-function-name
     - match: '(?={{identifier}}\s*\.\s*{{identifier}}\s*\()'
       set:
@@ -1570,7 +1570,7 @@ contexts:
             3: support.function.console.js
           set:
             - call-expression-method-meta
-            - function-call-params
+            - function-call-arguments
         - match: \b(process)(?:(\.)(abort|chdir|cwd|disconnect|exit|[sg]ete?[gu]id|send|[sg]etgroups|initgroups|kill|memoryUsage|nextTick|umask|uptime|hrtime))?\b
           captures:
             1: support.type.object.process.js
@@ -1578,7 +1578,7 @@ contexts:
             3: support.function.process.js
           set:
             - call-expression-method-meta
-            - function-call-params
+            - function-call-arguments
         - match: '(?={{identifier}}\s*\.)'
           push:
             - include: well-known-identifiers
@@ -1625,36 +1625,17 @@ contexts:
       scope: support.function.mutator.js
       set:
         - call-expression-method-meta
-        - function-call-params
+        - function-call-arguments
     - match: \b(s(ub(stringData|mit)|plitText|e(t(NamedItem|Attribute(Node)?)|lect))|has(ChildNodes|Feature)|namedItem|c(l(ick|o(se|neNode))|reate(C(omment|DATASection|aption)|T(Head|extNode|Foot)|DocumentFragment|ProcessingInstruction|E(ntityReference|lement)|Attribute))|tabIndex|i(nsert(Row|Before|Cell|Data)|tem)|open|delete(Row|C(ell|aption)|T(Head|Foot)|Data)|focus|write(ln)?|a(dd|ppend(Child|Data))|re(set|place(Child|Data)|move(NamedItem|Child|Attribute(Node)?)?)|get(NamedItem|Element(sBy(Name|TagName)|ById)|Attribute(Node)?)|blur)\b(?=\()
       scope: support.function.dom.js
       set:
         - call-expression-method-meta
-        - function-call-params
+        - function-call-arguments
     - match: '({{identifier}})\s*(?=\()'
       scope: variable.function.js
       set:
         - call-expression-method-meta
-        - function-call-params
-
-  function-call-params:
-    - match: '\)'
-      scope: meta.group.js punctuation.section.group.js
-      pop: true
-    - match: '\('
-      scope: punctuation.section.group.js
-      push:
-        - meta_scope: meta.group.js
-        - match: '(?=\))'
-          pop: true
-        # Consume comma plus any whitespace to prevent whitespace from
-        # getting meta scopes when they don't really apply
-        - match: '(,)\s+'
-          captures:
-            1: punctuation.separator.comma.js
-        - match: (?=\S)
-          push: expression-no-comma
-    - include: else-pop
+        - function-call-arguments
 
   literal-variable:
     - include: well-known-identifiers

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1135,17 +1135,17 @@ a = /foo\/bar/g // Ensure handling of escape / in regex detection
 //    ^ string.regexp
 //       ^ constant.character.escape
 
-var re = /^\/[^/]+/
+var re = /^\/[^/]+/;
 //             ^ constant.other.character-class.set.regexp
 //               ^ keyword.operator.quantifier
 
-(y - 1) / ((x - 1) / -2)
+(y - 1) / ((x - 1) / -2);
 //      ^ keyword.operator.arithmetic
 //        ^ punctuation.section.group
-(y - 1) / ((x - 1) /  2)
+(y - 1) / ((x - 1) /  2);
 //    ^ punctuation.section.group
 //      ^ keyword.operator.arithmetic
- y      / ((x - 1) / -2)
+ y      / ((x - 1) / -2);
 
 define(['common'], function(common) {
 //                 ^ meta.function.declaration


### PR DESCRIPTION
There were two separate code paths handling function arguments, and they worked slightly differently. As a result, some comma separators were being parsed as comma operators. This is not currently visible in the core syntax (though see #831), but JS Custom offers an option to distinguish them. Because the solution is a straight simplification, I thought it reasonable to handle this upstream.

Now, all function call arguments are handled with one context. I renamed this context `function-call-arguments` (from `function-call`).

I also added semicolons to some related syntax tests. They worked either way, but without the semicolons they were a bit misleading.