### PR TITLE
[C++/ObjC++] Add highlighting and indexing support for using aliases

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -435,7 +435,7 @@ contexts:
         - include: expressions
 
   using-namespace:
-    - match: '\b(using)\s+(namespace)\s+(?={{path_lookahead}})'
+    - match: '\b(using)\s+(namespace)'
       captures:
         1: keyword.control.c++
         2: keyword.control.c++
@@ -699,8 +699,6 @@ contexts:
       scope: punctuation.accessor.arrow.c++
       push: members-after-accessor-junction
 
-  
-
   using-alias:
     # consume keyword if followed by typename
     - match: '\b(using)\b(?=\s+typename\b)'
@@ -710,7 +708,7 @@ contexts:
       captures:
         1: storage.type.c++
         2: entity.name.type.using.c++
-        
+
   typedef:
     - match: \btypedef\b
       scope: storage.type.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -234,6 +234,7 @@ contexts:
     - include: comments
     - include: case-default
     - include: typedef
+    - include: using-alias
     - include: keywords-angle-brackets
     - include: keywords-parens
     - include: keywords
@@ -694,6 +695,12 @@ contexts:
       scope: punctuation.accessor.arrow.c++
       push: members-after-accessor-junction
 
+  using-alias:
+    - match: '\b(using)\b\s+({{identifier}})(?!\s*::)'
+      captures:
+        1: storage.type.c++
+        2: entity.name.type.using.c++
+        
   typedef:
     - match: \btypedef\b
       scope: storage.type.c++
@@ -1168,6 +1175,7 @@ contexts:
         - match: (?=\S)
           set: data-structures-modifier
     - include: typedef
+    - include: using-alias
     - match: \b({{visibility_modifiers}})\s*(:)(?!:)
       captures:
         1: storage.modifier.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -435,7 +435,7 @@ contexts:
         - include: expressions
 
   using-namespace:
-    - match: '\b(using)\s+(namespace)'
+    - match: '\b(using)\s+(namespace)\b'
       captures:
         1: keyword.control.c++
         2: keyword.control.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -934,7 +934,7 @@ contexts:
               set: function-definition-continue
             - match: '\bvoid\b'
               scope: storage.type.c++
-            - match: '{{identifier}}(?=\s*(\[|,|\)|=|$\n))'
+            - match: '{{identifier}}(?=\s*(\[|,|\)|=))'
               scope: variable.parameter.c++
             - match: '='
               scope: keyword.operator.assignment.c++
@@ -963,33 +963,6 @@ contexts:
       scope: keyword.operator.c++
     - match: \b0\b
       scope: constant.numeric.c++
