### PR TITLE
[Ruby] Fix hash keys with reserved keywords still being marked incorrectly

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -87,9 +87,9 @@ contexts:
     - include: expressions
 
   expressions:
+    - include: constants
     - include: class
     - include: module
-    - include: constants
     - include: invalid
     - include: blocks
     - include: keywords

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -89,6 +89,20 @@ Symbol === :foo
 # ^^^^ variable.other.constant.ruby -meta.constant.ruby
 #          ^^^^
 
+##################
+# Constant reserved keyword symbols
+##################
+
+begin: 'begin'
+# ^^^^ constant.other.symbol
+end: 'end'
+# ^^ constant.other.symbol
+require: 'require'
+# ^^^^^^ constant.other.symbol
+class: 'class'
+# ^^^^ constant.other.symbol
+module: 'module'
+# ^^^^^ constant.other.symbol
 
 ##################
 # Blocks


### PR DESCRIPTION
Fixes 'class:' and 'module:' being marked as keywords instead of symbols.
Adds test cases for this issue to the syntax test.

Fixes #1934