### PR TITLE
[ShellScript] Add .zshrc as a valid extension

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -24,6 +24,7 @@ file_extensions:
   - .bashrc
   - .profile
   - .textmate_init
+  - .zshrc
 
 first_line_match: |
   (?x)                     # ignore whitespace in this regex


### PR DESCRIPTION
This just adds `.zshrc` as a valid extension for shell scripts in the same vein as `.bashrc`.