### PR TITLE
[Latex] Add support for \parencites

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -663,7 +663,7 @@ contexts:
           (\\)
           (?:
             [cC]ite(?:author|title|year|date|url|t|p|alt|alp|text|yearpar)?
-          | (?:[pP]aren|foot|[tT]ext|[sS]mart|super|[aA]|no|full|footfull)cite|footcitetext
+          | (?:[pP]aren|foot|[tT]ext|[sS]mart|super|[aA]|no|full|footfull)cite(?:s)?|footcitetext
           )
           \*?
         )\b
@@ -672,6 +672,16 @@ contexts:
         2: punctuation.definition.backslash.latex
       push:
         - meta_scope: meta.function.citation.latex
+        - include: general-optional-arguments
+        - match: '\{'
+          scope: punctuation.definition.group.brace.begin.latex
+          push:
+            - meta_scope: meta.function.citation.latex meta.group.brace.latex
+            - match: '[a-zA-Z0-9\.:/*!^_-]+'
+              scope: constant.other.citation.latex
+            - match: '\}'
+              scope: punctuation.definition.group.brace.end.latex
+              pop: true
         - include: general-optional-arguments
         - match: '\{'
           scope: punctuation.definition.group.brace.begin.latex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -104,12 +104,25 @@
 % ^ support.function.cite.latex keyword.other.cite.latex
 %        ^ constant.other.citation
 
-
 \cite[\command]{my:bib:key}
 % ^ meta.function.citation.latex
 % ^ support.function.cite.latex
 %           ^ support.function
 %
+
+\parencite[Propositon~1]{Ref}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+%          ^ meta.group.bracket.latex
+%                         ^ constant.other.citation.latex
+
+\parencites[Proposition~1]{Firstref}[p.~2]{SecondRef}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+%           ^ meta.group.bracket.latex
+%                          ^ constant.other.citation.latex
+%                                     ^ meta.group.bracket.latex
+%                                          ^ constant.other.citation.latex
 
 
 % URL COMMAND


### PR DESCRIPTION
Fixes #1762.

The `biblatex` package includes the `\parencites` command that has a somewhat unusual argument structure in that multiple optional and mandatory arguments follow each other, e.g.
````latex
\parencites[Proposition~1]{Firstref}[p.~2]{SecondRef}
````
This PR adds support for this command.