### PR TITLE
[Lisp] allow ">" character in functions

### DIFF
--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
       scope: keyword.control.lisp
 
   functions:
-    - match: (\b(?i:(defun|defmethod|defmacro))\b)(\s+)((\w|\-|\!|\?)*)
+    - match: (\b(?i:(defun|defmethod|defmacro))\b)(\s+)((\w|\-|\>|\!|\?)*)
       scope: meta.function.lisp
       captures:
         2: storage.type.function-type.lisp


### PR DESCRIPTION
lisp allows a lot of symbols for function definitions, and we don't want to include them all, but ">" is a common pattern E.G. string->int