### PR TITLE
Fix missing coma for `grid-auto-flow` completion

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -266,7 +266,7 @@ PROPERTY_DICT = {
     'grid': [],
     'grid-area': [],
     'grid-auto-columns': ['auto', '<percentage>', '<length>'],
-    'grid-auto-flow': ['row', 'column' 'dense'],
+    'grid-auto-flow': ['row', 'column', 'dense'],
     'grid-auto-rows': ['auto', '<percentage>', '<length>'],
     'grid-column-gap': ['<length>', '<percentage>'],
     'grid-gap': ['<length>', '<percentage>'],


### PR DESCRIPTION
Missing coma was causing the completion to be `columndense` instead of `column` and `dense` for `grid-auto-flow`.