### PR TITLE
[SQL] handle schemas when scoping `create table` etc., for a more accurate symbol list

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -9,15 +9,16 @@ scope: source.sql
 contexts:
   main:
     - include: comments
-    - match: '(?i:\s*\b(create(?:\s+or\s+replace)?)\s+(aggregate|conversion|database|domain|function|group|(?:unique\s+)?index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\s+)(?:(\w+)|''(\w+)''|"(\w+)"|`(\w+)`)'
+    - match: |-
+        (?xi)
+        \b(create(?:\s+or\s+replace)?)\s+
+        (aggregate|conversion|database|domain|function|group|(?:unique\s+)?index|language|operator class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
+        \b\s*
       scope: meta.create.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
-        3: entity.name.function.sql
-        4: entity.name.function.sql
-        5: entity.name.function.sql
-        6: entity.name.function.sql
+      push: identifier_create
     - match: (?i:\s*\b(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))
       scope: meta.drop.sql
       captures:
@@ -38,23 +39,23 @@ contexts:
     - match: |-
         (?xi)
 
-        				# normal stuff, capture 1
-        				 \b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|datetime|double\sprecision|inet|int|integer|line|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text)\b
+                # normal stuff, capture 1
+                 \b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|datetime|double\sprecision|inet|int|integer|line|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text)\b
 
-        				# numeric suffix, capture 2 + 3i
-        				|\b(bit\svarying|character\s(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)
+                # numeric suffix, capture 2 + 3i
+                |\b(bit\svarying|character\s(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)
 
-        				# optional numeric suffix, capture 4 + 5i
-        				|\b(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
+                # optional numeric suffix, capture 4 + 5i
+                |\b(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
 
-        				# special case, capture 6 + 7i + 8i
-        				|\b(numeric|decimal)\b(?:\((\d+),(\d+)\))?
+                # special case, capture 6 + 7i + 8i
+                |\b(numeric|decimal)\b(?:\((\d+),(\d+)\))?
 
-        				# special case, captures 9, 10i, 11
-        				|\b(times?)\b(?:\((\d+)\))?(\swith(?:out)?\stime\szone\b)?
+                # special case, captures 9, 10i, 11
+                |\b(times?)\b(?:\((\d+)\))?(\swith(?:out)?\stime\szone\b)?
 
-        				# special case, captures 12, 13, 14i, 15
-        				|\b(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\stime\szone\b)?
+                # special case, captures 12, 13, 14i, 15
+                |\b(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\stime\szone\b)?
 
 
       captures:
@@ -222,3 +223,14 @@ contexts:
             0: punctuation.definition.string.end.sql
           pop: true
         - include: string_interpolation
+  identifier_create:
+    - meta_content_scope: entity.name.function.sql
+    - match: \w+
+    - match: \'[^']+\'
+    - match: \"[^"]+\"
+    - match: \`[^`]+\`
+    - match: \.
+      scope: punctuation.accessor.dot.sql
+    - match: \s*(?=[\w'"`.])
+    - match: ''
+      pop: true

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -9,6 +9,29 @@ SELECT "My "" Crazy Column Name" FROM my_table;
 ;CREATE TABLE foo (id INTEGER PRIMARY KEY);
  -- <- keyword.other.create
 --^^^^^ keyword.other.create
+--      ^^^^^ keyword.other
+--            ^^^ entity.name.function
+--               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - entity.name.function
+
+create table some_schema.test2( id serial );
+--^^^^ meta.create keyword.other.create
+--     ^^^^^ meta.create keyword.other
+--           ^^^^^^^^^^^^^^^^^ entity.name.function
+--                      ^ punctuation.accessor.dot
+--                            ^^^^^^^^^^^^^^^ - entity.name.function
+
+create table "testing123" (id integer);
+--^^^^ meta.create keyword.other.create
+--     ^^^^^ meta.create keyword.other
+--           ^^^^^^^^^^^^ entity.name.function
+--                       ^^^^^^^^^^^^^^^ - entity.name.function
+
+create table `dbo`."testing123" (id integer);
+--^^^^ meta.create keyword.other.create
+--     ^^^^^ meta.create keyword.other
+--           ^^^^^^^^^^^^^^^^^^ entity.name.function
+--                ^ punctuation.accessor.dot
+--                             ^^^^^^^^^^^^^^^ - entity.name.function
 
 SELECT
 (


### PR DESCRIPTION
Fixes #1844 