### PR TITLE
[Markdown] better support of inline images and links with whitespace

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -34,7 +34,7 @@ variables:
               ((\().+?(\)))       # Match title in parens…
             | ((")[^"]+("))       # or in double quotes…
             | ((')[^']+('))       # or in single quotes.
-          )?                      # Title is optional
+          )
         )
     escape: '\\[-`*_#+.!(){}\[\]\\>|]'
     backticks: |-
@@ -61,7 +61,7 @@ variables:
           ([ ])?                        # Space not allowed, but we check for it anyway to mark it as invalid
           (\()                          # Opening paren for url
               (<?)(\S+?)(>?)            # The url
-              {{link_title}}            # Optional title
+              {{link_title}}?           # Optional title
               \s*                       # Optional whitespace
           (\))
         )
@@ -565,24 +565,50 @@ contexts:
       scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
       pop: true
   image-inline-after-text:
-    - match: '{{url_and_title}}'
+    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
       captures:
         1: invalid.illegal.whitespace.markdown
         2: punctuation.definition.metadata.begin.markdown
-        3: punctuation.definition.link.begin.markdown
-        4: markup.underline.link.image.markdown
-        5: punctuation.definition.link.end.markdown
-        6: string.other.link.description.title.markdown
-        7: punctuation.definition.string.begin.markdown
-        8: punctuation.definition.string.end.markdown
-        9: string.other.link.description.title.markdown
-        10: punctuation.definition.string.begin.markdown
-        11: punctuation.definition.string.end.markdown
-        12: string.other.link.description.title.markdown
-        13: punctuation.definition.string.begin.markdown
-        14: punctuation.definition.string.end.markdown
-        15: punctuation.definition.metadata.end.markdown
-      scope: meta.image.inline.markdown
+      set:
+        - meta_scope: meta.image.inline.markdown
+        - match: \)
+          scope: punctuation.definition.metadata.end.markdown
+          pop: true
+        - match: <(?=[^>)]*>)
+          scope: punctuation.definition.link.begin.markdown
+          push:
+            - meta_content_scope: markup.underline.link.image.markdown
+            - match: \>
+              scope: punctuation.definition.link.end.markdown
+              set: image-title
+            - match: \s+
+              scope: invalid.illegal.unexpected-whitespace.markdown
+        - match: (?=\S)
+          set:
+            - meta_scope: meta.image.inline.markdown
+            - match: '[^\s)]+'
+              scope: markup.underline.link.image.markdown
+            - match: \)
+              scope: punctuation.definition.metadata.end.markdown
+              pop: true
+            - match: (?!\n)\s+(?!\s*(?:\)|$)|{{link_title}})
+              scope: invalid.illegal.unexpected-whitespace.markdown
+            - match: (?=\s*(?!\)))
+              push: image-title
+  image-title:
+    - match: '{{link_title}}'
+      captures:
+        1: string.other.link.description.title.markdown
+        2: punctuation.definition.string.begin.markdown
+        3: punctuation.definition.string.end.markdown
+        4: string.other.link.description.title.markdown
+        5: punctuation.definition.string.begin.markdown
+        6: punctuation.definition.string.end.markdown
+        7: string.other.link.description.title.markdown
+        8: punctuation.definition.string.begin.markdown
+        9: punctuation.definition.string.end.markdown
+      pop: true
+    - match: (?=\S|$)
       pop: true
   image-ref:
     - match: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -28,14 +28,6 @@ variables:
     atx_heading: (?:[#]{1,6}\s*)             # between 1 and 6 hashes, followed by any amount of whitespace
     indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
     list_item: (?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s) # between 0 and 3 spaces, followed by either: at least one integer and a full stop, or (a star, plus or dash), followed by whitespace
-    link_title: |-
-        (?x:[ \t]*                # Optional whitespace
-          (?:
-              ((\().+?(\)))       # Match title in parens…
-            | ((")[^"]+("))       # or in double quotes…
-            | ((')[^']+('))       # or in single quotes.
-          )
-        )
     escape: '\\[-`*_#+.!(){}\[\]\\>|]'
     backticks: |-
         (?x:
@@ -55,15 +47,6 @@ variables:
                 {{backticks}}?          #  balanced backticks
               )*\]                      #  closing square bracket
           )+                            # at least one character
-        )
-    url_and_title: |-
-        (?x:
-          ([ ])?                        # Space not allowed, but we check for it anyway to mark it as invalid
-          (\()                          # Opening paren for url
-              (<?)(\S+?)(>?)            # The url
-              {{link_title}}?           # Optional title
-              \s*                       # Optional whitespace
-          (\))
         )
     html_entity: '&([a-zA-Z0-9]+|#\d+|#x\h+);'
     skip_html_tags: (?:<[^>]+>)
@@ -593,7 +576,7 @@ contexts:
             - match: \)
               scope: punctuation.definition.metadata.end.markdown
               pop: true
-            - match: (?!\n)\s+(?!\s*(?:\)|$)|{{link_title}})
+            - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
@@ -780,7 +763,7 @@ contexts:
             - match: \)
               scope: punctuation.definition.metadata.end.markdown
               pop: true
