### PR TITLE
[JavaScript] Improved handling of class inheritance names.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -687,22 +687,25 @@ contexts:
     - match: (?=\S)
       push: expression-no-comma
 
-  expression-end:
+  left-expression-end:
     - include: expression-break
 
-    - include: postfix-operators
-    - include: binary-operators
-    - include: ternary-operator
-
     - include: property-access
+    - include: literal-string-template
 
     - match: (?=\()
       push: function-call-arguments
-    - include: literal-string-template
 
     - include: fallthrough
 
     - include: else-pop
+
+  expression-end:
+    - include: postfix-operators
+    - include: binary-operators
+    - include: ternary-operator
+
+    - include: left-expression-end
 
   expression-end-no-comma:
     - match: (?=,)
@@ -1068,18 +1071,13 @@ contexts:
       pop: true
 
   inherited-class-expression-end:
-    - include: expression-break
-
     - match: \.
       scope: punctuation.accessor.js
       push:
         - include: inherited-class-name
         - include: object-property
 
-    - include: property-access
-    - include: function-call
-    - include: fallthrough
-    - include: else-pop
+    - include: left-expression-end
 
   inherited-class-expression-begin:
     - include: inherited-class-name

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -20,7 +20,7 @@ variables:
   arrow_func_lookahead: '\s*(async\s*)?({{identifier}}|\(([^()]|\([^()]*\))*\))\s*=>'
   either_func_lookahead: (?:{{func_lookahead}}|{{arrow_func_lookahead}})
   binding_pattern_lookahead: (?:{{identifier}}|\[|\{)
-  accessor_expression: ({{identifier}}\s*\.\s*)+({{identifier}})
+  left_expression_end_lookahead: '(?!\s*[.\[\(])'
 
   property_name: >-
     (?x)(?:
@@ -1058,16 +1058,32 @@ contexts:
     - match: extends{{identifier_break}}
       scope: storage.modifier.extends.js
       set:
-        - match: (?={{accessor_expression}}\s*\{)
-          push:
-            - expect-dot-accessor
-            - literal-variable
-        - match: '{{identifier}}(?=\s*\{)'
-          scope: entity.other.inherited-class.js
-          pop: true
-        - match: (?=\S)
-          set: expression
+        - inherited-class-expression-end
+        - inherited-class-expression-begin
     - include: else-pop
+
+  inherited-class-name:
+    - match: '{{identifier}}{{left_expression_end_lookahead}}'
+      scope: entity.other.inherited-class.js
+      pop: true
+
+  inherited-class-expression-end:
+    - include: expression-break
+
+    - match: \.
+      scope: punctuation.accessor.js
+      push:
+        - include: inherited-class-name
+        - include: object-property
+
+    - include: property-access
+    - include: function-call
+    - include: fallthrough
+    - include: else-pop
+
+  inherited-class-expression-begin:
+    - include: inherited-class-name
+    - include: expression-begin
 
   class-name:
     - match: '{{identifier}}'
@@ -1575,21 +1591,7 @@ contexts:
 
     - match: \.
       scope: punctuation.accessor.js
-      push:
-        - match: |-
-            (?x)(?=
-              {{identifier}}
-              \s* = \s*
-              {{either_func_lookahead}}
-            )
-          set:
-            - function-initializer
-            - function-declaration-final-identifier
-        - match: '(?={{identifier}}\s*\()'
-          set:
-            - include: method-call
-            - include: else-pop
-        - include: object-property
+      push: object-property
 
   literal-number:
     - match: '[+-]?0[0-9]+{{identifier_break}}'
@@ -1836,6 +1838,19 @@ contexts:
       pop: true
 
   object-property:
+    - match: |-
+        (?x)(?=
+          {{identifier}}
+          \s* = \s*
+          {{either_func_lookahead}}
+        )
+      set:
+        - function-initializer
+        - function-declaration-final-identifier
+    - match: '(?={{identifier}}\s*\()'
+      set:
+        - include: method-call
+        - include: else-pop
     - match: __proto__{{identifier_break}}
       scope: variable.language.proto.js
       pop: true

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -704,6 +704,7 @@ class MyClass extends TheirClass {
 // <- storage.type.class
 //    ^^^^^^^ entity.name.class
 //            ^^^^^^^ storage.modifier.extends
+//                    ^^^^^^^^^^ entity.other.inherited-class
 //                               ^ meta.block
 
     x = 42;
@@ -865,7 +866,8 @@ class MyClass extends TheirClass {
 // <- meta.block
 
 class Foo extends React.Component {
-//                      ^ entity.other.inherited-class
+//                ^^^^^ - entity.other.inherited-class
+//                      ^^^^^^^^^ entity.other.inherited-class
     constructor()
     {}
 
@@ -876,6 +878,16 @@ class Foo extends React.Component {
         return this.a;
     }
 }
+
+class Foo extends (Foo).Bar {}
+//                      ^^^ entity.other.inherited-class
+
+class Foo extends Bar
+//                ^^^ entity.other.inherited-class
+    .baz {}
+//  ^^^^^^^ meta.class
+//  ^ punctuation.accessor
+//   ^^^ entity.other.inherited-class
 
 class Foo extends
 //        ^^^^^^^ storage.modifier.extends


### PR DESCRIPTION
Since #1348, `extend` has supported arbitrary expressions. This is actually overgenerous; only "left expressions" can be the target of `extend`. I have implemented the logic more thoroughly. As a result, the name of the extended class can be properly scoped `entity.other.inherited-class` in more cases than before. (Due to line lookahead limitations, there are a few cases where an identifier may be incorrectly scoped `entity.other.inherited-class`, but the syntax will recover immediately.) Tests have been added and improved.

As an added bonus, this is much of the logic we'll need to implement decorators. This also makes it much easier and less intrusive to extend the syntax to support a type system like Flow (e.g. `class Child extends Parent<TypeParam>`).