### PR TITLE
[JavaScript] Implemented decorators.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -277,6 +277,8 @@ contexts:
 
     - include: function-or-class-declaration
 
+    - include: decorator
+
     - match: (?=\S)
       set: expression-statement
 
@@ -669,6 +671,36 @@ contexts:
       set: parenthesized-expression
     - include: else-pop
 
+  decorator:
+    - match: '@'
+      scope: punctuation.definition.annotation.js
+      push:
+        - decorator-meta
+        - decorator-expression-end
+        - decorator-expression-begin
+
+  decorator-meta:
+    - meta_scope: meta.annotation.js
+    - include: immediately-pop
+
+  decorator-name:
+    - match: '{{identifier}}{{left_expression_end_lookahead}}'
+      scope: variable.annotation.js
+      pop: true
+
+  decorator-expression-end:
+    - match: \.
+      scope: punctuation.accessor.js
+      push:
+        - include: decorator-name
+        - include: object-property
+
+    - include: left-expression-end
+
+  decorator-expression-begin:
+    - include: decorator-name
+    - include: expression-begin
+
   expression-break:
     - match: (?=[;})\]])
       pop: true
@@ -1042,6 +1074,8 @@ contexts:
 
     - match: \;
       scope: punctuation.terminator.statement.js
+
+    - include: decorator
 
     - match: constructor{{identifier_break}}
       scope: entity.name.function.constructor.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -862,6 +862,25 @@ class MyClass extends TheirClass {
 
     constructor$() {}
 //  ^^^^^^^^^^^^ entity.name.function - entity.name.function.constructor
+
+    @foo bar() {}
+//  ^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.annotation
+//       ^^^ entity.name.function
+
+    @foo.bar bar() {}
+//  ^^^^^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.other.object - variable.annotation
+//       ^^^ variable.annotation
+//           ^^^ entity.name.function
+
+    @(whatever) bar() {}
+//  ^^^^^^^^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^^^^^^^^ meta.group
+//              ^^^ entity.name.function
 }
 // <- meta.block
 
@@ -895,6 +914,25 @@ Bar {}
 
 class Foo extends getSomeClass() {}
 //                ^^^^^^^^^^^^ meta.function-call variable.function - entity.other.inherited-class
+
+    @foo class Foo {}
+//  ^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.annotation
+//       ^^^^^ storage.type.class
+
+    @foo.bar class Foo {}
+//  ^^^^^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.other.object - variable.annotation
+//       ^^^ variable.annotation
+//           ^^^^^ storage.type.class
+
+    @(whatever) class Foo {}
+//  ^^^^^^^^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^^^^^^^^ meta.group
+//              ^^^^^ storage.type.class
 
 () => {}
 // <- meta.function.declaration punctuation.section.group


### PR DESCRIPTION
Supersedes #1236.

Implements the [decorators proposal](https://github.com/tc39/proposal-decorators), resolving #1477. The proposal is just shy of our usual standard of adoption: it's Stage 2 and expected to advance, and a conformant implementation is expected for Babel 7 (though a *nonconformant* implementation has existed for years). For historical reasons, there's a fair bit of code out there using decorators anyway, and because the feature is on the standards track I think it's reasonable to add it.

The proposed syntax is not completely finalized, but it is a virtual certainty that it will be a subset of this implementation (based on the `LeftExpression` production). Radical change is extremely unlikely at this point.

Currently, decorators are the sole major core ECMAScript feature [supported by Babel-sublime](https://github.com/babel/babel-sublime/issues/356) but absent from the core syntax. JS Custom offers an implementation, though it's lower-quality than this one. It is likely that Babel-sublime will be "rebased" off the core syntax some time after the next stable release, and core decorator support would be an asset to that change.