### PR TITLE
[ShellScript] Control Structure Improvements

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -187,7 +187,7 @@ contexts:
       scope:  keyword.control.loop.until.shell
     - match: \bcase{{keyword_boundary_end}}
       scope: keyword.control.conditional.case.shell
-      set: [case-clause-commands, case-clause-patterns, case-clause-patterns-first-character, case-word]
+      set: [case-body, case-word]
     - match: \bcontinue{{keyword_boundary_end}}
       scope: keyword.control.flow.continue.shell
     - match: \bbreak{{keyword_boundary_end}}
@@ -199,6 +199,31 @@ contexts:
       scope: keyword.control.in.shell
       pop: true
     - include: expansion-and-string
+
+  case-body:
+    - meta_scope: meta.conditional.case.shell
+    - match: \besac\b
+      scope: keyword.control.conditional.end.shell
+      pop: true
+    - match: (?=\()
+      push:
+        - clear_scopes: 1  # remove meta.conditional.case.shell
+        - match: \(
+          scope: keyword.control.conditional.patterns.begin.shell
+          set: case-clause-patterns
+    - match: (?=\S)
+      push: case-clause-patterns
+
+  case-clause-patterns:
+    - clear_scopes: 1  # remove meta.conditional.case.shell
+    - meta_scope: meta.conditional.case.clause.patterns.shell
+    - match: \)
+      scope: keyword.control.conditional.patterns.end.shell
+      set: case-clause-commands
+    # emergency pop off if ')' is missing
+    - match: (?=\besac\b|;;&?|;&)
+      pop: true
+    - include: case-clause-patterns-body
 
   case-clause-patterns-body:
     # [Bash] 3.2.4.2: Each pattern undergoes tilde expansion, parameter
@@ -213,54 +238,23 @@ contexts:
       scope: keyword.operator.logical.shell
     - match: \(
       scope: punctuation.section.parens.begin.shell
-      push: case-clause-patterns-inside
-
-  case-clause-patterns-inside:
-    - match: \)
-      scope: punctuation.section.parens.end.shell
-      pop: true
-    - include: case-clause-patterns-body
-
-  case-clause-patterns:
-    - match: \)
-      scope: keyword.control.conditional.pattern.end.shell
-      pop: true
-    - include: case-clause-patterns-body
-
-  case-clause-patterns-first-character:
-    - match: \(
-      scope: keyword.control.conditional.pattern.begin.shell
-      pop: true
-    - match: (?=\S)
-      pop: true
+      push:
+        - match: \)
+          scope: punctuation.section.parens.end.shell
+          pop: true
+        - include: case-clause-patterns-body
 
   case-clause-commands:
