### PR TITLE
[Diff] highlight diff section hints

### DIFF
--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
         1: punctuation.definition.separator.diff
     - match: ^\d+(,\d+)*(a|d|c)\d+(,\d+)*$\n?
       scope: meta.diff.range.normal
-    - match: ^(@@)\s*(.+?)\s*(@@)\s*(.*)\s*$\n?
+    - match: ^(@@)\s*(.+?)\s*(@@)\s*(.*?)\s*$\n?
       scope: meta.diff.range.unified
       captures:
         1: punctuation.definition.range.diff

--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -25,12 +25,13 @@ contexts:
         1: punctuation.definition.separator.diff
     - match: ^\d+(,\d+)*(a|d|c)\d+(,\d+)*$\n?
       scope: meta.diff.range.normal
-    - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
+    - match: ^(@@)\s*(.+?)\s*(@@)\s*(.*)\s*$\n?
       scope: meta.diff.range.unified
       captures:
         1: punctuation.definition.range.diff
         2: meta.toc-list.line-number.diff
         3: punctuation.definition.range.diff
+        4: entity.name.section.diff
     - match: '^(((\-{3}) .+ (\-{4}))|((\*{3}) .+ (\*{4})))$\n?'
       scope: meta.diff.range.context
       captures:

--- a/Diff/syntax_test_diff.diff
+++ b/Diff/syntax_test_diff.diff
@@ -17,8 +17,23 @@
 #^^^^^^^^^^^^^^^ meta.diff.range.unified
 # <-             punctuation.definition.range.diff
 #^               punctuation.definition.range.diff
+# ^ - punctuation
 #  ^^^^^^^^^^    meta.toc-list.line-number.diff
+#            ^ - punctuation
 #             ^^ punctuation.definition.range.diff
+#               ^ - entity - punctuation
+
+@@ -2,8 +2,11 @@ function_hint(int var)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.range.unified
+# <-             punctuation.definition.range.diff
+#^               punctuation.definition.range.diff
+# ^ - punctuation
+#  ^^^^^^^^^^    meta.toc-list.line-number.diff
+#            ^ - punctuation
+#             ^^ punctuation.definition.range.diff
+#               ^ - entity - punctuation
+#                ^^^^^^^^^^^^^^^^^^^^^^ entity.name.section.diff
+#                                      ^ - entity.name.section.diff
 
 --- Range ----
 #^^^^^^^^^^^^^ meta.diff.range.context


### PR DESCRIPTION
The toc-list of a changed hunk in a patch file can contain hints about the context of a change - maybe a function name.

As this hint was not yet respected in the diff syntax, the hint was highlighted as normal text. If a color scheme defines a background color not the whole line was highlighted.

Hence this commit adds support to properly highlight section hints.