### PR TITLE
Add support for Protobuf

### DIFF
--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -13,26 +13,20 @@ variables:
   field_name: '\b([A-Za-z][A-Za-z0-9_]*)\b'
   integer: '(?:\+|-)?(?:0|[1-9]\d*)'
   exp: '(?i:e(?:\+|-)?{{integer}})'
-  float: |-
-    (?xi:
-      {{integer}}?\.\d+{{exp}}?f?  # literal with a dot: .3 .3e+4 1.3 1.3f
-      |{{integer}}f                # literal with a 'f': 1f
-      |{{integer}}{{exp}}f?        # literal with an exp: .3e+4 1e-3 1e3f
-    )
 
 contexts:
   prototype:
-    # Captured for practical reasons (keeps other patterns simpler)
-    - match: '\s+'
-      scope: meta.whitespace.prototxt
     - include: comments
-  any_POP:
-    - match: '(?=[\S\s])'
+
+  or_pop:
+    - match: '(?=[\S])'
       comment: Pop if nothing matched
       pop: true
+
   main:
-    - include: fieldMessage
+    - include: field_message
     - include: field
+
   comments:
     - match: '#'
       scope: punctuation.definition.comment.begin.prototxt
@@ -41,8 +35,8 @@ contexts:
         - match: '$'
           pop: true
 
-  fieldMessage:
-    - match: '{{field_name}}(:?)\s*({|<)'
+  field_message:
+    - match: '{{field_name}}(:?)\s*(\{|<)'
       captures:
         1: variable.other.member.prototxt
         2: punctuation.separator.dictionary.key-value.prototxt
@@ -52,16 +46,18 @@ contexts:
         - match: '\}|>'
           scope: punctuation.definition.dictionary.end.prototxt
           pop: true
-        - include: fieldMessage
+        - include: field_message
         - include: field
-  fieldValue_POP:
+
+  field_value_or_pop:
     - include: constant
     - include: stringDoubleMultiline
     - include: stringSingleMultiline
     - include: enum_value
     - include: number
     - include: array
-    - include: any_POP
+    - include: or_pop
+
   array:
     - match: '\['
       scope: punctuation.definition.array.begin.prototxt
@@ -70,14 +66,16 @@ contexts:
           scope: punctuation.definition.array.end.prototxt
           pop: true
         - match: \,
-          scope: punctuation.separator.prototxt
-        - match: ""
-          push: fieldValue_POP
+          scope: punctuation.separator.array.prototxt
+        - match: (?=\S)
+          push: field_value_or_pop
+
   optionalComma:
     - match: \,
       scope: punctuation.separator.prototxt
       pop: true
-    - include: any_POP
+    - include: or_pop
+
   field:
     - match: '{{field_name}}\s*(:)'
       captures:
@@ -85,23 +83,38 @@ contexts:
         2: punctuation.separator.key-value.prototxt
       push:
         - optionalComma
-        - fieldValue_POP
+        - field_value_or_pop
+
   constant:
     - match: \b(?:true|false|null)\b
       scope: constant.language.prototxt
       pop: true
+
   number:
-    - match: '{{float}}\b'
+    - match: |-
+        (?xi:
+          {{integer}}?\.\d+{{exp}}?(f?)  # literal with a dot: .3 .3e+4 1.3 1.3f
+          |{{integer}}(f)                # literal with a 'f': 1f
+          |{{integer}}{{exp}}(f?)        # literal with an exp: .3e+4 1e-3 1e3f
+        )\b
       scope: constant.numeric.float.prototxt
+      captures:
+        1: punctuation.definition.numeric.float.prototxt
+        2: punctuation.definition.numeric.float.prototxt
+        3: punctuation.definition.numeric.float.prototxt
       pop: true
     - match: '{{integer}}\b'
       scope: constant.numeric.integer.prototxt
       pop: true
-    - match: '0[0-8]+\b'
+    - match: '(0)[0-8]+\b'
       scope: constant.numeric.octal.prototxt
+      captures:
+        1: punctuation.definition.numeric.octal.prototxt
       pop: true
-    - match: '0[xX][0-9A-Fa-f]+\b'
+    - match: '(0[xX])[0-9A-Fa-f]+\b'
       scope: constant.numeric.hex.prototxt
+      captures:
+        1: punctuation.definition.numeric.hex.prototxt
       pop: true
 
   enum_value:
@@ -123,7 +136,7 @@ contexts:
           scope: punctuation.definition.string.end.prototxt
           set:
             - include: stringDoubleMultiline
-            - include: any_POP
+            - include: or_pop
   stringSingleMultiline:
     - match: "'"
       scope: punctuation.definition.string.quoted.single.begin.prototxt
@@ -141,4 +154,4 @@ contexts:
           scope: punctuation.definition.string.quoted.single.end.prototxt
           set:
             - include: stringSingleMultiline
