### PR TITLE
[JavaScript] Scope plus/minus as part of number literals.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -784,6 +784,7 @@ contexts:
     - include: tagged-template
     - include: literal-string-template
     - include: constructor
+    - include: literal-number
     - include: prefix-operators
     - include: yield-expression
     - include: await-expression
@@ -798,7 +799,6 @@ contexts:
     - include: parenthesized-expression
     - include: array-literal
 
-    - include: literal-number
     - include: literal-call
     - include: literal-variable
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1533,10 +1533,19 @@ function yy (a, b) {
     0;
 //  ^ constant.numeric.decimal
 
-    123 .foo
+    123 .foo;
 //  ^^^ constant.numeric.decimal
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
+
+    +123;
+//  ^^^^ constant.numeric.decimal - keyword
+
+    -123;
+//  ^^^^ constant.numeric.decimal - keyword
+
+    + 123;
+//  ^ keyword.operator.arithmetic
 
     123xyz;
 //  ^^^^^^ invalid.illegal.numeric.decimal


### PR DESCRIPTION
In `+123`, the plus sign is part of the literal, not an operator. The syntax almost implemented this, but prefix operators were parsed before number literals. This has been corrected.