### PR TITLE
[Ruby] Add support for assert_no_match

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -496,6 +496,7 @@ contexts:
           |
           \b(
             assert_match|
+            assert_no_match|
             gsub|
             index|
             match|

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -463,3 +463,9 @@ foo / "bar/bla"
   /foo/ => :foo
 # ^^^^^ string.regexp.classic.ruby
 }
+
+assert_no_match /1/, "2"
+# <- source.ruby
+# <- support.function.builtin.ruby
+#               ^ punctuation.definition.string.ruby
+#                    ^ string.quoted.double.ruby


### PR DESCRIPTION
This PR adds support for properly handling Test::Unit::Assertions' assert_no_match. Before this fix, syntax highlighting falls over for the remainder of the file once an assert_no_match assertion is used.

(The [previous PR](https://github.com/sublimehq/Packages/pull/1520) was closed by GitHub when I switched to a topic branch.)