### PR TITLE
[HTML] Fix highlighting within <script type = "text/html">

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -310,6 +310,16 @@ contexts:
           embed_scope: source.js.embedded.html
           escape: (?i)(?=(?:-->\s*)?</script)
 
+  script-html:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - meta_content_scope: text.html.embedded.html
+        - include: script-close-tag
+        - include: main
+
   script-other:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
@@ -365,6 +375,11 @@ contexts:
     - match: (?i)(?=>|''|"")
       set:
         - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
+      set:
+        - script-html
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -33,6 +33,23 @@
         ##  ^^^^^^^^^^^^^^^ source.js.embedded
         </script>
 
+        <script type = "text/html"> <!--
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
+        ## ^ entity.name.tag.script - text.html.embedded.html
+        ##             ^ string.quoted.double.html - text.html.embedded.html
+        ##                          ^^^^ comment.block.html punctuation
+            <div></div>
+        ##  ^^^^^^^^^^^ text.html.basic text.html.embedded meta.tag.block.any
+            <script type=text/javascript>
+        ##  ^ text.html.basic text.html.embedded.html - source.js.embedded.html
+                function test() {}
+        ##  ^ text.html.basic text.html.embedded.html source.js.embedded.html
+            </script>
+        ##  ^^^^^^^^^ text.html.basic text.html.embedded.html meta.tag.script.end
+        </script>
+##     ^ text.html.basic text.html.embedded.html
+##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.script.end
+
         <script
         type
         =


### PR DESCRIPTION
Fixes #1492

Supersedes PR #1493

This PR is an alternative for #1493 as it seems to be stalled after @wbond's suggestion to handle <script type = "text/html"> content as ordinary part of the html syntax itself instead of using the `embed` command.

The code suggested by this PR is very much the same as the one of #1493, but

1. replaces the `embed` part by ordinary includes.
2. adds some extra lines of syntax test to verify the correct stacking of scopes.