### PR TITLE
[Go] Add builtin template support

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -596,9 +596,9 @@ contexts:
       push:
         - meta_scope: template.go
         - match: "\\s-"
-          scope: keyword.operator.begin.trim.template.go
+          scope: keyword.operator.right.trim.template.go
         - match: "-\\s"
-          scope: keyword.operator.end.trim.template.go
+          scope: keyword.operator.left.trim.template.go
         - match: ":="
           scope: keyword.operator.initialize.template.go
         - match: \|

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -596,13 +596,13 @@ contexts:
       push:
         - meta_scope: template.go
         - match: "\\s-"
-          scope: keyword.operator.right.trim.template.go
+          scope: keyword.operator.template.right.trim.go
         - match: "-\\s"
-          scope: keyword.operator.left.trim.template.go
+          scope: keyword.operator.template.left.trim.go
         - match: ":="
-          scope: keyword.operator.initialize.template.go
+          scope: keyword.operator.template.initialize.go
         - match: \|
-          scope: keyword.operator.pipe.template.go
+          scope: keyword.operator.template.pipe.go
         - match: '[.$][\w]*'
           scope: variable.other.template.go
         - match: \b(if|else|range|template|with|end|nil|define|block)\b
@@ -610,29 +610,27 @@ contexts:
         - match: \b(and|call|html|index|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
           scope: support.function.builtin.template.go
         - match: /\*
+          scope: punctuation.definition.comment.template.go
           push:
             - meta_scope: comment.block.template.go
             - match: \*/
+              scope: punctuation.definition.comment.template.go
               pop: true
         - match: '"'
-          captures:
-            0: punctuation.definition.string.begin.template.go
+          scope: punctuation.definition.string.begin.template.go
           push:
             - meta_scope: string.quoted.double.template.go
             - match: '"'
-              captures:
-                0: punctuation.definition.string.end.template.go
+              scope: punctuation.definition.string.end.template.go
               pop: true
             - include: string-placeholder
             - include: string-escaped-char
         - match: "`"
-          captures:
-            0: punctuation.definition.string.begin.template.go
+          scope: punctuation.definition.string.begin.template.go
           push:
             - meta_scope: string.quoted.raw.template.go
             - match: "`"
-              captures:
-                0: punctuation.definition.string.end.template.go
+              scope: punctuation.definition.string.end.template.go
               pop: true
             - include: string-placeholder
         - match: "}}"

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -590,6 +590,55 @@ contexts:
     - match: "%"
       scope: invalid.illegal.placeholder.go
 
+  string-template:
+    - match: "{{"
+      scope: punctuation.section.embedded.begin.template.go
+      push:
+        - meta_scope: template.go
+        - match: "\\s-"
+          scope: keyword.operator.begin.trim.template.go
+        - match: "-\\s"
+          scope: keyword.operator.end.trim.template.go
+        - match: ":="
+          scope: keyword.operator.initialize.template.go
+        - match: \|
+          scope: keyword.operator.pipe.template.go
+        - match: '[.$][\w]*'
+          scope: variable.other.template.go
+        - match: \b(if|else|range|template|with|end|nil|define|block)\b
+          scope: keyword.control.template.go
+        - match: \b(and|call|html|index|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
+          scope: support.function.builtin.template.go
+        - match: /\*
+          push:
+            - meta_scope: comment.block.template.go
+            - match: \*/
+              pop: true
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.begin.template.go
+          push:
+            - meta_scope: string.quoted.double.template.go
+            - match: '"'
+              captures:
+                0: punctuation.definition.string.end.template.go
+              pop: true
+            - include: string-placeholder
+            - include: string-escaped-char
+        - match: "`"
+          captures:
+            0: punctuation.definition.string.begin.template.go
+          push:
+            - meta_scope: string.quoted.raw.template.go
+            - match: "`"
+              captures:
+                0: punctuation.definition.string.end.template.go
+              pop: true
+            - include: string-placeholder
+        - match: "}}"
+          scope: punctuation.section.embedded.end.template.go
+          pop: true
+
   strings:
     - match: '"'
       scope: punctuation.definition.string.begin.go
@@ -600,6 +649,7 @@ contexts:
           pop: true
         - include: string-placeholder
         - include: string-escaped-char
+        - include: string-template
     - match: "`"
       scope: punctuation.definition.string.begin.go
       push:
@@ -608,6 +658,7 @@ contexts:
           scope: punctuation.definition.string.end.go
           pop: true
         - include: string-placeholder
+        - include: string-template
   char:
     - match: "'"
       scope: punctuation.definition.string.begin.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -309,3 +309,96 @@ func () {
 	// <- entity.name.label
 	//   ^ punctuation.separator
 }
+
+func template() {
+	t := "{{.Count}} items are made of {{.Material}}"
+	//    ^^^^^^^^^^ template.go
+	//    ^^ punctuation.section.embedded.begin.template.go
+	//            ^^ punctuation.section.embedded.end.template.go
+	//      ^^^^^^ variable.other.template.go
+	t := `{{.Count}} items are made of {{.Material}}`
+	//    ^^^^^^^^^^ template.go
+	//    ^^ punctuation.section.embedded.begin.template.go
+	//            ^^ punctuation.section.embedded.end.template.go
+	//      ^^^^^^ variable.other.template.go
+	t = "{{23 -}} < {{- 45}}"
+	//   ^^^^^^^^ template.go
+	//   ^^ punctuation.section.embedded.begin.template.go
+	//        ^ keyword.operator.begin.trim.template.go
+	//         ^^ punctuation.section.embedded.end.template.go
+	//                ^ keyword.operator.end.trim.template.go
+	t = "{{/* a comment */}}"
+	//     ^^^^^^^^^^^^^^^ comment.block.template.go
+	t = "{{if pipeline}} T1 {{else}}{{if pipeline}} T0 {{end}}{{end}}"
+	//     ^^ keyword.control.template.go
+	//                        ^^^^ keyword.control.template.go
+	//                                ^^ keyword.control.template.go
+	//                                                   ^^^ keyword.control.template.go
+	//                                                          ^^^ keyword.control.template.go
+	t = "{{range pipeline}} T1 {{else}} T0 {{end}}"
+	//     ^^^^^ keyword.control.template.go
+	//                           ^^^^ keyword.control.template.go
+	//                                       ^^^ keyword.control.template.go
+	t = "{{template "name" pipeline}}"
+	//     ^^^^^^^^ keyword.control.template.go
+	//              ^ punctuation.definition.string.begin.template.go
+	//              ^^^^^^ string.quoted.double.template.go
+	//                   ^ punctuation.definition.string.end.template.go
+	t = "{{block "name" pipeline}} T1 {{end}}"
+	//     ^^^^^ keyword.control.template.go
+	//                                  ^^^ keyword.control.template.go
+	t = "{{with pipeline}} T1 {{else}} T0 {{end}}"
+	//     ^^^^ keyword.control.template.go
+	//                          ^^^^ keyword.control.template.go
+	//                                      ^^^ keyword.control.template.go
+	t = "{{$piOver2}}"
+	//     ^^^^^^^^ variable.other.template.go
+	t = "{{.Field1.Field2}}"
+	//     ^^^^^^^^^^^^^^ variable.other.template.go
+	t = "{{$x.Field1.Field2}}"
+	//     ^^^^^^^^^^^^^^^^ variable.other.template.go
+	t = "{{$variable := pipeline}}"
+	//     ^^^^^^^^^ variable.other.template.go
+	//               ^^ keyword.operator.initialize.template.go
+	t = "{{range $index, $element := pipeline}}"
+	//     ^^^^^ keyword.control.template.go
+	//           ^^^^^^ variable.other.template.go
+	//                   ^^^^^^^^ variable.other.template.go
+	//                            ^^ keyword.operator.initialize.template.go
+	t = "{{`"output"`}}"
+	t = "{{printf "%q" "output"}}"
+	//     ^^^^^^ support.function.builtin.template.go
+	t = "{{"output" | printf "%q"}}"
+	//              ^ keyword.operator.pipe.template.go
+	//                ^^^^^^ support.function.builtin.template.go
+	t = "{{printf "%q" (print "out" "put")}}"
+	//     ^^^^^^ support.function.builtin.template.go
+	//                  ^^^^^ support.function.builtin.template.go
+	t = "{{"put" | printf "%s%s" "out" | printf "%q"}}"
+	//           ^ keyword.operator.pipe.template.go
+	//             ^^^^^^ support.function.builtin.template.go
+	//                                 ^ keyword.operator.pipe.template.go
+	//                                   ^^^^^^ support.function.builtin.template.go
+	t = "{{"output" | printf "%s" | printf "%q"}}"
+	t = "{{with "output"}}{{printf "%q" .}}{{end}}"
+	t = "{{with $x := "output" | printf "%q"}}{{$x}}{{end}}"
+	t = "{{with $x := "output"}}{{printf "%q" $x}}{{end}}"
+	t = "{{with $x := "output"}}{{$x | printf "%q"}}{{end}}"
+	t = `{{define "T1"}}ONE{{end}}
+{{define "T2"}}TWO{{end}}
+{{define "T3"}}{{template "T1"}} {{template "T2"}}{{end}}
+{{template "T3"}}`
+	t = `
+Dear {{.Name}},
+{{if .Attended}}
+It was a pleasure to see you at the wedding.
+{{- else}}
+It is a shame you couldn't make it to the wedding.
+{{- end}}
+{{with .Gift -}}
+Thank you for the lovely {{.}}.
+{{end}}
+Best wishes,
+Josie
+`
+}

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -324,10 +324,12 @@ func template() {
 	t = "{{23 -}} < {{- 45}}"
 	//   ^^^^^^^^ template.go
 	//   ^^ punctuation.section.embedded.begin.template.go
-	//        ^ keyword.operator.right.trim.template.go
+	//        ^ keyword.operator.template.right.trim.go
 	//         ^^ punctuation.section.embedded.end.template.go
-	//                ^ keyword.operator.left.trim.template.go
+	//                ^ keyword.operator.template.left.trim.go
 	t = "{{/* a comment */}}"
+	//     ^^ punctuation.definition.comment.template.go
+	//                  ^^ punctuation.definition.comment.template.go
 	//     ^^^^^^^^^^^^^^^ comment.block.template.go
 	t = "{{if pipeline}} T1 {{else}}{{if pipeline}} T0 {{end}}{{end}}"
 	//     ^^ keyword.control.template.go
@@ -359,46 +361,42 @@ func template() {
 	//     ^^^^^^^^^^^^^^^^ variable.other.template.go
 	t = "{{$variable := pipeline}}"
 	//     ^^^^^^^^^ variable.other.template.go
-	//               ^^ keyword.operator.initialize.template.go
+	//               ^^ keyword.operator.template.initialize.go
 	t = "{{range $index, $element := pipeline}}"
 	//     ^^^^^ keyword.control.template.go
 	//           ^^^^^^ variable.other.template.go
 	//                   ^^^^^^^^ variable.other.template.go
-	//                            ^^ keyword.operator.initialize.template.go
+	//                            ^^ keyword.operator.template.initialize.go
 	t = "{{`"output"`}}"
 	t = "{{printf "%q" "output"}}"
 	//     ^^^^^^ support.function.builtin.template.go
 	t = "{{"output" | printf "%q"}}"
-	//              ^ keyword.operator.pipe.template.go
+	//              ^ keyword.operator.template.pipe.go
 	//                ^^^^^^ support.function.builtin.template.go
 	t = "{{printf "%q" (print "out" "put")}}"
 	//     ^^^^^^ support.function.builtin.template.go
 	//                  ^^^^^ support.function.builtin.template.go
 	t = "{{"put" | printf "%s%s" "out" | printf "%q"}}"
-	//           ^ keyword.operator.pipe.template.go
+	//           ^ keyword.operator.template.pipe.go
 	//             ^^^^^^ support.function.builtin.template.go
-	//                                 ^ keyword.operator.pipe.template.go
+	//                                 ^ keyword.operator.template.pipe.go
 	//                                   ^^^^^^ support.function.builtin.template.go
 	t = "{{"output" | printf "%s" | printf "%q"}}"
+	//     ^^^^^^^^ string.quoted.double.template.go
+	//              ^ keyword.operator.template.pipe.go
+	//                ^^^^^^ support.function.builtin.template.go
+	//                       ^^^^ string.quoted.double.template.go
+	//                            ^ keyword.operator.template.pipe.go
+	//                              ^^^^^^ support.function.builtin.template.go
+	//                                     ^^^^ string.quoted.double.template.go
 	t = "{{with "output"}}{{printf "%q" .}}{{end}}"
+	//     ^^^^ keyword.control.template.go
+	//                                  ^ variable.other.template.go
 	t = "{{with $x := "output" | printf "%q"}}{{$x}}{{end}}"
-	t = "{{with $x := "output"}}{{printf "%q" $x}}{{end}}"
+	//          ^^ variable.other.template.go
+	//             ^^ keyword.operator.template.initialize.go
+	//                                          ^^ variable.other.template.go
 	t = "{{with $x := "output"}}{{$x | printf "%q"}}{{end}}"
-	t = `{{define "T1"}}ONE{{end}}
-{{define "T2"}}TWO{{end}}
-{{define "T3"}}{{template "T1"}} {{template "T2"}}{{end}}
-{{template "T3"}}`
-	t = `
-Dear {{.Name}},
-{{if .Attended}}
-It was a pleasure to see you at the wedding.
-{{- else}}
-It is a shame you couldn't make it to the wedding.
-{{- end}}
-{{with .Gift -}}
-Thank you for the lovely {{.}}.
-{{end}}
-Best wishes,
-Josie
-`
-}
+	//                            ^^ variable.other.template.go
+	//                               ^ keyword.operator.template.pipe.go
+	//                                 ^^^^^^ support.function.builtin.template.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -324,9 +324,9 @@ func template() {
 	t = "{{23 -}} < {{- 45}}"
 	//   ^^^^^^^^ template.go
 	//   ^^ punctuation.section.embedded.begin.template.go
-	//        ^ keyword.operator.begin.trim.template.go
+	//        ^ keyword.operator.right.trim.template.go
 	//         ^^ punctuation.section.embedded.end.template.go
-	//                ^ keyword.operator.end.trim.template.go
+	//                ^ keyword.operator.left.trim.template.go
 	t = "{{/* a comment */}}"
 	//     ^^^^^^^^^^^^^^^ comment.block.template.go
 	t = "{{if pipeline}} T1 {{else}}{{if pipeline}} T0 {{end}}{{end}}"


### PR DESCRIPTION
There is builtin template language in golang. This patch make it support template syntax highlighting.
Almost of syntax definition is derived from [GoSublime syntax definition](https://github.com/DisposaBoy/GoSublime/blob/master/syntax/GoSublime-Template.sublime-syntax), and I added a little tweak.