### PR TITLE
[HTML] Fix DOCTYPE and improve CDATA highlighting

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -41,6 +41,8 @@ variables:
       | text/livescript
     )
 
+  tag_name: '[[:alpha:]_][[:alnum:]:_.-]*'
+
 contexts:
   immediately-pop:
     - match: ''
@@ -52,6 +54,7 @@ contexts:
 
   main:
     - include: comment
+    - include: doctype
     - match: (<\?)(xml)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -71,14 +74,6 @@ contexts:
         - match: ">"
           scope: punctuation.definition.tag.html
           pop: true
-        - match: (?i:DOCTYPE)
-          scope: entity.name.tag.doctype.html
-          push:
-            - meta_scope: meta.tag.sgml.doctype.html
-            - match: (?=>)
-              pop: true
-            - match: '"[^">]*"'
-              scope: string.quoted.double.doctype.identifiers-and-DTDs.html
         - match: '\[CDATA\['
           push:
             - meta_scope: constant.other.inline-data.html
@@ -243,6 +238,48 @@ contexts:
           pop: true
         - match: '<!--(?!-?>)|--!>'
           scope: invalid.illegal.bad-comments-or-CDATA.html
+
+  doctype:
+    - match: (<!)(DOCTYPE)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: keyword.declaration.doctype.html
+      push:
+        - doctype-meta
+        - doctype-content
+        - doctype-content-type
+        - doctype-name
+
+  doctype-meta:
+    - meta_scope: meta.tag.sgml.doctype.html
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  doctype-name:
+    - match: '{{tag_name}}'
+      scope: variable.other.doctype.html
+      pop: true
+    - include: else-pop
+
+  doctype-content-type:
+    - match: (?:PUBLIC|SYSTEM)\b
+      scope: keyword.content.external.html
+      pop: true
+    - include: else-pop
+
+  doctype-content:
+    - match: \[
+      scope: punctuation.section.brackets.begin.html
+      set:
+        - meta_scope: meta.brackets.html meta.internal-subset.xml.html
+        - match: \]
+          scope: punctuation.section.brackets.end.html
+          pop: true
+        - include: comment
+    - include: string-double-quoted
+    - include: string-single-quoted
+    - include: else-pop
 
   style-css:
     - meta_content_scope: meta.tag.style.begin.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -261,7 +261,7 @@ contexts:
 
   doctype-name:
     - match: '{{tag_name}}'
-      scope: variable.other.doctype.html
+      scope: constant.language.doctype.html
       pop: true
     - include: else-pop
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -41,7 +41,8 @@ variables:
       | text/livescript
     )
 
-  tag_name: '[[:alpha:]_][[:alnum:]:_.-]*'
+  # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
+  tag_name: '[[:alpha:]_][^/>\s]*'
 
 contexts:
   immediately-pop:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -17,6 +17,9 @@ variables:
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
 
+  # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
+  tag_name: '[[:alpha:]_][^/>\s]*'
+
   block_tag_name: |-
     (?ix)(?:
       address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
@@ -40,9 +43,6 @@ variables:
       | text/jscript
       | text/livescript
     )
-
-  # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
-  tag_name: '[[:alpha:]_][^/>\s]*'
 
 contexts:
   immediately-pop:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -54,6 +54,7 @@ contexts:
 
   main:
     - include: comment
+    - include: cdata
     - include: doctype
     - match: (<\?)(xml)
       captures:
