### PR TITLE
[Makefile] Include newline chars in comment scopes

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -322,14 +322,15 @@ contexts:
         # I don't like putting the string "source.shell" here, as the delegation
         # seeps into this syntax now. But I don't see a cleaner way right now.
         - meta_scope: source.shell comment.line.number-sign.shell
-        - include: pop-on-line-end
+        - include: comments-pop-on-line-end
     # Otherwise, delegate to the shell syntax (with various extra prototypes).
     - match: ""
       set: scope:source.shell
       with_prototype:
+        - include: pop-on-line-end
+        - include: scope:source.shell#prototype
         - include: line-continuation
         - include: variable-substitutions
-        - include: pop-on-line-end
 
   line-continuation:
     - match: (\\)([ ]*)$\n?
@@ -374,6 +375,10 @@ contexts:
     - match: \\.
       scope: constant.character.escape.makefile
 
+  comments-pop-on-line-end:
+    - match: \n
+      pop: true
+
   comments:
     # This hack is here in order to circumvent false-positives for the big
     # rule lookahead. For example, if this match is not present, then things
@@ -388,14 +393,14 @@ contexts:
           scope: punctuation.definition.comment.makefile
           set:
             - meta_scope: comment.line.number-sign.makefile
-            - include: pop-on-line-end
+            - include: comments-pop-on-line-end
     # This is the "normal" comment parsing logic, but not sufficient in every
     # case (see above).
     - match: \#
       scope: punctuation.definition.comment.makefile
       push:
         - meta_scope: comment.line.number-sign.makefile
-        - include: pop-on-line-end
+        - include: comments-pop-on-line-end
 
   inside-function-call:
     - meta_content_scope: meta.function-call.arguments.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -253,6 +253,11 @@ all: foo.o # a comment
 	rm -rf /
 # <- meta.function.body
 
+# A make comment.
+#                ^ comment.line.number-sign.makefile
+foo: qux
+	@bar # A shell comment.
+	#                      ^ comment.line.number-sign.shell
 
 sources := $($(a1)_objects:.o=.c)
 # ^ variable


### PR DESCRIPTION
When typing a comment, the newline character should be scoped as a comment too.
Because otherwise, ST will provide wrong auto-complete suggestions.

Fixes https://github.com/sublimehq/Packages/issues/1670