### PR TITLE
[Groovy] Fix invalid highlighting after embedded code in string

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -66,14 +66,7 @@ contexts:
         6: entity.name.type.class.groovy
       push:
         - meta_scope: meta.definition.class.groovy
-        - match: $
-          captures:
-            1: storage.modifier.access-control.groovy
-            2: storage.modifier.static.groovy
-            3: storage.modifier.final.groovy
-            4: storage.modifier.other.groovy
-            5: storage.type.class.groovy
-            6: entity.name.type.class.groovy
+        - match: $|(?=\})
           pop: true
         - match: '(extends)\s+([a-zA-Z0-9_\.]+(?:<(?:[a-zA-Z0-9_, ])+>)?)\s*'
           scope: meta.definition.class.inherited.classes.groovy
@@ -152,7 +145,7 @@ contexts:
         1: keyword.control.assert.groovy
       push:
         - meta_scope: meta.declaration.assertion.groovy
-        - match: $
+        - match: $|(?=\})
           pop: true
         - match: ":"
           scope: keyword.operator.assert.expression-separator.groovy
@@ -180,7 +173,7 @@ contexts:
       scope: keyword.operator.ternary.groovy
       push:
         - meta_scope: meta.evaluation.ternary.groovy
-        - match: $
+        - match: $|(?=\})
           pop: true
         - match: ":"
           scope: keyword.operator.ternary.expression-separator.groovy

--- a/Groovy/syntax_test_groovy.groovy
+++ b/Groovy/syntax_test_groovy.groovy
@@ -46,4 +46,27 @@ interpretString("123.0")
 chartHistogram([1,1,2,3])
 // <- meta.method
 //           ^ meta.method
-//              ^ constant.numeric  
+//              ^ constant.numeric
+
+def greeting = "Hello ${true ? 'World' : 'Home'}"
+// <- storage.type.def
+//^ storage.type.def
+//           ^ keyword.operator.assignment
+//             ^ punctuation.definition.string.begin
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+//                    ^^ punctuation.section.embedded
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.groovy.embedded.source
+//                      ^^^^ constant.language
+//                           ^^^^^^^^^^^^^^^^^^ meta.evaluation.ternary
+//                                             ^^ - meta.evaluation.ternary
+//                           ^ keyword.operator.ternary
+//                             ^ punctuation.definition.string.begin
+//                             ^^^^^^^ string.quoted.single
+//                                   ^ punctuation.definition.string.end
+//                                     ^ keyword.operator.ternary.expression-separator
+//                                       ^ punctuation.definition.string.begin
+//                                       ^^^^^^ string.quoted.single
+//                                            ^ punctuation.definition.string.end
+//                                             ^ punctuation.section.embedded
+//                                              ^ punctuation.definition.string.end
+//                                               ^ - string.quoted - invalid


### PR DESCRIPTION
Fixes issue #1451, #1542

This commit fixes an issue with the closing `"` of a  string being matched as start of a new string, which caused the region after it to be scoped as invalid.

The reason for this issue was the end of the embedded code block `${ ... }` not being recognized due to the used expression inside, which expected the code block to end at the end of line only.