### PR TITLE
[Markdown] Allow empty alt/text in images/link

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -548,11 +548,11 @@ contexts:
   image-inline:
     - match: |-
         (?x:
-            (\!\[)                            # Images start with ![
-            (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
-                  \]                          # Closing square bracket
-                  [ ]?                        # Space not allowed, but we check for it anyway to mark it as invalid
-                  \(                          # Open paren
+            (\!\[)                             # Images start with ![
+            (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
+                  \]                           # Closing square bracket
+                  [ ]?                         # Space not allowed, but we check for it anyway to mark it as invalid
+                  \(                           # Open paren
             )
          )
       captures:
@@ -587,13 +587,13 @@ contexts:
   image-ref:
     - match: |-
         (?x:
-          (\!\[)                            # Images start with ![
-          (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
-                \]                          # Closing square bracket
-                [ ]?                        # Space
-                \[                          # [
-                [^\]]+                      # anything other than ]
-                \]                          # ]
+          (\!\[)                             # Images start with ![
+          (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
+                \]                           # Closing square bracket
+                [ ]?                         # Space
+                \[                           # [
+                [^\]]+                       # anything other than ]
+                \]                           # ]
           )
         )
       captures:
@@ -733,7 +733,7 @@ contexts:
         (?x:
             (\[)
             (?=
-                {{balance_square_brackets}}
+                {{balance_square_brackets}}?
                 \]
                 {{url_and_title}}
             )
@@ -771,12 +771,12 @@ contexts:
     - match: |-
         (?x:
           (\[)
-          (?=   {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
-                \]                          # Closing square bracket
-                [ ]?                        # Space
-                \[                          # [
-                [^\]]+                      # anything other than ]
-                \]                          # ]
+          (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
+                \]                           # Closing square bracket
+                [ ]?                         # Space
+                \[                           # [
+                [^\]]+                       # anything other than ]
+                \]                           # ]
           )
         )
       captures:
@@ -801,11 +801,11 @@ contexts:
         (?x:
           (\[)
           (?=
-              {{balance_square_brackets}} # balanced square brackets, backticks, taking into account escapes etc.
-              \]                          # Closing square bracket
-              [ ]?                        # Space
-              \[                          # [
-              \]                          # ]
+              {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
+              \]                           # Closing square bracket
+              [ ]?                         # Space
+              \[                           # [
+              \]                           # ]
           )
         )
       captures:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -59,6 +59,14 @@ Inline `code sample`.
 |      ^ punctuation.definition.raw
 |                  ^ punctuation.definition.raw
 
+Here is a [](https://example.com).
+|         ^^ meta.link.inline
+|         ^ punctuation.definition.link.begin
+|          ^ punctuation.definition.link.end
+|           ^ punctuation.definition.metadata
+|            ^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                               ^ punctuation.definition.metadata
+
 Here is a [reference link][name].
 |         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
 |                         ^ punctuation.definition.constant.begin
@@ -69,6 +77,14 @@ Here is a [blank reference link][].
 |         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
 |                               ^ punctuation.definition.constant.begin
 |                                ^ punctuation.definition.constant.end
+
+Here is a ![](https://example.com/cat.gif).
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
+|          ^ punctuation.definition.image.begin
+|           ^ punctuation.definition.image.end - string
+|            ^ punctuation.definition.metadata
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                        ^ punctuation.definition.metadata
 
 Here is a ![Image Alt Text](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline


### PR DESCRIPTION
Highlights 

```md
[](http://example.com)
![](http://example.com/cat.jpg)
```

They are grammatically correct.