### PR TITLE
[PHP] Add support for inline PHPDoc

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -698,7 +698,12 @@ contexts:
     # This only highlights a docblock if the first line contains only /** or
     # /**#@+ (which is used for docblock templates). Otherwise block-level
     # comment would be highlighted as invalid for constructs such as /**** ****/
-    - match: /\*\*(?:#@\+)?\s*$
+    - match: |-
+        (?x)/\*\*(?:
+          (?:\#@\+)?\s*$ (?# multi-line doc )
+          |
+          (?=\s+@.*\s\*/\s*$) (?# inline doc )
+        )
       scope: punctuation.definition.comment.begin.php
       push:
         - meta_scope: comment.block.documentation.phpdoc.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -236,6 +236,9 @@ $var->meth()[10];
  */
 // ^ source - comment.block
 
+/** @var Properties: class properties. */
+//  ^ keyword.other.phpdoc
+
 /**
  * @return
 //  ^ keyword.other.phpdoc


### PR DESCRIPTION
See http://docs.phpdoc.org/references/phpdoc/tags/var.html .

Currently we only have multi-line doc highlighted.

```php
/**
 * @var string $name        Should contain a description
 * @var string $description Should contain a description
 */
```

However, this inline doc is valid as well.

```php
/** @var string|null Should contain a description */
//  ^ keyword.other.phpdoc
```
