### PR TITLE
[C++/ObjC] Add support for paths in front of struct/class identifiers

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1018,8 +1018,9 @@ contexts:
       set: data-structures-class-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.class.c++ entity.name.class.c++
+        - meta_scope: meta.class.c++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.class.c++
           set: data-structures-class-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
@@ -1051,8 +1052,9 @@ contexts:
       set: data-structures-struct-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.struct.c++ entity.name.struct.c++
+        - meta_scope: meta.struct.c++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.struct.c++
           set: data-structures-struct-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
@@ -1084,8 +1086,9 @@ contexts:
       set: data-structures-enum-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.enum.c++ entity.name.enum.c++
+        - meta_scope: meta.enum.c++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.enum.c++
           set: data-structures-enum-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
@@ -1118,8 +1121,9 @@ contexts:
       set: data-structures-union-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.union.c++ entity.name.union.c++
+        - meta_scope: meta.union.c++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.union.c++
           set: data-structures-union-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1084,6 +1084,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.enum.forward-decl.c++
       set: data-structures-enum-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.enum.c++
+        - include: identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-enum-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.enum.c++
       set: data-structures-enum-definition-after-identifier
@@ -1113,6 +1119,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.union.forward-decl.c++
       set: data-structures-union-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.union.c++
+        - include: identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-union-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.union.c++
       set: data-structures-union-definition-after-identifier

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1016,6 +1016,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.class.forward-decl.c++
       set: data-structures-class-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.class.c++
+        - include: identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-class-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.class.c++
       set: data-structures-class-definition-after-identifier
@@ -1044,6 +1050,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.struct.forward-decl.c++
       set: data-structures-struct-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.struct.c++
+        - include: identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-struct-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.struct.c++
       set: data-structures-struct-definition-after-identifier

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1016,15 +1016,14 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.class.forward-decl.c++
       set: data-structures-class-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.class.c++
+        - meta_scope: meta.class.c++ entity.name.class.c++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-class-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
           set: data-structures-class-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.class.c++
-      set: data-structures-class-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-class-definition-after-identifier
     - match: '(?=;)'
@@ -1050,15 +1049,14 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.struct.forward-decl.c++
       set: data-structures-struct-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.struct.c++
+        - meta_scope: meta.struct.c++ entity.name.struct.c++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-struct-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
           set: data-structures-struct-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.struct.c++
-      set: data-structures-struct-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-struct-definition-after-identifier
     - match: '(?=;)'
@@ -1084,15 +1082,14 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.enum.forward-decl.c++
       set: data-structures-enum-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.enum.c++
+        - meta_scope: meta.enum.c++ entity.name.enum.c++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-enum-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
           set: data-structures-enum-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.enum.c++
-      set: data-structures-enum-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-enum-definition-after-identifier
     - match: '(?=;)'
@@ -1119,15 +1116,14 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.union.forward-decl.c++
       set: data-structures-union-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.union.c++
+        - meta_scope: meta.union.c++ entity.name.union.c++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-union-definition-after-identifier
         - include: identifiers
         - match: '(?=[^\w\s])'
           set: data-structures-union-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.union.c++
-      set: data-structures-union-definition-after-identifier
     - match: '(?=[{])'
       set: data-structures-union-definition-after-identifier
     - match: '(?=;)'

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1889,15 +1889,16 @@ template <class T> class Sample {
   }
 };
 
-struct Namespace::MyStruct
-/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
-/*              ^^ punctuation.accessor */
+class Namespace::MyClass MACRO1 MACRO2 : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+/*                       ^ - entity.name */
 {
 };
 
-class Namespace::MyClass : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
-/*             ^^ punctuation.accessor */
+struct Namespace::MyStruct
+/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
 {
 };
 
@@ -1912,6 +1913,35 @@ enum class Namespace::MyEnum
 /*                  ^^ punctuation.accessor */
 {
 };
