### PR TITLE
[C++/ObjC] Fix: Function type in template args

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -38,7 +38,15 @@ variables:
   other_keywords: 'typedef|decltype|nullptr|{{visibility_modifiers}}|static_assert|sizeof|using|typeid|alignof|alignas|namespace|template'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
   non_angle_brackets: '(?=<<|<=)'
-  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
+
+  regular: '[^(){}&;*^%=<>-]*'
+  paren_open: (?:\(
+  paren_close: '\))?'
+  generic_open: (?:<
+  generic_close: '>)?'
+  balance_parentheses: '{{regular}}{{paren_open}}{{regular}}{{paren_close}}{{regular}}'
+  generic_lookahead: <{{regular}}{{generic_open}}{{regular}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
+
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -558,6 +558,47 @@ static bool decode(const Node& node, T& sequence) {
   return true;
 }
 
+#include <functional>
+template <class T> struct A {};
+template <class T> struct B {};
+struct C {};
+A<B<C>> f(std::function<A<B<C>>()> g) {
+    /*   ^ punctuation.section.group.begin */
+    /*       ^^ punctuation.accessor */
+    /*                 ^ punctuation.section.generic.begin */
+    /*                   ^ punctuation.section.generic.begin */
+    /*                     ^ punctuation.section.generic.begin */
+    /*                       ^^ punctuation.section.generic.end */
+    /*                         ^ punctuation.section.group.begin */
+    /*                          ^ punctuation.section.group.end */
+    /*                           ^ punctuation.section.generic.end */
+    /*                             ^ variable.parameter */
+    /*                              ^ punctuation.section.group.end */
+    /*                                ^ punctuation.section.block.begin */
+    return g();
+}
+int main() {
+    std::function<C()> foo1;
+    /*          ^ - variabe.function */
+    std::function<B<C>()> foo2;
+    /*          ^ - variable.function */
+    auto f = [](std::function<A<B<C>>()> g) { return g(); };
+    /*         ^ punctuation.section.group.begin */
+    /*             ^^ punctuation.accessor */
+    /*                       ^ punctuation.section.generic.begin */
+    /*                         ^ punctuation.section.generic.begin */
+    /*                           ^ punctuation.section.generic.begin */
+    /*                             ^^ punctuation.section.generic.end */
+    /*                               ^ punctuation.section.group.begin */
+    /*                                ^ punctuation.section.group.end */
+    /*                                 ^ punctuation.section.generic.end */
+    /*                                    ^ punctuation.section.group.end */
+    /*                                      ^ punctuation.section.block.begin */
+    /*                                                    ^ punctuation.section.block.end */
+    return 0;
+}
+/* <- - invalid.illegal */
+
 // Example from section 14.2/4 of
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf
 struct X 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -657,6 +657,20 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+template<typename T> C<T> f(T t)
+{
+    return C<T> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*          ^ punctuation.section.block.begin */
+}
+
+template<typename T> C<X<T>> f(T t)
+{
+    return C<X<T>> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*             ^ punctuation.section.block.begin */
+}
+
 struct A { int foo; };
 int main() {
     A a, b;

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -26,7 +26,15 @@ variables:
   other_keywords: 'typedef|decltype|nullptr|{{visibility_modifiers}}|static_assert|sizeof|using|typeid|alignof|alignas|namespace|template'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
   non_angle_brackets: '(?=<<|<=)'
-  generic_lookahead: '<(?:\s*(?:{{path_lookahead}}|\d+)(?:{{path_lookahead}}|&(?!&)|\*|,|\.|<.*?>|\s|\d)*)?>'
+
+  regular: '[^(){}&;*^%=<>-]*'
+  paren_open: (?:\(
+  paren_close: '\))?'
+  generic_open: (?:<
+  generic_close: '>)?'
+  balance_parentheses: '{{regular}}{{paren_open}}{{regular}}{{paren_close}}{{regular}}'
+  generic_lookahead: <{{regular}}{{generic_open}}{{regular}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
+
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -557,6 +557,47 @@ static bool decode(const Node& node, T& sequence) {
   return true;
 }
 
+#include <functional>
+template <class T> struct A {};
+template <class T> struct B {};
+struct C {};
+A<B<C>> f(std::function<A<B<C>>()> g) {
+    /*   ^ punctuation.section.group.begin */
+    /*       ^^ punctuation.accessor */
+    /*                 ^ punctuation.section.generic.begin */
+    /*                   ^ punctuation.section.generic.begin */
+    /*                     ^ punctuation.section.generic.begin */
+    /*                       ^^ punctuation.section.generic.end */
+    /*                         ^ punctuation.section.group.begin */
+    /*                          ^ punctuation.section.group.end */
+    /*                           ^ punctuation.section.generic.end */
+    /*                             ^ variable.parameter */
+    /*                              ^ punctuation.section.group.end */
+    /*                                ^ punctuation.section.block.begin */
+    return g();
+}
+int main() {
+    std::function<C()> foo1;
+    /*          ^ - variabe.function */
+    std::function<B<C>()> foo2;
+    /*          ^ - variable.function */
+    auto f = [](std::function<A<B<C>>()> g) { return g(); };
+    /*         ^ punctuation.section.group.begin */
+    /*             ^^ punctuation.accessor */
+    /*                       ^ punctuation.section.generic.begin */
+    /*                         ^ punctuation.section.generic.begin */
+    /*                           ^ punctuation.section.generic.begin */
+    /*                             ^^ punctuation.section.generic.end */
+    /*                               ^ punctuation.section.group.begin */
+    /*                                ^ punctuation.section.group.end */
+    /*                                 ^ punctuation.section.generic.end */
+    /*                                    ^ punctuation.section.group.end */
+    /*                                      ^ punctuation.section.block.begin */
+    /*                                                    ^ punctuation.section.block.end */
+    return 0;
+}
+/* <- - invalid.illegal */
+
 // Example from section 14.2/4 of
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf
 struct X 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -656,6 +656,20 @@ void f()
     /*                           ^ - meta.method-call */
 };
 
+template<typename T> C<T> f(T t)
+{
+    return C<T> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*          ^ punctuation.section.block.begin */
+}
+
+template<typename T> C<X<T>> f(T t)
+{
+    return C<X<T>> { g<X<T>>(t) };
+    /*     ^ - variable.function */
+    /*             ^ punctuation.section.block.begin */
+}
+
 struct A { int foo; };
 int main() {
     A a;


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/issues/1713.
Fixes https://github.com/sublimehq/Packages/issues/1327.

For things like std::function<A<B<C>>()> f(g), the grammar got confused and
thought this was a templated function call (the function name being "function"
and the start of the opening parenthesis for the function call being the
parenthesis after the "f" identifier). However, this is a new variable called
"f" of type "std::function<A<B<C>>()>" initialized with the variable "g".

To address this, the generic_lookahead variable had to be changed to account
for possible opening and closing parentheses inside of its template argument.

The result is a somewhat insane generic_lookahead, but it makes the syntax more
correct.