### PR TITLE
[Python] Fix control keywords and punctuation

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -249,7 +249,7 @@ contexts:
     - match: \bif\b
       scope: keyword.control.conditional.if.python
       push:
-        - meta_scope: meta.statement.conditional.python
+        - meta_scope: meta.statement.conditional.if.python
         - include: line-continuation-or-pop
         - match: ':'
           scope: punctuation.section.block.conditional.python
@@ -265,7 +265,7 @@ contexts:
           pop: true
         - include: expressions
     - match: \b(else)\b(?:\s*(:))?
-      scope: meta.statement.conditional.python
+      scope: meta.statement.conditional.else.python
       captures:
         1: keyword.control.conditional.else.python
         2: punctuation.section.block.conditional.python
@@ -282,7 +282,7 @@ contexts:
     - match: \belif\b
       scope: keyword.control.conditional.elseif.python
       push:
-        - meta_scope: meta.statement.conditional.python
+        - meta_scope: meta.statement.conditional.elseif.python
         - match: ':'
           scope: punctuation.section.block.conditional.python
           pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -204,17 +204,17 @@ contexts:
     - match: \b(async +)?(for)\b
       captures:
         1: storage.modifier.async.python
-        2: keyword.control.flow.for.python
+        2: keyword.control.loop.for.python
       push:
-        - meta_scope: meta.statement.for.python
+        - meta_scope: meta.statement.loop.for.python
         - include: line-continuation-or-pop
-        - match: \b(in)\b
-          scope: keyword.control.flow.for.in.python
+        - match: \bin\b
+          scope: keyword.control.loop.for.in.python
           set:
-            - meta_scope: meta.statement.for.python
+            - meta_content_scope: meta.statement.loop.for.python
             - include: line-continuation-or-pop
             - match: ':'
-              scope: punctuation.section.block.for.python
+              scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
               pop: true
             - include: expressions
         - match: ':'
@@ -256,12 +256,12 @@ contexts:
           pop: true
         - include: expressions
     - match: \bwhile\b
-      scope: keyword.control.flow.while.python
+      scope: keyword.control.loop.while.python
       push:
-        - meta_scope: meta.statement.while.python
+        - meta_scope: meta.statement.loop.while.python
         - include: line-continuation-or-pop
         - match: ':'
-          scope: punctuation.section.block.while.python
+          scope: punctuation.section.block.loop.while.python
           pop: true
         - include: expressions
     - match: \b(else)\b(?:\s*(:))?
@@ -2105,12 +2105,12 @@ contexts:
     - match: \b(?:(async)\s+)?(for)\b
       captures:
         1: storage.modifier.async.python
-        2: keyword.control.flow.for.generator.python
+        2: keyword.control.loop.for.generator.python
       push:
         - include: comments
         - meta_scope: meta.expression.generator.python
-        - match: \b(in)\b
-          scope: keyword.control.flow.for.in.python
+        - match: \bin\b
+          scope: keyword.control.loop.for.in.python
           pop: true
         - match: '(?=[)\]}])'
           scope: invalid.illegal.missing-in.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -229,20 +229,20 @@ contexts:
       push: with-body
     # except ... as ...:
     - match: \bexcept\b
-      scope: keyword.control.exception.except.python
+      scope: keyword.control.exception.catch.python
       push:
-        - meta_scope: meta.statement.exception.except.python
+        - meta_scope: meta.statement.exception.catch.python
         - include: line-continuation-or-pop
         - match: ':'
-          scope: punctuation.section.block.exception.except.python
+          scope: punctuation.section.block.exception.catch.python
           pop: true
         - match: '\bas\b'
-          scope: keyword.control.exception.except.as.python
+          scope: keyword.control.exception.catch.as.python
           set:
-            - meta_content_scope: meta.statement.exception.except.python
+            - meta_content_scope: meta.statement.exception.catch.python
             - include: line-continuation-or-pop
             - match: ':'
-              scope: meta.statement.exception.except.python punctuation.section.block.exception.except.python
+              scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
               pop: true
             - include: name
         - include: target-list

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -247,9 +247,9 @@ contexts:
             - include: name
         - include: target-list
     - match: \bif\b
-      scope: keyword.control.flow.conditional.python
+      scope: keyword.control.conditional.if.python
       push:
