### PR TITLE
[Makefile] Fix highlighting of unbalanced quotations in functions

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -411,6 +411,9 @@ contexts:
       push: textual-parenthesis-balancer
     - match: \,
       scope: punctuation.separator.makefile
+    # eat escaped or unbalanced quotation marks in front of the `,` separator
+    # to highlight them as ordinary part of the surrounding unquoted string
+    - match: '\\[''""]|[''""](?=\s*,)'
     - include: variable-substitutions
     - include: quoted-string
 

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -840,6 +840,28 @@ LIBRARIES := $(filter $(notdir $(wildcard $(HOME)/energia_sketchbook/libraries/*
     #               ^ string.quoted.double.makefile punctuation.definition.string.begin.makefile
     #                                                          ^ string.quoted.double.makefile punctuation.definition.string.end.makefile
 
+# FIX: https://github.com/sublimehq/Packages/issues/1941
+escape_shellstring = $(subst `,\`,$(subst ",\",$(subst $$,\$$,$(subst \,\\,$1))))
+#                    ^^^^^^^^ meta.function-call.makefile
+#                            ^^^^^ meta.function-call.arguments.makefile - meta.function-call.makefile
+#                                 ^^^^^^^^ meta.function-call.arguments.makefile meta.function-call.makefile
+#                                         ^^^^^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile - meta.function-call.makefile
+#                                              ^^^^^^^^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.makefile
+#                                                      ^^^^^^^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.arguments.makefile - meta.function-call.makefile
+#                                                             ^^^^^^^^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.makefile
+#                                                                     ^^^^^^^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.arguments.makefile - meta.function-call.makefile
+#                                                                            ^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile meta.function-call.arguments.makefile keyword.other.block.end.makefile
+#                                                                             ^ meta.function-call.arguments.makefile meta.function-call.arguments.makefile keyword.other.block.end.makefile
+#                                                                              ^ meta.function-call.arguments.makefile keyword.other.block.end.makefile
+#                                                                               ^ keyword.other.block.end.makefile
+#                                                                                ^ - meta
+#                            ^ - punctuation
+#                             ^ punctuation.separator.makefile
+#                              ^^ - punctuation
+#                                         ^ - punctuation
+#                                          ^ punctuation.separator.makefile
+#                                           ^^ - punctuation
+
 .SECONDEXPANSION:
 # <- meta.function entity.name.function
 #               ^ keyword.operator.assignment - entity.name.function


### PR DESCRIPTION
Fixes #1941

### Issue Description

A quotation mark found in the arguments of a function-call causes the parser to push into the quoted-string context. The region up to the next quotation mark is then scoped as quoted string.

But make interprets single quotation marks in functions like `subst` as ordinary characters.

The following escapes all quotation marks in $1:

    $(subst ",\", $1)

### Solution Proposal

This commit proposes to just eat escaped quotation marks (\", \') or those followed by the arguments separator.

They are scoped as whatever the parent context scopes the current region. The example posted in issue #1941 causes the quotation marks to be scoped as `string.unquoted`.