### PR TITLE
[Perl] Fix member function vs. member variable matching

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -276,7 +276,7 @@ contexts:
     - include: control
     - include: sub
     - include: variables
-    - include: functions
+    - include: function-call
     - include: comment-line
     # /<find>/<flags> statement at line start
     - match: ^ *(?=/.*[^\\]/)
@@ -927,7 +927,8 @@ contexts:
 
 ###[ FUNCTIONS ]##############################################################
 
-  functions:
+  function-call:
+    # builtin function calls
     - match: |-
         \b(?x:
            abs|accept|alarm|atan2|bind|binmode|bless|chdir|chmod
@@ -955,9 +956,12 @@ contexts:
         ){{break}}
       scope: support.function.perl
       push: regexp-pop
-    - match: \b{{member}}{{break}}
-      scope: variable.function.perl
-      push: regexp-pop
+    # user defined function calls
+    - match: \b({{member}})\s*(?=\()
+      scope: meta.function-call.name.perl
+      captures:
+        1: variable.function.perl
+      push: function-call-arguments
 
   function-call-arguments:
     - match: \(

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -615,6 +615,19 @@ contexts:
       pop: true
     - include: else-pop
 
+  object-members-pop:
+    # member function
+    - match: ({{member}})\s*(?=\()
+      scope: meta.function-call.name.perl
+      captures:
+        1: variable.function.member.perl
+      set: function-call-arguments
+    # member variable
+    - match: '{{identifier}}'
+      scope: variable.other.member.perl
+      pop: true
+    - include: else-pop
+
 ###[ CONTROL KEYWORDS ]#######################################################
 
   control:
@@ -649,8 +662,8 @@ contexts:
       scope: keyword.operator.filetest.perl
       push: regexp-pop
     - match: '->'
-      scope: keyword.operator.arrow.perl
-      push: regexp-pop
+      scope: keyword.accessor.arrow.perl
+      push: object-members-pop
     - match: '[!~=]~'
       scope: keyword.operator.binary.perl
       push: regexp-pop

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -955,10 +955,6 @@ contexts:
         ){{break}}
       scope: support.function.perl
       push: regexp-pop
-    - match: ^\s*(AUTOLOAD|BEGIN|CHECK|DESTROY|END|INIT|UNITCHECK){{break}}
-      scope: meta.function.perl
-      captures:
-        1: entity.name.function.perl
     - match: \b{{member}}{{break}}
       scope: variable.function.perl
       push: regexp-pop
@@ -983,6 +979,9 @@ contexts:
 
   sub-name:
     - meta_scope: meta.function.perl
+    - match: \b(AUTOLOAD|BEGIN|CHECK|DESTROY|END|INIT|UNITCHECK){{break}}
+      scope: entity.name.function.callback.perl
+      set: sub-expect-parameters
     - match: '{{identifier}}'
       scope: entity.name.function.perl
       set: sub-expect-parameters

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -592,17 +592,27 @@ contexts:
   class:
     - match: '{{module}}(?=\s*(?:::|[#;]|$))'
       scope: support.class.perl
-      push: members-pop
+      push: class-members-pop
 
-  members-pop:
+  class-members-pop:
+    # nested class
     - match: \s*(::)\s*({{module}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: support.class.perl
+    # member function
+    - match: \s*(::)\s*(({{member}})\s*)(?=\()
+      captures:
+        1: punctuation.accessor.double-colon.perl
+        2: meta.function-call.name.perl
+        3: variable.function.member.perl
+      set: function-call-arguments
+    # member variable
     - match: \s*(::)\s*({{identifier}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: variable.other.member.perl
+      pop: true
     - include: else-pop
 
 ###[ CONTROL KEYWORDS ]#######################################################
@@ -953,6 +963,17 @@ contexts:
       scope: variable.function.perl
       push: regexp-pop
 
+  function-call-arguments:
+    - match: \(
+      scope: punctuation.section.arguments.begin.perl
+      set:
+        - - meta_scope: meta.function-call.arguments.perl
+          - match: \)
+            scope: punctuation.section.arguments.end.perl
+            pop: true
+          - include: main
+        - regexp-pop
+
 ###[ SUB ]####################################################################
 
   sub:
@@ -1046,8 +1067,9 @@ contexts:
         1: punctuation.definition.variable.perl
         2: support.class.perl
       push:
-        - meta_scope: variable.other.readwrite.global.perl
-        - include: members-pop
+        - - meta_scope: variable.other.readwrite.global.perl
+          - include: immediately-pop
+        - class-members-pop
     - match: (\$)(\^[A-Z]|[_ab\*\.\/\|,\\;#%=\-~^:?!\$<>\(\)\[\]@])(?!\w)
       scope: variable.other.predefined.perl
       captures:

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1298,6 +1298,12 @@ sub name ($) {}
 #         ^ variable.parameter.perl
 #          ^ punctuation.section.group.end.perl - variable.parameter.perl
 
+sub AUTOLOAD () {}
+#^^^^^^^^^^^^ meta.function.perl
+#            ^^ meta.function.parameters.perl
+#              ^^^ meta.function.perl
+#   ^^^^^^^^ entity.name.function.callback.perl
+
 ###[ EXPRESSIONS ]############################################################
 
   retry:

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -515,7 +515,7 @@ EOT
 #          ^^ punctuation.accessor.double-colon.perl
 #            ^^^ variable.other.member.perl
   $Foo :: Bar :: baz
-# ^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
 #  ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
@@ -532,7 +532,7 @@ EOT
 #            ^^^^ variable.other.readwrite.global.perl
 #            ^ punctuation.definition.variable.perl
   $Foo :: Bar -> $baz
-# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
 #  ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
@@ -540,6 +540,27 @@ EOT
 #             ^^ keyword.operator.arrow.perl - variable
 #                ^^^^ variable.other.readwrite.global.perl
 #                ^ punctuation.definition.variable.perl
+  $Foo::Bar::baz()
+# ^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ punctuation.accessor.double-colon.perl
+#            ^^^ meta.function-call.name.perl variable.function.member.perl
+#               ^ meta.function-call.arguments.perl punctuation.section.arguments.begin.perl
+#                ^ meta.function-call.arguments.perl punctuation.section.arguments.end.perl
+  $Foo :: Bar :: baz ()
+# ^^^^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#      ^^ punctuation.accessor.double-colon.perl
+#         ^^^ support.class.perl
+#             ^^ punctuation.accessor.double-colon.perl
+#                ^^^^ meta.function-call.name.perl
+#                ^^^ variable.function.member.perl
+#                    ^ meta.function-call.arguments.perl punctuation.section.arguments.begin.perl
+#                     ^ meta.function-call.arguments.perl punctuation.section.arguments.end.perl
   $c = C::Scan->new(KEY => 'value')
 # ^^ variable.other.readwrite.global.perl
 #    ^ keyword.operator.assignment.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -376,7 +376,7 @@ EOT
   ::
 # ^^ - punctuation.accessor.double-colon.perl
   ->
-# ^^ keyword.operator.arrow.perl
+# ^^ keyword.accessor.arrow.perl
   **=
 # ^^^ keyword.operator.assignment.perl
   -=
@@ -528,7 +528,7 @@ EOT
 #  ^^^ support.class.perl
 #     ^^ punctuation.accessor.double-colon.perl
 #       ^^^ support.class.perl
-#          ^^ keyword.operator.arrow.perl - variable
+#          ^^ keyword.accessor.arrow.perl - variable
 #            ^^^^ variable.other.readwrite.global.perl
 #            ^ punctuation.definition.variable.perl
   $Foo :: Bar -> $baz
@@ -537,7 +537,7 @@ EOT
 #  ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
 #         ^^^ support.class.perl
-#             ^^ keyword.operator.arrow.perl - variable
+#             ^^ keyword.accessor.arrow.perl - variable
 #                ^^^^ variable.other.readwrite.global.perl
 #                ^ punctuation.definition.variable.perl
   $Foo::Bar::baz()
@@ -569,8 +569,8 @@ EOT
 #      ^ support.class.perl
 #       ^^ punctuation.accessor.double-colon.perl
 #         ^^^^ support.class.perl
-#             ^^ keyword.operator.arrow.perl
-#               ^^^ variable.function.perl
+#             ^^ keyword.accessor.arrow.perl
+#               ^^^ variable.function.member.perl
 #                  ^ punctuation.section.arguments.begin.perl
 #                   ^^^ constant.other.perl
 #                       ^^ keyword.operator.assignment.perl
@@ -595,8 +595,8 @@ EOT
 #   ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
 #        ^^^ variable.other.member.perl
-#           ^^ keyword.operator.arrow.perl
-#             ^^^ variable.function.perl
+#           ^^ keyword.accessor.arrow.perl
+#             ^^^ variable.function.member.perl
   }
 # <- variable.other.readwrite.global.perl
 #^^ variable.other.readwrite.global.perl
@@ -1412,3 +1412,14 @@ _EOD_
 #                                                    ^ punctuation.section.block.begin.perl
   }
 # ^ punctuation.section.block.end.perl
+
+  if ($self->value <= $self->other);
+#            ^^^^^ variable.other.member.perl
+#                  ^^ keyword.operator.logical.perl
+#                  ^^^^^^^^^^ - string
+#                          ^^ keyword.accessor.arrow.perl
+  if ($value <= $self->other);
+#            ^^ keyword.operator.logical.perl
+#            ^^^^^^^^^^ - string
+#                    ^^ keyword.accessor.arrow.perl
+#                      ^^^^^ variable.other.member.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -562,6 +562,8 @@ EOT
 #                    ^ meta.function-call.arguments.perl punctuation.section.arguments.begin.perl
 #                     ^ meta.function-call.arguments.perl punctuation.section.arguments.end.perl
   $c = C::Scan->new(KEY => 'value')
+#               ^^^ meta.function-call.name.perl
+#                  ^^^^^^^^^^^^^^^^ meta.function-call.arguments.perl
 # ^^ variable.other.readwrite.global.perl
 #    ^ keyword.operator.assignment.perl
 #      ^ support.class.perl
@@ -569,11 +571,11 @@ EOT
 #         ^^^^ support.class.perl
 #             ^^ keyword.operator.arrow.perl
 #               ^^^ variable.function.perl
-#                  ^ punctuation.section.group.begin.perl
+#                  ^ punctuation.section.arguments.begin.perl
 #                   ^^^ constant.other.perl
 #                       ^^ keyword.operator.assignment.perl
 #                          ^^^^^^^ string.quoted.single.perl
-#                                 ^ punctuation.section.group.end.perl
+#                                 ^ punctuation.section.arguments.end.perl
   ${Foo::Bar::baz}
 # ^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^^ punctuation.definition.variable.begin.perl
@@ -1331,19 +1333,67 @@ sub AUTOLOAD () {}
   if(exists($curargs{$index}))
 # ^^ keyword.control.conditional.perl
 #   ^ punctuation.section.group.begin.perl
+#    ^^^^^^ support.function.perl
 #          ^ punctuation.section.group.begin.perl
+#           ^^^^^^^^ variable.other.readwrite.global.perl
 #                            ^ punctuation.section.group.end.perl
-  function_call /pattern/g;
+  if(exists $curargs{$index})
+# ^^ keyword.control.conditional.perl
+#   ^ punctuation.section.group.begin.perl
+#    ^^^^^^ support.function.perl
+#           ^^^^^^^^ variable.other.readwrite.global.perl
+#                           ^ punctuation.section.group.end.perl
+  print /pattern/g;
+# ^^^^^ support.function.perl
+#       ^ punctuation.section.generic.begin.perl
+#        ^^^^^^^ string.regexp.perl source.regexp
+#               ^ punctuation.section.generic.end.perl
+#                ^ constant.language.flags.regexp.perl
+#                 ^ punctuation.terminator.statement.perl
+  print(/pattern/g);
+# ^^^^^ support.function.perl
+#       ^ punctuation.section.generic.begin.perl
+#        ^^^^^^^ string.regexp.perl source.regexp
+#               ^ punctuation.section.generic.end.perl
+#                ^ constant.language.flags.regexp.perl
+#                  ^ punctuation.terminator.statement.perl
+  function_call(/pattern/g);
+# ^^^^^^^^^^^^^ meta.function-call.name.perl - meta.function-call.arguments.perl
+#              ^^^^^^^^^^^^ meta.function-call.arguments.perl - meta.function-call.name.perl
 # ^^^^^^^^^^^^^ variable.function.perl
+#              ^ punctuation.section.arguments.begin.perl
 #               ^ punctuation.section.generic.begin.perl
 #                ^^^^^^^ string.regexp.perl source.regexp
 #                       ^ punctuation.section.generic.end.perl
 #                        ^ constant.language.flags.regexp.perl
-#                         ^ punctuation.terminator.statement.perl
-  _function_call $var;
+#                         ^ punctuation.section.arguments.end.perl
+#                          ^ punctuation.terminator.statement.perl
+  _function_call($var);
+# ^^^^^^^^^^^^^^ meta.function-call.name.perl - meta.function-call.arguments.perl
+#               ^^^^^^ meta.function-call.arguments.perl - meta.function-call.name.perl
 # ^^^^^^^^^^^^^^ variable.function.perl
+#               ^ punctuation.section.arguments.begin.perl
 #                ^^^^ variable.other.readwrite.global.perl
-#                    ^ punctuation.terminator.statement.perl
+#                    ^ punctuation.section.arguments.end.perl
+#                     ^ punctuation.terminator.statement.perl
+  no_function_call $var;
+# ^^^^^^^^^^^^^^^^ - variable.function.perl
+
+  function_call(<<_EOD_;
+# ^^^^^^^^^^^^^ meta.function-call.name.perl - meta.function-call.arguments.perl
+#              ^^^^^^^^^^ meta.function-call.arguments.perl - meta.function-call.name.perl
+# ^^^^^^^^^^^^^ variable.function.perl
+#              ^ punctuation.section.arguments.begin.perl
+#               ^^^^^^^^^ meta.heredoc.perl
+#               ^^ keyword.operator.heredoc.perl
+#                 ^^^^^ constant.language.heredoc.plain.perl
+#                      ^ punctuation.terminator.statement.perl
+  foo bar baz
+# <- meta.function-call.arguments.perl meta.heredoc.perl string.quoted.other.perl
+#^^^^^^^^^^^^^ meta.function-call.arguments.perl meta.heredoc.perl string.quoted.other.perl
+_EOD_
+)
+# <- meta.function-call.arguments.perl punctuation.section.arguments.end.perl - meta.function-call.name.perl
 
   foreach my $vsn_mk (<lib/*/vsn.mk>, <erts/vsn.mk>) {
 # ^^^^^^^ keyword.control.flow.perl


### PR DESCRIPTION
Fixes #1902

Issue #1902 is triggered by not correctly distinguishing class/object member functions from member variables. An identifier after `->` which does not start with `$` was detected as function call.

As the same syntax was assumed for `builtin` function calls and user defined `sub` calls, the first token after the identifier was expected to be the first argument. In #1902 this means the `<` after `->value` was assumed to be the beginning of the first angular quoted string argument.

This PR therefore adds a couple of commits to fix that issue by correctly detecting functions and variable members. Please refere to the commit messages for more details about the single steps.