### PR TITLE
[Lua] Syntax number fixes

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -399,13 +399,13 @@ contexts:
       pop: true
 
   number:
-    - match: (0[Xx])\h*(?:\.\h*)?([Pp][-+]?\d*)?
+    - match: (0[Xx])\h*
       scope: constant.numeric.hexadecimal.lua
       captures:
         1: punctuation.definition.numeric.hexadecimal.lua
       pop: true
 
-    - match: \d+(?:\.\d*)?([Ee][-+]?\d*)?
+    - match: (\d+(?:\.\d+)?|\.\d+)([Ee][-+]?\d+)?
       scope: constant.numeric.decimal.lua
       pop: true
 

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -84,14 +84,6 @@
 --  ^^^^^^^^^^^^ constant.numeric.hexadecimal
 --  ^^ punctuation.definition.numeric.hexadecimal
 
-    0xa.bc;
---  ^^^^^^ constant.numeric.hexadecimal
---  ^^ punctuation.definition.numeric.hexadecimal
-
-    0x1p10;
---  ^^^^^^ constant.numeric.hexadecimal
---  ^^ punctuation.definition.numeric.hexadecimal
-
     'foo';
 --  ^^^^^ string.quoted.single
 --  ^ punctuation.definition.string.begin

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -125,7 +125,7 @@
 --   ^^^^^ constant.character.escape.unicode
 --         ^^^^^^^^ constant.character.escape.unicode
 
-    '\z  
+    '\z
 --   ^^^^^ constant.character.escape - invalid
     ';
 
@@ -395,6 +395,15 @@
         2 + 2
     end
 -- ^^^^ meta.block
+--  ^^^ keyword.control.end
+
+    if 2 > .2 then
+--  ^^ keyword.control.conditional
+--     ^ constant.numeric.decimal
+--         ^^ constant.numeric.decimal
+--            ^^^^ keyword.control.conditional
+
+    end
 --  ^^^ keyword.control.end
 
     do 2 + 2 end


### PR DESCRIPTION
Expression block fails for numbers like:
```
if number > .2 then

else

end
```