### PR TITLE
[HTML] Fix script-html context exit

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -381,8 +381,9 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - meta_content_scope: text.html.embedded.html
-        - include: main
+        - include: comment
         - include: script-close-tag
+        - include: main
 
   script-other:
     - meta_content_scope: meta.tag.script.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -83,6 +83,7 @@
         </script>
 ##     ^ text.html.basic text.html.embedded.html
 ##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.script.end
+##               ^ text.html.basic - text.html.embedded.html
 
         <script>42</script >
 ##      ^^^^^^^^ meta.tag.script.begin


### PR DESCRIPTION
Fixes #1827

This commit reorders the `script-html` context. The `script-close-tag` context needs to be called before `main` to pop off correctly. As it introduces an issue with html comments not being highlighted correctly
within the embedded <html> ... </html> block anymore, the `comment` context is included before `main` as well.