-            - include: any_POP
+            - include: or_pop

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -1,0 +1,156 @@
+%YAML 1.2
+---
+name: Protocol Buffer (TEXT)
+file_extensions:
+  - pb.txt
+  - proto.text
+  - textpb
+  - METADATA
+scope: source.protocolbuffertext
+variables:
+  stringEscape: |-
+    (?x:                # turn on extended mode
+      \\                # a literal backslash
+      (?:               # ...followed by...
+        ['"\\/bfnrt]     # one of these characters
+        |               # ...or...
+        [0-9]{3}        # and one or three decimal digits
+      )
+    )
+  field_name: '([\w_][\w\d_]*)'
+
+contexts:
+  prototype:
+    # Captured for practical reasons (keeps other patterns simpler)
+    - match: '\s+'
+      scope: meta.whitespace.protocolbuffertext
+    - include: comments
+  any_POP:
+    - match: '(?=[\S\s])'
+      comment: Pop if nothing matched
+      pop: true
+  main:
+    - include: fieldMessage
+    - include: field
+  comments:
+    - match: '((#))'
+      captures:
+        1: meta.comment.border.protocolbuffertext
+        2: punctuation.definition.comment.begin.protocolbuffertext
+      push:
+        - meta_scope: comment.line.protocolbuffertext
+        - match: '$'
+          pop: true
+        - match: '\/\/+'
+          scope: meta.comment.border.protocolbuffertext
+        - match: '\b(?i:todo|hack)\b'
+          scope: comment.line.todo.protocolbuffertext
+  fieldMessage:
+    - match: '{{field_name}}(:?)\s*({|<)'
+      captures:
+        1: entity.name.tag.protocolbuffertext
+        2: punctuation.separator.dictionary.key-value.protocolbuffertext
+        3: punctuation.definition.dictionary.begin.protocolbuffertext
+      push:
+        - meta_scope: meta.message.protocolbuffertext
+        - match: '\}|>'
+          scope: punctuation.definition.dictionary.end.protocolbuffertext
+          pop: true
+        - include: fieldMessage
+        - include: field
+  fieldValue_POP:
+    - include: constant
+    - include: stringDoubleMultiline
+    - include: stringSingleMultiline
+    - include: stringUnquoted
+    - include: number
+    - include: array
+    - include: any_POP
+  array:
+    - match: '\['
+      scope: punctuation.section.brackets.begin.protocolbuffertext
+      set:
+        - meta_scope: meta.brackets
+        - match: '\]'
+          scope: punctuation.section.brackets.end
+          pop: true
+        - match: \,
+          scope: punctuation.separator.protocolbuffertext
+        - match: ""
+          push: fieldValue_POP
+  optionalComma:
+    - match: \,
+      scope: punctuation.separator.protocolbuffertext
+      pop: true
+    - include: any_POP
+  field:
+    - match: '{{field_name}}\s*(:)'
+      captures:
+        1: entity.name.tag.protocolbuffertext
+        2: punctuation.separator.key-value.mapping.protocolbuffertext
+      push:
+        - optionalComma
+        - fieldValue_POP
+  constant:
+    - match: \b(?:true|false|null)\b
+      scope: constant.language.protocolbuffertext
+      pop: true
+  number:
+    - match: |-
+        (?x:         # turn on extended mode
+          -?         # an optional minus
+          (?:
+            0        # a zero
+            |        # ...or...
+            [1-9]    # a 1-9 character
+            \d*      # followed by zero or more digits
+          )
+          (?:
+            (?:
+              \.     # a period
+              \d+    # followed by one or more digits
+            )?
+            (?:
+              [eE]   # an e character
+              [+-]?  # followed by an option +/-
+              \d+    # followed by one or more digits
+            )?       # make exponent optional
+          )?         # make decimal portion optional
+        )
+      comment: handles integer and decimal numbers
+      scope: constant.numeric.protocolbuffertext
+      pop: true
+  stringUnquoted:
+    - match: '[a-zA-Z_]\w*'
+      scope: string.unquoted.protocolbuffertext
+      pop: true
+  stringDoubleMultiline:
+    - match: '"'
+      scope: punctuation.definition.string.begin.protocolbuffertext
+      set:
+        - meta_scope: string.quoted.double.protocolbuffertext
+        - meta_include_prototype: false
+        - match: '{{stringEscape}}'
+          scope: constant.character.escape.protocolbuffertext
+        - match: \\.
+          scope: invalid.illegal.unrecognized-string-escape.protocolbuffertext
+        - match: '"'
+          scope: punctuation.definition.string.end.protocolbuffertext
+          set:
+            - include: stringDoubleMultiline
+            - include: any_POP
+  stringSingleMultiline:
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.protocolbuffertext
+      set:
+        - meta_scope: string.quoted.single.protocolbuffertext
+        - meta_include_prototype: false
+        - match: '{{stringEscape}}'
+          scope: constant.character.escape.protocolbuffertext
+        - match: \\.
+          scope: invalid.illegal.unrecognized-string-escape.protocolbuffertext
+        - match: "'"
+          scope: punctuation.definition.string.quoted.single.end.protocolbuffertext
+          set:
+            - include: stringSingleMultiline
+            - include: any_POP

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -9,7 +9,7 @@ file_extensions:
   - prototxt
 scope: text.prototxt
 variables:
-  stringEscape: '(?:\\(?:[''"\\/bfnrt]|[0-9]{3}))'
+  stringEscape: '(?:\\(?:[''"\\/abfnrtv?]|[0-9]{3}|(?i:u|x)[0-9A-Fa-f]+))'
   field_name: '\b([A-Za-z][A-Za-z0-9_]*)\b'
   integer: '(?:\+|-)?(?:0|[1-9]\d*)'
   exp: '(?i:e(?:\+|-)?{{integer}})'
@@ -19,12 +19,11 @@ contexts:
     - include: comments
 
   or_pop:
-    - match: '(?=[\S])'
-      comment: Pop if nothing matched
+    # Pop if nothing matched (whitespace are ignored).
+    - match: '(?=\S)'
       pop: true
 
   main:
-    - include: field_message
     - include: field
 
   comments:
@@ -35,19 +34,38 @@ contexts:
         - match: '$'
           pop: true
 
-  field_message:
-    - match: '{{field_name}}(:?)\s*(\{|<)'
-      captures:
-        1: variable.other.member.prototxt
-        2: punctuation.separator.dictionary.key-value.prototxt
-        3: punctuation.definition.dictionary.begin.prototxt
+  field:
+    - match: '{{field_name}}'
+      scope: variable.other.member.prototxt
+      push: field_sep_or_pop
+    - match: \[
+      scope: punctuation.definition.field_name.begin.prototxt
       push:
+        - match: \]
+          set: field_sep_or_pop
+          scope: punctuation.definition.field_name.end.prototxt
+        - match: '{{field_name}}(\.)'
+          captures:
+            1: variable.other.namespace.prototxt
+            2: punctuation.accessor.prototxt
+        - match: '{{field_name}}'
+          scope: variable.other.member.prototxt
+
+  field_sep_or_pop:
+    - match: '(:?)\s*(\{|<)'
+      captures:
+        1: punctuation.separator.dictionary.key-value.prototxt
+        2: punctuation.definition.dictionary.begin.prototxt
+      set:
         - meta_scope: meta.message.prototxt
         - match: '\}|>'
           scope: punctuation.definition.dictionary.end.prototxt
           pop: true
-        - include: field_message
         - include: field
+    - match: ':'
+      scope: punctuation.separator.key-value.prototxt
+      set: [comma_or_pop, field_value_or_pop]
+    - include: or_pop
 
   field_value_or_pop:
     - include: constant
@@ -70,23 +88,20 @@ contexts:
         - match: (?=\S)
           push: field_value_or_pop
 
-  optionalComma:
-    - match: \,
+  comma_or_pop:
+    - match: ','
       scope: punctuation.separator.prototxt
       pop: true
     - include: or_pop
 
-  field:
-    - match: '{{field_name}}\s*(:)'
-      captures:
-        1: variable.other.member.prototxt
-        2: punctuation.separator.key-value.prototxt
-      push:
-        - optionalComma
-        - field_value_or_pop
-
   constant:
-    - match: \b(?:true|false|null)\b
+    - match: \b(true|True|t|false|False|f)\b
+      scope: constant.language.prototxt
+      pop: true
+    - match: (\+|-)?\b(?i:inf|infinity)\b
+      scope: constant.language.prototxt
+      pop: true
+    - match: \b(?i:nan)\b
       scope: constant.language.prototxt
       pop: true
 
@@ -137,6 +152,7 @@ contexts:
           set:
             - include: stringDoubleMultiline
             - include: or_pop
+
   stringSingleMultiline:
     - match: "'"
       scope: punctuation.definition.string.quoted.single.begin.prototxt

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -165,12 +165,12 @@ contexts:
       set:
         - meta_scope: string.quoted.single.prototxt
         - meta_include_prototype: false
+        # Note that technically "bytes" field main don't respect escapes,
+        # but there is no way to know if the given string will be interpreted as
+        # "bytes".
         - match: '{{stringEscape}}'
           scope: constant.character.escape.prototxt
         - match: \\.
-          # Invalid escapes are only allowed if the field is of kind 'bytes'.
-          # But we don't know in the text description if the field is meant to
-          # be a string or bytes.
           scope: invalid.illegal.unrecognized-string-escape.prototxt
         - match: "'"
           scope: punctuation.definition.string.quoted.single.end.prototxt

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -52,25 +52,31 @@ contexts:
           scope: variable.other.member.prototxt
 
   field_sep_or_pop:
-    - match: '(:?)\s*(\{|<)'
-      captures:
-        1: punctuation.separator.dictionary.key-value.prototxt
-        2: punctuation.definition.dictionary.begin.prototxt
-      set:
-        - meta_scope: meta.message.prototxt
-        - match: '\}|>'
-          scope: punctuation.definition.dictionary.end.prototxt
-          pop: true
-        - include: field
-    - match: ':'
+    - match: '(:)|(?=\{|<)'
       scope: punctuation.separator.key-value.prototxt
       set: [comma_or_pop, field_value_or_pop]
     - include: or_pop
 
   field_value_or_pop:
+    - match: '{'
+      scope: punctuation.definition.dictionary.begin.prototxt
+      set:
+        - meta_scope: meta.message.prototxt
+        - match: '}'
+          scope: punctuation.definition.dictionary.end.prototxt
+          pop: true
+        - include: field
+    - match: '<'
+      scope: punctuation.definition.dictionary.begin.prototxt
+      set:
+        - meta_scope: meta.message.prototxt
+        - match: '>'
+          scope: punctuation.definition.dictionary.end.prototxt
+          pop: true
+        - include: field
     - include: constant
-    - include: stringDoubleMultiline
-    - include: stringSingleMultiline
+    - include: string_double_multiline
+    - include: string_single_multiline
     - include: enum_value
     - include: number
     - include: array
@@ -137,7 +143,7 @@ contexts:
       scope: constant.numeric.enum.prototxt
       pop: true
 
-  stringDoubleMultiline:
+  string_double_multiline:
     - match: '"'
       scope: punctuation.definition.string.begin.prototxt
       set:
@@ -150,10 +156,10 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.prototxt
           set:
-            - include: stringDoubleMultiline
+            - include: string_double_multiline
             - include: or_pop
 
-  stringSingleMultiline:
+  string_single_multiline:
     - match: "'"
       scope: punctuation.definition.string.quoted.single.begin.prototxt
       set:
@@ -169,5 +175,5 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.quoted.single.end.prototxt
           set:
-            - include: stringSingleMultiline
+            - include: string_single_multiline
             - include: or_pop

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -1,5 +1,12 @@
 %YAML 1.2
 ---
+# Syntax for Protocol Buffer serialized as human readable text.
+# Works with proto2 and proto3.
+# See official Protobuff documentation at https://developers.google.com/protocol-buffers/docs/proto3
+#
+# Authors: Raul Rangel & Guillaume Wenzek
+#
+# .sublime-syntax reference: http://www.sublimetext.com/docs/3/syntax.html
 name: Protocol Buffer (TEXT)
 file_extensions:
   - pb.txt

--- a/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax
@@ -5,25 +5,26 @@ file_extensions:
   - pb.txt
   - proto.text
   - textpb
-  - METADATA
-scope: source.protocolbuffertext
+  - pbtxt
+  - prototxt
+scope: text.prototxt
 variables:
-  stringEscape: |-
-    (?x:                # turn on extended mode
-      \\                # a literal backslash
-      (?:               # ...followed by...
-        ['"\\/bfnrt]     # one of these characters
-        |               # ...or...
-        [0-9]{3}        # and one or three decimal digits
-      )
+  stringEscape: '(?:\\(?:[''"\\/bfnrt]|[0-9]{3}))'
+  field_name: '\b([A-Za-z][A-Za-z0-9_]*)\b'
+  integer: '(?:\+|-)?(?:0|[1-9]\d*)'
+  exp: '(?i:e(?:\+|-)?{{integer}})'
+  float: |-
+    (?xi:
+      {{integer}}?\.\d+{{exp}}?f?  # literal with a dot: .3 .3e+4 1.3 1.3f
+      |{{integer}}f                # literal with a 'f': 1f
+      |{{integer}}{{exp}}f?        # literal with an exp: .3e+4 1e-3 1e3f
     )
-  field_name: '([\w_][\w\d_]*)'
 
 contexts:
   prototype:
     # Captured for practical reasons (keeps other patterns simpler)
     - match: '\s+'
-      scope: meta.whitespace.protocolbuffertext
+      scope: meta.whitespace.prototxt
     - include: comments
   any_POP:
     - match: '(?=[\S\s])'
@@ -33,28 +34,23 @@ contexts:
     - include: fieldMessage
     - include: field
   comments:
-    - match: '((#))'
-      captures:
-        1: meta.comment.border.protocolbuffertext
-        2: punctuation.definition.comment.begin.protocolbuffertext
+    - match: '#'
+      scope: punctuation.definition.comment.begin.prototxt
       push:
-        - meta_scope: comment.line.protocolbuffertext
+        - meta_scope: comment.line.prototxt
         - match: '$'
           pop: true
-        - match: '\/\/+'
-          scope: meta.comment.border.protocolbuffertext
-        - match: '\b(?i:todo|hack)\b'
-          scope: comment.line.todo.protocolbuffertext
+
   fieldMessage:
     - match: '{{field_name}}(:?)\s*({|<)'
       captures:
-        1: entity.name.tag.protocolbuffertext
-        2: punctuation.separator.dictionary.key-value.protocolbuffertext
-        3: punctuation.definition.dictionary.begin.protocolbuffertext
+        1: variable.other.member.prototxt
+        2: punctuation.separator.dictionary.key-value.prototxt
+        3: punctuation.definition.dictionary.begin.prototxt
       push:
-        - meta_scope: meta.message.protocolbuffertext
+        - meta_scope: meta.message.prototxt
         - match: '\}|>'
-          scope: punctuation.definition.dictionary.end.protocolbuffertext
+          scope: punctuation.definition.dictionary.end.prototxt
           pop: true
         - include: fieldMessage
         - include: field
@@ -62,95 +58,87 @@ contexts:
     - include: constant
     - include: stringDoubleMultiline
     - include: stringSingleMultiline
-    - include: stringUnquoted
+    - include: enum_value
     - include: number
     - include: array
     - include: any_POP
   array:
     - match: '\['
-      scope: punctuation.section.brackets.begin.protocolbuffertext
+      scope: punctuation.definition.array.begin.prototxt
       set:
-        - meta_scope: meta.brackets
         - match: '\]'
-          scope: punctuation.section.brackets.end
+          scope: punctuation.definition.array.end.prototxt
           pop: true
         - match: \,
-          scope: punctuation.separator.protocolbuffertext
+          scope: punctuation.separator.prototxt
         - match: ""
           push: fieldValue_POP
   optionalComma:
     - match: \,
-      scope: punctuation.separator.protocolbuffertext
+      scope: punctuation.separator.prototxt
       pop: true
     - include: any_POP
   field:
     - match: '{{field_name}}\s*(:)'
       captures:
-        1: entity.name.tag.protocolbuffertext
-        2: punctuation.separator.key-value.mapping.protocolbuffertext
+        1: variable.other.member.prototxt
+        2: punctuation.separator.key-value.prototxt
       push:
         - optionalComma
         - fieldValue_POP
   constant:
     - match: \b(?:true|false|null)\b
-      scope: constant.language.protocolbuffertext
+      scope: constant.language.prototxt
       pop: true
   number:
-    - match: |-
-        (?x:         # turn on extended mode
-          -?         # an optional minus
-          (?:
-            0        # a zero
-            |        # ...or...
-            [1-9]    # a 1-9 character
-            \d*      # followed by zero or more digits
-          )
-          (?:
-            (?:
-              \.     # a period
-              \d+    # followed by one or more digits
-            )?
-            (?:
-              [eE]   # an e character
-              [+-]?  # followed by an option +/-
-              \d+    # followed by one or more digits
-            )?       # make exponent optional
-          )?         # make decimal portion optional
-        )
-      comment: handles integer and decimal numbers
-      scope: constant.numeric.protocolbuffertext
+    - match: '{{float}}\b'
+      scope: constant.numeric.float.prototxt
       pop: true
-  stringUnquoted:
-    - match: '[a-zA-Z_]\w*'
-      scope: string.unquoted.protocolbuffertext
+    - match: '{{integer}}\b'
+      scope: constant.numeric.integer.prototxt
       pop: true
+    - match: '0[0-8]+\b'
+      scope: constant.numeric.octal.prototxt
+      pop: true
+    - match: '0[xX][0-9A-Fa-f]+\b'
+      scope: constant.numeric.hex.prototxt
+      pop: true
+
+  enum_value:
+    - match: '{{field_name}}'
+      scope: constant.numeric.enum.prototxt
+      pop: true
+
   stringDoubleMultiline:
     - match: '"'
-      scope: punctuation.definition.string.begin.protocolbuffertext
+      scope: punctuation.definition.string.begin.prototxt
       set:
-        - meta_scope: string.quoted.double.protocolbuffertext
+        - meta_scope: string.quoted.double.prototxt
         - meta_include_prototype: false
         - match: '{{stringEscape}}'
-          scope: constant.character.escape.protocolbuffertext
+          scope: constant.character.escape.prototxt
         - match: \\.
-          scope: invalid.illegal.unrecognized-string-escape.protocolbuffertext
+          scope: invalid.illegal.unrecognized-string-escape.prototxt
         - match: '"'
-          scope: punctuation.definition.string.end.protocolbuffertext
+          scope: punctuation.definition.string.end.prototxt
           set:
             - include: stringDoubleMultiline
             - include: any_POP
   stringSingleMultiline:
     - match: "'"
-      scope: punctuation.definition.string.quoted.single.begin.protocolbuffertext
+      scope: punctuation.definition.string.quoted.single.begin.prototxt
       set:
-        - meta_scope: string.quoted.single.protocolbuffertext
+        - meta_scope: string.quoted.single.prototxt
         - meta_include_prototype: false
         - match: '{{stringEscape}}'
-          scope: constant.character.escape.protocolbuffertext
+          scope: constant.character.escape.prototxt
         - match: \\.
-          scope: invalid.illegal.unrecognized-string-escape.protocolbuffertext
+          # Invalid escapes are only allowed if the field is of kind 'bytes'.
+          # But we don't know in the text description if the field is meant to
+          # be a string or bytes.
+          scope: invalid.illegal.unrecognized-string-escape.prototxt
         - match: "'"
-          scope: punctuation.definition.string.quoted.single.end.protocolbuffertext
+          scope: punctuation.definition.string.quoted.single.end.prototxt
           set:
             - include: stringSingleMultiline
             - include: any_POP

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -293,6 +293,9 @@ contexts:
         1: storage.modifier.proto
         2: punctuation.definition.map.begin.proto
       push: [ messageField_END, field_name_POP, map_type ]
+    # field are assumed 'optional' by default in proto3.
+    - match: '(?=\S)'
+      push: [ messageField_END, field_name_POP, messageType_POP ]
 
   inlineOption:
     - match: '\b(option)\b'
@@ -419,9 +422,10 @@ contexts:
       push:
         - include: stringDouble
         - include: one_liner
-    - match: '\b(import)\b'
+    - match: '\b(import)\b\s*(weak|public)?\b'
       captures:
         1: keyword.other.import.proto
+        2: storage.modifier.proto
       push:
         - include: stringDouble
         - include: one_liner

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -5,7 +5,7 @@ name: Protocol Buffer
 file_extensions:
   - proto
   - protodevel
-scope: source.protocolbuffer
+scope: source.proto
 variables:
   PLA_anything: '(?=[\S\s])'
   messagePath: '\b(((?:[A-Za-z]\w*\.)*)([a-zA-Z]\w*))\b'
@@ -16,27 +16,27 @@ contexts:
   prototype:
     # Captured for practical reasons (keeps other patterns simpler)
     - match: '\s+'
-      scope: meta.whitespace.protocolbuffer
+      scope: meta.whitespace.proto
     - include: comments
   comments:
     - match: '((\/\/))'
       captures:
-        1: meta.comment.border.protocolbuffer
-        2: punctuation.definition.comment.begin.protocolbuffer
+        1: meta.comment.border.proto
+        2: punctuation.definition.comment.begin.proto
       push:
-        - meta_scope: comment.line.protocolbuffer
+        - meta_scope: comment.line.proto
         - match: '$'
           pop: true
         - match: '\/\/+'
-          scope: meta.comment.border.protocolbuffer
+          scope: meta.comment.border.proto
         - match: '\b(?i:todo|hack)\b'
-          scope: comment.line.todo.protocolbuffer
+          scope: comment.line.todo.proto
     - match: /\*
-      scope: punctuation.definition.comment.protocolbuffer
+      scope: punctuation.definition.comment.proto
       push:
-        - meta_scope: comment.block.protocolbuffer
+        - meta_scope: comment.block.proto
         - match: \*/
-          scope: punctuation.definition.comment.protocolbuffer
+          scope: punctuation.definition.comment.proto
           pop: true
   any_POP:
     - match: '(?=\S)'
@@ -46,125 +46,125 @@ contexts:
       pop: true
   stringDouble:
     - match: '"'
-      scope: punctuation.definition.string.begin.protocolbuffer
+      scope: punctuation.definition.string.begin.proto
       push:
-        - meta_scope: string.quoted.double.protocolbuffer
+        - meta_scope: string.quoted.double.proto
         - meta_include_prototype: false
         - match: '\\"'
-          scope: constant.character.escape.protocolbuffer
+          scope: constant.character.escape.proto
         - match: '"'
-          scope: punctuation.definition.string.end.protocolbuffer
+          scope: punctuation.definition.string.end.proto
           pop: true
 
   stringDoubleMultiline:
     - match: '"'
-      scope: punctuation.definition.string.quoted.double.begin.protocolbuffer
+      scope: punctuation.definition.string.quoted.double.begin.proto
       set:
-        - meta_scope: string.quoted.double.protocolbuffer
+        - meta_scope: string.quoted.double.proto
         - meta_include_prototype: false
         - match: '\\"'
-          scope: constant.character.escape.protocolbuffer
+          scope: constant.character.escape.proto
         - match: '"'
-          scope: punctuation.definition.string.quoted.double.end.protocolbuffer
+          scope: punctuation.definition.string.quoted.double.end.proto
           set:
             - include: stringDoubleMultiline
             - include: any_POP
   enum_START:
     - match: '\b(enum)\b'
-      scope: storage.modifier.enum.protocolbuffer
+      scope: storage.modifier.enum.proto
       push: [ enumBody_START, message_NAME]
   enumBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.enum.begin.protocolbuffer
+      scope: punctuation.definition.block.enum.begin.proto
       set: enumBody_AFTER_OPEN
   enumBody_AFTER_OPEN:
-    - meta_scope: meta.enum.body.protocolbuffer
+    - meta_scope: meta.enum.body.proto
     - match: '}'
-      scope: punctuation.definition.block.enum.end.protocolbuffer
+      scope: punctuation.definition.block.enum.end.proto
       pop: true
     - include: inlineOption_START
     - include: fieldAttributes
     - match: '[a-zA-z]\w*'
-      scope: support.variable.protocolbuffer
+      scope: support.variable.proto
     - match: =
-      scope: keyword.operator.assignment.protocolbuffer
+      scope: keyword.operator.assignment.proto
     - match: \d+
-      scope: constant.numeric.protocolbuffer
+      scope: constant.numeric.proto
     - match: ';'
-      scope: punctuation.terminator.protocolbuffer
+      scope: punctuation.terminator.proto
 
   oneof_START:
     - match: '\b(oneof)\b'
-      scope: storage.modifier.oneof.protocolbuffer
+      scope: storage.modifier.oneof.proto
       push: [ oneofBody_START, messageField_NAME]
   oneofBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.oneof.begin.protocolbuffer
+      scope: punctuation.definition.block.oneof.begin.proto
       set: oneofBody_AFTER_OPEN
   oneofBody_AFTER_OPEN:
-    - meta_scope: meta.oneof.body.protocolbuffer
+    - meta_scope: meta.oneof.body.proto
     - match: '}'
-      scope: punctuation.definition.block.oneof.end.protocolbuffer
+      scope: punctuation.definition.block.oneof.end.proto
       pop: true
     - match: ''
       push: [ messageField_END, messageField_NAME, messageField_TYPE ]
 
   extend_START:
     - match: '\b(extend)\b'
-      scope: storage.modifier.extend.protocolbuffer
+      scope: storage.modifier.extend.proto
       push: [ extendBody_START, messageField_TYPE]
   extendBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.extend.begin.protocolbuffer
+      scope: punctuation.definition.block.extend.begin.proto
       set: extendBody_AFTER_OPEN
   extendBody_AFTER_OPEN:
-    - meta_scope: meta.extend.body.protocolbuffer
+    - meta_scope: meta.extend.body.proto
     - match: '}'
-      scope: punctuation.definition.block.extend.end.protocolbuffer
+      scope: punctuation.definition.block.extend.end.proto
       pop: true
     - include: messageBody
 
   reserved_START:
     - match: '\b(reserved)\b'
-      scope: storage.modifier.reserved.protocolbuffer
+      scope: storage.modifier.reserved.proto
       push:
-        - meta_scope: meta.keyword.reserved.protocolbuffer
+        - meta_scope: meta.keyword.reserved.proto
         - match: \d+
-          scope: constant.numeric.protocolbuffer
+          scope: constant.numeric.proto
         - match: ','
-          scope: punctuation.separator.protocolbuffer
+          scope: punctuation.separator.proto
         - match: to
-          scope: keyword.other.to.protocolbuffer
+          scope: keyword.other.to.proto
         - match: ';'
-          scope: punctuation.terminator.protocolbuffer
+          scope: punctuation.terminator.proto
           pop: true
 
 
   # Service rules
   service_START:
     - match: '\b(service)\b'
-      scope: storage.modifier.service.protocolbuffer
+      scope: storage.modifier.service.proto
       push: [serviceBody_START, service_NAME]
 
   service_NAME:
     - match: \w+
-      scope: entity.name.type.service.protocolbuffer
+      scope: entity.name.type.service.proto
       pop: true
 
   serviceBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.service.begin.protocolbuffer
+      scope: punctuation.definition.block.service.begin.proto
       set: serviceBody_AFTER_OPEN
 
   serviceBody_AFTER_OPEN:
-    - meta_scope: meta.service.body.protocolbuffer
+    - meta_scope: meta.service.body.proto
     - match: '}'
-      scope: punctuation.definition.block.service.end.protocolbuffer
+      scope: punctuation.definition.block.service.end.proto
       pop: true
     - include: serviceBody
 
   serviceBody:
-    - meta_scope: meta.service.body.protocolbuffer
+    - meta_scope: meta.service.body.proto
     - include: inlineOption_START
     - include: rpc_START
 
@@ -172,81 +172,81 @@ contexts:
 
   rpc_START:
     - match: '\b(rpc)\b'
-      scope: storage.modifier.rpc.protocolbuffer
+      scope: storage.modifier.rpc.proto
       push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM, rpc_NAME]
 
   rpc_NAME:
     - match: \w+
-      scope: entity.name.function.rpc.protocolbuffer
+      scope: entity.name.function.rpc.proto
       pop: true
   rpc_RETURNS:
     - match: returns
-      scope: keyword.other.returns.protocolbuffer
+      scope: keyword.other.returns.proto
       pop: true
   rpc_PARAM:
     - match: \(
-      scope: punctuation.definition.parameter.rpc.start.protocolbuffer
+      scope: punctuation.definition.parameter.rpc.start.proto
       set:
         - match: \)
-          scope: punctuation.definition.parameter.rpc.end.protocolbuffer
+          scope: punctuation.definition.parameter.rpc.end.proto
           pop: true
         - match: '{{messagePath}}'
           captures:
-            1: storage.type.message.field.protocolbuffer
-            2: storage.type.message.field.path.protocolbuffer
-            3: storage.type.message.field.message.protocolbuffer
+            1: storage.type.message.field.proto
+            2: storage.type.message.field.path.proto
+            3: storage.type.message.field.message.proto
 
   rpcBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.rpc.begin.protocolbuffer
+      scope: punctuation.definition.block.rpc.begin.proto
       set: rpcBody_AFTER_OPEN
 
   rpcBody_AFTER_OPEN:
-    - meta_scope: meta.rpc.body.protocolbuffer
+    - meta_scope: meta.rpc.body.proto
     - match: '}'
-      scope: punctuation.definition.block.rpc.end.protocolbuffer
+      scope: punctuation.definition.block.rpc.end.proto
       pop: true
     - include: rpcBody
 
   rpcBody:
-    - meta_scope: meta.rpc.body.protocolbuffer
+    - meta_scope: meta.rpc.body.proto
     - include: inlineOption_START
 
   # Message Rules
 
   message_NAME:
     - match: \w+
-      scope: entity.name.type.message.protocolbuffer
+      scope: entity.name.type.message.proto
       pop: true
 
   message_START:
     - match: '\b(message)\b'
-      scope: storage.modifier.message.protocolbuffer
+      scope: storage.modifier.message.proto
       push: [messageBody_START, message_NAME]
 
   messageBody_START:
     - match: '\{'
-      scope: punctuation.definition.block.message.begin.protocolbuffer
+      scope: punctuation.definition.block.message.begin.proto
       set: messageBody_AFTER_OPEN
 
   messageBody_AFTER_OPEN:
-    - meta_scope: meta.message.body.protocolbuffer
+    - meta_scope: meta.message.body.proto
     - match: '}'
-      scope: punctuation.definition.block.message.end.protocolbuffer
+      scope: punctuation.definition.block.message.end.proto
       pop: true
     - include: messageBody
 
   messageType_META:
-    - meta_scope: storage.type.message.protocolbuffer
+    - meta_scope: storage.type.message.proto
     - match: ''
       pop: true
 
   messageType_POP:
     - match: '[A-Za-z]\w*'
-      scope: storage.type.message.part.protocolbuffer
+      scope: storage.type.message.part.proto
       set:
         - match: '\.'
-          scope: punctuation.accessor.protocolbuffer
+          scope: punctuation.accessor.proto
           set: messageType_POP
         - include: any_POP
     - include: any_POP
@@ -254,59 +254,59 @@ contexts:
   messageField_TYPE:
     - meta_scope: messageField_TYPE
     - match: '\bString\b|\bboolean\b'
-      scope: invalid.type.protocolbuffer
+      scope: invalid.type.proto
       pop: true
     - match: ''
       set: [messageType_META, messageType_POP]
   messageField_NAME:
     - match: \w+
-      scope: support.variable.protocolbuffer
+      scope: support.variable.proto
       pop: true
     - include: closingBraceUnexpected_POP
   messageField_END:
     - include: fieldAttributes
     - match: ';'
-      scope: punctuation.terminator.protocolbuffer
+      scope: punctuation.terminator.proto
       pop: true
     - match: =
-      scope: keyword.operator.assignment.protocolbuffer
+      scope: keyword.operator.assignment.proto
     - match: \d+
-      scope: constant.numeric.protocolbuffer
+      scope: constant.numeric.proto
     - include: closingBraceUnexpected_POP
   fieldAttributes:
     - match: '\['
-      scope: punctuation.definition.attributes.begin.protocolbuffer
+      scope: punctuation.definition.attributes.begin.proto
       push:
-        - meta_scope: meta.field.attributes.protocolbuffer
+        - meta_scope: meta.field.attributes.proto
         - include: fieldAttribute_BODY
         - match: \,
-          scope: punctuation.separator.option.protocolbuffer
+          scope: punctuation.separator.option.proto
         - match: '\]'
-          scope: punctuation.definition.attributes.end.protocolbuffer
+          scope: punctuation.definition.attributes.end.proto
           pop: true
   map_TYPES:
     - match: '<'
-      scope: punctuation.definition.map.start.protocolbuffer
+      scope: punctuation.definition.map.start.proto
       set:
         - match: '\b(((?:[A-Za-z][a-z0-9]+\.)*)([a-zA-Z]\w+))\b'
           captures:
-            1: storage.type.message.field.protocolbuffer
-            2: storage.type.message.field.path.protocolbuffer
-            3: storage.type.message.field.message.protocolbuffer
+            1: storage.type.message.field.proto
+            2: storage.type.message.field.path.proto
+            3: storage.type.message.field.message.proto
         - match: '>'
-          scope: punctuation.definition.map.end.protocolbuffer
+          scope: punctuation.definition.map.end.proto
           pop: true
   messageBodyField:
     - match: '\b(optional|required|repeated)\b'
       captures:
-        1: storage.modifier.protocolbuffer
+        1: storage.modifier.proto
       push: [ messageField_END, messageField_NAME, messageField_TYPE ]
     - match: '\b(map)\b'
       captures:
-        1: storage.modifier.protocolbuffer
+        1: storage.modifier.proto
       push: [ messageField_END, messageField_NAME, map_TYPES ]
   messageBody:
-    - meta_scope: meta.message.body.protocolbuffer
+    - meta_scope: meta.message.body.proto
     - include: inlineOption_START
     - include: message_START
     - include: extend_START
@@ -316,62 +316,62 @@ contexts:
     - include: messageBodyField
   inlineOption_START:
     - match: '\b(option)\b'
-      scope: keyword.other.option.protocolbuffer
+      scope: keyword.other.option.proto
       push:
-        - meta_scope: meta.option.protocolbuffer
+        - meta_scope: meta.option.proto
         - include: option_BODY
         - match: ';'
-          scope: punctuation.terminator.option.protocolbuffer
+          scope: punctuation.terminator.option.proto
           pop: true
 
   fieldAttribute_BODY:
     - match: \bdefault\b
-      scope: constant.language.default.protocolbuffer
+      scope: constant.language.default.proto
     - match: \bdeprecated\b
-      scope: constant.language.deprecated.protocolbuffer
+      scope: constant.language.deprecated.proto
     - match: \w+
-      scope: invalid.illegal.constant.protocolbuffer
+      scope: invalid.illegal.constant.proto
     - include: optionName
     - include: optionAssignment
 
   option_BODY:
     - match: \w+
-      scope: variable.option.other.protocolbuffer
+      scope: variable.option.other.proto
     - include: optionName
     - include: optionAssignment
 
   optionName:
     - match: \(
-      scope: punctuation.definition.name.option.begin.protocolbuffer
+      scope: punctuation.definition.name.option.begin.proto
       push:
         - match: \)
-          scope: punctuation.definition.name.option.end.protocolbuffer
+          scope: punctuation.definition.name.option.end.proto
           set:
             - meta_scope: foo
             - match: (\.)([\w\d]*)
               captures:
-                1: punctuation.accessor.protocolbuffer
-                2: storage.type.option.protocolbuffer
+                1: punctuation.accessor.proto
+                2: storage.type.option.proto
             - include: any_POP
         - match: '[^\)]+'
-          scope: storage.type.option.protocolbuffer
+          scope: storage.type.option.proto
 
   optionAssignment:
     - match: =
-      scope: keyword.operator.assignment.protocolbuffer
+      scope: keyword.operator.assignment.proto
       push: optionAfterAssignment_POP
 
   optionEnd_pop:
     - match: '}'
-      scope: punctuation.definition.block.option.end.protocolbuffer
+      scope: punctuation.definition.block.option.end.proto
       pop: true
 
   optionAfterAssignment_POP:
-    - meta_scope: meta.option.assignment.after.protocolbuffer
+    - meta_scope: meta.option.assignment.after.proto
     - match: '{'
-      scope: punctuation.definition.block.option.begin.protocolbuffer
+      scope: punctuation.definition.block.option.begin.proto
       set:
-        - meta_content_scope: source.protocolbuffertext
+        - meta_content_scope: source.prototext
         - include: optionEnd_pop
         - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax#prototype
         - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax
@@ -380,80 +380,80 @@ contexts:
     - include: constant_POP
 
   option_ASSIGN_BLOCK:
-    - meta_scope: meta.object-literal.protocolbuffer
+    - meta_scope: meta.object-literal.proto
     - match: '}'
-      scope: punctuation.definition.block.option.end.protocolbuffer
+      scope: punctuation.definition.block.option.end.proto
       pop: true
     - match: '(\w+)(:)'
       captures:
-        1: meta.object-literal.key.protocolbuffer
-        2: punctuation.separator.key-value.protocolbuffer
+        1: meta.object-literal.key.proto
+        2: punctuation.separator.key-value.proto
       push: [objectLiteralValue_META, constant_POP]
 
   # This is a hack to get the meta scope to wrap
   objectLiteralValue_META:
-    - meta_scope: meta.object-literal.value.protocolbuffer
+    - meta_scope: meta.object-literal.value.proto
     - match: ''
       pop: true
 
   constant_POP:
     - match: \d+
-      scope: constant.numeric.protocolbuffer
+      scope: constant.numeric.proto
       pop: true
     - match: \btrue\b|\bfalse\b
-      scope: constant.language.protocolbuffer
+      scope: constant.language.proto
       pop: true
     - match: \w+
-      scope: constant.other.protocolbuffer
+      scope: constant.other.proto
       pop: true
     - include: stringDoubleMultiline
     # No constants matched
     - include: any_POP
   main:
     - match: \b(package)\s+(\w[\w\.]+)
-      scope: meta.package.protocolbuffer
+      scope: meta.package.proto
       captures:
-        1: keyword.other.package.protocolbuffer
-        2: entity.name.package.protocolbuffer
+        1: keyword.other.package.proto
+        2: entity.name.package.proto
     - match: '\b(parsed)?\s*((class))\s+(\w+)\s+{'
-      scope: meta.parsed.message.protocolbuffer
+      scope: meta.parsed.message.proto
       captures:
-        1: storage.type.parsed.protocolbuffer
-        3: storage.type.message.protocolbuffer
-        4: invalid.deprecated.class.protocolbuffer
-        5: entity.name.function.protocolbuffer
+        1: storage.type.parsed.proto
+        3: storage.type.message.proto
+        4: invalid.deprecated.class.proto
+        5: entity.name.function.proto
     - match: '\b(rpc)\s+(\w+)\((\w+)\)\s+(returns)\s+\((\w+)\)\s+\{'
-      scope: meta.rpc.protocolbuffer
+      scope: meta.rpc.proto
       captures:
-        1: storage.type.rpc.protocolbuffer
-        2: entity.name.function.protocolbuffer
-        3: variable.parameter.protocolbuffer
-        4: keyword.other.returns.protocolbuffer
-        5: variable.parameter.protocolbuffer
+        1: storage.type.rpc.proto
+        2: entity.name.function.proto
+        3: variable.parameter.proto
+        4: keyword.other.returns.proto
+        5: variable.parameter.proto
     - match: '(?x)\b(group)\s+(\w+)\s+=\s+(\d+)\s+{'
-      scope: meta.group.protocolbuffer
+      scope: meta.group.proto
       captures:
-        1: storage.type.protocolbuffer
-        2: support.variable.protocolbuffer
-        3: constant.numeric.protocolbuffer
+        1: storage.type.proto
+        2: support.variable.proto
+        3: constant.numeric.proto
     - match: \b(syntax)\b
       captures:
-        1: keyword.other.syntax.protocolbuffer
+        1: keyword.other.syntax.proto
       push:
         - meta_scope: meta.keyword.syntax
         - match: ;
-          scope: punctuation.terminator.protocolbuffer
+          scope: punctuation.terminator.proto
           pop: true
         - match: =
-          scope: keyword.operator.assignment.protocolbuffer
+          scope: keyword.operator.assignment.proto
         - include: stringDouble
     - match: \b(import)\b
       captures:
-        1: keyword.other.import.protocolbuffer
+        1: keyword.other.import.proto
       push:
         - meta_scope: meta.keyword.import
         - match: ;
-          scope: punctuation.terminator.protocolbuffer
+          scope: punctuation.terminator.proto
           pop: true
         - include: stringDouble
     - include: inlineOption_START

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
           scope: punctuation.definition.comment.proto
           pop: true
 
-  any_POP:
+  or_pop:
     # Pop when seeing unexpected characters.
     - match: '(?=\S)'
       pop: true
@@ -61,7 +61,7 @@ contexts:
 
   stringDoubleMultiline:
     - include: stringDouble
-    - include: any_POP
+    - include: or_pop
 
   enum:
     - match: '\b(enum)\b\s*{{ident}}'
@@ -72,15 +72,15 @@ contexts:
         - meta_scope: meta.enum.proto
         - match: '\{'
           scope: punctuation.definition.block.enum.begin.proto
-          set: enumBody
-        - include: any_POP
+          set: enum_body
+        - include: or_pop
 
-  enumBody:
+  enum_body:
     - meta_scope: meta.enum.proto
     - match: '}'
       scope: punctuation.definition.block.enum.end.proto
       pop: true
-    - include: inlineOption
+    - include: inline_option
     - include: fieldAttributes
     - match: '{{ident}}'
       scope: support.variable.proto
@@ -92,37 +92,41 @@ contexts:
       scope: punctuation.terminator.proto
 
   oneof:
-    - match: '\b(oneof)\b'
-      scope: storage.modifier.oneof.proto
-      push: [ oneofBody_START, field_name_POP]
-  oneofBody_START:
-    - match: '\{'
-      scope: punctuation.definition.block.oneof.begin.proto
-      set: oneofBody_AFTER_OPEN
-  oneofBody_AFTER_OPEN:
+    - match: '\b(oneof)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.oneof.proto
+        2: entity.name.member.proto
+      push:
+        - match: '\{'
+          scope: punctuation.definition.block.oneof.begin.proto
+          set: oneof_body
+        - include: or_pop
+
+  oneof_body:
     - meta_scope: meta.oneof.body.proto
     - match: '}'
       scope: punctuation.definition.block.oneof.end.proto
       pop: true
-    - match: ''
-      push: [ messageField_END, field_name_POP, messageType_POP ]
+    - match: '(?=\S)'
+      push: [ messageField_END, field_name_POP, message_type_or_pop ]
 
-  extend_START:
+  extend:
     - match: '\b(extend)\b'
       scope: storage.modifier.extend.proto
-      push: [ extendBody_START, messageType_POP]
-  extendBody_START:
+      push: [ extend_body_or_pop, message_type_or_pop]
+
+  extend_body_or_pop:
     - match: '\{'
       scope: punctuation.definition.block.extend.begin.proto
-      set: extendBody_AFTER_OPEN
-  extendBody_AFTER_OPEN:
-    - meta_scope: meta.extend.body.proto
-    - match: '}'
-      scope: punctuation.definition.block.extend.end.proto
-      pop: true
-    - include: messageBody
+      set:
+        - meta_scope: meta.extend.body.proto
+        - match: '}'
+          scope: punctuation.definition.block.extend.end.proto
+          pop: true
+        - include: messageBody
+    - include: or_pop
 
-  reserved_START:
+  reserved:
     - match: '\b(reserved)\b'
       scope: storage.modifier.reserved.proto
       push:
@@ -136,8 +140,7 @@ contexts:
           scope: punctuation.terminator.proto
           pop: true
 
-
-  # Service rules
+  # Service definition.
   service:
     - match: '\b(service)\b\s*{{ident}}'
       captures:
@@ -152,24 +155,24 @@ contexts:
             - match: '}'
               scope: punctuation.definition.block.service.end.proto
               pop: true
-            - include: inlineOption
-            - include: rpc_START
-        - include: any_POP
+            - include: inline_option
+            - include: rpc
+        - include: or_pop
 
-  # RPC Service rules
-  rpc_START:
+  # Service RPCs.
+  rpc:
     - match: '\b(rpc)\b\s*{{ident}}'
       captures:
         1: storage.modifier.rpc.proto
         2: entity.name.function.rpc.proto
-      push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM]
+      push: [rpc_body, rpc_param, rpc_returns, rpc_param]
 
-  rpc_RETURNS:
+  rpc_returns:
     - match: returns
       scope: keyword.other.returns.proto
       pop: true
 
-  rpc_PARAM:
+  rpc_param:
     - match: \(
       scope: punctuation.definition.parameter.rpc.begin.proto
       set:
@@ -178,26 +181,21 @@ contexts:
           pop: true
         - match: '\bstream\b'
           scope: storage.modifier.proto
-        - include: messageType_POP
+        - include: message_type_or_pop
 
-  rpcBody_START:
+  rpc_body:
     - match: '\{'
       scope: punctuation.definition.block.rpc.begin.proto
-      set: rpcBody_AFTER_OPEN
+      set:
+        - meta_scope: meta.rpc.body.proto
+        - match: '}'
+          scope: punctuation.definition.block.rpc.end.proto
+          pop: true
+        - include: inline_option
     - match: ;
       scope: punctuation.terminator.proto
       pop: true
-
-  rpcBody_AFTER_OPEN:
-    - meta_scope: meta.rpc.body.proto
-    - match: '}'
-      scope: punctuation.definition.block.rpc.end.proto
-      pop: true
-    - include: rpcBody
-
-  rpcBody:
-    - meta_scope: meta.rpc.body.proto
-    - include: inlineOption
+    - include: any_pop
 
   # Message Rules
   message:
@@ -210,22 +208,22 @@ contexts:
         - match: '\{'
           scope: punctuation.definition.block.message.begin.proto
           set: messageBody
-        - include: any_POP
+        - include: or_pop
 
   messageBody:
     - meta_scope: meta.class.proto
     - match: '}'
       scope: punctuation.definition.block.message.end.proto
       pop: true
-    - include: inlineOption
+    - include: inline_option
     - include: message
-    - include: extend_START
+    - include: extend
     - include: oneof
     - include: enum
-    - include: reserved_START
+    - include: reserved
     - include: messageBodyField
 
-  messageType_POP:
+  message_type_or_pop:
     # see documentation for the list of base types:
     # https://developers.google.com/protocol-buffers/docs/proto#scalar
     - match: '(double|float|bool|string|bytes)'
@@ -244,7 +242,7 @@ contexts:
     - match: '{{ident}}'
       scope: variable.type.proto
       pop: true
-    - include: any_POP
+    - include: or_pop
 
   field_name_POP:
     - match: '{{ident}}'
@@ -257,10 +255,10 @@ contexts:
     - match: ';'
       scope: punctuation.terminator.proto
       pop: true
-    - match: =
-      scope: keyword.operator.assignment.proto
-    - match: \d+
-      scope: constant.numeric.proto
+    - match: (=)\s*(\d+)
+      captures:
+        1: keyword.operator.assignment.proto
+        2: constant.numeric.proto
     - include: closingBraceUnexpected_POP
 
   fieldAttributes:
@@ -274,6 +272,7 @@ contexts:
         - match: '\]'
           scope: punctuation.definition.attributes.end.proto
           pop: true
+
   map_type:
     - match: ','
       scope: punctuation.separator.map.proto
@@ -281,13 +280,13 @@ contexts:
       scope: punctuation.definition.map.end.proto
       pop: true
     - match: '(?={{ident}})'
-      push: messageType_POP
+      push: message_type_or_pop
 
   messageBodyField:
     - match: '\b(optional|required|repeated)\b'
       captures:
         1: storage.modifier.proto
-      push: [ messageField_END, field_name_POP, messageType_POP ]
+      push: [ messageField_END, field_name_POP, message_type_or_pop ]
     - match: '\b(map)\b\s*\b(<)'
       captures:
         1: storage.modifier.proto
@@ -295,9 +294,9 @@ contexts:
       push: [ messageField_END, field_name_POP, map_type ]
     # field are assumed 'optional' by default in proto3.
     - match: '(?=\S)'
-      push: [ messageField_END, field_name_POP, messageType_POP ]
+      push: [ messageField_END, field_name_POP, message_type_or_pop ]
 
-  inlineOption:
+  inline_option:
     - match: '\b(option)\b'
       scope: keyword.other.option.proto
       push:
@@ -308,9 +307,9 @@ contexts:
 
   fieldAttribute_BODY:
     - match: \b(default|deprecated|packed)\b
-      scope: constant.language.default.proto
+      scope: support.function.proto
     - match: '{{ident}}'
-      scope: variable.other.option.proto
+      scope: variable.annotation.proto
     - include: optionName
     - include: optionAssignment
 
@@ -331,7 +330,7 @@ contexts:
               captures:
                 1: punctuation.accessor.proto
                 2: storage.type.option.proto
-            - include: any_POP
+            - include: or_pop
         - match: '[^\)]+'
           scope: storage.type.option.proto
 
@@ -352,7 +351,7 @@ contexts:
       embed: scope:source.prototext
       embed_scope: source.prototext.embedded.proto
       escape: '}'
-    - include: constant_POP
+    - include: scope:text.prototxt#field_value_or_pop
 
   option_ASSIGN_BLOCK:
     - meta_scope: meta.object-literal.proto
@@ -383,7 +382,7 @@ contexts:
       pop: true
     - include: stringDoubleMultiline
     # No constants matched
-    - include: any_POP
+    - include: or_pop
 
   main:
     - match: \b(package)\b
@@ -429,8 +428,8 @@ contexts:
       push:
         - include: stringDouble
         - include: one_liner
-    - include: inlineOption
+    - include: inline_option
     - include: message
     - include: service
-    - include: extend_START
+    - include: extend
     - include: enum

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -234,13 +234,13 @@ contexts:
         1: variable.namespace.proto
         2: punctuation.accessor.proto
     - match: '{{ident}}'
-      scope: storage.type.message.proto
+      scope: variable.type.message.proto
       pop: true
     - include: any_POP
 
   field_name_POP:
     - match: '{{ident}}'
-      scope: support.variable.proto
+      scope: variable.other.field.proto
       pop: true
     - include: closingBraceUnexpected_POP
 
@@ -387,7 +387,7 @@ contexts:
 
   main:
     - match: \b(package)\b
-      scope: keyword.other.package.proto
+      scope: keyword.other.namespace.proto
       push:
         - match: '{{ident}}(\.)'
           captures:

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -59,10 +59,6 @@ contexts:
           scope: punctuation.definition.string.end.proto
           pop: true
 
-  stringDoubleMultiline:
-    - include: stringDouble
-    - include: or_pop
-
   enum:
     - match: '\b(enum)\b\s*{{ident}}'
       captures:
@@ -80,7 +76,7 @@ contexts:
     - match: '}'
       scope: punctuation.definition.block.enum.end.proto
       pop: true
-    - include: inline_option
+    - include: option
     - include: fieldAttributes
     - match: '{{ident}}'
       scope: support.variable.proto
@@ -155,7 +151,7 @@ contexts:
             - match: '}'
               scope: punctuation.definition.block.service.end.proto
               pop: true
-            - include: inline_option
+            - include: option
             - include: rpc
         - include: or_pop
 
@@ -191,11 +187,11 @@ contexts:
         - match: '}'
           scope: punctuation.definition.block.rpc.end.proto
           pop: true
-        - include: inline_option
+        - include: option
     - match: ;
       scope: punctuation.terminator.proto
       pop: true
-    - include: any_pop
+    - include: or_pop
 
   # Message Rules
   message:
@@ -215,7 +211,7 @@ contexts:
     - match: '}'
       scope: punctuation.definition.block.message.end.proto
       pop: true
-    - include: inline_option
+    - include: option
     - include: message
     - include: extend
     - include: oneof
@@ -266,12 +262,14 @@ contexts:
       scope: punctuation.definition.attributes.begin.proto
       push:
         - meta_scope: meta.field.attributes.proto
-        - include: fieldAttribute_BODY
+        - match: \b(default|deprecated|packed)\b
+          scope: support.function.proto
         - match: \,
           scope: punctuation.separator.option.proto
         - match: '\]'
           scope: punctuation.definition.attributes.end.proto
           pop: true
+        - include: option_inline
 
   map_type:
     - match: ','
@@ -296,93 +294,52 @@ contexts:
     - match: '(?=\S)'
       push: [ messageField_END, field_name_POP, message_type_or_pop ]
 
-  inline_option:
+  option:
     - match: '\b(option)\b'
       scope: keyword.other.option.proto
       push:
-        - include: option_BODY
         - match: ';'
           scope: punctuation.terminator.option.proto
           pop: true
+        - include: option_inline
+        - include: or_pop
 
-  fieldAttribute_BODY:
-    - match: \b(default|deprecated|packed)\b
-      scope: support.function.proto
+  option_inline:
     - match: '{{ident}}'
       scope: variable.annotation.proto
-    - include: optionName
-    - include: optionAssignment
+    - include: full_option_name
+    - match: =
+      scope: keyword.operator.assignment.proto
+      push: option_value
 
-  option_BODY:
-    - match: '{{ident}}'
-      scope: variable.other.option.proto
-    - include: optionName
-    - include: optionAssignment
-
-  optionName:
+  full_option_name:
     - match: \(
       scope: punctuation.definition.name.option.begin.proto
       push:
-        - match: \)
-          scope: punctuation.definition.name.option.end.proto
-          set:
-            - match: (\.)([\w\d]*)
-              captures:
-                1: punctuation.accessor.proto
-                2: storage.type.option.proto
-            - include: or_pop
-        - match: '[^\)]+'
-          scope: storage.type.option.proto
+        - match: (\))(?:(\.){{ident}})?
+          captures:
+            1: punctuation.definition.name.option.end.proto
+            2: punctuation.accessor.proto
+            3: variable.annotation.proto
+          pop: true
+        - match: '{{ident}}(\.)'
+          captures:
+            1: variable.namespace.proto
+            2: punctuation.accessor.proto
+        - match: '{{ident}}'
+          scope: variable.annotation.proto
 
-  optionAssignment:
-    - match: =
-      scope: keyword.operator.assignment.proto
-      push: optionAfterAssignment_POP
-
-  optionEnd_pop:
-    - match: '}'
-      scope: punctuation.definition.block.option.end.proto
-      pop: true
-
-  optionAfterAssignment_POP:
-    - meta_scope: meta.option.assignment.after.proto
+  option_value:
+    # Reuse prototxt syntax to parse embedded literal or protos.
     - match: '{'
       scope: punctuation.definition.block.option.begin.proto
-      embed: scope:source.prototext
-      embed_scope: source.prototext.embedded.proto
-      escape: '}'
+      push:
+        - meta_scope: meta.embedded.prototxt
+        - match: '}'
+          scope: punctuation.definition.block.option.end.proto
+          pop: true
+        - include: scope:text.prototxt#field
     - include: scope:text.prototxt#field_value_or_pop
-
-  option_ASSIGN_BLOCK:
-    - meta_scope: meta.object-literal.proto
-    - match: '}'
-      scope: punctuation.definition.block.option.end.proto
-      pop: true
-    - match: '(\w+)(:)'
-      captures:
-        1: meta.object-literal.key.proto
-        2: punctuation.separator.key-value.proto
-      push: [objectLiteralValue_META, constant_POP]
-
-  # This is a hack to get the meta scope to wrap
-  objectLiteralValue_META:
-    - meta_scope: meta.object-literal.value.proto
-    - match: ''
-      pop: true
-
-  constant_POP:
-    - match: \d+
-      scope: constant.numeric.proto
-      pop: true
-    - match: \btrue\b|\bfalse\b
-      scope: constant.language.proto
-      pop: true
-    - match: '{{ident}}'
-      scope: constant.other.proto
-      pop: true
-    - include: stringDoubleMultiline
-    # No constants matched
-    - include: or_pop
 
   main:
     - match: \b(package)\b
@@ -413,7 +370,7 @@ contexts:
       push:
         - match: '\}'
           pop: true
-        - include: field
+        - include: messageBody
     - match: '^\s*(syntax)\s*(=)'
       captures:
         1: keyword.other.syntax.proto
@@ -428,7 +385,7 @@ contexts:
       push:
         - include: stringDouble
         - include: one_liner
-    - include: inline_option
+    - include: option
     - include: message
     - include: service
     - include: extend

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -6,7 +6,7 @@ scope: source.proto
 file_extensions:
   - proto
   - protodevel
-first_line_match: 'syntax\s*=\s* "proto\d";'
+first_line_match: '^(syntax)\s*(=)\s*("proto\d")\s*(;)\s*$'
 variables:
   ident: '\b([A-Za-z][A-Za-z0-9_]*)\b'
 
@@ -14,8 +14,8 @@ contexts:
   prototype:
     # Captured for practical reasons (keeps other patterns simpler)
     - match: '\s+'
-      scope: meta.whitespace.proto
     - include: comments
+
   comments:
     - match: //
       scope: punctuation.definition.comment.begin.proto
@@ -30,11 +30,19 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.proto
           pop: true
+
   any_POP:
     # Pop when seeing unexpected characters.
-    # Contexts including this are suffixed by _POP.
     - match: '(?=\S)'
       pop: true
+
+  one_liner:
+    - match: ;
+      scope: punctuation.terminator.proto
+      pop: true
+    - match: $
+      pop: true
+
   closingBraceUnexpected_POP:
     - match: '(?=\})' # Recover from a non complete assignment
       pop: true
@@ -52,18 +60,8 @@ contexts:
           pop: true
 
   stringDoubleMultiline:
-    - match: '"'
-      scope: punctuation.definition.string.quoted.double.begin.proto
-      set:
-        - meta_scope: string.quoted.double.proto
-        - meta_include_prototype: false
-        - match: '\\"'
-          scope: constant.character.escape.proto
-        - match: '"'
-          scope: punctuation.definition.string.quoted.double.end.proto
-          set:
-            - include: stringDoubleMultiline
-            - include: any_POP
+    - include: stringDouble
+    - include: any_POP
 
   enum_START:
     - match: '\b(enum)\b'
@@ -82,7 +80,7 @@ contexts:
       pop: true
     - include: inlineOption
     - include: fieldAttributes
-    - match: '[a-zA-z]\w*'
+    - match: '{{ident}}'
       scope: support.variable.proto
     - match: =
       scope: keyword.operator.assignment.proto
@@ -140,42 +138,33 @@ contexts:
 
   # Service rules
   service_START:
-    - match: '\b(service)\b'
-      scope: storage.modifier.service.proto
-      push: [serviceBody_START, service_NAME]
-
-  service_NAME:
-    - match: '{{ident}}'
-      scope: entity.name.type.service.proto
-      pop: true
+    - match: '\b(service)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.service.proto
+        2: entity.name.type.service.proto
+      push: serviceBody_START
 
   serviceBody_START:
     - match: '\{'
       scope: punctuation.definition.block.service.begin.proto
       set: serviceBody_AFTER_OPEN
+    - include: any_POP
 
   serviceBody_AFTER_OPEN:
     - meta_scope: meta.service.body.proto
     - match: '}'
       scope: punctuation.definition.block.service.end.proto
       pop: true
-    - include: serviceBody
-
-  serviceBody:
-    - meta_scope: meta.service.body.proto
     - include: inlineOption
     - include: rpc_START
 
   # RPC Service rules
   rpc_START:
-    - match: '\b(rpc)\b'
-      scope: storage.modifier.rpc.proto
-      push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM, rpc_NAME]
-
-  rpc_NAME:
-    - match: '{{ident}}'
-      scope: entity.name.function.rpc.proto
-      pop: true
+    - match: '\b(rpc)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.rpc.proto
+        2: entity.name.function.rpc.proto
+      push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM]
 
   rpc_RETURNS:
     - match: returns
