### PR TITLE
[Bash] Add .zlogin, .zlogout, .zprofile, .zshenv extension

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -23,6 +23,10 @@ file_extensions:
   - .bashrc
   - .profile
   - .textmate_init
+  - .zlogin
+  - .zlogout
+  - .zprofile
+  - .zshenv
   - .zshrc
   - PKGBUILD  # https://jlk.fjfi.cvut.cz/arch/manpages/man/PKGBUILD.5
   - .ebuild


### PR DESCRIPTION
Closes #1834

According to https://unix.stackexchange.com/questions/71253/what-should-shouldnt-go-in-zshenv-zshrc-zlogin-zprofile-zlogout all the mentioned file extensions belong to the zsh ecosystem as well es the already supported .zshrc file extension. So we could safely support them.