-    - match: \s*(;;&?|;&)
-      captures:
-        1: punctuation.terminator.case.clause.shell
-      set:
-        # An opening parenthesis is optional
-        - match: (?=\()
-          set:
-            - match: \(
-              scope: keyword.control.conditional.pattern.begin.shell
-              set: case-clause-commands-pattern
-        - match: (?=\S)
-          set: case-clause-commands-pattern
-    - match: \s*\b(esac)\b
-      captures:
-        1: keyword.control.conditional.end.shell
+    - clear_scopes: 1  # remove meta.conditional.case.shell
+    - meta_content_scope: meta.conditional.case.clause.commands.shell
+    - match: ;;&?|;&
+      scope:
+        meta.conditional.case.clause.commands.shell
+        punctuation.terminator.case.clause.shell
+      pop: true
+    - match: (?=\besac\b)
       pop: true
     - include: main
-
-  case-clause-commands-pattern:
-    - match: \besac\b
-      scope: keyword.control.conditional.end.shell
-      pop: true
-    - match: \)
-      scope: keyword.control.conditional.pattern.end.shell
-      set: case-clause-commands
-    - include: case-clause-patterns-body
 
   # I don't think anybody will write a for-loop inside backticks. Hence no
   # for-args-bt context.

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1336,6 +1336,10 @@ contexts:
   operator-exclamation:
     - match: \!(?!\S)
       scope: keyword.operator.logical.shell
+    - match: (\!)(-?\d+|!)
+      scope: variable.language.history.shell
+      captures:
+        1: punctuation.definition.history.shell
     - match: \!
       scope: punctuation.definition.history.shell
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -155,17 +155,15 @@ contexts:
       push: cmd-bt
 
   control:
-    - match: \b(if){{keyword_break}}(?:\s*(!))?
-      captures:
-        1: keyword.control.conditional.if.shell
-        2: keyword.operator.logical.shell
+    - match: \bif{{keyword_break}}
+      scope: keyword.control.conditional.if.shell
+      set: maybe-operator-logical
     - match: \bthen{{keyword_break}}
       scope: keyword.control.conditional.then.shell
       pop: true
-    - match: \b(elif){{keyword_break}}(?:\s*(!))?
-      captures:
-        1: keyword.control.conditional.elseif.shell
-        2: keyword.operator.logical.shell
+    - match: \belif{{keyword_break}}
+      scope: keyword.control.conditional.elseif.shell
+      set: maybe-operator-logical
     - match: \bfi{{keyword_break}}
       scope: keyword.control.conditional.end.shell
       set: [cmd-post, cmd-args]
@@ -752,23 +750,23 @@ contexts:
         - match: '{{reset_semicolon}}'
           captures:
             1: keyword.operator.logical.continue.shell
-          pop: true
+          set: maybe-operator-logical
         - match: '{{reset_or}}'
           captures:
             1: keyword.operator.logical.or.shell
-          pop: true
+          set: maybe-operator-logical
         - match: '{{reset_pipe}}'
           captures:
             1: keyword.operator.logical.pipe.shell
-          pop: true
+          set: maybe-operator-logical
         - match: '{{reset_and}}'
           captures:
             1: keyword.operator.logical.and.shell
-          pop: true
+          set: maybe-operator-logical
         - match: '{{reset_job}}'
           captures:
             1: keyword.operator.logical.job.shell
-          pop: true
+          set: maybe-operator-logical
         - match: ""
           pop: true
 
@@ -1346,6 +1344,13 @@ contexts:
         - include: expansion-and-string
     - match: ==?|!=?|<|>|\|\||&&
       scope: keyword.operator.logical.shell
+
+  maybe-operator-logical:
+    - match: \!
+      scope: keyword.operator.logical.shell
+      pop: true
+    - match: $|(?=\S)
+      pop: true
 
   string:
     - include: string-quoted-double

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -206,7 +206,9 @@ contexts:
 
   case-body:
     - meta_scope: meta.conditional.case.shell
-    - include: case-end-ahead
+    - match: \besac{{keyword_break}}
+      scope: keyword.control.conditional.end.shell
+      pop: true
     - match: (?=\()
       push:
         - clear_scopes: 1  # remove meta.conditional.case.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -159,7 +159,7 @@ contexts:
       captures:
         1: keyword.control.conditional.if.shell
         2: keyword.operator.logical.shell
-    - match: \bthen\b
+    - match: \bthen{{keyword_break}}
       scope: keyword.control.conditional.then.shell
       pop: true
     - match: \b(elif){{keyword_break}}(?:\s*(!))?

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -193,6 +193,9 @@ contexts:
     - match: \bbreak{{keyword_break}}
       scope: keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]
+    - match: \besac{{keyword_break}}
+      scope: keyword.control.conditional.end.shell
+      pop: true
 
   case-word:
     - match: \bin{{keyword_break}}
@@ -203,9 +206,7 @@ contexts:
 
   case-body:
     - meta_scope: meta.conditional.case.shell
-    - match: \besac{{keyword_break}}
-      scope: keyword.control.conditional.end.shell
-      pop: true
+    - include: case-end-ahead
     - match: (?=\()
       push:
         - clear_scopes: 1  # remove meta.conditional.case.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1334,7 +1334,7 @@ contexts:
       scope: keyword.operator.logical.shell
 
   operator-exclamation:
-    - match: \!(?=\s)
+    - match: \!(?!\S)
       scope: keyword.operator.logical.shell
     - match: \!(?=\S)
       scope: punctuation.definition.history.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -65,7 +65,7 @@ variables:
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
   keyword_break_char: '[^-=\w]'
-  keyword_break: (?={{keyword_break_char}})
+  keyword_break: (?![-=\w])
 
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters: ‘|’, ‘&’, ‘;’,
@@ -165,7 +165,7 @@ contexts:
       pop: true
     - match: \b(elif){{keyword_break}}(?:\s*(!))?
       captures:
-        1: keyword.control.conditional.elif.shell
+        1: keyword.control.conditional.elseif.shell
         2: keyword.operator.logical.shell
     - match: \bfi{{keyword_break}}
       scope: keyword.control.conditional.end.shell
@@ -180,7 +180,7 @@ contexts:
       scope: keyword.control.loop.do.shell
       pop: true
     - match: \bdone{{keyword_break}}
-      scope: keyword.control.loop.done.shell
+      scope: keyword.control.loop.end.shell
       set: [cmd-post, cmd-args]
     - match: \bwhile{{keyword_break}}
       scope: keyword.control.loop.while.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -64,8 +64,8 @@ variables:
   is_path_component: (?=[^\s/]*/)
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
-  keyword_boundary_char: '[^-=\w]'
-  keyword_boundary_end: (?={{keyword_boundary_char}})
+  keyword_break_char: '[^-=\w]'
+  keyword_break: (?={{keyword_break_char}})
 
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters: ‘|’, ‘&’, ‘;’,
@@ -156,54 +156,54 @@ contexts:
       push: cmd-bt
 
   control:
-    - match: \b(if){{keyword_boundary_end}}(?:\s*(!))?
+    - match: \b(if){{keyword_break}}(?:\s*(!))?
       captures:
         1: keyword.control.conditional.if.shell
         2: keyword.operator.logical.shell
     - match: \bthen\b
       scope: keyword.control.conditional.then.shell
       pop: true
-    - match: \b(elif){{keyword_boundary_end}}(?:\s*(!))?
+    - match: \b(elif){{keyword_break}}(?:\s*(!))?
       captures:
         1: keyword.control.conditional.elif.shell
         2: keyword.operator.logical.shell
-    - match: \bfi{{keyword_boundary_end}}
+    - match: \bfi{{keyword_break}}
       scope: keyword.control.conditional.end.shell
       set: [cmd-post, cmd-args]
-    - match: \belse{{keyword_boundary_end}}
+    - match: \belse{{keyword_break}}
       scope: keyword.control.conditional.else.shell
       pop: true
-    - match: \bfor{{keyword_boundary_end}}
+    - match: \bfor{{keyword_break}}
       scope: keyword.control.loop.for.shell
       set: [cmd-post, for-args]
-    - match: \bdo{{keyword_boundary_end}}
+    - match: \bdo{{keyword_break}}
       scope: keyword.control.loop.do.shell
       pop: true
-    - match: \bdone{{keyword_boundary_end}}
+    - match: \bdone{{keyword_break}}
       scope: keyword.control.loop.done.shell
       set: [cmd-post, cmd-args]
-    - match: \bwhile{{keyword_boundary_end}}
+    - match: \bwhile{{keyword_break}}
       scope: keyword.control.loop.while.shell
-    - match: \buntil{{keyword_boundary_end}}
+    - match: \buntil{{keyword_break}}
       scope:  keyword.control.loop.until.shell
-    - match: \bcase{{keyword_boundary_end}}
+    - match: \bcase{{keyword_break}}
       scope: keyword.control.conditional.case.shell
       set: [case-body, case-word]
-    - match: \bcontinue{{keyword_boundary_end}}
+    - match: \bcontinue{{keyword_break}}
       scope: keyword.control.flow.continue.shell
-    - match: \bbreak{{keyword_boundary_end}}
+    - match: \bbreak{{keyword_break}}
       scope: keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]
 
   case-word:
-    - match: \bin{{keyword_boundary_end}}
+    - match: \bin{{keyword_break}}
       scope: keyword.control.in.shell
       pop: true
     - include: expansion-and-string
 
   case-body:
     - meta_scope: meta.conditional.case.shell
-    - match: \besac{{keyword_boundary_end}}
+    - match: \besac{{keyword_break}}
       scope: keyword.control.conditional.end.shell
       pop: true
     - match: (?=\()
@@ -224,7 +224,7 @@ contexts:
     # emergency bail outs if ')' is missing
     - match: (?=;;&?|;&)
       set: case-clause-commands
-    - match: (?=\besac{{keyword_boundary_char}})
+    - match: (?=\besac{{keyword_break_char}})
       pop: true
     - include: case-clause-patterns-body
 
@@ -255,7 +255,7 @@ contexts:
         meta.conditional.case.clause.commands.shell
         punctuation.terminator.case.clause.shell
       pop: true
-    - match: (?=\besac{{keyword_boundary_char}})
+    - match: (?=\besac{{keyword_break_char}})
       pop: true
     - include: main
 
@@ -267,7 +267,7 @@ contexts:
         - meta_scope: meta.group.for.shell
         - include: cmd-args-boilerplate
         - include: arithmetic
-        - match: \bin{{keyword_boundary_end}}
+        - match: \bin{{keyword_break}}
           scope: keyword.control.in.shell
 
   expansion-and-string:
@@ -279,7 +279,7 @@ contexts:
       captures:
         1: storage.type.function.shell
       push: [funcdef-body, funcdef-parens, funcdef-name]
-    - match: \bcoproc{{keyword_boundary_end}}
+    - match: \bcoproc{{keyword_break}}
       scope: keyword.other.coproc.shell
       push: [cmd-post, cmd-args, coproc-body]
 
@@ -288,7 +288,7 @@ contexts:
       captures:
         1: storage.type.function.shell
       push: [funcdef-body-bt, funcdef-parens, funcdef-name]
-    - match: \bcoproc{{keyword_boundary_end}}
+    - match: \bcoproc{{keyword_break}}
       scope: keyword.other.coproc.shell
       push: [cmd-post, cmd-args-bt, coproc-body]
 
@@ -349,7 +349,7 @@ contexts:
     - include: main-bt
 
   vardef:
-    - match: \s*\b(alias){{keyword_boundary_end}}
+    - match: \s*\b(alias){{keyword_break}}
       captures:
         1: support.function.alias.shell
       push:
@@ -359,7 +359,7 @@ contexts:
       - vardef-assign
       - vardef-alias-name
       - vardef-alias-options
-    - match: \s*\b(typeset|declare|local){{keyword_boundary_end}}
+    - match: \s*\b(typeset|declare|local){{keyword_break}}
       captures:
         1: storage.modifier.shell
       push:
@@ -369,7 +369,7 @@ contexts:
       - vardef-assign
       - vardef-name
       - vardef-declare-options
-    - match: \s*\b(export){{keyword_boundary_end}}
+    - match: \s*\b(export){{keyword_break}}
       captures:
         1: storage.modifier.shell
       push:
@@ -379,7 +379,7 @@ contexts:
       - vardef-assign
       - vardef-name
       - vardef-export-options
-    - match: \s*\b(readonly){{keyword_boundary_end}}
+    - match: \s*\b(readonly){{keyword_break}}
       captures:
         1: storage.modifier.shell
       push:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -157,50 +157,50 @@ contexts:
   control:
     - match: \b(if){{keyword_boundary_end}}(?:\s*(!))?
       captures:
-        1: keyword.control.if.begin.shell
+        1: keyword.control.conditional.if.shell
         2: keyword.operator.logical.shell
     - match: \bthen\b
-      scope: keyword.control.if.then.shell
+      scope: keyword.control.conditional.then.shell
       pop: true
     - match: \b(elif){{keyword_boundary_end}}(?:\s*(!))?
       captures:
-        1: keyword.control.if.elif.shell
+        1: keyword.control.conditional.elif.shell
         2: keyword.operator.logical.shell
     - match: \bfi{{keyword_boundary_end}}
-      scope: keyword.control.if.end.shell
+      scope: keyword.control.conditional.end.shell
       set: [cmd-post, cmd-args]
     - match: \belse{{keyword_boundary_end}}
-      scope: keyword.control.if.else.shell
+      scope: keyword.control.conditional.else.shell
       pop: true
     - match: \bfor{{keyword_boundary_end}}
-      scope: keyword.control.for.shell
+      scope: keyword.control.loop.for.shell
       set: [cmd-post, for-args]
     - match: \bdo{{keyword_boundary_end}}
-      scope: keyword.control.do.shell
+      scope: keyword.control.loop.do.shell
       pop: true
     - match: \bdone{{keyword_boundary_end}}
-      scope: keyword.control.done.shell
+      scope: keyword.control.loop.done.shell
       set: [cmd-post, cmd-args]
     - match: \bwhile{{keyword_boundary_end}}
-      scope: keyword.control.while.shell
+      scope: keyword.control.loop.while.shell
     - match: \buntil{{keyword_boundary_end}}
-      scope:  keyword.control.until.shell
+      scope:  keyword.control.loop.until.shell
     - match: \bcase{{keyword_boundary_end}}
-      scope: keyword.control.case.begin.shell
-      set: [case-body, case-item, case-item-first-character, case-preamble]
+      scope: keyword.control.conditional.case.shell
+      set: [case-clause-commands, case-clause-patterns, case-clause-patterns-first-character, case-word]
     - match: \bcontinue{{keyword_boundary_end}}
       scope: keyword.control.flow.continue.shell
     - match: \bbreak{{keyword_boundary_end}}
       scope: keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]
 
-  case-preamble:
+  case-word:
     - match: \bin(?=[^\w_-])
-      scope: keyword.control.case.in.shell
+      scope: keyword.control.in.shell
       pop: true
     - include: expansion-and-string
 
-  case-item-highlights:
+  case-clause-patterns-body:
     # [Bash] 3.2.4.2: Each pattern undergoes tilde expansion, parameter
     # expansion, command substitution, and arithmetic expansion.
     - include: expansion-pattern
@@ -213,56 +213,54 @@ contexts:
       scope: keyword.operator.logical.shell
     - match: \(
       scope: punctuation.section.parens.begin.shell
-      push: case-item-inside
+      push: case-clause-patterns-inside
 
-  case-item-inside:
+  case-clause-patterns-inside:
     - match: \)
       scope: punctuation.section.parens.end.shell
       pop: true
-    - include: case-item-highlights
+    - include: case-clause-patterns-body
 
-  case-item:
+  case-clause-patterns:
     - match: \)
