### PR TITLE
[Go] support positional fmt placeholders

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -501,7 +501,7 @@ contexts:
   # false positives in non-fmt strings that just happen to contain %, but don't
   # want too much coupling with the current version of fmt.
   match-fmt:
-    - match: '\%[ .\d#+-]*[A-Za-z]'
+    - match: '\%(?:\[\d+\])?[ .\d#+-]*[A-Za-z]'
       scope: constant.other.placeholder.go
 
   match-keyword-break:

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1968,6 +1968,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     "one %1.2d two"
 //  ^^^^^^^^^^^^^^^ string.quoted.double.go
 //       ^^^^^ constant.other.placeholder.go
+    "one %[1] two"
+//  ^^^^^^^^^^^ string.quoted.double.go
+//       ^^^^^^ constant.other.placeholder.go
+    "one %[1]v two"
+//  ^^^^^^^^^^^^ string.quoted.double.go
+//       ^^^^^ constant.other.placeholder.go
+    "one %[1]+v two"
+//  ^^^^^^^^^^^^^ string.quoted.double.go
+//       ^^^^^^ constant.other.placeholder.go
+    "one %[1]1.2d two"
+//  ^^^^^^^^^^^^^^^ string.quoted.double.go
+//       ^^^^^^^^ constant.other.placeholder.go
     "%"
 //  ^^^ string.quoted.double.go
 //   ^ -constant.other.placeholder
@@ -2026,6 +2038,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     `one %1.2d two`
 //  ^^^^^^^^^^^^^^^ string.quoted.other.go
 //       ^^^^^ constant.other.placeholder.go
+    `one %[1] two`
+//  ^^^^^^^^^^^ string.quoted.other.go
+//       ^^^^^^ constant.other.placeholder.go
+    `one %[1]v two`
+//  ^^^^^^^^^^^^ string.quoted.other.go
+//       ^^^^^ constant.other.placeholder.go
+    `one %[1]+v two`
+//  ^^^^^^^^^^^^^ string.quoted.other.go
+//       ^^^^^^ constant.other.placeholder.go
+    `one %[1]1.2d two`
+//  ^^^^^^^^^^^^^^^ string.quoted.other.go
+//       ^^^^^^^^ constant.other.placeholder.go
     `%`
 //  ^^^ string.quoted.other.go
 //   ^ -constant.other.placeholder


### PR DESCRIPTION
Adds missing support for positional `fmt` placeholders:

```go
fmt.Printf("%[1]v = %[1]v", "blah")
```

Addresses #1804.