### PR TITLE
[Go] Fix potential YAML syntax problem

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -253,7 +253,7 @@ contexts:
     {match: \-   , scope: keyword.operator.go},
     {match: /=   , scope: keyword.operator.assignment.go},
     {match: /    , scope: keyword.operator.go},
-    {match: :=   , scope: keyword.operator.assignment.go},
+    {match: ':=' , scope: keyword.operator.assignment.go},
     {match: <-   , scope: keyword.operator.go},
     {match: <    , scope: keyword.operator.go},
     {match: <<=  , scope: keyword.operator.assignment.go},


### PR DESCRIPTION
The YAML 1.2 parser we use in syntect has a problem handling the unquoted syntax, see https://github.com/trishume/syntect/issues/228

I also tried an [online parser that is based on pyyaml](http://yaml-online-parser.appspot.com/) where it results in this error:

```
while parsing a flow node
expected the node content, but found ':'
  in "<unicode string>", line 2, column 11:
      {match: :=   , scope: keyword.operator.a ... 
```

Ping @keith-hall :)