### PR TITLE
gitmodules are git config

### DIFF
--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -7,7 +7,6 @@ name: Git Config
 file_extensions:
   - gitconfig                # /etc/gitconfig
   - .gitconfig               # ~/.gitconfig
-  - gitmodules               # /etc/gitmodules
   - .gitmodules              # ~/.gitmodules
 first_line_match: ^\[core\]  # .git/config files always start with [core]
 scope: text.git.config

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -7,6 +7,8 @@ name: Git Config
 file_extensions:
   - gitconfig                # /etc/gitconfig
   - .gitconfig               # ~/.gitconfig
+  - gitmodules               # /etc/gitmodules
+  - .gitmodules              # ~/.gitmodules
 first_line_match: ^\[core\]  # .git/config files always start with [core]
 scope: text.git.config
 


### PR DESCRIPTION
Applies the Git Config syntax to .gitmodules files.

> The .gitmodules file, located in the top-level directory of a Git working tree, is a text file with a syntax matching the requirements of git-config[1].

https://www.git-scm.com/docs/gitmodules#_description