### PR TITLE
[Scala] Improved stop tokens in types

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -7,6 +7,9 @@ file_extensions:
   - sbt
 scope: source.scala
 variables:
+  # all reserved words (https://www.safaribooksonline.com/library/view/learning-scala/9781449368814/apa.html)
+  keywords: '\b(?:abstract|case|catch|class|def|do|else|extends|false|final|finally|for|forSome|if|implicit|import|lazy|match|new|null|object|override|package|private|protected|return|sealed|super|this|throw|trait|true|try|type|val|var|while|with|yield)\b'
+
   # lookaround for operators
   nonopchar: '[[[:alpha:]]0-9\s\(\)\[\]\{\}'']'
   # From http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html
@@ -1370,8 +1373,9 @@ contexts:
     - match: '{{typeid}}'
       scope: support.type.scala
     - include: base-type-expression
+    - match: '(?={{keywords}})'
+      pop: true
   single-type-expression:
-    - meta_scope: single-type-expression
     - match: '(?=\bif\b)'   # for pattern matching
       pop: true
     - match: '\b(type)\b'
@@ -1390,6 +1394,8 @@ contexts:
     - include: char-literal
     - include: scala-symbol
     - include: strings
+    - match: '(?={{keywords}})'
+      pop: true
     - match: '{{typeid}}'
       scope: support.type.scala
       set: single-type-expression-tail
@@ -1399,7 +1405,6 @@ contexts:
     - match: '(?=[\s,\)\}\]])'
       pop: true
   single-type-expression-tail:
-    - meta_scope: single-type-expression-tail
     - match: (?=@{{plainid}})
       set:
         - include: annotation
@@ -1424,6 +1429,8 @@ contexts:
       set: single-type-expression
     - match: (?={{typeid}})
       set: single-type-expression
+    - match: '(?={{keywords}})'
+      pop: true
     - match: \n
       set: single-type-expression-tail-newline
     - match: '(?=\S)'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1231,6 +1231,9 @@ contexts:
       scope: entity.name.val.scala
     - match: '{{typeprefix}}'
       push:
+        - match: '\bif\b'
+          scope: invalid.keyword.if-in-val-match.scala
+          pop: true
         - match: '(?=[\]\}\)])'
           pop: true
         - match: '(?={{nonopchar}}?={{nonopchar}})'
@@ -1364,6 +1367,9 @@ contexts:
       scope: support.type.scala
     - include: base-type-expression
   single-type-expression:
+    - meta_scope: single-type-expression
+    - match: '(?=\bif\b)'   # for pattern matching
+      pop: true
     - match: '\b(type)\b'
       scope: keyword.other.scala
     - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
@@ -1389,6 +1395,7 @@ contexts:
     - match: '(?=[\s,\)\}\]])'
       pop: true
   single-type-expression-tail:
+    - meta_scope: single-type-expression-tail
     - match: (?=@{{plainid}})
       set:
         - include: annotation
@@ -1405,6 +1412,8 @@ contexts:
           scope: punctuation.definition.generic.end.scala
           set: single-type-expression-tail
         - include: delimited-type-expression
+    - match: '(?=\bif\b)'
+      pop: true
     - match: '\b(with)(?:\s+|\b)'
       captures:
         1: keyword.declaration.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1248,9 +1248,13 @@ contexts:
           pop: true
         - include: val-pattern-match-inner
   val-pattern-match-inner:
+    # ascription with ',' stop token
+    - match: '{{typeprefix}}'
+      push:
+        - match: '(?=,)'
+          pop: true
+        - include: single-type-expression
     - include: val-pattern-match-main
-    - match: '{{upperid}}'
-      scope: support.class.scala
 
   base-pattern-match:
     - include: keywords

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1704,3 +1704,16 @@ type Foo = null
 
    type P = Repr.super
 //               ^^^^^ variable.language.scala
+
+a match {
+  case x: b if Foo =>
+//          ^^ keyword.control.flow.scala
+//             ^^^ support.constant.scala
+}
+
+val foo: Abc if bar = 42
+//           ^^ invalid.keyword.if-in-val-match.scala
+
+val (a: Foo, b: Bar) = ()
+//      ^^^ support.class.scala
+//              ^^^ support.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1717,3 +1717,9 @@ val foo: Abc if bar = 42
 val (a: Foo, b: Bar) = ()
 //      ^^^ support.class.scala
 //              ^^^ support.class.scala
+
+   if (true)
+     new BitSet
+   else
+// ^^^^ keyword.control.flow.scala
+     ()


### PR DESCRIPTION
There were some issues with the type context overflowing into subsequent contexts. This resolves *most* of these issues, but one still remains:

```scala
   type S = Map
   evalNT
// ^^^^^^ - support.type.scala

   new Foo
   evalNT
// ^^^^^^ - support.type.scala
```

Both of these tests fail. Unfortunately, we can't just treat `\n` as a stop token because of types like this:

```scala
type Foo = A ::
 B ::
 C ::
 D
```

And this:

```scala
type Foo =
  A
```

So it's tricky. I think we need to stop cheating and actually have the even/odd state machine in the type expressions (where the odd state uses `\n` as a stop character, but even doesn't), which would match Scala's own parser, but it's a pain to do this so I'm skipping it for now.