### PR TITLE
Avoid tricky YAML syntax in the Go definition

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -253,7 +253,7 @@ contexts:
     {match: \-   , scope: keyword.operator.go},
     {match: /=   , scope: keyword.operator.assignment.go},
     {match: /    , scope: keyword.operator.go},
-    {match: :=   , scope: keyword.operator.assignment.go},
+    {match: ":=" , scope: keyword.operator.assignment.go},
     {match: <-   , scope: keyword.operator.go},
     {match: <    , scope: keyword.operator.go},
     {match: <<=  , scope: keyword.operator.assignment.go},


### PR DESCRIPTION
Double `:` confuses my YAML parser.