### PR TITLE
[Perl] Fix upper-case labels

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -268,10 +268,11 @@ contexts:
   expressions:
     - include: blocks
     - include: groups
+    - include: quoted-like
+    - include: label
     - include: constants
     - include: class
     - include: operators
-    - include: quoted-like
     - include: control
     - include: sub
     - include: variables
@@ -616,7 +617,6 @@ contexts:
     - match: \b(?:do|for|foreach|until|while){{break}}
       scope: keyword.control.flow.perl
       push: regexp-pop
-    - include: label
 
   label:
     - match: ({{identifier}})(:)(?!:)

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1290,6 +1290,17 @@ sub name ($) {}
 #                 ^ punctuation.terminator.statement.perl
   retry::
 # ^^^^^^^ - entity.name.label.perl
+
+  LINE:
+# ^^^^ entity.name.label.perl
+#     ^ punctuation.separator.perl
+
+  LINE:exit -1
+# ^^^^ entity.name.label.perl
+#     ^ punctuation.separator.perl
+#      ^^^^ keyword.other.flow.perl
+#           ^^ constant.numeric.integer.perl
+
   if(exists($curargs{$index}))
 # ^^ keyword.control.conditional.perl
 #   ^ punctuation.section.group.begin.perl


### PR DESCRIPTION
This commit reorders the `label` and `quoted-like` expression contexts to fix upper-case labels scoping. Before this commit they were matched as `constants` which is wrong.