-            - match: (?!\n)\s+(?!\s*(?:\)|$)|{{link_title}})
+            - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -258,9 +258,7 @@ contexts:
         6: markup.underline.link.markdown
         7: punctuation.definition.link.end.markdown
         8: markup.underline.link.markdown
-      push:
-        - meta_scope: meta.link.reference.def.markdown
-        - include: link-title
+      push: [link-ref-def, after-link-title, link-title]
     - match: '^(?=\S)(?![=-]{3,}\s*$)'
       push:
         - meta_scope: meta.paragraph.markdown
@@ -296,6 +294,10 @@ contexts:
           captures:
             1: punctuation.definition.heading.setext.markdown
           pop: true
+  link-ref-def:
+    - meta_scope: meta.link.reference.def.markdown
+    - match: ''
+      pop: true
   ampersand:
     - match: (?!{{html_entity}})&
       comment: |
@@ -580,7 +582,7 @@ contexts:
             - meta_content_scope: markup.underline.link.image.markdown
             - match: \>
               scope: punctuation.definition.link.end.markdown
-              set: image-title
+              set: link-title
             - match: \s+
               scope: invalid.illegal.unexpected-whitespace.markdown
         - match: (?=\S)
@@ -594,22 +596,7 @@ contexts:
             - match: (?!\n)\s+(?!\s*(?:\)|$)|{{link_title}})
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
-              push: image-title
-  image-title:
-    - match: '{{link_title}}'
-      captures:
-        1: string.other.link.description.title.markdown
-        2: punctuation.definition.string.begin.markdown
-        3: punctuation.definition.string.end.markdown
-        4: string.other.link.description.title.markdown
-        5: punctuation.definition.string.begin.markdown
-        6: punctuation.definition.string.end.markdown
-        7: string.other.link.description.title.markdown
-        8: punctuation.definition.string.begin.markdown
-        9: punctuation.definition.string.end.markdown
-      pop: true
-    - match: (?=\S|$)
-      pop: true
+              push: link-title
   image-ref:
     - match: |-
         (?x:
@@ -761,37 +748,47 @@ contexts:
             (?=
                 {{balance_square_brackets}}?
                 \]
-                {{url_and_title}}
+                [ ]?\(
             )
         )
       captures:
         1: meta.link.inline.markdown punctuation.definition.link.begin.markdown
       push: [link-inline-after-text, link-inline-link-text]
+  link-inline-after-text:
+    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.metadata.begin.markdown
+      set:
+        - meta_scope: meta.link.inline.markdown
+        - match: \)
+          scope: punctuation.definition.metadata.end.markdown
+          pop: true
+        - match: <(?=[^>)]*>)
+          scope: punctuation.definition.link.begin.markdown
+          push:
+            - match: \>
+              scope: punctuation.definition.link.end.markdown
+              set: link-title
+            - match: \s+
+              scope: invalid.illegal.unexpected-whitespace.markdown
+        - match: (?=\S)
+          set:
+            - meta_scope: meta.link.inline.markdown
+            - match: '[^\s)]+'
+              scope: markup.underline.link.markdown
+            - match: \)
+              scope: punctuation.definition.metadata.end.markdown
+              pop: true
+            - match: (?!\n)\s+(?!\s*(?:\)|$)|{{link_title}})
+              scope: invalid.illegal.unexpected-whitespace.markdown
+            - match: (?=\s*(?!\)))
+              push: link-title
   link-inline-link-text:
     - meta_content_scope: meta.link.inline.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
-      pop: true
-  link-inline-after-text:
-    - match: '{{url_and_title}}'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.metadata.begin.markdown
-        3: punctuation.definition.link.begin.markdown
-        4: markup.underline.link.markdown
-        5: punctuation.definition.link.end.markdown
-        6: string.other.link.description.title.markdown
-        7: punctuation.definition.string.begin.markdown
-        8: punctuation.definition.string.end.markdown
-        9: string.other.link.description.title.markdown
-        10: punctuation.definition.string.begin.markdown
-        11: punctuation.definition.string.end.markdown
-        12: string.other.link.description.title.markdown
-        13: punctuation.definition.string.begin.markdown
-        14: punctuation.definition.string.end.markdown
-        15: punctuation.definition.metadata.end.markdown
-      scope: meta.link.inline.markdown
       pop: true
   link-ref:
     - match: |-