-      scope: keyword.control.case.item.shell
+      scope: keyword.control.conditional.pattern.end.shell
       pop: true
-    - include: case-item-highlights
+    - include: case-clause-patterns-body
 
-  case-item-first-character:
-    - match: (?=\()
-      set:
-        - match: \(
-          scope: keyword.control.case.item.shell
-          pop: true
+  case-clause-patterns-first-character:
+    - match: \(
+      scope: keyword.control.conditional.pattern.begin.shell
+      pop: true
     - match: (?=\S)
       pop: true
 
-  case-body:
+  case-clause-commands:
     - match: \s*(;;&?|;&)
       captures:
-        1: punctuation.terminator.case.shell
+        1: punctuation.terminator.case.clause.shell
       set:
         # An opening parenthesis is optional
         - match: (?=\()
           set:
             - match: \(
-              scope: keyword.control.case.item.shell
-              set: case-body-item
+              scope: keyword.control.conditional.pattern.begin.shell
+              set: case-clause-commands-pattern
         - match: (?=\S)
-          set: case-body-item
+          set: case-clause-commands-pattern
     - match: \s*\b(esac)\b
       captures:
-        1: keyword.control.case.end.shell
+        1: keyword.control.conditional.end.shell
       pop: true
     - include: main
 
-  case-body-item:
+  case-clause-commands-pattern:
     - match: \besac\b
-      scope: keyword.control.case.end.shell
+      scope: keyword.control.conditional.end.shell
       pop: true
     - match: \)
-      scope: keyword.control.case.item.shell
-      set: case-body
-    - include: case-item-highlights
+      scope: keyword.control.conditional.pattern.end.shell
+      set: case-clause-commands
+    - include: case-clause-patterns-body
 
   # I don't think anybody will write a for-loop inside backticks. Hence no
   # for-args-bt context.

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -72,11 +72,6 @@ variables:
   metachar: '[\s\t\n|&;()<>]'
 
   nbc: '[^{}()=\s]*' # non bracket characters (and also non-whitespace, parens)
-  reset_and: \s*(&&)
-  reset_job: \s*(&)
-  reset_or: \s*(\|\|)
-  reset_pipe: \s*(\|)
-  reset_semicolon: \s*(;)(?![;&])
   start_of_option: (?:\s+|^)--?(?=[\w$])
   varassign: '[+\-?]?='
 #-------------------------------------------------------------------------------
@@ -744,31 +739,23 @@ contexts:
     - include: line-continuation-or-pop-at-end
 
   cmd-post: # looks like [main, cmd-post] at this point
-    - match: ""
-      set:
-        - meta_content_scope: meta.post-cmd.shell
-        - match: '{{reset_semicolon}}'
-          captures:
-            1: keyword.operator.logical.continue.shell
-          set: maybe-operator-logical
-        - match: '{{reset_or}}'
-          captures:
-            1: keyword.operator.logical.or.shell
-          set: maybe-operator-logical
-        - match: '{{reset_pipe}}'
-          captures:
-            1: keyword.operator.logical.pipe.shell
-          set: maybe-operator-logical
-        - match: '{{reset_and}}'
-          captures:
-            1: keyword.operator.logical.and.shell
-          set: maybe-operator-logical
-        - match: '{{reset_job}}'
-          captures:
-            1: keyword.operator.logical.job.shell
-          set: maybe-operator-logical
-        - match: ""
-          pop: true
+    - match: ;(?![;&])
+      scope: keyword.operator.logical.continue.shell
+      set: maybe-operator-logical
+    - match: \|\|
+      scope: keyword.operator.logical.or.shell
+      set: maybe-operator-logical
+    - match: \|
+      scope: keyword.operator.logical.pipe.shell
+      set: maybe-operator-logical
+    - match: \&\&
+      scope: keyword.operator.logical.and.shell
+      set: maybe-operator-logical
+    - match: \&
+      scope: keyword.operator.logical.job.shell
+      set: maybe-operator-logical
+    - match: $|(?=\S)
+      pop: true
 
   cmd-args-boilerplate:
     - match: (?={{is_end_of_interpolation}})

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1336,7 +1336,7 @@ contexts:
   operator-exclamation:
     - match: \!(?!\S)
       scope: keyword.operator.logical.shell
-    - match: \!(?=\S)
+    - match: \!
       scope: punctuation.definition.history.shell
 
   string:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -64,7 +64,6 @@ variables:
   is_path_component: (?=[^\s/]*/)
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
-  keyword_break_char: '[^-=\w]'
   keyword_break: (?![-=\w])
 
   # A character that, when unquoted, separates words. A metacharacter is a
@@ -199,6 +198,7 @@ contexts:
     - match: \bin{{keyword_break}}
       scope: keyword.control.in.shell
       pop: true
+    - include: case-end-ahead
     - include: expansion-and-string
 
   case-body:
@@ -224,8 +224,7 @@ contexts:
     # emergency bail outs if ')' is missing
     - match: (?=;;&?|;&)
       set: case-clause-commands
-    - match: (?=\besac{{keyword_break_char}})
-      pop: true
+    - include: case-end-ahead
     - include: case-clause-patterns-body
 
   case-clause-patterns-body:
@@ -255,9 +254,12 @@ contexts:
         meta.conditional.case.clause.commands.shell
         punctuation.terminator.case.clause.shell
       pop: true
-    - match: (?=\besac{{keyword_break_char}})
-      pop: true
+    - include: case-end-ahead
     - include: main
+
+  case-end-ahead:
+    - match: (?=\besac{{keyword_break}})
+      pop: true
 
   # I don't think anybody will write a for-loop inside backticks. Hence no
   # for-args-bt context.

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -64,7 +64,8 @@ variables:
   is_path_component: (?=[^\s/]*/)
   is_start_of_arguments: '[`=|&;()<>\s]'
   is_variable: (?=\s*{{nbc}}(?:[({]{{nbc}}[)}])?{{nbc}}=)
-  keyword_boundary_end: (?!=)(?=[^\w_-]|$)
+  keyword_boundary_char: '[^-=\w]'
+  keyword_boundary_end: (?={{keyword_boundary_char}})
 
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters: ‘|’, ‘&’, ‘;’,
@@ -195,14 +196,14 @@ contexts:
       set: [cmd-post, cmd-args]
 
   case-word:
-    - match: \bin(?=[^\w_-])
+    - match: \bin{{keyword_boundary_end}}
       scope: keyword.control.in.shell
       pop: true
     - include: expansion-and-string
 
   case-body:
     - meta_scope: meta.conditional.case.shell
-    - match: \besac\b
+    - match: \besac{{keyword_boundary_end}}
       scope: keyword.control.conditional.end.shell
       pop: true
     - match: (?=\()
@@ -220,8 +221,10 @@ contexts:
     - match: \)
       scope: keyword.control.conditional.patterns.end.shell
       set: case-clause-commands
-    # emergency pop off if ')' is missing
-    - match: (?=\besac\b|;;&?|;&)
+    # emergency bail outs if ')' is missing
+    - match: (?=;;&?|;&)
+      set: case-clause-commands
+    - match: (?=\besac{{keyword_boundary_char}})
       pop: true
     - include: case-clause-patterns-body
 
@@ -252,7 +255,7 @@ contexts:
         meta.conditional.case.clause.commands.shell
         punctuation.terminator.case.clause.shell
       pop: true
-    - match: (?=\besac\b)
+    - match: (?=\besac{{keyword_boundary_char}})
       pop: true
     - include: main
 
@@ -264,7 +267,7 @@ contexts:
         - meta_scope: meta.group.for.shell
         - include: cmd-args-boilerplate
         - include: arithmetic
-        - match: \bin\b
+        - match: \bin{{keyword_boundary_end}}
           scope: keyword.control.in.shell
 
   expansion-and-string:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -425,10 +425,7 @@ contexts:
       pop: true
     - include: cmd-args-boilerplate
     - match: (?=\S)
-      push:
-      - vardef-value
-      - vardef-assign
-      - vardef-name
+      push: [vardef-value, vardef-assign, vardef-name]
 
   vardef-alias-options:
     - match: \s*((-)p)

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -129,6 +129,7 @@ contexts:
     - include: funcdef
     - include: vardef
     - include: redirection
+    - include: operator-exclamation
     - match: '{{is_command}}'
       push: cmd
 
@@ -152,13 +153,13 @@ contexts:
   control:
     - match: \bif{{keyword_break}}
       scope: keyword.control.conditional.if.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \bthen{{keyword_break}}
       scope: keyword.control.conditional.then.shell
       pop: true
     - match: \belif{{keyword_break}}
       scope: keyword.control.conditional.elseif.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \bfi{{keyword_break}}
       scope: keyword.control.conditional.end.shell
       set: [cmd-post, cmd-args]
@@ -741,19 +742,19 @@ contexts:
   cmd-post: # looks like [main, cmd-post] at this point
     - match: ;(?![;&])
       scope: keyword.operator.logical.continue.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \|\|
       scope: keyword.operator.logical.or.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \|
       scope: keyword.operator.logical.pipe.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \&\&
       scope: keyword.operator.logical.and.shell
-      set: maybe-operator-logical
+      pop: true
     - match: \&
       scope: keyword.operator.logical.job.shell
-      set: maybe-operator-logical
+      pop: true
     - match: $|(?=\S)
       pop: true
 
@@ -1332,12 +1333,11 @@ contexts:
     - match: ==?|!=?|<|>|\|\||&&
       scope: keyword.operator.logical.shell
 
-  maybe-operator-logical:
-    - match: \!
+  operator-exclamation:
+    - match: \!(?=\s)
       scope: keyword.operator.logical.shell
-      pop: true
-    - match: $|(?=\S)
-      pop: true
+    - match: \!(?=\S)
+      scope: punctuation.definition.history.shell
 
   string:
     - include: string-quoted-double

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1489,7 +1489,7 @@ for (( i = 0; i < 10; i++ )); do
     #    ^ meta.function-call.arguments punctuation.definition.variable
     #     ^ meta.function-call.arguments variable.other.readwrite
 done
-# <- keyword.control
+# <- keyword.control.loop.end
 
 for i in $(seq 100); do
 # <- keyword.control.loop.for
@@ -1503,7 +1503,7 @@ for i in $(seq 100); do
   :
   # <- meta.function-call support.function.colon
 done
-# <- keyword.control.loop.done
+# <- keyword.control.loop.end
 
 [[ "${foo}" == bar*baz ]]
  # <- support.function.double-brace.begin
@@ -1611,7 +1611,7 @@ if [ "$1" != "" -a "$2" != "" ]; then
     #     ^^^^^^ variable.other.readwrite.assignment
     #           ^ keyword.operator.assignment
 elif [ "$1" ]; then
-# <- keyword.control.conditional.elif
+# <- keyword.control.conditional.elseif
 #              ^^^^ keyword.control.conditional.then
     local DIR=$PWD
     # <- storage.modifier
@@ -1804,7 +1804,7 @@ else remotefilter="grep"
          #          ^ variable.other.readwrite.assignment
          #           ^ keyword.operator.assignment
      done
-     # <- keyword.control.loop.done
+     # <- keyword.control.loop.end
 fi
 # <- keyword.control.conditional.end
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1675,10 +1675,13 @@ f() {
     done
 }
 
-case "${foo}" in
-#^^^^^^^^^^^^^^^^^ meta.conditional.case.shell
+case "${foo}" in- in_ in=10 in
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.case.shell
 # <- keyword.control.conditional.case
-#             ^^ keyword.control.in
+#             ^^ - keyword.control.in
+#                 ^^ - keyword.control.in
+#                     ^^ - keyword.control.in
+#                           ^^ keyword.control.in
     ( help | h ) bar ;;
 #^^^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
 #   ^^^^^^^^^^^^ meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands - meta.conditional.case.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1073,6 +1073,12 @@ if [[ ' foobar' == [\ ]foo* ]]; then
   :
 fi
 
+case-
+#^ - keyword
+
+esac
+#^ keyword.control.conditional.end
+
 case
 #^ keyword.control.conditional.case
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -471,7 +471,7 @@ local-pid
 # ^ - storage.modifier
 #    ^^ - variable.parameter
 
-if [[ ! -z "$PLATFORM" ]] && ! cmd || !cmd2; then PLATFORM=docker; fi
+if [[ ! -z "$PLATFORM" ]] && ! cmd || ! cmd2; then PLATFORM=docker; fi
 #^ keyword.control.conditional.if
 #     ^ keyword.operator.logical
 #                         ^^ keyword.operator.logical.and
@@ -479,32 +479,41 @@ if [[ ! -z "$PLATFORM" ]] && ! cmd || !cmd2; then PLATFORM=docker; fi
 #                              ^^^ meta.function-call.shell variable.function
 #                                  ^^ keyword.operator.logical.or.shell
 #                                     ^ keyword.operator.logical.shell
-#                                      ^^^^ meta.function-call.shell variable.function.shell
-#                                          ^ keyword.operator.logical.continue
-#                                            ^^^^ keyword.control.conditional.then
-#                                                        ^ variable.other.readwrite.assignment
-#                                                         ^ keyword.operator.assignment
-#                                                          ^ string.unquoted
+#                                       ^^^^ meta.function-call.shell variable.function.shell
+#                                           ^ keyword.operator.logical.continue
+#                                             ^^^^ keyword.control.conditional.then
+#                                                         ^ variable.other.readwrite.assignment
+#                                                          ^ keyword.operator.assignment
+#                                                           ^ string.unquoted
 if cmd && \
     ! cmd
 #   ^ keyword.operator.logical.shell
 #     ^^^ meta.function-call.shell variable.function.shell
 if cmd &&
     ! cmd
-#   ^ - keyword
-#     ^^^ - variable.function.shell
+#   ^ keyword.operator.logical.shell
+#     ^^^ meta.function-call.shell variable.function.shell
 if cmd || \
     ! cmd
 #   ^ keyword.operator.logical.shell
 #     ^^^ meta.function-call.shell variable.function.shell
 if cmd ||
     ! cmd
-#   ^ - keyword
-#     ^^^ - variable.function.shell
+#   ^ keyword.operator.logical.shell
+#     ^^^ meta.function-call.shell variable.function.shell
 if \
-   !cmd
+   ! cmd
 #  ^ keyword.operator.logical.shell
+#    ^^^ meta.function-call.shell variable.function.shell
+if !cmd
+#  ^ punctuation.definition.history.shell
 #   ^^^ meta.function-call.shell variable.function.shell
+! cmd
+# <- keyword.operator.logical.shell
+# ^^^ meta.function-call.shell variable.function.shell
+!cmd
+# <- punctuation.definition.history.shell
+#^^^ meta.function-call.shell variable.function.shell
 
 then-
 #^^^^ - keyword

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -471,11 +471,45 @@ local-pid
 # ^ - storage.modifier
 #    ^^ - variable.parameter
 
-if [[ -z "$PLATFORM" ]]; then PLATFORM=docker; fi
-#                                    ^ variable.other.readwrite.assignment
-#                                     ^ keyword.operator.assignment
-#                                      ^ string.unquoted
+if [[ ! -z "$PLATFORM" ]] && ! cmd || !cmd2; then PLATFORM=docker; fi
+#^ keyword.control.conditional.if
+#     ^ keyword.operator.logical
+#                         ^^ keyword.operator.logical.and
+#                            ^ keyword.operator.logical.shell
+#                              ^^^ meta.function-call.shell variable.function
+#                                  ^^ keyword.operator.logical.or.shell
+#                                     ^ keyword.operator.logical.shell
+#                                      ^^^^ meta.function-call.shell variable.function.shell
+#                                          ^ keyword.operator.logical.continue
+#                                            ^^^^ keyword.control.conditional.then
+#                                                        ^ variable.other.readwrite.assignment
+#                                                         ^ keyword.operator.assignment
+#                                                          ^ string.unquoted
+if cmd && \
+    ! cmd
+#   ^ keyword.operator.logical.shell
+#     ^^^ meta.function-call.shell variable.function.shell
+if cmd &&
+    ! cmd
+#   ^ - keyword
+#     ^^^ - variable.function.shell
+if cmd || \
+    ! cmd
+#   ^ keyword.operator.logical.shell
+#     ^^^ meta.function-call.shell variable.function.shell
+if cmd ||
+    ! cmd
+#   ^ - keyword
+#     ^^^ - variable.function.shell
+if \
+   !cmd
+#  ^ keyword.operator.logical.shell
+#   ^^^ meta.function-call.shell variable.function.shell
 
+then-
+#^^^^ - keyword
+-then
+#^^^^ - keyword
 if-up
 # <- - keyword
 # ^ - keyword

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1077,13 +1077,13 @@ case-
 #^ - keyword
 
 esac
-#^ keyword.control.conditional.end
+#^ keyword.control.conditional.end - meta.conditional.case
 
 case
-#^ keyword.control.conditional.case
+#^ meta.conditional.case keyword.control.conditional.case
 
 esac
-#^ keyword.control.conditional.end
+#^ meta.conditional.case keyword.control.conditional.end
 
 case $_G_unquoted_arg in
 *[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -532,6 +532,15 @@ if !cmd
 ![[ ]]
 # <- punctuation.definition.history.shell
 #^^^^^ meta.function-call.arguments.shell
+!!
+# <- variable.language.history.shell punctuation.definition.history.shell
+#^ variable.language.history.shell
+!-1
+# <- variable.language.history.shell punctuation.definition.history.shell
+#^^ variable.language.history.shell
+!51
+# <- variable.language.history.shell punctuation.definition.history.shell
+#^^ variable.language.history.shell
 
 then-
 #^^^^ - keyword

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -481,6 +481,14 @@ if-up
 # ^ - keyword
 up-if
 #  ^^ - keyword
+then-
+#^^^^ - keyword
+-then
+#^^^^ - keyword
+then-fi
+#^^^^^^ - keyword
+if-then
+#^^^^^^ - keyword
 done-foo
 # <- - keyword
 foo-done

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -514,6 +514,24 @@ if !cmd
 !cmd
 # <- punctuation.definition.history.shell
 #^^^ meta.function-call.shell variable.function.shell
+! \
+# <- keyword.operator.logical.shell
+# ^ punctuation.separator.continuation.line.shell
+! \
+ cmd
+#^^^ meta.function-call.shell variable.function.shell
+!\
+# <- punctuation.definition.history.shell
+#^ punctuation.separator.continuation.line.shell
+!\
+ cmd
+#^^^ meta.function-call.shell variable.function.shell
+! [[ ]]
+# <- keyword.operator.logical.shell
+# ^^^^^ meta.function-call.arguments.shell
+![[ ]]
+# <- punctuation.definition.history.shell
+#^^^^^ meta.function-call.arguments.shell
 
 then-
 #^^^^ - keyword

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1483,7 +1483,7 @@ for (( i = 0; i < 10; i++ )); do
 #                      ^^ meta.group.for keyword.operator.arithmetic
 #                         ^^ meta.group.for punctuation.section.arithmetic.end
 #                           ^ keyword.operator.logical.continue
-#                             ^^ keyword.control.do
+#                             ^^ keyword.control.loop.do
     echo $i
     # <- meta.function-call support.function.echo
     #    ^ meta.function-call.arguments punctuation.definition.variable
@@ -1492,18 +1492,18 @@ done
 # <- keyword.control
 
 for i in $(seq 100); do
-# <- keyword.control.for
+# <- keyword.control.loop.for
 #     ^^ meta.group.for keyword.control.in
 #        ^ meta.group.for punctuation.definition.variable
 #         ^ meta.group.for punctuation.section.parens.begin
 #          ^^^ meta.group.for meta.function-call variable.function
 #                 ^ meta.group.for punctuation.section.parens.end
 #                  ^ keyword.operator.logical.continue
-#                    ^^ keyword.control.do
+#                    ^^ keyword.control.loop.do
   :
   # <- meta.function-call support.function.colon
 done
-# <- keyword.control.done
+# <- keyword.control.loop.done
 
 [[ "${foo}" == bar*baz ]]
  # <- support.function.double-brace.begin
@@ -1513,33 +1513,33 @@ done
 #                      ^^ meta.function-call.arguments support.function.double-brace.end
 
 case "$1" in
-# <- keyword.control.case
+# <- keyword.control.conditional.case
 #    ^ string.quoted.double punctuation.definition.string.begin
 #     ^ string.quoted.double punctuation.definition.variable
 #      ^ string.quoted.double variable.other.readwrite
 #       ^ string.quoted.double punctuation.definition.string.end
-#         ^^ keyword.control.case.in
+#         ^^ keyword.control.in
 setup )
 # <- - variable.function - support.function - meta.function-call
-#     ^ keyword.control.case.item
+#     ^ keyword.control.conditional.pattern
 echo Preparing the server...
 # <- meta.function-call support.function.echo
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
 ;;
-# <- punctuation.terminator.case
-#^ punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+#^ punctuation.terminator.case.clause
 deploy )
 # <- - variable.function - support.function - meta.function-call
-#      ^ keyword.control.case.item
+#      ^ keyword.control.conditional.pattern
 echo Deploying...
 # <- meta.function-call support.function.echo
 #   ^^^^^^^^^^^^^ meta.function-call.arguments
 ;;
-# <- punctuation.terminator.case
-#^ punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+#^ punctuation.terminator.case.clause
 * )
 # <- keyword.operator.regexp.quantifier
-# ^ keyword.control.case.item
+# ^ keyword.control.conditional.pattern
 cat <<'ENDCAT'
 # <- meta.function-call variable.function
 #   ^^ meta.function-call.arguments string.unquoted.heredoc keyword.operator.assignment.redirection
@@ -1551,10 +1551,10 @@ foo
 ENDCAT
 # <- meta.function-call.arguments string.unquoted.heredoc keyword.control.heredoc-token
 ;;
-# <- punctuation.terminator.case
-#^ punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+#^ punctuation.terminator.case.clause
 esac
-# <- keyword.control.case.end
+# <- keyword.control.conditional.end
 
 if [ ! -f q4m-$Q4MVER.tar.gz ]; then
   #^ support.function.test.begin
@@ -1593,7 +1593,7 @@ fi
 # ^ constant.numeric.integer.decimal.file-descriptor - variable.function
 
 if [ "$1" != "" -a "$2" != "" ]; then
-# <- keyword.control.if.begin
+# <- keyword.control.conditional.if
 #  ^ support.function.test.begin
 #         ^^ meta.function-call.arguments keyword.operator.logical
 #               ^ meta.function-call.arguments variable.parameter punctuation.definition.parameter
@@ -1601,7 +1601,7 @@ if [ "$1" != "" -a "$2" != "" ]; then
 #                       ^^ meta.function-call.arguments keyword.operator.logical
 #                             ^ meta.function-call.arguments support.function.test.end
 #                              ^ keyword.operator.logical.continue
-#                                ^^^^ keyword.control.if.then
+#                                ^^^^ keyword.control.conditional.then
     local DIR=$1
     # <- storage.modifier
     #     ^^^ variable.other.readwrite.assignment
@@ -1611,8 +1611,8 @@ if [ "$1" != "" -a "$2" != "" ]; then
     #     ^^^^^^ variable.other.readwrite.assignment
     #           ^ keyword.operator.assignment
 elif [ "$1" ]; then
-# <- keyword.control.if.elif
-#              ^^^^ keyword.control.if.then
+# <- keyword.control.conditional.elif
+#              ^^^^ keyword.control.conditional.then
     local DIR=$PWD
     # <- storage.modifier
     #     ^^^ variable.other.readwrite.assignment
@@ -1622,7 +1622,7 @@ elif [ "$1" ]; then
     #     ^^^^^^ variable.other.readwrite.assignment
     #           ^ keyword.operator.assignment
 fi
-# <- keyword.control.if.end
+# <- keyword.control.conditional.end
 
 function clk {
     typeset base=/sys/class/drm/card0/device
@@ -1638,7 +1638,7 @@ function clk {
             echo "Usage: $FUNCNAME [ low | high | default ]"
             printf '%s\n' "temp: $(<${base}/hwmon/hwmon0/temp1_input)C" "current profile: $(<${base}/power_profile)"
     esac
-    # <- meta.function keyword.control.case.end
+    # <- meta.function keyword.control.conditional.end
 }
 # <- punctuation
 
@@ -1661,7 +1661,7 @@ f() {
             $1|$2)
                 local "$x"'+=(4)'
         esac
-        # <- meta.function keyword.control.case.end
+        # <- meta.function keyword.control.conditional.end
 
         IFS=, local -a "$x"'=("${x}: ${'"$x"'[*]}")'
         # ^ variable.other.readwrite.assignment
@@ -1676,30 +1676,30 @@ f() {
 }
 
 case "${foo}" in
-# <- keyword.control.case.begin
-#             ^^ keyword.control.case.in
+# <- keyword.control.conditional.case
+#             ^^ keyword.control.in
     ( help | h ) bar ;;
-    # <- keyword.control
-    #          ^ keyword.control
-    #                ^^ punctuation
+    # <- keyword.control.conditional.pattern.begin
+    #          ^ keyword.control.conditional.pattern.end
+    #                ^^ punctuation.terminator.case.clause
     do1 ) foo1 ;&
-    #   ^ keyword.control
-    #          ^^ punctuation
+    #   ^ keyword.control.conditional.pattern.end
+    #          ^^ punctuation.terminator.case.clause
     (do2 ) foo2 ;;&
-    # <- keyword.control
-    #    ^ keyword.control
-    #           ^^^ punctuation
+    # <- keyword.control.conditional.pattern.begin
+    #    ^ keyword.control.conditional.pattern.end
+    #           ^^^ punctuation.terminator.case.clause
     *) bar
-    #^ keyword.control
+    #^ keyword.control.conditional.pattern.end
 esac
-# <- keyword.control.case.end
+# <- keyword.control.conditional.end
 
 case $TERM in
     sun-cmd)