-        - meta_scope: meta.statement.if.python
+        - meta_scope: meta.statement.conditional.python
         - include: line-continuation-or-pop
         - match: ':'
           scope: punctuation.section.block.conditional.python
@@ -267,8 +267,8 @@ contexts:
     - match: \b(else)\b(?:\s*(:))?
       scope: meta.statement.conditional.python
       captures:
-        1: keyword.control.flow.conditional.python
-        2: punctuation.section.block.python
+        1: keyword.control.conditional.else.python
+        2: punctuation.section.block.conditional.python
     - match: \b(try)\b(?:\s*(:))?
       scope: meta.statement.try.python
       captures:
@@ -280,11 +280,11 @@ contexts:
         1: keyword.control.flow.finally.python
         2: punctuation.section.block.finally.python
     - match: \belif\b
-      scope: keyword.control.flow.conditional.python
+      scope: keyword.control.conditional.elseif.python
       push:
         - meta_scope: meta.statement.conditional.python
         - match: ':'
-          scope: punctuation.section.block.python
+          scope: punctuation.section.block.conditional.python
           pop: true
         - match: $\n?
           pop: true
@@ -2119,10 +2119,10 @@ contexts:
         - include: target-list
 
   inline-if:
-    - match: \b(if)\b
-      scope: keyword.control.flow.if.inline.python
-    - match: \b(else)\b
-      scope: keyword.control.flow.else.inline.python
+    - match: \bif\b
+      scope: keyword.control.conditional.if.python
+    - match: \belse\b
+      scope: keyword.control.conditional.else.python
 
   target-list:
     - match: ','

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -228,21 +228,21 @@ contexts:
         2: keyword.control.flow.with.python
       push: with-body
     # except ... as ...:
-    - match: \b(except)\b
-      scope: keyword.control.flow.except.python
+    - match: \bexcept\b
+      scope: keyword.control.exception.except.python
       push:
-        - meta_scope: meta.statement.except.python
+        - meta_scope: meta.statement.exception.except.python
         - include: line-continuation-or-pop
         - match: ':'
-          scope: punctuation.section.block.except.python
+          scope: punctuation.section.block.exception.except.python
           pop: true
-        - match: '\b(as)\b'
-          scope: keyword.control.flow.as.python
+        - match: '\bas\b'
+          scope: keyword.control.exception.except.as.python
           set:
-            - meta_content_scope: meta.statement.except.python
+            - meta_content_scope: meta.statement.exception.except.python
             - include: line-continuation-or-pop
             - match: ':'
-              scope: meta.statement.except.python punctuation.section.block.except.python
+              scope: meta.statement.exception.except.python punctuation.section.block.exception.except.python
               pop: true
             - include: name
         - include: target-list
@@ -270,15 +270,15 @@ contexts:
         1: keyword.control.conditional.else.python
         2: punctuation.section.block.conditional.python
     - match: \b(try)\b(?:\s*(:))?
-      scope: meta.statement.try.python
+      scope: meta.statement.exception.try.python
       captures:
-        1: keyword.control.flow.try.python
-        2: punctuation.section.block.try.python
+        1: keyword.control.exception.try.python
+        2: punctuation.section.block.exception.try.python
     - match: \b(finally)\b(?:\s*(:))?
-      scope: meta.statement.finally.python
+      scope: meta.statement.exception.finally.python
       captures:
-        1: keyword.control.flow.finally.python
-        2: punctuation.section.block.finally.python
+        1: keyword.control.exception.finally.python
+        2: punctuation.section.block.exception.finally.python
     - match: \belif\b
       scope: keyword.control.conditional.elseif.python
       push:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -252,7 +252,7 @@ contexts:
         - meta_scope: meta.statement.conditional.if.python
         - include: line-continuation-or-pop
         - match: ':'
-          scope: punctuation.section.block.conditional.python
+          scope: punctuation.section.block.conditional.if.python
           pop: true
         - include: expressions
     - match: \bwhile\b
@@ -268,7 +268,7 @@ contexts:
       scope: meta.statement.conditional.else.python
       captures:
         1: keyword.control.conditional.else.python
-        2: punctuation.section.block.conditional.python
+        2: punctuation.section.block.conditional.else.python
     - match: \b(try)\b(?:\s*(:))?
       scope: meta.statement.exception.try.python
       captures:
