### PR TITLE
[Git Formats] Fix user-name references

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -75,7 +75,7 @@ contexts:
 
   username:
     # user reference
-    - match: (\@)\w+\b
+    - match: (\@)[-\w]+\b
       scope: meta.reference.username.git entity.name.reference.username.git
       captures:
         1: punctuation.definition.reference.username.git

--- a/Git Formats/syntax_test_git_commit
+++ b/Git Formats/syntax_test_git_commit
@@ -18,6 +18,9 @@ The message can contain # which is no comment start
 # <- meta.message.git.commit - meta.subject - meta.expect-subject
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 #                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line
+  @user-name
+# ^ punctuation.definition.reference.username
+# ^^^^^^^^^^ meta.reference.username entity.name.reference.username
 Thanks to @username <name@mail-host.domain>.
 # <- meta.message.git.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit


### PR DESCRIPTION
Fix an issue with user name references like @user-name which contain hyphens not being fully highlighted.