### PR TITLE
[Python] Fix tuple argument highlighting

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -610,10 +610,42 @@ contexts:
             - match: '(?=[,)=])'
               set: function-parameters
             - include: expressions
+    - include: function-parameters-tuble
     - include: illegal-names
     - match: '{{identifier}}'
       scope: variable.parameter.python
     - include: line-continuation
+
+  function-parameters-tuble:
+    # python 2 style tuble arguments
+    # removed from python 3 since PEP-3113
+    - match: \(
+      scope: punctuation.section.group.begin.python
+      push:
+        - meta_scope: meta.group.python
+        - match: \)
+          scope: punctuation.section.group.end.python
+          set: after-expression
+        - include: comments
+        - match: ','
+          scope: punctuation.separator.parameters.python
+          push: allow-unpack-operators
+        # default values should follow the argument
+        - match: '(?==)'
+          push:
+            - meta_scope: invalid.illegal.default-value.python
+            - match: '(?=[,)=])'
+              pop: true
+        # python 2 does not support type annotations
+        - match: '(?=:)'
+          push:
+            - meta_scope: invalid.illegal.annotation.python
+            - match: '(?=[,)=])'
+              pop: true
+        - include: illegal-names
+        - match: '{{identifier}}'
+          scope: variable.parameter.python
+        - include: line-continuation
 
   function-after-parameters:
     - meta_content_scope: meta.function.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -639,6 +639,45 @@ def func(
 ):
     pass
 
+def func(args, (x, y)=(0,0)):
+#       ^^^^^^^^^^^^^ meta.function.parameters.python
+#                    ^^^^^^ meta.function.parameters.default-value.python
+#                          ^ meta.function.parameters.python
+#              ^^^^^^ meta.group.python
+#                    ^ - meta.group.python
+#                     ^^^^^ meta.group.python
+#                          ^ - meta.group.python
+#       ^ punctuation.section.parameters.begin.python
+#            ^ punctuation.separator.parameters.python
+#              ^ punctuation.section.group.begin.python
+#               ^ variable.parameter.python
+#                ^ punctuation.separator.parameters.python
+#                  ^ variable.parameter.python
+#                   ^ punctuation.section.group.end.python
+#                    ^ keyword.operator.assignment.python
+#                     ^ punctuation.section.group.begin.python
+#                      ^ constant.numeric.integer.decimal.python
+#                       ^ punctuation.separator.tuple.python
+#                        ^ constant.numeric.integer.decimal.python
+#                         ^ punctuation.section.group.end.python
+#                          ^ punctuation.section.parameters.end.python
+    pass
+
+def foo(arg: int = 0, (x: float, y=20) = (0.0, "default")):
+#                     ^^^^^^^^^^^^^^^^ meta.group.python
+#                                     ^^^ - meta.group.python
+#                                        ^^^^^^^^^^^^^^^^ meta.group.python
+#                     ^ punctuation.section.group.begin.python
+#                      ^ variable.parameter.python
+#                       ^^^^^^^ invalid.illegal.annotation.python
+#                              ^ punctuation.separator.parameters.python
+#                                ^ variable.parameter.python
+#                                 ^^^ invalid.illegal.default-value.python
+#                                    ^ punctuation.section.group.end.python
+#                                      ^ keyword.operator.assignment.python
+#                                        ^ punctuation.section.group.begin.python
+#                                                       ^ punctuation.section.group.end.python
+    pass
 
 ##################
 # Class definitions


### PR DESCRIPTION
Fixes #990

Python 2 supports function definitions with tuble style parameters.

By PEP-3113 this style of function definitions was removed, but as python 2.7 is still a popular version being in active use, ST should still support that kind of function declaration.