### PR TITLE
[JSON] Remove prototype from object keys

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -101,6 +101,7 @@ contexts:
           push:
             - clear_scopes: 1
             - meta_scope: meta.mapping.key.json string.quoted.double.json
+            - meta_include_prototype: false
             - include: inside-string
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -76,4 +76,7 @@
 
   "typing json": {}
   ,,,, "another key": false,
+
+  "ke//y": "value"
+//^^^^^^^ meta.mapping.key.json string.quoted.double.json - comment
 }


### PR DESCRIPTION
Object keys are being highlighted using an anonymous context that includes `inside-string` instead of pushing it onto the stack. Thus the `meta_include_prototype: false` of the `inside-string` context does not apply, and comments are being matched inside object keys.