@@ -189,12 +178,17 @@ contexts:
         - match: \)
           scope: punctuation.definition.parameter.rpc.end.proto
           pop: true
+        - match: '\bstream\b'
+          scope: storage.modifier.proto
         - include: messageType_POP
 
   rpcBody_START:
     - match: '\{'
       scope: punctuation.definition.block.rpc.begin.proto
       set: rpcBody_AFTER_OPEN
+    - match: ;
+      scope: punctuation.terminator.proto
+      pop: true
 
   rpcBody_AFTER_OPEN:
     - meta_scope: meta.rpc.body.proto
@@ -232,7 +226,6 @@ contexts:
     - include: messageBody
 
   messageType_POP:
-    - meta_scope: storage.type.message.proto
     - match: '\bString\b|\bboolean\b'
       scope: invalid.type.proto
       pop: true
@@ -314,18 +307,16 @@ contexts:
           pop: true
 
   fieldAttribute_BODY:
-    - match: \bdefault\b
+    - match: \b(default|deprecated|packed)\b
       scope: constant.language.default.proto
-    - match: \bdeprecated\b
-      scope: constant.language.deprecated.proto
     - match: '{{ident}}'
-      scope: invalid.illegal.constant.proto
+      scope: variable.other.option.proto
     - include: optionName
     - include: optionAssignment
 
   option_BODY:
     - match: '{{ident}}'
