### PR TITLE
[Scala] Dispatch can immediately follow braces

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -458,7 +458,7 @@ contexts:
         - meta_scope: meta.group.scala
         - match: \)
           scope: punctuation.section.group.end.scala
-          pop: true
+          set: try-dispatch
         - include: main
     - match: \{
       scope: punctuation.section.block.begin.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1834,3 +1834,6 @@ val x: AnyVal
 
 val x: Nothing
 //     ^^^^^^^ storage.type.primitive.scala
+
+(abc)()
+//   ^^ - constant


### PR DESCRIPTION
The tests are valid Scala. For example:

```scala
val abc: () => Unit = () => println("hello, world")
(abc)()
```

This prints "hello, world". Before my fix, the `()` on the second line would scope the same as if it were on the line by itself (i.e. as a `constant`).