### PR TITLE
[JSON] Don't highlight comments in object keys

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -101,6 +101,7 @@ contexts:
           push:
             - clear_scopes: 1
             - meta_scope: meta.mapping.key.json string.quoted.double.json
+            - meta_include_prototype: false
             - include: inside-string
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -59,6 +59,10 @@
 
 // <- - string
 
+  "string/* not a comment */": "string /* also not a comment */",
+//       ^ - comment
+//                                     ^ - comment
+
 /**/: "test",
 // ^ meta.mapping.json comment.block.json
 //  ^ punctuation.separator.mapping.key-value.json - comment


### PR DESCRIPTION
Fixes an issue reported on the forum: https://forum.sublimetext.com/t/build-3200-json-bug/42685

![](https://forum.sublimetext.com/uploads/default/original/3X/3/4/348dcb3c996e87f333bee13b3b9f5bfb5e025f0a.png)
