### PR TITLE
[Scala] Fix overly-greedy consumption of ' character in string contexts

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1057,6 +1057,11 @@ contexts:
       scope: constant.other.formatting.scala
 
   interpolated-vars-expressions:
+    # we duplicate this pattern to encode a greedy ? on the [']
+    - match: '(\$)({{alphaid}})['']'
+      captures:
+        1: punctuation.definition.variable.scala variable.other.scala
+        2: variable.other.scala
     - match: '(\$){{alphaid}}'
       scope: variable.other.scala
       captures:

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1834,3 +1834,7 @@ val x: AnyVal
 
 val x: Nothing
 //     ^^^^^^^ storage.type.primitive.scala
+
+s"testing '$foo' bar"
+//        ^ string.quoted.interpolated.scala - variable
+//             ^ string.quoted.interpolated.scala - variable


### PR DESCRIPTION
Unit test gives a good example. It's a relatively common pattern in Scala, as in many languages, to use interpolated strings in the following way:

```scala
val x = "Daniel"
println(s"x = '$x'; printing it out!")
```

Note the quoting around the interpolated variable. That's not syntax: it's just, part of the string. Unfortunately, Scala identifiers can contain trailing `'` characters in Typelevel Scala (and this has been proposed as a change to upstream). The Sublime scala mode deals with this correctly, but what it *doesn't* do is correctly handle the situation where it appears within an interpolated string. It's kind of an edge case, but given the popularity of this particular syntactic pattern, one that is well worth addressing.

The Scala compiler appears to ignore trailing `'` characters within interpolated identifiers. It may not even support them *at all* within interpolated strings, but it's hard to say for certain without digging into the compiler source code. For the time being, I'm resolving this by forcing a greedy match on any trailing `'` characters within interpolated identifiers.