### PR TITLE
[C#] fix bug when "dynamic" is used as the return type of a method

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -497,8 +497,6 @@ contexts:
       scope: storage.modifier.cs
     - match: \bdelegate\b
       scope: storage.type.delegate.cs
-    - match: '\bdynamic\b'
-      scope: storage.modifier.cs
     - match: '\b(implicit|explicit)\b'
       scope: storage.modifier.cs
     - match: '{{visibility}}'

--- a/C#/syntax_test_c#.cs
+++ b/C#/syntax_test_c#.cs
@@ -176,3 +176,12 @@ class Car
     {
     }
 }
+
+public interface IObjectRepository
+{
+    bool CanGetObjects(IGetObjectsRequest request);
+    dynamic GetObjects(IGetObjectsRequest request);
+//  ^^^^^^^ support.type
+//          ^^^^^^^^^^ entity.name.function
+//                                                ^ punctuation.terminator
+}


### PR DESCRIPTION
fixes #1534