### PR TITLE
[Scala] Added missing var scope override for class parameters

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -593,6 +593,8 @@ contexts:
           pop: true
         - match: '\b(val)\b'
           scope: storage.type.scala
+        - match: '\b(var)\b'
+          scope: storage.type.volatile.scala
         - match: '({{alphaid}})(?=\s*:)'
           captures:
             1: variable.parameter.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1834,3 +1834,9 @@ val x: AnyVal
 
 val x: Nothing
 //     ^^^^^^^ storage.type.primitive.scala
+
+  class Context(var abc: Boolean, val fed: Int)
+//              ^^^ storage.type.volatile.scala
+//                  ^^^ variable.parameter.scala
+//                                ^^^ storage.type.scala
+//                                    ^^^ variable.parameter.scala


### PR DESCRIPTION
Without this override, `var` and `val` parameters were scoped inconsistently (with only `val` being consistent with unmodified params).