-      scope: variable.option.other.proto
+      scope: variable.other.option.proto
     - include: optionName
     - include: optionAssignment
 
@@ -336,7 +327,6 @@ contexts:
         - match: \)
           scope: punctuation.definition.name.option.end.proto
           set:
-            - meta_scope: foo
             - match: (\.)([\w\d]*)
               captures:
                 1: punctuation.accessor.proto
@@ -359,13 +349,9 @@ contexts:
     - meta_scope: meta.option.assignment.after.proto
     - match: '{'
       scope: punctuation.definition.block.option.begin.proto
-      set:
-        - meta_content_scope: source.prototext
-        - include: optionEnd_pop
-        - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax#prototype
-        - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax
-      with_prototype:
-        - include: comments
+      embed: scope:source.prototext
+      embed_scope: source.prototext.embedded.proto
+      escape: '}'
     - include: constant_POP
 
   option_ASSIGN_BLOCK:
@@ -400,52 +386,43 @@ contexts:
     - include: any_POP
 
   main:
-    - match: \b(package)\s+(\w[\w\.]+)
-      scope: meta.package.proto
-      captures:
-        1: keyword.other.package.proto
-        2: entity.name.package.proto
-    - match: '\b(parsed)?\s*((class))\s+(\w+)\s+{'
+    - match: \b(package)\b
+      scope: keyword.other.package.proto
+      push:
+        - match: '{{ident}}(\.)'
+          captures:
+            1: variable.namespace.proto
+            2: punctuation.separator.namespace.proto
+        - match: '{{ident}}'
+          scope: entity.name.namespace.proto
+        - include: one_liner
+    # This proto1 syntax is deprecated, only providing minimal support.
+    - match: '\b(parsed)?\s*((class))\s+{{ident}}\s+{'
       scope: meta.parsed.message.proto
       captures:
         1: storage.type.parsed.proto
         3: storage.type.message.proto
         4: invalid.deprecated.class.proto
         5: entity.name.function.proto
