### PR TITLE
[C#] correctly handle escapes in long string placeholders

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1558,11 +1558,16 @@ contexts:
   string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.cs
-    - include: escaped
+    - include: string_escaped
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
+    - match: '(\{)(\d+)'
+      captures:
+        1: punctuation.definition.placeholder.begin.cs
+        2: constant.numeric.cs
+      push: string_placeholder
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
@@ -1573,15 +1578,17 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
-    - include: escaped
+    - include: string_escaped
     - include: string_placeholder_escape
     - match: \{
       scope: punctuation.section.interpolation.begin.cs
       push:
-        - meta_scope: meta.string.interpolated.cs source.cs
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
         - clear_scopes: 2
         - match: $
           pop: true
+        - include: string_placeholder_format
         - include: string_interpolation
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
@@ -1590,8 +1597,7 @@ contexts:
   long_format_string:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.double.raw.cs
-    - match: '""'
-      scope: constant.character.escape.cs
+    - include: long_string_escaped
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
@@ -1599,8 +1605,10 @@ contexts:
     - match: \{
       scope: punctuation.section.interpolation.begin.cs
       push:
-        - meta_scope: meta.string.interpolated.cs source.cs
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
         - clear_scopes: 2
+        - include: long_string_placeholder_format
         - include: string_interpolation
 
   string_placeholder_escape:
@@ -1616,26 +1624,53 @@ contexts:
       captures:
         1: punctuation.definition.placeholder.begin.cs
         2: constant.numeric.cs invalid.illegal.unclosed-string-placeholder.cs
-    - match: '(\{)(\d+)'
-      captures:
-        1: punctuation.definition.placeholder.begin.cs
-        2: constant.numeric.cs
-      push: string_placeholder
 
-  string_placeholder:
-    - meta_scope: constant.other.placeholder.cs
+  inside_string_placeholder:
     - match: '(\})(\}(?!\}))?'
       captures:
         1: punctuation.definition.placeholder.end.cs
         2: invalid.illegal.unescaped-placeholder.cs
       pop: true
-    - match: '(?=[}"])'
+    - match: (?=[}"])
       pop: true
+
+  string_placeholder:
+    - meta_scope: constant.other.placeholder.cs
+    - include: inside_string_placeholder
     - include: string_placeholder_format
     - match: '[^"}]+'
       scope: invalid.illegal.unexpected-character-in-placeholder.cs
 
+  long_string_placeholder:
+    - meta_scope: constant.other.placeholder.cs
+    - include: inside_string_placeholder
+    - include: long_string_placeholder_format
+    - match: '[^"}]+'
+      scope: invalid.illegal.unexpected-character-in-placeholder.cs
+
   string_placeholder_format:
+    - match: '\s*(?:(,)\s*(-?\d+)\s*)?'
+      captures:
+        1: punctuation.separator.arguments.cs
+        2: constant.numeric.formatting.cs
+    - match: ':(?=")'
+      scope: invalid.illegal.unclosed-string-placeholder.cs
+      pop: true
+    - match: ':'
+      scope: punctuation.separator.cs
+      push:
+        - meta_scope: constant.other.format-spec.cs
+        - include: string_placeholder_escape
+        - include: string_escaped
+        - match: '(?=\})'
+          pop: true
+        - match: '([^}"\\]+(\\.)*)+(?=")'
+          scope: invalid.illegal.unclosed-string-placeholder.cs
+          pop: true
+        - match: '\{'
+          scope: invalid.illegal.unescaped-placeholder.cs
+
+  long_string_placeholder_format:
     - match: '\s*(?:(,)\s*(-?\d+)\s*)?'
       captures:
         1: punctuation.separator.arguments.cs
@@ -1648,17 +1683,18 @@ contexts:
       push:
         - meta_scope: constant.other.format-spec.cs
         - include: string_placeholder_escape
-        - include: escaped
-        - match: '(?=\})'
+        - include: long_string_escaped
+        - match: (?=\})
           pop: true
-        - match: '([^}"\\]+(\\.)*)+(?="(?!"))'
+        - match: \\(?:""|[^"])
+          scope: constant.character.escape.cs
+        - match: (?:[^}"]+|"")+(?="(?!"))
           scope: invalid.illegal.unclosed-string-placeholder.cs
           pop: true
-        - match: '\{'
+        - match: \{
           scope: invalid.illegal.unescaped-placeholder.cs
 
   string_interpolation:
-    - include: string_placeholder_format
     - match: '\}'
       scope: punctuation.section.interpolation.end.cs
       pop: true
@@ -1667,9 +1703,13 @@ contexts:
   long_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.raw.cs
-    - match: '""'
-      scope: constant.character.escape.cs
+    - include: long_string_escaped
     - include: string_placeholders
+    - match: '(\{)(\d+)'
+      captures:
+        1: punctuation.definition.placeholder.begin.cs
+        2: constant.numeric.cs
+      push: long_string_placeholder
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
@@ -1677,8 +1717,15 @@ contexts:
   escaped:
     - match: '{{escaped_char}}'
       scope: constant.character.escape.cs
+
+  string_escaped:
+    - include: escaped
     - match: \\
       scope: invalid.illegal.lone-escape.cs
+
+  long_string_escaped:
+    - match: '""'
+      scope: constant.character.escape.cs
 
   initializer_constructor:
     - meta_content_scope: meta.instance.cs meta.braces.cs

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1236,6 +1236,25 @@ namespace TestNamespace.Test
 ///                                     ^^^^^ variable.other - variable.parameter
 ///                                                    ^^^^^ variable.other - variable.parameter
 ///                                           ^^ keyword.operator - keyword.operator.assignment
+        formatted = string.Format(@"GMT is {0:yyyyMMdd\THHmmss\Z}", DateTime.Now.ToUniversalTime());
+///                                        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw constant.other.placeholder
+        formatted = string.Format("GMT is {0:yyyyMMdd\\THHmmss\\Z}", DateTime.Now.ToUniversalTime());
+///                                       ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double constant.other.placeholder
+        Console.WriteLine($@"GMT is {DateTime.Now:yyyyMMdd\THHmmss\Z}");
+///                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+///                                              ^ punctuation.separator
+///                                              ^^^^^^^^^^^^^^^^^^^ constant.other.format-spec
+        Console.WriteLine($"GMT is {DateTime.Now:yyyyMMdd\THHmmss\Z}");
+///                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+///                                             ^ punctuation.separator
+///                                             ^^^^^^^^^^^^^^^^^^^ constant.other.format-spec
+///                                                      ^ invalid.illegal.lone-escape
+///                                                              ^ invalid.illegal.lone-escape
+        Console.WriteLine($@"GMT is {DateTime.Now:yyyyMMdd\T\""\x1043HHmmss\Z}");
+///                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.format-spec - invalid
+///                                                       ^^^^^^^ constant.character.escape
+///                                                              ^^^^^^^^^^ - constant.character.escape
+///                                                                        ^^ constant.character.escape
     }
 }
 ///<- punctuation.section.block.end


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/issues/1866

To get this working, I had to duplicate and tweak the `string_placeholder_format` context so that it behaves correctly for normal strings as well as "long strings" and "long format strings". It sure would be great for maintenance if contexts could take parameters and then somehow the contents of that context could use those parameters to tweak the regex patterns ;)