### PR TITLE
[JavaScript] Remove isolated regexp flags from variables.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -19,7 +19,7 @@ variables:
 
   # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
   reserved_word: |-
-    (?x)(?:
+    (?x:
       break|case|catch|class|const|continue|debugger|default|delete|do|else|
       export|extends|finally|for|function|if|import|in|instanceof|new|return|
       super|switch|this|throw|try|typeof|var|void|while|with|yield|

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -21,7 +21,7 @@ variables:
   left_expression_end_lookahead: (?!\s*[.\[\(])
 
   property_name: >-
-    (?x)(?:
+    (?x:
       {{identifier}}
       | '(?:[^\\']|\\.)*'
       | "(?:[^\\"]|\\.)*"
@@ -29,21 +29,21 @@ variables:
     )
 
   class_element_name: |-
-    (?x)(?:
+    (?x:
       \*?
       {{property_name}}
       | \#{{identifier}}
     )
 
   func_lookahead: |-
-    (?x)(?:
+    (?x:
       \s*
       (?:async\s+)?
       function{{identifier_break}}
     )
 
   arrow_func_lookahead: |-
-    (?x)(?:
+    (?x:
       \s*
       (?:async\s*)?
       (?:
@@ -55,11 +55,11 @@ variables:
     )
 
   method_lookahead: |-
-    (?x)(?=
+    (?x:(?=
       (?: get|set|async ){{identifier_break}}
       | \*
       | {{property_name}} \s* \(
-    )
+    ))
 
   line_continuation_lookahead: >-
     (?x:


### PR DESCRIPTION
Because of https://github.com/SublimeTextIssues/Core/issues/2354, and because it's generally better anyway.