+
+class Namespace::
+MyClass MACRO1 
+/* <- entity.name.class */
+/*      ^ - entity.name */
+{
+};
+
+struct Namespace::
+MyStruct MACRO1
+/* <- entity.name.struct */
+/*       ^ - entity.name */
+{
+};
+
+union Namespace::
+MyUnion MACRO1
+/* <- entity.name.union */
+/*      ^ - entity.name */
+{
+};
+
+enum class Namespace::
+MyEnum MACRO1
+/* <- entity.name.enum */
+/*     ^ - entity.name */
+{
+};
+
 
 /////////////////////////////////////////////
 // Test preprocessor branching and C blocks

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1322,18 +1322,6 @@ class BaseClass;
 /*    ^ - meta.class meta.class */
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
-struct Namespace::BaseClass
-/*     ^^^^^^^^^^^^^^^^^^^^ entity.name.struct */
-/*              ^^ punctuation.accessor */
-{
-};
-
-class Namespace::BaseClass : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^^^ entity.name.class */
-/*             ^^ punctuation.accessor */
-{
-};
-
 class BaseClass // comment
 /* <- storage.type */
 /*    ^ entity.name.class */
@@ -1899,6 +1887,30 @@ template <class T> class Sample {
     /*^^^^^^^^ entity.name.function */
      return T;
   }
+};
+
+struct Namespace::MyStruct
+/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
+{
+};
+
+class Namespace::MyClass : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+{
+};
+
+union Namespace::MyUnion
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.union */
+/*             ^^ punctuation.accessor */
+{
+};
+
+enum class Namespace::MyEnum
+/*         ^^^^^^^^^^^^^^^^^ entity.name.enum */
+/*                  ^^ punctuation.accessor */
+{
 };
 
 /////////////////////////////////////////////

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1890,26 +1890,26 @@ template <class T> class Sample {
 };
 
 class Namespace::MyClass MACRO1 MACRO2 : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*               ^^^^^^^ entity.name.class */
 /*             ^^ punctuation.accessor */
 /*                       ^ - entity.name */
 {
 };
 
 struct Namespace::MyStruct
-/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*                ^^^^^^^^ entity.name.struct */
 /*              ^^ punctuation.accessor */
 {
 };
 
 union Namespace::MyUnion
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.union */
+/*               ^^^^^^^ entity.name.union */
 /*             ^^ punctuation.accessor */
 {
 };
 
 enum class Namespace::MyEnum
-/*         ^^^^^^^^^^^^^^^^^ entity.name.enum */
+/*                    ^^^^^^ entity.name.enum */
 /*                  ^^ punctuation.accessor */
 {
 };

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1322,6 +1322,18 @@ class BaseClass;
 /*    ^ - meta.class meta.class */
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
+struct Namespace::BaseClass
+/*     ^^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
+{
+};
+
+class Namespace::BaseClass : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+{
+};
+
 class BaseClass // comment
 /* <- storage.type */
 /*    ^ entity.name.class */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1088,8 +1088,9 @@ contexts:
       set: data-structures-class-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.class.objc++ entity.name.class.objc++
+        - meta_scope: meta.class.objc++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.class.objc++
           set: data-structures-class-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-class-definition-after-identifier
@@ -1122,8 +1123,9 @@ contexts:
       set: data-structures-struct-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.struct.objc++ entity.name.struct.objc++
+        - meta_scope: meta.struct.objc++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.struct.objc++
           set: data-structures-struct-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-struct-definition-after-identifier
@@ -1156,8 +1158,9 @@ contexts:
       set: data-structures-enum-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.enum.objc++ entity.name.enum.objc++
+        - meta_scope: meta.enum.objc++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.enum.objc++
           set: data-structures-enum-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-enum-definition-after-identifier
@@ -1191,8 +1194,9 @@ contexts:
       set: data-structures-union-definition-after-identifier
     - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: meta.union.objc++ entity.name.union.objc++
+        - meta_scope: meta.union.objc++
         - match: '{{identifier}}(?!\s*::)'
+          scope: entity.name.union.objc++
           set: data-structures-union-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-union-definition-after-identifier

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1124,7 +1124,7 @@ contexts:
       set:
         - meta_scope: meta.struct.objc++ entity.name.struct.objc++
         - match: '{{identifier}}(?!\s*::)'
-          set: data-structures-class-definition-after-identifier
+          set: data-structures-struct-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-struct-definition-after-identifier
         - match: '(?=[^\w\s])'
@@ -1158,7 +1158,7 @@ contexts:
       set:
         - meta_scope: meta.enum.objc++ entity.name.enum.objc++
         - match: '{{identifier}}(?!\s*::)'
-          set: data-structures-class-definition-after-identifier
+          set: data-structures-enum-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-enum-definition-after-identifier
         - match: '(?=[^\w\s])'
@@ -1193,7 +1193,7 @@ contexts:
       set:
         - meta_scope: meta.union.objc++ entity.name.union.objc++
         - match: '{{identifier}}(?!\s*::)'
