### PR TITLE
[C/ObjC] Fix: recognize pointers aligned to the type in function declarations

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -393,7 +393,7 @@ contexts:
     # All uppercase identifier just before a newline is most likely a macro
     - match: '[[:upper:][:digit:]_]+\s*$'
     # Identifier that is not the function name - likely a macro
-    - match: '{{identifier}}(?!\s*(\(|$))(?=\s+)'
+    - match: '{{identifier}}(?!\s*(\(|$))'
     # Real function definition
     - match: '{{identifier}}(?=\s*(\(|$))'
       scope: meta.function.c entity.name.function.c

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -289,11 +289,17 @@ struct point get_point() {}
 /*     ^ - entity.name.struct */
 /*           ^ entity.name.function */
 
-struct foo **alloc_foo();
+struct point **alloc_points();
 /* ^ storage.type */
 /*     ^ - entity.name.struct */
-/*         ^^ keyword.operator */
-/*           ^ entity.name.function */
+/*           ^^ keyword.operator */
+/*             ^ entity.name.function */
+
+struct point* alloc_point();
+/*                  ^ entity.name.function - variable.function */
+
+struct point FOO_API *alloc_point3();
+/*                     ^ entity.name.function - variable.function */
 
 int main(void)
 {

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -593,7 +593,7 @@ contexts:
     # All uppercase identifier just before a newline is most likely a macro
     - match: '[[:upper:][:digit:]_]+\s*$'
     # Identifier that is not the function name - likely a macro
-    - match: '{{identifier}}(?!\s*(\(|$))(?=\s+)'
+    - match: '{{identifier}}(?!\s*(\(|$))'
     # Real function definition
     - match: '{{identifier}}(?=\s*(\(|$))'
       scope: meta.function.objc entity.name.function.objc

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -290,11 +290,18 @@ struct point get_point() {}
 /*     ^ - entity.name.struct */
 /*           ^ entity.name.function */
 
-struct foo **alloc_foo();
+struct point **alloc_points();
 /* ^ storage.type */
 /*     ^ - entity.name.struct */
-/*         ^^ keyword.operator */
-/*           ^ entity.name.function */
+/*           ^^ keyword.operator */
+/*             ^ entity.name.function */
+
+struct point* alloc_point();
+/*                  ^ entity.name.function - variable.function */
+
+struct point FOO_API *alloc_point3();
+/*                     ^ entity.name.function - variable.function */
+
 
 int main(void)
 {


### PR DESCRIPTION
Closes #1282.

before this change:

```
struct point **alloc_points();
struct point* alloc_point();
```
`alloc_points` would be correctly highlighted as entity.name.function, while `alloc_point` would be incorrectly highlighted as variable.function. Now, both highlight as entity.name.function.