-        #  ^ keyword.control.case.item
+        #  ^ keyword.control.conditional.pattern
         update_terminal_cwd() { print -Pn "\e]l%~\e\\" };;
         #                                              ^ meta.function punctuation.section.braces.end
-        #                                               ^^ punctuation.terminator.case
+        #                                               ^^ punctuation.terminator.case.clause
     *xterm*|rxvt|(dt|k|E)term)
         # ^ keyword.operator.regexp.quantifier
         #  ^ keyword.operator.logical
@@ -1707,20 +1707,20 @@ case $TERM in
         #           ^ keyword.operator.logical
         #             ^ keyword.operator.logical
         #               ^ punctuation.section.parens.end
-        #                    ^ keyword.control.case.item
+        #                    ^ keyword.control.conditional.pattern
         update_terminal_cwd() { print -Pn "\e]2;%~\a" };;
         #                                             ^ meta.function punctuation.section.braces.end
-        #                                              ^^ punctuation.terminator.case
+        #                                              ^^ punctuation.terminator.case.clause
     *)
     # <- keyword.operator.regexp.quantifier
-    #^ keyword.control.case.item
+    #^ keyword.control.conditional.pattern
         update_terminal_cwd() {};;
         #                      ^ meta.function punctuation.section.braces.end
-        #                       ^^ punctuation.terminator.case
+        #                       ^^ punctuation.terminator.case.clause
 esac
 
 case $SERVER in
