### PR TITLE
[C++/ObjC] Fix: generic_lookahead variable

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -38,7 +38,7 @@ variables:
   other_keywords: 'typedef|decltype|nullptr|{{visibility_modifiers}}|static_assert|sizeof|using|typeid|alignof|alignas|namespace|template'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
   non_angle_brackets: '(?=<<|<=)'
-  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
+  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<[^{]*>|\s|\d)*)?>'
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -616,6 +616,20 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+template<typename T> C<T> f(T t)
+{
+    return C<T> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*          ^ punctuation.section.block.begin */
+}
+
+template<typename T> C<X<T>> f(T t)
+{
+    return C<X<T>> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*             ^ punctuation.section.block.begin */
+}
+
 struct A { int foo; };
 int main() {
     A a, b;

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -26,7 +26,7 @@ variables:
   other_keywords: 'typedef|decltype|nullptr|{{visibility_modifiers}}|static_assert|sizeof|using|typeid|alignof|alignas|namespace|template'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
   non_angle_brackets: '(?=<<|<=)'
-  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
+  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<[^{]*>|\s|\d)*)?>'
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -615,6 +615,20 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+template<typename T> C<T> f(T t)
+{
+    return C<T> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*          ^ punctuation.section.block.begin */
+}
+
+template<typename T> C<X<T>> f(T t)
+{
+    return C<X<T>> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*             ^ punctuation.section.block.begin */
+}
+
 struct A { int foo; };
 int main() {
     A a;


### PR DESCRIPTION
The generic_lookahead variable didn't work quite right when uniform init syntax
was involved. It hopefully does now. A `<.*?>` was changed into `<[^{]*>` in that variable.

Fixes https://github.com/sublimehq/Packages/issues/1713.