### PR TITLE
[JavaScript] Don't pop the main context.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -90,7 +90,13 @@ contexts:
   main:
     - include: comments
     - include: comments-top-level
-    - include: statements
+
+    - match: '\)|\}|\]'
+      scope: invalid.illegal.stray-bracket-end.js
+      # Don't pop or embedding could break.
+
+    - match: (?=\S)
+      push: statement
 
   prototype:
     - include: comments


### PR DESCRIPTION
Fix #1750. No change to JavaScript behavior except when embedded.