-# <- keyword.control.case.begin
+# <- keyword.control.conditional.case
 ws-+([0-9]).host.com) echo "Web Server"
 #  ^ keyword.operator.regexp.quantifier
 #   ^ punctuation.section.parens.begin
@@ -1728,10 +1728,10 @@ ws-+([0-9]).host.com) echo "Web Server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                   ^ keyword.control.case.item
+#                   ^ keyword.control.conditional.pattern
 ;;
-# <- punctuation.terminator.case
- # <- punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+ # <- punctuation.terminator.case.clause
 db-+([0-9])\.host\.com) echo "DB server"
 #  ^ keyword.operator.regexp.quantifier
 #   ^ punctuation.section.parens.begin
@@ -1739,10 +1739,10 @@ db-+([0-9])\.host\.com) echo "DB server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                     ^ keyword.control.case.item
+#                     ^ keyword.control.conditional.pattern
 ;;
-# <- punctuation.terminator.case
- # <- punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+ # <- punctuation.terminator.case.clause
 bk-+([0-9])\.host\.com) echo "Backup server"
 #  ^ keyword.operator.regexp.quantifier
 #   ^ punctuation.section.parens.begin
@@ -1750,18 +1750,18 @@ bk-+([0-9])\.host\.com) echo "Backup server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                     ^ keyword.control.case.item
+#                     ^ keyword.control.conditional.pattern
 ;;
