### PR TITLE
[Perl] Small whitespace related improvements

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -243,8 +243,8 @@ contexts:
     # SEE: http://perldoc.perl.org/index-pragmas.html
     #      http://perldoc.perl.org/perlmodlib.html#Pragmatic-Modules
     - match: |-
-        \b(?x)
-        (?:attributes|autodie(?:::(?:exception(?:::system)|hints|skip))?|autouse
+        \b(?x:
+           attributes|autodie(?:::(?:exception(?:::system)|hints|skip))?|autouse
           |base|bigint|bignum|bigrat|blib|bytes
           |charnames|constant
           |diagnostics

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -244,7 +244,7 @@ contexts:
     #      http://perldoc.perl.org/perlmodlib.html#Pragmatic-Modules
     - match: |-
         \b(?x:
-           attributes|autodie(?:::(?:exception(?:::system)|hints|skip))?|autouse
+           attributes|autodie(?:\s*::\s*(?:exception(?:\s*::\s*system)|hints|skip))?|autouse
           |base|bigint|bignum|bigrat|blib|bytes
           |charnames|constant
           |diagnostics
@@ -260,7 +260,7 @@ contexts:
           |threads|threads::shared
           |utf8
           |vars|vmsish
-          |warnings|warnings::register){{break}}
+          |warnings|warnings\s*::\s*register){{break}}
       scope: storage.modifier.perl
 
 ### [ EXPRESSIONS ]###########################################################

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -12,7 +12,7 @@ first_line_match: ^#!.*\bperl\b
 scope: source.perl
 
 variables:
-  break: (?!\w| *::)
+  break: (?!\w|\s*::)
   identifier: '\b[_[:alpha:]]\w*{{break}}'
   module: '\b[_[:upper:]]\w*\b'
   member: '\b[_[:lower:]]\w*\b'
@@ -589,16 +589,16 @@ contexts:
 ### [ CLASSES ]################################################################
 
   class:
-    - match: '{{module}}(?= *(?:::|[#;]|$))'
+    - match: '{{module}}(?=\s*(?:::|[#;]|$))'
       scope: support.class.perl
       push: members-pop
 
   members-pop:
-    - match: ' *(::) *({{module}})'
+    - match: \s*(::)\s*({{module}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: support.class.perl
-    - match: ' *(::) *({{identifier}})'
+    - match: \s*(::)\s*({{identifier}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: variable.other.member.perl
@@ -1029,7 +1029,7 @@ contexts:
         1: punctuation.definition.variable.perl
     # $Module::SubModule::member
     # $::SubModule::member
-    - match: ([\$\@\%]#?)({{module}})?(?= *::)
+    - match: ([\$\@\%]#?)({{module}})?(?=\s*::)
       captures:
         1: punctuation.definition.variable.perl
         2: support.class.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1076,6 +1076,17 @@ eval { require Mail::Send; };
 #      ^^^^^^^^^^^^^^^^^^ meta.import.require.perl
 #                        ^^^^ - meta.import.require.perl
 #      ^^^^^^^ keyword.control.import.require.perl
+eval { require Mail :: Send; };
+#<- support.function.perl
+#^^^ support.function.perl
+#    ^ punctuation.section.block.begin.perl
+#      ^^^^^^^^^^^^^^^^^^^^ meta.import.require.perl
+#              ^^^^ support.class.perl
+#                  ^^^^ - support.class
+#                   ^^ punctuation.accessor.double-colon.perl
+#                      ^^^^ support.class.perl
+#                          ^^^^ - meta.import.require.perl
+#      ^^^^^^^ keyword.control.import.require.perl
 use strict;
 # <- meta.use.perl keyword.control.import.use.perl
 #^^^^^^^^^ meta.use.perl
@@ -1103,7 +1114,6 @@ use File;
 #^^ keyword.control.import.use.perl
 #   ^^^^ support.class.perl
 #       ^ punctuation.terminator.statement.perl
-
 use File::data;
 # <- meta.use.perl keyword.control.import.use.perl
 #^^^^^^^^^^^^^ meta.use.perl
@@ -1112,6 +1122,15 @@ use File::data;
 #       ^^ punctuation.accessor.double-colon.perl
 #         ^^^^ variable.other.member.perl
 #             ^ punctuation.terminator.statement.perl
+use warnings :: register File :: data;
+# <- meta.use.perl keyword.control.import.use.perl
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.use.perl
+#^^ keyword.control.import.use.perl
+#   ^^^^^^^^^^^^^^^^^^^^ storage.modifier.perl
+#                        ^^^^ support.class.perl
+#                             ^^ punctuation.accessor.double-colon.perl
+#                                ^^^^ variable.other.member.perl
+#                                    ^ punctuation.terminator.statement.perl
 no strict;
 # <- meta.no.perl keyword.declaration.no.perl
 #^^^^^^^^ meta.no.perl


### PR DESCRIPTION
This PR applies a change inspired by @keith-hall to avoid possibly breaking the `break` variable if it is used in extended regex patterns. It includes surrounding the `::` by tabs as well.

The second commit turns an `(?x)` into an `(?x: ...` as the latter one was used in another context the same way like.
