### PR TITLE
[C++/ObjC] Fix: raw strings on their own line are scoped now

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -782,6 +782,7 @@ contexts:
         - match: '~{{identifier}}'
         - match: '(?=[^\w\s])'
           set: function-definition-params
+    - include: unique-strings
     - match: '(?=\S)'
       set: global-type
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -314,6 +314,14 @@ char rawStr2[] = R"A*!34( )" )A*!34";
 /*                           ^ punctuation.definition.string.end */
 /*                                 ^ punctuation.definition.string.end */
 
+const char IncludeRegexPattern[] =
+    R"(^[\t\ ]*#[\t\ ]*(import|include)[^"<]*(["<][^">]*[">]))";
+/*  ^ storage.type.string */
+/*   ^ punctuation.definition.string.begin */
+/*         ^^ - invalid */
+/*                 ^^ - invalid */
+/*                                                            ^ punctuation.definition.string.end */
+
 foo.f<5> /* foo */ ();
 
 /////////////////////////////////////////////

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -852,6 +852,7 @@ contexts:
         - match: '~{{identifier}}'
         - match: '(?=[^\w\s])'
           set: function-definition-params
+    - include: scope:source.c++#unique-strings
     - match: '(?=\S)'
       set: global-type
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -314,6 +314,14 @@ char rawStr2[] = R"A*!34( )" )A*!34";
 /*                           ^ punctuation.definition.string.end */
 /*                                 ^ punctuation.definition.string.end */
 
+const char IncludeRegexPattern[] =
+    R"(^[\t\ ]*#[\t\ ]*(import|include)[^"<]*(["<][^">]*[">]))";
+/*  ^ storage.type.string */
+/*   ^ punctuation.definition.string.begin */
+/*         ^^ - invalid */
+/*                 ^^ - invalid */
+/*                                                            ^ punctuation.definition.string.end */
+
 
 /////////////////////////////////////////////
 // Storage Types


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/issues/1349.
Fixes https://github.com/sublimehq/Packages/issues/1206.