### PR TITLE
[Haskell] Add missing (*) to infix functions

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -204,7 +204,7 @@ contexts:
           pop: true
     - include: block_comment
   infix_op:
-    - match: '(\([|!%$+:\-.=</>]+\)|\(,+\))'
+    - match: \([-+*/,|!%$:.=<>]+\)
       scope: entity.name.function.infix.haskell
   module_exports:
     - match: \(

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -88,3 +88,23 @@
 --                                     ^ keyword.other.arrow.haskell
    sequenceA = traverse id
 --           ^ keyword.operator.haskell
+
+--
+-- infix operators
+--
+   a a = (+) a 2
+--     ^ keyword.operator.haskell
+--       ^^^ entity.name.function.infix.haskell
+--             ^ constant.numeric.haskell
+   a a = (-) a 2
+--     ^ keyword.operator.haskell
+--       ^^^ entity.name.function.infix.haskell
+--             ^ constant.numeric.haskell
+   a a = (*) a 2
+--     ^ keyword.operator.haskell
+--       ^^^ entity.name.function.infix.haskell
+--             ^ constant.numeric.haskell
+   a a = (/) a 2
+--     ^ keyword.operator.haskell
+--       ^^^ entity.name.function.infix.haskell
+--             ^ constant.numeric.haskell


### PR DESCRIPTION
Fixes #1701

This commit adds the missing (*) operator and simplifies the whole pattern by adding the `|\(,+\)` token to the character first class.