### PR TITLE
[Lua] Don't cancel completions in lines with 'then'

### DIFF
--- a/Lua/Completion Rules.tmPreferences
+++ b/Lua/Completion Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>^.*\b(then|end|do|else)$</string>
+		<string>^.*\b(?:end|do|else)$</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
issue: https://forum.sublimetext.com/t/bug-lua-autocomplete-not-working-between-if-then/36635/2

Up to this commit auto completion is cancel, if a line contains the `then` keyword.

The original intention may have been to avoid auto completions after the keyword `then` but the user can't therefore make use of completions within the <condition> of an if-clause while altering an existing statement.

  Example:

    if (<condition>) then

    end

This commit enables those completions by removing `then` from the `cancelCompletion` rule.

_Note: It also removes the not required capture._