### PR TITLE
[C#] Fix lambda operator not matched in function arguments

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1395,7 +1395,7 @@ contexts:
     - match: (ref)\s
       captures:
         1: storage.modifier.argument.cs
-    - match: '({{name}})\s*(=)(?!=)'
+    - match: '({{name}})\s*(=)(?=[^>=])'
       captures:
         1: variable.parameter.cs
         2: keyword.operator.assignment.cs

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -837,6 +837,34 @@ namespace TestNamespace.Test
 ///                                     ^^^^^^^^^^ meta.function.anonymous
 ///                                       ^^ storage.type.function.lambda
 
+            var changes = refs.ToDictionary(kvp => kvp.key, arg => k + 5);
+///                                         ^^^^^^^^^^^^^^ meta.function.anonymous.cs
+///                                         ^^^ variable.parameter.cs
+///                                             ^^ storage.type.function.lambda.cs
+///                                                ^^^ variable.other.cs
+///                                                       ^ punctuation.separator.argument.cs
+///                                                       ^^ - meta.function.anonymous
+///                                                         ^^^^^^^^^^^^ meta.function.anonymous.cs
+///                                                         ^^^ variable.parameter.cs
+///                                                             ^^ storage.type.function.lambda.cs
+///                                                                ^ variable.other.cs
+///                                                                  ^ keyword.operator.cs
+///                                                                    ^ constant.numeric.integer.decimal.cs
+///                                                                     ^ - meta.function.anonymous
+
+            var shortDigits = digits.Where((digit, index) => digit.Length < index);
+///                                       ^ - meta.function.anonymous
+///                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs
+///                                                                              ^ - meta.function.anonymous
+///                                        ^ punctuation.section.group.begin.cs
+///                                        ^^^^^^^^^^^^^^ meta.group.cs
+///                                         ^^^^^ variable.parameter.cs
+///                                              ^ punctuation.separator.parameter.function.cs
+///                                                ^^^^^ variable.parameter.cs
+///                                                     ^ punctuation.section.group.end.cs
+///                                                       ^^ storage.type.function.lambda.cs
+///                                                          ^^^^^ variable.other.cs
+
         }
 
         void CodeContainingConstructors(){


### PR DESCRIPTION
Before this commit the lambda operator `=>` was not matched within function call arguments like `func(arg => anonymous)`.

To fix the issue the negative lookahead `(?!=)` in the `arguments` context is extended to restrict the matching of `=` as assignment. A positive lookahead with a negated character class is used as ST's regex engine can handle that much faster than negative lookaheads.