### PR TITLE
[JavaScript] Improved for loop conditions.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -690,9 +690,7 @@ contexts:
     - match: (?:const|let|var){{identifier_break}}
       scope: storage.type.js
       set:
-        - - match: (?:of|in){{identifier_break}}
-            scope: keyword.operator.word.js
-            set: expression
+        - - include: for-condition-decider
           - match: (?=\S)
             set:
               - statements-in-parens
@@ -700,8 +698,23 @@ contexts:
               - initializer
         - variable-binding-pattern
 
-    - match: (?=\S)
+    - match: (?=;)
       set: statements-in-parens
+
+    - match: (?=\S)
+      set:
+        - - include: for-condition-decider
+          - match: (?=\S)
+            set:
+              - statements-in-parens
+              - expect-semicolon
+        - expression-end-no-in
+        - expression-begin
+
+  for-condition-decider:
+    - match: (?:of|in){{identifier_break}}
+      scope: keyword.operator.word.js
+      set: expression
 
   statements-in-parens:
     - match: (?=\))
@@ -820,6 +833,11 @@ contexts:
 
   expression-end-no-comma:
     - match: (?=,)
+      pop: true
+    - include: expression-end
+
+  expression-end-no-in:
+    - match: (?=in{{identifier_break}})
       pop: true
     - include: expression-end
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -690,36 +690,34 @@ contexts:
     - match: (?:const|let|var){{identifier_break}}
       scope: storage.type.js
       set:
-        - - include: for-condition-decider
+        - - include: for-of-rest
           - match: (?=\S)
             set:
-              - statements-in-parens
+              - for-oldstyle-rest
               - variable-binding-list
               - initializer
         - variable-binding-pattern
 
-    - match: (?=;)
-      set: statements-in-parens
-
     - match: (?=\S)
       set:
-        - - include: for-condition-decider
+        - - include: for-of-rest
           - match: (?=\S)
-            set:
-              - statements-in-parens
-              - expect-semicolon
+            set: for-oldstyle-rest
         - expression-end-no-in
         - expression-begin
 
-  for-condition-decider:
+  for-of-rest:
     - match: (?:of|in){{identifier_break}}
       scope: keyword.operator.word.js
       set: expression
 
-  statements-in-parens:
+  for-oldstyle-rest:
     - match: (?=\))
       pop: true
-    - include: statements
+    - match: ;
+      scope: punctuation.separator.expression.js
+    - match: (?=\S)
+      push: expression
 
   block-scope:
     - include: block

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -630,8 +630,48 @@ for (var i = 0; i < 10; i++) {
 }
 // <- meta.block
 
-    for (const x of list) {}
+    for (; x in list;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^^^^ meta.group
+//       ^ punctuation.terminator.statement.empty
+//           ^^ keyword.operator
+//                  ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+    for (a[x in list];;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^^^^^^ meta.group
+//        ^^^^^^^^^^^ meta.brackets
+//           ^^ keyword.operator
+//                   ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//                    ^ punctuation.terminator.statement.empty
+
+    for (const x in list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ storage.type
+//               ^^ keyword.operator.word
+
+    for (const x of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ storage.type
+//               ^^ keyword.operator.word
+
+    for (x in list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.operator.word
+
+    for (x of list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.operator.word
 
     for await (const x of list) {}
 //  ^^^ keyword.control.loop

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -634,9 +634,9 @@ for (var i = 0; i < 10; i++) {
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop
 //      ^^^^^^^^^^^^^^ meta.group
-//       ^ punctuation.terminator.statement.empty
+//       ^ punctuation.separator.expression
 //           ^^ keyword.operator
-//                  ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//                  ^ punctuation.separator.expression
 
     for (a[x in list];;) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.for
@@ -644,8 +644,11 @@ for (var i = 0; i < 10; i++) {
 //      ^^^^^^^^^^^^^^^^ meta.group
 //        ^^^^^^^^^^^ meta.brackets
 //           ^^ keyword.operator
-//                   ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
-//                    ^ punctuation.terminator.statement.empty
+//                   ^ punctuation.separator.expression
+//                    ^ punctuation.separator.expression
+
+    for (;function () {}/a/g;) {}
+//                      ^ keyword.operator
 
     for (const x in list) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for


### PR DESCRIPTION
Fixes #1767.

Should correctly differentiate the various types of `for` loops and highlight `in`/`of` where appropriate. `for` loops were apparently undertested, so I've added a few tests.

Semi-related issues:

1. ~~Currently, semicolons in `for` loop conditions are scoped `punctuation.terminator.statement`. This is arguably incorrect; they are separating expressions and/or variable declarations, not terminating statements. They should probably be `punctuation.separator.expression` or somesuch.~~

2. ~~`for (; function() {} /a/g;);` is broken. This is because `for-condition-contents` uses `statements-in-parens`, which uses `statements`, which is wrong because the second and third terms are conditions, not statements. As a result, the `function() {}` is parsed as a function declaration, not a function expression, so the following slash is interpreted as the start of a regexp literal and not a division operator.~~

3. The `in` and `of` in `for` loop conditions are scoped `keyword.operator.word`, which is probably wrong because they're not really operators, but strangely, all of the actual wordlike operators are merely `keyword.operator`.