### PR TITLE
[Perl] Fix BEGIN/CHECK/END/... blocks

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -268,13 +268,13 @@ contexts:
   expressions:
     - include: blocks
     - include: groups
+    - include: sub
     - include: quoted-like
     - include: label
     - include: constants
     - include: class
     - include: operators
     - include: control
-    - include: sub
     - include: variables
     - include: function-call
     - include: comment-line
@@ -993,12 +993,23 @@ contexts:
     - match: \bsub\b
       scope: storage.type.function.perl
       push: sub-name
+    # special functions which are executed at compile time
+    # SEE: https://perldoc.perl.org/perlmod.html#BEGIN%2c-UNITCHECK%2c-CHECK%2c-INIT-and-END
+    - match: \b(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
+      scope: meta.function.perl entity.name.function.prepocessor.perl
+      push: sub-expect-parameters
 
   sub-name:
     - meta_scope: meta.function.perl
-    - match: \b(AUTOLOAD|BEGIN|CHECK|DESTROY|END|INIT|UNITCHECK){{break}}
+    # callback hook to auto load or destroy objects/functions
+    - match: \b(AUTOLOAD|DESTROY){{break}}
       scope: entity.name.function.callback.perl
       set: sub-expect-parameters
+    # special functions which are executed at compile time
+    - match: \b(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
+      scope: entity.name.function.prepocessor.perl
+      set: sub-expect-parameters
+    # ordinary function identifier
     - match: '{{identifier}}'
       scope: entity.name.function.perl
       set: sub-expect-parameters

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1161,6 +1161,74 @@ no strict;
 #  ^^^^^^ storage.modifier.perl
 #        ^ punctuation.terminator.statement.perl
 
+###[ PREPROCESSOR ]###########################################################
+
+  BEGIN {
+# ^^^^^^ meta.function.perl - meta.block
+# ^^^^^ entity.name.function.prepocessor.perl
+#       ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub BEGIN {
+# ^^^^^^^^^^ meta.function.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^^^^ entity.name.function.prepocessor.perl
+#           ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  CHECK {
+# ^^^^^^ meta.function.perl - meta.block
+# ^^^^^ entity.name.function.prepocessor.perl
+#       ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub CHECK {
+# ^^^^^^^^^^ meta.function.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^^^^ entity.name.function.prepocessor.perl
+#           ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  END {
+# ^^^^ meta.function.perl - meta.block
+# ^^^ entity.name.function.prepocessor.perl
+#     ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub END {
+# ^^^^^^^^ meta.function.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^^ entity.name.function.prepocessor.perl
+#         ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  INIT {
+# ^^^^^ meta.function.perl - meta.block
+# ^^^^ entity.name.function.prepocessor.perl
+#      ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub INIT {
+# ^^^^^^^^^ meta.function.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^^^ entity.name.function.prepocessor.perl
+#          ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  UNITCHECK {
+# ^^^^^^^^^^ meta.function.perl - meta.block
+# ^^^^^^^^^ entity.name.function.prepocessor.perl
+#           ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub UNITCHECK {
+# ^^^^^^^^^^^^^^ meta.function.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^^^^^^^^ entity.name.function.prepocessor.perl
+#               ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+
 ###[ SUB ]####################################################################
 
 sub


### PR DESCRIPTION
This commit fixes an issue with special preprocessor function blocks not being highlighted as such, if not following the `sub` keyword.

SEE: https://perldoc.perl.org/perlmod.html#BEGIN%2c-UNITCHECK%2c-CHECK%2c-INIT-and-END

Note:

The code blocks `BEGIN {}` are scoped as ordinary function blocks even though they are executed by the interpreter at compile time as there is no syntactical difference. It's therefore a little bit different situation than with preprocessor macros of other languages, which tend to differ from normal runtime code.