### PR TITLE
allow transpose for curly brackets

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -134,7 +134,7 @@ contexts:
         - meta_content_scope: meta.brackets.curly.matlab
         - match: '\}'
           scope: meta.brackets.curly.matlab
-          pop: true
+          set: transpose_post_parens
         - include: allofem
         - include: end_in_parens
   end_in_parens:

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -173,10 +173,10 @@ a = a' % is the conjugate and transpose
 a = a.' % is the transpose
 %   ^ -keyword.operator.transpose.matlab
 %    ^^ keyword.operator.transpose.matlab
-x = a[3]' + b(4)' % is the conjugate and transpose
+x = a[3]' + b(4)' + c{5}' % is the conjugate and transpose
 %       ^ keyword.operator.transpose.matlab
 %               ^ keyword.operator.transpose.matlab
-
+%                       ^ keyword.operator.transpose.matlab
 
 %---------------------------------------------
 % String


### PR DESCRIPTION
In Matlab, you can run into situations where the transpose of a cell array H behaves differently if you take H' or H{:}' (see example below).   We have a project that makes use of the H{:}' construct.  This PR fixes the highlighting for that case and does not seem to adversely affect the syntax_test_matlab.m file.

```
A = 'a,b,c,d'
H = textscan(A,'%q','delimiter',',')
h = H'
h2 = H{:}'
```

results in
```
A =

    'a,b,c,d'


H =

  1x1 cell array

    {4x1 cell}


h =

  1x1 cell array

    {4x1 cell}


h2 =

  1x4 cell array

    {'a'}    {'b'}    {'c'}    {'d'}
```