### PR TITLE
[JavaScript] Distinguish the comma operator from comma punctuation.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1038,7 +1038,7 @@ contexts:
       scope: keyword.operator.arithmetic.js
       push: expression-begin
     - match: ','
-      scope: punctuation.separator.comma.js # TODO: Change to keyword.operator.comma.js ?
+      scope: keyword.operator.comma.js # Comma operator, not punctuation.
       push: expression-begin
 
   ternary-operator:

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1329,6 +1329,17 @@ var re = /^\/[^/]+/;
 //      ^ keyword.operator.arithmetic
  y      / ((x - 1) / -2);
 
+    1, 2;
+//   ^ keyword.operator.comma - punctuation
+
+    a;
+    [1, 2];
+//    ^ meta.sequence punctuation.separator.comma - meta.brackets - keyword
+
+    a
+    [1, 2];
+//    ^ meta.brackets keyword.operator.comma - meta.sequence - punctuation
+
 define(['common'], function(common) {
 //                 ^ meta.function.declaration
     var namedFunc = function() {


### PR DESCRIPTION
(See also #831.)

JavaScript uses the comma in two distinct ways. The most common is as an item separator, such as in function parameters and array or object literals. In these cases, it is and ought to be scoped `punctuation.separator`.

There is also the relatively obscure [comma *operator*](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator). This is a binary operator that evaluates both of its operands and returns the right operand. It is a true operator syntactically and semantically, just like `+` or `-`. It is rarely used deliberately, although a developer who omits semicolons may *accidentally* use it, thereby producing a bug.

The formal ECMAScript grammar is carefully written to maintain the distinction between the comma operator and comma punctuation. Sublime's JavaScript syntax is also capable of making this distinction (since #1009 and others).

Currently, the comma is always scoped `punctuation.separator`, even when the comma is an operator. This PR highlights the comma operator as `keyword.operator.comma`, leaving all other commas as `punctuation.separator.comma`. This is a one-line change: because the comma operator is syntactically a very different thing from comma punctuation, they are matched in different places.

In addition to probably being more correct, this change has an important practical purpose. If a developer forgets a semicolon, the resulting code may be a valid expression with a very different meaning. In particular, commas that would have been punctuation can become operators. If the JavaScript syntax respects this distinction, the effects of the typo will become immediately visible. Example:

```js
someExpression()
[1, 2, 3].forEach(/*...*/);
```

In this example, the hapless programmer has forgotten the semicolon after `someExpression()`. The subsequent brackets, which were intended to be an array, are in fact a property access, and `1, 2, 3` is not a list of array items but an expression with two comma operators. The whole two-line expression is equivalent to `(someExpression()[3]).forEach(/*...*/)`. If the comma operator is marked as `punctuation`, the error is obscure. If the comma operator is marked `keyword.operator`, the error is obvious.

While I do think that this PR is useful, I mostly think that it's more correct. Now that we have the ability to reliably make the distinction, I think that we should.