### PR TITLE
[Lua] Gracefully recover from invalid reserved word usage

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -9,6 +9,11 @@ variables:
       and|break|do|elseif|else|end|false|for|function|goto|if|in|
       local|nil|not|or|repeat|return|then|true|until|while
     ){{identifier_break}})
+  reserved_word_statement: |- # excludes 'not', 'true', 'nil', 'false', 'function'
+    (?x:(?:
+      and|break|do|elseif|else|end|for|goto|if|in|
+      local|or|repeat|return|then|until|while
+    ){{identifier_break}})
 
   identifier_start: (?:[A-Za-z_])
   identifier_char: (?:[A-Za-z0-9_])
@@ -97,6 +102,7 @@ contexts:
           pop: true
         - match: ','
           scope: punctuation.separator.comma.lua
+        - include: reserved-word-pop
         - match: '{{identifier}}'
           scope: variable.parameter.function.lua
         - match: \.\.\.
@@ -307,6 +313,7 @@ contexts:
         - match: \]
           scope: punctuation.section.brackets.end.lua
           pop: true
+        - include: reserved-word-expression-pop
         - match: (?=\S)
           push: expression
 
@@ -320,6 +327,7 @@ contexts:
     - match: '{{identifier}}'
       scope: meta.property.lua
       pop: true
+    - include: reserved-word-pop
     - include: else-pop
 
   function-arguments-meta:
@@ -337,6 +345,7 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.lua
           pop: true
+        - include: reserved-word-expression-pop
         - match: (?=\S)
           push: expression-list
 
@@ -349,6 +358,16 @@ contexts:
       scope: keyword.operator.bitwise.lua
     - match: not{{identifier_break}}
       scope: keyword.operator.logical.lua
+
+  reserved-word-pop:
+    - match: '{{reserved_word}}'
+      scope: invalid.unexpected-keyword.lua
+      pop: true
+
+  reserved-word-expression-pop:
+    - match: '{{reserved_word_statement}}'
+      scope: invalid.unexpected-keyword.lua
+      pop: true
 
   builtin:
     - match: true{{identifier_break}}
@@ -471,6 +490,7 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.lua
           pop: true
+        - include: reserved-word-expression-pop
         - match: (?=\S)
           push: expression
 

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -314,6 +314,24 @@
 --     ^ punctuation.section.brackets.begin
 --               ^ punctuation.section.brackets.end
 
+    (not nil)
+--   ^^^ keyword.operator.logical.lua
+--       ^^^ constant.language.null.lua
+
+    (function () return; end)
+--   ^^^^^^^^^^^^^^^^^^^^^^^ - illegal
+
+    (return)
+--   ^^^^^^ meta.group.lua invalid.unexpected-keyword.lua
+
+    foo[return] foo[false]
+--      ^^^^^^ invalid.unexpected-keyword.lua
+--            ^ - meta.brackets
+--                  ^^^^^ constant.language.boolean.true.lua
+
+    some.return
+--       ^^^^^^ invalid.unexpected-keyword.lua
+
 --FUNCTION CALLS
 
     f(42);
@@ -337,6 +355,11 @@
     f {};
 --  ^ variable.function
 --    ^^ meta.function-call.arguments meta.mapping
+
+    f( 'unclosed)
+    return x
+--  ^^^^^^ meta.function-call.arguments.lua meta.group.lua invalid.unexpected-keyword.lua
+--         ^ - meta.function-call
 
 --FUNCTIONS
 
@@ -391,6 +414,9 @@
 
     foo.bar = function() end;
 --      ^^^ meta.property entity.name.function
+
+    function (return) end;
+--            ^^^^^^ invalid.unexpected-keyword.lua
 
 --STATEMENTS
 


### PR DESCRIPTION
Reserved words are now recognized and highlighted as invalid in:
- function definitions
- function calls
- item access
- member access
- parenthesized expressions

Fixes #1916.