-          set: data-structures-class-definition-after-identifier
+          set: data-structures-union-definition-after-identifier
         - include: scope:source.c++#identifiers
         - match: data-structures-union-definition-after-identifier
         - match: '(?=[^\w\s])'

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1154,6 +1154,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.enum.forward-decl.objc++
       set: data-structures-enum-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.enum.objc++
+        - include: scope:source.c++#identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-enum-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.enum.objc++
       set: data-structures-enum-definition-after-identifier
@@ -1183,6 +1189,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.union.forward-decl.objc++
       set: data-structures-union-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.union.objc++
+        - include: scope:source.c++#identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-union-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.union.objc++
       set: data-structures-union-definition-after-identifier

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1086,15 +1086,15 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.class.forward-decl.objc++
       set: data-structures-class-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.class.objc++
+        - meta_scope: meta.class.objc++ entity.name.class.objc++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-class-definition-after-identifier
         - include: scope:source.c++#identifiers
+        - match: data-structures-class-definition-after-identifier
         - match: '(?=[^\w\s])'
           set: data-structures-class-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.class.objc++
-      set: data-structures-class-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-class-definition-after-identifier
     - match: '(?=;)'
@@ -1120,15 +1120,15 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.struct.forward-decl.objc++
       set: data-structures-struct-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.struct.foo.objc++
+        - meta_scope: meta.struct.objc++ entity.name.struct.objc++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-class-definition-after-identifier
         - include: scope:source.c++#identifiers
+        - match: data-structures-struct-definition-after-identifier
         - match: '(?=[^\w\s])'
           set: data-structures-struct-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.struct.objc++
-      set: data-structures-struct-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-struct-definition-after-identifier
     - match: '(?=;)'
@@ -1154,15 +1154,15 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.enum.forward-decl.objc++
       set: data-structures-enum-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.enum.objc++
+        - meta_scope: meta.enum.objc++ entity.name.enum.objc++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-class-definition-after-identifier
         - include: scope:source.c++#identifiers
+        - match: data-structures-enum-definition-after-identifier
         - match: '(?=[^\w\s])'
           set: data-structures-enum-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.enum.objc++
-      set: data-structures-enum-definition-after-identifier
     - match: '(?=[:{])'
       set: data-structures-enum-definition-after-identifier
     - match: '(?=;)'
@@ -1189,15 +1189,15 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.union.forward-decl.objc++
       set: data-structures-union-definition-after-identifier
-    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+    - match: '(?={{path_lookahead}})'
       set:
-        - meta_scope: entity.name.union.objc++
+        - meta_scope: meta.union.objc++ entity.name.union.objc++
+        - match: '{{identifier}}(?!\s*::)'
+          set: data-structures-class-definition-after-identifier
         - include: scope:source.c++#identifiers
+        - match: data-structures-union-definition-after-identifier
         - match: '(?=[^\w\s])'
           set: data-structures-union-definition-after-identifier
-    - match: '{{identifier}}'
-      scope: entity.name.union.objc++
-      set: data-structures-union-definition-after-identifier
     - match: '(?=[{])'
       set: data-structures-union-definition-after-identifier
     - match: '(?=;)'

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1086,6 +1086,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.class.forward-decl.objc++
       set: data-structures-class-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.class.objc++
+        - include: scope:source.c++#identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-class-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.class.objc++
       set: data-structures-class-definition-after-identifier
@@ -1114,6 +1120,12 @@ contexts:
     - match: '{{identifier}}(?={{data_structures_forward_decl_lookahead}})'
       scope: entity.name.struct.forward-decl.objc++
       set: data-structures-struct-definition-after-identifier
+    - match: '(?={{path_lookahead}}\s*::\s*{{identifier}})'
+      set:
+        - meta_scope: entity.name.struct.foo.objc++
+        - include: scope:source.c++#identifiers
+        - match: '(?=[^\w\s])'
+          set: data-structures-struct-definition-after-identifier
     - match: '{{identifier}}'
       scope: entity.name.struct.objc++
       set: data-structures-struct-definition-after-identifier

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1294,6 +1294,18 @@ class BaseClass;
 /*    ^ - meta.class meta.class */
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
+struct Namespace::BaseClass
+/*     ^^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
+{
+};
+
+class Namespace::BaseClass : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+{
+};
+
 class BaseClass // comment
 /* <- storage.type */
 /*    ^ entity.name.class */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1862,26 +1862,26 @@ template <class T> class Sample {
 };
 
 class Namespace::MyClass MACRO1 MACRO2 : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*               ^^^^^^^ entity.name.class */
 /*             ^^ punctuation.accessor */
 /*                       ^ - entity.name */
 {
 };
 
 struct Namespace::MyStruct
