### PR TITLE
[C#] remove duplicate match pattern

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1475,10 +1475,6 @@ contexts:
       scope: constant.character.cs
       captures:
         2: constant.character.escape.cs
-    - match: (')({{escaped_char}})(')
-      scope: constant.character.cs
-      captures:
-        2: constant.character.escape.cs
     - match: (').(')
       scope: constant.character.cs
     - match: (')[^']+(')


### PR DESCRIPTION
I noticed one of the `match` patterns (along with the `scope`/`captures`) was duplicated in the C# syntax, so this PR removes the duplicate.