### PR TITLE
[ShellScript] Make snippets friendlier to other shell packages

### DIFF
--- a/ShellScript/Snippets/#!-usr-bin-env-(!env).sublime-snippet
+++ b/ShellScript/Snippets/#!-usr-bin-env-(!env).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[#!/usr/bin/env ${1:${TM_SCOPE/(?:source|.*)\.(?:(shell)|(\w+)).*/(?1:bash:$2)/}}
+	<content><![CDATA[#!/usr/bin/env ${1:${TM_SCOPE/(?:source|.*)\.(?:(shell\.(?!bash)(\w+))|(shell)|(\w+)).*/(?1$2)(?3bash:$4)/}}
 ]]></content>
 	<tabTrigger>!env</tabTrigger>
 	<scope>source.actionscript.2, source.applescript, source.clojure, source.cs, source.d, source.dart, source.fsharp, source.groovy, source.haskell, source.java, source.js, source.julia, source.lisp, source.lua, source.makefile, source.ocaml, source.perl, source.php, source.python, source.r, source.ruby, source.rust, source.scala, source.shell, source.swift, source.tcl, source.ts</scope>

--- a/ShellScript/Snippets/case-..-esac-(case).sublime-snippet
+++ b/ShellScript/Snippets/case-..-esac-(case).sublime-snippet
@@ -4,6 +4,6 @@
 		$0;;
 esac]]></content>
 	<tabTrigger>case</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>case … esac</description>
 </snippet>

--- a/ShellScript/Snippets/elif-..-(elif).sublime-snippet
+++ b/ShellScript/Snippets/elif-..-(elif).sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[elif ${2:[[ ${1:condition} ]]}; then
 	${0:#statements}]]></content>
 	<tabTrigger>elif</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>elif …</description>
 </snippet>

--- a/ShellScript/Snippets/for-...-done-(for).sublime-snippet
+++ b/ShellScript/Snippets/for-...-done-(for).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:#statements}
 done]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>for … done</description>
 </snippet>

--- a/ShellScript/Snippets/for-in-done-(forin).sublime-snippet
+++ b/ShellScript/Snippets/for-in-done-(forin).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:#statements}
 done]]></content>
 	<tabTrigger>forin</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>for … in … done</description>
 </snippet>

--- a/ShellScript/Snippets/if-...-then-(if).sublime-snippet
+++ b/ShellScript/Snippets/if-...-then-(if).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:#statements}
 fi]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>if … fi</description>
 </snippet>

--- a/ShellScript/Snippets/until-(done).sublime-snippet
+++ b/ShellScript/Snippets/until-(done).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:#statements}
 done]]></content>
 	<tabTrigger>until</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>until … done</description>
 </snippet>

--- a/ShellScript/Snippets/while-(done).sublime-snippet
+++ b/ShellScript/Snippets/while-(done).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:#statements}
 done]]></content>
 	<tabTrigger>while</tabTrigger>
-	<scope>source.shell</scope>
+	<scope>source.shell.bash</scope>
 	<description>while … done</description>
 </snippet>


### PR DESCRIPTION
This PR follows on from discussion in #1663. Though no clear consensus was reached, I present a potential solution to the issue for practical discussion.

Specifically, the problem is that snippets which only work in Bash (or other Bourne-like shells) are suggested for the `source.shell` scope, which includes `source.shell.fish` ([Phidica/sublime-fish](https://github.com/Phidica/sublime-fish)) despite the syntaxes being entirely incompatible. The `run_shell_script` command also provided by the ShellScript package is shell-agnostic, and makes a good case for `source.shell` to be the underlying scope for all shell scripts regardless of their compatibility with Bash.

Accepting this PR would change the applicable scope of the snippets to be the scope assigned by the Bash syntax, `source.shell.bash`, to prevent these snippets being suggested in fish scripts. It would also extend the `!env` snippet to read the intended shell from `source.shell.<name>` and insert `#!/usr/bin/env <name>` rather than always `#!/usr/bin/env bash` (though in the case of `source.shell` it would continue to assume `bash`).

`source.shell` used to be the scope for the Bash syntax, and in some older locations they may still be considered interchangeable. Is it acceptable to change these snippets such that they would no longer work in a simple `source.shell` scope?