### PR TITLE
[PHP] More precise php-end-tag scoping

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -77,34 +77,34 @@ contexts:
     - include: statements
 
   embedded-html:
-    - match: '\?>(\s*\n)?'
-      scope: meta.embedded.block.php punctuation.section.embedded.end.php
+    - match: (\?>)(\s*\n)?
+      scope: meta.embedded.block.php
       captures:
-        1: meta.html-newline-after-php.php
+        1: punctuation.section.embedded.end.php
+        2: meta.html-newline-after-php.php
       push:
         - meta_scope: embedding.php text.html.basic
         - clear_scopes: true
-        - match: '<\?(?i:php)?'
+        - match: <\?(?i:php)?
           scope: meta.embedded.block.php punctuation.section.embedded.begin.php
           pop: true
         - match: ''
           with_prototype:
             - include: single-line-php-tag
-            - match: '(?=<\?(?i:php)?)'
+            - match: (?=<\?(?i:php)?)
               pop: true
-          push:
-            - include: scope:text.html.basic
+          push: scope:text.html.basic
 
   single-line-php-tag:
-    - match: '(<\?=|<\?(?i:php)?(?=.*\?>))'
+    - match: (?:<\?=|<\?(?i:php)?(?=.*\?>))
       scope: punctuation.section.embedded.begin.php
       push:
         - meta_scope: meta.embedded.line.nested.php
         - meta_content_scope: source.php
-        - match: \?>(\s*\n)?
-          scope: punctuation.section.embedded.end.php
+        - match: (\?>)(\s*\n)?
           captures:
-            1: meta.html-newline-after-php.php
+            1: punctuation.section.embedded.end.php
+            2: meta.html-newline-after-php.php
           pop: true
         - include: statements
 

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -15,27 +15,26 @@ scope: embedding.php
 contexts:
   main:
     - match: ''
-      push: 'scope:text.html.basic'
+      push: scope:text.html.basic
       with_prototype:
-        - match: '<\?(?i:php|=)?(?![^?]*\?>)'
+        - match: <\?(?i:php|=)?(?![^?]*\?>)
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.block.php
             - meta_content_scope: source.php
-            - match: \?>(\s*\n)?
-              scope: punctuation.section.embedded.end.php
-              captures:
-                1: meta.html-newline-after-php.php
-              pop: true
-            - include: 'scope:source.php'
+            - include: php-end-tag-pop
+            - include: scope:source.php
         - match: <\?(?i:php|=)?
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.line.php
             - meta_content_scope: source.php
-            - match: \?>(\s*\n)?
-              scope: punctuation.section.embedded.end.php
-              captures:
-                1: meta.html-newline-after-php.php
-              pop: true
-            - include: 'scope:source.php'
+            - include: php-end-tag-pop
+            - include: scope:source.php
+
+  php-end-tag-pop:
+    - match: (\?>)(\s*\n)?
+      captures:
+        1: punctuation.section.embedded.end.php
+        2: meta.html-newline-after-php.php
+      pop: true

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1270,15 +1270,17 @@ class OutputsHtml {
         else {
 //           ^ meta.function meta.block punctuation.section.block.begin
             ?>
-//          ^^ punctuation.section.embedded.end
+//          ^^ meta.embedded.block punctuation.section.embedded.end - source.php
+//            ^ meta.embedded.block meta.html-newline-after-php - punctuation.section.embedded - source.php
             <span></span>
 //          ^^^^^^ meta.tag - source.php
             <?
-//          ^^ punctuation.section.embedded.begin
+//          ^^ meta.embedded.block punctuation.section.embedded.begin
         }
 //      ^ meta.function meta.block punctuation.section.block.end
         ?>
-//      ^^ punctuation.section.embedded.end - source.php
+//      ^^ meta.embedded.block punctuation.section.embedded.end - source.php
+//        ^ meta.embedded.block meta.html-newline-after-php - punctuation.section.embedded - source.php
 
         <div class="acf-gallery-side-info acf-cf<?php if (true) { echo ' class-name'; } ?>" id="myid"></div>
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
@@ -1298,10 +1300,11 @@ class OutputsHtml {
 //      ^^^ punctuation.section.embedded.begin - source.php
 //         ^^^^^^^^^^^^^^^ source.php
         ?>
-//      ^^ punctuation.section.embedded.end - source.php
+//      ^^ meta.embedded.line.nested punctuation.section.embedded.end - source.php
+//        ^ meta.embedded.line.nested meta.html-newline-after-php - punctuation.section.embedded - source.php
 
         <?php
-//      ^^^^^ punctuation.section.embedded.begin
+//      ^^^^^ meta.embedded.block punctuation.section.embedded.begin - source.php
     }
 }
 
@@ -1313,7 +1316,8 @@ function embedHtml() {
     else {
 //       ^ meta.function meta.block punctuation.section.block.begin
         ?>
-//      ^^ punctuation.section.embedded.end - source.php
+//      ^^ meta.embedded.block.php punctuation.section.embedded.end - source.php
+//        ^ meta.embedded.block.php meta.html-newline-after-php - punctuation.section.embedded.end
         <span></span>
 //      ^^^^^^ meta.tag - source.php
         <?
@@ -1324,6 +1328,8 @@ function embedHtml() {
     $myClass = new class {
         function foo() {
             ?>
+//          ^^ meta.embedded.block.php punctuation.section.embedded.end - source.php
+//            ^ meta.embedded.block.php meta.html-newline-after-php - punctuation.section.embedded.end
             <div></div>
 //          ^^^^^^^^^^^ meta.tag - source.php
             <?


### PR DESCRIPTION
Up to this commit, the trailing white space after a closing php tag `?>` up to the end of line is scoped as `punctuation.`.

1. As white space is no punctuation, this commit therefore removes this scope. Trailing white space is already tagged as `meta.html-newline-after-php.php` anyway.

2. The `php-end-tag-pop` section is introduced to reduce duplicated rule definitions in the PHP.sublime-syntax.