### PR TITLE
[Matlab] Fix auto-indenting for OOP

### DIFF
--- a/Matlab/Indent.tmPreferences
+++ b/Matlab/Indent.tmPreferences
@@ -31,7 +31,8 @@
 		<key>increaseIndentPattern</key>
 		<string>(?x)^\s*
 		\b(
-		function
+		classdef|properties|events|methods|enumeration
+		|function
 		|if|else|elseif
 		|switch|case|otherwise
 		|for|while


### PR DESCRIPTION
Indent is not added automatically after `classdef` or `properties`, etc like:

![wrong auto indent](https://user-images.githubusercontent.com/2605235/45726553-e9422380-bbe9-11e8-81ee-7541c4c2080b.png)

This pull request added auto indenting for:   
- `classdef`
- `properties`
- `methods`
- `events`
- `enumeration`

This is my first pull request, if somehow I made mistake, please help me to correct it