### PR TITLE
[C++] Remove redundant meta.group.c++ scope from brace

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1341,7 +1341,7 @@ contexts:
           set:
             - meta_content_scope: meta.method.parameters.c++ meta.group.c++
             - match : \)
-              scope: meta.group.c++ punctuation.section.group.end.c++
+              scope: punctuation.section.group.end.c++
               set: method-definition-continue
             - match: '\bvoid\b'
               scope: storage.type.c++

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -148,6 +148,12 @@ struct FOO1 FOO2 FOO3 Test {
   /*                               ^ storage.modifier */
 }
 
+struct X {
+  X();
+   /* <- meta.group */
+  /*^ meta.group - meta.group meta.group */
+};
+
 #define DEPRECATED(msg) [[deprecated(msg)]]
 
 struct Test {

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -147,6 +147,12 @@ struct FOO1 FOO2 FOO3 Test {
   /*                               ^ storage.modifier */
 }
 
+struct X {
+  X();
+   /* <- meta.group */
+  /*^ meta.group - meta.group meta.group */
+};
+
 #define DEPRECATED(msg) [[deprecated(msg)]]
 
 struct Test {


### PR DESCRIPTION
I found that a closing brace found inside a class definition gets a redundant `meta.group.c++` which separates it from the openining brace. This should not happen, since the opening and closing braces should have the same amount of `meta.group.c++` scopes.

Fix #1406 
Fix #1500 

I struggle to find the appropriate way to write syntax tests for this. Would you mind helping me?