### PR TITLE
[C++/ObjC] Fix: recognize comments just before a function/method definition

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -184,6 +184,18 @@ contexts:
     - include: keywords-angle-brackets
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
+    # Take care of comments just before a function definition.
+    - match: /\*
+      scope: punctuation.definition.comment.c
+      push:
+        - - match: \s*(?=\w)
+            set: global-modifier
+          - match: ""
+            pop: true
+        - - meta_scope: comment.block.c
+          - match: \*/
+            scope: punctuation.definition.comment.c
+            pop: true
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.c++
@@ -211,7 +223,7 @@ contexts:
             - include: global
         - match: (?=\S)
           set: global-modifier
-    - match: '^\s*(?=\w+)'
+    - match: ^\s*(?=\w)
       push: global-modifier
     - include: late-expressions
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1090,9 +1090,23 @@ void FooBar :: baz(int a)
 /*                     ^ variable.parameter */
 /*                      ^ punctuation.section.group.end */
 {
-
 }
-
+/* A comment. */ void FooBar :: baz(int a)
+/*                    ^^^^^^^^^^^^^^^^^^^^ meta.function */
+/*                    ^^^^^^^^^^^^^ entity.name.function */
+/*                           ^^ punctuation.accessor */
+/*                                 ^^^^^^^ meta.function.parameters meta.group */
+/*                                 ^ punctuation.section.group.begin */
+/*                                      ^ variable.parameter */
+/*                                       ^ punctuation.section.group.end */
+{
+}
+// prevent leading comment from function recognition
+/**/ HRESULT A::b()
+/*           ^ meta.function entity.name.function */
+{
+    return S_OK;
+}
 FooBar::FooBar(int a)
 /*^^^^^^^^^^^^^^^^^^^ meta.function */
 /*^^^^^^^^^^^^ entity.name.function */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -49,6 +49,18 @@ contexts:
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
     - include: objc-structures
+    # Take care of comments just before a function definition.
+    - match: /\*
+      scope: punctuation.definition.comment.c
+      push:
+        - - match: \s*(?=\w)
+            set: global-modifier
+          - match: ""
+            pop: true
+        - - meta_scope: comment.block.c
+          - match: \*/
+            scope: punctuation.definition.comment.c
+            pop: true
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.objc++
@@ -76,7 +88,7 @@ contexts:
             - include: global
         - match: (?=\S)
           set: global-modifier
-    - match: '^\s*(?=\w+)'
+    - match: ^\s*(?=\w)
       push: global-modifier
     - include: late-expressions
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1062,9 +1062,23 @@ void FooBar :: baz(int a)
 /*                     ^ variable.parameter */
 /*                      ^ punctuation.section.group.end */
 {
-
 }
-
+/* A comment. */ void FooBar :: baz(int a)
+/*                    ^^^^^^^^^^^^^^^^^^^^ meta.function */
+/*                    ^^^^^^^^^^^^^ entity.name.function */
+/*                           ^^ punctuation.accessor */
+/*                                 ^^^^^^^ meta.function.parameters meta.group */
+/*                                 ^ punctuation.section.group.begin */
+/*                                      ^ variable.parameter */
+/*                                       ^ punctuation.section.group.end */
+{
+}
+// prevent leading comment from function recognition
+/**/ HRESULT A::b()
+/*           ^ meta.function entity.name.function */
+{
+    return S_OK;
+}
 FooBar::FooBar(int a)
 /*^^^^^^^^^^^^^^^^^^^ meta.function */
 /*^^^^^^^^^^^^ entity.name.function */


### PR DESCRIPTION
Partially fixes https://github.com/sublimehq/Packages/issues/1356.