### PR TITLE
[C++] Teach the C++ comments settings about doxygen comment prefixes.

### DIFF
--- a/C++/Comments (C++).tmPreferences
+++ b/C++/Comments (C++).tmPreferences
@@ -33,6 +33,18 @@
 				<key>value</key>
 				<string>yes</string>
 			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
+				<key>value</key>
+				<string>/// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_4</string>
+				<key>value</key>
+				<string>//! </string>
+			</dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
Without this, tools like Wrap Lines Plus won't be able to correctly wrap doxygen comments.