### PR TITLE
[JavaScript] Better highlighting of invalid identifiers while typing.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -75,14 +75,15 @@ variables:
     ))
 
   line_continuation_lookahead: >-
-    (?x:
+    (?x:(?=
+      \s*
       (?! \+\+ | -- )
       (?=
         != |
-        [ -+*/% ><= &|^ \[( ;,.:? ] |
+        [-+*/%><=&|^\[(;,.:?] |
         (?:in|instanceof){{identifier_break}}
       )
-    )
+    ))
 
 contexts:
   main:
@@ -201,7 +202,7 @@ contexts:
     - match: '\{'
       scope: punctuation.section.block.begin.js
       set: import-brace
-    - match: '{{identifier}}'
+    - match: '{{non_reserved_identifier}}'
       scope: variable.other.readwrite.js
       pop: true
     - match: '\*'
@@ -258,7 +259,7 @@ contexts:
     - match: '\{'
       scope: punctuation.section.block.begin.js
       set: export-brace
-    - match: '{{identifier}}'
+    - match: '{{non_reserved_identifier}}'
       scope: variable.other.readwrite.js
       pop: true
     - match: '\*'
@@ -331,8 +332,11 @@ contexts:
     - include: else-pop
 
   expect-label:
-    - match: '{{identifier}}'
+    - match: '{{non_reserved_identifier}}'
       scope: variable.label.js
+      pop: true
+    - match: '{{identifier}}'
+      scope: invalid.illegal.identifier.js variable.label.js
       pop: true
     - match: $
       pop: true
@@ -355,7 +359,7 @@ contexts:
     - include: else-pop
 
   variable-binding-name:
-    - match: (?={{identifier}})
+    - match: (?={{non_reserved_identifier}})
       set:
         - meta_scope: meta.binding.name.js
         - include: literal-variable
@@ -419,14 +423,14 @@ contexts:
       set:
         - initializer
         - variable-binding-pattern
+    - include: else-pop
+
+  variable-binding-list-top:
     - match: \n
       set:
         - match: '{{line_continuation_lookahead}}'
           set: variable-binding-top
         - include: else-pop
-    - include: else-pop
-
-  variable-binding-list-top:
     - match: ','
       scope: punctuation.separator.comma.js
       push: variable-binding-top
@@ -447,8 +451,10 @@ contexts:
     - include: else-pop
 
   function-parameter-binding-name:
-    - match: '{{identifier}}'
+    - match: '{{non_reserved_identifier}}'
       scope: meta.binding.name.js variable.parameter.function.js
+    - match: '{{identifier}}'
+      scope: invalid.illegal.identifier.js meta.binding.name.js variable.parameter.function.js
 
   function-parameter-binding-array-destructuring:
     - match: '\['
@@ -1371,7 +1377,7 @@ contexts:
     - include: else-pop
 
   function-declaration-expect-name:
-    - match: '{{identifier}}'
+    - match: '{{non_reserved_identifier}}'
       scope: entity.name.function.js
       pop: true
     - include: else-pop

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -27,6 +27,11 @@ import thing, {identifier as otherIdentifier}, * as otherName from "otherplace";
 import 'module';
 // ^^^^^^^^^^^^^ meta.import
 
+// Better highlighting while typing.
+import
+import;
+// <- keyword.control.import-export
+
 export { name1, name2 as name3 };
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^ keyword.control.import-export
@@ -147,6 +152,11 @@ export { import1 as name1, import2 as name2, nameN } from "./othermod";
 //                                 ^ keyword.control.import-export
 //                                                   ^ keyword.control.import-export
 
+// Better highlighting while typing.
+export
+export;
+// <- keyword.control.import-export
+
 import * as
     alias from "module";
 // ^^^^^^^^^^^^^^^^^^^^^ meta.import.js
@@ -245,6 +255,11 @@ someFunction({
     {
 
     }
+
+// Better highlighting when typing
+function
+function() {}
+// <- storage.type.function - entity.name.function
 
 if (true)
 // <- keyword.control.conditional
@@ -682,6 +697,9 @@ while (true)
     foo;
 //  ^^^ variable.other.readwrite - variable.label
 
+    break function;
+//        ^^^^^^^^ invalid.illegal.identifier variable.label
+
     continue;
 //  ^^^^^^^^ keyword.control.loop
 
@@ -1013,6 +1031,11 @@ class Foo extends getSomeClass() {}
 //                 ^^^^^^^^ meta.class meta.class
 //                 ^^^^^ storage.type.class
 
+// Better highlighting while typing.
+class
+class
+// <- storage.type.class - entity.name.class
+
     () => {}
 //  ^^^^^^^^ meta.function - meta.function meta.function
 //  ^^^^^ meta.function.declaration
@@ -1159,7 +1182,7 @@ var anotherSingle = function(){a = param => param; return param2 => param2 * a}
 //                                                                           ^ meta.block meta.block variable.other.readwrite
 //                                                                            ^ meta.block punctuation.section.block.end
 
-var var = ~{a:function(){}.a()}
+var foo = ~{a:function(){}.a()}
 //  ^^^ meta.binding.name
 //  ^^^ variable.other.readwrite
 //      ^ keyword.operator.assignment

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -1,5 +1,8 @@
 // SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
+
+// Variable declarations
+
 const x = value;
 //    ^ meta.binding.name variable.other.readwrite
 
@@ -40,6 +43,35 @@ const { a, b: c, ...d } = value;
 const x;
 //    ^ meta.binding.name variable.other.readwrite
 
+let
+// <- storage.type
+w
+//  <- meta.binding.name variable.other.readwrite
+,
+// <- punctuation.separator.comma
+x
+// <- meta.binding.name variable.other.readwrite
+y
+// <- variable.other.readwrite - meta.binding.name
+,
+// <- keyword.operator.comma
+z
+// <- variable.other.readwrite - meta.binding.name
+
+// `let` is only reserved in strict mode, and we can't distinguish that yet.
+
+let let;
+//  ^^^ meta.binding.name variable.other.readwrite
+
+let
+let;
+// <- meta.binding.name variable.other.readwrite
+
+const
+const x = 0;
+// <- storage.type
+
+// Function parameters
 
 function f ([ x, y, ...z, ]) {}
 //          ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
@@ -78,6 +110,10 @@ function f (a, ...rest) {}
 //          ^ meta.binding.name variable.parameter.function
 //             ^^^ keyword.operator.spread
 //                ^^^^ variable.parameter.function
+
+function f (new) {}
+// ^^^^^^^^^^^^^^^^ meta.function
+//          ^^^ invalid.illegal.identifier meta.binding.name variable.parameter.function
 
 let f = ([ x, y, ...z, ]) => {};
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
@@ -125,3 +161,7 @@ let f = (a, ...rest) => {};
 //       ^ meta.binding.name variable.parameter.function
 //          ^^^ keyword.operator.spread
 //             ^^^^ meta.binding.name variable.parameter.function
+
+let f = (new) => {};
+//  ^^^^^^^^^^^^^^^ meta.function
+//       ^^^ invalid.illegal.identifier meta.binding.name variable.parameter.function


### PR DESCRIPTION
Example:

```js
const /* cursor here while typing */
const bar = 42;
```

This is not valid JavaScript, so we should choose the most convenient highlighting. Previously, the second `const` would be scoped as the name of a variable. After this change, the first `const` declaration will terminate and the second `const` will be scoped `storage.type`. Similar changes have been applied to `function`, `class`, `import`, and `export` declarations.

The result should be less “churn” while typing.

A couple of other obscure issues have been fixed along the way.