### PR TITLE
[JavaScript] Fix a couple of problems with method parsing.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -27,7 +27,7 @@ variables:
       {{identifier}}
       | '(?:[^\\']|\\.)*'
       | "(?:[^\\"]|\\.)*"
-      | \[ {{identifier}} (?:\.{{identifier}})* \]
+      | \[ .* \]
     )
 
   class_element_name: |-
@@ -1568,6 +1568,7 @@ contexts:
         - function-declaration-expect-parameters
         - method-name
         - method-declaration-expect-prefix
+        - function-declaration-expect-async
 
   method-declaration-expect-prefix:
     - match: \*

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -889,6 +889,19 @@ class MyClass extends TheirClass {
 
     constructor$() {}
 //  ^^^^^^^^^^^^ entity.name.function - entity.name.function.constructor
+
+
+    ['foo']() {}
+//  ^^^^^^^^^ meta.function.declaration
+
+    static ['foo']() {}
+//         ^^^^^^^^^ meta.function.declaration
+
+    async foo() {}
+//  ^^^^^ storage.type
+
+    static async foo() {}
+//         ^^^^^ storage.type
 }
 // <- meta.block punctuation.section.block.end
 


### PR DESCRIPTION
Fixes #1521.

```js
class Test {
    ['foo']() {}
//  ^^^^^^^^^ meta.function.declaration

    static ['foo']() {}
//         ^^^^^^^^^ meta.function.declaration

    async foo() {}
//  ^^^^^ storage.type

    static async foo() {}
//         ^^^^^ storage.type
}
```

The lookahead handling computed property names is a bit problematic. The bracket could contain an arbitrary expression, so it's not really possible to look over it with a regexp. I have loosened it here, but it would be nice to find a better solution.