### PR TITLE
[HTML] html5 custom element and other tag names

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -10,13 +10,15 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
+  ascii_space: '\t\n\f '
+
   attribute_char: (?:[^ "'>/=\x00-\x1f\x7f-\x9f])
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
-  tag_name_break: (?=[ \t\f\n/<>])
-  tag_name_char: '[^ \t\f\n/<>]'
+  tag_name_char: '[^{{ascii_space}}/<>]'
+  tag_name_break: (?=[^{{tag_name_char}}])
   tag_name: '[A-Za-z]{{tag_name_char}}*'
 
   block_tag_name: |-
@@ -164,33 +166,43 @@ contexts:
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)([a-z]{{custom_element_char}}*?-{{custom_element_char}}*)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.custom.html
+    - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
+      scope: punctuation.definition.tag.begin.html
       push:
-        - meta_scope: meta.tag.custom.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)([A-Z]{{tag_name_char}}*?-{{tag_name_char}}*)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: invalid.illegal.uppercase-custom-tag-name.html
+        - tag-custom-body
+        - tag-custom-name
+    - match: </?(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
       push:
-        - meta_scope: meta.tag.custom.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)({{tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.other.html
-      push:
-        - meta_scope: meta.tag.other.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
+        - tag-other-body
+        - tag-other-name
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
+
+  tag-custom-name:
+      - meta_content_scope: entity.name.tag.custom.html
+      - match: '{{tag_name_break}}'
+        pop: true
+      - match: '{{custom_element_char}}+'
+        # no scope
+      - match: '{{tag_name_char}}'
+        scope: invalid.illegal.custom-tag-name.html
+
+  tag-custom-body:
+      - meta_scope: meta.tag.custom.html
+      - include: tag-end-maybe-self-closing
+      - include: tag-attributes
+
+  tag-other-name:
+      - meta_content_scope: entity.name.tag.other.html
+      - match: '{{tag_name_break}}'
+        pop: true
+
+  tag-other-body:
+      - meta_scope: meta.tag.other.html
+      - include: tag-end-maybe-self-closing
+      - include: tag-attributes
 
   entities:
     - match: (&#[xX])\h+(;)

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -15,9 +15,9 @@ variables:
   not_equals_lookahead: (?=\s*[^\s=])
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
-  tag_name_break: (?=[\s/>])
-  tag_name_char: '[^\s/>]'
-  tag_name: '[[:alpha:]_]{{tag_name_char}}*'
+  tag_name_break: (?=[ \t\f\n/<>])
+  tag_name_char: '[^ \t\f\n/<>]'
+  tag_name: '[A-Za-z]{{tag_name_char}}*'
 
   block_tag_name: |-
     (?ix:
@@ -674,16 +674,16 @@ contexts:
     - include: tag-generic-attribute
 
   tag-end:
-    - match: '>'
+    - match: '>|(?=<)'
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-self-closing:
-    - match: '/>'
+    - match: '/>|(?=<)'
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-maybe-self-closing:
-    - match: '/?>'
+    - match: '/?>|(?=<)'
       scope: punctuation.definition.tag.end.html
       pop: true

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -15,22 +15,24 @@ variables:
   not_equals_lookahead: (?=\s*[^\s=])
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
-  tag_name: '[[:alpha:]_][^/>\s]*'
+  tag_name_break: (?=[\s/>])
+  tag_name_char: '[^\s/>]'
+  tag_name: '[[:alpha:]_]{{tag_name_char}}*'
 
   block_tag_name: |-
     (?ix:
       address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
-    )\b
+    ){{tag_name_break}}
 
   inline_tag_name: |-
     (?ix:
       abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
-    )\b
+    ){{tag_name_break}}
 
   form_tag_name: |-
     (?ix:
       button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
-    )\b
+    ){{tag_name_break}}
 
   javascript_mime_type: |-
     (?ix:
@@ -39,6 +41,26 @@ variables:
       | text/javascript1\.[0-5]
       | text/jscript
       | text/livescript
+    )
+
+  custom_element_char: |-
+    (?x:
+      # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
+        [-_a-z0-9\x{00B7}]
+      | \\\.
+      | [\x{00C0}-\x{00D6}]
+      | [\x{00D8}-\x{00F6}]
+      | [\x{00F8}-\x{02FF}]
+      | [\x{0300}-\x{037D}]
+      | [\x{037F}-\x{1FFF}]
+      | [\x{200C}-\x{200D}]
+      | [\x{203F}-\x{2040}]
+      | [\x{2070}-\x{218F}]
+      | [\x{2C00}-\x{2FEF}]
+      | [\x{3001}-\x{D7FF}]
+      | [\x{F900}-\x{FDCF}]
+      | [\x{FDF0}-\x{FFFD}]
+      | [\x{10000}-\x{EFFFF}]
     )
 
 contexts:
@@ -66,27 +88,19 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: (</?)([a-z_][a-z0-9:_]*-[a-z0-9:_-]+)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.custom.html
-      push:
-        - meta_scope: meta.tag.custom.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (<)((?i:style))\b
+    - match: (<)((?i:style)){{tag_name_break}}
       captures:
         0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push: style-css
-    - match: '(<)((?i:script))\b'
+    - match: '(<)((?i:script)){{tag_name_break}}'
       captures:
         0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push: script-javascript
-    - match: (</?)((?i:body|head|html)\b)
+    - match: (</?)((?i:body|head|html){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.any.html
@@ -102,7 +116,7 @@ contexts:
         - meta_scope: meta.tag.block.any.html
         - include: tag-end
         - include: tag-attributes
-    - match: (</?)((?i:hr)\b)
+    - match: (</?)((?i:hr){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
@@ -110,7 +124,7 @@ contexts:
         - meta_scope: meta.tag.block.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:form|fieldset)\b)
+    - match: (</?)((?i:form|fieldset){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.form.html
@@ -134,7 +148,7 @@ contexts:
         - meta_scope: meta.tag.inline.form.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:a)\b)
+    - match: (</?)((?i:a){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.a.html
@@ -142,7 +156,7 @@ contexts:
         - meta_scope: meta.tag.inline.a.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr)\b)
+    - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html
@@ -150,7 +164,15 @@ contexts:
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)([A-Za-z0-9:_]+-[A-Za-z0-9:_-]+)
+    - match: (</?)([a-z]{{custom_element_char}}*?-{{custom_element_char}}*)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.custom.html
+      push:
+        - meta_scope: meta.tag.custom.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (</?)([A-Z]{{tag_name_char}}*?-{{tag_name_char}}*)
       captures:
         1: punctuation.definition.tag.begin.html
         2: invalid.illegal.uppercase-custom-tag-name.html
@@ -158,7 +180,7 @@ contexts:
         - meta_scope: meta.tag.custom.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)([a-zA-Z0-9:]+)
+    - match: (</?)({{tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.other.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -686,16 +686,16 @@ contexts:
     - include: tag-generic-attribute
 
   tag-end:
-    - match: '>|(?=<)'
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-self-closing:
-    - match: '/>|(?=<)'
+    - match: '/>'
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-maybe-self-closing:
-    - match: '/?>|(?=<)'
+    - match: '/?>'
       scope: punctuation.definition.tag.end.html
       pop: true

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -461,6 +461,15 @@ class="foo"></div>
         ##    ^^ entity.name.tag.block.any
         ##       ^^ punctuation.definition.tag.end
 
+        # make sure to stop tag names before the next < to prevent php
+        # and other syntaxes from breaking.
+        <article<?php>
+        ##^^^^^^ entity.name.tag.block.any.html
+        ##      ^^^^^^ - entity.name.tag
+
+        <_notag>
+        ##^^^^^ - entity.name.tag
+
         <2notag>
         ##^^^^^ - entity.name.tag
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -377,8 +377,13 @@ class="foo"></div>
         <body-custom·tag₡name/>
         ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
 
-        <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
-        ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html
+        <INVALID-custom-TAG></INVALID-CUSTOM-TAG>
+        ## ^^^^^ invalid.illegal.custom-tag-name.html
+        ##       ^^^^^^ - invalid.illegal.custom-tag-name.html
+        ##              ^^^ invalid.illegal.custom-tag-name.html
+        ##                    ^^^^^^^ invalid.illegal.custom-tag-name.html
+        ##                            ^^^^^^ invalid.illegal.custom-tag-name.html
+        ##                                   ^^^ invalid.illegal.custom-tag-name.html
 
         <form name="formName" type="post">
         ## ^ entity.name.tag.block.form.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -339,6 +339,29 @@ class="foo"></div>
         ##                                           ^ - punctuation.definition.tag.end.html
         ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
 
+        <body·other attrib=1/>
+        ## ^^^^^^^^ entity.name.tag.other.html
+        ##          ^^^^^^ entity.other.attribute-name.html
+
+        <xsl:tag></xsl:tag>
+        ##^^^^^^ entity.name.tag.other.html
+        ##         ^^^^^^^ entity.name.tag.other.html
+
+        <t*([&/>
+        ##^^^^ entity.name.tag.other.html
+        ##    ^^ punctuation.definition.tag.end.html
+
+        <t*℗[& *([&\="₦"></t*([&>
+        ##^^^^ entity.name.tag.other.html
+        ##^^^^^^^^^^^^^^^^^^^^^^^ - invalid
+        ##     ^^^^^ entity.other.attribute-name.html
+        ##          ^ punctuation.separator.key-value.html
+        ##           ^^^ string.quoted.double.html
+        ##              ^ punctuation.definition.tag.end.html
+        ##               ^^ punctuation.definition.tag.begin.html
+        ##                 ^^^^^ entity.name.tag.other.html
+        ##                      ^ punctuation.definition.tag.end.html
+
         <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
         ##^^^^^^^^^^^^^^ entity.name.tag.custom.html
         ##                ^^^^^^^^^^^^^^ entity.name.tag.custom.html
@@ -350,6 +373,9 @@ class="foo"></div>
         ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
         ##              ^^ punctuation.definition.tag.end.html
         ##                ^ - meta.tag.custom.html - punctuation.definition.tag.end.html
+
+        <body-custom·tag₡name/>
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
 
         <INVALID-CUSTOM-TAG></INVALID-CUSTOM-TAG>
         ## ^^^^^^^^^^^^^^^^ invalid.illegal.uppercase-custom-tag-name.html
@@ -434,6 +460,10 @@ class="foo"></div>
         ## ^^ meta.tag.block.any punctuation.definition.tag.end
         ##    ^^ entity.name.tag.block.any
         ##       ^^ punctuation.definition.tag.end
+
+        <2notag>
+        ##^^^^^ - entity.name.tag
+
     </body>
     # ^^^^ entity.name.tag.structure
 </html>

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1457,6 +1457,41 @@ var_dump(new C(42));
 //                                      ^^^^^ punctuation.section.embedded.begin
 //                                                   ^^ punctuation.section.embedded.end
 
+  <tag-<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.custom.html
+//^ punctuation.definition.tag.begin.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+//     ^^^^^ punctuation.section.embedded.begin.php
+//     ^^^^^^^^^^^^^ meta.embedded.line.php
+//                ^^ punctuation.section.embedded.end
+//                    ^^^^^ punctuation.section.embedded.begin.php
+//                    ^^^^^^^^^^^^^ meta.embedded.line.php
+//                               ^^ punctuation.section.embedded.end
+//                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html
+//                                    ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
+//                                       ^^^^^ punctuation.section.embedded.begin.php
+//                                       ^^^^^^^^^^^^^ meta.embedded.line.php
+//                                                  ^^ punctuation.section.embedded.end
+//                                                              ^^ punctuation.definition.tag.end.html
+
+  <tag<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//^ punctuation.definition.tag.begin.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
+//    ^^^^^ punctuation.section.embedded.begin.php
+//    ^^^^^^^^^^^^^ meta.embedded.line.php
+//               ^^ punctuation.section.embedded.end
+//                   ^^^^^ punctuation.section.embedded.begin.php
+//                   ^^^^^^^^^^^^^ meta.embedded.line.php
+//                              ^^ punctuation.section.embedded.end
+//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html
+//                                   ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
+//                                      ^^^^^ punctuation.section.embedded.begin.php
+//                                      ^^^^^^^^^^^^^ meta.embedded.line.php
+//                                                 ^^ punctuation.section.embedded.end
+//                                                             ^^ punctuation.definition.tag.end.html
+
+
 <div class="test <?= $foo ?>"></div>
 //   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html
 //         ^ punctuation.definition.string.begin.html


### PR DESCRIPTION
Fixes #1619 

1. According to https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state a html5 tag name may contain nearly any character, which is scoped as `entity.name.tag.other` by this commit. A couple of really weird tag names were tested and worked with Firefox.

2. According to https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts custom element tags may contain lower case characters which are not limited to ASCII or digits. Hence this commit uses the `custom_element_char` variable from the CSS.sublime-syntax to match custom-element-tags as it defines the same rule for them.

3. In order to make sure custom/other tag names don't interfere with normal html tags, the `\b` is replaced by `{{tag_name_break}}` in all tag name patterns. This avoids matching tags like `<body·other>` correctly. Without this change body would be matched as normal tag name and `other` as attribute.

4. Step 3 allows the custom-element-tag rule to be moved to the end right next to its illegal-uppercase sister and save some milliseconds on ordinary html code, which makes no use of custom/other tags. The impact is very small (ca. 3-4%) though.