### PR TITLE
[Python] Python 3.7 support

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -869,7 +869,7 @@ contexts:
   builtin-functions:
     - match: |-
         (?x)\b(
-        	__import__|all|abs|any|apply|ascii|bin|callable|chr|classmethod|cmp|coerce|
+        	__import__|all|abs|any|apply|ascii|bin|breakpoint|callable|chr|classmethod|cmp|coerce|
         	compile|delattr|dir|divmod|enumerate|eval|exec|execfile|filter|format|getattr|
         	globals|hasattr|hash|help|hex|id|input|intern|isinstance|issubclass|iter|
         	len|locals|map|max|min|next|oct|open|ord|pow|print|property|range|
@@ -1056,7 +1056,11 @@ contexts:
           # descriptors
           delete|get|set|set_name|
           # class-specific
-          subclasses
+          subclasses|
+          # dataclasses (PEP 557)
+          post_init|
+          # for typing core support (PEP 560)
+          class_getitem|mro_entries
         )__\b
       comment: these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
       scope: support.function.magic.python


### PR DESCRIPTION
Not many changes for 3.7, which is currently in rc1 and the scheduled release date is at the [end of this month](https://www.python.org/dev/peps/pep-0537/#schedule), in exactly one week.

Syntax changes were the deprecation of `async` and `await` as non-keywords, which we cannot address in the syntax definition, and addition of a `__future__` import to prevent type annotation evaluation at load time, which also doesn't matter for us.

A single built-in function was added and three new magic methods from features in the stdlib.

See https://docs.python.org/3.7/whatsnew/3.7.html for the complete list.

Also no tests because …