### PR TITLE
[Haskell] Fix type signature context not popping when encountering a guard or an instance declaration.

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -163,8 +163,7 @@ contexts:
         3: keyword.other.double-colon.haskell
       push:
         - meta_scope: meta.function.type-declaration.haskell
-        - include: comments
-        - match: ^(?!\1\s)
+        - match: ^(?!\s*(?:--|{-|$)|\1\s)
           pop: true
         - include: type_signature
     - match: '\b[A-Z]\w*\b'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -157,19 +157,14 @@ contexts:
         4: constant.character.escape.hexadecimal.haskell
         5: constant.character.escape.control.haskell
         6: punctuation.definition.string.end.haskell
-    - match: '^\s*([a-z_][a-zA-Z0-9_'']*|\([|!%$+\-.,=</>]+\))\s*(::|∷)'
+    - match: '^(\s*)([a-z_][a-zA-Z0-9_'']*|\([|!%$+\-.,=</>]+\))\s*(::|∷)'
       captures:
-        1: entity.name.function.haskell
-        2: keyword.other.double-colon.haskell
+        2: entity.name.function.haskell
+        3: keyword.other.double-colon.haskell
       push:
         - meta_scope: meta.function.type-declaration.haskell
-        - match: |-
-            (?x)
-                ^(data|newtype|type|class|deriving)\s  # When a top level declaration starts
-              | ^[^=]*(=)[\sa-zA-Z0-9_\(]                # A function declaration
-          captures:
-            1: keyword.other.haskell
-            2: keyword.operator.haskell
+        - include: comments
+        - match: ^(?!\1\s)
           pop: true
         - include: type_signature
     - match: '\b[A-Z]\w*\b'

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -72,7 +72,6 @@
 -- ^^^^^^^^^^^^ meta.function.type-declaration.haskell
 --  ^^ keyword.other.arrow.haskell
    traverse f = sequenceA . fmap f
--- ^^^^^^^^^^^^^ meta.function.type-declaration.haskell
 --            ^ keyword.operator.haskell
 --                        ^ keyword.operator.haskell
 
@@ -108,3 +107,25 @@
 --     ^ keyword.operator.haskell
 --       ^^^ entity.name.function.infix.haskell
 --             ^ constant.numeric.haskell
+
+-- Tests for #1320, #1880.
+
+   class TooMany a where
+     tooMany :: a -> Bool
+-- ^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
+     tooManyToo ::
+-- ^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
+      a -> Bool
+-- ^^^^^^^^^^^^ meta.function.type-declaration.haskell
+
+   instance TooMany Int where
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.instance.haskell
+     tooMany n = n > 42
+
+   foldBoolGuard :: a -> a -> Bool -> a
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
+   foldBoolGuard x y z
+-- ^^^^^^^^^^^^^^^^^^^ source.haskell
+       | z         = y
+--     ^ keyword.operator.haskell
+       | otherwise = x

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -115,8 +115,8 @@
 -- ^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
      tooManyToo ::
 -- ^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
-      a -> Bool
--- ^^^^^^^^^^^^ meta.function.type-declaration.haskell
+       a -> Bool
+-- ^^^^^^^^^^^^^ meta.function.type-declaration.haskell
 
    instance TooMany Int where
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.instance.haskell
@@ -126,6 +126,20 @@
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
    foldBoolGuard x y z
 -- ^^^^^^^^^^^^^^^^^^^ source.haskell
-       | z         = y
---     ^ keyword.operator.haskell
-       | otherwise = x
+     | z         = y
+--   ^ keyword.operator.haskell
+     | otherwise = x
+
+   countTheBeforeVowel :: String
+   -- This comment should not interrupt the type signature.
+
+   -- The blank line above should not interrupt the type signature.
+
+   {-
+      This multiline comment should
+      not interrupt the type signature.
+   -}
+
+     -> Integer
+-- ^^^^^^^^^^^^ meta.function.type-declaration.haskell
+   countTheBeforeVowel = undefined


### PR DESCRIPTION
Addresses #1320 and #1880. Shamelessly adapted from `SublimeHaskell`'s syntax file [here](https://github.com/SublimeHaskell/SublimeHaskell/blob/master/Syntaxes/Haskell-SublimeHaskell.sublime-syntax#L311).

The test on [line 75](https://github.com/sublimehq/Packages/pull/1885/files#diff-38b1f0659739bb29fa8ff5fc5899f9efL75) of `syntax_test_haskell.hs` was deleted because it relied on the `=` operator to pop the type signature context.

Sublime's default Haskell syntax is a bit dated and could use a rewrite. There are a number of problems inherent to its current design, like #1321. A merge with `SublimeHaskell` may be a good start, but I've found that it too has a couple of idiosyncrasies. I'm not sure how to best engage the community.