### PR TITLE
[ShellScript] Fix vardef-name context not popping

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -380,6 +380,8 @@ contexts:
 
   vardef-maybe-more:
     - meta_include_prototype: false
+    - match: (?=`)
+      pop: true
     - match: (?=\s*#)
       pop: true
     - include: cmd-args-boilerplate
@@ -426,7 +428,7 @@ contexts:
         - meta_content_scope: variable.other.readwrite.assignment.shell
         - include: line-continuation-or-pop-at-end
         - include: any-escape
-        - match: (?={{varassign}}|\s)|$|(?=[;&])
+        - match: (?={{varassign}}|\s)|$|(?=[;&`]|{{metachar}})
           pop: true
         - include: array
         - match: \s*$
@@ -464,12 +466,14 @@ contexts:
                   pop: true
             - include: expansion-and-string
         - include: expansion-and-string
-    - match: (?=&)
+    - match: (?=[&`])
       pop: true
     - match: ""
       set:
         - meta_include_prototype: false
         - meta_scope: string.unquoted.shell
+        - match: (?=`)
+          pop: true
         - include: expansion-and-string
         - include: line-continuation-or-pop-at-end
         - include: any-escape

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -340,6 +340,32 @@ declare ret&
 #          ^ keyword.operator
 declare ret &
 #           ^ keyword.operator
+printFunction "$variableString1" "$(declare -p variableArray)"
+#                                ^ string.quoted.double punctuation.definition.string.begin
+#                                 ^ string.quoted.double meta.group.expansion.command.parens punctuation.definition.variable
+#                                  ^ string.quoted.double meta.group.expansion.command.parens punctuation.section.parens.begin
+#                                         ^ string.quoted.double meta.group.expansion.command.parens storage.modifier
+#                                                          ^ string.quoted.double meta.group.expansion.command.parens variable.other
+#                                                           ^ string.quoted.double meta.group.expansion.command.parens punctuation.section.parens.end
+#                                                            ^ string.quoted.double punctuation.definition.string.end
+
+# <- - variable.other
+printFunction "$variableString1" "`declare -p variableArray`"
+#                                ^ string.quoted.double punctuation.definition.string.begin
+#                                 ^ string.quoted.double meta.group.expansion.command.backticks punctuation.section.group.begin
+#                                        ^ string.quoted.double meta.group.expansion.command.backticks storage.modifier
+#                                                         ^ string.quoted.double meta.group.expansion.command.backticks variable.other
+#                                                          ^ string.quoted.double meta.group.expansion.command.backticks punctuation.section.group.end
+#                                                           ^ string.quoted.double punctuation.definition.string.end
+foo=`readonly x=5`
+# <- variable.other.readwrite.assignment
+#   ^ meta.group.expansion.command.backticks punctuation.section.group.begin
+#             ^ meta.group.expansion.command.backticks variable.other.readwrite.assignment
+#              ^ meta.group.expansion.command.backticks keyword.operator.assignment
+#               ^ meta.group.expansion.command.backticks string.unquoted
+#                ^ meta.group.expansion.command.backticks punctuation.section.group.end
+
+# <- - meta.group.expansion.command.backticks
 export foo          # 'foo' is a variable name
 #^^^^^^^^^ meta.function-call
 # <- storage.modifier


### PR DESCRIPTION
For example, in
```
printFunction "$variableString1" "$(declare -p variableArray)"
```
the token `variableArray` is scoped with the vardef-name context, and it should
pop when encountering the closing parenthesis. We solve this by looking ahead
for a metacharacter.

In general more gratuitous popping in the vardef-* contexts is applied in order
to not get stuck in an unwanted context.

Closes https://github.com/sublimehq/Packages/issues/1535.