### PR TITLE
[Markdown] Allow whitespace between opening fence and language

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -98,10 +98,10 @@ variables:
           [ ]*
           ([ ]{0,3})   # up to 3 spaces
           (
-            `{3,}      #   3 or more backticks
+            (`){3,}    #   3 or more backticks
             (?![^`]*`) #   not followed by any more backticks on the same line
           |            # or
-            ~{3,}      #   3 or more tildas
+            (~){3,}    #   3 or more tildas
             (?![^~]*~) #   not followed by any more tildas on the same line
           )
           \s*          # allow for whitespace between code block start and info string
@@ -117,12 +117,13 @@ variables:
         )
     code_fence_escape: |-
       (?x:
-        ^         # the beginning of the line
-        #\1        # whitespace previously captured
-        #[ ]{0,3}  # up to 3 spaces - doesn't have to be the same as the opening fence, but within 3 spaces
+        ^             # the beginning of the line
         [ ]*
-        (\2)      # the backtick/tilde combination that opened the code fence
-        \s*$      # any amount of whitespace until EOL
+        (
+          \2          # the backtick/tilde combination that opened the code fence
+          (?:\3|\4)*  # plus optional additional closing characters
+        )
+        \s*$          # any amount of whitespace until EOL
       )
     html_tag_open_commonmark: |-
       (?xi:
@@ -939,7 +940,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.xml.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:text.xml
       embed_scope: markup.raw.code-fence.xml.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -954,7 +955,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.sql.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.sql
       embed_scope: markup.raw.code-fence.sql.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -969,7 +970,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.python.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.python
       embed_scope: markup.raw.code-fence.python.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -984,7 +985,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.graphviz.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.dot
       embed_scope: markup.raw.code-fence.graphviz.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -999,7 +1000,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.javascript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.javascript
       embed_scope: markup.raw.code-fence.javascript.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1014,7 +1015,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.json.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.json
       embed_scope: markup.raw.code-fence.json.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1029,7 +1030,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.java.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.java
       embed_scope: markup.raw.code-fence.java.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1044,7 +1045,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.csharp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.cs
       embed_scope: markup.raw.code-fence.csharp.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1059,7 +1060,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.rust.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.rust
       embed_scope: markup.raw.code-fence.rust.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1074,7 +1075,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.shell-script.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.shell.bash
       embed_scope: markup.raw.code-fence.shell-script.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1089,7 +1090,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.php
       embed_scope: markup.raw.code-fence.php.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1104,7 +1105,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.html-php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:embedding.php
       embed_scope: markup.raw.code-fence.html-php.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1119,7 +1120,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.r.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.r
       embed_scope: markup.raw.code-fence.r.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1134,7 +1135,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.go.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.go
       embed_scope: markup.raw.code-fence.go.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1149,7 +1150,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.ruby.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.ruby
       embed_scope: markup.raw.code-fence.ruby.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1164,7 +1165,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.objc.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.objc
       embed_scope: markup.raw.code-fence.objc.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1179,7 +1180,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.objc++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.objc++
       embed_scope: markup.raw.code-fence.objc++.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1194,7 +1195,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.c.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.c
       embed_scope: markup.raw.code-fence.c.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1209,7 +1210,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.c++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.c++
       embed_scope: markup.raw.code-fence.c++.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1224,7 +1225,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.regexp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.regexp
       embed_scope: markup.raw.code-fence.regexp.markdown-gfm
       escape: '{{code_fence_escape}}'
@@ -1239,7 +1240,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.text.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       push:
         - meta_content_scope: markup.raw.code-fence.markdown-gfm
         - match: '{{code_fence_escape}}'

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -924,6 +924,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:xml))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -939,6 +940,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:sql))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -954,6 +956,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:python|py))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -969,6 +972,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:graphviz))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -984,6 +988,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:javascript|js))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -999,6 +1004,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:json))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1014,6 +1020,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:java))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1029,6 +1036,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:csharp|c\#|cs))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1044,6 +1052,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:rust))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1059,6 +1068,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:shell-script|sh|bash|zsh))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1074,6 +1084,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:php|inc))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1089,6 +1100,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:html\+php))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1104,6 +1116,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:rscript|r|splus))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1119,6 +1132,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:golang))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1134,6 +1148,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:ruby|rb|rbx))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1149,6 +1164,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:objc|obj-c|objectivec|objective-c))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1164,6 +1180,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1179,6 +1196,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:c))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1194,6 +1212,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:c\+\+|cpp))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1209,6 +1228,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ((?i:regexp|regex))
           \s*$\n?          # any whitespace until EOL
       captures:
