### PR TITLE
[HTML] Fix ]]> being scoped as invalid

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -199,8 +199,6 @@ contexts:
         - match: ']]>'
           scope: punctuation.definition.tag.end.html
           pop: true
-    - match: ']]>'
-      scope: invalid.illegal.missing-entity.html
 
   comment:
     - match: (<!--)(-?>)?

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -163,7 +163,10 @@
 ##              ^ - punctuation.definition.tag.begin
 ##                          ^^^ punctuation.definition.tag.end
     ]]>
-##  ^^^ invalid.illegal.missing-entity
+##  ^^^ - punctuation.definition.tag.end - illegal
+
+    <code>]]></code>
+##        ^^^ - punctuation.definition.tag.end - illegal
 
         <!-- Comment -->
 ##      ^^^^^^^^^^^^^^^^ comment.block.html


### PR DESCRIPTION
Fixes #1786

As described in #1786 the `]]>` was found to be valid text. Hence the normally used `invalid.illegal.stray` handling can't be applied.

This issue is an oversight/regression introduced with commit 015472d.