### PR TITLE
[Python] Ensure variable.annotation/function

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -729,17 +729,16 @@ contexts:
 
   function-call-wrapper:
     - meta_scope: meta.function-call.python
-    - match: \)
-      scope: punctuation.section.arguments.end.python
-      set: after-expression
-    - match: \(
-      scope: meta.function-call.python punctuation.section.arguments.begin.python
-      push:
-        - clear_scopes: 1
-        - meta_content_scope: meta.function-call.arguments.python
-        - match: (?=\))
-          pop: true
-        - include: arguments
+    - match: (?=\()  # need to remove meta.function-call.python from opening parens
+      set:
+        - match: \(
+          scope: punctuation.section.arguments.begin.python
+          set:
+            - meta_scope: meta.function-call.arguments.python
+            - match: \)
+              scope: punctuation.section.arguments.end.python
+              set: after-expression
+            - include: arguments
     - match: (\.)\s*(?={{identifier}})
       captures:
         1: punctuation.accessor.dot.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -335,8 +335,7 @@ contexts:
       captures:
         1: punctuation.section.arguments.begin.python
       push:
-        - meta_scope: meta.function-call.python
-        - meta_content_scope: meta.function-call.arguments.python
+        - meta_scope: meta.function-call.arguments.python
         - match: \)
           scope: punctuation.section.arguments.end.python
           pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -733,8 +733,9 @@ contexts:
       scope: punctuation.section.arguments.end.python
       set: after-expression
     - match: \(
-      scope: punctuation.section.arguments.begin.python
+      scope: meta.function-call.python punctuation.section.arguments.begin.python
       push:
+        - clear_scopes: 1
         - meta_content_scope: meta.function-call.arguments.python
         - match: (?=\))
           pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -652,25 +652,54 @@ contexts:
           pop: true
 
   decorator-wrapper:
-    - match: '{{identifier}}'
-      scope: meta.qualified-name.python variable.annotation.python
+    - match: (\.)\s*
+      captures:
+        1: punctuation.accessor.dot.python
+      set:
+        - meta_scope: meta.qualified-name.python
+        - meta_content_scope: variable.annotation.python
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
     - match: ''
-      pop: true
+      set:
+        - meta_scope: meta.qualified-name.python variable.annotation.python
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
 
   decorator-function-call-wrapper:
     - meta_scope: meta.annotation.function.python
-    - match: '{{identifier}}'
-      scope: meta.qualified-name.python variable.annotation.function.python
     - match: \)
       scope: punctuation.section.arguments.end.python
       set: after-expression
     - match: \(
-      scope: punctuation.section.arguments.begin.python
+      scope: meta.annotation.function.python punctuation.section.arguments.begin.python
       push:
+        - clear_scopes: 1
         - meta_content_scope: meta.annotation.arguments.python
         - match: (?=\))
           pop: true
         - include: arguments
+    - match: (\.)\s*
+      captures:
+        1: punctuation.accessor.dot.python
+      push:
+        - meta_scope: meta.qualified-name.python
+        - meta_content_scope: variable.annotation.function.python
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: ''
+      push:
+        - meta_scope: meta.qualified-name.python variable.annotation.function.python
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
 
   item-access:
     - match: '(?={{path}}\s*\[)'
@@ -700,8 +729,6 @@ contexts:
 
   function-call-wrapper:
     - meta_scope: meta.function-call.python
-    - match: '{{identifier}}'
-      scope: meta.qualified-name.python variable.function.python
     - match: \)
       scope: punctuation.section.arguments.end.python
       set: after-expression
@@ -712,6 +739,23 @@ contexts:
         - match: (?=\))
           pop: true
         - include: arguments
+    - match: (\.)\s*(?={{identifier}})
+      captures:
+        1: punctuation.accessor.dot.python
+      push:
+        - meta_scope: meta.qualified-name.python
+        - meta_content_scope: variable.function.python
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: (?={{identifier}})
+      push:
+        - meta_scope: meta.qualified-name.python variable.function.python
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
 
   arguments:
     - include: keyword-arguments
@@ -885,17 +929,14 @@ contexts:
     # until the last non-special identifier (if any).
     # This allows the leaf to be scoped individually.
     - meta_scope: meta.qualified-name.python
-    - include: name-specials
     # If a line continuation follows, this may or may not be the last leaf (most likley not though)
-    - match: '{{identifier}}(?=\s*\\)'
-      scope: meta.generic-name.python
-    - match: (?={{identifier}}\s*\.)
+    - match: (?={{identifier}}\s*(\.|\\))
       push:
         - include: name-specials
         - include: generic-names
         - match: ''
           pop: true
-    - match: (\.)\s*(?={{identifier}}\s*\.)
+    - match: (\.)\s*(?={{identifier}}\s*(\.|\\))
       captures:
         1: punctuation.accessor.dot.python
       push:
@@ -903,13 +944,8 @@ contexts:
         - include: generic-names
         - match: ''
           pop: true
-    - match: (\.)\s*(?={{identifier}})
-      captures:
-        1: punctuation.accessor.dot.python
-      set:
-        - include: dotted-name-specials
-        - match: ''
-          pop: true
+    - match: \.(?!\s*{{identifier}})  # don't match last dot
+      scope: punctuation.accessor.dot.python
     - match: (?=\S|$)
       pop: true
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -170,7 +170,7 @@ IDENTIFIER()
 
 dotted . identifier(12, True)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call - meta.function-call meta.function-call
