### PR TITLE
[ShellScript] Add coproc keyword

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -270,12 +270,35 @@ contexts:
       captures:
         1: storage.type.function.shell
       push: [funcdef-body, funcdef-parens, funcdef-name]
+    - match: \bcoproc{{keyword_boundary_end}}
+      scope: keyword.other.coproc.shell
+      push: [cmd-post, cmd-args, coproc-body]
 
   funcdef-bt:
     - match: '{{is_function}}'
       captures:
         1: storage.type.function.shell
       push: [funcdef-body-bt, funcdef-parens, funcdef-name]
+    - match: \bcoproc{{keyword_boundary_end}}
+      scope: keyword.other.coproc.shell
+      push: [cmd-post, cmd-args-bt, coproc-body]
+
+  coproc-body:
+    - match: \s*(?=\S+\s*\{)
+      set:
+        - meta_content_scope: entity.name.function.coproc.shell
+        - match: (?=\s*\{)
+          set:
+            - match: \{
+              scope: punctuation.section.braces.begin.shell
+              set:
+                - meta_scope: meta.function.coproc.shell
+                - match: \}
+                  scope: punctuation.section.braces.end.shell
+                  pop: true
+                - include: main
+    - match: ""
+      set: main-with-pop-at-end
 
   funcdef-name:
     - match: \s*

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1063,6 +1063,46 @@ case $1 in
 *)
   _G_unquoted_arg=$1 ;;
 esac
+coproc sed s/^/foo/
+# <- keyword.other.coproc
+#      ^^^ variable.function
+coproc ls thisfiledoesntexist; read; 2>&1
+# <- keyword.other.coproc
+#      ^^ meta.function-call variable.function
+#                            ^ keyword.operator
+#                              ^^^^ support.function
+#                                  ^ keyword.operator
+#                                    ^ constant.numeric.integer.decimal.file-descriptor
+#                                     ^^ keyword.operator.assignment.redirection
+#                                       ^ constant.numeric.integer.decimal.file-descriptor
+coproc awk '{print "foo" $0;fflush()}'
+# <- keyword.other.coproc
+#      ^^^ variable.function
+#          ^ string.quoted.single punctuation.definition.string.begin
+#                                    ^ string.quoted.single punctuation.definition.string.end
+{ coproc tee { tee logfile ;} >&3 ;} 3>&1
+# <- punctuation.definition.compound.braces.begin
+# ^^^^^^ keyword.other.coproc
+#        ^^^ entity.name.function.coproc
+#            ^ punctuation.section.braces.begin
+#              ^^^ variable.function
+#                           ^ punctuation.section.braces.end
+#                             ^^ keyword.operator.assignment.redirection
+#                               ^ constant.numeric.integer.decimal.file-descriptor
+#                                  ^ punctuation.definition.compound.braces.end
+#                                    ^ constant.numeric.integer.decimal.file-descriptor
+#                                     ^^ keyword.operator.assignment.redirection
+#                                       ^ constant.numeric.integer.decimal.file-descriptor
+coproc foobar {
+    #  ^^^^^^ entity.name.function.coproc
+    read
+    # <- meta.function.coproc meta.function-call
+}
+
+# <- - meta.function
+exec >&${tee[1]} 2>&1
+#    ^^ keyword.operator.assignment.redirection
+#      ^ meta.group.expansion.parameter punctuation.definition.variable
 
 ###################
 # Misc. operators #


### PR DESCRIPTION
Add highlighting for the coproc construct, introduced in bash 4.0. [Read more about coproc here](https://unix.stackexchange.com/a/86372).

One piece of the puzzle for https://github.com/sublimehq/Packages/issues/1358.