### PR TITLE
[Perl] Fix angle quoted strings break highlighting

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -644,6 +644,9 @@ contexts:
     - match: '[!~=]~'
       scope: keyword.operator.binary.perl
       push: regexp-pop
+    - match: <<|>>
+      scope: keyword.operator.bitwise.perl
+      push: regexp-pop
     - match: <=>|//|\&\&|\|\||==|!=|>=|<=|[<>:!?]
       scope: keyword.operator.logical.perl
       push: regexp-pop
@@ -901,6 +904,15 @@ contexts:
       escape_captures:
         1: punctuation.section.generic.end.perl
         2: constant.language.flags.regexp.perl
+    # angle quoted strings
+    - match: \<(?=[^<])
+      scope: punctuation.definition.string.begin.perl
+      set:
+        - meta_scope: string.quoted.angle.perl
+        - match: \>
+          scope: punctuation.definition.string.end.perl
+          pop: true
+        - include: character-escape
     - include: else-pop
 
 ### [ FUNCTIONS ]#############################################################

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1306,3 +1306,21 @@ sub name ($) {}
 # ^^^^^^^^^^^^^^ variable.function.perl
 #                ^^^^ variable.other.readwrite.global.perl
 #                    ^ punctuation.terminator.statement.perl
+
+  foreach my $vsn_mk (<lib/*/vsn.mk>, <erts/vsn.mk>) {
+# ^^^^^^^ keyword.control.flow.perl
+#         ^^ keyword.declaration.variable.perl
+#            ^ punctuation.definition.variable.perl
+#            ^^^^^^^ variable.other.readwrite.global.perl
+#                    ^ punctuation.section.group.begin.perl
+#                     ^ punctuation.definition.string.begin.perl
+#                     ^^^^^^^^^^^^^^ string.quoted.angle.perl
+#                                  ^ punctuation.definition.string.end.perl
+#                                   ^ punctuation.separator.sequence.perl
+#                                     ^ punctuation.definition.string.begin.perl
+#                                     ^^^^^^^^^^^^^ string.quoted.angle.perl
+#                                                 ^ punctuation.definition.string.end.perl
+#                                                  ^ punctuation.section.group.end.perl
+#                                                    ^ punctuation.section.block.begin.perl
+  }
+# ^ punctuation.section.block.end.perl


### PR DESCRIPTION
This PR adds support for angle-bracket quoted strings to the Perl syntax definition.

see: https://docs.perl6.org/language/quoting#Word_quoting:_%3C_%3E

### Example

https://github.com/erlang/otp/blob/master/make/fixup_development_runtime_dependencies

#### without this fix

![grafik](https://user-images.githubusercontent.com/16542113/51426247-13334300-1be8-11e9-97b7-bf8f9dd8c40a.png)


#### with this fix

![grafik](https://user-images.githubusercontent.com/16542113/51426257-2ba35d80-1be8-11e9-8b40-98fac08f5d10.png)
