### PR TITLE
[Go] support built-in types and funcs

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -2,10 +2,8 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 
-
 # The structure and terminology of this syntax reflects the spec:
 # https://golang.org/ref/spec
-
 
 # The following is a simplified model of Sublime Text's syntax engine, reverse-
 # engineered through experience. This model uses assertive language for brevity,
@@ -66,6 +64,12 @@ variables:
   # https://golang.org/ref/spec#Keywords
   # These are the only words that can't be used as identifiers.
   keyword: \b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b
+
+  # https://golang.org/ref/spec#Predeclared_identifiers
+  predeclared_type: \b(?:bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr)\b
+
+  # https://golang.org/ref/spec#Predeclared_identifiers
+  predeclared_func: \b(?:append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\b
 
   # Note: this matches ALL valid identifiers, including predeclared constants,
   # functions and types.
@@ -135,7 +139,7 @@ contexts:
     # Including the newline allows the scope to visually stretch to the right,
     # and ensures that functionality that relies on comment scoping, such as
     # contextual hotkeys, works properly at EOL while typing a comment. This
-    # should also match \r\n due to internal conversions.
+    # should also match \r\n due to Sublime's internal normalization.
     - match: $\n?
       pop: true
 
@@ -177,7 +181,7 @@ contexts:
 
   # See `match-selector` for field scoping.
   match-identifiers:
-    - include: match-predefined-identifiers
+    - include: match-predeclared-constants
     - include: match-call-or-cast
     - include: match-short-variable-declarations
     - match: \b_\b
@@ -186,25 +190,67 @@ contexts:
       scope: variable.other.go
 
   # https://golang.org/ref/spec#Predeclared_identifiers
-  match-predefined-identifiers:
-    # Note: these are NOT keywords, but rather predeclared identifiers that can
-    # be redefined. We treat them as regular identifiers in variable
-    # declarations, types, function names, etc. This rule should be used in
-    # places that are "left over". Detecting redefinition is beyond the scope of
-    # this syntax engine.
+  #
+  # In Go, the predeclared constants are not keywords, and can be redefined. In
+  # many places such as variable declarations, types, function names, etc, we
+  # allow them to be scoped the same way as other identifiers. This "constant"
+  # rule should be used in places that are "left over". Detecting redefinition
+  # would be ideal, but is beyond the scope of this syntax engine; we simply
+  # expect it to be very rare.
+  match-predeclared-constants:
     - match: \b(?:true|false|nil)\b
       scope: constant.language.go
-    - include: match-new
-    - include: match-make
 
-  # Note: calls and casts are syntactically identical. Detecting casts and
-  # scoping them as types is beyond the capabilities of this syntax engine.
+  # Note: in Go, calls and casts are syntactically identical. Detecting casts
+  # and scoping them as types is beyond the capabilities of this syntax engine.
   #
-  # This is somewhat duplicated in `match-selector`, which must be included
-  # before this rule.
+  # https://golang.org/ref/spec#Predeclared_identifiers
+  #
+  # Notes on built-in functions
+  #
+  # Most built-in functions don't need special syntactic support. We scope them
+  # for the benefit of the users who prefer to distinguish them from
+  # user-defined identifiers. Two exceptions are `make` and `new`, where the
+  # first argument is scoped as a type, matching the special-case support in
+  # the compiler. When built-ins are redefined, this leads to incorrect
+  # scoping; like with constants, we expect such redefinition to be very rare.
+  #
+  # Note that we limit this detection to plain function calls, ignoring method
+  # calls and other identifier occurrences. The language currently allows
+  # built-in functions ONLY in a function call position. This helps minimize
+  # false positives.
+  #
+  # Notes on built-in types
+  #
+  # Unlike casts involving a user-defined type, casts involving a built-in
+  # types could be scoped purely as types rather than function calls. However,
+  # we stick to `variable.function.go` to make the treatment of built-ins
+  # purely additive, allowing the user to opt out.
   match-call-or-cast:
+    - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
+      scope: variable.function.go support.function.builtin.go
+      push: pop-arguments-starting-with-type
+    - match: '{{predeclared_type}}(?=(?:{{noise}}\))*{{noise}}\()'
+      scope: variable.function.go support.type.builtin.go
+    - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
+      scope: variable.function.go support.function.builtin.go
     - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go
+
+  # See notes on `match-call-or-cast`.
+  pop-call-or-cast:
+    - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
+      scope: variable.function.go support.function.builtin.go
+      set: pop-arguments-starting-with-type
+    - match: '{{predeclared_type}}(?=(?:{{noise}}\))*{{noise}}\()'
+      scope: variable.function.go support.type.builtin.go
+      pop: true
+    - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
+      scope: variable.function.go support.function.builtin.go
+      pop: true
+    - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
+      scope: variable.function.go
+      pop: true
 
   # Note: this currently doesn't work across multiple lines.
   match-short-variable-declarations:
@@ -217,20 +263,6 @@ contexts:
           scope: variable.declaration.go
         - include: match-comma
         - include: pop-before-nonblank
-
-  # Note: `new` can be redefined, invalidating this scoping, but such
-  # redefinition should be very uncommon.
-  match-new:
-    - match: \bnew\b(?={{noise}}\()
-      scope: variable.function.go
-      push: pop-first-argument-as-type
-
-  # Note: `make` can be redefined, invalidating this scoping, but such
-  # redefinition should be very uncommon.
-  match-make:
-    - match: \bmake\b(?={{noise}}\()
-      scope: variable.function.go
-      push: pop-first-argument-as-type
 
   # https://golang.org/ref/spec#Operators_and_punctuation
   match-operators: [
@@ -310,13 +342,12 @@ contexts:
         - include: match-comments
         - include: pop-type-assertion
 
-        # See `match-call-or-cast` on notes about call/cast ambiguity.
+        # Note: calls and casts are syntactically identical.
         - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
           scope: variable.function.go
           pop: true
 
         - include: pop-member
-
         # Note: newlines between dot and assertion/field are ok
         - include: pop-before-nonblank
 
@@ -327,9 +358,7 @@ contexts:
         - match: \)
           scope: punctuation.section.parens.end.go
           pop: true
-        - match: '{{ident}}(?={{noise}}\){{noise}}\()'
-          scope: variable.function.go
-          pop: true
+        - include: pop-call-or-cast
         - include: match-any
     - match: \)
       scope: punctuation.section.parens.end.go
@@ -348,9 +377,7 @@ contexts:
         - match: \b_\b
           scope: variable.language.blank.go
           pop: true
-        - match: '{{ident}}'
-          scope: storage.type.go
-          pop: true
+        - include: pop-type-identifier
         - include: pop-before-nonblank
 
   match-braces:
@@ -890,6 +917,8 @@ contexts:
               scope: variable.other.go
             - match: \.
               scope: punctuation.accessor.dot.go
+            - match: '{{predeclared_type}}(?={{noise}}(?:"|`|//|;|\}|$))'
+              scope: entity.other.inherited-class.go support.type.builtin.go
             - match: '{{ident}}(?={{noise}}(?:"|`|//|;|\}|$))'
               scope: entity.other.inherited-class.go
 
@@ -929,6 +958,8 @@ contexts:
               scope: variable.other.go
             - match: \.
               scope: punctuation.accessor.dot.go
+            - match: '{{predeclared_type}}(?={{noise}}(?://|;|\}|$))'
+              scope: entity.other.inherited-class.go support.type.builtin.go
             - match: '{{ident}}(?={{noise}}(?://|;|\}|$))'
               scope: entity.other.inherited-class.go
 
@@ -985,10 +1016,16 @@ contexts:
     - match: \b_\b
       scope: variable.language.blank.go
       pop: true
+    - include: pop-type-identifier
+    - include: pop-before-nonblank
+
+  pop-type-identifier:
+    - match: '{{predeclared_type}}'
+      scope: storage.type.go support.type.builtin.go
+      pop: true
     - match: '{{ident}}'
       scope: storage.type.go
       pop: true
-    - include: pop-before-nonblank
 
   pop-type-alias-or-typedef:
     - include: pop-on-terminator
@@ -1077,8 +1114,10 @@ contexts:
       scope: variable.other.member.go
       pop: true
 
-  pop-first-argument-as-type:
+  pop-arguments-starting-with-type:
     - include: match-comments
+    - match: \)
+      scope: punctuation.section.parens.end.go
     - match: \(
       scope: punctuation.section.parens.begin.go
       set:

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1,6 +1,5 @@
 // SYNTAX TEST "Go.sublime-syntax"
 
-
 /*
 NOTES
 
@@ -103,11 +102,15 @@ You may have to disable Go-specific linters when working on this file.
     )
 
 
-// # Types
+// # Type Keywords and Syntax
 
-// Types are covered early because they're involved in most tests.
-// Note: Go permits an arbitrary number of parens around a type.
+/*
+Type keywords are tested early because they're used in many other tests.
 
+Note: Go permits an arbitrary number of parens around a type.
+
+Note: built-ins are tested separately. Search for "# Built-in Types".
+*/
 
 // ## chan
 
@@ -334,8 +337,7 @@ You may have to disable Go-specific linters when working on this file.
     func()
 //  ^^^^ storage.type.keyword.function.go
     ident
-//  ^^^^^ -storage
-//  ^^^^^ variable.other.go
+//  ^^^^^ variable.other.go -storage
 
     func(true false) (nil iota)
 //  ^^^^ storage.type.keyword.function.go
@@ -415,10 +417,10 @@ You may have to disable Go-specific linters when working on this file.
     )
 
     func(
-        param, param []byte,
+        param, param []typ,
 //      ^^^^^ variable.parameter.go
 //             ^^^^^ variable.parameter.go
-//                     ^^^^ storage.type.go
+//                     ^^^ storage.type.go
         param ...typ,
 //      ^^^^^ variable.parameter.go
 //            ^^^ keyword.operator.variadic.go
@@ -426,10 +428,10 @@ You may have to disable Go-specific linters when working on this file.
     )
 
     func(
-        param, param (([]byte)),
+        param, param (([]typ)),
 //      ^^^^^ variable.parameter.go
 //             ^^^^^ variable.parameter.go
-//                       ^^^^ storage.type.go
+//                       ^^^ storage.type.go
         param typ,
 //      ^^^^^ variable.parameter.go
 //            ^^^ storage.type.go
@@ -751,8 +753,7 @@ You may have to disable Go-specific linters when working on this file.
 //      ^^^ storage.type.go
 //         ^ punctuation.section.brackets.end.go
 //          ^^^ storage.type.go
-//              ^^^^^ -storage
-//              ^^^^^ variable.other.go
+//              ^^^^^ variable.other.go -storage
 
     map[typ]
 //  ^^^ storage.type.keyword.map.go
@@ -1239,8 +1240,7 @@ You may have to disable Go-specific linters when working on this file.
 
     [0]
     ident
-//  ^^^^^ -storage
-//  ^^^^^ variable.other.go
+//  ^^^^^ variable.other.go -storage
 
     [/**/
 //   ^^^^ comment.block.go
@@ -1251,8 +1251,7 @@ You may have to disable Go-specific linters when working on this file.
 
     []
     ident
-//  ^^^^^ -storage
-//  ^^^^^ variable.other.go
+//  ^^^^^ variable.other.go -storage
 
     []func(
 //    ^^^^ storage.type.keyword.function.go
@@ -1264,7 +1263,12 @@ You may have to disable Go-specific linters when working on this file.
 //        ^^^^^ variable.other.go
 
 
-// # Type Definitions
+// ## type
+
+    type _ typ
+//  ^^^^ storage.type.keyword.type.go
+//       ^ variable.language.blank.go
+//         ^^^ storage.type.go
 
     type Type typ
 //  ^^^^ storage.type.keyword.type.go
@@ -1432,7 +1436,6 @@ You may have to disable Go-specific linters when working on this file.
 // cause identifiers in those expressions to be incorrectly scoped as constants
 // or variables.
 
-// Empty identifier is NOT scoped
     const _ = 10
 //  ^^^^^ storage.type.keyword.const.go
 //        ^ variable.language.blank.go
@@ -1582,56 +1585,55 @@ You may have to disable Go-specific linters when working on this file.
 //             ^^^^ constant.numeric.integer.go
     )
 
-const ident typ = ident +
-// ^^ storage.type.keyword.const.go
-//    ^^^^^ variable.other.constant.declaration.go
-//          ^^^ storage.type.go
-//              ^ keyword.operator.assignment.go
-//                ^^^^^ variable.other.go
-//                      ^ keyword.operator.go
-    ident +
-//  ^^^^^ variable.other.go
-//        ^ keyword.operator.go
-    ident +
-//  ^^^^^ variable.other.go
-//        ^ keyword.operator.go
-    ident
-//  ^^^^^ variable.other.go
-
-const (
-// ^^ storage.type.keyword.const.go
-    ident typ = ident +
-//  ^^^^^ variable.other.constant.declaration.go
-//        ^^^ storage.type.go
-//            ^ keyword.operator.assignment.go
-//              ^^^^^ variable.other.go
-//                    ^ keyword.operator.go
+    const ident typ = ident +
+//  ^^^^^ storage.type.keyword.const.go
+//        ^^^^^ variable.other.constant.declaration.go
+//              ^^^ storage.type.go
+//                  ^ keyword.operator.assignment.go
+//                    ^^^^^ variable.other.go
+//                          ^ keyword.operator.go
         ident +
-//      ^^^^^ variable.other.constant.declaration.go
+//      ^^^^^ variable.other.go
 //            ^ keyword.operator.go
+        ident +
+//      ^^^^^ variable.other.go
+//            ^ keyword.operator.go
+        ident
+//      ^^^^^ variable.other.go
+
+    const (
+//  ^^^^^ storage.type.keyword.const.go
+        ident typ = ident +
+//      ^^^^^ variable.other.constant.declaration.go
+//            ^^^ storage.type.go
+//                ^ keyword.operator.assignment.go
+//                  ^^^^^ variable.other.go
+//                        ^ keyword.operator.go
+            ident +
+//          ^^^^^ variable.other.constant.declaration.go
+//                ^ keyword.operator.go
 
 // BUG: this is incorrectly scoped as a type. TODO consider detecting multiline
 // expressions, or find another way of handling this properly.
-        ident +
+            ident +
 
-        ident
-//      ^^^^^ variable.other.constant.declaration.go
-)
+            ident
+//          ^^^^^ variable.other.constant.declaration.go
+    )
 
 // iota is predefined only in constant declarations. It's not a reserved word.
-func _() {
-    var iota = 0
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^ variable.declaration.go
-//           ^ keyword.operator.assignment.go
-//             ^ constant.numeric.integer.go
-    var _ = iota
-//  ^^^ storage.type.keyword.var.go
-//      ^ variable.language.blank.go
-//        ^ keyword.operator.assignment.go
-//          ^^^^ variable.other.go
-//          ^^^^ -constant
-}
+    func _() {
+        var iota = 0
+//      ^^^ storage.type.keyword.var.go
+//          ^^^^ variable.declaration.go
+//               ^ keyword.operator.assignment.go
+//                 ^ constant.numeric.integer.go
+        var _ = iota
+//      ^^^ storage.type.keyword.var.go
+//          ^ variable.language.blank.go
+//            ^ keyword.operator.assignment.go
+//              ^^^^ variable.other.go -constant
+    }
 
     var _ = log.Println
 //  ^^^ storage.type.keyword.var.go
@@ -1971,8 +1973,7 @@ func _() {
 //   ^ -constant.other.placeholder
 
     "one /* two */ three"
-//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.go
-//  ^^^^^^^^^^^^^^^^^^^^^ -comment
+//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.go -comment
 
     "_\n_"
 //  ^^^^^^ string.quoted.double.go
@@ -2009,8 +2010,7 @@ func _() {
 //  ^^^^^^^^^ string.quoted.other.go
 //          ^ punctuation.definition.string.end.go
     `one \\ \n two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go
-//  ^^^^^^^^^^^^^^^ -constant.character.escape
+//  ^^^^^^^^^^^^^^^ string.quoted.other.go -constant.character.escape
     `one %% two`
 //  ^^^^^^^^^^^^ string.quoted.other.go
 //       ^^ constant.character.escape.go
@@ -2042,8 +2042,7 @@ func _() {
 //  ^ string.quoted.other.go punctuation.definition.string.end.go
 
     `one /* two */ three`
-//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.go
-//  ^^^^^^^^^^^^^^^^^^^^^ -comment
+//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.go -comment
 
 
 // # Operators
@@ -2362,13 +2361,13 @@ func _() {
 //           ^^^ storage.type.go
 //                ^^^^^ variable.other.go
 
-    []byte(ident)
-//    ^^^^ storage.type.go
-//         ^^^^^ variable.other.go
+    []typ(ident)
+//    ^^^ storage.type.go
+//        ^^^^^ variable.other.go
 
-    ([]byte)(ident)
-//     ^^^^ storage.type.go
-//           ^^^^^ variable.other.go
+    ([]typ)(ident)
+//     ^^^ storage.type.go
+//          ^^^^^ variable.other.go
 
 
 // # Keywords
@@ -2495,43 +2494,251 @@ func _() {
 //        ^ meta.block.go punctuation.section.braces.begin.go
 //         ^ meta.block.go punctuation.section.braces.end.go
 
-// # Identifiers
+
+// # Predeclared Constants
 
     true false nil
 //  ^^^^ constant.language.go
 //       ^^^^^ constant.language.go
 //             ^^^ constant.language.go
 
-    new(typ)
-//  ^^^ variable.function.go
-//     ^ punctuation.section.parens.begin.go
-//      ^^^ storage.type.go
-//         ^ punctuation.section.parens.end.go
 
-    new /**/ (
-//  ^^^ variable.function.go
-//      ^^^^ comment.block.go
-        /**/ typ /**/ ,
-//      ^^^^ comment.block.go
-//           ^^^ storage.type.go
-//               ^^^^ comment.block.go
-    )
+// # Built-in Types
+
+/*
+These tests make sure that the treatment of built-ins is consistent with
+non-built-ins and is purely additive.
+
+Due to how they're combined in the syntax definition, we don't need to test
+every type individually.
+*/
+
+    chan typ
+//  ^^^^ storage.type.keyword.chan.go
+//       ^^^ storage.type.go -support
+
+    chan int
+//  ^^^^ storage.type.keyword.chan.go
+//       ^^^ storage.type.go support.type.builtin.go
+
+    func(typ)
+//  ^^^^ storage.type.keyword.function.go
+//       ^^^ storage.type.go -support
+
+    func(int)
+//  ^^^^ storage.type.keyword.function.go
+//       ^^^ storage.type.go support.type.builtin.go
+
+    map[typ]typ
+//  ^^^ storage.type.keyword.map.go
+//      ^^^ storage.type.go -support
+//          ^^^ storage.type.go -support
+
+    map[int]int
+//  ^^^ storage.type.keyword.map.go
+//      ^^^ storage.type.go support.type.builtin.go
+//          ^^^ storage.type.go support.type.builtin.go
+
+    struct { ident typ; typ }
+//  ^^^^^^ storage.type.keyword.struct.go
+//           ^^^^^ meta.type.go variable.other.member.declaration.go
+//                 ^^^ meta.type.go storage.type.go -support
+//                      ^^^ meta.type.go entity.other.inherited-class.go -support
+
+    struct { ident int; int }
+//  ^^^^^^ storage.type.keyword.struct.go
+//           ^^^^^ meta.type.go variable.other.member.declaration.go
+//                 ^^^ meta.type.go storage.type.go support.type.builtin.go
+//                      ^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
+
+    interface { typ }
+//  ^^^^^^^^^ storage.type.keyword.interface.go
+//              ^^^ meta.type.go entity.other.inherited-class.go -support
+
+    interface { error }
+//  ^^^^^^^^^ storage.type.keyword.interface.go
+//              ^^^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
+
+    [...]typ
+//   ^^^ keyword.operator.variadic.go
+//       ^^^ storage.type.go -support
+
+    [...]int
+//   ^^^ keyword.operator.variadic.go
+//       ^^^ storage.type.go support.type.builtin.go
+
+    []typ
+//    ^^^ storage.type.go -support
+
+    []int
+//    ^^^ storage.type.go support.type.builtin.go
+
+    type _ typ
+//  ^^^^ storage.type.keyword.type.go
+//       ^ variable.language.blank.go
+//         ^^^ storage.type.go -support
+
+    type _ int
+//  ^^^^ storage.type.keyword.type.go
+//       ^ variable.language.blank.go
+//         ^^^ storage.type.go support.type.builtin.go
+
+    const ident typ
+//  ^^^^^ storage.type.keyword.const.go
+//        ^^^^^ variable.other.constant.declaration.go
+//              ^^^ storage.type.go -support
+
+    const ident int
+//  ^^^^^ storage.type.keyword.const.go
+//        ^^^^^ variable.other.constant.declaration.go
+//              ^^^ storage.type.go support.type.builtin.go
+
+    var ident typ
+//  ^^^ storage.type.keyword.var.go
+//      ^^^^^ variable.declaration.go
+//            ^^^ storage.type.go -support
+
+    var ident int
+//  ^^^ storage.type.keyword.var.go
+//      ^^^^^ variable.declaration.go
+//            ^^^ storage.type.go support.type.builtin.go
+
+    ident.(typ)
+//  ^^^^^ variable.other.go
+//         ^^^ storage.type.go -support
+
+    ident.(int)
+//  ^^^^^ variable.other.go
+//         ^^^ storage.type.go support.type.builtin.go
+
+    (typ)(ident)
+//   ^^^ variable.function.go -support
+//        ^^^^^ variable.other.go
+
+    (int)(ident)
+//   ^^^ variable.function.go support.type.builtin.go
+//        ^^^^^ variable.other.go
+
+
+// # Built-in Functions
+
+// ## Special Functions
 
     make(typ)
-//  ^^^^ variable.function.go
-//      ^ punctuation.section.parens.begin.go
-//       ^^^ storage.type.go
-//          ^ punctuation.section.parens.end.go
+//  ^^^^ variable.function.go support.function.builtin.go
+//       ^^^ storage.type.go -support
+
+    make(int)
+//  ^^^^ variable.function.go support.function.builtin.go
+//       ^^^ storage.type.go support.type.builtin.go
 
     make /**/ (
-//  ^^^^ variable.function.go
+//  ^^^^ variable.function.go support.function.builtin.go
 //       ^^^^ comment.block.go
         /**/ typ /**/,
 //      ^^^^ comment.block.go
-//           ^^^ storage.type.go
+//           ^^^ storage.type.go -support
 //               ^^^^ comment.block.go
         ident,
 //      ^^^^^ variable.other.go
         ident,
 //      ^^^^^ variable.other.go
     )
+
+    make /**/ (
+//  ^^^^ variable.function.go support.function.builtin.go
+//       ^^^^ comment.block.go
+        /**/ int /**/,
+//      ^^^^ comment.block.go
+//           ^^^ storage.type.go support.type.builtin.go
+//               ^^^^ comment.block.go
+        ident,
+//      ^^^^^ variable.other.go
+        ident,
+//      ^^^^^ variable.other.go
+    )
+
+    make
+//  ^^^^ variable.other.go -support
+
+    var make
+//  ^^^ storage.type.keyword.var.go
+//      ^^^^ variable.declaration.go -support
+
+    new(typ, ident)
+//  ^^^ variable.function.go support.function.builtin.go
+//      ^^^ storage.type.go -support
+//           ^^^^^ variable.other.go
+
+    new(int, ident)
+//  ^^^ variable.function.go support.function.builtin.go
+//      ^^^ storage.type.go support.type.builtin.go
+//           ^^^^^ variable.other.go
+
+    ((new))(typ, ident)
+//    ^^^ variable.function.go support.function.builtin.go
+//          ^^^ storage.type.go -support
+//               ^^^^^ variable.other.go
+
+    ((new))(int, ident)
+//    ^^^ variable.function.go support.function.builtin.go
+//          ^^^ storage.type.go support.type.builtin.go
+//               ^^^^^ variable.other.go
+
+    new /**/ (
+//  ^^^ variable.function.go support.function.builtin.go
+//      ^^^^ comment.block.go
+        /**/ typ /**/ ,
+//      ^^^^ comment.block.go
+//           ^^^ storage.type.go -support
+//               ^^^^ comment.block.go
+    )
+
+    new /**/ (
+//  ^^^ variable.function.go support.function.builtin.go
+//      ^^^^ comment.block.go
+        /**/ int /**/ ,
+//      ^^^^ comment.block.go
+//           ^^^ storage.type.go support.type.builtin.go
+//               ^^^^ comment.block.go
+    )
+
+    new
+//  ^^^ variable.other.go -support
+
+    var new
+//  ^^^ storage.type.keyword.var.go
+//      ^^^ variable.declaration.go -support
+
+// ## Other Functions
+
+/*
+These tests make sure that the treatment of built-ins is consistent with
+non-built-ins, is purely additive, and sufficiently limited.
+
+Due to how they're combined in the syntax definition, we don't need to test
+every function individually.
+*/
+
+    ident(ident)
+//  ^^^^^ variable.function.go -support
+//        ^^^^^ variable.other.go
+
+    close(ident)
+//  ^^^^^ variable.function.go support.function.builtin.go
+//        ^^^^^ variable.other.go
+
+    ((ident))(ident)
+//    ^^^^^ variable.function.go -support
+//            ^^^^^ variable.other.go
+
+    ((close))(ident)
+//    ^^^^^ variable.function.go support.function.builtin.go
+//            ^^^^^ variable.other.go
+
+    close
+//  ^^^^^ variable.other.go -support
+
+    var close
+//  ^^^ storage.type.keyword.var.go
+//      ^^^^^ variable.declaration.go -support


### PR DESCRIPTION
The syntax now supports all built-in types and functions rather than just `make` and `new`. This feature is purely additive: built-ins receive additional `support` scopes; the user can opt out by not including these scopes into a color scheme.