### PR TITLE
[PHP] fix bug whereby indentation isn't decreased with `<? }`

### DIFF
--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -9,10 +9,13 @@
 	<dict>
 		<key>decreaseIndentPattern</key>
 		<string><![CDATA[(?x)
+			^                                                                                 # the start of the line
 			(
-			    ^                                                                             # start of the line
-			    (.*\*/)?                                                                      # optionally with an end block comment somewhere on the line
-			    \s* [}\])]                                                                    # optionally followed by whitespace, followed by a closing curly brace, square bracket or paren
+			    (
+			        .*\*/                                                                     # with an end block comment somewhere on the line
+			    |   \s* (<\?(php)?\s+)?                                                       # OR a PHP open tag
+			    )?                                                                            # the above is optional
+			    \s* [}\])]                                                                    # optionally followed by whitespace, followed by a closing: curly brace, square bracket or paren
 			|                                                                                 # OR
 			    \s* (<\?(php)?\s+)?                                                           # an optional PHP open tag
 			    (else(if)?\b.*:\s*($|//|/\*)|(end(if|for(each)?|switch|while))\b)             # followed by an keyword that ends a control flow block


### PR DESCRIPTION
as reported at https://forum.sublimetext.com/t/sublime-text-3-1/36591/34