### PR TITLE
[JavaScript] Remove special scoping of escape/unescape.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2060,11 +2060,6 @@ contexts:
       scope: support.function.js
       pop: true
 
-    # Annex B
-    - match: (?:escape|unescape){{identifier_break}}
-      scope: invalid.deprecated.js support.function.js
-      pop: true
-
   support-property-ecma-array:
     - match: (?:from|isArray|of){{identifier_break}}
       scope: support.function.builtin.js

--- a/JavaScript/tests/syntax_test_js_support_builtin.js
+++ b/JavaScript/tests/syntax_test_js_support_builtin.js
@@ -117,11 +117,6 @@
     encodeURIComponent;
 //  ^^^^^^^^^^^^^^^^^^ support.function
 
-    escape;
-//  ^^^^^^ invalid.deprecated support.function
-    unescape;
-//  ^^^^^^^^ invalid.deprecated support.function
-
 
 foo.constructor;
 //  ^^^^^^^^^^^ variable.language.constructor


### PR DESCRIPTION
https://forum.sublimetext.com/t/js-deprecated-feature-highlighting-sucks/42979

`escape()` and `unescape()` are old functions implemented in some browsers. They are mostly nonstandard — the ECMAScript spec catalogues them in Annex B. We currently scope them `invalid.deprecated support.function`. However, while developers should avoid creating variables that share names with builtins like `isNaN` or `Object`, it's perfectly reasonable to have a variable named `escape`. This PR eliminates the special treatment of `escape` and `unescape`.

We also use `invalid.deprecated` for the Annex B properties `__proto__`, `__defineGetter__`, `__defineSetter__`, and `__lookupGetter__`. It seems unlikely that anyone would use a property with one of those names for legitimate purposes, but I suppose it's possible. This PR does not remove those, but it could.

In addition, we scope the old nonstandard octal literals `invalid.deprecated.numeric.octal`. This, I think, is beneficial; no one should ever use that syntax deliberately, and the highlighting will help developers who unthinkingly type leading zeros in literals.