### PR TITLE
[JavaScript] Simplify parsing of new operator.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -896,14 +896,9 @@ contexts:
           - include: scope:source.regexp.js
 
   constructor:
-    - match: new{{identifier_break}}(?=\s*\.)
-      scope: keyword.operator.word.new.js
-      set: new-target
-
-    - match: 'new{{identifier_break}}'
+    - match: new{{identifier_break}}
       scope: keyword.operator.word.new.js
       set:
-        - meta_scope: meta.instance.constructor.js meta.function-call.constructor.js
         - match: (?=\s*\.)
           set: new-target
         - match: (?=\s*\S)
@@ -914,7 +909,7 @@ contexts:
             - constructor-body-expect-class-begin
 
   constructor-meta:
-    - meta_scope: meta.instance.constructor.js meta.function-call.constructor.js
+    - meta_scope: meta.function-call.constructor.js
     - include: immediately-pop
 
   constructor-body-expect-arguments:
@@ -926,10 +921,9 @@ contexts:
     - include: else-pop
 
   constructor-body-expect-class-begin:
-    - include: well-known-identifiers
-
     - match: (?={{identifier}}\s*\()
       set:
+        - include: well-known-identifiers
         - match: '{{dollar_only_identifier}}'
           scope: variable.type.dollar.only.js punctuation.dollar.js
           pop: true
@@ -969,8 +963,6 @@ contexts:
       scope: keyword.operator.spread.js
     - match: \+|\-
       scope: keyword.operator.arithmetic.js
-    - match: new{{identifier_break}}
-      scope: keyword.operator.word.new.js
     - match: (?:delete|typeof|void){{identifier_break}}
       scope: keyword.operator.js
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1149,9 +1149,11 @@ var Constructor = function() {
 var abc = new ABC(
 //        ^^^ keyword.operator.word.new
 //            ^^^^ meta.function-call.constructor
+//        ^^^^^^^^ - meta.instance.constructor
     'my-name-is-abc',
     new (function () {
 //  ^^^ keyword.operator.word.new
+//  ^^^^^^^^^^^^^^^^^^ - meta.instance.constructor
 //      ^^^^^^^^^^^^^^ meta.function-call.constructor meta.function-call.constructor meta.group
         var foo = 1;
 //      ^^^^^^^^^^^^ meta.function-call.constructor meta.function-call.constructor meta.group meta.block
@@ -1174,6 +1176,7 @@ function f() {
 new Date().getTime()
 //  ^^^^^^ meta.function-call.constructor
 //  ^^^^ support.class.builtin
+//^^^^^^^^^^^^^^^^^^ - meta.instance.constructor
 
 new $();
 //  ^ variable.type.dollar.only punctuation.dollar

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1105,6 +1105,7 @@ func(a, b);
 //       ^ punctuation.section.group.end
 
 var instance = new Constructor(param1, param2)
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.constructor
 //                 ^^^^^^^^^^^ variable.type
 //                            ^^^^^^^^^^^^^^^^ meta.group
 //                            ^ punctuation.section.group.begin
@@ -1146,15 +1147,14 @@ var Constructor = function() {
 // Tests to ensure the new keyword is highlighted properly even when the
 // following element is not an identifier
 var abc = new ABC(
-//         ^ meta.instance.constructor keyword.operator.word.new
-//               ^ meta.instance.constructor meta.function-call.constructor
-//               ^ - meta.instance.constructor meta.instance.constructor
+//        ^^^ keyword.operator.word.new
+//            ^^^^ meta.function-call.constructor
     'my-name-is-abc',
     new (function () {
-//  ^ meta.instance.constructor meta.function-call.constructor meta.instance.constructor keyword.operator.word.new
-//      ^ meta.instance.constructor meta.function-call.constructor meta.instance.constructor meta.function-call.constructor meta.group
+//  ^^^ keyword.operator.word.new
+//      ^^^^^^^^^^^^^^ meta.function-call.constructor meta.function-call.constructor meta.group
         var foo = 1;
-//      ^ meta.instance.constructor meta.function-call.constructor meta.instance.constructor meta.function-call.constructor meta.group meta.block
+//      ^^^^^^^^^^^^ meta.function-call.constructor meta.function-call.constructor meta.group meta.block
     })
 );
 
@@ -1172,10 +1172,8 @@ function f() {
 }
 
 new Date().getTime()
-// ^^^^^^^ meta.instance.constructor
 //  ^^^^^^ meta.function-call.constructor
 //  ^^^^ support.class.builtin
-//        ^^^^^^^^^^ - meta.instance.constructor
 
 new $();
 //  ^ variable.type.dollar.only punctuation.dollar


### PR DESCRIPTION
Removed the `meta.instance.constructor` scope and simplified the parsing of the `new` operator. The `new` operator itself is no longer scoped `meta.function-call.constructor`; only the call itself is. This PR de-kludges the changes made in #1424.