-# <- punctuation.terminator.case
- # <- punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+ # <- punctuation.terminator.case.clause
 *)echo "Unknown server"
 # <- keyword.operator.regexp.quantifier
- # <- keyword.control.case.item
+ # <- keyword.control.conditional.pattern
 ;;
-# <- punctuation.terminator.case
- # <- punctuation.terminator.case
+# <- punctuation.terminator.case.clause
+ # <- punctuation.terminator.case.clause
 esac
-# <- keyword.control.case.end
+# <- keyword.control.conditional.end
 
 if   [ "$*" = '*' ]
 then remotefilter="cat"
@@ -1785,9 +1785,9 @@ else remotefilter="grep"
          #          ^ variable.other.readwrite.assignment
          #           ^ keyword.operator.assignment
      done
-     # <- keyword.control.done
+     # <- keyword.control.loop.done
 fi
-# <- keyword.control.if.end
+# <- keyword.control.conditional.end
 
 ################################
 # And, or, pipes, redirections #
@@ -2261,7 +2261,7 @@ foo=$(
   }
   # <- punctuation.section
   func
-  
+
   # <- meta.group.expansion.command
 )
 # <- punctuation.section
@@ -2312,7 +2312,7 @@ __git_aliased_command ()
         case "$word" in
         {)  : skip start of shell helper function ;;
 #       ^ - punctuation.section.expansion.brace.begin
