### PR TITLE
[Markdown] better support for loose list items

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -837,7 +837,7 @@ contexts:
         2: meta.link.reference.literal.footnote-id.markdown
         3: punctuation.definition.link.end.markdown
   list-paragraph:
-    - match: '^(?=\s+(?![>+*\s-]))(?={{indented_code_block}})'
+    - match: '^(?=(?:[ ]{4}|\t){2,}(?![>+*\s-]))(?={{indented_code_block}})'
       push:
         - include: indented-code-block
         - match: $

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1576,6 +1576,16 @@ paragraph
 Normal paragraph
 | <- meta.paragraph - markup
 
+1. List
+    1. Nested list
+    2. Second item
+
+    This line is still list item 1
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered - markup.raw.block
+
+Test
+| <- meta.paragraph - markup.list
+
 http://spec.commonmark.org/0.28/#example-116
 
 <table><tr><td>


### PR DESCRIPTION
This PR provides better support for loose list items - instead of treating them as indented code blocks, it correctly identifies that they continue the list item. Fixes #1466.