### PR TITLE
[JavaScript] Support private property accessors.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2264,6 +2264,11 @@ contexts:
     - match: '{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.illegal-identifier.js
       pop: true
+    - match: (#)({{identifier}})
+      captures:
+        1: punctuation.definition.variable.js
+        2: meta.property.object.js
+      pop: true
 
   support-property:
     - include: support-property-ecma

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -968,6 +968,10 @@ class MyClass extends TheirClass {
 //             ^ punctuation.definition.variable
 //              ^ variable.other.readwrite
 //                ^ keyword.operator.arithmetic
+
+        for (const param of this.#data.get('value')) {}
+//                               ^ punctuation.definition.variable
+//                                ^^^^ meta.property.object
     }
 
     constructor(el)


### PR DESCRIPTION
Fix #1949.

The original implementation in #1292 did not properly support private property accessors, but in most cases they worked almost-correctly by coincidence. #1949 identifies a case in which they do not work at all. This PR implements them correctly.

Private fields are part of the [TC39 class fields proposal](https://github.com/tc39/proposal-class-fields), which is Stage 3.