### PR TITLE
[JavaScript] Eliminate goto, add break/continue labels.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -270,9 +270,11 @@ contexts:
       scope: keyword.control.trycatch.js
       set: restricted-production
 
-    - match: (?:break|continue|goto){{identifier_break}}
+    - match: (?:break|continue){{identifier_break}}
       scope: keyword.control.loop.js
-      set: expect-semicolon
+      set:
+        - expect-semicolon
+        - expect-label
 
     - match: return{{identifier_break}}
       scope: keyword.control.flow.js
@@ -292,6 +294,14 @@ contexts:
   expect-semicolon:
     - match: \;
       scope: punctuation.terminator.statement.js
+      pop: true
+    - include: else-pop
+
+  expect-label:
+    - match: '{{identifier}}'
+      scope: variable.label.js
+      pop: true
+    - match: $
       pop: true
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -663,7 +663,29 @@ while (true)
 //            ^^^^^ keyword.control.flow
 
     break;
-//  ^^^^^^ meta.while meta.block
+//  ^^^^^ keyword.control.loop
+
+    break foo;
+//  ^^^^^ keyword.control.loop
+//        ^^^ variable.label
+
+    break
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    continue;
+//  ^^^^^^^^ keyword.control.loop
+
+    continue foo;
+//  ^^^^^^^^ keyword.control.loop
+//           ^^^ variable.label
+
+    continue
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    goto;
+//  ^^^^ variable.other.readwrite - keyword
 }
 // <- meta.block
 


### PR DESCRIPTION
- `goto` has no meaning in JavaScript, but it was erroneously marked as a keyword.
- `break` and `continue` take optional labels. The syntax did not handle this, leading to bugs in corner cases.
- `continue` had no tests at all.

Part of #1600.