### PR TITLE
[HTML] Fix comment highlighting within script tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -326,8 +326,8 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - meta_content_scope: text.html.embedded.html
-        - include: script-close-tag
         - include: main
+        - include: script-close-tag
 
   script-other:
     - meta_content_scope: meta.tag.script.begin.html
@@ -338,9 +338,8 @@ contexts:
         - include: script-close-tag
 
   script-close-tag:
-    - match: \s*(<!--)
-      captures:
-        1: comment.block.html punctuation.definition.comment.begin.html
+    - match: <!--
+      scope: comment.block.html punctuation.definition.comment.begin.html
     - match: (?i)(?:(-->)\s*)?(</)(script)(>)
       scope: meta.tag.script.end.html
       captures:

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -7,6 +7,24 @@
 <html>
     <head>
         <title>Test HTML</title>
+
+        <script> <!--
+        ## ^^^^^ meta.tag.script.begin.html
+        ## ^ entity.name.tag.script - source.js.embedded.html
+        ##       ^^^^ comment.block.html punctuation.definition.comment.begin.html
+            var foo = 100;
+            var baz = function() {
+                ## <- entity.name.function.js
+            }
+
+            (a --> b);
+            ## ^^^ source.js.embedded.html meta.group.js keyword.operator
+        --> </script>
+        ## <- comment.block.html punctuation.definition.comment.end.html
+        ##    ^^^^^^ entity.name.tag.script.html
+        ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##           ^ - meta.tag
+
         <script type="text/javascript"> <!--
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
@@ -38,6 +56,8 @@
         ## ^ entity.name.tag.script - text.html.embedded.html
         ##             ^ string.quoted.double.html - text.html.embedded.html
         ##                          ^^^^ comment.block.html punctuation
+            comment -->
+        ##  ^^^^^^^^^^^ text.html.embedded.html comment.block.html
             <div></div>
         ##  ^^^^^^^^^^^ text.html.basic text.html.embedded meta.tag.block.any
             <script type=text/javascript>


### PR DESCRIPTION
Fixes #1575

This commit enables correct comment highlighting within following tags.

```
  <script type="text/html">
	<!-- comment -->
  </script>
```

The issue was caused by two reasons:

1. By including the `main` context after the `script-close-tag` in html scripts its "full featured" comment rule could never match.

   -> Change include order.

2. The `script-close-tag` context matches `<!--` WITH preceding whitespace.

   -> Remove `\s*`

#### Remarks

1. The embedded JavaScript syntax in `<script>` does not allow normal html highlighting.
2. The embedded CSS syntax in `<style>` does not allow normal html highlighting.

HTML comments were used there in order to prevent parsing issues with old browsers.

Not sure how to handle `script-other` or `style-other`.
