### PR TITLE
[Python] Fix Oniguruma incompatibility with regex for path

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -32,7 +32,7 @@ variables:
   identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
   identifier_constant: '\b(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
   digitpart: (?:\d(?:_?\d)*)
-  path: '({{identifier}} *\. *)*{{identifier}}'
+  path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH)\b
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
   format_spec: |-


### PR DESCRIPTION
In 0550509bcd5, `path` was modified to allow spaces around `.`. Later, `simple_expression` started using `path` but within a `(?x:...)`, which means this:

    \b[[:alpha:]_][[:alnum:]_]*\b *\. *

is equivalent to:

    \b[[:alpha:]_][[:alnum:]_]*\b*\.*

While sregex doesn't complain about that, `\b*` is invalid in Oniguruma:

<img width="480" alt="Screen Shot 2019-03-11 at 17 20 12" src="https://user-images.githubusercontent.com/16778/54103833-f36b0f00-4421-11e9-9714-2576f8d13673.png">

Note that even with sregex, the meaning of the regex changes.

By using a character class for the space, the pattern works the same way
whether it's within a `(?x:...)` or not.