@@ -67,20 +68,6 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: <!
-      scope: punctuation.definition.tag.html
-      push:
-        - meta_scope: meta.tag.sgml.html
-        - match: ">"
-          scope: punctuation.definition.tag.html
-          pop: true
-        - match: '\[CDATA\['
-          push:
-            - meta_scope: constant.other.inline-data.html
-            - match: ']](?=>)'
-              pop: true
-        - match: (\s*)(?!--|>)\S(\s*)
-          scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: (</?)([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -223,6 +210,21 @@ contexts:
       captures:
         1: punctuation.definition.entity.html
         3: punctuation.definition.entity.html
+
+  cdata:
+    - match: (<!\[)(CDATA)(\[)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: keyword.declaration.cdata.html
+        3: punctuation.definition.tag.begin.html
+      push:
+        - meta_scope: meta.tag.sgml.cdata.html
+        - meta_content_scope: string.unquoted.cdata.html
+        - match: ']]>'
+          scope: punctuation.definition.tag.end.html
+          pop: true
+    - match: ']]>'
+      scope: invalid.illegal.missing-entity.html
 
   comment:
     - match: (<!--)(-?>)?

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -51,6 +51,7 @@ contexts:
       pop: true
 
   main:
+    - include: comment
     - match: (<\?)(xml)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -63,19 +64,6 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: (<!--)(-?>)?
-      captures:
-        1: punctuation.definition.comment.begin.html
-        2: invalid.illegal.bad-comments-or-CDATA.html
-      push:
-        - meta_scope: comment.block.html
-        - match: '(<!-)?(--\s*>)'
-          captures:
-            1: invalid.illegal.bad-comments-or-CDATA.html
-            2: punctuation.definition.comment.end.html
-          pop: true
-        - match: '<!--(?!-?>)|--!>'
-          scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html
       push:
@@ -240,6 +228,21 @@ contexts:
       captures:
         1: punctuation.definition.entity.html
         3: punctuation.definition.entity.html
+
+  comment:
+    - match: (<!--)(-?>)?
+      captures:
+        1: punctuation.definition.comment.begin.html
+        2: invalid.illegal.bad-comments-or-CDATA.html
+      push:
+        - meta_scope: comment.block.html
+        - match: '(<!-)?(--\s*>)'
+          captures:
+            1: invalid.illegal.bad-comments-or-CDATA.html
+            2: punctuation.definition.comment.end.html
+          pop: true
+        - match: '<!--(?!-?>)|--!>'
+          scope: invalid.illegal.bad-comments-or-CDATA.html
 
   style-css:
     - meta_content_scope: meta.tag.style.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -3,7 +3,21 @@
 ## <- meta.tag.preprocessor punctuation.definition.tag.begin
 ##^^^entity.name.tag.xml
 ##                                   ^ punctuation.definition.tag.end
-<!DOCTYPE html>
+<!DOCTYPE html SYSTEM "html5.dtd" [ <!-- comment -->
+## <- meta.tag.sgml.doctype punctuation.definition.tag.begin
+##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype
+##^^^^^^^ keyword.declaration.doctype
+##        ^^^^ variable.other.doctype
+##             ^^^^^^ keyword.content.external
+##                    ^^^^^^^^^^^ string.quoted.double
+##                                ^ meta.brackets meta.internal-subset punctuation.section.brackets.begin
+##                                  ^^^^^^^^^^^^^^^^ comment.block
+##                                  ^^^^ punctuation.definition.comment.begin
+##                                               ^^^ punctuation.definition.comment.end
+    <!ENTITY name "&#160;">;
+##  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype meta.brackets meta.internal-subset
+]>
+## <- meta.tag.sgml.doctype meta.brackets meta.internal-subset punctuation.section.brackets.end
 <html>
     <head>
         <title>Test HTML</title>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -115,6 +115,36 @@
         ## ^ meta.tag.script entity.name.tag.script
     </head>
     <body>
+
+     <![CDATA[<!DOCTYPE catalog plist "dtd">]]>
+##   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata
+##   ^^^ punctuation.definition.tag.begin
+##      ^^^^^ keyword.declaration.cdata
+##           ^ punctuation.definition.tag.begin
+##            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##                                          ^ - string.unquoted.cdata
+##                                          ^^^ punctuation.definition.tag.end
+     <![CDATA[
+##   ^^^^^^^^^^ meta.tag.sgml.cdata
+##   ^^^ punctuation.definition.tag.begin
+##      ^^^^^ keyword.declaration.cdata
+##           ^ punctuation.definition.tag.begin
+        <!DOCTYPE catalog plist "dtd">
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+    ]]>
+##  ^ - string.unquoted.cdata
+##  ^^^ punctuation.definition.tag.end
+
+     <![CDATA[
+        <![CDATA[ unparsed! ]]>
+##      ^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##      ^^^ - punctuation.definition.tag.begin
+##         ^^^^^ - keyword.declaration.cdata
+##              ^ - punctuation.definition.tag.begin
+##                          ^^^ punctuation.definition.tag.end
+    ]]>
+##  ^^^ invalid.illegal.missing-entity
+
         <!-- Comment -->
 ##      ^^^^^^^^^^^^^^^^ comment.block.html
 ##      ^^^^ punctuation.definition.comment.begin.html
@@ -238,7 +268,7 @@ class="foo"></div>
         ##                     ^ punctuation.definition.string.end.html - source.css
         ##          ^^^^^ meta.property-name.css support.type.property-name.css
         ##                 ^^^ meta.property-value.css constant.numeric.css
-        
+
         <div style='width: 100%;'></div>
         ##  ^ - meta.attribute-with-value.style
         ##   ^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style
@@ -294,7 +324,7 @@ class="foo"></div>
         ##                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
         ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        
+
         <test-custom-tag/>
         ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
         ##              ^^ punctuation.definition.tag.end.html
@@ -377,7 +407,7 @@ class="foo"></div>
         <a href="http://google.com/?one=1&two=2"></a>
         ##                               ^ - constant.character.entity
         ##                               ^ - invalid.illegal
-        
+
         <hr/><hr />
         ## ^^ meta.tag.block.any punctuation.definition.tag.end
         ##    ^^ entity.name.tag.block.any

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -7,7 +7,7 @@
 ## <- meta.tag.sgml.doctype punctuation.definition.tag.begin
 ##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype
 ##^^^^^^^ keyword.declaration.doctype
-##        ^^^^ variable.other.doctype
+##        ^^^^ constant.language.doctype
 ##             ^^^^^^ keyword.content.external
 ##                    ^^^^^^^^^^^ string.quoted.double
 ##                                ^ meta.brackets meta.internal-subset punctuation.section.brackets.begin

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1827,7 +1827,7 @@ okay
 http://spec.commonmark.org/0.28/#example-148
 
 <!DOCTYPE html>
-| ^^^^^^^ meta.disable-markdown meta.tag.sgml.html meta.tag.sgml.doctype.html entity.name.tag.doctype.html
+| ^^^^^^^ meta.disable-markdown meta.tag.sgml.doctype.html keyword.declaration.doctype.html
 okay
 | <- - meta.disable-markdown
 

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1834,7 +1834,7 @@ okay
 http://spec.commonmark.org/0.28/#example-149
 
 <![CDATA[
-| ^^^^^^^^ meta.disable-markdown meta.tag.sgml.html constant.other.inline-data.html
+| ^^^^^^^^ meta.disable-markdown meta.tag.sgml.cdata.html
 function matchwo(a,b)
 {
   if (a < b && a < 0) then {
@@ -1846,7 +1846,7 @@ function matchwo(a,b)
   }
 }
 ]]>
-|^ meta.disable-markdown meta.tag.sgml.html constant.other.inline-data.html
+|^ meta.disable-markdown meta.tag.sgml.cdata.html
 okay
 | <- - meta.disable-markdown
 


### PR DESCRIPTION
This commit introduces/proposes the following changes:

1. A fix for issue #1565 which is caused by not handling all the DOCTYPE internal syntax elements.
2. Highlight the CDATA tag as self closing xml/html tag.
3. Don't handle unknown `<! ... >` tags leaving them to special purpose syntaxes, which include this general purpose html syntax.

Point 2. and 3. are not directly related to #1565 but were part of handling opening/closing brackets within special tags. CDATA was the only remaining one within the `<!` context, which somehow made no sense but putting it into another PR would have caused conflicts.

For details about the changes please refer to the commit messages as this PR is split for better readability.