### PR TITLE
[C#] deconstructed tuple doesnt require space between `var` and `(`

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -955,7 +955,7 @@ contexts:
         2: variable.other.cs
         3: keyword.operator.assignment.variable.cs
       set: line_of_code_in
-    - match: (?=var\s+\()
+    - match: (?=var\s*\()
       push: var_declaration
     - include: lambdas
     - match: (?:\b(ref)\s+)?\b(?={{namespaced_name}}{{type_suffix}}\s+{{name}}(?!\s*(?:[(:])))
@@ -1954,7 +1954,7 @@ contexts:
       pop: true
 
   var_declaration:
-    - match: (var)\s+(\()
+    - match: (var)\s*(\()
       captures:
         1: storage.type.variable.cs
         2: meta.group.tuple.cs punctuation.definition.group.begin.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -465,6 +465,23 @@ class Foo {
         {
             Console.WriteLine($"{name} is {age} years old.");
         }
+
+        var positions = new List<(int, int)> { (0, 1), (1, 2), (2, 4) };
+        foreach (var(x, y) in positions)
+///             ^ punctuation.section.group.begin
+///              ^^^storage.type.variable
+///                 ^^^^^^ meta.group.tuple
+///                 ^ punctuation.definition.group.begin
+///                  ^ variable.other
+///                   ^ punctuation.separator.tuple
+///                     ^ variable.other
+///                      ^ punctuation.definition.group.end
+///                        ^^ keyword.control.flow
+///                           ^^^^^^^^^ variable.other
+///                                    ^ punctuation.section.group.end
+        {
+            Console.WriteLine($"x={x} y={y}");
+        }
     }
 
     private static (int Max, int Min) Range(IEnumerable<int> numbers)


### PR DESCRIPTION
fixes #1946