### PR TITLE
[Makefile] Fix: call functions with no arguments

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -419,6 +419,8 @@ contexts:
         - meta_content_scope:
             meta.function-call.makefile
             variable.function.makefile
+        - match: (?=\))
+          set: inside-function-call
         - match: (?=,)
           set:
             - meta_content_scope: meta.function-call.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -349,6 +349,15 @@ foo = $(call reverse,a,b)
 #                      ^ string.unquoted meta.function-call.arguments
 #                       ^ string.unquoted keyword.other.block.end
 
+foo = $(call something)
+#                     ^ - variable.function
+
+foo = $(eval $(call bar))
+#       ^ support.function
+#                 ^ constant.language
+#                     ^ variable.function
+#                      ^^ string.unquoted keyword.other.block.end - variable.function
+
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 #              ^^^^^^^^^ meta.function-call support.function
 #                          ^^^^^^^^ meta.function-call.arguments meta.function-call support.function


### PR DESCRIPTION
The syntax tripped up when calling a function with no arguments.
This is now fixed.

Fixes #1682.