### PR TITLE
[Perl] Fix lt operator not being scoped

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -697,7 +697,7 @@ contexts:
     - match: \bx\b
       scope: keyword.operator.arithmetic.perl
       push: regexp-pop
-    - match: \b(and|or|xor|as|cmp|eq|gt|ge|lg|le|ne|not){{break}}
+    - match: \b(and|or|xor|as|cmp|eq|gt|ge|lt|le|ne|not){{break}}
       scope: keyword.operator.logical.perl
       push: regexp-pop
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -444,6 +444,33 @@ EOT
   ..
 # ^^ keyword.operator.range.perl
 
+  and or xor as cmp eq gt ge lt le ne not
+#^ - keyword
+# ^^^ keyword.operator.logical.perl
+#    ^ - keyword
+#     ^^ keyword.operator.logical.perl
+#       ^ - keyword
+#        ^^^ keyword.operator.logical.perl
+#           ^ - keyword
+#            ^^ keyword.operator.logical.perl
+#              ^ - keyword
+#               ^^^ keyword.operator.logical.perl
+#                  ^ - keyword
+#                   ^^ keyword.operator.logical.perl
+#                     ^ - keyword
+#                      ^^ keyword.operator.logical.perl
+#                        ^ - keyword
+#                         ^^ keyword.operator.logical.perl
+#                           ^ - keyword
+#                            ^^ keyword.operator.logical.perl
+#                              ^ - keyword
+#                               ^^ keyword.operator.logical.perl
+#                                 ^ - keyword
+#                                  ^^ keyword.operator.logical.perl
+#                                    ^ - keyword
+#                                     ^^^ keyword.operator.logical.perl
+#                                        ^ - keyword
+
 ###[ VARIABLES ]##############################################################
 
   $&


### PR DESCRIPTION
This commit fixes a typo, which causes the `lt` operator not to be scoped. Also adds test cases to ensure it doesn't happen again.