### PR TITLE
[TCL] Fix nested lists and strings

### DIFF
--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -396,6 +396,7 @@ contexts:
       pop: true
     - match: '\\[\\{}n]'
       scope: constant.character.escape.tcl
+    - include: braces
 
   braces:
     - match: (\{)(\*)(\})
@@ -415,7 +416,7 @@ contexts:
           scope: punctuation.section.block.end.tcl
           pop: true
         - include: commands
-    - match: '\{(?=[\s{}])'
+    - match: '\{(?=[\s{}]|(?:\w[^}]*)?\{)'
       scope: punctuation.section.block.begin.tcl
       push: non-command-braces
     - match: '\{'

--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -140,7 +140,7 @@ contexts:
             - match: '\{(?=(\n|\s*({{most_likely_code}})))'
               scope: punctuation.section.block.begin.tcl
               set: [command-braces, command-name]
-            - match: '\{(?=\s)'
+            - match: '\{(?=[\s{}])'
               scope: punctuation.section.block.begin.tcl
               set: non-command-braces
             - match: '\{'
@@ -415,7 +415,7 @@ contexts:
           scope: punctuation.section.block.end.tcl
           pop: true
         - include: commands
-    - match: '\{(?=\s|\})'
+    - match: '\{(?=[\s{}])'
       scope: punctuation.section.block.begin.tcl
       push: non-command-braces
     - match: '\{'

--- a/TCL/syntax_test_tcl.tcl
+++ b/TCL/syntax_test_tcl.tcl
@@ -225,6 +225,9 @@ set objRegExp {(^[a-zA-Z]{2}[a-zA-Z0-9-]{2,12}$)}
 set objRegExp {(.{0,200})}
 #             ^^^^^^^^^^^^ string.quoted.brace - invalid
 #                         ^ - meta.block
+set objRegExp {word(.{0,200})}
+#             ^^^^^^^^^^^^^^^^ string.quoted.brace - invalid
+#                             ^ - meta.block
 
 proc test {} {
 
@@ -347,6 +350,30 @@ set w { {{foobar}} }
 #                                   ^^^^^^^^^^^^^ string.quoted.brace
 #                                               ^ punctuation.definition.string.end
 #                                                ^ punctuation.section.block.end
+}
+# <- meta.block punctuation.section.block.end
+
+{
+# <- meta.block punctuation.section.block.begin
+    set w {{first ONE} {{second TWO} third THREE} {fourth {FOUR}} {fifth FIVE}}
+#         ^ punctuation.section.block.begin
+#          ^^^^^^^^^^^ string.quoted.brace
+#          ^ punctuation.definition.string.begin
+#                    ^ punctuation.definition.string.end
+#                      ^ punctuation.section.block.begin
+#                       ^ punctuation.definition.string.begin
+#                       ^^^^^^^^^^^^ string.quoted.brace
+#                                  ^ punctuation.definition.string.end
+#                                               ^ punctuation.section.block.end
+#                                                 ^ punctuation.section.block.begin
+#                                                         ^ punctuation.definition.string.begin
+#                                                         ^^^^^^ string.quoted.brace
+#                                                              ^ punctuation.definition.string.end
+#                                                               ^ punctuation.section.block.end
+#                                                                 ^ punctuation.definition.string.begin
+#                                                                 ^^^^^^^^^^^^ string.quoted.brace
+#                                                                            ^ punctuation.definition.string.end
+#                                                                             ^ punctuation.section.block.end
 }
 # <- meta.block punctuation.section.block.end
 

--- a/TCL/syntax_test_tcl.tcl
+++ b/TCL/syntax_test_tcl.tcl
@@ -288,6 +288,68 @@ set w {foobar}
 #     ^ punctuation.definition.string.begin
 #            ^ punctuation.definition.string.end
 
+# https://github.com/sublimehq/Packages/issues/1681
+# https://github.com/sublimehq/Packages/issues/1734
+
+set w {{foobar}}
+#     ^^^^^^^^^^ meta.block
+#     ^ punctuation.section.block.begin
+#      ^^^^^^^^ string.quoted.brace
+#      ^ punctuation.definition.string.begin
+#             ^ punctuation.definition.string.end
+#              ^ punctuation.section.block.end
+
+set w { {{foobar}} }
+#     ^^^^^^^^^^^^^^ meta.block
+#     ^ punctuation.section.block.begin
+#       ^ punctuation.section.block.begin
+#        ^^^^^^^^ string.quoted.brace
+#        ^ punctuation.definition.string.begin
+#               ^ punctuation.definition.string.end
+#                ^ punctuation.section.block.end
+#                  ^ punctuation.section.block.end
+
+{
+# <- meta.block punctuation.section.block.begin
+    set w {{1 -1 0}}
+#         ^ punctuation.section.block.begin
+#          ^^^^^^^^ string.quoted.brace
+#          ^ punctuation.definition.string.begin
+#                 ^ punctuation.definition.string.end
+#                  ^ punctuation.section.block.end
+}
+# <- meta.block punctuation.section.block.end
+
+{
+# <- meta.block punctuation.section.block.begin
+    set w {{ 1 -1 0 } { 1 -1 0 }}
+#         ^ meta.block punctuation.section.block.begin
+#         ^ meta.block meta.block punctuation.section.block.begin
+#          ^ meta.block meta.block meta.block punctuation.section.block.begin
+#                   ^ meta.block meta.block meta.block punctuation.section.block.end
+#                     ^ meta.block meta.block meta.block punctuation.section.block.begin
+#                              ^ meta.block meta.block meta.block punctuation.section.block.end
+#                               ^ meta.block meta.block punctuation.section.block.end
+}
+# <- meta.block punctuation.section.block.end
+
+{
+# <- meta.block punctuation.section.block.begin
+    set w {{first ONE} {second TWO} {third THREE}}
+#         ^ punctuation.section.block.begin
+#          ^^^^^^^^^^^ string.quoted.brace
+#          ^ punctuation.definition.string.begin
+#                    ^ punctuation.definition.string.end
+#                      ^ punctuation.definition.string.begin
+#                      ^^^^^^^^^^^^ string.quoted.brace
+#                                 ^ punctuation.definition.string.end
+#                                   ^ punctuation.definition.string.begin
+#                                   ^^^^^^^^^^^^^ string.quoted.brace
+#                                               ^ punctuation.definition.string.end
+#                                                ^ punctuation.section.block.end
+}
+# <- meta.block punctuation.section.block.end
+
 # For set when the brace is not followed by a newline,
 # we treat it as expression, but without command names
 set x { 1 { 2 3 } }
@@ -404,4 +466,3 @@ if { $mpv(radar) eq "VHF" } {
         }
     }
 }
-


### PR DESCRIPTION
Fixes ~#1681,~ #1734

This commit modifies highlighting by only scoping the most inner {foo} token as string. If there are several levels of opening braces, they are handled as blocks.

This change allows highlighting of nested lists correctly.