### PR TITLE
[JavaScript] Recognize line endings in block comments.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -18,6 +18,11 @@ variables:
   dollar_only_identifier: (?:\${{identifier_break}})
   dollar_identifier: '(?:(\$){{identifier_part}}*{{identifier_break}})'
 
+  block_comment_contents: (?:(?:[^*]|\*(?!/))*)
+  block_comment: (?:/\*{{block_comment_contents}}\*/)
+  nothing: (?x:(?:\s+|{{block_comment}})*)
+  line_ending_ahead: (?={{nothing}}(?:/\*{{block_comment_contents}})?$)
+
   # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
   reserved_word: |-
     (?x:
@@ -52,7 +57,7 @@ variables:
   func_lookahead: |-
     (?x:
       \s*
-      (?:async\s+)?
+      (?:async{{identifier_break}}{{nothing}})?
       function{{identifier_break}}
     )
 
@@ -339,15 +344,17 @@ contexts:
     - include: else-pop
 
   expect-label:
-    - match: '{{non_reserved_identifier}}'
-      scope: variable.label.js
-      pop: true
-    - match: '{{identifier}}'
-      scope: invalid.illegal.identifier.js variable.label.js
-      pop: true
-    - match: $
-      pop: true
-    - include: else-pop
+    - meta_include_prototype: false
+    - match: '(?={{nothing}}{{identifier}})'
+      set:
+        - match: '{{non_reserved_identifier}}'
+          scope: variable.label.js
+          pop: true
+        - match: '{{identifier}}'
+          scope: invalid.illegal.identifier.js variable.label.js
+          pop: true
+        - include: else-pop
+    - include: immediately-pop
 
   block:
     - match: '\{'
@@ -435,7 +442,7 @@ contexts:
     - include: else-pop
 
   variable-binding-list-top:
-    - match: \n
+    - match: '{{line_ending_ahead}}'
       set:
         - match: '{{line_continuation_lookahead}}'
           set: variable-binding-top
@@ -553,7 +560,7 @@ contexts:
         - expression-begin
 
   expression-statement-end:
-    - match: \n
+    - match: '{{line_ending_ahead}}'
       set:
         - match: '{{line_continuation_lookahead}}'
           set: expression-statement-end
@@ -561,9 +568,10 @@ contexts:
     - include: expression-end
 
   restricted-production:
-    - match: \n
+    - meta_include_prototype: false
+    - match: '{{line_ending_ahead}}'
       pop: true
-    - match: (?=\S)
+    - match: ''
       set: expression-statement
 
   expect-case-colon:

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -256,6 +256,9 @@ someFunction({
 
     }
 
+    async /**//**//**/ function foo() {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+
 // Better highlighting when typing
 function
 function() {}
@@ -755,6 +758,13 @@ while (true)
     foo;
 //  ^^^ variable.other.readwrite - variable.label
 
+    break/**/foo;
+//           ^^^ variable.label - variable.other.readwrite
+
+    break/*
+    */foo;
+//    ^^^ variable.other.readwrite - variable.label
+
     break function;
 //        ^^^^^^^^ invalid.illegal.identifier variable.label
 
@@ -768,6 +778,13 @@ while (true)
     continue
     foo;
 //  ^^^ variable.other.readwrite - variable.label
+
+    continue/**/foo;
+//              ^^^ variable.label - variable.other.readwrite
+
+    continue/*
+    */ foo;
+//     ^^^ variable.other.readwrite - variable.label
 
     goto;
 //  ^^^^ variable.other.readwrite - keyword
@@ -1684,9 +1701,16 @@ return;
 {a: 1};
 // ^ meta.block - meta.object-literal
 
+return/**/{a: 1}
+//        ^^^^^^ meta.object-literal - meta.block
+
 return
 {a: 1};
 // ^ meta.block - meta.object-literal
+
+return/*
+*/{a: 1}
+//^^^^^^ meta.block - meta.object-literal
 
 const abc = new Set
 if (true) {};


### PR DESCRIPTION
Comments in JavaScript are usually not tokenized, but block comments containing newlines are tokenized as LineTerminators. This has implications for constructs that care about LineTerminators, like `break`, `continue`, `return`, `throw`, and `async function`.