### PR TITLE
[Matlab] Fix typo in unwind snippet

### DIFF
--- a/Matlab/Snippets/unwind_protect-cleanup-end.sublime-snippet
+++ b/Matlab/Snippets/unwind_protect-cleanup-end.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[unwind_protect
 	$1
-unwnd_protect_cleanup 
+unwind_protect_cleanup 
 	$0
 end_unwind_protect]]></content>
 	<tabTrigger>unwind</tabTrigger>


### PR DESCRIPTION
There's a typo in one of the identifiers in the Octave-oriented "unwind" snippet in the Matlab package.