### PR TITLE
[Rust] support paths to constants for sizes in nested array types

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -503,6 +503,8 @@ contexts:
         - include: constant-integer-expression
     - match: '{{identifier}}'
       scope: variable.other.constant.rust
+    - match: '::'
+      scope: punctuation.accessor.double-colon.rust
     - match: '[-+%/*]'
       scope: keyword.operator.arithmetic.rust
 

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -1075,6 +1075,24 @@ let _: Box<[[bool; (FOO + 1) / 2]; FOO * 3 % 12 - 1]>;
 //                                                  ^ punctuation.definition.generic.end
 //                                                   ^ punctuation.terminator
 
+let _: Box<[[u8; aa::COUNT - 1]; 5]>;
+//        ^ punctuation.definition.generic.begin
+//         ^ punctuation.section.group.begin
+//          ^ punctuation.section.group.begin
+//           ^^ storage.type
+//             ^ punctuation.separator
+//               ^^ variable.other.constant
+//                 ^^ punctuation.accessor.double-colon
+//                   ^^^^^ variable.other.constant
+//                         ^ keyword.operator.arithmetic
+//                           ^ constant.numeric.integer.decimal
+//                            ^ punctuation.section.group.end
+//                             ^ punctuation.separator
+//                               ^ constant.numeric.integer.decimal
+//                                ^ punctuation.section.group.end
+//                                 ^ punctuation.definition.generic.end
+//                                  ^ punctuation.terminator
+
 let x = 5;
 let raw = &x as *const i32;
 //              ^^^^^^ storage.type


### PR DESCRIPTION
fixes #1747 