@@ -284,7 +284,7 @@ contexts:
       push:
         - meta_scope: meta.statement.conditional.elseif.python
         - match: ':'
-          scope: punctuation.section.block.conditional.python
+          scope: punctuation.section.block.conditional.elseif.python
           pop: true
         - match: $\n?
           pop: true

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -561,27 +561,27 @@ def _():
 #   ^^ keyword.control.conditional.if.python
 #      ^^^ constant.numeric.integer.decimal.python
 #          ^^ keyword.operator.logical.python
-#                ^ punctuation.section.block.conditional.python
+#                ^ punctuation.section.block.conditional.if.python
         pass
     elif:
 #   ^^^^^ meta.statement.conditional.elseif.python
-#       ^ punctuation.section.block.conditional.python
+#       ^ punctuation.section.block.conditional.elseif.python
         pass
     elif False :
 #   ^^^^^^^^^^^^ meta.statement.conditional.elseif.python
 #        ^^^^^ constant.language
-#              ^ punctuation.section.block.conditional.python
+#              ^ punctuation.section.block.conditional.elseif.python
         pass
     else  :
 #   ^^^^^^^ meta.statement.conditional.else.python
-#         ^ punctuation.section.block.conditional.python
+#         ^ punctuation.section.block.conditional.else.python
         pass
 
     if \
         True:
 #       ^^^^^ meta.statement.conditional.if.python
 #       ^^^^ constant.language.python
-#           ^ punctuation.section.block.conditional.python
+#           ^ punctuation.section.block.conditional.if.python
 #
 
     # verify that keywords also work when they are bare (useful when typing)

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -232,8 +232,8 @@ def _():
 #         ^^^^ - keyword
 
     a if b else c
-#     ^^ keyword.control.flow
-#          ^^^^ keyword.control.flow
+#     ^^ keyword.control.conditional.if
+#          ^^^^ keyword.control.conditional.else
 
     c = lambda: pass
 #       ^^^^^^^ meta.function.inline
@@ -557,29 +557,29 @@ def _():
 #           ^^^^^^^^ keyword.control.flow.continue.python
 
     if 213 is 231:
-#   ^^^^^^^^^^^^^^ meta.statement.if.python
-#   ^^ keyword.control.flow.conditional.python
+#   ^^^^^^^^^^^^^^ meta.statement.conditional.python
+#   ^^ keyword.control.conditional.if.python
 #      ^^^ constant.numeric.integer.decimal.python
 #          ^^ keyword.operator.logical.python
 #                ^ punctuation.section.block.conditional.python
         pass
     elif:
 #   ^^^^^ meta.statement.conditional.python
-#       ^ punctuation.section.block.python
+#       ^ punctuation.section.block.conditional.python
         pass
     elif False :
 #   ^^^^^^^^^^^^ meta.statement.conditional.python
 #        ^^^^^ constant.language
-#              ^ punctuation.section.block.python
+#              ^ punctuation.section.block.conditional.python
         pass
     else  :
 #   ^^^^^^^ meta.statement.conditional.python
-#         ^ punctuation.section.block.python
+#         ^ punctuation.section.block.conditional.python
         pass
 
     if \
         True:
-#       ^^^^^ meta.statement.if.python
+#       ^^^^^ meta.statement.conditional.python
 #       ^^^^ constant.language.python
 #           ^ punctuation.section.block.conditional.python
 #
@@ -590,11 +590,11 @@ def _():
     with
 #   ^^^^ keyword.control.flow.with.python
     if
-#   ^^ keyword.control.flow.conditional.python
+#   ^^ keyword.control.conditional.if.python
     finally
 #   ^^^^^^^ keyword.control.flow.finally.python
     else
-#   ^^^^ keyword.control.flow.conditional.python
+#   ^^^^ keyword.control.conditional.else.python
     while
 #   ^^^^^ keyword.control.flow.while.python
     return
@@ -1004,8 +1004,8 @@ dict_ = {i: i for i in range(100)}
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
-#                              ^^ keyword.control.flow.if.inline
-#                                       ^^^^ keyword.control.flow.else.inline
+#                              ^^ keyword.control.conditional.if
+#                                       ^^^^ keyword.control.conditional.else
 
 list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #           ^^ keyword.operator.logical

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -557,29 +557,29 @@ def _():
 #           ^^^^^^^^ keyword.control.flow.continue.python
 
     if 213 is 231:
-#   ^^^^^^^^^^^^^^ meta.statement.conditional.python
+#   ^^^^^^^^^^^^^^ meta.statement.conditional.if.python
 #   ^^ keyword.control.conditional.if.python
 #      ^^^ constant.numeric.integer.decimal.python
 #          ^^ keyword.operator.logical.python
 #                ^ punctuation.section.block.conditional.python
         pass
     elif:
-#   ^^^^^ meta.statement.conditional.python
+#   ^^^^^ meta.statement.conditional.elseif.python
 #       ^ punctuation.section.block.conditional.python
         pass
     elif False :
-#   ^^^^^^^^^^^^ meta.statement.conditional.python
+#   ^^^^^^^^^^^^ meta.statement.conditional.elseif.python
 #        ^^^^^ constant.language
 #              ^ punctuation.section.block.conditional.python
         pass
     else  :
-#   ^^^^^^^ meta.statement.conditional.python
+#   ^^^^^^^ meta.statement.conditional.else.python
 #         ^ punctuation.section.block.conditional.python
         pass
 
     if \
         True:
-#       ^^^^^ meta.statement.conditional.python
+#       ^^^^^ meta.statement.conditional.if.python
 #       ^^^^ constant.language.python
 #           ^ punctuation.section.block.conditional.python
 #

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -525,12 +525,12 @@ def _():
         raise
 #       ^^^^^ meta.statement.raise.python keyword.control.flow.raise.python
     except Exception as x:
-#   ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.except.python - meta.statement.exception.except.python meta.statement.exception.except.python
-#   ^^^^^^ keyword.control.exception.except.python
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch.python - meta.statement.exception.catch.python meta.statement.exception.catch.python
+#   ^^^^^^ keyword.control.exception.catch.python
 #          ^^^^^^^^^ support.type.exception.python
-#                    ^^ keyword.control.exception.except.as.python
+#                    ^^ keyword.control.exception.catch.as.python
 #                       ^ meta.generic-name.python
-#                        ^ punctuation.section.block.exception.except.python
+#                        ^ punctuation.section.block.exception.catch.python
         pass
     finally :
 #   ^^^^^^^^^ meta.statement.exception.finally.python
