### PR TITLE
[Perl] Fix regexp patterns at line start with tabs

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -279,7 +279,7 @@ contexts:
     - include: function-call
     - include: comment-line
     # /<find>/<flags> statement at line start
-    - match: ^ *(?=/.*[^\\]/)
+    - match: ^\s*(?=/.*[^\\]/)
       push: regexp-pop
 
 ###[ BLOCKS AND GROUPS ]######################################################

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -770,6 +770,8 @@ EOT
 #  ^^^^^^^^^^^^^^ string.regexp.perl source.regexp
 #                ^ punctuation.section.generic.end.perl - string.regexp - source.regexp
 #                 ^ constant.language.flags.regexp.perl
+	/[a-z]test\d{3}/g;
+#^ punctuation.section.generic.begin.perl
   ( /[a-z]test\d{3}/g );
 #   ^ punctuation.section.generic.begin.perl - string.regexp - source.regexp
 #    ^^^^^^^^^^^^^^ string.regexp.perl source.regexp


### PR DESCRIPTION
This commit fixes an issue with regexp patterns not being detected, if tabs are used for indention.

**Example:**

    $var =~
    /pattern/;

The `/pattern/` is now detected as such, even if the line starts with tabs.

~_Note: Can't add a test as PackageDev complains about tabs being used as indention._~