-    - match: '\b(rpc)\s+(\w+)\((\w+)\)\s+(returns)\s+\((\w+)\)\s+\{'
-      scope: meta.rpc.proto
-      captures:
-        1: storage.type.rpc.proto
-        2: entity.name.function.proto
-        3: variable.parameter.proto
-        4: keyword.other.returns.proto
-        5: variable.parameter.proto
     - match: '(?x)\b(group)\s+(\w+)\s+=\s+(\d+)\s+{'
       scope: meta.group.proto
       captures:
         1: storage.type.proto
         2: support.variable.proto
         3: constant.numeric.proto
-    - match: \b(syntax)\b
+    - match: '^\s*(syntax)\s*(=)'
       captures:
         1: keyword.other.syntax.proto
+        2: keyword.operator.assignment.proto
       push:
-        - meta_scope: meta.keyword.syntax
-        - match: ;
-          scope: punctuation.terminator.proto
-          pop: true
-        - match: =
-          scope: keyword.operator.assignment.proto
         - include: stringDouble
-    - match: \b(import)\b
+        - include: one_liner
+    - match: '\b(import)\b'
       captures:
         1: keyword.other.import.proto
       push:
-        - meta_scope: meta.keyword.import
-        - match: ;
-          scope: punctuation.terminator.proto
-          pop: true
         - include: stringDouble
+        - include: one_liner
     - include: inlineOption
     - include: message_START
     - include: service_START

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -1,0 +1,463 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Protocol Buffer
+file_extensions:
+  - proto
+  - protodevel
+scope: source.protocolbuffer
+variables:
+  PLA_anything: '(?=[\S\s])'
+  messagePath: '\b(((?:[A-Za-z]\w*\.)*)([a-zA-Z]\w*))\b'
+  keywordLanguage: >-
+    syntax | package | import | optional | required | repeated | message
+
+contexts:
+  prototype:
+    # Captured for practical reasons (keeps other patterns simpler)
+    - match: '\s+'
+      scope: meta.whitespace.protocolbuffer
+    - include: comments
+  comments:
+    - match: '((\/\/))'
+      captures:
+        1: meta.comment.border.protocolbuffer
+        2: punctuation.definition.comment.begin.protocolbuffer
+      push:
+        - meta_scope: comment.line.protocolbuffer
+        - match: '$'
+          pop: true
+        - match: '\/\/+'
+          scope: meta.comment.border.protocolbuffer
+        - match: '\b(?i:todo|hack)\b'
+          scope: comment.line.todo.protocolbuffer
+    - match: /\*
+      scope: punctuation.definition.comment.protocolbuffer
+      push:
+        - meta_scope: comment.block.protocolbuffer
+        - match: \*/
+          scope: punctuation.definition.comment.protocolbuffer
+          pop: true
+  any_POP:
+    - match: '(?=\S)'
+      pop: true
+  closingBraceUnexpected_POP:
+    - match: '(?=\})' # Recover from a non complete assignment
+      pop: true
+  stringDouble:
+    - match: '"'
+      scope: punctuation.definition.string.begin.protocolbuffer
+      push:
+        - meta_scope: string.quoted.double.protocolbuffer
+        - meta_include_prototype: false
+        - match: '\\"'
+          scope: constant.character.escape.protocolbuffer
+        - match: '"'
+          scope: punctuation.definition.string.end.protocolbuffer
+          pop: true
+
+  stringDoubleMultiline:
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.protocolbuffer
+      set:
+        - meta_scope: string.quoted.double.protocolbuffer
+        - meta_include_prototype: false
+        - match: '\\"'
+          scope: constant.character.escape.protocolbuffer
+        - match: '"'
+          scope: punctuation.definition.string.quoted.double.end.protocolbuffer
+          set:
+            - include: stringDoubleMultiline
+            - include: any_POP
+  enum_START:
+    - match: '\b(enum)\b'
+      scope: storage.modifier.enum.protocolbuffer
+      push: [ enumBody_START, message_NAME]
+  enumBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.enum.begin.protocolbuffer
+      set: enumBody_AFTER_OPEN
+  enumBody_AFTER_OPEN:
+    - meta_scope: meta.enum.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.enum.end.protocolbuffer
+      pop: true
+    - include: inlineOption_START
+    - include: fieldAttributes
+    - match: '[a-zA-z]\w*'
+      scope: support.variable.protocolbuffer
+    - match: =
+      scope: keyword.operator.assignment.protocolbuffer
+    - match: \d+
+      scope: constant.numeric.protocolbuffer
+    - match: ';'
+      scope: punctuation.terminator.protocolbuffer
+
+  oneof_START:
+    - match: '\b(oneof)\b'
+      scope: storage.modifier.oneof.protocolbuffer
+      push: [ oneofBody_START, messageField_NAME]
+  oneofBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.oneof.begin.protocolbuffer
+      set: oneofBody_AFTER_OPEN
+  oneofBody_AFTER_OPEN:
+    - meta_scope: meta.oneof.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.oneof.end.protocolbuffer
+      pop: true
+    - match: ''
+      push: [ messageField_END, messageField_NAME, messageField_TYPE ]
+
+  extend_START:
+    - match: '\b(extend)\b'
+      scope: storage.modifier.extend.protocolbuffer
+      push: [ extendBody_START, messageField_TYPE]
+  extendBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.extend.begin.protocolbuffer
+      set: extendBody_AFTER_OPEN
+  extendBody_AFTER_OPEN:
+    - meta_scope: meta.extend.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.extend.end.protocolbuffer
+      pop: true
+    - include: messageBody
+
+  reserved_START:
+    - match: '\b(reserved)\b'
+      scope: storage.modifier.reserved.protocolbuffer
+      push:
+        - meta_scope: meta.keyword.reserved.protocolbuffer
+        - match: \d+
+          scope: constant.numeric.protocolbuffer
+        - match: ','
+          scope: punctuation.separator.protocolbuffer
+        - match: to
+          scope: keyword.other.to.protocolbuffer
+        - match: ';'
+          scope: punctuation.terminator.protocolbuffer
+          pop: true
+
+
+  # Service rules
+  service_START:
+    - match: '\b(service)\b'
+      scope: storage.modifier.service.protocolbuffer
+      push: [serviceBody_START, service_NAME]
+
+  service_NAME:
+    - match: \w+
+      scope: entity.name.type.service.protocolbuffer
+      pop: true
+
+  serviceBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.service.begin.protocolbuffer
+      set: serviceBody_AFTER_OPEN
+
+  serviceBody_AFTER_OPEN:
+    - meta_scope: meta.service.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.service.end.protocolbuffer
+      pop: true
+    - include: serviceBody
+
+  serviceBody:
+    - meta_scope: meta.service.body.protocolbuffer
+    - include: inlineOption_START
+    - include: rpc_START
+
+  # RPC Service rules
+
+  rpc_START:
+    - match: '\b(rpc)\b'
+      scope: storage.modifier.rpc.protocolbuffer
+      push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM, rpc_NAME]
+
+  rpc_NAME:
+    - match: \w+
+      scope: entity.name.function.rpc.protocolbuffer
+      pop: true
+  rpc_RETURNS:
+    - match: returns
+      scope: keyword.other.returns.protocolbuffer
+      pop: true
+  rpc_PARAM:
+    - match: \(
+      scope: punctuation.definition.parameter.rpc.start.protocolbuffer
+      set:
+        - match: \)
+          scope: punctuation.definition.parameter.rpc.end.protocolbuffer
+          pop: true
+        - match: '{{messagePath}}'
+          captures:
+            1: storage.type.message.field.protocolbuffer
+            2: storage.type.message.field.path.protocolbuffer
+            3: storage.type.message.field.message.protocolbuffer
+
+  rpcBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.rpc.begin.protocolbuffer
+      set: rpcBody_AFTER_OPEN
+
+  rpcBody_AFTER_OPEN:
+    - meta_scope: meta.rpc.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.rpc.end.protocolbuffer
+      pop: true
+    - include: rpcBody
+
+  rpcBody:
+    - meta_scope: meta.rpc.body.protocolbuffer
+    - include: inlineOption_START
+
+  # Message Rules
+
+  message_NAME:
+    - match: \w+
+      scope: entity.name.type.message.protocolbuffer
+      pop: true
+
+  message_START:
+    - match: '\b(message)\b'
+      scope: storage.modifier.message.protocolbuffer
+      push: [messageBody_START, message_NAME]
+
+  messageBody_START:
+    - match: '\{'
+      scope: punctuation.definition.block.message.begin.protocolbuffer
+      set: messageBody_AFTER_OPEN
+
+  messageBody_AFTER_OPEN:
+    - meta_scope: meta.message.body.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.message.end.protocolbuffer
+      pop: true
+    - include: messageBody
+
+  messageType_META:
+    - meta_scope: storage.type.message.protocolbuffer
+    - match: ''
+      pop: true
+
+  messageType_POP:
+    - match: '[A-Za-z]\w*'
+      scope: storage.type.message.part.protocolbuffer
+      set:
+        - match: '\.'
+          scope: punctuation.accessor.protocolbuffer
+          set: messageType_POP
+        - include: any_POP
+    - include: any_POP
+
+  messageField_TYPE:
+    - meta_scope: messageField_TYPE
+    - match: '\bString\b|\bboolean\b'
+      scope: invalid.type.protocolbuffer
+      pop: true
+    - match: ''
+      set: [messageType_META, messageType_POP]
+  messageField_NAME:
+    - match: \w+
+      scope: support.variable.protocolbuffer
+      pop: true
+    - include: closingBraceUnexpected_POP
+  messageField_END:
+    - include: fieldAttributes
+    - match: ';'
+      scope: punctuation.terminator.protocolbuffer
+      pop: true
+    - match: =
+      scope: keyword.operator.assignment.protocolbuffer
+    - match: \d+
+      scope: constant.numeric.protocolbuffer
+    - include: closingBraceUnexpected_POP
+  fieldAttributes:
+    - match: '\['
+      scope: punctuation.definition.attributes.begin.protocolbuffer
+      push:
+        - meta_scope: meta.field.attributes.protocolbuffer
+        - include: fieldAttribute_BODY
+        - match: \,
+          scope: punctuation.separator.option.protocolbuffer
+        - match: '\]'
+          scope: punctuation.definition.attributes.end.protocolbuffer
+          pop: true
+  map_TYPES:
+    - match: '<'
+      scope: punctuation.definition.map.start.protocolbuffer
+      set:
+        - match: '\b(((?:[A-Za-z][a-z0-9]+\.)*)([a-zA-Z]\w+))\b'
+          captures:
+            1: storage.type.message.field.protocolbuffer
+            2: storage.type.message.field.path.protocolbuffer
+            3: storage.type.message.field.message.protocolbuffer
+        - match: '>'
+          scope: punctuation.definition.map.end.protocolbuffer
+          pop: true
+  messageBodyField:
+    - match: '\b(optional|required|repeated)\b'
+      captures:
+        1: storage.modifier.protocolbuffer
+      push: [ messageField_END, messageField_NAME, messageField_TYPE ]
+    - match: '\b(map)\b'
+      captures:
+        1: storage.modifier.protocolbuffer
+      push: [ messageField_END, messageField_NAME, map_TYPES ]
+  messageBody:
+    - meta_scope: meta.message.body.protocolbuffer
+    - include: inlineOption_START
+    - include: message_START
+    - include: extend_START
+    - include: oneof_START
+    - include: enum_START
+    - include: reserved_START
+    - include: messageBodyField
+  inlineOption_START:
+    - match: '\b(option)\b'
+      scope: keyword.other.option.protocolbuffer
+      push:
+        - meta_scope: meta.option.protocolbuffer
+        - include: option_BODY
+        - match: ';'
+          scope: punctuation.terminator.option.protocolbuffer
+          pop: true
+
+  fieldAttribute_BODY:
+    - match: \bdefault\b
+      scope: constant.language.default.protocolbuffer
+    - match: \bdeprecated\b
+      scope: constant.language.deprecated.protocolbuffer
+    - match: \w+
+      scope: invalid.illegal.constant.protocolbuffer
+    - include: optionName
+    - include: optionAssignment
+
+  option_BODY:
+    - match: \w+
+      scope: variable.option.other.protocolbuffer
+    - include: optionName
+    - include: optionAssignment
+
+  optionName:
+    - match: \(
+      scope: punctuation.definition.name.option.begin.protocolbuffer
+      push:
+        - match: \)
+          scope: punctuation.definition.name.option.end.protocolbuffer
+          set:
+            - meta_scope: foo
+            - match: (\.)([\w\d]*)
+              captures:
+                1: punctuation.accessor.protocolbuffer
+                2: storage.type.option.protocolbuffer
+            - include: any_POP
+        - match: '[^\)]+'
+          scope: storage.type.option.protocolbuffer
+
+  optionAssignment:
+    - match: =
+      scope: keyword.operator.assignment.protocolbuffer
+      push: optionAfterAssignment_POP
+
+  optionEnd_pop:
+    - match: '}'
+      scope: punctuation.definition.block.option.end.protocolbuffer
+      pop: true
+
+  optionAfterAssignment_POP:
+    - meta_scope: meta.option.assignment.after.protocolbuffer
+    - match: '{'
+      scope: punctuation.definition.block.option.begin.protocolbuffer
+      set:
+        - meta_content_scope: source.protocolbuffertext
+        - include: optionEnd_pop
+        - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax#prototype
+        - include: Packages/google-syntax/Protocol-Buffer-Text.sublime-syntax
+      with_prototype:
+        - include: comments
+    - include: constant_POP
+
+  option_ASSIGN_BLOCK:
+    - meta_scope: meta.object-literal.protocolbuffer
+    - match: '}'
+      scope: punctuation.definition.block.option.end.protocolbuffer
+      pop: true
+    - match: '(\w+)(:)'
+      captures:
+        1: meta.object-literal.key.protocolbuffer
+        2: punctuation.separator.key-value.protocolbuffer
+      push: [objectLiteralValue_META, constant_POP]
+
+  # This is a hack to get the meta scope to wrap
+  objectLiteralValue_META:
+    - meta_scope: meta.object-literal.value.protocolbuffer
+    - match: ''
+      pop: true
+
+  constant_POP:
+    - match: \d+
+      scope: constant.numeric.protocolbuffer
+      pop: true
+    - match: \btrue\b|\bfalse\b
+      scope: constant.language.protocolbuffer
+      pop: true
+    - match: \w+
+      scope: constant.other.protocolbuffer
+      pop: true
+    - include: stringDoubleMultiline
+    # No constants matched
+    - include: any_POP
+  main:
+    - match: \b(package)\s+(\w[\w\.]+)
+      scope: meta.package.protocolbuffer
+      captures:
+        1: keyword.other.package.protocolbuffer
+        2: entity.name.package.protocolbuffer
+    - match: '\b(parsed)?\s*((class))\s+(\w+)\s+{'
+      scope: meta.parsed.message.protocolbuffer
+      captures:
+        1: storage.type.parsed.protocolbuffer
+        3: storage.type.message.protocolbuffer
+        4: invalid.deprecated.class.protocolbuffer
+        5: entity.name.function.protocolbuffer
+    - match: '\b(rpc)\s+(\w+)\((\w+)\)\s+(returns)\s+\((\w+)\)\s+\{'
+      scope: meta.rpc.protocolbuffer
+      captures:
+        1: storage.type.rpc.protocolbuffer
+        2: entity.name.function.protocolbuffer
+        3: variable.parameter.protocolbuffer
+        4: keyword.other.returns.protocolbuffer
+        5: variable.parameter.protocolbuffer
+    - match: '(?x)\b(group)\s+(\w+)\s+=\s+(\d+)\s+{'
+      scope: meta.group.protocolbuffer
+      captures:
+        1: storage.type.protocolbuffer
+        2: support.variable.protocolbuffer
+        3: constant.numeric.protocolbuffer
+    - match: \b(syntax)\b
+      captures:
+        1: keyword.other.syntax.protocolbuffer
+      push:
+        - meta_scope: meta.keyword.syntax
+        - match: ;
+          scope: punctuation.terminator.protocolbuffer
+          pop: true
+        - match: =
+          scope: keyword.operator.assignment.protocolbuffer
+        - include: stringDouble
+    - match: \b(import)\b
+      captures:
+        1: keyword.other.import.protocolbuffer
+      push:
+        - meta_scope: meta.keyword.import
+        - match: ;
+          scope: punctuation.terminator.protocolbuffer
+          pop: true
+        - include: stringDouble
+    - include: inlineOption_START
+    - include: message_START
+    - include: service_START
+    - include: extend_START
+    - include: enum_START

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -63,18 +63,20 @@ contexts:
     - include: stringDouble
     - include: any_POP
 
