### PR TITLE
[JavaScript] Add handling for incomplete control statements.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -518,7 +518,7 @@ contexts:
       set:
         - switch-meta
         - switch-block
-        - parenthesized-expression
+        - expect-parenthesized-expression
 
     - match: do{{identifier_break}}
       scope: keyword.control.loop.js
@@ -540,21 +540,21 @@ contexts:
       set:
         - while-meta
         - block-scope
-        - parenthesized-expression
+        - expect-parenthesized-expression
 
     - match: with{{identifier_break}}
       scope: keyword.control.with.js
       set:
         - with-meta
         - block-scope
-        - parenthesized-expression
+        - expect-parenthesized-expression
 
     - match: (?:else\s+if|if){{identifier_break}}
       scope: keyword.control.conditional.js
       set:
         - conditional-meta
         - block-scope
-        - parenthesized-expression
+        - expect-parenthesized-expression
 
     - match: else{{identifier_break}}
       scope: keyword.control.conditional.js
@@ -579,7 +579,11 @@ contexts:
       set:
         - catch-meta
         - block-scope
-        - parenthesized-expression
+        - expect-parenthesized-expression
+
+  expect-parenthesized-expression:
+    - include: parenthesized-expression
+    - include: else-pop
 
   switch-meta:
     - meta_scope: meta.switch.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -615,6 +615,10 @@ do {
 // ^^^^ keyword.control.loop
 //      ^^^^^^^^ meta.group
 
+do // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.do-while
+
 for (var i = 0; i < 10; i++) {
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
 //   ^^^^^^^^^^^^^^^^^^^^^^ meta.group
@@ -631,6 +635,10 @@ for (var i = 0; i < 10; i++) {
     for await (const x of list) {}
 //  ^^^ keyword.control.loop
 //      ^^^^^ keyword.control.loop
+
+for
+    42;
+//  ^^ constant.numeric - meta.for
 
 while (true)
 // ^^^^^^^^^ meta.while
@@ -667,12 +675,20 @@ while (true)
 }
 // <- meta.block
 
+while // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
 with (undefined) {
 // <- keyword.control.with
 //^^^^^^^^^^ meta.with
 //    ^^^^^^^^^ constant.language.undefined
     return;
 }
+
+with // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
 
 switch ($foo) {
 // ^^^^^^^^^^^^ meta.switch
@@ -726,6 +742,10 @@ try {
 //  ^^^^^^^^^^^ meta.finally meta.block
 }
 // <- meta.block
+
+switch // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.switch
 
 class MyClass extends TheirClass {
 // <- storage.type.class


### PR DESCRIPTION
Effectively makes parenthesized parts of control statements optional, improving behavior when typing. Fixes #1589.

This also suffices to implement the [TC39 optional catch binding](https://github.com/tc39/proposal-optional-catch-binding) proposal.