-#        ^ keyword.control.case.item
+#        ^ keyword.control.conditional.pattern
         \'*)    : skip opening quote after sh -c ;;
         *)
             echo "$word"

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1521,7 +1521,7 @@ case "$1" in
 #         ^^ keyword.control.in
 setup )
 # <- - variable.function - support.function - meta.function-call
-#     ^ keyword.control.conditional.pattern
+#     ^ keyword.control.conditional.patterns
 echo Preparing the server...
 # <- meta.function-call support.function.echo
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
@@ -1530,7 +1530,7 @@ echo Preparing the server...
 #^ punctuation.terminator.case.clause
 deploy )
 # <- - variable.function - support.function - meta.function-call
-#      ^ keyword.control.conditional.pattern
+#      ^ keyword.control.conditional.patterns
 echo Deploying...
 # <- meta.function-call support.function.echo
 #   ^^^^^^^^^^^^^ meta.function-call.arguments
@@ -1539,7 +1539,7 @@ echo Deploying...
 #^ punctuation.terminator.case.clause
 * )
 # <- keyword.operator.regexp.quantifier
-# ^ keyword.control.conditional.pattern
+# ^ keyword.control.conditional.patterns
 cat <<'ENDCAT'
 # <- meta.function-call variable.function
 #   ^^ meta.function-call.arguments string.unquoted.heredoc keyword.operator.assignment.redirection
