### PR TITLE
[Python] Fix invalid highlighting of closing brackets in generators

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1790,11 +1790,14 @@ contexts:
     - match: ','
       scope: punctuation.separator.target-list.python
     - match: \(
+      scope: punctuation.section.target-list.begin.python
       push:
         - include: comments
         - match: ','
           scope: punctuation.separator.target-list.python
         - match: \)
+          scope: punctuation.section.target-list.end.python
           pop: true
+        - include: target-list
         - include: name
     - include: name

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -880,6 +880,40 @@ list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #                              ^^ keyword.control.flow.for.in
 #                                                 ^^ keyword.operator.logical
 
+generator = ((k1, k2, v) for ((k1, k2), v) in xs)
+#           ^ meta.group.python
+#            ^^^^^^^^^^^ meta.group.python meta.group.python
+#                       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.python
+#           ^^ punctuation.section.group.begin.python
+#                      ^ punctuation.section.group.end.python
+#                            ^^ punctuation.section.target-list.begin.python
+#                                    ^ punctuation.section.target-list.end.python
+#                                        ^ punctuation.section.target-list.end.python
+#                                               ^ punctuation.section.group.end.python
+
+list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.list.python
+#        ^^^^^^^^^^^ meta.group.python
+#                   ^ - meta.group.python - meta.expression.generator.python
+#       ^ punctuation.section.list.begin.python
+#        ^ punctuation.section.group.begin.python
+#                  ^ punctuation.section.group.end.python
+#                        ^^ punctuation.section.target-list.begin.python
+#                                ^ punctuation.section.target-list.end.python
+#                                    ^ punctuation.section.target-list.end.python
+#                                           ^ punctuation.section.list.end.python
+
+dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.structure.dictionary-or-set.python
+#       ^ punctuation.section.dictionary-or-set.begin.python
+#            ^^^^^^^ meta.group.python
+#            ^ punctuation.section.group.begin.python
+#                  ^ punctuation.section.group.end.python
+#                        ^^ punctuation.section.target-list.begin.python
+#                                ^ punctuation.section.target-list.end.python
+#                                    ^ punctuation.section.target-list.end.python
+#                                           ^ punctuation.section.dictionary-or-set.end.python
+
 list(i for i in generator)
 #      ^^^^^^^^ meta.expression.generator
 list((i for i in generator), 123)


### PR DESCRIPTION
Fixes #1505

In generator expressions after `for` a `target-list` section is used to scope the temporary variables. This section highlights names only and therefore fails in case of nested groups. The result is described in #1505.

This commit enables nested groups. Instead of using `groups` another `target-list` is included for nesting with the assumption of those nested groups not supporting all kinds of expressions anyway.

Furthermore the opening and closing parentheses are scoped as `punctuation.section` to be addressable by color schemes.