### PR TITLE
[Python] Add special bindings for auto-pairing

### DIFF
--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -7,6 +7,7 @@
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
         ]
     },
@@ -16,6 +17,7 @@
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
         ]
     },

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -1,6 +1,7 @@
 [
     // Auto-pair quotes even after string modifiers.
-    // Copied over from the default bindings with moficiations to `preceding_text`.
+    // Copied over from the default bindings with modifications to `preceding_text`
+    // and an added selector condition.
     { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -6,7 +6,7 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^$|[^\"a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i)\\b[bfru]+$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
         ]
@@ -16,7 +16,7 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^$|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i)\\b[bfru]+$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
         ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -6,7 +6,7 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^$|[^\"a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
         ]
@@ -16,7 +16,7 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^$|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "source.python" },
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
         ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -1,0 +1,22 @@
+[
+    // Auto-pair quotes even after string modifiers.
+    // Copied over from the default bindings with moficiations to `preceding_text`.
+    { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+        ]
+    },
+    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'$0'"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^|[^'a-zA-Z0-9_]$|(?i)\b[bfru]+$", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
+        ]
+    },
+]


### PR DESCRIPTION
Auto-pairing was disabled when following the string modifiers.

Closes #1441.