### PR TITLE
[Rust] enable Goto Definition for enums, functions, structs etc.

### DIFF
--- a/Rust/RustSymbols.tmPreferences
+++ b/Rust/RustSymbols.tmPreferences
@@ -9,6 +9,8 @@
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR simply enables the indexed symbol list for Rust symbols, to allow Goto Definition to be used in Rust code.