-  enum_START:
-    - match: '\b(enum)\b'
-      scope: storage.modifier.enum.proto
-      push: [ enumBody_START, message_NAME]
+  enum:
+    - match: '\b(enum)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.enum.proto
+        2: entity.name.enum.proto
+      push:
+        - meta_scope: meta.enum.proto
+        - match: '\{'
+          scope: punctuation.definition.block.enum.begin.proto
+          set: enumBody
+        - include: any_POP
 
-  enumBody_START:
-    - match: '\{'
-      scope: punctuation.definition.block.enum.begin.proto
-      set: enumBody_AFTER_OPEN
-
-  enumBody_AFTER_OPEN:
-    - meta_scope: meta.enum.body.proto
+  enumBody:
+    - meta_scope: meta.enum.proto
     - match: '}'
       scope: punctuation.definition.block.enum.end.proto
       pop: true
@@ -124,7 +126,6 @@ contexts:
     - match: '\b(reserved)\b'
       scope: storage.modifier.reserved.proto
       push:
-        - meta_scope: meta.keyword.reserved.proto
         - match: \d+
           scope: constant.numeric.proto
         - match: ','
@@ -137,26 +138,23 @@ contexts:
 
 
   # Service rules
-  service_START:
+  service:
     - match: '\b(service)\b\s*{{ident}}'
       captures:
         1: storage.modifier.service.proto
-        2: entity.name.type.service.proto
-      push: serviceBody_START
-
-  serviceBody_START:
-    - match: '\{'
-      scope: punctuation.definition.block.service.begin.proto
-      set: serviceBody_AFTER_OPEN
-    - include: any_POP
-
-  serviceBody_AFTER_OPEN:
-    - meta_scope: meta.service.body.proto
-    - match: '}'
-      scope: punctuation.definition.block.service.end.proto
-      pop: true
-    - include: inlineOption
-    - include: rpc_START
+        2: entity.name.class.proto
+      push:
+        - meta_scope: meta.service.proto
+        - match: '\{'
+          scope: punctuation.definition.block.service.begin.proto
+          set:
+            - meta_scope: meta.service.proto
+            - match: '}'
+              scope: punctuation.definition.block.service.end.proto
+              pop: true
+            - include: inlineOption
+            - include: rpc_START
+        - include: any_POP
 
   # RPC Service rules
   rpc_START:
@@ -202,39 +200,49 @@ contexts:
     - include: inlineOption
 
   # Message Rules
+  message:
+    - match: '\b(message)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.message.proto
+        2: entity.name.class.proto
+      push:
+        - meta_scope: meta.class.proto
+        - match: '\{'
+          scope: punctuation.definition.block.message.begin.proto
+          set: messageBody
+        - include: any_POP
 
-  message_NAME:
-    - match: '{{ident}}'
-      scope: entity.name.type.message.proto
-      pop: true
-
-  message_START:
-    - match: '\b(message)\b'
-      scope: storage.modifier.message.proto
-      push: [messageBody_START, message_NAME]
-
-  messageBody_START:
-    - match: '\{'
-      scope: punctuation.definition.block.message.begin.proto
-      set: messageBody_AFTER_OPEN
-
-  messageBody_AFTER_OPEN:
-    - meta_scope: meta.message.body.proto
+  messageBody:
+    - meta_scope: meta.class.proto
     - match: '}'
       scope: punctuation.definition.block.message.end.proto
       pop: true
-    - include: messageBody
+    - include: inlineOption
+    - include: message
+    - include: extend_START
+    - include: oneof
+    - include: enum
+    - include: reserved_START
+    - include: messageBodyField
 
   messageType_POP:
-    - match: '\bString\b|\bboolean\b'
-      scope: invalid.type.proto
+    # see documentation for the list of base types:
+    # https://developers.google.com/protocol-buffers/docs/proto#scalar
+    - match: '(double|float|bool|string|bytes)'
+      scope: support.type.proto
+      pop: true
+    - match: '(u|s)?int(32|64)'
+      scope: support.type.proto
+      pop: true
+    - match: 's?fixed(32|64)'
+      scope: support.type.proto
       pop: true
     - match: '{{ident}}(\.)'
       captures:
         1: variable.namespace.proto
         2: punctuation.accessor.proto
     - match: '{{ident}}'
-      scope: variable.type.message.proto
+      scope: variable.type.proto
       pop: true
     - include: any_POP
 
@@ -286,21 +294,10 @@ contexts:
         2: punctuation.definition.map.begin.proto
       push: [ messageField_END, field_name_POP, map_type ]
 
-  messageBody:
-    - meta_scope: meta.message.body.proto
-    - include: inlineOption
-    - include: message_START
-    - include: extend_START
-    - include: oneof
-    - include: enum_START
-    - include: reserved_START
-    - include: messageBodyField
-
   inlineOption:
     - match: '\b(option)\b'
       scope: keyword.other.option.proto
       push:
-        - meta_scope: meta.option.proto
         - include: option_BODY
         - match: ';'
           scope: punctuation.terminator.option.proto
@@ -396,7 +393,7 @@ contexts:
         - match: '{{ident}}'
           scope: entity.name.namespace.proto
         - include: one_liner
-    # This proto1 syntax is deprecated, only providing minimal support.
+    # This is proto1 syntax which is deprecated, only providing minimal support.
     - match: '\b(parsed)?\s*((class))\s+{{ident}}\s+{'
       scope: meta.parsed.message.proto
       captures:
@@ -404,12 +401,17 @@ contexts:
         3: storage.type.message.proto
         4: invalid.deprecated.class.proto
         5: entity.name.function.proto
+    # Groups are deprecated, only providing minimal support.
     - match: '(?x)\b(group)\s+(\w+)\s+=\s+(\d+)\s+{'
       scope: meta.group.proto
       captures:
-        1: storage.type.proto
+        1: storage.type.proto invalid.deprecated.group.proto
         2: support.variable.proto
         3: constant.numeric.proto
+      push:
+        - match: '\}'
+          pop: true
+        - include: field
     - match: '^\s*(syntax)\s*(=)'
       captures:
         1: keyword.other.syntax.proto
@@ -424,7 +426,7 @@ contexts:
         - include: stringDouble
         - include: one_liner
     - include: inlineOption
-    - include: message_START
-    - include: service_START
+    - include: message
+    - include: service
     - include: extend_START
-    - include: enum_START
+    - include: enum

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -1,6 +1,12 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# Syntax for Protocol Buffer definition files.
+# Works with proto2 and proto3.
+# See official Protobuff documentation at https://developers.google.com/protocol-buffers/docs/proto3
+#
+# Authors: Raul Rangel & Guillaume Wenzek
+#
+# .sublime-syntax reference: http://www.sublimetext.com/docs/3/syntax.html
 name: Protocol Buffer
 scope: source.proto
 file_extensions:

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -177,7 +177,8 @@ contexts:
           pop: true
         - match: '\bstream\b'
           scope: storage.modifier.proto
-        - include: message_type_or_pop
+        - match: (?=\S)
+          push: message_type_or_pop
 
   rpc_body:
     - match: '\{'
@@ -238,7 +239,6 @@ contexts:
     - match: '{{ident}}'
       scope: variable.type.proto
       pop: true
-    - include: or_pop
 
   field_name_POP:
     - match: '{{ident}}'

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -4,13 +4,9 @@
 name: Protocol Buffer
 file_extensions:
   - proto
-  - protodevel
 scope: source.proto
 variables:
-  PLA_anything: '(?=[\S\s])'
-  messagePath: '\b(((?:[A-Za-z]\w*\.)*)([a-zA-Z]\w*))\b'
-  keywordLanguage: >-
-    syntax | package | import | optional | required | repeated | message
+  ident: '\b([A-Za-z][A-Za-z0-9_]*)\b'
 
 contexts:
   prototype:
@@ -19,18 +15,12 @@ contexts:
       scope: meta.whitespace.proto
     - include: comments
   comments:
-    - match: '((\/\/))'
-      captures:
-        1: meta.comment.border.proto
-        2: punctuation.definition.comment.begin.proto
+    - match: //
+      scope: punctuation.definition.comment.begin.proto
       push:
         - meta_scope: comment.line.proto
         - match: '$'
           pop: true
-        - match: '\/\/+'
-          scope: meta.comment.border.proto
-        - match: '\b(?i:todo|hack)\b'
-          scope: comment.line.todo.proto
     - match: /\*
       scope: punctuation.definition.comment.proto
       push:
@@ -39,11 +29,14 @@ contexts:
           scope: punctuation.definition.comment.proto
           pop: true
   any_POP:
+    # Pop when seeing unexpected characters.
+    # Contexts including this are suffixed by _POP.
     - match: '(?=\S)'
       pop: true
   closingBraceUnexpected_POP:
     - match: '(?=\})' # Recover from a non complete assignment
       pop: true
+
   stringDouble:
     - match: '"'
       scope: punctuation.definition.string.begin.proto
@@ -69,14 +62,17 @@ contexts:
           set:
             - include: stringDoubleMultiline
             - include: any_POP
+
   enum_START:
     - match: '\b(enum)\b'
       scope: storage.modifier.enum.proto
       push: [ enumBody_START, message_NAME]
+
   enumBody_START:
     - match: '\{'
       scope: punctuation.definition.block.enum.begin.proto
       set: enumBody_AFTER_OPEN
+
   enumBody_AFTER_OPEN:
     - meta_scope: meta.enum.body.proto
     - match: '}'
@@ -147,7 +143,7 @@ contexts:
       push: [serviceBody_START, service_NAME]
 
   service_NAME:
-    - match: \w+
+    - match: '{{ident}}'
       scope: entity.name.type.service.proto
       pop: true
 
@@ -169,20 +165,21 @@ contexts:
     - include: rpc_START
 
   # RPC Service rules
-
   rpc_START:
     - match: '\b(rpc)\b'
       scope: storage.modifier.rpc.proto
       push: [rpcBody_START, rpc_PARAM, rpc_RETURNS, rpc_PARAM, rpc_NAME]
 
   rpc_NAME:
-    - match: \w+
+    - match: '{{ident}}'
       scope: entity.name.function.rpc.proto
       pop: true
+
   rpc_RETURNS:
     - match: returns
       scope: keyword.other.returns.proto
       pop: true
+
   rpc_PARAM:
     - match: \(
       scope: punctuation.definition.parameter.rpc.start.proto
@@ -190,11 +187,12 @@ contexts:
         - match: \)
           scope: punctuation.definition.parameter.rpc.end.proto
           pop: true
-        - match: '{{messagePath}}'
+        - match: '{{ident}}\.'
           captures:
-            1: storage.type.message.field.proto
-            2: storage.type.message.field.path.proto
-            3: storage.type.message.field.message.proto
+            1: storage.type.message.field.path.proto
+            2: punctuation.separator.proto
+        - match: '{{ident}}'
+          scope: storage.type.message.field.message.proto
 
   rpcBody_START:
     - match: '\{'
@@ -215,7 +213,7 @@ contexts:
   # Message Rules
 
   message_NAME:
-    - match: \w+
+    - match: '{{ident}}'
       scope: entity.name.type.message.proto
       pop: true
 
@@ -258,11 +256,13 @@ contexts:
       pop: true
     - match: ''
       set: [messageType_META, messageType_POP]
+
   messageField_NAME:
-    - match: \w+
+    - match: '{{ident}}'
       scope: support.variable.proto
       pop: true
     - include: closingBraceUnexpected_POP
+
   messageField_END:
     - include: fieldAttributes
     - match: ';'
@@ -273,6 +273,7 @@ contexts:
     - match: \d+
       scope: constant.numeric.proto
     - include: closingBraceUnexpected_POP
+
   fieldAttributes:
     - match: '\['
       scope: punctuation.definition.attributes.begin.proto
@@ -314,6 +315,7 @@ contexts:
     - include: enum_START
     - include: reserved_START
     - include: messageBodyField
+
   inlineOption_START:
     - match: '\b(option)\b'
       scope: keyword.other.option.proto
@@ -329,13 +331,13 @@ contexts:
       scope: constant.language.default.proto
     - match: \bdeprecated\b
       scope: constant.language.deprecated.proto
-    - match: \w+
+    - match: '{{ident}}'
       scope: invalid.illegal.constant.proto
     - include: optionName
     - include: optionAssignment
 
   option_BODY:
-    - match: \w+
+    - match: '{{ident}}'
       scope: variable.option.other.proto
     - include: optionName
     - include: optionAssignment
@@ -403,12 +405,13 @@ contexts:
     - match: \btrue\b|\bfalse\b
       scope: constant.language.proto
       pop: true
-    - match: \w+
+    - match: '{{ident}}'
       scope: constant.other.proto
       pop: true
     - include: stringDoubleMultiline
     # No constants matched
     - include: any_POP
+
   main:
     - match: \b(package)\s+(\w[\w\.]+)
       scope: meta.package.proto

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -2,9 +2,11 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Protocol Buffer
+scope: source.proto
 file_extensions:
   - proto
-scope: source.proto
+  - protodevel
+first_line_match: 'syntax\s*=\s* "proto\d";'
 variables:
   ident: '\b([A-Za-z][A-Za-z0-9_]*)\b'
 
