### PR TITLE
[Perl] Fix regexp flags matching

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -764,7 +764,7 @@ contexts:
     - match: '{{regexp_flags}}'
       scope: constant.language.flags.regexp.perl
       pop: true
-    - include: else-pop
+    - include: immediately-pop
 
   quoted-like-args-find-rexexp:
     - match: \{

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -828,7 +828,7 @@ EOT
 #   ^ punctuation.section.braces.begin.perl
     bar[a-z]{1,3} \/ .+
 # <- meta.function-call.perl meta.braces.perl string.regexp.perl
-  } [repl] gx; # comment
+  } [repl]gx; # comment
 # <- meta.function-call.perl meta.braces.perl string.regexp.perl
 #^^^^^^^^ meta.function-call.perl
 # ^ meta.braces.perl punctuation.section.braces.end.perl
@@ -836,10 +836,10 @@ EOT
 #   ^ punctuation.section.brackets.begin.perl
 #    ^^^^ string.unquoted.perl
 #        ^ punctuation.section.brackets.end.perl
-#          ^^ constant.language.flags.regexp.perl
-#            ^ punctuation.terminator.statement.perl
-#              ^^^^^^^^^ comment.line.number-sign.perl
-#              ^ punctuation.definition.comment.begin.perl
+#         ^^ constant.language.flags.regexp.perl
+#           ^ punctuation.terminator.statement.perl
+#             ^^^^^^^^^ comment.line.number-sign.perl
+#             ^ punctuation.definition.comment.begin.perl
   s/foo[a-z]{1,3} \/ .+/ bar $1 \/ /g; # comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
@@ -946,6 +946,33 @@ EOT
 #    ^^^^ string.regexp.perl source.regexp
 #        ^ punctuation.section.generic.end.perl
 #         ^ punctuation.terminator.statement.perl
+
+###[ REGEXP FLAGS ]###########################################################
+
+  /^<pattern>$/g;
+#              ^ constant.language.flags.regexp.perl
+  /^<pattern>$/ g;
+#               ^ - constant.language.flags.regexp.perl
+  m/^<pattern>$/g;
+#               ^ constant.language.flags.regexp.perl
+  m/^<pattern>$/ g;
+#                ^ - constant.language.flags.regexp.perl
+  m{^<pattern>$}g;
+#               ^ constant.language.flags.regexp.perl
+  m{^<pattern>$} g;
+#                ^ - constant.language.flags.regexp.perl
+  m<^[pattern]$>g;
+#               ^ constant.language.flags.regexp.perl
+  m<^[pattern]$> g;
+#                ^ - constant.language.flags.regexp.perl
+  s/<pattern>/<repl>/g;
+#                    ^ constant.language.flags.regexp.perl
+  s/<pattern>/<repl>/ g;
+#                     ^ - constant.language.flags.regexp.perl
+  s[<pattern>] [<repl>]g;
+#                      ^ constant.language.flags.regexp.perl
+  s[<pattern>] [<repl>] g;
+#                       ^ - constant.language.flags.regexp.perl
 
 ###[ DECLARATIONS ]###########################################################
 


### PR DESCRIPTION
The `<flags>` of a regexp expression like `s/<pattern>/<repl>/<flags>` must directly follow the separator `/` without any whitespace in between.

This PR applies this rule to the Perl.sublime-syntax by immediately popping the `quoted-like-flags` off the stack, if anything but a valid flags character is matched (including whitespace).