### PR TITLE
[#1769] Fix for Clojure code block

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -940,7 +940,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.begin.clojure.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
-        3: constant.other.language-name.markdown
+        5: constant.other.language-name.markdown
       embed: scope:source.clojure
       embed_scope: markup.raw.code-fence.clojure.markdown-gfm
       escape: '{{code_fence_escape}}'

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -935,6 +935,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:clojure|clj))
+          \s*$\n?          # any whitespace until EOL
+      captures:
+        0: meta.code-fence.definition.begin.clojure.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        3: constant.other.language-name.markdown
+      embed: scope:source.clojure
+      embed_scope: markup.raw.code-fence.clojure.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.clojure.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:xml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -936,7 +936,7 @@ contexts:
          (?x)
           {{fenced_code_block_start}}
           ((?i:clojure|clj))
-          \s*$\n?          # any whitespace until EOL
+          {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.clojure.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1867,6 +1867,19 @@ okay
 1. Test 2
 |^ markup.list.numbered.bullet punctuation.definition.list_item
 
+```clojure
+|^^^^^^^^^ meta.code-fence.definition.begin.clojure
+|  ^^^^^^^ constant.other.language-name
+ (/ 10 3.0)
+|<- - meta.sexpr.clojure
+|^^^^^^^^^^ meta.sexpr.clojure
+|          ^ - meta.sexpr.clojure
+| ^ keyword.operator.clojure
+|   ^^ constant.numeric.float.clojure
+|      ^^^ constant.numeric.float.clojure
+```
+|^^ meta.code-fence.definition.end.clojure punctuation.definition.raw.code-fence.end
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name


### PR DESCRIPTION
There was an issue in that the rendering of the Clojure code block in
a Markdown file would not be rendered properly. This is documented in
Issue #1769 - with screen grabs. This addition to the syntax file
corrects that issue by adding the section for the Clojure code block in
the Markdown file.