### PR TITLE
[Rust] Add eprint and eprintln macros

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -158,7 +158,7 @@ contexts:
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
       scope: support.function.rust
 
-    - match: '\b((?:format|print|println)!)\s*(\()'
+    - match: '\b((?:format|print|println|eprint|eprintln)!)\s*(\()'
       captures:
         1: support.macro.rust
         2: meta.group.rust punctuation.section.group.begin.rust


### PR DESCRIPTION
New versions of Rust support `eprint!(..)` and `eprintln!(..)` in addition to the `print!(..)` and `println!(..)` macros: https://doc.rust-lang.org/stable/std/macro.eprint.html