### PR TITLE
[JavaScript] Extend `meta.function` scope to entire function.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -768,7 +768,9 @@ contexts:
     # If an arrow function has the ( and ) on different lines, we won't have matched
     - match: =>
       scope: storage.type.function.arrow.js
-      push: arrow-function-expect-body
+      push:
+        - function-meta
+        - arrow-function-expect-body
 
   literal-string:
     - match: "'"
@@ -1069,6 +1071,7 @@ contexts:
     - match: constructor{{identifier_break}}
       scope: entity.name.function.constructor.js
       push:
+        - function-meta
         - function-declaration-expect-body
         - function-declaration-meta
         - function-declaration-expect-parameters
@@ -1140,6 +1143,7 @@ contexts:
   field-initializer-or-method-declaration:
     - match: (?=\()
       set:
+        - function-meta
         - function-declaration-expect-body
         - function-declaration-meta
         - function-declaration-expect-parameters
@@ -1287,6 +1291,7 @@ contexts:
   function-declaration:
     - match: ''
       set:
+        - function-meta
         - function-declaration-expect-body
         - function-declaration-meta
         - function-declaration-expect-parameters
@@ -1299,9 +1304,15 @@ contexts:
     - match: (?=\S)
       set: function-block
 
+  function-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.js
+    - include: immediately-pop
+
   function-declaration-meta:
     - meta_include_prototype: false
     - meta_scope: meta.function.declaration.js
+    - clear_scopes: 1
     - include: immediately-pop
 
   function-declaration-expect-parameters:
@@ -1335,6 +1346,7 @@ contexts:
   arrow-function-declaration:
     - match: ''
       set:
+        - function-meta
         - arrow-function-expect-body
         - function-declaration-meta
         - arrow-function-expect-arrow
@@ -1555,6 +1567,7 @@ contexts:
   method-declaration:
     - match: ''
       set:
+        - function-meta
         - function-declaration-expect-body
         - function-declaration-meta
         - function-declaration-expect-parameters

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -196,35 +196,31 @@ someFunction({
 //                ^ variable.other.readwrite
 });
 
-function foo() {
-// <- meta.function.declaration
- // <- meta.function.declaration
-  // <- meta.function.declaration
-// ^^^^^^^^^^^ meta.function.declaration - meta.function.declaration meta.function.declaration
-// ^ storage.type.function
-//        ^ entity.name.function
-//             ^ - meta.function.declaration
-}
-// <- meta.block
+    function foo() {
+//  ^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
+//  ^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^ storage.type.function
+//           ^^^ entity.name.function
+//                ^^ - meta.function.declaration
+    }
+//  ^ meta.function meta.block
 
-var bar = function() {
-//  ^^^^^^^^^^^^^^^^ meta.function.declaration
-// <- storage.type
-//   ^ variable.other.readwrite entity.name.function
-//         ^ storage.type.function
-}
+    var bar = function() {
+//  ^^^ storage.type
+//      ^^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
+//      ^^^^^^^^^^^^^^^^ meta.function.declaration
+//      ^^^ variable.other.readwrite entity.name.function
+//            ^^^^^^^^ storage.type.function
+    }
 
-baz = function*()
-// <- meta.function.declaration
- // <- meta.function.declaration
-  // <- meta.function.declaration
-// ^^^^^^^^^^^^^^ meta.function.declaration
-// <- variable.other.readwrite entity.name.function
-//     ^ storage.type.function
-//            ^ keyword.generator.asterisk
-{
+    baz = function*()
+//  ^^^^^^^^^^^^^^^^^ meta.function.declaration - meta.function meta.function
+//  ^^^ variable.other.readwrite entity.name.function
+//        ^^^^^^^^ storage.type.function
+//                ^ keyword.generator.asterisk
+    {
 
-}
+    }
 
 if (true)
 // <- keyword.control.conditional
@@ -897,7 +893,7 @@ class Foo extends getSomeClass() {}
 //                ^^^^^^^^^^^^ meta.function-call variable.function - entity.other.inherited-class
 
     () => {}
-//  ^^^^^^^^ meta.function
+//  ^^^^^^^^ meta.function - meta.function meta.function
 //  ^^^^^ meta.function.declaration
 //  ^ punctuation.section.group.begin
 //   ^ punctuation.section.group.end

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1472,7 +1472,7 @@ function yy (a, b) {
 //            ^ punctuation.separator.parameter.function
 //              ^ variable.parameter.function
 //               ^ punctuation.section.group.end
-//                 ^ meta.block punctuation.section.block.begin - meta.function
+//                 ^ meta.block punctuation.section.block.begin
 }
 // <- meta.function meta.block punctuation.section.block
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -801,11 +801,11 @@ class MyClass extends TheirClass {
 //  ^^^^^^^^^^^^^^^ meta.function.declaration
     // ^ entity.name.function.constructor
     {
-//  ^ meta.class meta.block meta.block punctuation.section.block
+//  ^ meta.class meta.block meta.function meta.block punctuation.section.block
         $.foo = "";
         super(el);
     }
-//  ^ meta.class meta.block meta.block punctuation.section.block
+//  ^ meta.class meta.block meta.function meta.block punctuation.section.block
 
     get foo()
 //  ^^^^^^^^^ meta.function.declaration
@@ -896,14 +896,19 @@ Bar {}
 class Foo extends getSomeClass() {}
 //                ^^^^^^^^^^^^ meta.function-call variable.function - entity.other.inherited-class
 
-() => {}
-// <- meta.function.declaration punctuation.section.group
- // <- meta.function.declaration punctuation.section.group
-//^^^ meta.function.declaration
-//    ^^ meta.block punctuation.section.block
+    () => {}
+//  ^^^^^^^^ meta.function
+//  ^^^^^ meta.function.declaration
+//  ^ punctuation.section.group.begin
+//   ^ punctuation.section.group.end
+//     ^^ storage.type.function.arrow
+//        ^^ meta.block
+//        ^ punctuation.section.block
+//         ^ punctuation.section.block
 
 const test = ({a, b, c=()=>({active:false}) }) => {};
 //    ^ entity.name.function
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring
 //            ^ punctuation.section.block.begin
@@ -919,6 +924,7 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 // We can't currently detect this properly, but we need to consume => properly
 ([a,
   b]) => { return x; }
+//    ^^^^^^^^^^^^^^^^ meta.function
 //    ^^ storage.type.function.arrow
 //         ^^^^^^ meta.block keyword.control.flow
 
@@ -1425,6 +1431,7 @@ let str = navigator.userAgent.toLowerCase();
 //        ^^^^^^^^^ support.type.object
 
 function yy (a, b) {
+// ^^^^^^^^^^^^^^^^^ meta.function
 // ^^^^^^^^^^^^^^^ meta.function.declaration
 //       ^^ entity.name.function
 //          ^ punctuation.section.group.begin
@@ -1432,8 +1439,9 @@ function yy (a, b) {
 //            ^ punctuation.separator.parameter.function
 //              ^ variable.parameter.function
 //               ^ punctuation.section.group.end
-//                 ^ meta.block punctuation.section.block - meta.function
+//                 ^ meta.block punctuation.section.block - meta.function.declaration
 }
+// <- meta.function meta.block punctuation.section.block
 
 // Integers
 


### PR DESCRIPTION
Functions should be enclosed in a `meta.function` scope. Currently, the JavaScript syntax does not do this. However, it does enclose part of the function in a `meta.function.declaration` scope.

This PR encloses the entire function in `meta.function`. The old `meta.function.declaration` behavior is preserved exactly. The scope changes between `meta.function.js` and `meta.function.declaration.js`; it does not use both at once.