### PR TITLE
[JavaScript] Fix function declarations within objects break highlighting

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1338,8 +1338,8 @@ contexts:
         - function-declaration-expect-async
 
   function-declaration-expect-body:
-    - match: (?=\S)
-      set: function-block
+    - include: function-block
+    - include: else-pop
 
   function-declaration-meta:
     - meta_include_prototype: false
@@ -1384,8 +1384,7 @@ contexts:
         - function-declaration-expect-async
 
   arrow-function-expect-body:
-    - match: (?=\{)
-      set: function-block
+    - include: function-block
     - match: (?=\S)
       set:
         - block-meta
@@ -1405,17 +1404,14 @@ contexts:
     - include: else-pop
 
   function-block:
-    - meta_scope: meta.block.js
-    - match: '\}'
-      scope: punctuation.section.block.end.js
-      pop: true
     - match: '\{'
       scope: punctuation.section.block.begin.js
-      push:
-        - match: '(?=\})'
+      set:
+        - meta_scope: meta.block.js
+        - match: '\}'
+          scope: punctuation.section.block.end.js
           pop: true
         - include: statements
-    - include: else-pop
 
   function-declaration-parameters:
     - match: \(

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1090,6 +1090,29 @@ var anotherSingle = function(){a = param => param; return param2 => param2 * a}
 //                                                                           ^ meta.block meta.block variable.other.readwrite
 //                                                                            ^ meta.block punctuation.section.block.end
 
+var var = ~{a:function(){}.a()}
+//  ^^^ meta.binding.name
+//  ^^^ variable.other.readwrite
+//      ^ keyword.operator.assignment
+//        ^ keyword.operator.bitwise
+//         ^ punctuation.section.block.begin
+//         ^^^^^^^^^^^^^^^^^^^^ meta.object-literal
+//          ^^^^^^^^^^^^ meta.function.declaration
+//          ^ entity.name.function
+//           ^ punctuation.separator.key-value
+//            ^^^^^^^^ storage.type.function
+//                    ^ punctuation.section.group.begin
+//                     ^ punctuation.section.group.end
+//                      ^ meta.block punctuation.section.block.begin
+//                       ^ meta.block punctuation.section.block.end
+//                        ^ meta.object-literal
+//                         ^^^ meta.function.declaration
+//                         ^ entity.name.function
+//                          ^ punctuation.section.group.begin
+//                           ^ punctuation.section.group.end
+//                            ^ punctuation.section.block.end
+//                             ^ - meta
+
 baz(foo(x => x('bar')));
 //                   ^ meta.function-call meta.function-call punctuation.section.group.end
 //                    ^ meta.function-call punctuation.section.group.end


### PR DESCRIPTION
Fixes #1593

### Issue

According to the minimal test case, if `.a()` is not followed by an opening `{` (a real `function-block`), the closing `}` of the owning object is matched as closing punctuation of the none present function block.

As a result the context of the owning object (`meta.object-literal`) is never popped off anymore.

### Reason

The reason for that issue is located within the `function-block` context, which consumes the next available `}` after a function declaration without respect to a prior `{` to be required.

### Solution

The code structure and the use of the `function-block` context is adapted to `function-declaration-parameters`.

It now contains the rule to set the `meta.block` context only.
An opening `{` is required before looking for a closing `}` for it.
By removing the `else-pop`, some look aheads are removed from

  - `function-declaration-expect-body`
  - `arrow-function-expect-body`