### PR TITLE
[JavaScript] Fix extended anonymous class declarations

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1149,7 +1149,7 @@ contexts:
     - include: expression-begin
 
   class-name:
-    - match: (?=\bextends\b)
+    - match: (?=extends{{identifier_break}})
       pop: true
     - match: '{{identifier}}'
       scope: entity.name.class.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1149,6 +1149,8 @@ contexts:
     - include: expression-begin
 
   class-name:
+    - match: (?=\bextends\b)
+      pop: true
     - match: '{{identifier}}'
       scope: entity.name.class.js
       pop: true

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -973,6 +973,42 @@ class Foo extends getSomeClass() {}
 //   ^^^^^^^^^^ meta.group
 //              ^^^^^ storage.type.class
 
+    class {
+//  ^^^^^^^^ meta.class
+//        ^^ meta.block
+//  ^^^^^ storage.type.class
+//        ^ punctuation.section.block.begin
+        init() {}
+//  ^^^^^^^^^^^^^ meta.class.js meta.block.js
+//      ^^^^^^ meta.function.declaration.js
+//      ^^^^ entity.name.function.js
+//          ^ punctuation.section.group.begin.js
+//           ^ punctuation.section.group.end.js
+//             ^ punctuation.section.block.begin.js
+//              ^ punctuation.section.block.end.js
+    };
+//  ^ meta.class.js meta.block.js punctuation.section.block.end.js
+//   ^ punctuation.terminator.statement.empty.js
+
+    class extends B {
+//  ^^^^^^^^^^^^^^^^^ meta.class
+//                  ^^ meta.block
+//  ^^^^^ storage.type.class
+//        ^^^^^^^ storage.modifier.extends.js
+//                ^ entity.other.inherited-class.js
+//                  ^ punctuation.section.block.begin
+        init() {}
+//  ^^^^^^^^^^^^^ meta.class.js meta.block.js
+//      ^^^^^^ meta.function.declaration.js
+//      ^^^^ entity.name.function.js
+//          ^ punctuation.section.group.begin.js
+//           ^ punctuation.section.group.end.js
+//             ^ punctuation.section.block.begin.js
+//              ^ punctuation.section.block.end.js
+    };
+//  ^ meta.class.js meta.block.js punctuation.section.block.end.js
+//   ^ punctuation.terminator.statement.empty.js
+
 () => {}
 // <- meta.function.declaration punctuation.section.group.begin
  // <- meta.function.declaration punctuation.section.group.end
@@ -1602,7 +1638,7 @@ function yy (a, b) {
 
     12345e6_7_8;
 //  ^^^^^^^^^^^ constant.numeric.decimal
-    
+
     123.456e+789;
 //  ^^^^^^^^^^^^ constant.numeric.decimal
 


### PR DESCRIPTION
Fixes #1576

### Issue

The `extend` keyword is matched as class name rather than keyword if directly following the `class` keyword in anonymous class definitions breaking the highlighting of the whole class body.

### Solution

Pop off from `class-name` context, if `extend` was found.