### PR TITLE
[TCL] Fix detection and highlighting of braces (#1681)

### DIFF
--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -140,7 +140,7 @@ contexts:
             - match: '\{(?=(\n|\s*({{most_likely_code}})))'
               scope: punctuation.section.block.begin.tcl
               set: [command-braces, command-name]
-            - match: '\{(?=\s)'
+            - match: '\{(?=\s*)'
               scope: punctuation.section.block.begin.tcl
               set: non-command-braces
             - match: '\{'
@@ -415,7 +415,7 @@ contexts:
           scope: punctuation.section.block.end.tcl
           pop: true
         - include: commands
-    - match: '\{(?=\s|\})'
+    - match: '\{(?=\s*|\})'
       scope: punctuation.section.block.begin.tcl
       push: non-command-braces
     - match: '\{'

--- a/TCL/syntax_test_tcl.tcl
+++ b/TCL/syntax_test_tcl.tcl
@@ -275,8 +275,17 @@ proc test {} {
             set ifoid $paroid
             set eaoid [elm_oid_by_iface $ifoid]
             set earole [objectGetField -oid $eaoid -fieldname role]
-		}
-	}
+        }
+    }
+}
+
+# https://github.com/sublimehq/Packages/issues/1681
+
+# When set has a brace followed by non-whitespace,
+# based on Manual Braces[6] https://wiki.tcl.tk/10259,
+# we don't treat it as a string, we treat it as list
+foreach var ${list_of_vars} {
+    set list_of_lists {{first ONE} {second TWO} {third THREE} {fourth FOUR}}
 }
 
 # https://github.com/sublimehq/Packages/issues/1145


### PR DESCRIPTION
As I said in discussion on #1681 based on [man Braces [6]](https://wiki.tcl.tk/10259):
> If the first character of a word is an open brace (“{”) and rule [5] does not apply, then the word is terminated by the matching close brace (“}”). Braces nest within the word: for each additional open brace there must be an additional close brace (however, if an open brace or close brace within the word is quoted with a backslash then it is not counted in locating the matching close brace). <...> The word will consist of exactly the characters between the outer braces, not including the braces themselves.

It will be correct to determine lines between braces as list, not as string.
But this solution in conflict with #1145. So, let's discuss on this.