### PR TITLE
[HTML] The .inc (and some others) extension could be generally any language

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -6,7 +6,6 @@ file_extensions:
   - htm
   - shtml
   - xhtml
-  - inc
   - tmpl
   - tpl
 first_line_match: (?i)<(!DOCTYPE\s*)?html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -6,8 +6,6 @@ file_extensions:
   - htm
   - shtml
   - xhtml
-  - tmpl
-  - tpl
 first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 


### PR DESCRIPTION
`inc` means `include`, which is not a language-specific term.
`tpl` and `tmpl` which mean `template` are the same.

But I am **NOT** sure about this change. Maybe people use these file extensions in HTML more? Feel free to reject this PR.

Related: https://forum.sublimetext.com/t/first-line-match-mode-shell-script/36742/3