### PR TITLE
[Perl] Apply numeric scopes

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -334,9 +334,9 @@ contexts:
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
     - match: 0b[01]+(?![\.\w+])
-      scope: constant.numeric.binary.perl
+      scope: constant.numeric.integer.binary.perl
     - match: 0x[\h_]+(?![\.\w+])
-      scope: constant.numeric.hex.perl
+      scope: constant.numeric.integer.hexadecimal.perl
     - include: constants-numbers-float
     - include: constants-numbers-integer
 
@@ -345,32 +345,32 @@ contexts:
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.float.perl
+        2: constant.numeric.float.decimal.perl
         3: punctuation.definition.string.end.perl
     - match: (')([-+]?\d+\.\d+(?:e[-+]?\d+)?)(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.float.perl
+        2: constant.numeric.float.decimal.perl
         3: punctuation.definition.string.end.perl
     - match: (?:[-+]|\b)\d+\.\d+(?:e[-+]?\d+)?(?![\.\w+])
-      scope: constant.numeric.float.perl
+      scope: constant.numeric.float.decimal.perl
 
   constants-numbers-integer:
     - match: (")([-+]?\d+)(")
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.perl
+        2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
     - match: (')([-+]?\d+)(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.perl
+        2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
     - match: (?:[-+]|\b)\d+(?![\.\w+])
-      scope: constant.numeric.integer.perl
+      scope: constant.numeric.integer.decimal.perl
 
   constants-language:
     - match: \b__(?:END|DATA|FILE|LINE|PACKAGE|SUB)__\b

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -616,37 +616,37 @@ EOT
 ###[ CONSTANTS ] #############################################################
 
   1234             # decimal integer
-# ^^^^ constant.numeric.integer.perl
+# ^^^^ constant.numeric.integer.decimal.perl
   -1234            # decimal integer
-# ^^^^^ constant.numeric.integer.perl
+# ^^^^^ constant.numeric.integer.decimal.perl
   - 1234           # decimal integer
 # ^ keyword.operator.arithmetic.perl
-#   ^^^^ constant.numeric.integer.perl
+#   ^^^^ constant.numeric.integer.decimal.perl
   0b0              # binary integer
-# ^^^ constant.numeric.binary.perl
+# ^^^ constant.numeric.integer.binary.perl
   0b1110011        # binary integer
-# ^^^^^^^^^ constant.numeric.binary.perl
+# ^^^^^^^^^ constant.numeric.integer.binary.perl
   01234            # octal integer
-# ^^^^^ constant.numeric.integer.perl
+# ^^^^^ constant.numeric.integer.decimal.perl
   0x1234           # hexadecimal integer
-# ^^^^^^ constant.numeric.hex.perl
+# ^^^^^^ constant.numeric.integer.hexadecimal.perl
   0x9              # hexadecimal integer
-# ^^^ constant.numeric.hex.perl
+# ^^^ constant.numeric.integer.hexadecimal.perl
   12.34e56         # exponential notation
-# ^^^^^^^^ constant.numeric.float.perl
+# ^^^^^^^^ constant.numeric.float.decimal.perl
   -12.34e-56       # exponential notation
-# ^^^^^^^^^^ constant.numeric.float.perl
+# ^^^^^^^^^^ constant.numeric.float.decimal.perl
   - 12.34e-56      # exponential notation
 # ^ keyword.operator.arithmetic.perl
-#   ^^^^^^^^^ constant.numeric.float.perl
+#   ^^^^^^^^^ constant.numeric.float.decimal.perl
   12.34e+56        # exponential notation
-# ^^^^^^^^^ constant.numeric.float.perl
+# ^^^^^^^^^ constant.numeric.float.decimal.perl
   "-12.34e56"      # number specified as a string
 # ^^^^^^^^^^^ string.quoted.double.perl
-#  ^^^^^^^^^ constant.numeric.float.perl
+#  ^^^^^^^^^ constant.numeric.float.decimal.perl
   "1234"           # number specified as a string
 # ^^^^^^ string.quoted.double.perl
-#  ^^^^ constant.numeric.integer.perl
+#  ^^^^ constant.numeric.integer.decimal.perl
   '0.00_01'
 #  ^^^^^^^ - constant.numeric
   '01bau'
@@ -1299,7 +1299,7 @@ sub name ($) {}
 # ^^^^ entity.name.label.perl
 #     ^ punctuation.separator.perl
 #      ^^^^ keyword.other.flow.perl
-#           ^^ constant.numeric.integer.perl
+#           ^^ constant.numeric.integer.decimal.perl
 
   if(exists($curargs{$index}))
 # ^^ keyword.control.conditional.perl


### PR DESCRIPTION
This commit applies the latest standardized `constant.numeric` scope names to the perl syntax.

See: https://www.sublimetext.com/docs/3/scope_naming.html#constant