### PR TITLE
[Python] Fix mapping element starting with 'for'

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1016,7 +1016,7 @@ contexts:
       push:
         - clear_scopes: 1
         - meta_content_scope: meta.mapping.value.python
-        - match: (?=\s*(\}|,|for))
+        - match: (?=\s*(\}|,|for\b))
           pop: true
         - include: expressions
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1003,7 +1003,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.mapping.python
           set: inside-dictionary
-    - match: (?=for)
+    - match: (?=for\b)
       push:
         - match: (?=\})
           pop: true

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -950,6 +950,10 @@ mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
 #                                              ^ invalid.illegal.expected-colon.python
 #                                               ^ punctuation.section.mapping.end - meta.mapping.key
 
+mydict = { 'a' : xform, 'b' : form, 'c' : frm }
+#                                 ^ meta.mapping.python punctuation.separator.mapping.python
+#                                       ^ punctuation.separator.mapping.key-value.python
+
 myset = {"key", True, key2, [-1], {}:1}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set
 #       ^ punctuation.section.set.begin.python


### PR DESCRIPTION
Add missing \b to capture inline for inside a dict.
Add relevant test.

Reported in forum: https://forum.sublimetext.com/t/python-syntax-highlight-bug-after-update/42248