@@ -1120,30 +1120,30 @@ generator = (
 ##################
 
 except Exception:
-#^^^^^^^^^^^^^^^^ meta.statement.exception.except
-#^^^^^ keyword.control.exception.except
+#^^^^^^^^^^^^^^^^ meta.statement.exception.catch
+#^^^^^ keyword.control.exception.catch
 #      ^^^^^^^^^ support.type.exception
 #               ^ punctuation.section.block
 except (KeyError, NameError) as e:
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.except
-#^^^^^ keyword.control.exception.except
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch
+#^^^^^ keyword.control.exception.catch
 #       ^^^^^^^^ support.type.exception
 #               ^ punctuation.separator.target-list
 #                 ^^^^^^^^^ support.type.exception
-#                            ^^ keyword.control.exception.except.as
+#                            ^^ keyword.control.exception.catch.as
 #                                ^ punctuation.section.block
 except \
     StopIteration \
     as \
     err:
-#   ^^^^ meta.statement.exception.except
+#   ^^^^ meta.statement.exception.catch
 
 except StopIteration
     as
-#   ^^ invalid.illegal.name - meta.statement.exception.except
+#   ^^ invalid.illegal.name - meta.statement.exception.catch
 
 except
-#^^^^^ keyword.control.exception.except
+#^^^^^ keyword.control.exception.catch
 
 raise
 #^^^^ meta.statement.raise keyword.control.flow.raise

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -519,23 +519,23 @@ def _():
 #       ^^^^^ keyword.other.await
 
     try:
-#   ^^^^ meta.statement.try.python
-#   ^^^ keyword.control.flow.try.python
-#      ^ punctuation.section.block.try.python
+#   ^^^^ meta.statement.exception.try.python
+#   ^^^ keyword.control.exception.try.python
+#      ^ punctuation.section.block.exception.try.python
         raise
 #       ^^^^^ meta.statement.raise.python keyword.control.flow.raise.python
     except Exception as x:
-#   ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.except.python - meta.statement.except.python meta.statement.except.python
-#   ^^^^^^ keyword.control.flow.except.python
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.except.python - meta.statement.exception.except.python meta.statement.exception.except.python
+#   ^^^^^^ keyword.control.exception.except.python
 #          ^^^^^^^^^ support.type.exception.python
-#                    ^^ keyword.control.flow.as.python
+#                    ^^ keyword.control.exception.except.as.python
 #                       ^ meta.generic-name.python
-#                        ^ punctuation.section.block.except.python
+#                        ^ punctuation.section.block.exception.except.python
         pass
     finally :
-#   ^^^^^^^^^ meta.statement.finally.python
-#   ^^^^^^^ keyword.control.flow.finally.python
-#           ^ punctuation.section.block.finally.python
+#   ^^^^^^^^^ meta.statement.exception.finally.python
+#   ^^^^^^^ keyword.control.exception.finally.python
+#           ^ punctuation.section.block.exception.finally.python
     try_except_raise:
 #   ^^^ - keyword
 
@@ -592,7 +592,7 @@ def _():
     if
 #   ^^ keyword.control.conditional.if.python
     finally
-#   ^^^^^^^ keyword.control.flow.finally.python
+#   ^^^^^^^ keyword.control.exception.finally.python
     else
 #   ^^^^ keyword.control.conditional.else.python
     while
@@ -1120,30 +1120,30 @@ generator = (
 ##################
 
 except Exception:
-#^^^^^^^^^^^^^^^^ meta.statement.except
-#^^^^^ keyword.control.flow.except
+#^^^^^^^^^^^^^^^^ meta.statement.exception.except
+#^^^^^ keyword.control.exception.except
 #      ^^^^^^^^^ support.type.exception
 #               ^ punctuation.section.block
 except (KeyError, NameError) as e:
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.except
-#^^^^^ keyword.control.flow.except
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.except
+#^^^^^ keyword.control.exception.except
 #       ^^^^^^^^ support.type.exception
 #               ^ punctuation.separator.target-list
 #                 ^^^^^^^^^ support.type.exception
-#                            ^^ keyword.control.flow.as
+#                            ^^ keyword.control.exception.except.as
 #                                ^ punctuation.section.block
 except \
     StopIteration \
     as \
     err:
-#   ^^^^ meta.statement.except
+#   ^^^^ meta.statement.exception.except
 
 except StopIteration
     as
-#   ^^ invalid.illegal.name - meta.statement.except
+#   ^^ invalid.illegal.name - meta.statement.exception.except
 
 except
-#^^^^^ keyword.control.flow.except
+#^^^^^ keyword.control.exception.except
 
 raise
 #^^^^ meta.statement.raise keyword.control.flow.raise

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -417,23 +417,23 @@ def _():
 ##################
 def _():
     for
-#   ^^^ keyword.control.flow.for
+#   ^^^ keyword.control.loop.for
     b = c in d
-#         ^^ keyword.operator.logical - keyword.control.flow.for.in
+#         ^^ keyword.operator.logical - keyword.control.loop.for.in
 
     for \
         a \
         in \
         b:
-#       ^^ meta.statement.for
-#        ^ punctuation.section.block.for.python
+#       ^^ meta.statement.loop.for
+#        ^ punctuation.section.block.loop.for.python
 
     async for i in myfunc():
-#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.for
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for
 #   ^^^^^ storage.modifier.async
-#         ^^^ keyword.control.flow.for
-#               ^^ keyword.control.flow.for.in
-#                          ^ punctuation.section.block.for
+#         ^^^ keyword.control.loop.for
+#               ^^ keyword.control.loop.for.in
+#                          ^ punctuation.section.block.loop.for
         pass
 
     for i:
@@ -540,14 +540,14 @@ def _():
 #   ^^^ - keyword
 
     while (
-#   ^^^^^^^^ meta.statement.while.python
-#   ^^^^^ keyword.control.flow.while.python
-#         ^ meta.statement.while.python meta.group.python punctuation.section.group.begin.python
+#   ^^^^^^^^ meta.statement.loop.while.python
+#   ^^^^^ keyword.control.loop.while.python
+#         ^ meta.statement.loop.while.python meta.group.python punctuation.section.group.begin.python
         a is b
-#       ^^^^^^ meta.statement.while.python
+#       ^^^^^^ meta.statement.loop.while.python
 #         ^^ keyword.operator.logical.python
     ):
-#    ^ meta.statement.while.python punctuation.section.block.while.python
+#    ^ meta.statement.loop.while.python punctuation.section.block.loop.while.python
         sleep()
         if a:
             break
@@ -586,7 +586,7 @@ def _():
 
     # verify that keywords also work when they are bare (useful when typing)
     for
-#   ^^^ keyword.control.flow.for.python
+#   ^^^ keyword.control.loop.for.python
     with
 #   ^^^^ keyword.control.flow.with.python
     if
@@ -596,7 +596,7 @@ def _():
     else
 #   ^^^^ keyword.control.conditional.else.python
     while
-#   ^^^^^ keyword.control.flow.while.python
+#   ^^^^^ keyword.control.loop.while.python
     return
 #   ^^^^^^ keyword.control.flow.return.python
     raise
@@ -980,18 +980,18 @@ complex_mapping = {(): "value"}
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 #              ^^^^^^^^ meta.expression.generator
-#              ^^^ keyword.control.flow.for.generator
-#                    ^^ keyword.control.flow.for.in
+#              ^^^ keyword.control.loop.for.generator
+#                    ^^ keyword.control.loop.for.in
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
-#          ^^^ keyword.control.flow.for.generator
-#                ^^ keyword.control.flow.for.in
+#          ^^^ keyword.control.loop.for.generator
+#                ^^ keyword.control.loop.for.in
 set_ = {i for i in range(100)}
 #      ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping-or-set
 #         ^^^^^^^^ meta.expression.generator
-#         ^^^ keyword.control.flow.for.generator
-#               ^^ keyword.control.flow.for.in
+#         ^^^ keyword.control.loop.for.generator
+#               ^^ keyword.control.loop.for.in
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #        ^ meta.mapping.key.python
@@ -999,8 +999,8 @@ dict_ = {i: i for i in range(100)}
 #           ^ meta.mapping.value.python
 #            ^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.value
 #             ^^^^^^^^ meta.expression.generator
-#             ^^^ keyword.control.flow.for.generator
-#                   ^^ keyword.control.flow.for.in
+#             ^^^ keyword.control.loop.for.generator
+#                   ^^ keyword.control.loop.for.in
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
@@ -1009,7 +1009,7 @@ list_ = [i for i in range(100) if i > 0 else -1]
 
 list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #           ^^ keyword.operator.logical
-#                              ^^ keyword.control.flow.for.in
+#                              ^^ keyword.control.loop.for.in
 #                                                 ^^ keyword.operator.logical
 
 generator = ((k1, k2, v) for ((k1, k2), v) in xs)
@@ -1055,11 +1055,11 @@ list((i for i in generator), 123)
 
 _ = [m
      for cls in self.__class__.mro()
-#    ^^^ keyword.control.flow.for.generator
-#            ^^ keyword.control.flow.for.in
+#    ^^^ keyword.control.loop.for.generator
+#            ^^ keyword.control.loop.for.in
      for m in cls.__dict__]
-#    ^^^ keyword.control.flow.for.generator
-#          ^^ keyword.control.flow.for.in
+#    ^^^ keyword.control.loop.for.generator
+#          ^^ keyword.control.loop.for.in
 
 result = [i async for i in aiter() if i % 2]
 #           ^^^^^ storage.modifier.async
@@ -1107,10 +1107,10 @@ s = {*d, *set()}
 generator = (
     i
     for
-#   ^^^ keyword.control.flow.for.generator
+#   ^^^ keyword.control.loop.for.generator
     i
     in
-#   ^^ keyword.control.flow.for.in
+#   ^^ keyword.control.loop.for.in
     range(100)
 )
 

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -645,7 +645,7 @@ f'   \
 # ^^^^^ source source.python.embedded
 
 f"{d for d in range(10)}"  # yes, this doesn't make sense
-#    ^^^ keyword.control.flow.for.generator.python
+#    ^^^ keyword.control.loop.for.generator.python
 
 f'
 # ^ invalid.illegal.unclosed-string


### PR DESCRIPTION
This commit 

1. applies `keyword.control` scopes as discussed in #1228.
2. fixes some inconsistencies with punctuation `:` scopes in control flow statements.
3. removes some unrequired capture groups.