### PR TITLE
[MATLAB] add parfor as a keyword

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -193,7 +193,7 @@ contexts:
       comment: Data Analysis
       scope: keyword.analysis.matlab
   matlab_keyword_control:
-    - match: \b(break|case|catch|continue|else|elseif|end|for|if|otherwise|pause|rethrow|return|start|startat|stop|switch|try|wait|while)\b
+    - match: \b(break|case|catch|continue|else|elseif|end|for|parfor|if|otherwise|pause|rethrow|return|start|startat|stop|switch|try|wait|while)\b
       comment: Control keywords
       scope: keyword.control.matlab
   matlab_keyword_desktop:

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -201,3 +201,9 @@ s1="00:06:57";
 %   ^^^^^^^^ string.quoted.double.matlab
 %           ^ punctuation.definition.string.end.matlab
 
+%---------------------------------------------
+% parfor keyword test
+% parfor
+parfor x = 1:10
+^ keyword.control.matlab
+end

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -205,5 +205,5 @@ s1="00:06:57";
 % parfor keyword test
 % parfor
 parfor x = 1:10
-^ keyword.control.matlab
+%^ keyword.control.matlab
 end


### PR DESCRIPTION
Add parfor as a keyword in MATLAB syntax.

(https://uk.mathworks.com/help/distcomp/parfor.html)