### PR TITLE
[Perl] Add array item access

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -652,6 +652,9 @@ contexts:
     - match: '{{identifier}}'
       scope: variable.other.member.perl
       set: maybe-item-access
+    # item access like $array->[0]
+    - match: (?=[{\[])
+      set: maybe-item-access
     - include: else-pop
 
 ###[ CONTROL KEYWORDS ]#######################################################

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -267,6 +267,7 @@ contexts:
 
   expressions:
     - include: blocks
+    - include: brackets
     - include: groups
     - include: quoted-like
     - include: label
@@ -303,6 +304,27 @@ contexts:
       pop: true
     - include: expressions
 
+  brackets:
+    # can't push into scope due to HEREDOCs!
+    - match: \[
+      scope: punctuation.section.brackets.begin.perl
+      push: regexp-pop
+    - match: \]
+      scope: punctuation.section.brackets.end.perl
+
+  brackets-nested:
+    - match: \[
+      scope: punctuation.section.brackets.begin.perl
+      push: [brackets-nested-body, regexp-pop]
+
+  brackets-nested-body:
+    - match: \]
+      scope: punctuation.section.brackets.end.perl
+      pop: true
+    - include: blocks-nested
+    - include: brackets-nested
+    - include: expressions
+
   groups:
     # can't push into scope due to HEREDOCs!
     - match: \(
@@ -312,14 +334,17 @@ contexts:
       scope: punctuation.section.group.end.perl
 
   groups-nested:
-    - match: \{
+    - match: \(
       scope: punctuation.section.group.begin.perl
       push: [groups-nested-body, regexp-pop]
 
   groups-nested-body:
-    - match: \}
+    - match: \)
       scope: punctuation.section.group.end.perl
       pop: true
+    - include: blocks-nested
+    - include: brackets-nested
+    - include: groups-nested
     - include: expressions
 
 ###[ CONSTANTS ]##############################################################
@@ -600,6 +625,7 @@ contexts:
       captures:
         1: punctuation.accessor.double-colon.perl
         2: support.class.perl
+      push: maybe-item-access
     # member function
     - match: \s*(::)\s*(({{member}})\s*)(?=\()
       captures:
@@ -612,7 +638,7 @@ contexts:
       captures:
         1: punctuation.accessor.double-colon.perl
         2: variable.other.member.perl
-      pop: true
+      set: maybe-item-access
     - include: else-pop
 
   object-members-pop:
@@ -625,7 +651,7 @@ contexts:
     # member variable
     - match: '{{identifier}}'
       scope: variable.other.member.perl
-      pop: true
+      set: maybe-item-access
     - include: else-pop
 
 ###[ CONTROL KEYWORDS ]#######################################################
@@ -1052,30 +1078,37 @@ contexts:
       scope: variable.other.regexp.match.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)`(?!\w)
       scope: variable.other.regexp.pre-match.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)\'(?!\w)
       scope: variable.other.regexp.post-match.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)\+(?!\w)
       scope: variable.other.regexp.last-paren-match.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)\"(?!\w)
       scope: variable.other.readwrite.list-separator.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)0\b
       scope: variable.other.predefined.program-name.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: (\$)[0-9]+\b
       scope: variable.other.subpattern.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     # $Module::SubModule::member
     # $::SubModule::member
     - match: ([\$\@\%]#?)({{module}})?(?=\s*::)
@@ -1090,16 +1123,50 @@ contexts:
       scope: variable.other.predefined.perl
       captures:
         1: punctuation.definition.variable.perl
-    - match: ([\$\@\%]#?)(\w+)\b
+      push: maybe-item-access
+    - match: ([\$\@\%]#?)\w+\b
       scope: variable.other.readwrite.global.perl
       captures:
         1: punctuation.definition.variable.perl
+      push: maybe-item-access
     - match: ([\$\@\%])(\{)
       scope: punctuation.definition.variable.begin.perl
       push:
         - meta_scope: meta.braces.perl variable.other.readwrite.global.perl
         - match: \}
           scope: punctuation.definition.variable.end.perl
-          pop: true
+          set:
+            - meta_content_scope: variable.other.readwrite.global.perl
+            - include: maybe-item-access
         - include: blocks-nested
+        - include: brackets-nested
+        - include: groups-nested
         - include: expressions
+
+  maybe-item-access:
+    # SEE: https://perldoc.perl.org/perllol.html
+    - match: \[
+      scope: punctuation.section.item-access.begin.perl
+      push:
+        - - meta_scope: meta.item-access.perl
+          - match: \]
+            scope: punctuation.section.item-access.end.perl
+            pop: true
+          - include: blocks-nested
+          - include: brackets-nested
+          - include: groups-nested
+          - include: expressions
+        - regexp-pop
+    - match: \{
+      scope: punctuation.section.item-access.begin.perl
+      push:
+        - - meta_scope: meta.item-access.perl
+          - match: \}
+            scope: punctuation.section.item-access.end.perl
+            pop: true
+          - include: blocks-nested
+          - include: brackets-nested
+          - include: groups-nested
+          - include: expressions
+        - regexp-pop
+    - include: immediately-pop

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -621,6 +621,14 @@ EOT
 #       ^^^ support.class.perl
 #          ^^ keyword.accessor.arrow.perl
 #            ^^^ variable.other.member.perl
+  $Foo::Bar->[0]
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ keyword.accessor.arrow.perl
+#            ^^^ meta.item-access.perl
   $Foo::Bar->baz[0]
 # ^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
@@ -639,7 +647,7 @@ EOT
 #          ^^ keyword.accessor.arrow.perl
 #            ^^^ variable.other.member.perl
 #               ^^^^^^^ meta.item-access.perl
-  $Foo::Bar->$baz
+  $Foo::Bar->$baz->[-1]
 # ^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
 #  ^^^ support.class.perl
@@ -648,6 +656,9 @@ EOT
 #          ^^ keyword.accessor.arrow.perl - variable
 #            ^^^^ variable.other.readwrite.global.perl
 #            ^ punctuation.definition.variable.perl
+#                  ^ punctuation.section.item-access.begin.perl
+#                  ^^^^ meta.item-access.perl
+#                     ^ punctuation.section.item-access.end.perl
   $Foo :: Bar -> $baz
 # ^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -506,6 +506,86 @@ EOT
   %#_
 # ^^^ variable.other.readwrite.global.perl
 # ^^ punctuation.definition.variable.perl
+  $&[0]
+# ^^ variable.other.regexp.match.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $`[0]
+# ^^ variable.other.regexp.pre-match.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $'[0]
+# ^^ variable.other.regexp.post-match.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $+[0]
+# ^^ variable.other.regexp.last-paren-match.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $"[0]
+# ^^ variable.other.readwrite.list-separator.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $0[0]
+# ^^ variable.other.predefined.program-name.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  @0[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  %0[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $1[0]
+# ^^ variable.other.subpattern.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  @1[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  %1[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $_[0]
+# ^^ variable.other.predefined.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  @_[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  %_[0]
+# ^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#   ^^^ meta.item-access.perl
+  $#0[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
+  @#0[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
+  %#0[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
+  $#_[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
+  @#_[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
+  %#_[0]
+# ^^^ variable.other.readwrite.global.perl
+# ^^ punctuation.definition.variable.perl
+#    ^^^ meta.item-access.perl
   $Foo::Bar::baz
 # ^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
@@ -522,6 +602,43 @@ EOT
 #         ^^^ support.class.perl
 #             ^^ punctuation.accessor.double-colon.perl
 #                ^^^ variable.other.member.perl
+  $Foo::Bar::baz[4]
+# ^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ punctuation.accessor.double-colon.perl
+#            ^^^ variable.other.member.perl - meta.item-access.perl
+#               ^ meta.item-access.perl punctuation.section.item-access.begin.perl
+#                ^ meta.item-access.perl constant.numeric.integer
+#                 ^ meta.item-access.perl punctuation.section.item-access.end.perl
+  $Foo::Bar->baz
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ keyword.accessor.arrow.perl
+#            ^^^ variable.other.member.perl
+  $Foo::Bar->baz[0]
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ keyword.accessor.arrow.perl
+#            ^^^ variable.other.member.perl
+#               ^^^ meta.item-access.perl
+  $Foo::Bar->baz{'key'}
+# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#  ^^^ support.class.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^ support.class.perl
+#          ^^ keyword.accessor.arrow.perl
+#            ^^^ variable.other.member.perl
+#               ^^^^^^^ meta.item-access.perl
   $Foo::Bar->$baz
 # ^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
@@ -585,6 +702,9 @@ EOT
 #           ^^ punctuation.accessor.double-colon.perl
 #             ^^^ variable.other.member.perl
 #                ^ punctuation.definition.variable.end.perl
+  ${Foo::Bar::baz}[$var]
+# ^^^^^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+#                 ^^^^^^ meta.item-access.perl
   ${
 #^ - variable
 # ^^ punctuation.definition.variable.begin.perl
@@ -603,7 +723,8 @@ EOT
 # ^ punctuation.definition.variable.end.perl
 #  ^ - variable
   $::Config{'cf_email'}
-# ^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+#          ^^^^^^^^^^^^ meta.item-access.perl
 # ^ punctuation.definition.variable.perl
 #  ^^ punctuation.accessor.double-colon.perl
 #    ^^^^^^ support.class.perl
@@ -629,6 +750,7 @@ EOT
 #              ^ punctuation.terminator.statement.perl
   %{$foo{'bar'}{'bar'}} = 'excl';
 # ^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+#       ^^^^^^^^^^^^^^ meta.item-access.perl
 # ^^ punctuation.definition.variable.begin.perl
 #   ^ punctuation.definition.variable.perl
 #   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
@@ -636,6 +758,36 @@ EOT
 #                       ^ keyword.operator.assignment.perl
 #                         ^^^^^^ string.quoted.single.perl
 #                               ^ punctuation.terminator.statement.perl
+
+  # addin items to an array
+  $AoA[$i] = [ somefunc($i) ];
+# ^^^^ variable.other.readwrite.global.perl - meta.item-access
+#     ^^^^ meta.item-access.perl
+#     ^ punctuation.section.item-access.begin.perl
+#      ^^ variable.other.readwrite.global.perl
+#        ^ punctuation.section.item-access.end.perl
+#          ^ keyword.operator.assignment.perl
+#            ^ punctuation.section.brackets.begin.perl
+#                           ^ punctuation.section.brackets.end.perl
+#                            ^ punctuation.terminator.statement.perl
+  # add new columns to an existing row
+  push @{ $AoA[0] }, "wilma", "betty";   # explicit deref
+# ^^^^ support.function.perl
+#      ^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+#         ^^^^ variable.other.readwrite.global.perl - meta.item-access
+#             ^^^ meta.item-access.perl
+#      ^^  punctuation.definition.variable.begin.perl
+#         ^ punctuation.definition.variable.perl
+#             ^ punctuation.section.item-access.begin.perl
+#              ^ constant.numeric.integer
+#               ^ punctuation.section.item-access.end.perl
+#                 ^ punctuation.definition.variable.end.perl
+#                  ^ punctuation.separator.sequence.perl
+#                    ^^^^^^^ string.quoted.double.perl
+#                           ^ punctuation.separator.sequence.perl
+#                             ^^^^^^^ string.quoted.double.perl
+#                                    ^ punctuation.terminator.statement.perl
+
 ###[ CONSTANTS ] #############################################################
 
   1234             # decimal integer


### PR DESCRIPTION
This PR adds support to scope the item access of an array or a map.

**Examples:**

    $array[0][2]
    $dict{'key1'}{'key2'}

This change is required to properly highlight those expressions in string interpolations. Otherwise the array index would not be part of the interpolation.

It turned out an array is initialized with the following expression:

    $array = [ item1, item2, ...];

This PR therefore adds the "brackets" contexts with rules to scope the opening and closing brackets.

**Note:**

  1. The `groups-nested` is not added everywhere to reduce the risk of interfering with HEREDOCs. It is assumed no one decides to define a HEREDOC within an array item access expression.
  2. The `groups-nested` was not yet used and contained a therefore unrevealed issue, which is fixed as well. It used the wrong match patterns. `{` instead of `(`.