### PR TITLE
[Perl] Fix identifier break

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -13,7 +13,7 @@ scope: source.perl
 
 variables:
   break: (?!\w|\s*::)
-  identifier: '\b[_[:alpha:]]\w*{{break}}'
+  identifier: '\b[_[:alpha:]]\w*\b'
   module: '\b[_[:upper:]]\w*\b'
   member: '\b[_[:lower:]]\w*\b'
   pod: '={{identifier}}'


### PR DESCRIPTION
An identifier can be followed by a double-colon. Hence using the `{{break}}` is not appropriate and needs to be fixed.

This is a theoretical issue which is not triggered at any point of the current implementation. This commit therefore has no functional effect to the current syntax definition, but may have due to future changes.

Note: This change is covered by existing test cases.