### PR TITLE
[PHP] Fix PHPDoc annotations: @property-read, @property-write

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1123,7 +1123,7 @@ contexts:
       captures:
         1: keyword.other.phpdoc.php
         2: markup.underline.link.php
-    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|property|method|source)\b
+    - match: \@(a(bstract|pi|uthor)|c(ategory|opyright)|example|global|i(nternal|gnore)|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|fi(nal|lesource)|property(-(read|write))?|method|source)\b
       scope: keyword.other.phpdoc.php
     - match: '\{(@(link)).+?\}'
       scope: meta.tag.inline.phpdoc.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -328,12 +328,12 @@ $var->meth()[10];
 
 /**
  * @property-read Class: allows a class to know which ‘magic’ properties are present that are read-only.
-//  ^ keyword.other.phpdoc
+//  ^^^^^^^^^^^^^ keyword.other.phpdoc
  */
 
 /**
  * @property-write Class: allows a class to know which ‘magic’ properties are present that are write-only.
-//  ^ keyword.other.phpdoc
+//  ^^^^^^^^^^^^^^ keyword.other.phpdoc
  */
 
 /**


### PR DESCRIPTION
`@property-read` and `@property-write` should be highlighted as a whole.

```diff
 /**
  * @property-read Class: allows a class to know which ‘magic’ properties are present that are read-only.
-//  ^ keyword.other.phpdoc
+//  ^^^^^^^^^^^^^ keyword.other.phpdoc
  */
 
 /**
  * @property-write Class: allows a class to know which ‘magic’ properties are present that are write-only.
-//  ^ keyword.other.phpdoc
+//  ^^^^^^^^^^^^^^ keyword.other.phpdoc
  */
```