### PR TITLE
[C/ObjC] Fix: be more lenient about macro identifiers with enum return types

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -465,12 +465,24 @@ contexts:
   data-structures-struct-definition:
     - meta_scope: meta.struct.c
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.struct.forward-decl.c
     - match: '{{identifier}}'
       scope: entity.name.struct.c
+      set: data-structures-struct-definition-after-name
+    - include: data-structures-struct-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-struct-definition-after-name:
+    - meta_scope: meta.struct.c
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-struct-definition-block-start
+
+  data-structures-struct-definition-block-start:
     - match: '\{'
       scope: meta.block.c punctuation.section.block.begin.c
       set:
@@ -483,12 +495,24 @@ contexts:
   data-structures-enum-definition:
     - meta_scope: meta.enum.c
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.enum.forward-decl.c
     - match: '{{identifier}}'
       scope: entity.name.enum.c
+      set: data-structures-enum-definition-after-name
+    - include: data-structures-enum-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-enum-definition-after-name:
+    - meta_scope: meta.enum.c
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-enum-definition-block-start
+
+  data-structures-enum-definition-block-start:
     - match: '\{'
       scope: meta.block.c punctuation.section.block.begin.c
       set:
@@ -502,12 +526,24 @@ contexts:
   data-structures-union-definition:
     - meta_scope: meta.union.c
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.union.forward-decl.c
     - match: '{{identifier}}'
       scope: entity.name.union.c
+      set: data-structures-union-definition-after-name
+    - include: data-structures-union-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-union-definition-after-name:
+    - meta_scope: meta.union.c
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-union-definition-block-start
+
+  data-structures-union-definition-block-start:
     - match: '\{'
       scope: meta.block.c punctuation.section.block.begin.c
       set:
@@ -523,8 +559,10 @@ contexts:
       pop: true
     - include: modifiers-parens
     - include: modifiers
+
+  data-structures-definition-common-macro:
     # Handle macros so they aren't matched as the class name
-    - match: '\b[[:upper:][:digit:]_]+\b'
+    - match: '\b[[:upper:][:digit:]_]+\b(?!\s*($|\{))'
 
   data-structures-definition-common-end:
     - match: '(?=;)'

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -337,14 +337,11 @@ contexts:
     - include: comments
     - match: \*
       scope: keyword.operator.c
