### PR TITLE
[C++/ObjC] Fix: macro_identifier should be at least two characters long

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -22,7 +22,7 @@ scope: source.c++
 variables:
   identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
   path_lookahead: '(?:::\s*)?(?:{{identifier}}\s*::\s*)*(?:template\s+)?{{identifier}}'
-  macro_identifier: '\b[[:upper:]_][[:upper:][:digit:]_]*\b'
+  macro_identifier: '\b[[:upper:]_][[:upper:][:digit:]_]+\b'
   operator_method_name: '\boperator\s*(?:[-+*/%^&|~!=<>]|[-+*/%^&|=!<>]=|<<=?|>>=?|&&|\|\||\+\+|--|,|->\*?|\(\)|\[\]|""\s*{{identifier}})'
   casts: 'const_cast|dynamic_cast|reinterpret_cast|static_cast'
   operator_keywords: 'and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq|noexcept'

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1802,6 +1802,33 @@ class __declspec(dllimport) SkBitmap {}
 /*               ^ constant.other */
 /*                          ^ entity.name.class */
 
+// Make sure not to match macros that have "too few characters".
+template <class T> class Sample {
+ public:
+  // The T here should not be consumed as a macro.
+  T operator()  (const foo x) {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+    return T;
+  }
+  int operator == (const int x) {
+    /*^^^^^^^^^^^ entity.name.function */
+    return 0;
+  }
+  // The T here should not be consumed as a macro.
+  T operator()(int a) {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+    return T;
+  }
+  // The T here should not be consumed as a macro.
+  T operator[](int a)  {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+     return T;
+  }
+};
+
 /////////////////////////////////////////////
 // Test preprocessor branching and C blocks
 /////////////////////////////////////////////

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -10,7 +10,7 @@ scope: source.objc++
 variables:
   identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
   path_lookahead: '(?:::\s*)?(?:{{identifier}}\s*::\s*)*(?:template\s+)?{{identifier}}'
-  macro_identifier: '\b[[:upper:]_][[:upper:][:digit:]_]*\b'
+  macro_identifier: '\b[[:upper:]_][[:upper:][:digit:]_]+\b'
   operator_method_name: '\boperator\s*(?:[-+*/%ˆ&|~!=<>]|[-+*/%^&|=!<>]=|<<=?|>>=?|&&|\|\||\+\+|--|,|->\*?|\(\)|\[\]|""\s*{{identifier}})'
   casts: 'const_cast|dynamic_cast|reinterpret_cast|static_cast'
   operator_keywords: 'and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq|noexcept'

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1773,6 +1773,33 @@ class __declspec(dllimport) SkBitmap {}
 /*               ^ constant.other */
 /*                          ^ entity.name.class */
 
+// Make sure not to match macros that have "too few characters".
+template <class T> class Sample {
+ public:
+  // The T here should not be consumed as a macro.
+  T operator()  (const foo x) {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+    return T;
+  }
+  int operator == (const int x) {
+    /*^^^^^^^^^^^ entity.name.function */
+    return 0;
+  }
+  // The T here should not be consumed as a macro.
+  T operator()(int a) {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+    return T;
+  }
+  // The T here should not be consumed as a macro.
+  T operator[](int a)  {
+    /* <- entity.name.function */
+    /*^^^^^^^^ entity.name.function */
+     return T;
+  }
+};
+
 /////////////////////////////////////////////
 // Test preprocessor branching and C blocks
 /////////////////////////////////////////////


### PR DESCRIPTION
Closes https://github.com/sublimehq/Packages/issues/1527.

The `macro_identifier` variable is too greedy right now. It may match tokens like `T` or `A` or `B`. Defining single-character macros is extremely unwise and frowned upon. Moreover, the syntax may incorrectly parse an operator overload like this one:

```
template <class T> class Sample {
  T operator[](const int x);
};
```
Here, the `T` is assumed to be a macro, while it should be a proper return type (namely the template type `T`). This PR changes the `macro_identifier` variable so that only identifiers with at least two characters get parsed as a macro.

It is still possible to trip up the syntax with two-character template parameters like `T1` or `T2`.