### PR TITLE
[Markdown] Fix reference to Javascript Syntax

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -990,7 +990,7 @@ contexts:
         0: meta.code-fence.definition.begin.javascript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         3: constant.other.language-name.markdown
-      embed: scope:source.javascript
+      embed: scope:source.js
       embed_scope: markup.raw.code-fence.javascript.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1173,6 +1173,7 @@ __test!*test__ Issue 1163
 | <- punctuation.definition.raw.code-fence.begin
 |  ^^ constant.other.language-name
 for (var i = 0; i < 10; i++) {
+| ^ keyword.control.loop.js
     console.log(i);
 }
 ```


### PR DESCRIPTION
The Javascript syntax uses `source.js`. This caused failures in syntect where a broken reference is an error, which perhaps it shouldn't be if it isn't in Sublime.

cc @keith-hall