### PR TITLE
[JavaScript] Remove meta.prototype scopes.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -777,8 +777,6 @@ contexts:
   expression-begin:
     - include: expression-break
 
-    - include: literal-prototype
-
     - include: regexp-complete
     - include: literal-string
     - include: tagged-template
@@ -1207,42 +1205,6 @@ contexts:
       scope: constant.language.nan.js
       pop: true
 
-  literal-prototype:
-    - match: |-
-        (?x)
-          ({{identifier}})
-          \s*(\.)\s*
-          (prototype)
-          (?=\s*=\s*{{either_func_lookahead}})
-      scope: meta.prototype.declaration.js
-      captures:
-        1: support.class.js
-        2: punctuation.accessor.js
-        3: support.constant.prototype.js
-      set:
-        - function-initializer
-    - match: |-
-        (?x)
-          ({{identifier}})
-          \s*(\.)\s*
-          (prototype)\s*(\.)\s*
-          (?={{identifier}}\s*=\s*{{either_func_lookahead}})
-      captures:
-        1: support.class.js
-        2: punctuation.accessor.js
-        3: support.constant.prototype.js
-        4: punctuation.accessor.js
-      set:
-        - function-initializer
-        - function-declaration-single-identifier
-    - match: '({{identifier}})(\.)(prototype){{identifier_break}}'
-      scope: meta.prototype.access.js
-      captures:
-        1: support.class.js
-        2: punctuation.accessor.js
-        3: support.constant.prototype.js
-      pop: true
-
   function-assignment:
     - match: |-
         (?x)(?=
@@ -1260,6 +1222,9 @@ contexts:
       push:
         - expect-dot-accessor
         - function-declaration-identifiers-expect-class
+    - match: 'prototype{{identifier_break}}'
+      scope: support.constant.prototype.js
+      pop: true
     - include: function-declaration-single-identifier
 
   expect-dot-accessor:
@@ -1922,7 +1887,7 @@ contexts:
       scope: variable.language.constructor.js
       pop: true
     - match: prototype{{identifier_break}}
-      scope: variable.language.prototype.js
+      scope: support.constant.prototype.js
       pop: true
     - match: '{{dollar_only_identifier}}'
       scope: meta.property.object.dollar.only.js punctuation.dollar.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1053,14 +1053,12 @@ Proto.prototype.getVar = () => this._var;
 //                           ^ storage.type.function.arrow
 
 Class3.prototype = function() {
-// ^^^^^^^^^^^^^ meta.prototype.declaration
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 // ^ support.class
 //       ^ support.constant.prototype
 }
 
 Proto.prototype.attr
-// ^^^^^^^^^^^^ meta.prototype.access
 // ^ support.class
 //     ^ support.constant.prototype
 //               ^ meta.property.object


### PR DESCRIPTION
See #1569. As far as I can tell, these scopes are not useful for anything. Maybe they once were, in the `tmLanguage` days. The benefit to removing them is simplicity: they will no longer interfere with the `support` scopes that need updating (#1563).

Examples of formerly scoped constructs:

```js
Class3.prototype = function() {};
// ^^^^^^^^^^^^^ meta.prototype.declaration

Proto.prototype.attr
// ^^^^^^^^^^^^ meta.prototype.access
```