### PR TITLE
[Scala] Arrow scoping unification

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -197,7 +197,7 @@ contexts:
 
   lambdas:
     # lambda lookahead
-    - match: '(?=({{idorunder}}|{{idorunder}}\s*:(\s*{{id}}\s*{{withinbrackets}}?(\s*[\.#]\s*{{id}}\s*{{withinbrackets}}?)*)+|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
+    - match: '(?=({{idorunder}}|{{idorunder}}\s*:(\s*{{id}}\s*{{withinbrackets}}?(\s*[\.#]\s*{{id}}\s*{{withinbrackets}}?)*)+|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})(?:/\*|//|[[[:alpha:]]0-9\s\)\]\}]))'
       push:
         - match: '{{rightarrow}}'
           scope: storage.type.function.arrow.lambda.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -200,7 +200,7 @@ contexts:
     - match: '(?=({{idorunder}}|{{idorunder}}\s*:(\s*{{id}}\s*{{withinbrackets}}?(\s*[\.#]\s*{{id}}\s*{{withinbrackets}}?)*)+|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})[[[:alpha:]]0-9\s\)\]\}])'
       push:
         - match: '{{rightarrow}}'
-          scope: storage.type.function.arrow.scala
+          scope: storage.type.function.arrow.lambda.scala
           pop: true
         - include: lambda-declaration
   lambda-declaration-base:
@@ -362,14 +362,14 @@ contexts:
             1: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
-              scope: keyword.operator.arrow.scala
+              scope: storage.type.function.arrow.case.scala
               set: case-body-first
             - include: main-no-lambdas
         # eliminates arrow from the pattern meta scope
         - match: '(?={{rightarrow}})'
           set:
             - match: '{{rightarrow}}'
-              scope: keyword.operator.arrow.scala
+              scope: storage.type.function.arrow.case.scala
               set: case-body-first
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
@@ -422,14 +422,14 @@ contexts:
             1: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
-              scope: keyword.operator.arrow.scala
+              scope: storage.type.function.arrow.case.scala
               set: case-body-non-first
             - include: main-no-lambdas
         # eliminates arrow from the pattern meta scope
         - match: '(?={{rightarrow}})'
           set:
             - match: '{{rightarrow}}'
-              scope: keyword.operator.arrow.scala
+              scope: storage.type.function.arrow.case.scala
               set: case-body-non-first
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1838,3 +1838,11 @@ val x: Nothing
 fold(a => b, { case c => d })
 //     ^^ storage.type.function.arrow.lambda.scala
 //                    ^^ storage.type.function.arrow.case.scala
+
+gzis =>/* foo */
+//   ^^ storage.type.function.arrow.lambda.scala
+//     ^^^^^^^^^ comment.block.scala
+
+gzis =>// foo
+//   ^^ storage.type.function.arrow.lambda.scala
+//     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -447,14 +447,14 @@ type Foo = Bar[A] forSome { type A }
 //            ^^^ support.class
 //                 ^^^ variable.parameter
 //                       ^ variable.language.underscore.scala
-//                          ^^ keyword.operator.arrow.scala
+//                          ^^ storage.type.function.arrow.case.scala
 
    case abc @ `abc` =>
 //      ^^^ variable.parameter
 //          ^ keyword.operator.at.scala
 //            ^ punctuation.definition.identifier.scala
 //                ^ punctuation.definition.identifier.scala
-//                  ^^ keyword.operator.arrow.scala
+//                  ^^ storage.type.function.arrow.case.scala
 //            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
@@ -790,7 +790,7 @@ type Foo >: Bar
    case _ if thing =>
 // ^^^^ keyword.other.declaration.scala
 //           ^^^^^ - variable.parameter
-//                 ^^ - storage.type.function.arrow
+//                 ^^ - keyword
 }
 
    a =>a
@@ -1077,7 +1077,7 @@ val Stuff(thing, other) = ???
 
    x: List[Int] => ()
 // ^ variable.parameter.scala
-//              ^^ storage.type.function.arrow.scala
+//              ^^ storage.type.function.arrow.lambda.scala
 
 /** private */ class Foo
 //             ^^^^^ storage.type.class
@@ -1230,11 +1230,11 @@ def foo: Map[Bar]=42
 
    x: Foo.Bar => ()
 // ^ variable.parameter.scala
-//            ^^ storage.type.function.arrow.scala
+//            ^^ storage.type.function.arrow.lambda.scala
 
    x: Foo#Bar => ()
 // ^ variable.parameter.scala
-//            ^^ storage.type.function.arrow.scala
+//            ^^ storage.type.function.arrow.lambda.scala
 
     object Stuff {
       case
@@ -1252,13 +1252,13 @@ def foo: Map[Bar]=42
 
 for {
   abc = () => 42
-//         ^^ storage.type.function.arrow.scala
+//         ^^ storage.type.function.arrow.lambda.scala
 }
 
 
 for (
   abc = () => 42
-//         ^^ storage.type.function.arrow.scala
+//         ^^ storage.type.function.arrow.lambda.scala
 )
 
 new {
@@ -1834,3 +1834,7 @@ val x: AnyVal
 
 val x: Nothing
 //     ^^^^^^^ storage.type.primitive.scala
+
+fold(a => b, { case c => d })
+//     ^^ storage.type.function.arrow.lambda.scala
+//                    ^^ storage.type.function.arrow.case.scala


### PR DESCRIPTION
This is a slightly bigger change than I normally do, at least in terms of concept. Most of my PRs are effectively bug fixes, or just refining functionality that already exists. Here I'm *changing* the scope of an existing and very common construct, and I want to be quite clear that this is intentional and *why* I think this is a good idea. Flagging specifically so you can consider this as such, @wbond.

Here's what I'm changing:

```scala
foo match {
  case bar => ???
//         ^^ storage.type.function.arrow.case.scala
}
```

The assertion above is the *new* scope. It was previously `keyword.operator.arrow.scala`. While there's nothing particularly *wrong* with the `keyword` scope here, it is inconsistent. The following is valid:

```scala
either.fold(
  x => 42,
  { case y => 24 })
```

Both the second and third lines represent lambda expressions. In the second line, the `=>` is scoped the same as it is in the JavaScript mode, which is `storage.type.function.arrow`. The third line, prior to my change, scoped the `=>` as `keyword.operator`. These are semantically almost identical constructs, and it really seemed a bit strange to me when I saw them side by side like this and realized that they were inconsistent.

To that end, I've rescoped the lambda arrows a bit and rescoped the `case` arrows a *lot*. Adding assertions to the above for documentation:

```scala
either.fold(
  x => 42,
//  ^^ storage.type.function.arrow.lambda.scala
  { case y => 24 })
//         ^^ storage.type.function.arrow.case.scala
```

People who really want the old coloring can do so by modifying their color scheme, since they still have distinct scopes, but *by default* they will be styled uniformly. I think this is better all around.

Oh, I also threw in a bug fix for good measure, since lambda lookahead was broken with comments that weren't separate by whitespace.