### PR TITLE
[HTML] html5 complient attribute names

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -11,11 +11,7 @@ scope: text.html.basic
 
 variables:
   # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-  # 0000-0020   -- code point, C0 control (space)
-  # 007F-009F   -- controls
-  # FDD0-FDEF   -- noncharacters
-  # ?FFFE-?FFFF -- noncharacters
-  attribute_char: '[^''">/=\x{0000}-\x{0020}\x{007F}-\x{009F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]'
+  attribute_char: '[^\t\n\f />=]'
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -15,7 +15,7 @@ variables:
   # 007F-009F   -- controls
   # FDD0-FDEF   -- noncharacters
   # ?FFFE-?FFFF -- noncharacters
-  attribute_name: '[^''">/=\x{0000}-\x{0020}\x{007F}-\x{009F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]+'
+  attribute_char: '[^''">/=\x{0000}-\x{0020}\x{007F}-\x{009F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]'
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
@@ -434,11 +434,16 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: '{{attribute_name}}'
-      scope: entity.other.attribute-name.html
+    - match: (?={{attribute_char}})
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
+        - tag-generic-attribute-name
+
+  tag-generic-attribute-name:
+    - meta_scope: entity.other.attribute-name.html
+    - match: (?!{{attribute_char}})
+      pop: true
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -17,7 +17,6 @@ variables:
   # ?FFFE-?FFFF -- noncharacters
   attribute_name: '[^''">/=\x{0000}-\x{0020}\x{007F}-\x{009F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]+'
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
-  not_equals_lookahead: (?=\s*[^\s=])
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
   tag_name: '[[:alpha:]_][^/>\s]*'
@@ -449,8 +448,7 @@ contexts:
     - match: '='
       scope: punctuation.separator.key-value.html
       set: tag-generic-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
+    - include: else-pop
 
   tag-generic-attribute-value:
     - match: '"'
@@ -489,8 +487,7 @@ contexts:
     - match: '='
       scope: punctuation.separator.key-value.html
       set: tag-class-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
+    - include: else-pop
 
   tag-class-attribute-value:
     - match: '"'
@@ -531,8 +528,7 @@ contexts:
     - match: '='
       scope: punctuation.separator.key-value.html
       set: tag-id-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
+    - include: else-pop
 
   tag-id-attribute-value:
     - match: '"'
@@ -573,8 +569,7 @@ contexts:
     - match: '='
       scope: punctuation.separator.key-value.html
       set: tag-style-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
+    - include: else-pop
 
   tag-style-attribute-value:
     - match: '"'
@@ -619,8 +614,7 @@ contexts:
     - match: '='
       scope: punctuation.separator.key-value.html
       set: tag-event-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
+    - include: else-pop
 
   tag-event-attribute-value:
     - match: '"'

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -10,9 +10,16 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
+  ascii_space: '\t\n\f '
+
   # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-  attribute_char: '[^\t\n\f />=]'
-  unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
+  attribute_char: '[^{{ascii_space}}=/>]'
+
+  # https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-value
+  unquoted_attribute_break: (?=[{{ascii_space}}]|/?>)
+  unquoted_attribute_value: '[^{{ascii_space}}=<>`''"]+?{{unquoted_attribute_break}}'
+  # looks like an unquoted attribute value but may contain forbidden characters (=<>`'")
+  unquoted_attribute_invalid: '[^{{ascii_space}}>]+?{{unquoted_attribute_break}}'
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
   tag_name: '[[:alpha:]_][^/>\s]*'
@@ -307,7 +314,7 @@ contexts:
           set: style-css
 
   style-type-decider:
-    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
+    - match: (?i)(?=text/css{{unquoted_attribute_break}}|'text/css'|"text/css")
       set:
         - style-css
         - tag-generic-attribute-meta
@@ -384,12 +391,12 @@ contexts:
           set: script-javascript
 
   script-type-decider:
-    - match: (?i)(?={{javascript_mime_type}}(?!{{unquoted_attribute_value}})|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
+    - match: (?i)(?={{javascript_mime_type}}{{unquoted_attribute_break}}|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
       set:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
+    - match: (?i)(?=module{{unquoted_attribute_break}}|'module'|"module")
       set:
         - script-javascript
         - tag-generic-attribute-meta
@@ -399,7 +406,7 @@ contexts:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
+    - match: (?i)(?=text/html{{unquoted_attribute_break}}|'text/html'|"text/html")
       set:
         - script-html
         - tag-generic-attribute-meta
@@ -471,6 +478,9 @@ contexts:
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html
       pop: true
+    - match: '{{unquoted_attribute_invalid}}'
+      scope: invalid.illegal.attribute-value.html
+      pop: true
     - include: else-pop
 
   tag-class-attribute:
@@ -512,6 +522,9 @@ contexts:
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.class-name.html
       pop: true
+    - match: '{{unquoted_attribute_invalid}}'
+      scope: invalid.illegal.attribute-value.html meta.class-name.html
+      pop: true
     - include: else-pop
 
   tag-id-attribute:
@@ -552,6 +565,9 @@ contexts:
         - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.toc-list.id.html
+      pop: true
+    - match: '{{unquoted_attribute_invalid}}'
+      scope: invalid.illegal.attribute-value.html meta.toc-list.id.html
       pop: true
     - include: else-pop
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -13,13 +13,13 @@ variables:
   ascii_space: '\t\n\f '
 
   # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-  attribute_char: '[^{{ascii_space}}=/>]'
+  attribute_name_char: '[{{ascii_space}}=/>]'
+  attribute_name_start: (?=[^{{attribute_name_char}}])
+  attribute_name_break: (?={{attribute_name_char}})
 
   # https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-value
+  unquoted_attribute_start: (?=[^{{ascii_space}}=>])
   unquoted_attribute_break: (?=[{{ascii_space}}]|/?>)
-  unquoted_attribute_value: '[^{{ascii_space}}=<>`''"]+?{{unquoted_attribute_break}}'
-  # looks like an unquoted attribute value but may contain forbidden characters (=<>`'")
-  unquoted_attribute_invalid: '[^{{ascii_space}}>]+?{{unquoted_attribute_break}}'
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
   tag_name: '[[:alpha:]_][^/>\s]*'
@@ -437,7 +437,7 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: (?={{attribute_char}})
+    - match: '{{attribute_name_start}}'
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
@@ -445,8 +445,10 @@ contexts:
 
   tag-generic-attribute-name:
     - meta_scope: entity.other.attribute-name.html
-    - match: (?!{{attribute_char}})
+    - match: '{{attribute_name_break}}'
       pop: true
+    - match: '["''`<]'
+      scope: invalid.illegal.attribute-name.html
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html
@@ -475,12 +477,13 @@ contexts:
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html
-      pop: true
-    - match: '{{unquoted_attribute_invalid}}'
-      scope: invalid.illegal.attribute-value.html
-      pop: true
+    - match: '{{unquoted_attribute_start}}'
+      set:
+        - meta_scope: string.unquoted.html
+        - match: '{{unquoted_attribute_break}}'
+          pop: true
+        - match: '["''`<]'
+          scope: invalid.illegal.attribute-value.html
     - include: else-pop
 
   tag-class-attribute:
@@ -519,12 +522,13 @@ contexts:
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html meta.class-name.html
-      pop: true
-    - match: '{{unquoted_attribute_invalid}}'
-      scope: invalid.illegal.attribute-value.html meta.class-name.html
-      pop: true
+    - match: '{{unquoted_attribute_start}}'
+      set:
+        - meta_scope: string.unquoted.html meta.class-name.html
+        - match: '{{unquoted_attribute_break}}'
+          pop: true
+        - match: '["''`<]'
+          scope: invalid.illegal.attribute-value.html
     - include: else-pop
 
   tag-id-attribute:
@@ -563,12 +567,13 @@ contexts:
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html meta.toc-list.id.html
-      pop: true
-    - match: '{{unquoted_attribute_invalid}}'
-      scope: invalid.illegal.attribute-value.html meta.toc-list.id.html
-      pop: true
+    - match: '{{unquoted_attribute_start}}'
+      set:
+        - meta_scope: string.unquoted.html meta.toc-list.id.html
+        - match: '{{unquoted_attribute_break}}'
+          pop: true
+        - match: '["''`<]'
+          scope: invalid.illegal.attribute-value.html
     - include: else-pop
 
   tag-style-attribute:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -10,7 +10,12 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
-  attribute_char: (?:[^ "'>/=\x00-\x1f\x7f-\x9f])
+  # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+  # 0000-0020   -- code point, C0 control (space)
+  # 007F-009F   -- controls
+  # FDD0-FDEF   -- noncharacters
+  # ?FFFE-?FFFF -- noncharacters
+  attribute_name: '[^''">/=\x{0000}-\x{0020}\x{007F}-\x{009F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]+'
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
 
@@ -430,17 +435,11 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: (?={{attribute_char}})
+    - match: '{{attribute_name}}'
       scope: entity.other.attribute-name.html
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
-        - generic-attribute-name
-
-  generic-attribute-name:
-    - meta_scope: entity.other.attribute-name.html
-    - match: (?!{{attribute_char}})
-      pop: true
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -199,6 +199,13 @@
         ##   ^^^^^ meta.attribute-with-value
         ##        ^^ punctuation.definition.tag.end.html
 
+        <img src=//>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^ entity.other.attribute-name
+        ##   ^^^^^ meta.attribute-with-value
+        ##       ^ string.unquoted.html
+        ##        ^^ punctuation.definition.tag.end.html
+
         <img src=/f̱oo⏡/bar/baz//>
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
@@ -218,17 +225,17 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^ meta.attribute-with-value
-        ##         ^^^^ invalid.illegal.attribute-value.html
-        ##            ^ - punctuation
+        ##         ^^^^ string.unquoted.html
+        ##            ^ invalid.illegal.attribute-value.html
         ##             ^^ punctuation.definition.tag.end.html
 
         <img title=/f̱oo⏡/"bar"/baz//>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##         ^^^^^^^^^^^^^^^^^ invalid.illegal.attribute-value.html
-        ##                ^ - punctuation
-        ##                    ^ - punctuation
+        ##         ^^^^^^^^^^^^^^^^^ string.unquoted.html
+        ##                ^ invalid.illegal.attribute-value.html
+        ##                    ^ invalid.illegal.attribute-value.html
         ##                          ^^ punctuation.definition.tag.end.html
 
         <div title=description></div>
@@ -351,6 +358,15 @@ class="foo"></div>
         ##                                   ^ entity.other.attribute-name.html
         ##                                                         ^^^^^^^^^^^^^ entity.other.attribute-name.html
         ##                                                                       ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
+
+        <tag "f'o`o<bar"="bar"></tag>
+        ##   ^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html
+        ##   ^^^^^^^^^^^ entity.other.attribute-name.html
+        ##   ^ invalid.illegal.attribute-name.html
+        ##     ^ invalid.illegal.attribute-name.html
+        ##       ^ invalid.illegal.attribute-name.html
+        ##         ^ invalid.illegal.attribute-name.html
+        ##             ^ invalid.illegal.attribute-name.html
 
         <tag *([&\=></tag>
         ##   ^^^^^^^ - invalid

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -186,6 +186,51 @@
 ##          ^^ invalid.illegal.bad-comments-or-CDATA
 ##                      ^^^^^^^^^^^^^^^ - invalid.illegal.bad-comments-or-CDATA
 
+        <script type=html/text/>
+        ##     ^ - meta.attribute-with-value
+        ##      ^^^^ entity.other.attribute-name
+        ##      ^^^^^^^^^^^^^^ meta.attribute-with-value
+        ##           ^^^^^^^^^ string.unquoted
+        ##                    ^^ punctuation.definition.tag.end.html
+
+        <img title/>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^^ entity.other.attribute-name
+        ##   ^^^^^ meta.attribute-with-value
+        ##        ^^ punctuation.definition.tag.end.html
+
+        <img src=/f̱oo⏡/bar/baz//>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^ entity.other.attribute-name
+        ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
+        ##       ^^^^^^^^^^^^^^^ string.unquoted
+        ##                      ^^ punctuation.definition.tag.end.html
+
+        <img src=/f̱oo⏡/bar/baz/ />
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^ entity.other.attribute-name
+        ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
+        ##       ^^^^^^^^^^^^^^^ string.unquoted
+        ##                      ^ - meta.attribute-with-value
+        ##                       ^^ punctuation.definition.tag.end.html
+
+        <img title=foo"/>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^^ entity.other.attribute-name
+        ##   ^^^^^^^^^^ meta.attribute-with-value
+        ##         ^^^^ invalid.illegal.attribute-value.html
+        ##            ^ - punctuation
+        ##             ^^ punctuation.definition.tag.end.html
+
+        <img title=/f̱oo⏡/"bar"/baz//>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^^ entity.other.attribute-name
+        ##   ^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
+        ##         ^^^^^^^^^^^^^^^^^ invalid.illegal.attribute-value.html
+        ##                ^ - punctuation
+        ##                    ^ - punctuation
+        ##                          ^^ punctuation.definition.tag.end.html
+
         <div title=description></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1446,10 +1446,13 @@ var_dump(new C(42));
 <div><?php include 'image.svg' ?></div>
 //                             ^^ punctuation.section.embedded.end.php
 
-<div attr-<?= $bar ?>-true></div>
-//   ^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name
+<div attr-<?= $bar ?>-true=va<? $baz ?>l?ue></div>
+//   ^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name
 //        ^^^ punctuation.section.embedded.begin
 //                 ^^ punctuation.section.embedded.end
+//                         ^^^^^^^^^^^^^^^^ string.unquoted
+//                           ^^ punctuation.section.embedded.begin.php
+//                                   ^^ punctuation.section.embedded.end.php
 
 <option<?php if($condition): ?> selected<?php endif; ?>></option>
 //     ^^^^^ punctuation.section.embedded.begin


### PR DESCRIPTION
This PR is an extension for PR #1784.

It provides the following changes:

1. Adds [noncharacters](https://infra.spec.whatwg.org/#noncharacter) to the list of characters an attribute must not contain.
2. Renames the variable `attribute_char` to `attribute_name`
3. Changes the hex notation to `\x{0000}` to match the `custom_element_name` style.
4. Replaces the negative lookaheads to improve parsing performance by 35..40%
5. The second commit of this PR replaces the `not_equals_lookahead` in favor of the existing `else-pop` context.

After merging PR #1784 and this one the parsing time for the following file with about 55k lines of code reduced from 1.5s to 0.9s on my box.

```html
<!DOCTYPE html>
<html>
<head>
    <title></title>
</head>
<body>
    <tag-name attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test">
    <tag-name attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test" attribute="test">
    <!-- 55k lines -->
</body>
</html>
```