### PR TITLE
[C#] support tuple deconstruction in foreach

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -955,21 +955,8 @@ contexts:
         2: variable.other.cs
         3: keyword.operator.assignment.variable.cs
       set: line_of_code_in
-    - match: (var)\s+(\()
-      captures:
-        1: storage.type.variable.cs
-        2: meta.group.tuple.cs punctuation.definition.group.begin.cs
-      set:
-        - meta_content_scope: meta.group.tuple.cs
-        - match: \)
-          scope: meta.group.tuple.cs punctuation.definition.group.end.cs
-          set: line_of_code_in
-        - match: _\b
-          scope: variable.language.deconstruction.discard.cs
-        - match: '{{name}}'
-          scope: variable.other.cs
-        - match: ','
-          scope: punctuation.separator.tuple.cs
+    - match: (?=var\s+\()
+      push: var_declaration
     - include: lambdas
     - match: (?:\b(ref)\s+)?\b(?={{namespaced_name}}{{type_suffix}}\s+{{name}}(?!\s*(?:[(:])))
       captures:
@@ -1920,6 +1907,21 @@ contexts:
       pop: true
 
   var_declaration:
+    - match: (var)\s+(\()
+      captures:
+        1: storage.type.variable.cs
+        2: meta.group.tuple.cs punctuation.definition.group.begin.cs
+      set:
+        - meta_content_scope: meta.group.tuple.cs
+        - match: \)
+          scope: meta.group.tuple.cs punctuation.definition.group.end.cs
+          pop: true
+        - match: _\b
+          scope: variable.language.deconstruction.discard.cs
+        - match: '{{name}}'
+          scope: variable.other.cs
+        - match: ','
+          scope: punctuation.separator.tuple.cs
     - match: '(var)\s+({{name}})\s*'
       captures:
         1: storage.type.variable.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -451,6 +451,20 @@ class Foo {
 ///                                  ^ punctuation.separator.tuple
 ///                                    ^^ meta.group.tuple constant.numeric.integer.decimal
 ///                                      ^ punctuation.section.group.end
+
+        var dic = new Dictionary<string, int> { ["Bob"] = 32, ["Alice"] = 17 };
+        foreach (var (name, age) in dic.Select(x => (x.Key, x.Value)))
+///              ^^^ storage.type.variable
+///                  ^^^^^^^^^^^ meta.group.tuple
+///                  ^ punctuation.definition.group.begin
+///                   ^^^^ variable.other
+///                       ^ punctuation.separator.tuple
+///                         ^^^ variable.other
+///                            ^ punctuation.definition.group.end
+///                              ^^ keyword.control.flow
+        {
+            Console.WriteLine($"{name} is {age} years old.");
+        }
     }
 
     private static (int Max, int Min) Range(IEnumerable<int> numbers)


### PR DESCRIPTION
This updates the C# syntax definition to correctly handle tuple deconstruction in `foreach` constructs. The newly added test case came from https://stackoverflow.com/a/51281398/4473405.