-#                   ^^^^^^^^ meta.function-call.arguments
+#                  ^^^^^^^^^^ meta.function-call.arguments
 #^^^^^^^^^^^^^^^^^^ meta.qualified-name
 #^^^^^^ - variable.function
 #      ^ punctuation.accessor.dot

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -168,19 +168,19 @@ identifier()
 IDENTIFIER()
 #^^^^^^^^^ meta.qualified-name variable.function - variable.other.constant
 
-dotted.identifier(12, True)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
-#                 ^^^^^^^^ meta.function-call.arguments
-#^^^^^^^^^^^^^^^^ meta.qualified-name
+dotted . identifier(12, True)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+#                   ^^^^^^^^ meta.function-call.arguments
+#^^^^^^^^^^^^^^^^^^ meta.qualified-name
 #^^^^^^ - variable.function
-#     ^ punctuation.accessor.dot
-#      ^^^^^^^^^^ variable.function
+#      ^ punctuation.accessor.dot
+#        ^^^^^^^^^^ variable.function
 
 open.__new__(12, \
 #^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 #^^^ support.function.builtin
 #   ^ punctuation.accessor.dot
-#    ^^^^^^^ support.function.magic
+#    ^^^^^^^ variable.function support.function.magic
 #                ^ punctuation.separator.continuation.line.python
              True)
 
@@ -189,8 +189,7 @@ TypeError()
 #
 module.TypeError()
 #^^^^^^^^^^^^^^^ meta.function-call
-#      ^^^^^^^^^ - support
-#      ^^^^^^^^^ variable.function
+#      ^^^^^^^^^ variable.function - support
 
 open.open.open()
 #^^^ support.function.builtin
@@ -707,18 +706,20 @@ class Unterminated(Inherited:
 # ^^^^^^^^^^^^^^^^^^ meta.qualified-name
 # ^^^^^^ meta.generic-name - variable.annotation
 #          ^^^^^^^^^ variable.annotation
-#        ^ punctuation.accessor.dot
+#        ^ punctuation.accessor.dot - variable
 #                   ^ - meta.annotation
 class Class():
 
     @functools.wraps(method, 12, kwarg=None)# comment
 #^^^ - meta.annotation
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.function
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation - meta.annotation meta.annotation
+#                    ^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.arguments
 #   ^ punctuation.definition.annotation
+#    ^^^^^^^^^^^^^^^^ meta.annotation.function
 #    ^^^^^^^^^^^^^^^ meta.qualified-name
 #    ^^^^^^^^^ meta.generic-name - variable.annotation
 #             ^ punctuation.accessor.dot
-#              ^^^^^ variable.annotation.function
+#              ^^^^^ variable.annotation.function meta.generic-name
 #                   ^ punctuation.section.arguments.begin
 #                          ^ punctuation.separator.arguments
 #                            ^^ constant.numeric
@@ -726,7 +727,7 @@ class Class():
 #                                     ^ keyword.operator
 #                                      ^^^^ constant.language
 #                              ^ punctuation.separator.arguments
-#                                          ^ punctuation.section.arguments.end
+#                                          ^ meta.annotation.function punctuation.section.arguments.end
 #                                           ^^^^^^^^^ comment - meta.annotation
     def wrapper(self):
         return self.__class__(method)
@@ -740,8 +741,18 @@ class Class():
 
     @staticmethod
 #   ^^^^^^^^^^^^^ meta.annotation
-#    ^^^^^^^^^^^^ support.function.builtin
+#    ^^^^^^^^^^^^ variable.annotation support.function.builtin
 #                ^ - meta.annotation
+
+    @not_a.staticmethod
+#   ^^^^^^^^^^^^^^^^^^^ meta.annotation
+#          ^^^^^^^^^^^^ variable.annotation - support
+#         ^ punctuation.accessor.dot
+
+    @not_a.__init__()
+#   ^^^^^^^^^^^^^^^ meta.annotation
+#          ^^^^^^^^ variable.annotation support.function.magic
+#         ^ punctuation.accessor.dot
 
     @deco[4]
 #        ^ invalid.illegal.character
@@ -753,7 +764,7 @@ class Class():
 
     @ deco \
         . rator()
-#       ^^^^^^^ meta.annotation.function
+#       ^^^^^^^^^ meta.annotation.function
 #         ^^^^^ variable.annotation.function
 
     @ deco \

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -296,6 +296,7 @@ myobj.method().attribute
 func()(1, 2)
 # <- meta.function-call
 #^^^^^^^^^^^ meta.function-call
+#^^^^^^^^^^^ - meta.function-call meta.function-call
 
 myobj[1](True)
 #^^^^^^^ meta.item-access

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -169,7 +169,7 @@ IDENTIFIER()
 #^^^^^^^^^ meta.qualified-name variable.function - variable.other.constant
 
 dotted . identifier(12, True)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call - meta.function-call meta.function-call
 #                   ^^^^^^^^ meta.function-call.arguments
 #^^^^^^^^^^^^^^^^^^ meta.qualified-name
 #^^^^^^ - variable.function


### PR DESCRIPTION
Allow special names to override `variable.annotation` and `variable.function` and ensure that these scopes are *still* being set before the special ones.

This is noticeable when you set italics rendering on these two scopes and have foreground color overrides on the special names like `support`.