### PR TITLE
[Matlab] Make octfun and unwind snippets available in source.octave code

### DIFF
--- a/Matlab/Snippets/Octave-function.sublime-snippet
+++ b/Matlab/Snippets/Octave-function.sublime-snippet
@@ -29,6 +29,6 @@ $0
 
 endfunction]]></content>
 	<tabTrigger>octfun</tabTrigger>
-	<scope>source.matlab</scope>
+	<scope>source.matlab, source.octave</scope>
 	<description>Octave function</description>
 </snippet>

--- a/Matlab/Snippets/unwind_protect-cleanup-end.sublime-snippet
+++ b/Matlab/Snippets/unwind_protect-cleanup-end.sublime-snippet
@@ -5,6 +5,6 @@ unwnd_protect_cleanup
 	$0
 end_unwind_protect]]></content>
 	<tabTrigger>unwind</tabTrigger>
-	<scope>source.matlab</scope>
+	<scope>source.matlab, source.octave</scope>
 	<description>unwind_protect … cleanup … end</description>
 </snippet>


### PR DESCRIPTION
Most of the Matlab snippets are applied to both `source.matlab` and `source.octave` code. Except for the `octfun` and `unwind` snippets, which are, curiously, Octave-specific.

This PR makes them available in `source.octave` code as well.