### PR TITLE
[Rust] Fix raw string punctuation

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -1002,14 +1002,14 @@ contexts:
           scope: punctuation.separator.continuation.line.rust
 
   raw-string:
-    - match: (r)(#*)"
+    - match: (r)((#*)")
       captures:
         1: storage.type.string.rust
         2: punctuation.definition.string.begin.rust
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.raw.rust
-        - match: '"\2'
+        - match: '"\3'
           scope: punctuation.definition.string.end.rust
           pop: true
 

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -42,11 +42,14 @@ let s = "This is a string \x01_\u{007F}_\"_\'_\\_\r_\n_\t_\0";
 //                                                  ^^ constant.character.escape
 //                                                     ^^ constant.character.escape
 //                                                        ^^ constant.character.escape
-let r = r#"This is a raw string, no escapes! \x00 \0 \n"#;
+let r = r##"This is a raw string, no escapes! \x00 \0 \n"###;
 // <- storage.type
 //    ^ keyword.operator
 //      ^ storage.type
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double - constant.character.escape
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw - constant.character.escape
+//       ^^^ punctuation.definition.string.begin.rust
+//                                                      ^^^ punctuation.definition.string.end.rust
+//                                                         ^ - string
 
 let bytes = b"This won't escape unicode \u{0123}, but will do \x01_\"_\'_\\_\r_\n_\t_\0";
 // <- storage.type


### PR DESCRIPTION
The opening `"` wasn't included previously.