### PR TITLE
[Perl] Extend first_line_match to support editorconfig

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -8,7 +8,11 @@ file_extensions:
   - pod
   - t
   - PL
-first_line_match: ^#!.*\bperl\b
+first_line_match: |-
+  (?x:
+    ^\#! .* \bperl\b |                     # shebang
+    ^\# \s* -\*- [^*]* [Pp]erl [^*]* -\*-  # editorconfig
+  )
 scope: source.perl
 
 variables:


### PR DESCRIPTION
This PR enables Sublime Text to detect Perl syntax via certain tags in the first line, like:

```
# -*- perl -*-
# -*- Perl -*-
```

This commit is inspired by the way ShellScript provides such support.