@@ -78,7 +80,7 @@ contexts:
     - match: '}'
       scope: punctuation.definition.block.enum.end.proto
       pop: true
-    - include: inlineOption_START
+    - include: inlineOption
     - include: fieldAttributes
     - match: '[a-zA-z]\w*'
       scope: support.variable.proto
@@ -89,10 +91,10 @@ contexts:
     - match: ';'
       scope: punctuation.terminator.proto
 
-  oneof_START:
+  oneof:
     - match: '\b(oneof)\b'
       scope: storage.modifier.oneof.proto
-      push: [ oneofBody_START, messageField_NAME]
+      push: [ oneofBody_START, field_name_POP]
   oneofBody_START:
     - match: '\{'
       scope: punctuation.definition.block.oneof.begin.proto
@@ -103,12 +105,12 @@ contexts:
       scope: punctuation.definition.block.oneof.end.proto
       pop: true
     - match: ''
-      push: [ messageField_END, messageField_NAME, messageField_TYPE ]
+      push: [ messageField_END, field_name_POP, messageType_POP ]
 
   extend_START:
     - match: '\b(extend)\b'
       scope: storage.modifier.extend.proto
-      push: [ extendBody_START, messageField_TYPE]
+      push: [ extendBody_START, messageType_POP]
   extendBody_START:
     - match: '\{'
       scope: punctuation.definition.block.extend.begin.proto
@@ -161,7 +163,7 @@ contexts:
 
   serviceBody:
     - meta_scope: meta.service.body.proto
-    - include: inlineOption_START
+    - include: inlineOption
     - include: rpc_START
 
   # RPC Service rules
@@ -182,17 +184,12 @@ contexts:
 
   rpc_PARAM:
     - match: \(
-      scope: punctuation.definition.parameter.rpc.start.proto
+      scope: punctuation.definition.parameter.rpc.begin.proto
       set:
         - match: \)
           scope: punctuation.definition.parameter.rpc.end.proto
           pop: true
-        - match: '{{ident}}\.'
-          captures:
-            1: storage.type.message.field.path.proto
-            2: punctuation.separator.proto
-        - match: '{{ident}}'
-          scope: storage.type.message.field.message.proto
+        - include: messageType_POP
 
   rpcBody_START:
     - match: '\{'
@@ -208,7 +205,7 @@ contexts:
 
   rpcBody:
     - meta_scope: meta.rpc.body.proto
-    - include: inlineOption_START
+    - include: inlineOption
 
   # Message Rules
 
@@ -234,30 +231,21 @@ contexts:
       pop: true
     - include: messageBody
 
-  messageType_META:
-    - meta_scope: storage.type.message.proto
-    - match: ''
-      pop: true
-
   messageType_POP:
-    - match: '[A-Za-z]\w*'
-      scope: storage.type.message.part.proto
-      set:
-        - match: '\.'
-          scope: punctuation.accessor.proto
-          set: messageType_POP
-        - include: any_POP
-    - include: any_POP
-
-  messageField_TYPE:
-    - meta_scope: messageField_TYPE
+    - meta_scope: storage.type.message.proto
     - match: '\bString\b|\bboolean\b'
       scope: invalid.type.proto
       pop: true
-    - match: ''
-      set: [messageType_META, messageType_POP]
+    - match: '{{ident}}(\.)'
+      captures:
+        1: variable.namespace.proto
+        2: punctuation.accessor.proto
+    - match: '{{ident}}'
+      scope: storage.type.message.proto
+      pop: true
+    - include: any_POP
 
-  messageField_NAME:
+  field_name_POP:
     - match: '{{ident}}'
       scope: support.variable.proto
       pop: true
@@ -285,38 +273,37 @@ contexts:
         - match: '\]'
           scope: punctuation.definition.attributes.end.proto
           pop: true
-  map_TYPES:
-    - match: '<'
-      scope: punctuation.definition.map.start.proto
-      set:
-        - match: '\b(((?:[A-Za-z][a-z0-9]+\.)*)([a-zA-Z]\w+))\b'
-          captures:
-            1: storage.type.message.field.proto
-            2: storage.type.message.field.path.proto
-            3: storage.type.message.field.message.proto
-        - match: '>'
-          scope: punctuation.definition.map.end.proto
-          pop: true
+  map_type:
+    - match: ','
+      scope: punctuation.separator.map.proto
+    - match: '>'
+      scope: punctuation.definition.map.end.proto
+      pop: true
+    - match: '(?={{ident}})'
+      push: messageType_POP
+
   messageBodyField:
     - match: '\b(optional|required|repeated)\b'
       captures:
         1: storage.modifier.proto
-      push: [ messageField_END, messageField_NAME, messageField_TYPE ]
-    - match: '\b(map)\b'
+      push: [ messageField_END, field_name_POP, messageType_POP ]
+    - match: '\b(map)\b\s*\b(<)'
       captures:
         1: storage.modifier.proto
-      push: [ messageField_END, messageField_NAME, map_TYPES ]
+        2: punctuation.definition.map.begin.proto
+      push: [ messageField_END, field_name_POP, map_type ]
+
   messageBody:
     - meta_scope: meta.message.body.proto
-    - include: inlineOption_START
+    - include: inlineOption
     - include: message_START
     - include: extend_START
-    - include: oneof_START
+    - include: oneof
     - include: enum_START
     - include: reserved_START
     - include: messageBodyField
 
-  inlineOption_START:
+  inlineOption:
     - match: '\b(option)\b'
       scope: keyword.other.option.proto
       push:
@@ -459,7 +446,7 @@ contexts:
           scope: punctuation.terminator.proto
           pop: true
         - include: stringDouble
-    - include: inlineOption_START
+    - include: inlineOption
     - include: message_START
     - include: service_START
     - include: extend_START

--- a/Protocol-Buffer/Protocol-Buffer.sublime-syntax
+++ b/Protocol-Buffer/Protocol-Buffer.sublime-syntax
@@ -12,8 +12,6 @@ variables:
 
 contexts:
   prototype:
-    # Captured for practical reasons (keeps other patterns simpler)
-    - match: '\s+'
     - include: comments
 
   comments:
@@ -43,11 +41,7 @@ contexts:
     - match: $
       pop: true
 
-  closingBraceUnexpected_POP:
-    - match: '(?=\})' # Recover from a non complete assignment
-      pop: true
-
-  stringDouble:
+  string_double:
     - match: '"'
       scope: punctuation.definition.string.begin.proto
       push:
@@ -58,6 +52,8 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.proto
           pop: true
+        - match: (?=$)
+          pop: true
 
   enum:
     - match: '\b(enum)\b\s*{{ident}}'
@@ -66,7 +62,7 @@ contexts:
         2: entity.name.enum.proto
       push:
         - meta_scope: meta.enum.proto
-        - match: '\{'
+        - match: '{'
           scope: punctuation.definition.block.enum.begin.proto
           set: enum_body
         - include: or_pop
@@ -77,15 +73,13 @@ contexts:
       scope: punctuation.definition.block.enum.end.proto
       pop: true
     - include: option
-    - include: fieldAttributes
     - match: '{{ident}}'
       scope: support.variable.proto
-    - match: =
-      scope: keyword.operator.assignment.proto
-    - match: \d+
-      scope: constant.numeric.proto
-    - match: ';'
-      scope: punctuation.terminator.proto
+      push:
+        - terminator_or_pop
+        - field_attributes_or_pop
+        - number_or_pop
+        - assignment_or_pop
 
   oneof:
     - match: '\b(oneof)\b\s*{{ident}}'
@@ -93,18 +87,18 @@ contexts:
         1: storage.modifier.oneof.proto
         2: entity.name.member.proto
       push:
-        - match: '\{'
+        - meta_scope: meta.oneof.proto
+        - match: '{'
           scope: punctuation.definition.block.oneof.begin.proto
           set: oneof_body
         - include: or_pop
 
   oneof_body:
-    - meta_scope: meta.oneof.body.proto
     - match: '}'
       scope: punctuation.definition.block.oneof.end.proto
       pop: true
     - match: '(?=\S)'
-      push: [ messageField_END, field_name_POP, message_type_or_pop ]
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
 
   extend:
     - match: '\b(extend)\b'
@@ -112,7 +106,7 @@ contexts:
       push: [ extend_body_or_pop, message_type_or_pop]
 
   extend_body_or_pop:
-    - match: '\{'
+    - match: '{'
       scope: punctuation.definition.block.extend.begin.proto
       set:
         - meta_scope: meta.extend.body.proto
@@ -144,7 +138,7 @@ contexts:
         2: entity.name.class.proto
       push:
         - meta_scope: meta.service.proto
-        - match: '\{'
+        - match: '{'
           scope: punctuation.definition.block.service.begin.proto
           set:
             - meta_scope: meta.service.proto
@@ -181,7 +175,7 @@ contexts:
           push: message_type_or_pop
 
   rpc_body:
-    - match: '\{'
+    - match: '{'
       scope: punctuation.definition.block.rpc.begin.proto
       set:
         - meta_scope: meta.rpc.body.proto
@@ -202,7 +196,7 @@ contexts:
         2: entity.name.class.proto
       push:
         - meta_scope: meta.class.proto
-        - match: '\{'
+        - match: '{'
           scope: punctuation.definition.block.message.begin.proto
           set: messageBody
         - include: or_pop
@@ -240,27 +234,42 @@ contexts:
       scope: variable.type.proto
       pop: true
 
-  field_name_POP:
+  field_name_or_pop:
     - match: '{{ident}}'
       scope: variable.other.field.proto
       pop: true
-    - include: closingBraceUnexpected_POP
+    - include: or_pop
 
-  messageField_END:
-    - include: fieldAttributes
-    - match: ';'
+  assignment_or_pop:
+    - match: =
+      scope: keyword.operator.assignment.proto
+      pop: true
+    - include: or_pop
+
+  number_or_pop:
+    - match: \d+
+      scope: constant.numeric.proto
+      pop: true
+    - include: or_pop
+
+  terminator_or_pop:
+    - match: ;
       scope: punctuation.terminator.proto
       pop: true
-    - match: (=)\s*(\d+)
-      captures:
-        1: keyword.operator.assignment.proto
-        2: constant.numeric.proto
-    - include: closingBraceUnexpected_POP
+    - include: or_pop
 
-  fieldAttributes:
+  field_end_or_pop:
+    - match: ''
+      set:
+        - terminator_or_pop
+        - field_attributes_or_pop
+        - number_or_pop
+        - assignment_or_pop
+
+  field_attributes_or_pop:
     - match: '\['
       scope: punctuation.definition.attributes.begin.proto
-      push:
+      set:
         - meta_scope: meta.field.attributes.proto
         - match: \b(default|deprecated|packed)\b
           scope: support.function.proto
@@ -270,6 +279,7 @@ contexts:
           scope: punctuation.definition.attributes.end.proto
           pop: true
         - include: option_inline
+    - include: or_pop
 
   map_type:
     - match: ','
@@ -284,15 +294,15 @@ contexts:
     - match: '\b(optional|required|repeated)\b'
       captures:
         1: storage.modifier.proto
-      push: [ messageField_END, field_name_POP, message_type_or_pop ]
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
     - match: '\b(map)\b\s*\b(<)'
       captures:
-        1: storage.modifier.proto
+        1: support.type.map.proto
         2: punctuation.definition.map.begin.proto
-      push: [ messageField_END, field_name_POP, map_type ]
+      push: [ field_end_or_pop, field_name_or_pop, map_type ]
     # field are assumed 'optional' by default in proto3.
     - match: '(?=\S)'
-      push: [ messageField_END, field_name_POP, message_type_or_pop ]
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
 
   option:
     - match: '\b(option)\b'
@@ -338,7 +348,7 @@ contexts:
         - match: '}'
           scope: punctuation.definition.block.option.end.proto
           pop: true
-        - include: scope:text.prototxt#field
+        - include: scope:text.prototxt
     - include: scope:text.prototxt#field_value_or_pop
 
   main:
@@ -376,14 +386,14 @@ contexts:
         1: keyword.other.syntax.proto
         2: keyword.operator.assignment.proto
       push:
-        - include: stringDouble
+        - include: string_double
         - include: one_liner
     - match: '\b(import)\b\s*(weak|public)?\b'
       captures:
         1: keyword.other.import.proto
         2: storage.modifier.proto
       push:
-        - include: stringDouble
+        - include: string_double
         - include: one_liner
     - include: option
     - include: message

--- a/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
+++ b/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
@@ -1,4 +1,4 @@
-# SYNTAX TEST "Packages/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax"
+# SYNTAX TEST "Protocol-Buffer-Text.sublime-syntax"
 
 name: "player_1"
 # <- variable.other.member.prototxt
@@ -11,14 +11,17 @@ health: 100.0
 #       ^^^^^ constant.numeric.float.prototxt
 health: 100f
 #       ^^^^ constant.numeric.float.prototxt
+#          ^ punctuation.definition.numeric.float.prototxt
 health: 1e+2
 #       ^^^^ constant.numeric.float.prototxt
 xp: 4200   # normal digit
 #   ^^^^ constant.numeric.integer.prototxt
 xp: 04200  # octal
 #   ^^^^^ constant.numeric.octal.prototxt
+#   ^ punctuation.definition.numeric.octal.prototxt
 xp: 0xFFFF # hex
 #   ^^^^^^ constant.numeric.hex.prototxt
+#   ^^ punctuation.definition.numeric.hex.prototxt
 xp: -24
 #   ^^^ constant.numeric.integer.prototxt
 xp: +24
@@ -39,13 +42,17 @@ stats {
 }
 # <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
 
-stats {
+stats <
+# <- meta.message.prototxt variable.other.member.prototxt
+#     ^ punctuation.definition.dictionary.begin.prototxt
   key: "INT"
-  value {
+  value <
+    # <- meta.message.prototxt meta.message.prototxt variable.other.member.prototxt
+    #   ^ punctuation.definition.dictionary.begin.prototxt
     id: "INT"
     max_value: 20
-  }
-}
+  >
+>
 
 buffs: [BURNING, POISONED]
 # <- variable.other.member.prototxt
@@ -54,6 +61,11 @@ buffs: [BURNING, POISONED]
 #       ^^^^^^^ constant.numeric.enum.prototxt
 #                ^^^^^^^^ constant.numeric.enum.prototxt
 #                        ^ punctuation.definition.array.end.prototxt
-avatar: "aaabbbccc\c"
-#       ^^^^^^^^^^^^^ string.quoted.double.prototxt
+avatar: "aaabbb\nccc\c"
+#       ^^^^^^^^^^^^^^^ string.quoted.double.prototxt
+#              ^^ constant.character.escape.prototxt
+#                   ^^ invalid.illegal
+        "dddddddd"
+#       ^^^^^^^^^^ string.quoted.double.prototxt
+name: "Conan"
 alive: true

--- a/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
+++ b/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
@@ -28,9 +28,13 @@ xp: +24
 #   ^^^ constant.numeric.integer.prototxt
 xp: 0
 #   ^ constant.numeric.integer.prototxt