@@ -1021,38 +1018,38 @@ contexts:
     - match: \s*(')
       captures:
         1: punctuation.definition.string.begin.markdown
-      push:
+      set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \'
           scope: punctuation.definition.string.end.markdown
-          set: after-link-title
+          pop: true
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.link-title.markdown
           pop: true
     - match: \s*(")
       captures:
         1: punctuation.definition.string.begin.markdown
-      push:
+      set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \"
           scope: punctuation.definition.string.end.markdown
-          set: after-link-title
+          pop: true
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.link-title.markdown
           pop: true
     - match: \s*(\()
       captures:
         1: punctuation.definition.string.begin.markdown
-      push:
+      set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \)
           scope: punctuation.definition.string.end.markdown
-          set: after-link-title
+          pop: true
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.link-title.markdown
           pop: true
     - match: \s*
-      set: after-link-title
+      pop: true
   after-link-title:
     - match: '(.*)$\n?'
       captures:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -154,9 +154,26 @@ Here is a ![Image Ref Alt][1].
 |                           ^ punctuation.definition.constant
 
 now you can access the [The Ever Cool Site: Documentation about Sites](
-  www.thecoolsite.com.ca/documentations/about/cool) for more information about...
+  www.thecoolsite.com.ca/documentations/about/cool ) for more information about...
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline markup.underline.link
-|                                                 ^ meta.link.inline punctuation.definition.metadata.end
+|                                                 ^ - invalid
+|                                                  ^ meta.link.inline punctuation.definition.metadata.end
+
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca /documentations/about/cool ) for more information about...
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inline
+| ^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                       ^ invalid.illegal.unexpected-whitespace
+|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                                  ^ - invalid
+|                                                   ^ punctuation.definition.metadata.end
+
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca/documentations/about/cool
+  (title)) for more information about...
+| ^^^^^^^^ meta.paragraph meta.link.inline
+|        ^ punctuation.definition.metadata.end
+| ^^^^^^^ string.other.link.description.title.markdown
 
   1. Ordered list item
 | ^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -153,6 +153,10 @@ Here is a ![Image Ref Alt][1].
 |                          ^ constant.other.reference.link
 |                           ^ punctuation.definition.constant
 
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca/documentations/about/cool) for more information about...
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline markup.underline.link
+|                                                 ^ meta.link.inline punctuation.definition.metadata.end
 
   1. Ordered list item
 | ^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -94,6 +94,57 @@ Here is a ![Image Alt Text](https://example.com/cat.gif).
 |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
 |                                                      ^ punctuation.definition.metadata
 
+Here is a ![Image Alt Text](  https://example.com/cat.gif  ).
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
+|          ^ punctuation.definition.image.begin
+|                         ^ punctuation.definition.image.end - string
+|                          ^ punctuation.definition.metadata
+|                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                                          ^ punctuation.definition.metadata
+
+Here is a ![Image Alt Text](
+  https://example.com/cat.gif  ).
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                              ^ punctuation.definition.metadata
+
+Here is a ![Image Alt Text](
+  https://example.com/cat.gif
+ "hello"   ).
+|^^^^^^^ meta.image.inline string.other.link.description.title
+|       ^^^^ meta.image.inline
+|          ^ punctuation.definition.metadata.end
+
+Here is a ![Image Alt Text](
+  <https://example.com/cat.gif> "hello"   ).
+| ^ punctuation.definition.link.begin
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                             ^ punctuation.definition.link.end
+|                               ^^^^^^^ string.other.link.description.title
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
+|                                         ^ punctuation.definition.metadata.end
+
+Here is a ![Image Alt Text](
+  <https://example .com /cat.gif> (hello)   ).
+| ^ punctuation.definition.link.begin
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                 ^ invalid.illegal.unexpected-whitespace
+|                      ^ invalid.illegal.unexpected-whitespace
+|                               ^ punctuation.definition.link.end
+|                                 ^^^^^^^ string.other.link.description.title
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
+|                                           ^ punctuation.definition.metadata.end
+
+Here is a ![Image Alt Text](
+  https://example .com /cat.gif (hello)   ).
+| ^^^^^^^^^^^^^^^ markup.underline.link.image
+|                ^ invalid.illegal.unexpected-whitespace
+|                 ^^^^ markup.underline.link.image
+|                     ^ invalid.illegal.unexpected-whitespace
+|                      ^^^^^^^^ markup.underline.link.image
+|                               ^^^^^^^ string.other.link.description.title
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
+|                                         ^ punctuation.definition.metadata.end
+
 Here is a ![Image Ref Alt][1].
 |         ^^^^^^^^^^^^^^^^^^^ meta.image.reference
 |         ^^ punctuation.definition.image.begin


### PR DESCRIPTION
This fixes a bug whereby if one had invalid spaces inside an inline image link, the rest of the file would be stuck in the `image-inline-after-text` context. Also, it previously didn't correctly handle newlines before/around the link uri and title - this has also now been resolved. I have, of course, added some new assertions to prove that it now works as expected.