### PR TITLE
[Perl] Refactor whole syntax definition to drop Oniguruma

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -2,7 +2,6 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Perl
-comment: "TODO:    Include RegExp syntax"
 file_extensions:
   - pl
   - pm
@@ -11,1092 +10,1046 @@ file_extensions:
   - PL
 first_line_match: ^#!.*\bperl\b
 scope: source.perl
+
+variables:
+  break: (?!\w| *::)
+  identifier: '\b[_[:alpha:]]\w*{{break}}'
+  module: '\b[_[:upper:]]\w*\b'
+  member: '\b[_[:lower:]]\w*\b'
+  pod: '={{identifier}}'
+  regexp_delim: '[^\w\s\)\]\}\>]'
+  regexp_flags: '[msixpodualngcer]+\b'
+
 contexts:
   main:
-    - include: line_comment
-    - match: ^=
-      captures:
-        0: punctuation.definition.comment.perl
+    - include: comment-pod
+    - include: declarations
+    - include: expressions
+
+### [ PROTOTYPES ] ###########################################################
+
+  immediately-pop:
+    - match: ''
+      pop: true
+
+  else-pop:
+    - match: $|(?=\S)
+      pop: true
+
+  eol-pop:
+    - match: $|(?=[;#])
+      pop: true
+
+  term-pop:
+    - match: (?=;)
+      pop: true
+
+### [ COMMENTS ] #############################################################
+
+  comment-line:
+    - match: \#+
+      scope: punctuation.definition.comment.begin.perl
+      push:
+        - meta_scope: comment.line.number-sign.perl
+        - match: $
+          pop: true
+
+  comment-pod:
+    # SEE: http://perldoc.perl.org/perlpod.html
+    - match: ^{{pod}}
+      scope: entity.name.tag.pod.perl
       push:
         - meta_scope: comment.block.documentation.perl
-        - match: ^=cut
-          captures:
-            0: punctuation.definition.comment.perl
-          pop: true
-    - include: variable
-    - match: '\b(?=qr\s*[^\s\w])'
-      comment: string.regexp.compile.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: $\n?
+          set: comment-pod-body
+        - include: comment-pod-formatting
+
+  comment-pod-body:
+    - meta_content_scope: comment.block.documentation.perl
+    - match: ^=cut\b
+      scope: comment.block.documentation.perl entity.name.tag.pod.perl
+      pop: true
+    - include: comment-pod-embedded
+    - include: comment-pod-keyword
+    - include: comment-pod-formatting
+    - match: \t+
+      scope: invalid.deprecated.perl
+
+  comment-pod-embedded:
+    - match: ^=begin\s+
+      scope: entity.name.tag.pod.perl
       push:
-        - match: '(qr)\s*\{'
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.nested_braces.perl
-            - match: '\}'
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_braces_interpolated
-        - match: '(qr)\s*\['
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.nested_brackets.perl
-            - match: '\]'
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_brackets_interpolated
-        - match: (qr)\s*<
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.nested_ltgt.perl
-            - match: ">"
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_ltgt_interpolated
-        - match: (qr)\s*\(
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.nested_parens.perl
-            - match: \)
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_parens_interpolated
-        - match: (qr)\s*\'
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.single-quote.perl
-            - match: \'
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-        - match: '(qr)\s*([^\s\w\''\{\[\(\<])'
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.compile.simple-delimiter.perl
-            - match: \2
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - match: '\$(?=[^\s\w\''\{\[\(\<])'
-              comment: This is to prevent thinks like qr/foo$/ to treat $/ as a variable
-              scope: keyword.control.anchor.perl
-            - include: escaped_char
-            - include: variable
-            - include: nested_parens_interpolated
-        - match: '((([egimosx]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|$))'
-          captures:
-            1: string.regexp.compile.perl
-            2: punctuation.definition.string.perl
-            3: keyword.control.regexp-option.perl
+        # end embedded section
+        - match: ^=end\b
+          scope: entity.name.tag.pod.perl
           pop: true
-    - match: '\b(?=(?<!\&)(s)(\s+\S|\s*[;\,\#\{\}\(\)\[<]|$))'
-      comment: string.regexp.replace.perl
+        # embedded css
+        - match: \bcss\b
+          scope: string.unquoted.perl
+          embed: scope:source.css
+          embed_scope: source.css.embedded.perl
+          escape: (?=^{{pod}})
+        # embedded html
+        - match: \bhtml\b
+          scope: string.unquoted.perl
+          embed: scope:text.html.basic
+          embed_scope: text.html.embedded.perl
+          escape: (?=^{{pod}})
+        # embedded javascript
+        - match: \b(?:js|javascript)\b
+          scope: string.unquoted.perl
+          embed: scope:source.js
+          embed_scope: source.js.embedded.perl
+          escape: (?=^{{pod}})
+        # embedded json
+        - match: \bjson\b
+          scope: string.unquoted.perl
+          embed: scope:source.json
+          embed_scope: source.json.embedded.perl
+          escape: (?=^{{pod}})
+        # embedded sql
+        - match: \bsql\b
+          scope: string.unquoted.perl
+          embed: scope:source.sql
+          embed_scope: source.sql.embedded.perl
+          escape: (?=^{{pod}})
+        # embedded xml
+        - match: \bxml\b
+          scope: string.unquoted.perl
+          embed: scope:text.xml
+          embed_scope: text.xml.embedded.perl
+          escape: (?=^{{pod}})
+        # unexpected pod command
+        - match: ^{{pod}}
+          scope: invalid.illegal.end-expected.perl
+          pop: true
+        - include: else-pop
+
+  comment-pod-keyword:
+    - match: ^{{pod}}
+      scope: entity.name.tag.pod.perl
       push:
-        - match: '(s)\s*\{'
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.nested_braces.perl
-            - match: '\}'
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: nested_braces
-        - match: '(s)\s*\['
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.nested_brackets.perl
-            - match: '\]'
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: nested_brackets
-        - match: (s)\s*<
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.nested_ltgt.perl
-            - match: ">"
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: nested_ltgt
-        - match: (s)\s*\(
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.nested_parens.perl
-            - match: \)
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-            - include: nested_parens
-        - match: '\{'
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.nested_braces.perl
-            - match: '\}'
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_braces_interpolated
-        - match: '\['
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.nested_brackets.perl
-            - match: '\]'
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_brackets_interpolated
-        - match: "<"
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.nested_ltgt.perl
-            - match: ">"
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_ltgt_interpolated
-        - match: \(
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.nested_parens.perl
-            - match: \)
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-            - include: nested_parens_interpolated
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.single_quote.perl
-            - match: "'"
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - match: '\\[''\\]'
-              scope: constant.character.escape.perl
-        - match: '([^\s\w\[({<;])'
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.format.simple_delimiter.perl
-            - match: \1
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-        - match: \s+
-        - match: '((([egimosx]*)))(?=(\s+\S|\s*[;\,\#\{\}\)\]>]|$))'
-          captures:
-            1: string.regexp.replace.perl
-            2: punctuation.definition.string.perl
-            3: keyword.control.regexp-option.perl
-          pop: true
-    - match: '\b(?=s([^\s\w\[({<]).*\1([egimos]*)([\}\)\;\,]|\s+))'
-      comment: string.regexp.replaceXXX
+        - meta_content_scope: markup.heading.perl
+        - include: eol-pop
+        - include: comment-pod-formatting
+
+  comment-pod-formatting:
+    # non-breaking spaces : S<content>
+    - match: (B)(<)
+      captures:
+        1: entity.name.tag.bold.perl
+        2: punctuation.definition.tag.begin.perl
       push:
-        - match: '((([egimos]*)))(?=([\}\)\;\,]|\s+|$))'
-          captures:
-            1: string.regexp.replace.perl
-            2: punctuation.definition.string.perl
-            3: keyword.control.regexp-option.perl
-          pop: true
-        - match: '(s\s*)([^\s\w\[({<])'
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.replaceXXX.simple_delimiter.perl
-            - match: (?=\2)
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.replaceXXX.format.single_quote.perl
-            - match: "'"
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - match: '\\[''\\]'
-              scope: constant.character.escape.perl.perl
-        - match: '([^\s\w\[({<])'
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.replaceXXX.format.simple_delimiter.perl
-            - match: \1
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
-    - match: '\b(?=(?<!\\)s\s*([^\s\w\[({<]))'
-      comment: string.regexp.replace.extended
+        - meta_content_scope: markup.bold.perl
+        - include: comment-pod-format-body
+    # inline code : C<code>
+    - match: (C)(<)
+      captures:
+        1: entity.name.tag.code.perl
+        2: punctuation.definition.tag.begin.perl
       push:
-        - match: '\2((([egimos]*x[egimos]*)))\b'
-          captures:
-            1: string.regexp.replace.perl
-            2: punctuation.definition.string.perl
-            3: keyword.control.regexp-option.perl
-          pop: true
-        - match: (s)\s*(.)
-          captures:
-            0: punctuation.definition.string.perl
-            1: support.function.perl
-          push:
-            - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
-            - match: (?=\2)
-              captures:
-                0: punctuation.definition.string.perl
-                1: support.function.perl
-              pop: true
-            - include: escaped_char
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
-            - match: '''(?=[egimos]*x[egimos]*)\b'
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-        - match: (.)
-          captures:
-            0: punctuation.definition.string.perl
-          push:
-            - meta_scope: string.regexp.replace.extended.simple_delimiter.perl
-            - match: '\1(?=[egimos]*x[egimos]*)\b'
-              captures:
-                0: punctuation.definition.string.perl
-              pop: true
-            - include: escaped_char
-            - include: variable
+        - meta_content_scope: markup.quote.perl
+        - include: comment-pod-format-body
+    # escaped character : E<escaped>
+    - match: (E)(<)
+      captures:
+        1: entity.name.tag.escaped.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - meta_content_scope: constant.character.escape.perl
+        - include: comment-pod-format-body
+    # italic text : I<italic>
+    - match: (I)(<)
+      captures:
+        1: entity.name.tag.italic.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - meta_content_scope: markup.italic.perl
+        - include: comment-pod-format-body
+    # filename : F<filename>
+    - match: (F)(<)
+      captures:
+        1: entity.name.tag.filename.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - meta_content_scope: string.unquoted.perl
+        - include: comment-pod-format-body
+    # hyperlink : L<label|url>
+    - match: (L)(<)
+      captures:
+        1: entity.name.tag.link.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - meta_content_scope: markup.underline.link.perl
+        - include: comment-pod-format-body
+    # non-breaking spaces : S<content>
+    - match: (S)(<)
+      captures:
+        1: entity.name.tag.none-braeking.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - include: comment-pod-format-body
+    # index entry : X<title>
+    - match: (X)(<)
+      captures:
+        1: entity.name.tag.index.perl
+        2: punctuation.definition.tag.begin.perl
+      push:
+        - meta_content_scope: entity.name.label.perl
+        - include: comment-pod-format-body
+
+  comment-pod-format-body:
+    - match: \>
+      scope: punctuation.definition.tag.end.perl
+      pop: true
+    - include: comment-pod-formatting
+    - include: literal-ltgt-nested
+
+### [ DECLARATIONS ]##########################################################
+
+  declarations:
+      # KEYWORD package
+      - match: \bpackage{{break}}
+        scope: keyword.declaration.package.perl
+      # KEYWORD 'my' and its friends
+      - match: \b(?:local|my|our|state){{break}}
+        scope: keyword.declaration.variable.perl
+      # KEYWORD no
+      - match: \bno{{break}}
+        scope: keyword.declaration.no.perl
+        push:
+          - meta_scope: meta.no.perl
+          - include: eol-pop
+          - include: pragma
+          - include: expressions
+      # KEYWORD use
+      - match: \buse{{break}}
+        scope: keyword.control.import.use.perl
+        push:
+          - meta_scope: meta.use.perl
+          - include: eol-pop
+          - include: pragma
+          - include: expressions
+      # KEYWORD require
+      - match: \brequire{{break}}
+        scope: keyword.control.import.require.perl
+        push:
+          - meta_scope: meta.import.require.perl
+          - include: eol-pop
+          - include: expressions
+
+  pragma:
+    # SEE: http://perldoc.perl.org/index-pragmas.html
+    #      http://perldoc.perl.org/perlmodlib.html#Pragmatic-Modules
+    - match: |-
+        \b(?x)
+        (?:attributes|autodie(?:::(?:exception(?:::system)|hints|skip))?|autouse
+          |base|bigint|bignum|bigrat|blib|bytes
+          |charnames|constant
+          |diagnostics
+          |encoding
+          |feature|fields|filetest
+          |if|integer
+          |less|lib|locale
+          |mro
+          |ok|open|ops|overload|overloading
+          |parent
+          |re
+          |sigtrap|sort|strict|subs
+          |threads|threads::shared
+          |utf8
+          |vars|vmsish
+          |warnings|warnings::register){{break}}
+      scope: storage.modifier.perl
+
+### [ EXPRESSIONS ]###########################################################
+
+  expressions:
+    - include: blocks
+    - include: groups
+    - include: constants
+    - include: class
+    - include: operators
+    - include: quoted-like
+    - include: control
+    - include: sub
+    - include: variables
+    - include: functions
+    - include: comment-line
+    # /<find>/<flags> statement at line start
+    - match: ^ *(?=/.*[^\\]/)
+      push: regexp-pop
+
+### [ BLOCKS AND GROUPS ]#####################################################
+
+  blocks:
+    # can't push into scope due to HEREDOCs!
+    - match: \{
+      scope: punctuation.section.block.begin.perl
+      push: regexp-pop
+    - match: \}
+      scope: punctuation.section.block.end.perl
+
+  blocks-nested:
+    - match: \{
+      scope: punctuation.section.block.begin.perl
+      push: [blocks-nested-body, regexp-pop]
+
+  blocks-nested-body:
+    - match: \}
+      scope: punctuation.section.block.end.perl
+      pop: true
+    - include: expressions
+
+  groups:
+    # can't push into scope due to HEREDOCs!
+    - match: \(
+      scope: punctuation.section.group.begin.perl
+      push: regexp-pop
+    - match: \)
+      scope: punctuation.section.group.end.perl
+
+  groups-nested:
+    - match: \{
+      scope: punctuation.section.group.begin.perl
+      push: [groups-nested-body, regexp-pop]
+
+  groups-nested-body:
+    - match: \}
+      scope: punctuation.section.group.end.perl
+      pop: true
+    - include: expressions
+
+### [ CONSTANTS ]#############################################################
+
+  constants:
+    - include: constants-numbers
+    - include: constants-language
+    - include: string
     - match: \b\w+\s*(?==>)
       scope: constant.other.key.perl
-    - match: '(?<={)\s*\w+\s*(?=})'
-      scope: constant.other.bareword.perl
-    - match: '(?<!\\)((~\s*)?\/)(\S.*?)(?<!\\)(\\{2})*(\/)'
-      scope: string.regexp.find.perl
+
+  constants-numbers:
+    # SEE: http://perldoc.perl.org/perlnumber.html
+    - match: 0b[01]+(?![\.\w+])
+      scope: constant.numeric.binary.perl
+    - match: 0x[\h_]+(?![\.\w+])
+      scope: constant.numeric.hex.perl
+    - include: constants-numbers-float
+    - include: constants-numbers-integer
+
+  constants-numbers-float:
+    - match: (")([-+]?\d+\.\d+(?:e[-+]?\d+)?)(")
+      scope: string.quoted.double.perl
       captures:
-        1: punctuation.definition.string.perl
-        5: punctuation.definition.string.perl
-    - match: (?<!\\)(\~\s*\/)
+        1: punctuation.definition.string.begin.perl
+        2: constant.numeric.float.perl
+        3: punctuation.definition.string.end.perl
+    - match: (')([-+]?\d+\.\d+(?:e[-+]?\d+)?)(')
+      scope: string.quoted.single.perl
       captures:
-        0: punctuation.definition.string.perl
+        1: punctuation.definition.string.begin.perl
+        2: constant.numeric.float.perl
+        3: punctuation.definition.string.end.perl
+    - match: (?:[-+]|\b)\d+\.\d+(?:e[-+]?\d+)?(?![\.\w+])
+      scope: constant.numeric.float.perl
+
+  constants-numbers-integer:
+    - match: (")([-+]?\d+)(")
+      scope: string.quoted.double.perl
+      captures:
+        1: punctuation.definition.string.begin.perl
+        2: constant.numeric.integer.perl
+        3: punctuation.definition.string.end.perl
+    - match: (')([-+]?\d+)(')
+      scope: string.quoted.single.perl
+      captures:
+        1: punctuation.definition.string.begin.perl
+        2: constant.numeric.integer.perl
+        3: punctuation.definition.string.end.perl
+    - match: (?:[-+]|\b)\d+(?![\.\w+])
+      scope: constant.numeric.integer.perl
+
+  constants-language:
+    - match: \b__(?:END|DATA|FILE|LINE|PACKAGE|SUB)__\b
+      scope: constant.language.perl
+    - match: \b(?:ARGV|ARGVOUT|STDERR|STDIN|STDOUT|DATA|IN|OUT){{break}}
+      scope: constant.language.filehandle.perl
+    - match: \b[A-Z0-9_]+{{break}}
+      scope: constant.other.perl
+
+### [ STRINGS ]###############################################################
+
+  string:
+    - include: string-quoted-backtick
+    - include: string-quoted-double
+    - include: string-quoted-single
+    - include: string-format
+    - include: string-heredoc
+
+  string-quoted-backtick:
+    - match: \`
+      scope: punctuation.definition.string.begin.perl
       push:
-        - meta_scope: string.regexp.find.extended.perl
-        - match: '\/([cgimos]*x[cgimos]*)\b'
-          captures:
-            1: keyword.control.regexp-option.perl
+        - meta_scope: string.quoted.backtick.perl
+        - match: \`
+          scope: punctuation.definition.string.end.perl
           pop: true
-        - include: escaped_char
-        - include: variable
-    - match: ^\s*(package)\s+(\S+)\s*((#).*)?$\n?
-      scope: meta.class.perl
+        - include: character-escape
+
+  string-quoted-double:
+    - match: \"
+      scope: punctuation.definition.string.begin.perl
+      push:
+        - meta_scope: string.quoted.double.perl
+        - match: \"
+          scope: punctuation.definition.string.end.perl
+          pop: true
+        - include: character-escape
+
+  string-quoted-single:
+    - match: \'
+      scope: punctuation.definition.string.begin.perl
+      push:
+        - meta_scope: string.quoted.single.perl
+        - match: \'
+          scope: punctuation.definition.string.end.perl
+          pop: true
+        - include: character-escape
+
+  string-format:
+    # SEE: http://perldoc.perl.org/perlform.html
+    - match: ^\s*(format)\s+(\w+)\s*(=)\s*$
       captures:
-        1: keyword.control.perl
-        2: entity.name.type.class.perl
-        3: comment.line.number-sign.perl
-        4: punctuation.definition.comment.perl
-    - match: '^\s*(sub)\s+([-a-zA-Z0-9_]+)\s*(\([\$\@\*;]*\))?'
-      scope: meta.function.perl
+        1: storage.type.format.perl
+        2: variable.other.perl
+        3: keyword.operator.assignment.perl
+      push:
+        - meta_scope: meta.block.format.perl
+        - meta_content_scope: string.unquoted.format.perl
+        - match: ^\.(?=\s*$)
+          scope: punctuation.terminator.format.perl
+          pop: true
+        - match: \.{3}
+          scope: constant.character.escape.perl
+        - match: ~{1,2}(?!~)
+          scope: constant.character.escape.perl
+        - match: '[@\^]\*'
+          scope: variable.parameter.multiline-width.perl
+        - match: (\@)[0#\.|<>]+
+          scope: variable.parameter.regular-field.perl
+          captures:
+            1: punctuation.definition.placeholder.begin.perl
+        - match: (\^)[0#\.|<>]+
+          scope: variable.parameter.special-field.perl
+          captures:
+            1: punctuation.definition.placeholder.begin.perl
+        - include: variables
+
+  string-heredoc:
+    # SEE: http://www.perlmeme.org/howtos/syntax/here_document.html
+    - match: (<<) *(?=['"]? *{{identifier}})
       captures:
-        1: storage.type.sub.perl
-        2: entity.name.function.perl
-        3: storage.type.method.perl
-    - match: ^\s*(BEGIN|END|DESTROY)\b
+        1: keyword.operator.heredoc.perl
+      push: [string-heredoc-meta, string-heredoc-body]
+
+  string-heredoc-meta:
+    - meta_scope: meta.heredoc.perl
+    - include: immediately-pop
+
+  string-heredoc-body:
+    # embedded css
+    - match: ((['"]?)( *CSS)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.css.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-css, string-heredoc-expr]
+    # embedded html
+    - match: ((['"]?)( *HTML)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.html.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-html, string-heredoc-expr]
+    # embedded javascript
+    - match: ((['"]?)( *JAVASCRIPT)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.js.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-javascript, string-heredoc-expr]
+    # embedded json
+    - match: ((['"]?)( *JSON)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.json.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-json, string-heredoc-expr]
+    # embedded sql
+    - match: ((['"]?)( *SQL)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.sql.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-sql, string-heredoc-expr]
+    # embedded xml
+    - match: ((['"]?)( *XML)(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.xml.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-xml, string-heredoc-expr]
+    # any other tag like (EOD, EOT, FOO, ...) is handled as string
+    - match: ((['"]?)( *{{identifier}})(\2))
+      captures:
+        1: string.other.heredoc.perl
+        2: punctuation.definition.string.begin.perl
+        3: constant.language.heredoc.plain.perl
+        4: punctuation.definition.string.end.perl
+      set: [string-heredoc-other, string-heredoc-expr]
+    - include: else-pop
+
+  string-heredoc-expr:
+    # The rest of the line right after the heredoc tag needs to be handled
+    # as ordinary perl. The embedded syntax starts at the next line.
+    - clear_scopes: 1 # remove 'string.quoted'
+    - match: $
+      pop: true
+    - include: expressions
+
+  string-heredoc-css:
+    - meta_content_scope: source.css.embedded.perl
+    # pop off only, if keyword is indented correctly
+    - match: ^\3$
+      scope: constant.language.heredoc.css.perl
+      pop: true
+    - match: ''
+      embed: scope:source.css
+      escape: (?=^ *CSS$)
+
+  string-heredoc-html:
+    - meta_content_scope: text.html.embedded.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.html.perl
+      pop: true
+    - match: ''
+      embed: scope:text.html.basic
+      escape: (?=^ *HTML$)
+
+  string-heredoc-javascript:
+    - meta_content_scope: source.js.embedded.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.js.perl
+      pop: true
+    - match: ''
+      embed: scope:source.js
+      escape: (?=^ *JAVASCRIPT$)
+
+  string-heredoc-json:
+    - meta_content_scope: source.json.embedded.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.json.perl
+      pop: true
+    - match: ''
+      embed: scope:source.json
+      escape: (?=^ *JSON$)
+
+  string-heredoc-sql:
+    - meta_content_scope: source.sql.embedded.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.sql.perl
+      pop: true
+    - match: ''
+      embed: scope:source.sql
+      escape: (?=^ *SQL$)
+
+  string-heredoc-xml:
+    - meta_content_scope: text.xml.embedded.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.xml.perl
+      pop: true
+    - match: ''
+      embed: scope:text.xml
+      escape: (?=^ *XML$)
+
+  string-heredoc-other:
+    - meta_content_scope: string.quoted.other.perl
+    - match: ^\3$
+      scope: constant.language.heredoc.plain.perl
+      pop: true
+
+### [ CLASSES ]################################################################
+
+  class:
+    - match: '{{module}}(?= *(?:::|[#;]|$))'
+      scope: support.class.perl
+      push: members-pop
+
+  members-pop:
+    - match: ' *(::) *({{module}})'
+      captures:
+        1: punctuation.accessor.double-colon.perl
+        2: support.class.perl
+    - match: ' *(::) *({{identifier}})'
+      captures:
+        1: punctuation.accessor.double-colon.perl
+        2: variable.other.member.perl
+    - include: else-pop
+
+### [ CONTROL KEYWORDS ]#######################################################
+
+  control:
+    - match: \b(?:default|else|elsif|given|if|unless|when){{break}}
+      scope: keyword.control.conditional.perl
+      push: regexp-pop
+    - match: \b(?:break|caller|continue|die|dump|exit|goto|last|next|redo|return|wait){{break}}
+      scope: keyword.other.flow.perl
+      push: regexp-pop
+    - match: \b(?:do|for|foreach|until|while){{break}}
+      scope: keyword.control.flow.perl
+      push: regexp-pop
+    - include: label
+
+  label:
+    - match: ({{identifier}})(:)(?!:)
+      captures:
+        1: entity.name.label.perl
+        2: punctuation.separator.perl
+      push: regexp-pop
+
+### [ OPERATORS ]#############################################################
+
+  operators:
+    # SEE: https://www.tutorialspoint.com/perl/perl_operators.htm
+    - match: ','
+      scope: punctuation.separator.sequence.perl
+      push: regexp-pop
+    - match: ;
+      scope: punctuation.terminator.statement.perl
+      push: regexp-pop
+    - match: -[rwx0RWXOezsfdlpSbctugkTBMAC]\b
+      scope: keyword.operator.filetest.perl
+      push: regexp-pop
+    - match: '->'
+      scope: keyword.operator.arrow.perl
+      push: regexp-pop
+    - match: '[!~=]~'
+      scope: keyword.operator.binary.perl
+      push: regexp-pop
+    - match: <=>|//|\&\&|\|\||==|!=|>=|<=|[<>:!?]
+      scope: keyword.operator.logical.perl
+      push: regexp-pop
+    - match: '\*\*=|[-+*/%]='
+      scope: keyword.operator.assignment.perl
+      push: regexp-pop
+    - match: '[-+*]{1,2}|/'
+      scope: keyword.operator.arithmetic.perl
+      push: regexp-pop
+    - match: '[&|^~]'
+      scope: keyword.operator.bitwise.perl
+      push: regexp-pop
+    - match: =>?
+      scope: keyword.operator.assignment.perl
+      push: regexp-pop
+    - match: \.\.
+      scope: keyword.operator.range.perl
+      push: regexp-pop
+    # string concat
+    - match: \.=?
+      scope: keyword.operator.concat.perl
+      push: regexp-pop
+    # string concation
+    #  "string" x 10
+    - match: \bx\b
+      scope: keyword.operator.arithmetic.perl
+      push: regexp-pop
+    - match: \b(and|or|xor|as|cmp|eq|gt|ge|lg|le|ne|not){{break}}
+      scope: keyword.operator.logical.perl
+      push: regexp-pop
+
+### [ QUOTED LIKE ]###########################################################
+
+  quoted-like:
+    # SEE: http://perldoc.perl.org/perlop.html#Regexp-Quote-Like-Operators
+    - include: quoted-like-match
+    - include: quoted-like-replace
+
+  quoted-like-match:
+    - match: \bq[qwx]?\b
+      scope: support.function.perl
+      push:
+        - quoted-like-meta
+        - quoted-like-args-find-literal
+    - match: \b(m|qr)(?=\s*[\(\[\{<])
+      scope: support.function.perl
+      push:
+        - quoted-like-meta
+        - quoted-like-flags
+        - quoted-like-args-find-rexexp
+    - match: \b(m|qr)({{regexp_delim}})
+      captures:
+        0: meta.function-call.perl
+        1: support.function.perl
+        2: punctuation.section.generic.begin.perl
+      embed_scope: meta.function-call.perl string.regexp.perl
+      embed: scope:source.regexp
+      escape: (?<!(?<!\\)\\)(\2)({{regexp_flags}})?
+      escape_captures:
+        0: meta.function-call.perl
+        1: punctuation.section.generic.end.perl
+        2: constant.language.flags.regexp.perl
+
+  quoted-like-replace:
+    - match: \b(s|ty|y)(?=\s*[\(\[\{<])
+      scope: support.function.perl
+      push:
+        - quoted-like-meta
+        - quoted-like-flags
+        - quoted-like-args-replace
+        - quoted-like-args-find-rexexp
+    - match: \b(s|tr|y)({{regexp_delim}})
+      captures:
+        0: meta.function-call.perl
+        1: support.function.perl
+        2: punctuation.section.generic.begin.perl
+      embed_scope: meta.function-call.perl string.regexp.perl
+      embed: scope:source.regexp
+      escape: ((?<!(?<!\\)\\)\2)(.*?)((?<!(?<!\\)\\)\2)({{regexp_flags}})?
+      escape_captures:
+        0: meta.function-call.perl
+        1: punctuation.separator.sequence.perl
+        2: string.unquoted.perl
+        3: punctuation.section.generic.end.perl
+        4: constant.language.flags.regexp.perl
+
+  quoted-like-meta:
+    - meta_scope: meta.function-call.perl
+    - include: immediately-pop
+
+  quoted-like-flags:
+    - match: '{{regexp_flags}}'
+      scope: constant.language.flags.regexp.perl
+      pop: true
+    - include: else-pop
+
+  quoted-like-args-find-rexexp:
+    - match: \{
+      scope: punctuation.section.braces.begin.perl
+      set:
+        - meta_scope: meta.braces.perl
+        - meta_content_scope: string.regexp.perl
+        - match: \}
+          scope: punctuation.section.braces.end.perl
+          pop: true
+        - include: scope:source.regexp#base-literal-extended
+    - match: \[
+      scope: punctuation.section.brackets.begin.perl
+      set:
+        - meta_scope: meta.brackets.perl
+        - meta_content_scope: string.regexp.perl
+        - match: \]
+          scope: punctuation.section.brackets.end.perl
+          pop: true
+        - include: scope:source.regexp#base-literal-extended
+    - match: \<
+      scope: punctuation.section.generic.begin.perl
+      set:
+        - meta_scope: meta.generic.perl
+        - meta_content_scope: string.regexp.perl
+        - match: \>
+          scope: punctuation.section.generic.end.perl
+          pop: true
+        - include: scope:source.regexp#base-literal-extended
+    - match: \(
+      scope: punctuation.section.parens.begin.perl
+      set:
+        - meta_scope: meta.parens.perl
+        - meta_content_scope: string.regexp.perl
+        - match: \)
+          scope: punctuation.section.parens.end.perl
+          pop: true
+        - include: scope:source.regexp#base-literal-extended
+    - include: else-pop
+
+  quoted-like-args-find-literal:
+    - include: literal-braces-pop
+    - include: literal-brackets-pop
+    - include: literal-ltgt-pop
+    - include: literal-parens-pop
+    - include: literal-generic-pop
+    - include: else-pop
+
+  quoted-like-args-replace:
+    - include: literal-braces-pop
+    - include: literal-brackets-pop
+    - include: literal-ltgt-pop
+    - include: literal-parens-pop
+    - include: else-pop
+
+  literal-braces-pop:
+    - match: \{
+      scope: punctuation.section.braces.begin.perl
+      set:
+        - meta_scope: meta.braces.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: \}
+          scope: punctuation.section.braces.end.perl
+          pop: true
+        - include: literal-braces-nested
+        - include: character-escape
+
+  literal-braces-nested:
+    - match: \{
+      push:
+        - match: \}
+          pop: true
+        - include: literal-braces-nested
+        - include: character-escape
+
+  literal-brackets-pop:
+    - match: \[
+      scope: punctuation.section.brackets.begin.perl
+      set:
+        - meta_scope: meta.brackets.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: \]
+          scope: punctuation.section.brackets.end.perl
+          pop: true
+        - include: literal-brackets-nested
+        - include: character-escape
+
+  literal-brackets-nested:
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: literal-brackets-nested
+        - include: character-escape
+
+  literal-ltgt-pop:
+    - match: \<
+      scope: punctuation.section.generic.begin.perl
+      set:
+        - meta_scope: meta.generic.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: \>
+          scope: punctuation.section.generic.end.perl
+          pop: true
+        - include: literal-ltgt-nested
+        - include: character-escape
+
+  literal-ltgt-nested:
+    - match: \<
+      push:
+        - match: \>
+          pop: true
+        - include: literal-ltgt-nested
+        - include: character-escape
+
+  literal-parens-pop:
+    - match: \(
+      scope: punctuation.section.parens.begin.perl
+      set:
+        - meta_scope: meta.parens.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: \)
+          scope: punctuation.section.parens.end.perl
+          pop: true
+        - include: literal-parens-nested
+        - include: character-escape
+
+  literal-parens-nested:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: literal-parens-nested
+        - include: character-escape
+
+  literal-generic-pop:
+    - match: ({{regexp_delim}})
+      scope: punctuation.section.generic.begin.perl
+      set:
+        - meta_scope: meta.generic.perl
+        - meta_content_scope: string.unquoted.perl
+        - match: \1
+          scope: punctuation.section.generic.end.perl
+          pop: true
+        - include: character-escape
+
+  character-escape:
+    - match: \\.
+      scope: constant.character.escape.perl
+
+### [ REGEXP ] ###############################################################
+
+  regexp-pop:
+    # /<pattern>/<flags>
+    - match: /
+      scope: punctuation.section.generic.begin.perl
+      embed_scope: string.regexp.perl
+      embed: scope:source.regexp
+      escape: (?<!(?<!\\)\\)(/)({{regexp_flags}})?
+      escape_captures:
+        1: punctuation.section.generic.end.perl
+        2: constant.language.flags.regexp.perl
+    - include: else-pop
+
+### [ FUNCTIONS ]#############################################################
+
+  functions:
+    - match: |-
+        \b(?x:
+           abs|accept|alarm|atan2|bind|binmode|bless|chdir|chmod
+          |chomp|chop|chown|chr|chroot|close|closedir|connect|cos|crypt
+          |dbmclose|dbmopen|defined|delete|each|endgrent|endhostent
+          |endnetent|endprotoent|endpwent|endservent|eof|eval|evalbytes|exec
+          |exists|exp|fc|fcntl|fileno|flock|fork|formline|getc
+          |getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent
+          |getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp
+          |getppid|getpriority|getprotobyname|getprotobynumber|getprotoent
+          |getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent
+          |getsockname|getsockopt|glob|gmtime|grep|hex|index|int|ioctl|join
+          |keys|kill|lc|lcfirst|length|link|listen|localtime|lock|log
+          |lstat|map|mkdir|msgctl|msgget|msgrcv|msgsnd|oct|open|opendir|ord
+          |pack|pipe|pop|pos|print|printf|prototype|push|quotemeta
+          |rand|read|readdir|readline|readlink|readpipe|recv|ref|rename
+          |reset|reverse|rewinddir|rindex|rmdir|say|scalar|seek|seekdir|select
+          |semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp
+          |setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl
+          |shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort
+          |splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall
+          |sysopen|sysread|sysseek|system|syswrite|tell|telldir|tie|tied|time
+          |times|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie
+          |utime|values|vec|wait|waitpid|wantarray|warn|write
+        ){{break}}
+      scope: support.function.perl
+      push: regexp-pop
+    - match: ^\s*(AUTOLOAD|BEGIN|CHECK|DESTROY|END|INIT|UNITCHECK){{break}}
       scope: meta.function.perl
       captures:
         1: entity.name.function.perl
-        2: punctuation.definition.parameters.perl
-        3: variable.parameter.function.perl
-    - match: '^(?=(\t| {4}))'
-      push:
-        - meta_scope: meta.leading-tabs
-        - match: '(?=[^\t\s])'
-          pop: true
-        - match: '(\t| {4})(\t| {4})?'
-          captures:
-            1: meta.odd-tab
-            2: meta.even-tab
-    - match: '\b(m)\s*(?<!\\)([^\[\{\(A-Za-z0-9\s])(.*?)(?<!\\)(\\{2})*(\2)'
-      scope: string.regexp.find-m.perl
-      captures:
-        1: support.function.perl
-        2: punctuation.definition.string.perl
-        5: punctuation.definition.string.perl
-    - match: \b(m)\s*(?<!\\)\(
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.regexp.find-m-paren.perl
-        - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_parens_interpolated
-        - include: variable
-    - match: '\b(m)\s*(?<!\\)\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.regexp.find-m-brace.perl
-        - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_braces_interpolated
-        - include: variable
-    - match: '\b(m)\s*(?<!\\)\['
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.regexp.find-m-bracket.perl
-        - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_brackets_interpolated
-        - include: variable
-    - match: \b(m)\s*(?<!\\)\<
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.regexp.find-m-ltgt.perl
-        - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_ltgt_interpolated
-        - include: variable
-    - match: '\b(s|tr|y)\s*([^A-Za-z0-9\s])(.*?)(?<!\\)(\\{2})*(\2)(.*?)(?<!\\)(\\{2})*(\2)'
-      scope: string.regexp.replace.perl
-      captures:
-        1: support.function.perl
-        2: punctuation.definition.string.perl
-        5: punctuation.definition.string.perl
-        8: punctuation.definition.string.perl
-    - match: \b(__FILE__|__LINE__|__PACKAGE__)\b
-      scope: constant.language.perl
-    - match: (?<!->)\b(continue|die|do|else|elsif|exit|for|foreach|goto|if|last|next|redo|return|select|unless|until|wait|while|switch|case|package|require|use|eval)\b
-      scope: keyword.control.perl
-    - match: \b(my|our|local)\b
-      scope: storage.modifier.perl
-    - match: '(?<!\w)\-[rwx0RWXOezsfdlpSbctugkTBMAC]\b'
-      scope: keyword.operator.filetest.perl
-    - match: \b(and|or|xor|as)\b
-      scope: keyword.operator.logical.perl
-    - match: (<=>| =>|->)
-      scope: keyword.operator.comparison.perl
-    - match: ((<<) *"HTML").*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.html.embedded.perl
-        - match: (^HTML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:text.html.basic
-    - match: ((<<) *"XML").*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.xml.embedded.perl
-        - match: (^XML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:text.xml
-    - match: ((<<) *"CSS").*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.css.embedded.perl
-        - match: (^CSS$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:source.css
-    - match: ((<<) *"JAVASCRIPT").*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.js.embedded.perl
-        - match: (^JAVASCRIPT$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:source.js
-    - match: ((<<) *"SQL").*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: source.sql.embedded.perl
-        - match: (^SQL$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:source.sql
-    - match: '((<<) *"([^"]*)").*\n?'
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.doublequote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: string.unquoted.heredoc.doublequote.perl
-        - match: (^\3$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.doublequote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: ((<<) *'HTML').*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.html.embedded.perl
-        - match: (^HTML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: scope:text.html.basic
-    - match: ((<<) *'XML').*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.xml.embedded.perl
-        - match: (^XML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: scope:text.xml
-    - match: ((<<) *'CSS').*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.css.embedded.perl
-        - match: (^CSS$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: scope:source.css
-    - match: ((<<) *'JAVASCRIPT').*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.js.embedded.perl
-        - match: (^JAVASCRIPT$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: scope:source.js
-    - match: ((<<) *'SQL').*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: source.sql.embedded.perl
-        - match: (^SQL$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: scope:source.sql
-    - match: '((<<) *''([^'']*)'').*\n?'
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.quote.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: string.unquoted.heredoc.quote.perl
-        - match: (^\3$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.quote.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-    - match: '((<<) *`([^`]*)`).*\n?'
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.backtick.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: string.unquoted.heredoc.backtick.perl
-        - match: (^\3$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.backtick.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: ((<<) *HTML\b).*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.html.embedded.perl
-        - match: (^HTML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:text.html.basic
-    - match: ((<<) *XML\b).*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: text.xml.embedded.perl
-        - match: (^XML$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:text.xml
-    - match: ((<<) *SQL\b).*\n?
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: source.sql.embedded.perl
-        - match: (^SQL$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: scope:source.sql
-    - match: '((<<) *((?![=\d\$ ])[^;,''"`\s)]*)).*\n?'
-      captures:
-        0: punctuation.definition.string.perl
-        1: string.unquoted.heredoc.perl
-        2: punctuation.definition.heredoc.perl
-      push:
-        - meta_content_scope: string.unquoted.heredoc.perl
-        - match: (^\3$)
-          captures:
-            0: punctuation.definition.string.perl
-            1: string.unquoted.heredoc.perl
-            2: punctuation.definition.heredoc.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: '\bqq\s*([^\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.qq.perl
-        - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: '\bqx\s*([^''\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx.perl
-        - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: \bqx\s*'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx.single-quote.perl
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-    - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.double.perl
-        - match: '"'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: '\bqw?\s*([^\(\{\[\<\w\s])'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.q.perl
-        - match: \1
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-    - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.single.perl
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - match: '\\[''\\]'
-          scope: constant.character.escape.perl
-    - match: "`"
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.perl
-        - match: "`"
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-    - match: \bqq\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.qq-paren.perl
-        - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_parens_interpolated
-        - include: variable
-    - match: '\bqq\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.qq-brace.perl
-        - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_braces_interpolated
-        - include: variable
-    - match: '\bqq\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.qq-bracket.perl
-        - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_brackets_interpolated
-        - include: variable
-    - match: \bqq\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.qq-ltgt.perl
-        - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_ltgt_interpolated
-        - include: variable
-    - match: \bqx\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx-paren.perl
-        - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_parens_interpolated
-        - include: variable
-    - match: '\bqx\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx-brace.perl
-        - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_braces_interpolated
-        - include: variable
-    - match: '\bqx\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx-bracket.perl
-        - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_brackets_interpolated
-        - include: variable
-    - match: \bqx\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.interpolated.qx-ltgt.perl
-        - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_ltgt_interpolated
-        - include: variable
-    - match: \bqw?\s*\(
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.q-paren.perl
-        - match: \)
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_parens
-    - match: '\bqw?\s*\{'
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.q-brace.perl
-        - match: '\}'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_braces
-    - match: '\bqw?\s*\['
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.q-bracket.perl
-        - match: '\]'
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_brackets
-    - match: \bqw?\s*\<
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.quoted.other.q-ltgt.perl
-        - match: \>
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_ltgt
-    - match: ^__\w+__
-      captures:
-        0: punctuation.definition.string.begin.perl
-      push:
-        - meta_scope: string.unquoted.program-block.perl
-        - match: $
-          captures:
-            0: punctuation.definition.string.end.perl
-          pop: true
-    - match: '\b(format)\s+([A-Za-z]+)\s*='
-      captures:
-        1: support.function.perl
-        2: entity.name.function.format.perl
-      push:
-        - meta_scope: meta.format.perl
-        - match: ^\.\s*$
-          pop: true
-        - include: line_comment
-        - include: variable
-    - match: \b(ARGV|DATA|ENV|SIG|STDERR|STDIN|STDOUT|atan2|bind|binmode|bless|caller|chdir|chmod|chomp|chop|chown|chr|chroot|close|closedir|cmp|connect|cos|crypt|dbmclose|dbmopen|defined|delete|dump|each|endgrent|endhostent|endnetent|endprotoent|endpwent|endservent|eof|eq|eval|exec|exists|exp|fcntl|fileno|flock|fork|format|formline|ge|getc|getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent|getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp|getppid|getpriority|getprotobyname|getprotobynumber|getprotoent|getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent|getsockname|getsockopt|glob|gmtime|grep|gt|hex|import|index|int|ioctl|join|keys|kill|lc|lcfirst|le|length|link|listen|local|localtime|log|lstat|lt|m|map|mkdir|msgctl|msgget|msgrcv|msgsnd|ne|no|oct|open|opendir|ord|pack|pipe|pop|pos|print|printf|push|q|qq|quotemeta|qw|qx|rand|read|readdir|readlink|recv|ref|rename|reset|reverse|rewinddir|rindex|rmdir|s|scalar|seek|seekdir|semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp|setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl|shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort|splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall|sysopen|sysread|system|syswrite|tell|telldir|tie|tied|time|times|tr|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie|utime|values|vec|waitpid|wantarray|warn|write|y|q|qw|qq|qx)\b
-      scope: support.function.perl
-  escaped_char:
-    - match: \\.
-      scope: constant.character.escape.perl
-  line_comment:
-    - match: ^((#).*$\n?)
-      scope: meta.comment.full-line.perl
-      captures:
-        1: comment.line.number-sign.perl
-        2: punctuation.definition.comment.perl
-    - match: (#).*$\n?
-      scope: comment.line.number-sign.perl
-      captures:
-        1: punctuation.definition.comment.perl
-  nested_braces:
-    - match: '\{'
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: '\}'
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_braces
-  nested_braces_interpolated:
-    - match: '\{'
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: '\}'
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: nested_braces_interpolated
-  nested_brackets:
-    - match: '\['
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: '\]'
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: escaped_char
-        - include: nested_brackets
-  nested_brackets_interpolated:
-    - match: '\['
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: '\]'
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: escaped_char
-        - include: variable
-        - include: nested_brackets_interpolated
-  nested_ltgt:
-    - match: "<"
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: ">"
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: nested_ltgt
-  nested_ltgt_interpolated:
-    - match: "<"
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: ">"
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - include: variable
-        - include: nested_ltgt_interpolated
-  nested_parens:
+    - match: \b{{member}}{{break}}
+      scope: variable.function.perl
+      push: regexp-pop
+
+### [ SUB ]###################################################################
+
+  sub:
+    - match: \bsub\b
+      scope: keyword.control.sub.perl
+      push: sub-name
+
+  sub-name:
+    - meta_scope: meta.function.perl
+    - match: '{{identifier}}'
+      scope: entity.name.function.perl
+      set: sub-expect-parameters
+    - include: sub-expect-block
+
+  sub-expect-parameters:
+    - meta_content_scope: meta.function.perl
+    - match: (?=\()
+      set: sub-parameters
+    - include: sub-expect-block
+    - match: \S
+      scope: invalid.illegal.function-name.perl
+
+  sub-parameters:
     - match: \(
-      captures:
-        1: punctuation.section.scope.perl
-      push:
+      scope: punctuation.section.group.begin.perl
+      set:
+        - meta_scope: meta.function.parameters.perl
         - match: \)
-          captures:
-            1: punctuation.section.scope.perl
+          scope: punctuation.section.group.end.perl
+          set: sub-expect-block
+        - match: '[\$\@\*;][^\s,\)]*'
+          scope: variable.parameter.perl
+        - include: expressions
+
+  sub-expect-block:
+    - meta_content_scope: meta.function.perl
+    - include: term-pop
+    - match: $|(?=\{)
+      set:
+        - match: \{
+          scope: punctuation.section.block.begin.perl
+          set: [sub-block-body, regexp-pop]
+        - include: comment-line
+        - include: comment-pod
+        - match: (?=\S)
           pop: true
-        - include: escaped_char
-        - include: nested_parens
-  nested_parens_interpolated:
-    - match: \(
-      captures:
-        1: punctuation.section.scope.perl
-      push:
-        - match: \)
-          captures:
-            1: punctuation.section.scope.perl
-          pop: true
-        - match: '\$(?=[^\s\w\''\{\[\(\<])'
-          comment: This is to prevent thinks like qr/foo$/ to treat $/ as a variable
-          scope: keyword.control.anchor.perl
-        - include: escaped_char
-        - include: variable
-        - include: nested_parens_interpolated
-  variable:
-    - match: '(\$)&(?![A-Za-z0-9_])'
+
+  sub-block-body:
+    - meta_scope: meta.function.perl meta.block.perl
+    - match: \}
+      scope: punctuation.section.block.end.perl
+      pop: true
+    - include: main
+
+### [ VARIABLES ]#############################################################
+
+  variables:
+    # SEE: http://perldoc.perl.org/perlvar.html
+    - match: (\$)&(?!\w)
       scope: variable.other.regexp.match.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)`(?![A-Za-z0-9_])'
+    - match: (\$)`(?!\w)
       scope: variable.other.regexp.pre-match.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)''(?![A-Za-z0-9_])'
+    - match: (\$)\'(?!\w)
       scope: variable.other.regexp.post-match.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)\+(?![A-Za-z0-9_])'
+    - match: (\$)\+(?!\w)
       scope: variable.other.regexp.last-paren-match.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)"(?![A-Za-z0-9_])'
+    - match: (\$)\"(?!\w)
       scope: variable.other.readwrite.list-separator.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)0(?![A-Za-z0-9_])'
+    - match: (\$)0\b
       scope: variable.other.predefined.program-name.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$)[_ab\*\.\/\|,\\;#%=\-~^:?!\$<>\(\)\[\]@](?![A-Za-z0-9_])'
-      scope: variable.other.predefined.perl
-      captures:
-        1: punctuation.definition.variable.perl
-    - match: '(\$)[0-9]+(?![A-Za-z0-9_])'
+    - match: (\$)[0-9]+\b
       scope: variable.other.subpattern.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '([\$\@\%](#)?)([a-zA-Zx7f-xff\$]|::)([a-zA-Z0-9_x7f-xff\$]|::)*\b'
+    # $Module::SubModule::member
+    # $::SubModule::member
+    - match: ([\$\@\%]#?)({{module}})?(?= *::)
+      captures:
+        1: punctuation.definition.variable.perl
+        2: support.class.perl
+      push:
+        - meta_scope: variable.other.readwrite.global.perl
+        - include: members-pop
+    - match: (\$)(\^[A-Z]|[_ab\*\.\/\|,\\;#%=\-~^:?!\$<>\(\)\[\]@])(?!\w)
+      scope: variable.other.predefined.perl
+      captures:
+        1: punctuation.definition.variable.perl
+    - match: ([\$\@\%]#?)(\w+)\b
       scope: variable.other.readwrite.global.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: '(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})'
-      scope: variable.other.readwrite.global.perl
-      captures:
-        1: punctuation.definition.variable.perl
-        2: punctuation.definition.variable.perl
-    - match: '([\$\@\%](#)?)[0-9_]\b'
-      scope: variable.other.readwrite.global.special.perl
-      captures:
-        1: punctuation.definition.variable.perl
+    - match: ([\$\@\%])(\{)
+      scope: punctuation.definition.variable.begin.perl
+      push:
+        - meta_scope: meta.braces.perl variable.other.readwrite.global.perl
+        - match: \}
+          scope: punctuation.definition.variable.end.perl
+          pop: true
+        - include: blocks-nested
+        - include: expressions

--- a/Perl/Snippets/Conditional-if-(if).sublime-snippet
+++ b/Perl/Snippets/Conditional-if-(if).sublime-snippet
@@ -5,5 +5,5 @@
 ]]></content>
 	<tabTrigger>if</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Conditional</description>
+	<description>if.. Conditional</description>
 </snippet>

--- a/Perl/Snippets/Conditional-if..else-(ife).sublime-snippet
+++ b/Perl/Snippets/Conditional-if..else-(ife).sublime-snippet
@@ -7,5 +7,5 @@
 ]]></content>
 	<tabTrigger>ife</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Conditional if..else</description>
+	<description>if..else.. Conditional</description>
 </snippet>

--- a/Perl/Snippets/Conditional-one-line-(xif).sublime-snippet
+++ b/Perl/Snippets/Conditional-one-line-(xif).sublime-snippet
@@ -3,5 +3,5 @@
 ]]></content>
 	<tabTrigger>xif</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Conditional One-line</description>
+	<description>if.. Conditional One-line</description>
 </snippet>

--- a/Perl/Snippets/Conditional-one-line-(xunless).sublime-snippet
+++ b/Perl/Snippets/Conditional-one-line-(xunless).sublime-snippet
@@ -3,5 +3,5 @@
 ]]></content>
 	<tabTrigger>xunless</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Conditional One-line</description>
+	<description>unless. Conditional One-line</description>
 </snippet>

--- a/Perl/Snippets/Conditional-one-line-(xwhen).sublime-snippet
+++ b/Perl/Snippets/Conditional-one-line-(xwhen).sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[${1:expression} when ${2:condition};
+]]></content>
+	<tabTrigger>xwhen</tabTrigger>
+	<scope>source.perl</scope>
+	<description>when.. Conditional One-line</description>
+</snippet>

--- a/Perl/Snippets/Conditional-unless-(unless).sublime-snippet
+++ b/Perl/Snippets/Conditional-unless-(unless).sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[unless ($1) {
+	${2:# body...}
+}
+]]></content>
+	<tabTrigger>unless</tabTrigger>
+	<scope>source.perl</scope>
+	<description>unless.. Conditional</description>
+</snippet>

--- a/Perl/Snippets/Conditional-unless..else-(unlesse).sublime-snippet
+++ b/Perl/Snippets/Conditional-unless..else-(unlesse).sublime-snippet
@@ -1,9 +1,11 @@
 <snippet>
 	<content><![CDATA[unless ($1) {
 	${2:# body...}
+} else {
+	${3:# else...}
 }
 ]]></content>
-	<tabTrigger>unless</tabTrigger>
+	<tabTrigger>unlesse</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Conditional</description>
+	<description>unless..else.. Conditional</description>
 </snippet>

--- a/Perl/Snippets/Conditional-unless..elsif..else-(unlessee).sublime-snippet
+++ b/Perl/Snippets/Conditional-unless..elsif..else-(unlessee).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[if ($1) {
+	<content><![CDATA[unless ($1) {
 	${2:# body...}
 } elsif ($3) {
 	${4:# elsif...}
@@ -7,7 +7,7 @@
 	${5:# else...}
 }
 ]]></content>
-	<tabTrigger>ifee</tabTrigger>
+	<tabTrigger>unlessee</tabTrigger>
 	<scope>source.perl</scope>
-	<description>if..elsif..else.. Conditional</description>
+	<description>unless..elsif..else.. Conditional</description>
 </snippet>

--- a/Perl/Snippets/Conditional-when-(when).sublime-snippet
+++ b/Perl/Snippets/Conditional-when-(when).sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[when ($1) {
+	${2:# body...}
+}
+]]></content>
+	<tabTrigger>when</tabTrigger>
+	<scope>source.perl</scope>
+	<description>when.. Conditional</description>
+</snippet>

--- a/Perl/Snippets/Loop-for-(for).sublime-snippet
+++ b/Perl/Snippets/Loop-for-(for).sublime-snippet
@@ -5,5 +5,5 @@
 ]]></content>
 	<tabTrigger>for</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Loop</description>
+	<description>for.. Loop</description>
 </snippet>

--- a/Perl/Snippets/Loop-foreach-(fore).sublime-snippet
+++ b/Perl/Snippets/Loop-foreach-(fore).sublime-snippet
@@ -5,5 +5,5 @@
 ]]></content>
 	<tabTrigger>fore</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Loop</description>
+	<description>foreach.. Loop</description>
 </snippet>

--- a/Perl/Snippets/Loop-one-line-(xfor).sublime-snippet
+++ b/Perl/Snippets/Loop-one-line-(xfor).sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[${1:expression} for @${2:array};
+]]></content>
+	<tabTrigger>xfor</tabTrigger>
+	<scope>source.perl</scope>
+	<description>for.. Loop One-line</description>
+</snippet>

--- a/Perl/Snippets/Loop-one-line-(xfore).sublime-snippet
+++ b/Perl/Snippets/Loop-one-line-(xfore).sublime-snippet
@@ -3,5 +3,5 @@
 ]]></content>
 	<tabTrigger>xfore</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Loop One-line</description>
+	<description>foreach.. Loop One-line</description>
 </snippet>

--- a/Perl/Snippets/Loop-one-line-(xuntil).sublime-snippet
+++ b/Perl/Snippets/Loop-one-line-(xuntil).sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[${1:expression} until ${2:condition};
+]]></content>
+	<tabTrigger>xuntil</tabTrigger>
+	<scope>source.perl</scope>
+	<description>until.. Loop One-line</description>
+</snippet>

--- a/Perl/Snippets/Loop-one-line-(xwhile).sublime-snippet
+++ b/Perl/Snippets/Loop-one-line-(xwhile).sublime-snippet
@@ -3,5 +3,5 @@
 ]]></content>
 	<tabTrigger>xwhile</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Loop One-line</description>
+	<description>while.. Loop One-line</description>
 </snippet>

--- a/Perl/Snippets/Loop-while-(while).sublime-snippet
+++ b/Perl/Snippets/Loop-while-(while).sublime-snippet
@@ -5,5 +5,5 @@
 ]]></content>
 	<tabTrigger>while</tabTrigger>
 	<scope>source.perl</scope>
-	<description>Loop</description>
+	<description>while.. Loop</description>
 </snippet>

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1,0 +1,1289 @@
+# SYNTAX TEST "Perl.sublime-syntax"
+
+# comment ; still in here
+# ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.perl
+#         ^ - punctuation
+
+### [ POD TESTS ] ############################################################
+
+=pod
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+=encoding utf8
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^ comment.block.documentation.perl
+#^^^^^^^^ entity.name.tag.pod.perl
+#         ^^^^ markup.heading.perl
+=head1 B<--param>
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^^^^ comment.block.documentation.perl
+#^^^^^ entity.name.tag.pod.perl
+#      ^^^^^^^^^^ markup.heading.perl
+#      ^ entity.name.tag.bold.perl
+#       ^ punctuation.definition.tag.begin.perl
+#        ^^^^^^^ markup.bold.perl
+#               ^ punctuation.definition.tag.end.perl
+   B<bold>
+#  ^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.bold.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^ markup.bold.perl
+#        ^ punctuation.definition.tag.end.perl
+   C<code>
+#  ^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.code.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^ markup.quote.perl
+#        ^ punctuation.definition.tag.end.perl
+   E<lt>
+#  ^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.escaped.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^ constant.character.escape.perl
+#      ^ punctuation.definition.tag.end.perl
+   F<file.ext>
+#  ^^^^^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.filename.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^^^^^ string.unquoted.perl
+#            ^ punctuation.definition.tag.end.perl
+   I<italic>
+#  ^^^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.italic.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^^^ markup.italic.perl
+#          ^ punctuation.definition.tag.end.perl
+
+   L<http://www.perl.org/>
+#  ^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.link.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^^^^^^^^^^^^^^^^^ markup.underline.link.perl
+#                        ^ punctuation.definition.tag.end.perl
+   L<The Perl Home Page|http://www.perl.org/>
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.link.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.perl
+#                                           ^ punctuation.definition.tag.end.perl
+  S<[ B<-A> ]>
+# ^ entity.name.tag.none-braeking.perl
+#  ^ punctuation.definition.tag.begin.perl
+#     ^ entity.name.tag.bold.perl
+#      ^ punctuation.definition.tag.begin.perl
+#       ^^ markup.bold.perl
+#         ^ punctuation.definition.tag.end.perl
+#            ^ punctuation.definition.tag.end.perl
+   X<index entry>
+#  ^^^^^^^^^^^^^^ comment.block.documentation.perl
+#  ^ entity.name.tag.index.perl
+#   ^ punctuation.definition.tag.begin.perl
+#    ^^^^^^^^^^^ entity.name.label.perl
+#               ^ punctuation.definition.tag.end.perl
+    Copyright 2018 E<lt>email@provider.comE<gt>
+#                  ^ entity.name.tag.escaped.perl
+#                                         ^ entity.name.tag.escaped.perl
+
+=begin css
+# <- entity.name.tag.pod.perl
+#^^^^^^ entity.name.tag.pod.perl
+#      ^^^ string.unquoted.perl
+  a {  };
+# ^^^^^^^ comment.block.documentation.perl source.css.embedded.perl source.css
+=end
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+=begin html
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^ comment.block.documentation.perl
+#      ^^^^ string.unquoted.perl
+    <html>
+# <- comment.block.documentation.perl text.html.embedded.perl
+#^^^^^^^^^ comment.block.documentation.perl text.html.embedded.perl
+    </html>
+# <- comment.block.documentation.perl text.html.embedded.perl
+#^^^^^^^^^ comment.block.documentation.perl text.html.embedded.perl
+=end
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+=begin json
+# <- entity.name.tag.pod.perl
+#^^^^^^ entity.name.tag.pod.perl
+#      ^^^ string.unquoted.perl
+  {
+# ^ comment.block.documentation.perl source.json.embedded.perl source.json
+    "key": "value",
+#   ^^^^^^^^^^^^^^^ comment.block.documentation.perl source.json.embedded.perl source.json
+  }
+# ^ comment.block.documentation.perl source.json.embedded.perl source.json
+=end
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+=begin sql
+# <- entity.name.tag.pod.perl
+#^^^^^^ entity.name.tag.pod.perl
+#      ^^^ string.unquoted.perl
+  SELECT * FROM `table`
+# ^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl source.sql.embedded.perl source.sql
+=end
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+=cut
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+### [ FORMAT ] ###############################################################
+
+format name =
+# <- meta.block.format.perl storage.type.format.perl
+#^^^^^^^^^^^^^ meta.block.format.perl
+#^^^^^ storage.type.format.perl
+#      ^^^^ variable.other.perl
+#           ^ keyword.operator.assignment.perl
+  ^#.###
+# ^ punctuation.definition.placeholder.begin.perl
+# ^^^^^^ variable.parameter.special-field.perl
+  @#.###
+# ^ punctuation.definition.placeholder.begin.perl
+# ^^^^^^ variable.parameter.regular-field.perl
+  ^*
+# ^^ variable.parameter.multiline-width.perl
+  @*
+# ^^ variable.parameter.multiline-width.perl
+  @variable
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  ...
+# ^^^ constant.character.escape.perl
+  ~
+# ^ constant.character.escape.perl
+  ~~
+# ^^ constant.character.escape.perl
+.
+# <- punctuation.terminator.format.perl
+
+### [ HEREDOC ] ##############################################################
+
+$var = << CSS;
+#      ^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#         ^^^ string.other.heredoc.perl constant.language.heredoc.css.perl
+#            ^ punctuation.terminator.statement.perl
+  a {  };
+# ^^^^^^^ meta.heredoc.perl source.css.embedded.perl source.css
+CSS
+# <- meta.heredoc.perl constant.language.heredoc.css.perl
+#^^ meta.heredoc.perl constant.language.heredoc.css.perl
+
+$var = <<HTML;
+# <- variable.other.readwrite.global.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^ string.other.heredoc.perl constant.language.heredoc.html.perl
+#            ^ punctuation.terminator.statement.perl
+  <div />
+# <- meta.heredoc.perl text.html.embedded.perl
+#^^^^^^^^^ meta.heredoc.perl text.html.embedded.perl
+HTML
+# <- meta.heredoc.perl constant.language.heredoc.html.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.html.perl
+
+$var = <<'HTML';
+# <- variable.other.readwrite.global.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^^^ string.other.heredoc.perl
+#        ^ punctuation.definition.string.begin.perl
+#         ^^^^ constant.language.heredoc.html.perl
+#             ^ punctuation.definition.string.end.perl
+#              ^ punctuation.terminator.statement.perl
+  <div />
+# <- meta.heredoc.perl text.html.embedded.perl
+#^^^^^^^^^ meta.heredoc.perl text.html.embedded.perl
+HTML
+# <- meta.heredoc.perl constant.language.heredoc.html.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.html.perl
+
+$var = <<"HTML";
+# <- variable.other.readwrite.global.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^^^ string.other.heredoc.perl
+#        ^ punctuation.definition.string.begin.perl
+#         ^^^^ constant.language.heredoc.html.perl
+#             ^ punctuation.definition.string.end.perl
+#              ^ punctuation.terminator.statement.perl
+  <div />
+# <- meta.heredoc.perl text.html.embedded.perl
+#^^^^^^^^^ meta.heredoc.perl text.html.embedded.perl
+HTML
+# <- meta.heredoc.perl constant.language.heredoc.html.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.html.perl
+
+$var ? <<HTML : <<HTML;
+# <- variable.other.readwrite.global.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.logical.perl
+#      ^^^^^^^^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^ string.other.heredoc.perl constant.language.heredoc.html.perl
+#             ^ keyword.operator.logical.perl
+#               ^^ keyword.operator.heredoc.perl
+#                 ^^^^ string.other.heredoc.perl constant.language.heredoc.html.perl
+#                     ^ punctuation.terminator.statement.perl
+  <div />
+# <- meta.heredoc.perl text.html.embedded.perl
+#^^^^^^^^^ meta.heredoc.perl text.html.embedded.perl
+HTML
+# <- meta.heredoc.perl constant.language.heredoc.html.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.html.perl
+  <div />
+# <- meta.heredoc.perl text.html.embedded.perl
+#^^^^^^^^^ meta.heredoc.perl text.html.embedded.perl
+   HTML
+#  ^^^^ meta.heredoc.perl text.html.embedded.perl - constant.language.heredoc.html.perl
+HTML
+# <- meta.heredoc.perl constant.language.heredoc.html.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.html.perl
+HTML
+# <- constant.other.perl
+#^^^ constant.other.perl
+
+$var = <<JAVASCRIPT;
+# <- variable.other.readwrite.global.perl punctuation.definition.variable.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^^^^^^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^^^^^^^ string.other.heredoc.perl constant.language.heredoc.js.perl
+  var basic;
+# <- meta.heredoc.perl source.js.embedded.perl source.js
+# ^^^ meta.heredoc.perl source.js.embedded.perl source.js storage.type.js
+JAVASCRIPT
+# <- meta.heredoc.perl constant.language.heredoc.js.perl
+#^^^^^^^^^ meta.heredoc.perl constant.language.heredoc.js.perl
+
+$var = <<JSON;
+#      ^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^ string.other.heredoc.perl constant.language.heredoc.json.perl
+#            ^ punctuation.terminator.statement.perl
+JSON
+# <- meta.heredoc.perl constant.language.heredoc.json.perl
+#^^^ meta.heredoc.perl constant.language.heredoc.json.perl
+
+$var = <<SQL;
+#      ^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^ string.other.heredoc.perl constant.language.heredoc.sql.perl
+#           ^ punctuation.terminator.statement.perl
+  SELECT * FROM `table`
+# ^^^^^^^^^^^^^^^^^^^^^ meta.heredoc.perl source.sql.embedded.perl
+SQL
+# <- meta.heredoc.perl constant.language.heredoc.sql.perl
+#^^ meta.heredoc.perl constant.language.heredoc.sql.perl
+
+$var = <<XML;
+#      ^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^ string.other.heredoc.perl constant.language.heredoc.xml.perl
+#           ^ punctuation.terminator.statement.perl
+  <t:tag></t:tag>
+# ^^^^^^^^^^^^^^^ meta.heredoc.perl text.xml.embedded.perl
+XML
+# <- meta.heredoc.perl constant.language.heredoc.xml.perl
+#^^ meta.heredoc.perl constant.language.heredoc.xml.perl
+
+$var = <<_EOD_;
+#      ^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#        ^^^^^ constant.language.heredoc.plain.perl
+#             ^ punctuation.terminator.statement.perl
+  foo bar baz
+# <- meta.heredoc.perl string.quoted.other.perl
+#^^^^^^^^^^^^^ meta.heredoc.perl string.quoted.other.perl
+_EOD_
+# <- meta.heredoc.perl constant.language.heredoc.plain.perl
+#^^^^ meta.heredoc.perl constant.language.heredoc.plain.perl
+
+$var = << "    _EOD_";
+#      ^^^^^^^^^^^^^^^ meta.heredoc.perl
+#      ^^ keyword.operator.heredoc.perl
+#         ^ punctuation.definition.string.begin.perl
+#         ^^^^^^^^^^^ string.other.heredoc.perl
+#          ^^^^^^^^^ constant.language.heredoc.plain.perl
+#                   ^ punctuation.definition.string.end.perl
+#                    ^ punctuation.terminator.statement.perl
+  foo bar baz
+# <- meta.heredoc.perl string.quoted.other.perl
+#^^^^^^^^^^^^^ meta.heredoc.perl string.quoted.other.perl
+  _EOD_
+# ^^^^^^ meta.heredoc.perl string.quoted.other.perl
+    _EOD_
+# <- meta.heredoc.perl constant.language.heredoc.plain.perl
+#^^^^^^^^ meta.heredoc.perl constant.language.heredoc.plain.perl
+
+chomp (my $common_end = <<"EOF") =~ s/(.*)/$1/g if $opt_o;
+# <- support.function.perl
+#^^^^ support.function.perl
+#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.heredoc.perl
+#                       ^^ keyword.operator.heredoc.perl
+#                                ^^ keyword.operator.binary.perl
+  foo bar baz
+# <- meta.heredoc.perl string.quoted.other.perl
+# ^^^^^^^^^^^^ meta.heredoc.perl string.quoted.other.perl
+EOF
+# <- meta.heredoc.perl constant.language.heredoc.plain.perl
+#^^ meta.heredoc.perl constant.language.heredoc.plain.perl
+
+$var ? <<'EOT' : <<'EOT';
+  foo bar baz
+# <- meta.heredoc.perl string.quoted.other.perl
+# ^^^^^^^^^^^^ meta.heredoc.perl string.quoted.other.perl
+EOT
+# <- meta.heredoc.perl constant.language.heredoc.plain.perl
+#^^ meta.heredoc.perl constant.language.heredoc.plain.perl
+  foo bar baz
+# <- meta.heredoc.perl string.quoted.other.perl
+# ^^^^^^^^^^^^ meta.heredoc.perl string.quoted.other.perl
+EOT
+# <- meta.heredoc.perl constant.language.heredoc.plain.perl
+#^^ meta.heredoc.perl constant.language.heredoc.plain.perl
+
+# MUST NOT BE HEREDOC
+  (1 << 0) ;
+#    ^^^^^^^ - meta.heredoc.perl
+#    ^^ - keyword.operator.heredoc.perl
+  (1 << $var) ;
+#    ^^^^^^^^^^ - meta.heredoc.perl
+#    ^^ - keyword.operator.heredoc.perl
+
+### [ OPERATORS ]#############################################################
+  ,
+# ^ punctuation.separator.sequence.perl
+  ;
+# ^ punctuation.terminator.statement.perl
+  ::
+# ^^ - punctuation.accessor.double-colon.perl
+  ->
+# ^^ keyword.operator.arrow.perl
+  **=
+# ^^^ keyword.operator.assignment.perl
+  -=
+# ^^ keyword.operator.assignment.perl
+  +=
+# ^^ keyword.operator.assignment.perl
+  *=
+# ^^ keyword.operator.assignment.perl
+  /=
+# ^^ keyword.operator.assignment.perl
+  %=
+# ^^ keyword.operator.assignment.perl
+  --
+# ^^ keyword.operator.arithmetic.perl
+  ++
+# ^^ keyword.operator.arithmetic.perl
+  **
+# ^^ keyword.operator.arithmetic.perl
+  /
+# ^ keyword.operator.arithmetic.perl
+  !~
+# ^^ keyword.operator.binary.perl
+  =~
+# ^^ keyword.operator.binary.perl
+  ~~
+# ^^ keyword.operator.binary.perl
+  <=>
+# ^^^ keyword.operator.logical.perl
+  //
+# ^^ keyword.operator.logical.perl
+  &&
+# ^^ keyword.operator.logical.perl
+  ||
+# ^^ keyword.operator.logical.perl
+  ==
+# ^^ keyword.operator.logical.perl
+  !=
+# ^^ keyword.operator.logical.perl
+  >=
+# ^^ keyword.operator.logical.perl
+  <=
+# ^^ keyword.operator.logical.perl
+  >
+# ^ keyword.operator.logical.perl
+  <
+# ^ keyword.operator.logical.perl
+  !
+# ^ keyword.operator.logical.perl
+  ?
+# ^ keyword.operator.logical.perl
+  :
+# ^ keyword.operator.logical.perl
+  &
+# ^ keyword.operator.bitwise.perl
+  |
+# ^ keyword.operator.bitwise.perl
+  ^
+# ^ keyword.operator.bitwise.perl
+  ~
+# ^ keyword.operator.bitwise.perl
+  .
+# ^ keyword.operator.concat.perl
+  .=
+# ^^ keyword.operator.concat.perl
+  ..
+# ^^ keyword.operator.range.perl
+
+### [ VARIABLES ]#############################################################
+
+  $&
+# ^^ variable.other.regexp.match.perl
+# ^ punctuation.definition.variable.perl
+  $`
+# ^^ variable.other.regexp.pre-match.perl
+# ^ punctuation.definition.variable.perl
+  $'
+# ^^ variable.other.regexp.post-match.perl
+# ^ punctuation.definition.variable.perl
+  $+
+# ^^ variable.other.regexp.last-paren-match.perl
+# ^ punctuation.definition.variable.perl
+  $"
+# ^^ variable.other.readwrite.list-separator.perl
+# ^ punctuation.definition.variable.perl
+  $0
+# ^^ variable.other.predefined.program-name.perl
+# ^ punctuation.definition.variable.perl
+  @0
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  %0
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  $1
+# ^^ variable.other.subpattern.perl
+# ^ punctuation.definition.variable.perl
+  @1
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  %1
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  $_
+# ^^ variable.other.predefined.perl
+# ^ punctuation.definition.variable.perl
+  @_
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  %_
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+  $#0
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  @#0
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  %#0
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  $#_
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  @#_
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  %#_
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+  $Foo::Bar::baz
+# ^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ punctuation.accessor.double-colon.perl
+#            ^^^ variable.other.member.perl
+  $Foo :: Bar :: baz
+# ^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#      ^^ punctuation.accessor.double-colon.perl
+#         ^^^ support.class.perl
+#             ^^ punctuation.accessor.double-colon.perl
+#                ^^^ variable.other.member.perl
+  $Foo::Bar->$baz
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ keyword.operator.arrow.perl - variable
+#            ^^^^ variable.other.readwrite.global.perl
+#            ^ punctuation.definition.variable.perl
+  $Foo :: Bar -> $baz
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#      ^^ punctuation.accessor.double-colon.perl
+#         ^^^ support.class.perl
+#             ^^ keyword.operator.arrow.perl - variable
+#                ^^^^ variable.other.readwrite.global.perl
+#                ^ punctuation.definition.variable.perl
+  $c = C::Scan->new(KEY => 'value')
+# ^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^ support.class.perl
+#       ^^ punctuation.accessor.double-colon.perl
+#         ^^^^ support.class.perl
+#             ^^ keyword.operator.arrow.perl
+#               ^^^ variable.function.perl
+#                  ^ punctuation.section.group.begin.perl
+#                   ^^^ constant.other.perl
+#                       ^^ keyword.operator.assignment.perl
+#                          ^^^^^^^ string.quoted.single.perl
+#                                 ^ punctuation.section.group.end.perl
+  ${Foo::Bar::baz}
+# ^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.begin.perl
+#   ^^^ support.class.perl
+#      ^^ punctuation.accessor.double-colon.perl
+#        ^^^ support.class.perl
+#           ^^ punctuation.accessor.double-colon.perl
+#             ^^^ variable.other.member.perl
+#                ^ punctuation.definition.variable.end.perl
+  ${
+#^ - variable
+# ^^ punctuation.definition.variable.begin.perl
+# ^^^ variable.other.readwrite.global.perl
+    Foo::bar->baz()
+# <- variable.other.readwrite.global.perl
+#^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+#   ^^^ support.class.perl
+#      ^^ punctuation.accessor.double-colon.perl
+#        ^^^ variable.other.member.perl
+#           ^^ keyword.operator.arrow.perl
+#             ^^^ variable.function.perl
+  }
+# <- variable.other.readwrite.global.perl
+#^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.end.perl
+#  ^ - variable
+  $::Config{'cf_email'}
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^ punctuation.accessor.double-colon.perl
+#    ^^^^^^ support.class.perl
+  -f
+# ^^ keyword.operator.filetest.perl
+  -foo
+# ^^ - keyword.operator.filetest.perl
+  $_foo = "bar";
+# ^ punctuation.definition.variable.perl
+# ^^^^^ variable.other.readwrite.global.perl
+#       ^ keyword.operator.assignment.perl
+#         ^ punctuation.definition.string.begin.perl
+#         ^^^^^ string.quoted.double.perl
+#             ^ punctuation.definition.string.end.perl
+#              ^ punctuation.terminator.statement.perl
+  %_foo = "bar";
+# ^ punctuation.definition.variable.perl
+# ^^^^^ variable.other.readwrite.global.perl
+#       ^ keyword.operator.assignment.perl
+#         ^ punctuation.definition.string.begin.perl
+#         ^^^^^ string.quoted.double.perl
+#             ^ punctuation.definition.string.end.perl
+#              ^ punctuation.terminator.statement.perl
+  %{$foo{'bar'}{'bar'}} = 'excl';
+# ^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.begin.perl
+#   ^ punctuation.definition.variable.perl
+#   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#                     ^ punctuation.definition.variable.end.perl
+#                       ^ keyword.operator.assignment.perl
+#                         ^^^^^^ string.quoted.single.perl
+#                               ^ punctuation.terminator.statement.perl
+### [ CONSTANTS ] ############################################################
+
+  1234             # decimal integer
+# ^^^^ constant.numeric.integer.perl
+  -1234            # decimal integer
+# ^^^^^ constant.numeric.integer.perl
+  - 1234           # decimal integer
+# ^ keyword.operator.arithmetic.perl
+#   ^^^^ constant.numeric.integer.perl
+  0b0              # binary integer
+# ^^^ constant.numeric.binary.perl
+  0b1110011        # binary integer
+# ^^^^^^^^^ constant.numeric.binary.perl
+  01234            # octal integer
+# ^^^^^ constant.numeric.integer.perl
+  0x1234           # hexadecimal integer
+# ^^^^^^ constant.numeric.hex.perl
+  0x9              # hexadecimal integer
+# ^^^ constant.numeric.hex.perl
+  12.34e56         # exponential notation
+# ^^^^^^^^ constant.numeric.float.perl
+  -12.34e-56       # exponential notation
+# ^^^^^^^^^^ constant.numeric.float.perl
+  - 12.34e-56      # exponential notation
+# ^ keyword.operator.arithmetic.perl
+#   ^^^^^^^^^ constant.numeric.float.perl
+  12.34e+56        # exponential notation
+# ^^^^^^^^^ constant.numeric.float.perl
+  "-12.34e56"      # number specified as a string
+# ^^^^^^^^^^^ string.quoted.double.perl
+#  ^^^^^^^^^ constant.numeric.float.perl
+  "1234"           # number specified as a string
+# ^^^^^^ string.quoted.double.perl
+#  ^^^^ constant.numeric.integer.perl
+  '0.00_01'
+#  ^^^^^^^ - constant.numeric
+  '01bau'
+#  ^^^^^ - constant.numeric
+  __PACKAGE__
+# ^^^^^^^^^^^ constant.language.perl
+  __FILE__
+# ^^^^^^^^ constant.language.perl
+  __LINE__
+# ^^^^^^^^ constant.language.perl
+  __END__
+# ^^^^^^^ constant.language.perl
+  ARGV
+# ^^^^ constant.language.filehandle.perl
+
+### [ STRINGS ] ##############################################################
+
+  "quoted \"interpolated\" foo 'bar' baz"
+# ^ punctuation.definition.string.begin.perl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.perl
+#         ^^ constant.character.escape.perl
+#                       ^^ constant.character.escape.perl
+#                                       ^ punctuation.definition.string.end.perl
+  'quoted "interpolated" foo \'bar\' baz'
+# ^ punctuation.definition.string.begin.perl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.perl
+#                            ^^ constant.character.escape.perl
+#                                 ^^ constant.character.escape.perl
+#                                       ^ punctuation.definition.string.end.perl
+  `quoted "interpolated" foo \`bar\` baz`
+# ^ punctuation.definition.string.begin.perl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.backtick.perl
+#                            ^^ constant.character.escape.perl
+#                                 ^^ constant.character.escape.perl
+#                                       ^ punctuation.definition.string.end.perl
+  q/quoted "interpolated" foo 'bar' \/ baz/
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl - string
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                   ^^ constant.character.escape.perl
+#                                         ^ punctuation.section.generic.end.perl - string
+  q{quoted "interpolated" {foo} 'bar' \/ baz}
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.braces.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                     ^^ constant.character.escape.perl
+#                                           ^ punctuation.section.braces.end.perl - string
+  q[quoted "interpolated" [foo] 'bar' \] baz]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.brackets.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.brackets.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                     ^^ constant.character.escape.perl
+#                                           ^ punctuation.section.brackets.end.perl - string
+  q<quoted "interpolated" <foo> 'bar' \> baz>
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                     ^^ constant.character.escape.perl
+#                                           ^ punctuation.section.generic.end.perl - string
+  q(quoted "interpolated" [foo] 'bar' \] baz)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.parens.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.parens.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                     ^^ constant.character.escape.perl
+#                                           ^ punctuation.section.parens.end.perl - string
+  q['
+# ^ support.function.perl
+#  ^ punctuation.section.brackets.begin.perl - string
+#   ^^ string
+    string
+#   ^^^^^^^ string
+  ']
+# ^ string
+#  ^ punctuation.section.brackets.end.perl - string
+  q<'
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl - string
+#   ^^ string
+    string
+#   ^^^^^^^ string
+  '>
+# ^ string
+#  ^ punctuation.section.generic.end.perl - string
+
+### [ REGEX ] ################################################################
+
+  /[a-z]test\d{3}/g;
+# ^ punctuation.section.generic.begin.perl - string.regexp - source.regexp
+#  ^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                ^ punctuation.section.generic.end.perl - string.regexp - source.regexp
+#                 ^ constant.language.flags.regexp.perl
+  ( /[a-z]test\d{3}/g );
+#   ^ punctuation.section.generic.begin.perl - string.regexp - source.regexp
+#    ^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                  ^ punctuation.section.generic.end.perl - string.regexp - source.regexp
+#                   ^ constant.language.flags.regexp.perl
+  $@ = /[a-z]test\d{3}/g;
+#      ^ punctuation.section.generic.begin.perl - string.regexp - source.regexp
+#       ^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                     ^ punctuation.section.generic.end.perl - string.regexp - source.regexp
+#                      ^ constant.language.flags.regexp.perl
+  m{^\s*(?:(-?\s*)(\d+(?:\.\d+){0,3})/(\d+))}; # comment
+# ^ support.function.perl - meta.braces
+#  ^ punctuation.section.braces.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.perl
+#                                           ^ punctuation.section.braces.end.perl - string
+#                                            ^ punctuation.terminator.statement.perl
+#                                              ^ comment.line.number-sign.perl punctuation.definition.comment.begin.perl
+  m(^\s*(?:(-?\s*)(\d+(?:\.\d+){0,3})/(\d+))); # comment
+# ^ support.function.perl - meta.parens
+#  ^ punctuation.section.parens.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.parens.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.perl
+#                                           ^ punctuation.section.parens.end.perl - string
+#                                            ^ punctuation.terminator.statement.perl
+#                                              ^ comment.line.number-sign.perl punctuation.definition.comment.begin.perl
+  m[^\s*(?:(-?\s*)(\d+(?:\.\d+){0,3})/(\d+))]; # comment
+# ^ support.function.perl - meta.brackets
+#  ^ punctuation.section.brackets.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.brackets.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.perl
+#                                           ^ punctuation.section.brackets.end.perl - string
+#                                            ^ punctuation.terminator.statement.perl
+#                                              ^ comment.line.number-sign.perl punctuation.definition.comment.begin.perl
+  m<^\s*(?:(-?\s*)(\d+(?:\.\d+){0,3})/(\d+))>; # comment
+# ^ support.function.perl - meta.generic
+#  ^ punctuation.section.generic.begin.perl - string
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.perl
+#                                           ^ punctuation.section.generic.end.perl - string
+#                                            ^ punctuation.terminator.statement.perl
+#                                              ^ comment.line.number-sign.perl punctuation.definition.comment.begin.perl
+  m/^\s*(?:(-?\s*)(\d+(?:\.\d+){0,3})\/(\d+))/g; # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.regexp.perl
+#                                            ^ punctuation.section.generic.end.perl
+#                                             ^ constant.language.flags.regexp.perl
+#                                              ^ punctuation.terminator.statement.perl
+#                                                ^ comment.line.number-sign.perl punctuation.definition.comment.begin.perl
+  s {
+# ^^^^ meta.function-call.perl
+#   ^^ meta.braces.perl
+# ^ support.function.perl
+#   ^ punctuation.section.braces.begin.perl
+    bar[a-z]{1,3} \/ .+
+# <- meta.function-call.perl meta.braces.perl string.regexp.perl
+  } [repl] gx; # comment
+# <- meta.function-call.perl meta.braces.perl string.regexp.perl
+#^^^^^^^^ meta.function-call.perl
+# ^ meta.braces.perl punctuation.section.braces.end.perl
+#   ^^^^^^ meta.brackets.perl
+#   ^ punctuation.section.brackets.begin.perl
+#    ^^^^ string.unquoted.perl
+#        ^ punctuation.section.brackets.end.perl
+#          ^^ constant.language.flags.regexp.perl
+#            ^ punctuation.terminator.statement.perl
+#              ^^^^^^^^^ comment.line.number-sign.perl
+#              ^ punctuation.definition.comment.begin.perl
+  s/foo[a-z]{1,3} \/ .+/ bar $1 \/ /g; # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^^^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                      ^ punctuation.separator.sequence.perl
+#                       ^^^^^^^^^^^ string.unquoted.perl
+#                                  ^ punctuation.section.generic.end.perl
+#                                   ^ constant.language.flags.regexp.perl
+#                                    ^ punctuation.terminator.statement.perl
+#                                      ^^^^^^^^^ comment.line.number-sign.perl
+#                                      ^ punctuation.definition.comment.begin.perl
+  s#foo[a-z]{1,3} \# .+# bar $1 \# #g; # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^^^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                      ^ punctuation.separator.sequence.perl
+#                       ^^^^^^^^^^^ string.unquoted.perl
+#                                  ^ punctuation.section.generic.end.perl
+#                                   ^ constant.language.flags.regexp.perl
+#                                    ^ punctuation.terminator.statement.perl
+#                                      ^^^^^^^^^ comment.line.number-sign.perl
+#                                      ^ punctuation.definition.comment.begin.perl
+  s;foo[a-z]{1,3} \; .+; bar $1 \; ;g; # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^^^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                      ^ punctuation.separator.sequence.perl
+#                       ^^^^^^^^^^^ string.unquoted.perl
+#                                  ^ punctuation.section.generic.end.perl
+#                                   ^ constant.language.flags.regexp.perl
+#                                    ^ punctuation.terminator.statement.perl
+#                                      ^^^^^^^^^ comment.line.number-sign.perl
+#                                      ^ punctuation.definition.comment.begin.perl
+  s!foo[a-z]{1,3} \! .+! bar $1 \! !g; # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^^^^^^^^^^^^^^^^ string.regexp.perl source.regexp
+#                      ^ punctuation.separator.sequence.perl
+#                       ^^^^^^^^^^^ string.unquoted.perl
+#                                  ^ punctuation.section.generic.end.perl
+#                                   ^ constant.language.flags.regexp.perl
+#                                    ^ punctuation.terminator.statement.perl
+#                                      ^^^^^^^^^ comment.line.number-sign.perl
+#                                      ^ punctuation.definition.comment.begin.perl
+  s:\\:/:;
+# ^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^ string.regexp.perl source.regexp constant.character.escape.regexp
+#     ^ punctuation.separator.sequence.perl
+#      ^ string.unquoted.perl
+#       ^ punctuation.section.generic.end.perl
+#        ^ punctuation.terminator.statement.perl
+  s:\\\\:/\\\\:;
+# ^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^ string.regexp.perl source.regexp constant.character.escape.regexp
+#       ^ punctuation.separator.sequence.perl
+#        ^^^^^ string.unquoted.perl
+#             ^ punctuation.section.generic.end.perl
+#              ^ punctuation.terminator.statement.perl
+  s/^\s+//;
+# ^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^^^^ string.regexp.perl source.regexp
+#       ^ punctuation.separator.sequence.perl
+#        ^ punctuation.section.generic.end.perl
+#         ^ punctuation.terminator.statement.perl
+  $opt{s}
+#      ^ - support.function.perl
+  s///msixpodualngcer;
+# ^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl
+#   ^ punctuation.separator.sequence.perl
+#    ^ punctuation.section.generic.end.perl
+#     ^^^^^^^^^^^^^^^ constant.language.flags.regexp.perl
+#                    ^ punctuation.terminator.statement.perl
+  qr:\\:;
+# ^^^^^^ meta.function-call.perl
+# ^^ support.function.perl
+#   ^ punctuation.section.generic.begin.perl
+#    ^^ string.regexp.perl source.regexp constant.character.escape.regexp
+#      ^ punctuation.section.generic.end.perl
+#       ^ punctuation.terminator.statement.perl
+  qr:\\\\:/;
+# ^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#   ^ punctuation.section.generic.begin.perl
+#    ^^^^ string.regexp.perl source.regexp constant.character.escape.regexp
+#        ^ punctuation.section.generic.end.perl
+#         ^ keyword.operator.arithmetic.perl
+#          ^ punctuation.terminator.statement.perl
+  qr/^\s+/;
+# ^^^^^^^^ meta.function-call.perl
+# ^^ support.function.perl
+#   ^ punctuation.section.generic.begin.perl
+#    ^^^^ string.regexp.perl source.regexp
+#        ^ punctuation.section.generic.end.perl
+#         ^ punctuation.terminator.statement.perl
+
+### [ DECLARATIONS ]##########################################################
+
+my
+# <- keyword.declaration.variable
+#^ keyword.declaration.variable
+  my $foo
+#^ - storage
+# ^^ keyword.declaration.variable
+#   ^ - keyword.declaration.variable - variable.other.readwrite
+#    ^ punctuation.definition.variable.perl
+#    ^^^^ variable.other.readwrite
+#        ^ - variable.other.readwrite
+my $foo;
+# <-  keyword.declaration.variable.perl
+#^ keyword.declaration.variable.perl
+#  ^ punctuation.definition.variable.perl
+#  ^^^^ variable.other.readwrite.global.perl
+#      ^ punctuation.terminator.statement.perl
+my $foo = "bar";
+# <-  keyword.declaration.variable.perl
+#^ keyword.declaration.variable.perl
+#  ^ punctuation.definition.variable.perl
+#  ^^^^ variable.other.readwrite.global.perl
+#       ^ keyword.operator.assignment.perl
+#         ^ punctuation.definition.string.begin.perl
+#         ^^^^^ string.quoted.double.perl
+#             ^ punctuation.definition.string.end.perl
+#              ^ punctuation.terminator.statement.perl
+my (
+# <- keyword.declaration.variable.perl
+#^ keyword.declaration.variable.perl
+  $foo, $bar,
+# ^ punctuation.definition.variable.perl
+# ^^^^ variable.other.readwrite.global.perl
+#     ^ punctuation.separator.sequence.perl
+#       ^ punctuation.definition.variable.perl
+#       ^^^^ variable.other.readwrite.global.perl
+  $baz
+# ^ punctuation.definition.variable.perl
+# ^^^^ variable.other.readwrite.global.perl
+  );
+# ^ punctuation.section.group.end.perl
+#  ^ punctuation.terminator.statement.perl
+  eval { my $foo = /pattern/; }
+# ^^^^ support.function.perl
+#      ^ punctuation.section.block.begin.perl
+#        ^^ keyword.declaration.variable.perl
+#           ^^^^ variable.other.readwrite.global.perl
+#                ^ keyword.operator.assignment.perl
+#                  ^ punctuation.section.generic.begin.perl
+#                   ^^^^^^^ string.regexp.perl source.regexp meta.literal.regexp
+#                          ^ punctuation.section.generic.end.perl
+#                           ^ punctuation.terminator.statement.perl
+#                             ^ punctuation.section.block.end.perl
+  my::foo::bar
+# ^^ - keyword.declaration.variable.perl
+our
+# <-  keyword.declaration.variable
+#^^ keyword.declaration.variable
+  our $foo
+# <-
+#^ - storage
+# ^^^ keyword.declaration.variable
+#    ^ - keyword.declaration.variable - variable.other.readwrite
+#     ^ punctuation.definition.variable.perl
+#     ^^^^ variable.other.readwrite
+#         ^ - variable.other.readwrite
+our $foo;
+# <-  keyword.declaration.variable.perl
+#^^ keyword.declaration.variable.perl
+#   ^ punctuation.definition.variable.perl
+#   ^^^^ variable.other.readwrite.global.perl
+#       ^ punctuation.terminator.statement.perl
+our $foo = "bar";
+# <-  keyword.declaration.variable.perl
+#^^ keyword.declaration.variable.perl
+#   ^ punctuation.definition.variable.perl
+#   ^^^^ variable.other.readwrite.global.perl
+#        ^ keyword.operator.assignment.perl
+#          ^ punctuation.definition.string.begin.perl
+#          ^^^^^ string.quoted.double.perl
+#              ^ punctuation.definition.string.end.perl
+#               ^ punctuation.terminator.statement.perl
+our (
+# <- keyword.declaration.variable.perl
+#^^ keyword.declaration.variable.perl
+  $foo, $bar,
+# ^ punctuation.definition.variable.perl
+# ^^^^ variable.other.readwrite.global.perl
+#     ^ punctuation.separator.sequence.perl
+#       ^ punctuation.definition.variable.perl
+#       ^^^^ variable.other.readwrite.global.perl
+  $baz
+# ^ punctuation.definition.variable.perl
+# ^^^^ variable.other.readwrite.global.perl
+  );
+# ^ punctuation.section.group.end.perl
+#  ^ punctuation.terminator.statement.perl
+our $VERSION = do {
+# <- keyword.declaration.variable.perl
+#^^ keyword.declaration.variable.perl
+#   ^^^^^^^^ variable.other.readwrite.global.perl
+#            ^ keyword.operator.assignment.perl
+#              ^^ keyword.control.flow.perl
+#                 ^ punctuation.section.block.begin.perl
+  my @r = (q$Revision: 2.20 $ =~ /\d+/g);
+# ^^ keyword.declaration.variable.perl
+#    ^^ variable.other.readwrite.global.perl
+#       ^ keyword.operator.assignment.perl
+#         ^ punctuation.section.group.begin.perl
+#          ^ meta.function-call.perl support.function.perl
+#           ^^^^^^^^^^^^^^^^^ meta.function-call.perl meta.generic.perl
+#           ^ punctuation.section.generic.begin.perl
+#            ^^^^^^^^^^^^^^^ string.unquoted.perl
+#                      ^^^^ - constant.numeric
+#                           ^ punctuation.section.generic.end.perl
+#                             ^^ keyword.operator.binary.perl
+#                                ^ punctuation.section.generic.begin.perl
+#                                 ^^^ string.regexp.perl source.regexp
+#                                    ^ punctuation.section.generic.end.perl
+#                                     ^ constant.language.flags.regexp.perl
+  sprintf "%d."."%02d" x $#r, @r
+# ^^^^^^^ support.function.perl
+};
+# <- punctuation.section.block.end.perl
+state
+# <- keyword.declaration.variable
+#^^^^ keyword.declaration.variable
+  state $foo
+# <-
+#^ - storage
+# ^^^^^ keyword.declaration.variable
+#      ^ - keyword.declaration.variable - variable.other.readwrite
+#       ^ punctuation.definition.variable.perl
+#       ^^^^ variable.other.readwrite
+#           ^ - variable.other.readwrite
+require
+# <- meta.import.require.perl keyword.control.import.require.perl
+#^^^^^^ meta.import.require.perl keyword.control.import.require.perl
+require "v5.1.0";
+# <- meta.import.require.perl keyword.control.import.require.perl
+#^^^^^^^^^^^^^^^ meta.import.require.perl
+#^^^^^^ keyword.control.import.require.perl
+#       ^^^^^^^^ string.quoted.double.perl - constant.numeric
+#               ^ punctuation.terminator.statement.perl
+eval { require Mail::Send; };
+#<- support.function.perl
+#^^^ support.function.perl
+#    ^ punctuation.section.block.begin.perl
+#      ^^^^^^^^^^^^^^^^^^ meta.import.require.perl
+#                        ^^^^ - meta.import.require.perl
+#      ^^^^^^^ keyword.control.import.require.perl
+use strict;
+# <- meta.use.perl keyword.control.import.use.perl
+#^^^^^^^^^ meta.use.perl
+#^^ keyword.control.import.use.perl
+#   ^^^^^^ storage.modifier.perl
+#         ^ punctuation.terminator.statement.perl
+use strict "vars";
+# <- meta.use.perl keyword.control.import.use.perl
+#^^^^^^^^^^^^^^^^ meta.use.perl
+#^^ keyword.control.import.use.perl
+#   ^^^^^^ storage.modifier.perl
+#          ^ punctuation.definition.string.begin.perl
+#          ^^^^^^ string.quoted.double.perl
+#               ^ punctuation.definition.string.end.perl
+#                ^ punctuation.terminator.statement.perl
+  use attributes __PACKAGE__, \&foo, 'method';
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.use.perl
+# ^^^ keyword.control.import.use.perl
+#     ^^^^^^^^^^ storage.modifier.perl
+#                ^^^^^^^^^^^ constant.language.perl
+#                           ^ punctuation.separator.sequence.perl
+use File;
+# <- meta.use.perl keyword.control.import.use.perl
+#^^^^^^^ meta.use.perl
+#^^ keyword.control.import.use.perl
+#   ^^^^ support.class.perl
+#       ^ punctuation.terminator.statement.perl
+
+use File::data;
+# <- meta.use.perl keyword.control.import.use.perl
+#^^^^^^^^^^^^^ meta.use.perl
+#^^ keyword.control.import.use.perl
+#   ^^^^ support.class.perl
+#       ^^ punctuation.accessor.double-colon.perl
+#         ^^^^ variable.other.member.perl
+#             ^ punctuation.terminator.statement.perl
+no strict;
+# <- meta.no.perl keyword.declaration.no.perl
+#^^^^^^^^ meta.no.perl
+#^ keyword.declaration.no.perl
+#  ^^^^^^ storage.modifier.perl
+#        ^ punctuation.terminator.statement.perl
+
+### [ SUB ]###################################################################
+
+sub
+# <- meta.function.perl keyword.control.sub.perl
+#^^ meta.function.perl keyword.control.sub.perl
+#  ^ - invalid
+sub name
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#       ^ - invalid
+sub name invalid
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^^^^^^^ invalid.illegal.function-name.perl
+sub name;
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#       ^ punctuation.terminator.statement.perl
+sub name invalid;
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^^^^^^^ invalid.illegal.function-name.perl
+#               ^ punctuation.terminator.statement.perl
+sub {
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^ punctuation.section.block.begin.perl
+  say "Hello";
+# <- meta.function.perl
+#^^^^^^^^^^^^^^ meta.function.perl
+# ^^^ support.function.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub
+{
+# <- meta.function.perl punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name {
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^ punctuation.section.block.begin.perl
+  say "Hello";
+# <- meta.function.perl
+#^^^^^^^^^^^^^^ meta.function.perl
+# ^^^ support.function.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+
+sub name
+{
+# <- meta.function.perl punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name invalid {
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^^^^^^^ invalid.illegal.function-name.perl
+#                ^ punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name invalid
+{
+# <- meta.function.perl punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+
+sub name ($arg, $arg) {
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^ meta.function.perl - meta.function.parameters.perl
+#        ^^^^^^^^^^^^ meta.function.parameters.perl - meta.function.perl
+#                    ^^ meta.function.perl - meta.function.parameters.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^ punctuation.section.group.begin.perl
+#         ^^^^ variable.parameter.perl
+#             ^ punctuation.separator.sequence.perl
+#               ^^^^ variable.parameter.perl
+#                   ^ punctuation.section.group.end.perl
+#                     ^ punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name ($arg, $arg)
+{
+# <- meta.function.perl punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+
+sub name invalid ($arg, $arg) {
+# <- meta.function.perl keyword.control.sub.perl
+#^^^^^^^^^^^^^^^^ meta.function.perl - meta.function.parameters.perl
+#                ^^^^^^^^^^^^ meta.function.parameters.perl - meta.function.perl
+#                            ^^ meta.function.perl - meta.function.parameters.perl
+#^^ keyword.control.sub.perl
+#   ^^^^ entity.name.function.perl
+#        ^^^^^^^ invalid.illegal.function-name.perl
+#                ^ punctuation.section.group.begin.perl
+#                 ^^^^ variable.parameter.perl
+#                     ^ punctuation.separator.sequence.perl
+#                       ^^^^ variable.parameter.perl
+#                           ^ punctuation.section.group.end.perl
+#                             ^ punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name invalid ($arg, $arg)
+{
+# <- meta.function.perl punctuation.section.block.begin.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+$var = sub {
+# <- variable.other.readwrite.global.perl punctuation.definition.variable.perl
+#^^^ variable.other.readwrite.global.perl
+#    ^ keyword.operator.assignment.perl
+#      ^^^^^^^ meta.function.perl
+#      ^^^ keyword.control.sub.perl
+  say "hello";
+# <- meta.function.perl
+# ^^^ meta.function.perl support.function.perl
+}
+# <- meta.function.perl punctuation.section.block.end.perl
+sub name ($) {}
+#        ^ punctuation.section.group.begin.perl - variable.parameter.perl
+#        ^^^ meta.function.parameters.perl
+#         ^ variable.parameter.perl
+#          ^ punctuation.section.group.end.perl - variable.parameter.perl
+
+### [ EXPRESSIONS ]###########################################################
+
+  retry:
+# ^^^^^ entity.name.label.perl
+#      ^ punctuation.separator.perl
+  retry:die "bye!";
+# ^^^^^ entity.name.label.perl
+#      ^ punctuation.separator.perl
+#       ^^^ keyword.other.flow.perl
+#           ^^^^^^ string.quoted.double.perl
+#                 ^ punctuation.terminator.statement.perl
+  retry::
+# ^^^^^^^ - entity.name.label.perl
+  if(exists($curargs{$index}))
+# ^^ keyword.control.conditional.perl
+#   ^ punctuation.section.group.begin.perl
+#          ^ punctuation.section.group.begin.perl
+#                            ^ punctuation.section.group.end.perl
+  function_call /pattern/g;
+# ^^^^^^^^^^^^^ variable.function.perl
+#               ^ punctuation.section.generic.begin.perl
+#                ^^^^^^^ string.regexp.perl source.regexp
+#                       ^ punctuation.section.generic.end.perl
+#                        ^ constant.language.flags.regexp.perl
+#                         ^ punctuation.terminator.statement.perl
+  _function_call $var;
+# ^^^^^^^^^^^^^^ variable.function.perl
+#                ^^^^ variable.other.readwrite.global.perl
+#                    ^ punctuation.terminator.statement.perl


### PR DESCRIPTION
Fixes #541, #1029, #1325, #1326, #1495

Supersedes #1556

According to #481 this PR provides an Oniguruma free Perl syntax definition written from scratch.

### OUTLINE

  1. fixes all currently open issues
  2. much more feature complete
  3. completely compatible with new regex engine
  4. uses embed to include custom syntaxes within POD and HEREDOCS (CSS,JS,JSON,HTML,SQL,XML)
  5. provides a syntax test file
  6. uses as much atomic rules from Perl.sublime-syntax and
     ModernPerl package as possible (with some fixes/modifications)
  7. follows the doc http://perldoc.perl.org as close as possible
  8. add some snippets with some files renamed to match naming style

### REMARKS

1. The benchmark tests on a 100k file with all kinds of statements output about 360ms for evaluation on a Windows box.

2. The main focus is to create a robust base for syntax highlighting rather than scoping each language entity/construct in detail.

   a) Not all meta scoping RFCs are implemented in detail due to some limitations caused by HEREDOC. Especially pushing in/out of `meta.block` or `meta.braces` breaks some HEREDOC constructs.

   b) Scope names were changed to follow the scope naming guidelines as close as possible and try to use as general names as possible.
    -> Maybe needs some refines?

3. At the current point the implementation is a work in progress and needs testing by perl power users to

   a) check for highlighting to work in all situations

   b) constants/variables/functions are scoped correctly

4. This commit adds some snippets but does not include any completions in favor of https://packagecontrol.io/packages/Perl%20Completions

