### PR TITLE
[C++/ObjC] Fix: final class

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1137,6 +1137,8 @@ contexts:
 
   data-structures-definition-common-end:
     - include: angle-brackets
+    - match: \bfinal\b
+      scope: storage.modifier.c++
     - match: ':'
       scope: punctuation.separator.c++
       push:

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1687,6 +1687,12 @@ class Adapter : public Abstraction
 
 }
 
+struct Base {};
+class Derived final : Base {};
+/*             ^ storage.modifier */
+struct Derived final : Base {};
+/*             ^ storage.modifier */
+
 /* C++11 "uniform initialization" in initializer lists */
 class Foo {
 public:

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1207,6 +1207,8 @@ contexts:
 
   data-structures-definition-common-end:
     - include: angle-brackets
+    - match: \bfinal\b
+      scope: storage.modifier.c++
     - match: ':'
       scope: punctuation.separator.objc++
       push:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1659,6 +1659,12 @@ class Adapter : public Abstraction
 
 }
 
+struct Base {};
+class Derived final : Base {};
+/*             ^ storage.modifier */
+struct Derived final : Base {};
+/*             ^ storage.modifier */
+
 /* C++11 "uniform initialization" in initializer lists */
 class Foo {
 public:


### PR DESCRIPTION
The 'final' keyword for a class declaration is highlighted as storage.modifier
now.

Closes https://github.com/sublimehq/Packages/issues/1131.