-    # If a struct/union/enum followed by a name that is not a macro or declspec
-    # then this is likely a return type of a function. This is uncommon.
     - match: |-
         (?x:
           ({{before_tag}})
           \s+
           (?=
-            (?![[:upper:][:digit:]_]+\b|__declspec)
             {{identifier}}
             (\s+{{identifier}}(?!\s*[{=;])|\s*\*+)
           )

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -9,6 +9,18 @@ int main(){
     /*          ^^ keyword.operator.arithmetic */
 }
 
+enum Foo { kFoo, kBar };
+#define FOO Foo
+enum FOO do_the_foo(void);
+/*       ^ entity.name.function */
+/*                  ^ storage.type */
+
+#define APIC_CAPABILITY TheEnum
+enum TheEnum { kFoo, kBar };
+static enum APIC_CAPABILITY apic_capabilities(void) { return kFoo; };
+/*                          ^ entity.name.function */
+/*                                            ^ storage.type */
+
 #define EXTTS_BUFSIZE (PTP_BUF_TIMESTAMPS /* comment block */ * sizeof(struct ptp_extts_event)) // comment line
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.macro */
 /*                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -21,6 +21,28 @@ static enum APIC_CAPABILITY apic_capabilities(void) { return kFoo; };
 /*                          ^ entity.name.function */
 /*                                            ^ storage.type */
 
+struct __declspec(dllimport) X {};
+/*     ^ storage.modifier */
+/*                           ^ entity.name.struct */
+
+struct __declspec(dllimport) baz X {};
+/*     ^ storage.modifier */
+/*                           ^ entity.name.struct */
+
+struct foo {
+/*     ^ entity.name.struct */
+    union {
+/*  ^ storage.type */
+        struct {
+/*      ^ storage.type */
+            int a;
+/*          ^ storage.type */
+            int b;
+/*          ^ storage.type */
+        }
+    }
+}
+
 #define EXTTS_BUFSIZE (PTP_BUF_TIMESTAMPS /* comment block */ * sizeof(struct ptp_extts_event)) // comment line
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.macro */
 /*                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group */

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -537,14 +537,11 @@ contexts:
     - include: comments
     - match: \*
       scope: keyword.operator.objc
-    # If a struct/union/enum followed by a name that is not a macro or declspec
-    # then this is likely a return type of a function. This is uncommon.
     - match: |-
         (?x:
           ({{before_tag}})
           \s+
           (?=
-            (?![[:upper:][:digit:]_]+\b|__declspec)
             {{identifier}}
             (\s+{{identifier}}(?!\s*[{=;])|\s*\*+)
           )

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -665,12 +665,24 @@ contexts:
   data-structures-struct-definition:
     - meta_scope: meta.struct.objc
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.struct.forward-decl.objc
     - match: '{{identifier}}'
       scope: entity.name.struct.objc
+      set: data-structures-struct-definition-after-name
+    - include: data-structures-struct-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-struct-definition-after-name:
+    - meta_scope: meta.struct.objc
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-struct-definition-block-start
+
+  data-structures-struct-definition-block-start:
     - match: '\{'
       scope: meta.block.objc punctuation.section.block.begin.objc
       set:
@@ -683,12 +695,24 @@ contexts:
   data-structures-enum-definition:
     - meta_scope: meta.enum.objc
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.enum.forward-decl.objc
     - match: '{{identifier}}'
       scope: entity.name.enum.objc
+      set: data-structures-enum-definition-after-name
+    - include: data-structures-enum-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-enum-definition-after-name:
+    - meta_scope: meta.enum.objc
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-enum-definition-block-start
+
+  data-structures-enum-definition-block-start:
     - match: '\{'
       scope: meta.block.objc punctuation.section.block.begin.objc
       set:
@@ -702,12 +726,24 @@ contexts:
   data-structures-union-definition:
     - meta_scope: meta.union.objc
     - include: data-structures-definition-common-begin
+    - include: data-structures-definition-common-macro
     - match: '{{identifier}}(?=\s*;)'
       scope: entity.name.union.forward-decl.objc
     - match: '{{identifier}}'
       scope: entity.name.union.objc
+      set: data-structures-union-definition-after-name
+    - include: data-structures-union-definition-block-start
     - match: '(?=;)'
       pop: true
+
+  data-structures-union-definition-after-name:
+    - meta_scope: meta.union.objc
+    - include: data-structures-definition-common-begin
+    - match: '(?=;)'
+      pop: true
+    - include: data-structures-union-definition-block-start
+
+  data-structures-union-definition-block-start:
     - match: '\{'
       scope: meta.block.objc punctuation.section.block.begin.objc
       set:
@@ -723,8 +759,10 @@ contexts:
       pop: true
     - include: modifiers-parens
     - include: modifiers
+
+  data-structures-definition-common-macro:
     # Handle macros so they aren't matched as the class name
-    - match: '\b[[:upper:][:digit:]_]+\b'
+    - match: '\b[[:upper:][:digit:]_]+\b(?!\s*($|\{))'
 
   data-structures-definition-common-end:
     - match: '(?=;)'

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -9,6 +9,18 @@ int main(){
     /*          ^^ keyword.operator.arithmetic */
 }
 
+enum Foo { kFoo, kBar };
+#define FOO Foo
+enum FOO do_the_foo(void);
+/*       ^ entity.name.function */
+/*                  ^ storage.type */
+
+#define APIC_CAPABILITY TheEnum
+enum TheEnum { kFoo, kBar };
+static enum APIC_CAPABILITY apic_capabilities(void) { return kFoo; };
+/*                          ^ entity.name.function */
+/*                                            ^ storage.type */
+
 #define EXTTS_BUFSIZE (PTP_BUF_TIMESTAMPS /* comment block */ * sizeof(struct ptp_extts_event)) // comment line
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.macro */
 /*                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -21,6 +21,28 @@ static enum APIC_CAPABILITY apic_capabilities(void) { return kFoo; };
 /*                          ^ entity.name.function */
 /*                                            ^ storage.type */
 
+struct __declspec(dllimport) X {};
+/*     ^ storage.modifier */
+/*                           ^ entity.name.struct */
+
+struct __declspec(dllimport) baz X {};
+/*     ^ storage.modifier */
+/*                           ^ entity.name.struct */
+
+struct foo {
+/*     ^ entity.name.struct */
+    union {
+/*  ^ storage.type */
+        struct {
+/*      ^ storage.type */
+            int a;
+/*          ^ storage.type */
+            int b;
+/*          ^ storage.type */
+        }
+    }
+}
+
 #define EXTTS_BUFSIZE (PTP_BUF_TIMESTAMPS /* comment block */ * sizeof(struct ptp_extts_event)) // comment line
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.macro */
 /*                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group */


### PR DESCRIPTION
Fixes #1712.

Since there were not any tests that failed after removing a line in the match rule, I am somewhat hesitant about merging this. @wbond let me know what could go wrong in this case.