### PR TITLE
[Git Formats] fix misspelling (asterix → asterisk)

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -115,7 +115,7 @@ contexts:
     - match: \.(?!.*[./]) # the last dot not followed by path sep
       scope: punctuation.separator.path.extension.fnmatch.git
     - match: '[*?]'       # unescapable operators
-      scope: keyword.operator.path.asterix.fnmatch.git
+      scope: keyword.operator.path.asterisk.fnmatch.git
     - match: '\\[^$*?]'   # backslash escapes nearly everything
       scope: constant.character.escape.path.fnmatch.git
     - match: \$\w+
@@ -155,7 +155,7 @@ contexts:
       pop: true
     - match: '\\\]'   # backslash escapes only ']'
       scope: constant.character.escape.char-class.fnmatch.git
-    - match: '[*?]'   # asterix is ignored by fnmatch
+    - match: '[*?]'   # asterisk is ignored by fnmatch
       scope: invalid.illegal.unexpected.char-class.fnmatch.git
     - match: \S
       scope: constant.character.char-class.fnmatch.git

--- a/Git Formats/syntax_test_git_attributes
+++ b/Git Formats/syntax_test_git_attributes
@@ -79,7 +79,7 @@
 # <- string.quoted.double.git.attributes punctuation.definition.string.begin.git.attributes - entity.name.pattern.git
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.git.attributes
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
-#  ^ keyword.operator.path.asterix.fnmatch.git
+#  ^ keyword.operator.path.asterisk.fnmatch.git
 #    ^^ constant.character.escape.path.fnmatch.git
 #       ^^^^ meta.char-class.fnmatch.git
 #       ^ keyword.control.char-class.begin.fnmatch.git
@@ -103,9 +103,9 @@
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes - meta.pattern
 #^^^^^^^^^^^^^^ string.unquoted.git.attributes
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ keyword.operator.path.asterix.fnmatch.git
+#     ^ keyword.operator.path.asterisk.fnmatch.git
 #      ^ punctuation.separator.path.extension.fnmatch.git
-#         ^ keyword.operator.path.asterix.fnmatch.git
+#         ^ keyword.operator.path.asterisk.fnmatch.git
 #              ^ - variable.language.attribute - keyword.operator.logical
 #               ^^^^^^ variable.language.attribute.git.attributes
 #                     ^ - variable.language.attribute - keyword.operator.logical

--- a/Git Formats/syntax_test_git_ignore
+++ b/Git Formats/syntax_test_git_ignore
@@ -8,9 +8,9 @@
 #  ^ variable.language.environment.home.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ - constant
-#       ^ keyword.operator.path.asterix.fnmatch.git
+#       ^ keyword.operator.path.asterisk.fnmatch.git
 #               ^ punctuation.separator.path.fnmatch.git
-#                ^ keyword.operator.path.asterix.fnmatch.git
+#                ^ keyword.operator.path.asterisk.fnmatch.git
 #                 ^ punctuation.separator.path.extension.fnmatch.git
 
   ~/../f..o\'ld\"er/fo\*l\?der/fol../der
@@ -22,9 +22,9 @@
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                      ^ keyword.operator.path.asterix.fnmatch.git
+#                      ^ keyword.operator.path.asterisk.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                         ^ keyword.operator.path.asterix.fnmatch.git
+#                         ^ keyword.operator.path.asterisk.fnmatch.git
 #                                 ^^ - constant.language.path.parent.fnmatch.git
 #                                       ^ - entity.name.pattern
 
@@ -35,7 +35,7 @@
 #       ^ - variable.language.environment.home.fnmatch.git
 #         ^ punctuation.separator.path.extension.fnmatch.git
 #          ^ - variable.language.environment.home.fnmatch.git
-#            ^ keyword.operator.path.asterix.fnmatch.git
+#            ^ keyword.operator.path.asterisk.fnmatch.git
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git


### PR DESCRIPTION
“asterisk” is misspelled in git-formats syntax scope names. This corrects the spelling.