### PR TITLE
[CSS] support Named Grid Lines

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -584,6 +584,7 @@ contexts:
     - include: comment-block
     - include: vendor-prefix
     - include: builtin-functions
+    - include: line-names
     - include: unicode-range
     - include: numeric-values
     - include: color-values
@@ -1308,6 +1309,7 @@ contexts:
           - include: minmax-function
           - include: integer-type
           - include: var-function
+          - include: line-names
           - match: \b(auto-fill|auto-fit)\b
             scope: support.keyword.repetitions.css
           - match: \b(max-content|min-content|auto)\b
@@ -1907,6 +1909,18 @@ contexts:
       scope: punctuation.terminator.rule.css
     - match: (?=;|$)
       pop: true
+
+  # Named Grid Lines
+  # https://drafts.csswg.org/css-grid/#named-lines
+  line-names:
+    - match: '\['
+      scope: punctuation.section.begin.css
+      push:
+        - match: '{{ident}}'
+          scope: string.unquoted.line-name.css
+        - match: '\]'
+          scope: punctuation.section.end.css
+          pop: true
 
   unquoted-string:
     - match: '[^\s''"]'

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -921,6 +921,22 @@
 /*                               ^^^^^^ support.type.custom-property.css */
 /*                                     ^^ punctuation.definition.group.end.css */
 /*                                          ^^^^^^ support.function.grid.css */
+    grid-template-columns:
+      [a-line-name] auto
+/*    ^ punctuation.section.begin.css */
+/*     ^^^^^^^^^^^  string.unquoted.line-name.css */
+/*                ^ punctuation.section.end.css */
+      [b]     minmax(min-content, 1fr)
+      [b c d] repeat(2, [e] 40px)
+/*    ^                     punctuation.section.begin.css */
+/*     ^                    string.unquoted.line-name.css */
+/*      ^                   - string.unquoted.line-name.css */
+/*       ^                  string.unquoted.line-name.css */
+/*          ^               punctuation.section.end.css */
+/*                      ^   punctuation.section.begin.css */
+/*                       ^  string.unquoted.line-name.css */
+/*                        ^ punctuation.section.end.css */
+              repeat(5, auto);
 }
 
 .test-filter-functions {


### PR DESCRIPTION
https://drafts.csswg.org/css-grid/#named-lines

Grids have a thing where you can name lines, via the `[<custom-ident>*]` syntax:

```
grid-template-columns: [first nav-start] 150px [main-start] 1fr [last];
grid-template-rows: [first header-start] 50px [main-start] 1fr [footer-start] 50px [last];
```

I'm not 100% sure of the scope naming here and decided to keep it simple. 