### PR TITLE
[JavaScript] Fixed bug with tagged template literals.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -753,7 +753,9 @@ contexts:
     - include: expression-break
 
     - include: property-access
-    - include: literal-string-template
+
+    - match: (?=`)
+      push: literal-string-template
 
     - match: (?=\()
       push: function-call-arguments
@@ -838,9 +840,7 @@ contexts:
   tagged-template:
     - match: '{{identifier}}(?=\s*`)'
       scope: variable.function.tagged-template.js
-      set:
-        - include: literal-string-template
-        - include: else-pop
+      pop: true
 
   literal-string-template:
     - match: '`'

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -380,6 +380,12 @@ x ? y // y is a template tag!
 `template` : z;
 //         ^ keyword.operator.ternary
 
+    1``
+    /a/;
+//  ^^^ - string
+//  ^ keyword.operator.arithmetic
+//    ^ keyword.operator.arithmetic
+
 mylabel:
 // ^ entity.name.label
 //     ^ punctuation.separator


### PR DESCRIPTION
Tagged template literals were handled specially when the tag was an identifier, but the general case was broken (it caused the expression to end early). The general case has been fixed and the special case eliminated.

```js
    1``
    /a/;
//  ^^^ - string
//  ^ keyword.operator.arithmetic
//    ^ keyword.operator.arithmetic
```

Part of #1600.