### PR TITLE
[ShellScript] Remove fish as an extension for shell script

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -13,7 +13,6 @@ file_extensions:
   - sh
   - bash
   - zsh
-  - fish
   - .bash_aliases
   - .bash_completions
   - .bash_functions


### PR DESCRIPTION
The shell script syntax and snippets do not support fish.

In the future, we should consider importing https://github.com/Phidica/sublime-fish