### PR TITLE
[JavaScript] Fix: Remove unnecessary semi-colon before 'case'

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -732,7 +732,6 @@ contexts:
     - match: case{{identifier_break}}
       scope: keyword.control.switch.js
       push:
-        - expect-case-colon
         - expression
 
     - match: default{{identifier_break}}


### PR DESCRIPTION
When we have the below : 
```javascript
switch (var) {
  case 'a': {
    // code
    break;
  }
  case 'b': {
    // code
   break;
  }
}
```

`case b:` is not syntax-highlighted until we add a semi-colon before it, just like the below
```javascript
switch (var) {
  case 'a': {
    // code
    break;
  }; // <--- semi-colon required to have "case 'b'" highlighted by the syntax
  case 'b': {
    // code
   break;
  }
}
```

This behavior is incorrect, especially when you use eslint because it will return `Unreachable code (no-unreachable)` for that unecessary semi-colon.

So by removing `- expect-case-colon` we can keep the syntax-highlight on `case` and have eslint happy.