### PR TITLE
[SQL] NULL-safe equal to operator ligature.

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -99,7 +99,7 @@ contexts:
       scope: keyword.other.order.sql
     - match: \*
       scope: keyword.operator.star.sql
-    - match: "[!<>]?=|<>|<|>"
+    - match: "<=>|[!<>]?=|<>|<|>"
       scope: keyword.operator.comparison.sql
     - match: '-|\+|/'
       scope: keyword.operator.math.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -30,5 +30,5 @@ multiline comment
 select
 
 
-<=>  
+   <=>  
 -- ^^^ keyword.operator.comparison.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -28,3 +28,6 @@ multiline comment
 -- ^ source.sql comment.block.c
 */
 select
+
+
+<=>  -- <- keyword.operator.star.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -30,4 +30,5 @@ multiline comment
 select
 
 
-<=>  -- <- keyword.operator.comparison.sql
+<=>  
+-- ^^^ keyword.operator.comparison.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -30,4 +30,4 @@ multiline comment
 select
 
 
-<=>  -- <- keyword.operator.star.sql
+<=>  -- <- keyword.operator.comparison.sql


### PR DESCRIPTION
Problem described at [Sublime forum](https://forum.sublimetext.com/t/wrong-ligature-for-null-safe-equal-to-operator-in-sql-syntax/37407/4).