### PR TITLE
[Ruby] Fixed keybind for interpolation and improved scopes.

### DIFF
--- a/Ruby/Default.sublime-keymap
+++ b/Ruby/Default.sublime-keymap
@@ -1,5 +1,5 @@
 [
-	{ "keys": ["#"], "command": "insert_snippet", "args": {"contents": "#{${1:$SELECTION}}$0"}, "context":
+	{ "keys": ["#"], "command": "insert_snippet", "args": {"contents": "#{${0:$SELECTION}}"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1259,7 +1259,7 @@ contexts:
         - meta_scope: meta.interpolation
         - meta_content_scope: source.ruby.embedded
         - match: '\}'
-          scope: punctuation.definition.interpolation.end.ruby
+          scope: punctuation.section.interpolation.end.ruby
           pop: true
         - include: nest-curly-expressions
         - include: expressions

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1252,17 +1252,14 @@ contexts:
       scope: constant.character.escape.ruby
 
   interpolated-ruby:
-    - match: '(#\{)(\})'
-      scope: punctuation.section.embedded.ruby
-      captures:
-        1: source.ruby.embedded.source
-        2: source.ruby.embedded.source.empty
     - match: '#\{'
-      scope: punctuation.section.embedded.ruby
+      scope: punctuation.definition.interpolation.begin.ruby
       push:
-        - meta_scope: source.ruby.embedded.source
+        - clear_scopes: 1
+        - meta_scope: meta.interpolation
+        - meta_content_scope: source.ruby.embedded
         - match: '\}'
-          scope: punctuation.section.embedded.ruby
+          scope: punctuation.definition.interpolation.end.ruby
           pop: true
         - include: nest-curly-expressions
         - include: expressions

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1253,7 +1253,7 @@ contexts:
 
   interpolated-ruby:
     - match: '#\{'
-      scope: punctuation.definition.interpolation.begin.ruby
+      scope: punctuation.section.interpolation.begin.ruby
       push:
         - clear_scopes: 1
         - meta_scope: meta.interpolation

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -21,7 +21,7 @@ puts <<-HTML
 class_eval <<-RUBY, __FILE__, __LINE__ + 1
   def #{sym}(*args, &block)
 #     ^^ punctuation.section.interpolation.begin
-#          ^ punctuation.definition.interpolation.end
+#          ^ punctuation.section.interpolation.end
     custom(Mime[:#{sym}], *args, &block)
   end
 RUBY

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -20,7 +20,7 @@ puts <<-HTML
 
 class_eval <<-RUBY, __FILE__, __LINE__ + 1
   def #{sym}(*args, &block)
-#     ^^ punctuation.definition.interpolation.begin
+#     ^^ punctuation.section.interpolation.begin
 #          ^ punctuation.definition.interpolation.end
     custom(Mime[:#{sym}], *args, &block)
   end

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -20,7 +20,8 @@ puts <<-HTML
 
 class_eval <<-RUBY, __FILE__, __LINE__ + 1
   def #{sym}(*args, &block)
-#     ^^ punctuation.section.embedded
+#     ^^ punctuation.definition.interpolation.begin
+#          ^ punctuation.definition.interpolation.end
     custom(Mime[:#{sym}], *args, &block)
   end
 RUBY
@@ -61,8 +62,11 @@ str = sprintf("%1$*2$s %2$d", "hello", -8)
 
   %I[#{ENV['APP_NAME']} apple orange]
 # ^^^ punctuation.definition.string.begin.ruby
+# ^^^ string.quoted.other.literal.upper.ruby
+#    ^^^^^^^^^^^^^^^^^^ meta.interpolation
+#    ^^^^^^ - string
 #      ^ meta.environment-variable.ruby variable.other.constant.ruby
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.literal.upper.ruby
+#                      ^^^^^^^^^^^^^^ string.quoted.other.literal.upper.ruby
 
 ##################
 # Constants


### PR DESCRIPTION
Fixes #1458. Uses interpolation scopes based on Python. See #1432 for further discussion.