-/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*                ^^^^^^^^ entity.name.struct */
 /*              ^^ punctuation.accessor */
 {
 };
 
 union Namespace::MyUnion
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.union */
+/*               ^^^^^^^ entity.name.union */
 /*             ^^ punctuation.accessor */
 {
 };
 
 enum class Namespace::MyEnum
-/*         ^^^^^^^^^^^^^^^^^ entity.name.enum */
+/*                    ^^^^^^ entity.name.enum */
 /*                  ^^ punctuation.accessor */
 {
 };

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1861,15 +1861,16 @@ template <class T> class Sample {
   }
 };
 
-struct Namespace::MyStruct
-/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
-/*              ^^ punctuation.accessor */
+class Namespace::MyClass MACRO1 MACRO2 : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+/*                       ^ - entity.name */
 {
 };
 
-class Namespace::MyClass : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
-/*             ^^ punctuation.accessor */
+struct Namespace::MyStruct
+/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
 {
 };
 
@@ -1882,6 +1883,34 @@ union Namespace::MyUnion
 enum class Namespace::MyEnum
 /*         ^^^^^^^^^^^^^^^^^ entity.name.enum */
 /*                  ^^ punctuation.accessor */
+{
+};
+
+class Namespace::
+MyClass MACRO1 
+/* <- entity.name.class */
+/*      ^ - entity.name */
+{
+};
+
+struct Namespace::
+MyStruct MACRO1
+/* <- entity.name.struct */
+/*       ^ - entity.name */
+{
+};
+
+union Namespace::
+MyUnion MACRO1
+/* <- entity.name.union */
+/*      ^ - entity.name */
+{
+};
+
+enum class Namespace::
+MyEnum MACRO1
+/* <- entity.name.enum */
+/*     ^ - entity.name */
 {
 };
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1294,18 +1294,6 @@ class BaseClass;
 /*    ^ - meta.class meta.class */
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
-struct Namespace::BaseClass
-/*     ^^^^^^^^^^^^^^^^^^^^ entity.name.struct */
-/*              ^^ punctuation.accessor */
-{
-};
-
-class Namespace::BaseClass : public SuperClass
-/*    ^^^^^^^^^^^^^^^^^^^^ entity.name.class */
-/*             ^^ punctuation.accessor */
-{
-};
-
 class BaseClass // comment
 /* <- storage.type */
 /*    ^ entity.name.class */
@@ -1871,6 +1859,30 @@ template <class T> class Sample {
     /*^^^^^^^^ entity.name.function */
      return T;
   }
+};
+
+struct Namespace::MyStruct
+/*     ^^^^^^^^^^^^^^^^^^^ entity.name.struct */
+/*              ^^ punctuation.accessor */
+{
+};
+
+class Namespace::MyClass : public SuperClass
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.class */
+/*             ^^ punctuation.accessor */
+{
+};
+
+union Namespace::MyUnion
+/*    ^^^^^^^^^^^^^^^^^^ entity.name.union */
+/*             ^^ punctuation.accessor */
+{
+};
+
+enum class Namespace::MyEnum
+/*         ^^^^^^^^^^^^^^^^^ entity.name.enum */
+/*                  ^^ punctuation.accessor */
+{
 };
 
 /////////////////////////////////////////////


### PR DESCRIPTION
I'm sorry for the new pull request. The old one was automatically closed for some reason.

## _Copied from old PR_:

When a struct or class has been forward declared in a namespace or other class, the class or struct can be defined using an identifier with a path in front of it. I added this possibility.


**Example**
```C++
namespace Namespace
{
  class BaseClass;
}

class Namespace::BaseClass {};
```

## _Last reply_:

Hi! Thank you all for your feedback. 

> @wbond The :: should not get entity.name.class, neither should the namespace. The namespace name should be something like support.namespace.

Yes that’s what I thought too and then I looked at how scopes got applied to function definitions and function calls with namespace paths and realised that `entity.name.function` and `variable.function` where applied to the entire path including the namespace. 

With my addition, indexing works as expected as the namespace gets stripped away in `Symbol Index.tmPreferences`.