### PR TITLE
[Lua] Fix missing \b in do/then indent rule

### DIFF
--- a/Lua/Indent.tmPreferences
+++ b/Lua/Indent.tmPreferences
@@ -10,7 +10,7 @@
 			<key>decreaseIndentPattern</key>
 			<string>(^\s*\b(elsei|elseif|else|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
 			<key>increaseIndentPattern</key>
-			<string>(^\s*\b((local[\s\w=]+)?function|repeat|else|elseif|if|while)\b((?!\bend\b).)*$|^.*\b(do|then)((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+			<string>(^\s*\b((local[\s\w=]+)?function|repeat|else|elseif|if|while)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
 		</dict>
 	</dict>
 </plist>


### PR DESCRIPTION
Fixes incorrectly indenting after strings like doSomething, thenSomething

```lua
local blah = doSomething()
```

Fixes #1910