### PR TITLE
[JavaScript] Key bindings for backtick strings.

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -1,0 +1,54 @@
+[
+    // Auto-pair backticks
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js - string" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+        ]
+    },
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js - string" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
+    { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+        ]
+    },
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js string.template" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+        ]
+    },
+
+    // Auto-pair interpolation
+    { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js", "match_all": true },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
+        ]
+    },
+    { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js - meta.template.expression.js", "match_all": true },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
+]

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -26,7 +26,7 @@
     },
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js string.template" },
+            { "key": "selector", "operator": "equal", "operand": "string.template.js" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
@@ -38,7 +38,7 @@
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
@@ -46,7 +46,7 @@
     },
     { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js - meta.template.expression.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
         ]

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -804,16 +804,15 @@ contexts:
 
   literal-string-template:
     - match: '`'
-      scope: punctuation.definition.string.template.begin.js
+      scope: punctuation.definition.string.begin.js
       set:
         - meta_include_prototype: false
         - meta_scope: string.template.js
         - match: "`"
-          scope: punctuation.definition.string.template.end.js
+          scope: punctuation.definition.string.end.js
           pop: true
         - match: '\$\{'
-          captures:
-            0: punctuation.definition.template-expression.begin.js
+          scope: punctuation.definition.template-expression.begin.js
           push:
             - clear_scopes: 1
             - meta_scope: meta.template.expression.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -336,7 +336,7 @@ var str2 = NaN;
 
 tag`Hello ${ a + b } world\nanother ${expression}.`;
 // <- variable.function.tagged-template.js
-// ^ punctuation.definition.string.template.begin.js
+// ^ punctuation.definition.string.begin.js
 //   ^ string.template.js
 //        ^ punctuation.definition.template-expression.begin.js
 //           ^ variable.other.readwrite.js
@@ -344,7 +344,7 @@ tag`Hello ${ a + b } world\nanother ${expression}.`;
 //               ^ meta.template.expression.js source.js.embedded.expression
 //                 ^ punctuation.definition.template-expression.end.js
 //                        ^ constant.character.escape.js
-//                                                ^ punctuation.definition.string.template.end.js
+//                                                ^ punctuation.definition.string.end.js
 
 tag `template`;
 // <- variable.function.tagged-template


### PR DESCRIPTION
Supersedes #1137.

The key bindings are modeled after the defaults and after the Babel package.

There is a minor change to the syntax. Generally, string punctuation is marked simply `punctuation.definition.string.begin|end` regardless of string type. The JavaScript syntax has been updated to conform to this convention.