### PR TITLE
[CSS] Add `will-change` to CSS completions

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -407,6 +407,7 @@ PROPERTY_DICT = {
     'white-space': ['normal', 'pre', 'nowrap', 'pre-wrap', 'pre-line'],
     'widows': ['<integer>'],
     'width': ['<length>', '<percentage>', 'auto'],
+    'will-change': ['auto', 'contents', 'scroll-position', '<custom-ident>'],
     'word-break': ['normal', 'break-all', 'keep-all'],
     'word-spacing': ['normal', '<length>'],
     'word-wrap': ['normal', 'break-word'],


### PR DESCRIPTION
This will add completions for [`will-change `](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) as it exists in the syntax file but its completions were missing.