+xp: +Inf
+#   ^^^^ constant.language.prototxt
+xp: NaN
+#   ^^^ constant.language.prototxt
 
 stats {
-# <- meta.message.prototxt variable.other.member.prototxt
+# <- variable.other.member.prototxt
 #     ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
   key: "STR"
   value {
@@ -43,16 +47,18 @@ stats {
 # <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
 
 stats <
-# <- meta.message.prototxt variable.other.member.prototxt
-#     ^ punctuation.definition.dictionary.begin.prototxt
+# <- variable.other.member.prototxt
+#     ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
   key: "INT"
   value <
-    # <- meta.message.prototxt meta.message.prototxt variable.other.member.prototxt
-    #   ^ punctuation.definition.dictionary.begin.prototxt
+    # <- variable.other.member.prototxt
+    #   ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
     id: "INT"
     max_value: 20
   >
+# ^ punctuation.definition.dictionary.end.prototxt
 >
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
 
 buffs: [BURNING, POISONED]
 # <- variable.other.member.prototxt
@@ -67,5 +73,36 @@ avatar: "aaabbb\nccc\c"
 #                   ^^ invalid.illegal
         "dddddddd"
 #       ^^^^^^^^^^ string.quoted.double.prototxt
-name: "Conan"
+
+escaped_chars: "\x12  \" \' \u124"
+#               ^^^^ constant.character.escape.prototxt
+#                     ^^ constant.character.escape.prototxt
+#                        ^^ constant.character.escape.prototxt
+#                           ^^^^^ constant.character.escape.prototxt
+
+name: "Conan", name: "The barbar"
+#            ^ punctuation.separator.prototxt
+#              ^^^^ variable.other.member.prototxt
 alive: true
+
+[extension.field]: 20
+# <- punctuation.definition.field_name.begin.prototxt
+#^^^^^^^^^ variable.other.namespace.prototxt
+#         ^ punctuation.accessor.prototxt
+#          ^^^^^ variable.other.member.prototxt
+#               ^ punctuation.definition.field_name.end.prototxt
+#                ^ punctuation.separator.key-value.prototxt
+#                  ^^ constant.numeric.integer.prototxt
+
+[extension.field_message] {
+# <- punctuation.definition.field_name.begin.prototxt
+#^^^^^^^^^ variable.other.namespace.prototxt
+#         ^ punctuation.accessor.prototxt
+#          ^^^^^^^^^^^^^ variable.other.member.prototxt
+#                       ^ punctuation.definition.field_name.end.prototxt
+#                         ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+
+  value: 20
+#        ^^ constant.numeric.integer.prototxt
+}
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt

--- a/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
+++ b/Protocol-Buffer/tests/syntax_test_pbtxt.pbtxt
@@ -1,0 +1,59 @@
+# SYNTAX TEST "Packages/Protocol-Buffer/Protocol-Buffer-Text.sublime-syntax"
+
+name: "player_1"
+# <- variable.other.member.prototxt
+#   ^ punctuation.separator.key-value.prototxt
+#     ^ string.quoted.double.prototxt punctuation.definition.string.begin.prototxt
+#      ^^^^^^^^ string.quoted.double.prototxt
+health: 100.0
+# <- variable.other.member.prototxt
+#     ^ punctuation.separator.key-value.prototxt
+#       ^^^^^ constant.numeric.float.prototxt
+health: 100f
+#       ^^^^ constant.numeric.float.prototxt
+health: 1e+2
+#       ^^^^ constant.numeric.float.prototxt
+xp: 4200   # normal digit
+#   ^^^^ constant.numeric.integer.prototxt
+xp: 04200  # octal
+#   ^^^^^ constant.numeric.octal.prototxt
+xp: 0xFFFF # hex
+#   ^^^^^^ constant.numeric.hex.prototxt
+xp: -24
+#   ^^^ constant.numeric.integer.prototxt
+xp: +24
+#   ^^^ constant.numeric.integer.prototxt
+xp: 0
+#   ^ constant.numeric.integer.prototxt
+
+stats {
+# <- meta.message.prototxt variable.other.member.prototxt
+#     ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+  key: "STR"
+  value {
+    id: "STR"
+    max_value: 100
+    # <- meta.message.prototxt meta.message.prototxt variable.other.member.prototxt
+  }
+# ^ meta.message.prototxt meta.message.prototxt punctuation.definition.dictionary.end.prototxt
+}
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
+
+stats {
+  key: "INT"
+  value {
+    id: "INT"
+    max_value: 20
+  }
+}
+
+buffs: [BURNING, POISONED]
+# <- variable.other.member.prototxt
+#    ^ punctuation.separator.key-value.prototxt
+#      ^ punctuation.definition.array.begin.prototxt
+#       ^^^^^^^ constant.numeric.enum.prototxt
+#                ^^^^^^^^ constant.numeric.enum.prototxt
+#                        ^ punctuation.definition.array.end.prototxt
+avatar: "aaabbbccc\c"
+#       ^^^^^^^^^^^^^ string.quoted.double.prototxt
+alive: true

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -75,6 +75,7 @@ message Config {
 message LevelConfig {
   optional int32 max_level = 1 [default = 100];
   repeated uint64 xp_levels = 2 [packed=true];
+  optional int32 min_level = 3 [my_option="important"];
 }
 
 enum Buff {

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -11,6 +11,12 @@ import "escape_dungeon/weapons.proto";
 // <- keyword.other.import.proto
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.proto
 
+option java_package = "com.example.foo";
+// <- keyword.other.option.proto
+//     ^^^^^^^^^^^^ variable.annotation.proto
+//                  ^ keyword.operator.assignment.proto
+//                    ^^^^^^^^^^^^^^^^^ string
+
 message Player {
 // <- meta.class.proto storage.modifier.message.proto
 //      ^^^^^^ entity.name.class.proto
@@ -57,6 +63,10 @@ message Player {
     // <- storage.modifier.proto
     optional int32 max_value = 2;
     optional int32 value = 3 [(custom.annotation) = -1];
+    //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.field.attributes.proto
+    //                         ^^^^^^ variable.namespace.proto
+    //                                ^^^^^^^^^^ variable.annotation.proto
+    //                                              ^^ constant.numeric
   }
 
 // <- meta.class.proto -(meta.class.proto meta.class.proto)
@@ -74,8 +84,23 @@ message Config {
 
 message LevelConfig {
   optional int32 max_level = 1 [default = 100];
+  //                            ^^^^^^^ support.function.proto
+  //                                      ^^^ constant.numeric
   repeated uint64 xp_levels = 2 [packed=true];
-  optional int32 min_level = 3 [my_option="important"];
+  //                             ^^^^^^ support.function.proto
+  //                                    ^^^^ constant.language
+  optional int32 min_level = 3 [(str.option)="important"];
+  //                             ^^^ variable.namespace.proto
+  //                                 ^^^^^^ variable.annotation.proto
+  //                                         ^^^^^^^^^^^ string.quoted
+  optional int32 another_value = 4 [proto={ enum: FROZEN }];
+  //                                      ^^^^^^^^^^^^^^^^ meta.embedded.prototxt
+  //                                        ^^^^ variable.other.member.prototxt
+  //                                              ^^^^^^ meta.embedded.prototxt constant.numeric.enum.prototxt
+  optional int32 another_value = 4 [proto={ nested {} enum: FROZEN }];
+  //                                               ^^ meta.embedded.prototxt
+  optional int32 another_value = 4 [unset=];
+  //                                      ^ punctuation.definition.attributes.end.proto
 }
 
 enum Buff {

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -35,7 +35,7 @@ message Player {
   //       ^^^^^^ support.type.proto
 
   map<string, Stats> stats = 4;
-  // <- storage.modifier.proto
+  // <- support.type.map.proto
   //  ^^^^^^ support.type.proto
   //          ^^^^^ variable.type.proto
   //                 ^^^^^ variable.other.field.proto
@@ -46,6 +46,15 @@ message Player {
 
   optional bool alive = 8;
   //       ^^^^ support.type.proto
+
+  optional
+  // ^^^^^ storage.modifier.proto
+      very_long_namespace_name.VeryLongMessageType
+  //  ^^^^^^^^^^^^^^^^^^^^^^^^ variable.namespace.proto
+  //                           ^^^^^^^^^^^^^^^^^^^ meta.class.proto variable.type.proto
+          very_long_field_name = 9;
+  //      ^^^^^^^^^^^^^^^^^^^^ variable.other.field.proto
+
   reserved 42;
   // <- storage.modifier.reserved.proto
   //       ^^ constant.numeric.proto
@@ -89,10 +98,11 @@ message LevelConfig {
   repeated uint64 xp_levels = 2 [packed=true];
   //                             ^^^^^^ support.function.proto
   //                                    ^^^^ constant.language
-  optional int32 min_level = 3 [(str.option)="important"];
+  optional int32 min_level = 3 [(str.option)="important", (another)="foo"];
   //                             ^^^ variable.namespace.proto
   //                                 ^^^^^^ variable.annotation.proto
   //                                         ^^^^^^^^^^^ string.quoted
+  //                                                       ^^^^^^^ variable.annotation.proto
   optional int32 another_value = 4 [proto={ enum: FROZEN }];
   //                                      ^^^^^^^^^^^^^^^^ meta.embedded.prototxt
   //                                        ^^^^ variable.other.member.prototxt
@@ -109,11 +119,17 @@ enum Buff {
 
   option allow_alias = true;
   // <- keyword.other.option.proto
+  //     ^^^^^^^^^^^ variable.annotation.proto
+  //                 ^ keyword.operator.assignment.proto
+  //                   ^^^^ constant.language
 
   NO_BUFF = 0;
   FROZEN = 1;
   BURNING = 2;
-  POISONED = 2;
+  POISONED = 2 [(doc) = "Poisoned by a magic weapon."];
+  INVALID == 2;
+  //       ^ -keyword
+  //         ^ -constant
 }
 
 service PlayerService {

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -123,7 +123,9 @@ service PlayerService {
   //  ^^^^^^^^^ entity.name.function.rpc.proto
   //             ^^^^^^^^^^^^^ variable.type.proto
   //                            ^^^^^^^ keyword.other.returns.proto
+  //                                    ^ punctuation.definition.parameter.rpc.begin.proto
   //                                     ^^^^^^^^^^^^^^ variable.type.proto
+  //                                                   ^ punctuation.definition.parameter.rpc.end.proto
 
   rpc GetAllPlayers(AllPlayersRequest) returns (stream PlayerResponse) {
   // <- storage.modifier.rpc.proto

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -1,4 +1,4 @@
-// SYNTAX TEST "Packages/Protocol-Buffer/Protocol-Buffer.sublime-syntax"
+// SYNTAX TEST "Protocol-Buffer.sublime-syntax"
 syntax = "proto2";
 // <- keyword.other.syntax.proto
 //        ^^^^^^ string.quoted.double.proto

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -151,5 +151,25 @@ service PlayerService {
   //                                            ^^^^^^ storage.modifier
   //                                                   ^^^^^^^^^^^^^^ variable.type.proto
     option security_label = "read";
+    // <- meta.service.proto meta.rpc.body.proto
+    //     ^^^^^^^^^^^^^^ meta.service.proto meta.rpc.body.proto variable.annotation.proto
+    //                    ^ meta.service.proto meta.rpc.body.proto keyword.operator.assignment.proto
+    //                      ^^^^^^ meta.service.proto meta.rpc.body.proto string.quoted.double.prototxt
+    //                            ^ meta.service.proto meta.rpc.body.proto punctuation.terminator.option.proto
+    option deadline = 5.0;
+    // <- keyword.other.option.proto
+    //     ^^^^^^^^ variable.annotation.proto
+    //              ^ keyword.operator.assignment.proto
+    //                ^^^ constant.numeric.float.prototxt
+    //                   ^ punctuation.terminator.option.proto
+    option (method_doc) =
+    // <- keyword.other.option.proto
+    //      ^^^^^^^^^^ variable.annotation.proto
+    //                  ^ keyword.operator.assignment.proto
+        "Returns all the player."
+        "This documentation doesn't fit in one line,"
+        "nor in two.";
+    //   ^^^^^^^^^^^ string.quoted.double.prototxt
+    //               ^ punctuation.terminator.option.proto
   }
 }

--- a/Protocol-Buffer/tests/syntax_test_proto2.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto2.proto
@@ -1,0 +1,111 @@
+// SYNTAX TEST "Packages/Protocol-Buffer/Protocol-Buffer.sublime-syntax"
+syntax = "proto2";
+// <- keyword.other.syntax.proto
+//        ^^^^^^ string.quoted.double.proto
+
+package escape_dungeon;
+// <- keyword.other.namespace.proto
+//      ^^^^^^^^^^^^^^ entity.name.namespace.proto
+
+import "escape_dungeon/weapons.proto";
+// <- keyword.other.import.proto
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.proto
+
+message Player {
+// <- meta.class.proto storage.modifier.message.proto
+//      ^^^^^^ entity.name.class.proto
+
+  required string name = 1;
+  // ^^^^^ storage.modifier.proto
+  //       ^^^^^^ support.type.proto
+  //              ^^^^ variable.other.field.proto
+  //                   ^ keyword.operator.assignment.proto
+  //                     ^ constant.numeric.proto
+  //                      ^ punctuation.terminator.proto
+  optional float health = 2;
+  //       ^^^^^ support.type.proto
+
+  optional uint64 xp = 3;
+  //       ^^^^^^ support.type.proto
+
+  map<string, Stats> stats = 4;
+  // <- storage.modifier.proto
+  //  ^^^^^^ support.type.proto
+  //          ^^^^^ variable.type.proto
+  //                 ^^^^^ variable.other.field.proto
+  repeated Buff buffs = 5;
+  repeated escape_dungeon.Weapon weapons = 6;
+  optional bytes avatar = 7;
+  //       ^^^^^ support.type.proto
+
+  optional bool alive = 8;
+  //       ^^^^ support.type.proto
+  reserved 42;
+  // <- storage.modifier.reserved.proto
+  //       ^^ constant.numeric.proto
+  reserved 100 to 200;
+  // <- storage.modifier.reserved.proto
+  //       ^^^ constant.numeric.proto
+  //           ^^ keyword.other.to.proto
+  //              ^^^ constant.numeric.proto
+
+  // Stats describing the user characteristic (Strenght, Intelligence, ...).
+  // <- comment.line.proto punctuation.definition.comment.begin.proto
+  message Stats {
+  // <- meta.class.proto meta.class.proto storage.modifier.message.proto
+    required string id = 1;
+    // <- storage.modifier.proto
+    optional int32 max_value = 2;
+    optional int32 value = 3 [(custom.annotation) = -1];
+  }
+
+// <- meta.class.proto -(meta.class.proto meta.class.proto)
+}
+
+// <- - meta.class.proto
+
+message Config {
+  oneof config {
+    StatConfig stat = 1;
+    LevelConfig level = 2;
+    WeaponConfig weapon = 3;
+  }
+}
+
+message LevelConfig {
+  optional int32 max_level = 1 [default = 100];
+  repeated uint64 xp_levels = 2 [packed=true];
+}
+
+enum Buff {
+// <- meta.enum.proto storage.modifier.enum.proto
+//   ^^^^ entity.name.enum.proto
+
+  option allow_alias = true;
+  // <- keyword.other.option.proto
+
+  NO_BUFF = 0;
+  FROZEN = 1;
+  BURNING = 2;
+  POISONED = 2;
+}
+
+service PlayerService {
+// <- meta.service.proto storage.modifier.service.proto
+  rpc GetPlayer (PlayerRequest) returns (PlayerResponse);
+  // <- storage.modifier.rpc.proto
+  //  ^^^^^^^^^ entity.name.function.rpc.proto
+  //             ^^^^^^^^^^^^^ variable.type.proto
+  //                            ^^^^^^^ keyword.other.returns.proto
+  //                                     ^^^^^^^^^^^^^^ variable.type.proto
+
+  rpc GetAllPlayers(AllPlayersRequest) returns (stream PlayerResponse) {
+  // <- storage.modifier.rpc.proto
+  //  ^^^^^^^^^^^^^ entity.name.function.rpc.proto
+  //                ^^^^^^^^^^^^^^^^^ variable.type.proto
+  //                                   ^^^^^^^ keyword.other
+  //                                            ^^^^^^ storage.modifier
+  //                                                   ^^^^^^^^^^^^^^ variable.type.proto
+    option security_label = "read";
+  }
+}

--- a/Protocol-Buffer/tests/syntax_test_proto3.proto
+++ b/Protocol-Buffer/tests/syntax_test_proto3.proto
@@ -1,0 +1,29 @@
+// SYNTAX TEST "Protocol-Buffer.sublime-syntax"
+syntax = "proto3";
+// <- keyword.other.syntax.proto
+//        ^^^^^^ string.quoted.double.proto
+
+import public "escape_dungeon/weapons.proto";
+// <- keyword.other.import.proto
+//     ^^^^^^ storage.modifier.proto
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.proto
+
+message Player {
+
+  required string name = 1;
+  // ^^^^^ storage.modifier.proto
+  //       ^^^^^^ support.type.proto
+  //              ^^^^ variable.other.field.proto
+  //                   ^ keyword.operator.assignment.proto
+  //                     ^ constant.numeric.proto
+  //                      ^ punctuation.terminator.proto
+
+  float health = 2;
+  // <- support.type.proto
+  //    ^^^^^^ variable.other.field.proto
+  //           ^ keyword.operator.assignment.proto
+  //             ^ constant.numeric.proto
+  //              ^ punctuation.terminator.proto
+}
+
+// Proto3 is really similar to Proto2 so no more tests here.


### PR DESCRIPTION
Syntax for Protocol Buffer definition files and Protobuff serialized as text.

Works with proto2 and proto3.
See official Protobuff documentation at https://developers.google.com/protocol-buffers/docs/proto3

There is no official documentation for the text format but it works with the official c++ implementation of the parser.