@@ -1676,27 +1676,43 @@ f() {
 }
 
 case "${foo}" in
+#^^^^^^^^^^^^^^^^^ meta.conditional.case.shell
 # <- keyword.control.conditional.case
 #             ^^ keyword.control.in
     ( help | h ) bar ;;
-    # <- keyword.control.conditional.pattern.begin
-    #          ^ keyword.control.conditional.pattern.end
+#^^^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+#   ^^^^^^^^^^^^ meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands - meta.conditional.case.shell
+#               ^^^^^^^ meta.conditional.case.clause.commands - meta.conditional.case.clause.patterns - meta.conditional.case.shell
+#                      ^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+    # <- keyword.control.conditional.patterns.begin
+    #          ^ keyword.control.conditional.patterns.end
     #                ^^ punctuation.terminator.case.clause
     do1 ) foo1 ;&
-    #   ^ keyword.control.conditional.pattern.end
+#^^^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+#   ^^^^^ meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands - meta.conditional.case.shell
+#        ^^^^^^^^ meta.conditional.case.clause.commands - meta.conditional.case.clause.patterns - meta.conditional.case.shell
+#                ^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+    #   ^ keyword.control.conditional.patterns.end
     #          ^^ punctuation.terminator.case.clause
     (do2 ) foo2 ;;&
-    # <- keyword.control.conditional.pattern.begin
-    #    ^ keyword.control.conditional.pattern.end
+#^^^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+#   ^^^^^^ meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands - meta.conditional.case.shell
+#         ^^^^^^^^^ meta.conditional.case.clause.commands - meta.conditional.case.clause.patterns - meta.conditional.case.shell
+#                  ^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+    # <- keyword.control.conditional.patterns.begin
+    #    ^ keyword.control.conditional.patterns.end
     #           ^^^ punctuation.terminator.case.clause
     *) bar
-    #^ keyword.control.conditional.pattern.end
+#^^^ meta.conditional.case.shell - meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands
+#   ^^ meta.conditional.case.clause.patterns - meta.conditional.case.clause.commands - meta.conditional.case.shell
+#     ^^^^^ meta.conditional.case.clause.commands - meta.conditional.case.clause.patterns - meta.conditional.case.shell
+    #^ keyword.control.conditional.patterns.end
 esac
 # <- keyword.control.conditional.end
 
 case $TERM in
     sun-cmd)
-        #  ^ keyword.control.conditional.pattern
+        #  ^ keyword.control.conditional.patterns
         update_terminal_cwd() { print -Pn "\e]l%~\e\\" };;
         #                                              ^ meta.function punctuation.section.braces.end
         #                                               ^^ punctuation.terminator.case.clause
@@ -1707,13 +1723,13 @@ case $TERM in
         #           ^ keyword.operator.logical
         #             ^ keyword.operator.logical
         #               ^ punctuation.section.parens.end
-        #                    ^ keyword.control.conditional.pattern
+        #                    ^ keyword.control.conditional.patterns
         update_terminal_cwd() { print -Pn "\e]2;%~\a" };;
         #                                             ^ meta.function punctuation.section.braces.end
         #                                              ^^ punctuation.terminator.case.clause
     *)
     # <- keyword.operator.regexp.quantifier
-    #^ keyword.control.conditional.pattern
+    #^ keyword.control.conditional.patterns
         update_terminal_cwd() {};;
         #                      ^ meta.function punctuation.section.braces.end
         #                       ^^ punctuation.terminator.case.clause
@@ -1728,7 +1744,7 @@ ws-+([0-9]).host.com) echo "Web Server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                   ^ keyword.control.conditional.pattern
+#                   ^ keyword.control.conditional.patterns
 ;;
 # <- punctuation.terminator.case.clause
  # <- punctuation.terminator.case.clause
@@ -1739,7 +1755,7 @@ db-+([0-9])\.host\.com) echo "DB server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                     ^ keyword.control.conditional.pattern
+#                     ^ keyword.control.conditional.patterns
 ;;
 # <- punctuation.terminator.case.clause
  # <- punctuation.terminator.case.clause
@@ -1750,13 +1766,13 @@ bk-+([0-9])\.host\.com) echo "Backup server"
 #      ^ keyword.operator.word
 #        ^ keyword.control.regexp.set.end
 #         ^ punctuation.section.parens.end
-#                     ^ keyword.control.conditional.pattern
+#                     ^ keyword.control.conditional.patterns
 ;;
 # <- punctuation.terminator.case.clause
  # <- punctuation.terminator.case.clause
 *)echo "Unknown server"
 # <- keyword.operator.regexp.quantifier
- # <- keyword.control.conditional.pattern
+ # <- keyword.control.conditional.patterns
 ;;
 # <- punctuation.terminator.case.clause
  # <- punctuation.terminator.case.clause
@@ -2312,7 +2328,7 @@ __git_aliased_command ()
         case "$word" in
         {)  : skip start of shell helper function ;;
 #       ^ - punctuation.section.expansion.brace.begin
-#        ^ keyword.control.conditional.pattern
+#        ^ keyword.control.conditional.patterns
         \'*)    : skip opening quote after sh -c ;;
         *)
             echo "$word"

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1072,6 +1072,13 @@ if [[ ' foobar' == [\ ]foo* ]]; then
   #                         ^^ support.function.double-brace.end
   :
 fi
+
+case
+#^ keyword.control.conditional.case
+
+esac
+#^ keyword.control.conditional.end
+
 case $_G_unquoted_arg in
 *[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")
 #^ keyword.control.regexp.set.begin


### PR DESCRIPTION
Fixes #1868 
Fixes #1871

This PR ...

1. proposes to rename the control keywords in order to comply with #1228 inspired by the structure of the C# syntax, which should be applied to other syntaxes in the future as well

2. fixes a design issue with the _case_ context
3. improves the keyword boundary lookahead and applies it to the case contexts

For details please refere to the commit messages.