@@ -1224,6 +1244,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          \s*
           ([\w-]*)     # any number of word characters or dashes
           .*$\n?       # all characters until EOL
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -104,6 +104,16 @@ variables:
             ~{3,}      #   3 or more tildas
             (?![^~]*~) #   not followed by any more tildas on the same line
           )
+          \s*          # allow for whitespace between code block start and info string
+        )
+    fenced_code_block_trailing_infostring_characters: |-
+        (?x:
+          (
+            \s*        # any whitespace, or ..
+          |
+            \s[^`]*    # any characters (except backticks), separated by whitespace ...
+          )
+          $\n?         # ... until EOL
         )
     code_fence_escape: |-
       (?x:
@@ -924,9 +934,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:xml))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.xml.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -940,9 +949,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:sql))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.sql.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -956,9 +964,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:python|py))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.python.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -972,9 +979,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:graphviz))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.graphviz.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -988,9 +994,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:javascript|js))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.javascript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1004,9 +1009,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:json))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.json.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1020,9 +1024,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:java))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.java.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1036,9 +1039,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:csharp|c\#|cs))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.csharp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1052,9 +1054,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:rust))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.rust.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1068,9 +1069,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:shell-script|sh|bash|zsh))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.shell-script.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1084,9 +1084,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:php|inc))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1100,9 +1099,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:html\+php))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.html-php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1116,9 +1114,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:rscript|r|splus))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.r.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1132,9 +1129,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:golang))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.go.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1148,9 +1144,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:ruby|rb|rbx))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.ruby.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1164,9 +1159,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:objc|obj-c|objectivec|objective-c))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.objc.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1180,9 +1174,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.objc++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1196,9 +1189,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:c))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.c.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1212,9 +1204,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:c\+\+|cpp))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.c++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1228,9 +1219,8 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ((?i:regexp|regex))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.regexp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
@@ -1244,7 +1234,6 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          \s*
           ([\w-]*)     # any number of word characters or dashes
           .*$\n?       # all characters until EOL
       captures:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1927,7 +1927,7 @@ var_dump(expression);
 |^^^ meta.paragraph meta.code-fence.definition.end.regexp - markup
 |^^ punctuation.definition.raw.code-fence.end
 
-``` bash
+```bash
 # test
 | ^^^^^ source.shell comment.line.number-sign
 echo hello, \
@@ -1936,3 +1936,23 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 |                       ^^ constant.character.escape
 ```
 | <- meta.code-fence.definition.end.shell-script punctuation.definition.raw.code-fence.end
+
+```     bash
+| <- punctuation.definition.raw.code-fence.begin
+|  ^^^^^ meta.code-fence.definition.begin.shell-script.markdown-gfm
+|       ^^^^ constant.other.language-name
+# test
+| ^^^^^ source.shell comment.line.number-sign
+```
+| <- meta.code-fence.definition.end.shell-script punctuation.definition.raw.code-fence.end
+
+~~~~    ruby startline=3 $%@#$
+| <- punctuation.definition.raw.code-fence.begin
+|   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm
+|       ^^^^ constant.other.language-name
+|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm
+def foo(x)
+  return 3
+end
+~~~~
+| <- meta.code-fence.definition.end.ruby punctuation.definition.raw.code-fence.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1954,5 +1954,5 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 def foo(x)
   return 3
 end
-~~~~
+~~~~~~~
 | <- meta.code-fence.definition.end.ruby punctuation.definition.raw.code-fence.end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1927,7 +1927,7 @@ var_dump(expression);
 |^^^ meta.paragraph meta.code-fence.definition.end.regexp - markup
 |^^ punctuation.definition.raw.code-fence.end
 
-```bash
+``` bash
 # test
 | ^^^^^ source.shell comment.line.number-sign
 echo hello, \


### PR DESCRIPTION
Allow for code blocks like

    ``` ruby
    def foo(x)
      return 3
    end
    ```

with whitespace between the opening fence and the 'ruby' keyword.

closes #1615