-    - match: ':'
-      scope: punctuation.separator.initializer-list.c++
-      set:
-        - meta_scope: meta.function.initializer-list.c++
-        - match: '{{identifier}}'
-          scope: variable.other.readwrite.member.c++
-          push:
-            - match: \(
-              scope: meta.group.c++ punctuation.section.group.begin.c++
-              set:
-                - meta_content_scope: meta.group.c++
-                - match: \)
-                  scope: meta.group.c++ punctuation.section.group.end.c++
-                  pop: true
-                - include: expressions
-            - match: \{
-              scope: meta.group.c++ punctuation.section.group.begin.c++
-              set:
-                - meta_content_scope: meta.group.c++
-                - match: \}
-                  scope: meta.group.c++ punctuation.section.group.end.c++
-                  pop: true
-                - include: expressions
-            - include: comments
-        - match: (?=\{|;)
-          set: function-definition-continue
-        - include: expressions
     - match: \b(default|delete)\b
       scope: storage.modifier.c++
     - match: '(?=\{)'
@@ -1395,7 +1368,7 @@ contexts:
               set: method-definition-continue
             - match: '\bvoid\b'
               scope: storage.type.c++
-            - match: '{{identifier}}(?=\s*(\[|,|\)|=|$\n))'
+            - match: '{{identifier}}(?=\s*(\[|,|\)|=))'
               scope: variable.parameter.c++
             - match: '='
               scope: keyword.operator.assignment.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -41,7 +41,6 @@ variables:
   generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
-  ivu_macro_identifier: '\bEXP_[[:alnum:]_]*\b'
 
 contexts:
   main:
@@ -1045,7 +1044,7 @@ contexts:
 
   preprocessor-workaround-eat-macro-before-identifier:
     # Handle macros so they aren't matched as the class name
-    - match: ({{macro_identifier}}|{{ivu_macro_identifier}})(?=\s+~?{{identifier}})
+    - match: ({{macro_identifier}})(?=\s+~?{{identifier}})
       captures:
         1: meta.assumed-macro.c
 

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -41,6 +41,7 @@ variables:
   generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
+  ivu_macro_identifier: '\bEXP_[[:alnum:]_]*\b'
 
 contexts:
   main:
@@ -180,6 +181,7 @@ contexts:
         - include: template
         - match: (?=\S)
           set: global-modifier
+    - include: using-namespace
     - include: namespace
     - include: keywords-angle-brackets
     - match: '(?={{path_lookahead}}\s*<)'
@@ -233,6 +235,7 @@ contexts:
     - include: preprocessor-expressions
     - include: comments
     - include: case-default
+    - include: using-namespace
     - include: typedef
     - include: using-alias
     - include: keywords-angle-brackets
@@ -432,7 +435,7 @@ contexts:
           pop: true
         - include: expressions
 
-  namespace:
+  using-namespace:
     - match: '\b(using)\s+(namespace)\s+(?={{path_lookahead}})'
       captures:
         1: keyword.control.c++
@@ -441,6 +444,8 @@ contexts:
         - include: identifiers
         - match: ''
           pop: true
+
+  namespace:
     - match: '\b(namespace)\s+(?=({{path_lookahead}})?(?!\s*[;,]))'
       scope: meta.namespace.c++
       captures:
@@ -930,7 +935,7 @@ contexts:
               set: function-definition-continue
             - match: '\bvoid\b'
               scope: storage.type.c++
-            - match: '{{identifier}}(?=\s*(\[|,|\)|=))'
+            - match: '{{identifier}}(?=\s*(\[|,|\)|=|$\n))'
               scope: variable.parameter.c++
             - match: '='
               scope: keyword.operator.assignment.c++
@@ -959,6 +964,33 @@ contexts:
       scope: keyword.operator.c++
     - match: \b0\b
       scope: constant.numeric.c++
+    - match: ':'
+      scope: punctuation.separator.initializer-list.c++
+      set:
+        - meta_scope: meta.function.initializer-list.c++
+        - match: '{{identifier}}'
+          scope: variable.other.readwrite.member.c++
+          push:
+            - match: \(
+              scope: meta.group.c++ punctuation.section.group.begin.c++
+              set:
+                - meta_content_scope: meta.group.c++
+                - match: \)
+                  scope: meta.group.c++ punctuation.section.group.end.c++
+                  pop: true
+                - include: expressions
+            - match: \{
+              scope: meta.group.c++ punctuation.section.group.begin.c++
+              set:
+                - meta_content_scope: meta.group.c++
+                - match: \}
+                  scope: meta.group.c++ punctuation.section.group.end.c++
+                  pop: true
+                - include: expressions
+            - include: comments
+        - match: (?=\{|;)
+          set: function-definition-continue
+        - include: expressions
     - match: \b(default|delete)\b
       scope: storage.modifier.c++
     - match: '(?=\{)'
@@ -1013,7 +1045,7 @@ contexts:
 
   preprocessor-workaround-eat-macro-before-identifier:
     # Handle macros so they aren't matched as the class name
-    - match: ({{macro_identifier}})(?=\s+~?{{identifier}})
+    - match: ({{macro_identifier}}|{{ivu_macro_identifier}})(?=\s+~?{{identifier}})
       captures:
         1: meta.assumed-macro.c
 
@@ -1174,6 +1206,7 @@ contexts:
         - include: template
         - match: (?=\S)
           set: data-structures-modifier
+    - include: using-namespace
     - include: typedef
     - include: using-alias
     - match: \b({{visibility_modifiers}})\s*(:)(?!:)
@@ -1363,7 +1396,7 @@ contexts:
               set: method-definition-continue
             - match: '\bvoid\b'
               scope: storage.type.c++
-            - match: '{{identifier}}(?=\s*(\[|,|\)|=))'
+            - match: '{{identifier}}(?=\s*(\[|,|\)|=|$\n))'
               scope: variable.parameter.c++
             - match: '='
               scope: keyword.operator.assignment.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -699,8 +699,14 @@ contexts:
       scope: punctuation.accessor.arrow.c++
       push: members-after-accessor-junction
 
+  
+
   using-alias:
-    - match: '\b(using)\b\s+({{identifier}})(?!\s*::)'
+    # consume keyword if followed by typename
+    - match: '\b(using)\b(?=\s+typename\b)'
+      captures:
+        1: keyword.control.c++
+    - match: '\b(using)\b\s+({{identifier}})(?!\s*(<|::))'
       captures:
         1: storage.type.c++
         2: entity.name.type.using.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -706,7 +706,7 @@ contexts:
         1: keyword.control.c++
     - match: '\b(using)\b\s+({{identifier}})(?!\s*(<|::))'
       captures:
-        1: storage.type.c++
+        1: keyword.control.c++
         2: entity.name.type.using.c++
 
   typedef:

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -401,9 +401,23 @@ class MyClass : public SuperClass
 /*  ^ storage.type */
 /*        ^^^^ entity.name.type.using */
 
+    using MyInt
+/*  ^ storage.type */
+        = int32_t;
+
     using SuperClass::SuperClass;
 /*  ^ keyword.control */
 /*        ^ - entity.name */
+};
+
+class MyClass : public CrtpClass<MyClass>
+{
+    using typename CrtpClass<MyClass>::PointerType;
+/*  ^ keyword.control */
+/*        ^ storage.modifier */ 
+    using CrtpClass<
+/*  ^ keyword.control */
+        MyClass>::method;
 };
 
 typedef struct Books Book;

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1272,6 +1272,14 @@ using namespace NAME __attribute__((visibility ("hidden")));
 /*                   ^ storage.modifier */
 /*                                               ^ string */
 
+void func() {
+    using namespace NAME __attribute__((visibility ("hidden")));
+/*  ^ keyword.control */
+/*        ^ keyword.control */
+/*                       ^ storage.modifier */
+/*                                                   ^ string */
+}
+
 using namespace myNameSpace;
 /* <- keyword.control */
 /*    ^ keyword.control */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -381,7 +381,7 @@ using Alias = Foo;
 
 using Alias
   = NewLineFoo;
-/*^ - entity.name */
+/*^ - entity.name */ 
 
 template <typename T>
 using TemplateAlias = Foo<T>;
@@ -1293,6 +1293,10 @@ void func() {
 /*                       ^ storage.modifier */
 /*                                                   ^ string */
 }
+
+using namespace 
+/* <- keyword.control */
+/*    ^ keyword.control */
 
 using namespace myNameSpace;
 /* <- keyword.control */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -376,7 +376,7 @@ typedef struct Books {
 /*^ entity.name.type */
 
 using Alias = Foo;
-/* <- storage.type */
+/* <- keyword.control */
 /*    ^^^^^ entity.name.type.using */
 
 using Alias
@@ -398,11 +398,11 @@ using std::
 class MyClass : public SuperClass
 {
     using This = MyClass;
-/*  ^ storage.type */
+/*  ^ keyword.control */
 /*        ^^^^ entity.name.type.using */
 
     using MyInt
-/*  ^ storage.type */
+/*  ^ keyword.control */
         = int32_t;
 
     using SuperClass::SuperClass;

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -376,7 +376,7 @@ typedef struct Books {
 /*^ entity.name.type */
 
 using Alias = Foo;
-/* <- storage.type.c++ */
+/* <- storage.type */
 /*    ^^^^^ entity.name.type.using */
 
 using Alias
@@ -398,7 +398,7 @@ using std::
 class MyClass : public SuperClass
 {
     using This = MyClass;
-/*  ^ storage.type.c++ */
+/*  ^ storage.type */
 /*        ^^^^ entity.name.type.using */
 
     using SuperClass::SuperClass;

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -375,6 +375,37 @@ typedef struct Books {
 } Book;
 /*^ entity.name.type */
 
+using Alias = Foo;
+/* <- storage.type.c++ */
+/*    ^^^^^ entity.name.type.using */
+
+using Alias
+  = NewLineFoo;
+/*^ - entity.name */
+
+template <typename T>
+using TemplateAlias = Foo<T>;
+/*    ^^^^^^^^^^^^^ entity.name.type.using */
+
+using std::cout;
+/* <- keyword.control */
+/*    ^ - entity.name */
+
+using std::
+  cout;
+/*^ - entity.name */
+
+class MyClass : public SuperClass
+{
+    using This = MyClass;
+/*  ^ storage.type.c++ */
+/*        ^^^^ entity.name.type.using */
+
+    using SuperClass::SuperClass;
+/*  ^ keyword.control */
+/*        ^ - entity.name */
+};
+
 typedef struct Books Book;
 /*             ^ - entity.name.type.struct */
 /*                   ^ entity.name.type.typedef */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -770,7 +770,11 @@ contexts:
       push: members-after-accessor-junction
 
   using-alias:
-    - match: '\b(using)\b\s+({{identifier}})(?!\s*::)'
+    # consume keyword if followed by typename
+    - match: '\b(using)\b(?=\s+typename\b)'
+      captures:
+        1: keyword.control.objc++
+    - match: '\b(using)\b\s+({{identifier}})(?!\s*(<|::))'
       captures:
         1: storage.type.objc++
         2: entity.name.type.using.objc++

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -44,6 +44,7 @@ contexts:
         - include: template
         - match: (?=\S)
           set: global-modifier
+    - include: using-namespace
     - include: namespace
     - include: keywords-angle-brackets
     - match: '(?={{path_lookahead}}\s*<)'
@@ -98,6 +99,7 @@ contexts:
   early-expressions-before-generic-type:
     - include: comments
     - include: case-default
+    - include: using-namespace
     - include: typedef
     - include: using-alias
     - include: keywords-angle-brackets
@@ -508,7 +510,7 @@ contexts:
           pop: true
         - include: expressions
 
-  namespace:
+  using-namespace:
     - match: '\b(using)\s+(namespace)\s+(?={{path_lookahead}})'
       captures:
         1: keyword.control.objc++
@@ -517,6 +519,8 @@ contexts:
         - include: scope:source.c++#identifiers
         - match: ''
           pop: true
+
+  namespace:
     - match: '\b(namespace)\s+(?=({{path_lookahead}})?(?!\s*[;,]))'
       scope: meta.namespace.objc++
       captures:

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -99,6 +99,7 @@ contexts:
     - include: comments
     - include: case-default
     - include: typedef
+    - include: using-alias
     - include: keywords-angle-brackets
     - include: keywords-parens
     - include: keywords
@@ -763,6 +764,12 @@ contexts:
     - match: ->
       scope: punctuation.accessor.arrow.objc++
       push: members-after-accessor-junction
+
+  using-alias:
+    - match: '\b(using)\b\s+({{identifier}})(?!\s*::)'
+      captures:
+        1: storage.type.objc++
+        2: entity.name.type.using.objc++
 
   typedef:
     - match: \btypedef\b

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -511,7 +511,7 @@ contexts:
         - include: expressions
 
   using-namespace:
-    - match: '\b(using)\s+(namespace)\s+(?={{path_lookahead}})'
+    - match: '\b(using)\s+(namespace)\b'
       captures:
         1: keyword.control.objc++
         2: keyword.control.objc++

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -776,7 +776,7 @@ contexts:
         1: keyword.control.objc++
     - match: '\b(using)\b\s+({{identifier}})(?!\s*(<|::))'
       captures:
-        1: storage.type.objc++
+        1: keyword.control.objc++
         2: entity.name.type.using.objc++
 
   typedef:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -404,9 +404,23 @@ class MyClass : public SuperClass
 /*  ^ storage.type */
 /*        ^^^^ entity.name.type.using */
 
+    using MyInt
+/*  ^ storage.type */
+        = int32_t;
+
     using SuperClass::SuperClass;
 /*  ^ keyword.control */
 /*        ^ - entity.name */
+};
+
+class MyClass : public CrtpClass<MyClass>
+{
+    using typename CrtpClass<MyClass>::PointerType;
+/*  ^ keyword.control */
+/*        ^ storage.modifier */ 
+    using CrtpClass<
+/*  ^ keyword.control */
+        MyClass>::method;
 };
 
 template class MyStack<int, 6>;

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1248,6 +1248,14 @@ using namespace myNameSpace;
 /* <- keyword.control */
 /*    ^ keyword.control */
 
+void func() {
+    using namespace NAME __attribute__((visibility ("hidden")));
+/*  ^ keyword.control */
+/*        ^ keyword.control */
+/*                       ^ storage.modifier */
+/*                                                   ^ string */
+}
+
 namespace ns :: abc /* Neither this comment... */
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.namespace */
 /*        ^^^^^^^^^ entity.name.namespace */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -378,6 +378,37 @@ typedef struct Books Book;
 /*             ^ - entity.name.type.struct */
 /*                   ^ entity.name.type.typedef */
 
+using Alias = Foo;
+/* <- storage.type.c++ */
+/*    ^^^^^ entity.name.type.using */
+
+using Alias
+  = NewLineFoo;
+/*^ - entity.name */
+
+template <typename T>
+using TemplateAlias = Foo<T>;
+/*    ^^^^^^^^^^^^^ entity.name.type.using */
+
+using std::cout;
+/* <- keyword.control */
+/*    ^ - entity.name */
+
+using std::
+  cout;
+/*^ - entity.name */
+
+class MyClass : public SuperClass
+{
+    using This = MyClass;
+/*  ^ storage.type.c++ */
+/*        ^^^^ entity.name.type.using */
+
+    using SuperClass::SuperClass;
+/*  ^ keyword.control */
+/*        ^ - entity.name */
+};
+
 template class MyStack<int, 6>;
 /* <- storage.type.template */
 /*                    ^ punctuation.section.generic */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -379,7 +379,7 @@ typedef struct Books Book;
 /*                   ^ entity.name.type.typedef */
 
 using Alias = Foo;
-/* <- storage.type */
+/* <- keyword.control */
 /*    ^^^^^ entity.name.type.using */
 
 using Alias
@@ -401,11 +401,11 @@ using std::
 class MyClass : public SuperClass
 {
     using This = MyClass;
-/*  ^ storage.type */
+/*  ^ keyword.control */
 /*        ^^^^ entity.name.type.using */
 
     using MyInt
-/*  ^ storage.type */
+/*  ^ keyword.control */
         = int32_t;
 
     using SuperClass::SuperClass;

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -379,7 +379,7 @@ typedef struct Books Book;
 /*                   ^ entity.name.type.typedef */
 
 using Alias = Foo;
-/* <- storage.type.c++ */
+/* <- storage.type */
 /*    ^^^^^ entity.name.type.using */
 
 using Alias
@@ -401,7 +401,7 @@ using std::
 class MyClass : public SuperClass
 {
     using This = MyClass;
-/*  ^ storage.type.c++ */
+/*  ^ storage.type */
 /*        ^^^^ entity.name.type.using */
 
     using SuperClass::SuperClass;
@@ -1476,6 +1476,11 @@ class DerivedClass : public ::BaseClass // Comment
     typedef std::vector<int> qux;
 /*                           ^^^ entity.name.type.typedef */
 };
+
+DerivedClass::DerivedClass()
+  : a(a),
+    base_id_(BaseClass::None().ToInt())
+{}
 
 
 template<typename A>

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1258,6 +1258,10 @@ using namespace NAME __attribute__((visibility ("hidden")));
 /*                   ^ storage.modifier */
 /*                                               ^ string */
 
+using namespace 
+/* <- keyword.control */
+/*    ^ keyword.control */
+
 using namespace myNameSpace;
 /* <- keyword.control */
 /*    ^ keyword.control */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1477,11 +1477,6 @@ class DerivedClass : public ::BaseClass // Comment
 /*                           ^^^ entity.name.type.typedef */
 };
 
-DerivedClass::DerivedClass()
-  : a(a),
-    base_id_(BaseClass::None().ToInt())
-{}
-
 
 template<typename A>
 class class1<A> : class2<A>


### PR DESCRIPTION
This PR adds indexing support for using aliases, just like typedefs.

fixes #1578

```c++
typedef Foo MyAlias;  
using MyAlias = Foo; 
```