### PR TITLE
 [HTML] More precise html-end-tag scoping

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -623,6 +623,6 @@ contexts:
       pop: true
 
   tag-end-maybe-self-closing:
-    - match: '(?: ?/)?>'
+    - match: '/?>'
       scope: punctuation.definition.tag.end.html
       pop: true

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -104,9 +104,7 @@ contexts:
         2: entity.name.tag.custom.html
       push:
         - meta_scope: meta.tag.custom.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (<)((?i:style))\b
       captures:
@@ -126,9 +124,7 @@ contexts:
         2: entity.name.tag.structure.any.html
       push:
         - meta_scope: meta.tag.structure.any.html
-        - match: '>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end
         - include: tag-attributes
     - match: (</?)({{block_tag_name}})
       captures:
@@ -136,9 +132,7 @@ contexts:
         2: entity.name.tag.block.any.html
       push:
         - meta_scope: meta.tag.block.any.html
-        - match: '>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end
         - include: tag-attributes
     - match: (</?)((?i:hr)\b)
       captures:
@@ -146,9 +140,7 @@ contexts:
         2: entity.name.tag.block.any.html
       push:
         - meta_scope: meta.tag.block.any.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)((?i:form|fieldset)\b)
       captures:
@@ -156,9 +148,7 @@ contexts:
         2: entity.name.tag.block.form.html
       push:
         - meta_scope: meta.tag.block.form.html
-        - match: '>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end
         - include: tag-attributes
     - match: (</?)({{inline_tag_name}})
       captures:
@@ -166,9 +156,7 @@ contexts:
         2: entity.name.tag.inline.any.html
       push:
         - meta_scope: meta.tag.inline.any.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)({{form_tag_name}})
       captures:
@@ -176,9 +164,7 @@ contexts:
         2: entity.name.tag.inline.form.html
       push:
         - meta_scope: meta.tag.inline.form.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)((?i:a)\b)
       captures:
@@ -186,9 +172,7 @@ contexts:
         2: entity.name.tag.inline.a.html
       push:
         - meta_scope: meta.tag.inline.a.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr)\b)
       captures:
@@ -196,9 +180,7 @@ contexts:
         2: entity.name.tag.inline.table.html
       push:
         - meta_scope: meta.tag.inline.table.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)([A-Za-z0-9:_]+-[A-Za-z0-9:_-]+)
       captures:
@@ -206,9 +188,7 @@ contexts:
         2: invalid.illegal.uppercase-custom-tag-name.html
       push:
         - meta_scope: meta.tag.custom.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)([a-zA-Z0-9:]+)
       captures:
@@ -216,9 +196,7 @@ contexts:
         2: entity.name.tag.other.html
       push:
         - meta_scope: meta.tag.other.html
-        - match: '(?: ?/)?>'
-          scope: punctuation.definition.tag.end.html
-          pop: true
+        - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - include: entities
     - match: <>
@@ -273,9 +251,7 @@ contexts:
   style-common:
     - include: style-type-attribute
     - include: tag-attributes
-    - match: '/>'
-      scope: punctuation.definition.tag.end.html
-      pop: true
+    - include: tag-end-self-closing
 
   style-type-attribute:
     - match: (?i)\btype\b
@@ -353,9 +329,7 @@ contexts:
   script-common:
     - include: script-type-attribute
     - include: tag-attributes
-    - match: '/>'
-      scope: punctuation.definition.tag.end.html
-      pop: true
+    - include: tag-end-self-closing
 
   script-type-attribute:
     - match: (?i)\btype\b
@@ -637,3 +611,18 @@ contexts:
     - include: tag-style-attribute
     - include: tag-event-attribute
     - include: tag-generic-attribute
+
+  tag-end:
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  tag-end-self-closing:
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  tag-end-maybe-self-closing:
+    - match: '(?: ?/)?>'
+      scope: punctuation.definition.tag.end.html
+      pop: true

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -272,6 +272,7 @@ class="foo"></div>
         ## ^^^^^ entity.name.tag.block.any.html
         ##        ^^^^ entity.name.tag.inline.any.html
         ##              ^^^^^^^^ entity.name.tag.other.html
+        ##                                           ^ - punctuation.definition.tag.end.html
         ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
 
         <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
@@ -284,6 +285,7 @@ class="foo"></div>
         <test-custom-tag/>
         ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
         ##              ^^ punctuation.definition.tag.end.html
+        ##                ^ - meta.tag.custom.html - punctuation.definition.tag.end.html
 
         <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
         ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html


### PR DESCRIPTION
Whitespace is no punctuation and should therefore not scoped as such.

This commit changes the `tag-end-maybe-self-closing` to no longer include the preceding space into the `punctuation.tag.end.html`.

The reason for it to be included here is not obvious anyway as none, one or any number of spaces would cause the `/?>` to be detected as `end of tag` anyway.

_Note:_ In order to reduce duplication and increase code reuse dedicated contexts for the 3 different tag-end punctuation rules were created before fixing the issue.