### PR TITLE
[PHP] PHP 7.4 new syntax

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -222,7 +222,7 @@ contexts:
       scope: punctuation.terminator.expression.php
     - include: heredoc
     - include: numbers
-    - match: (\+|-|\*|/|%|&|\||\^|>>|<<|\.)=
+    - match: (\+|-|\*|/|%|&|\||\^|>>|<<|\.|\?\?)=
       scope: keyword.operator.assignment.augmented.php
     - match: "=>"
       scope: keyword.operator.key.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -150,6 +150,7 @@ contexts:
           pop: true
     - match: \b(catch|try|throw|finally)\b
       scope: keyword.control.exception.php
+    - include: arrow-function
     - include: closure
     - include: invoke-call
     - match: |-
@@ -564,6 +565,30 @@ contexts:
             - match: \(
               scope: meta.function.parameters.php meta.group.php punctuation.section.group.begin.php
               set: function-parameters
+        # Exit on unexpected content
+        - match: (?=\S)
+          pop: true
+
+  # https://wiki.php.net/rfc/arrow_functions_v2
+  arrow-function:
+    - match: '(?i)\b(fn)\b\s*(&)?\s*(?=\()'
+      scope: meta.function.arrow-function.php
+      captures:
+        1: storage.type.function.php
+        2: storage.modifier.reference.php
+      push:
+        - match: \(
+          scope: meta.function.parameters.php meta.group.php punctuation.section.group.begin.php
+          push:
+            - include: function-parameters
+            - match: (?==>)
+              pop: true
+        - match: "=>"
+          scope: punctuation.definition.arrow-function.php
+          push:
+            - match: '(?=;|,|\)|\s*\?>)'
+              pop: true
+            - include: expressions
         # Exit on unexpected content
         - match: (?=\S)
           pop: true

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -244,6 +244,8 @@ contexts:
     - match: (?i)(!|&&|\|\|)|\b(and|or|xor|as)\b
       scope: keyword.operator.logical.php
     - include: function-call
+    - match: \.\.\.
+      scope: keyword.operator.spread.php
     - match: \.
       scope: keyword.operator.string.php
     - match: "="
@@ -630,6 +632,8 @@ contexts:
     # Class name type hint
     - match: '{{identifier}}'
       scope: meta.path.php support.class.php
+    - match: '\.\.\.'
+      scope: keyword.operator.spread.php
     - match: '\?'
       scope: storage.type.nullable.php
     - match: '&'

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -544,6 +544,24 @@ contexts:
               pop: true
         - match: ','
           scope: punctuation.separator.php
+    # https://wiki.php.net/rfc/typed_properties_v2
+    - match: (?=\b(?:public|private|protected|static)\b)
+      push:
+        - match: (?=\b(?:const|function)\b)
+          pop: true
+        - match: \b(?:public|private|protected|static)\b
+          scope: storage.modifier.php
+        - match: (?=(?:\?\s*)?{{identifier}})
+          set:
+            - match: '(?:(\?)\s*)?({{identifier}})'
+              captures:
+                1: storage.type.nullable.php
+                2: support.class.php
+              pop: true
+            - match: ''
+              pop: true
+        - match: (?=\S)
+          pop: true
     - include: statements
 
   function:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1074,23 +1074,32 @@ contexts:
         1: punctuation.definition.variable.php
         2: variable.other.php
       push: function-call-parameters
+  # Trailing underscores are allowed to prevent numbers from flickering while typing
+  # The underscore is for PHP 7.4: https://wiki.php.net/rfc/numeric_literal_separator
   numbers:
-    - match: '\b(0[bB])[01]*\b'
+    - match: '\b(0[bB])(?!_)([01]|_(?!_))*\b'
       scope: constant.numeric.integer.binary.php
       captures:
         1: punctuation.definition.numeric.binary.php
-    - match: '\b(0[xX])\h*\b'
+    - match: '\b(0[xX])(?!_)(\h|_(?!_))*\b'
       scope: constant.numeric.integer.hexadecimal.php
       captures:
         1: punctuation.definition.numeric.hexadecimal.php
     - match: |-
         (?x:
-          (?:(\b\d+|\B)\.\d+|\b\d+\.\d*)(?:[eE][+-]?\d+)?\b
+          (?:
+            (?# such as 123.4 or .123)
+            (?:\b(?!_)(?:\d|_(?!_))+|\B)\.(?!_)(?:\d|_(?!_))+
+            |
+            (?# such as 123.)
+            \b(?!_)(?:\d|_(?!_))+\.
+          )(?:[eE][+-]?(?!_)(?:\d|_(?!_))+)?\b
           |
-          \b\d+(?:[eE][+-]?\d+)\b
+          (?# such as 123e-4)
+          \b(?!_)(?:\d|_(?!_))+(?:[eE][+-]?(?!_)(?:\d|_(?!_))+)\b
         )
       scope: constant.numeric.float.decimal.php
-    - match: '\b\d+\b'
+    - match: '\b(?!_)(?:\d|_(?!_))+\b'
       scope: constant.numeric.integer.decimal.php
   object:
     - match: '(->)(\$?\{)'

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -545,21 +545,18 @@ contexts:
         - match: ','
           scope: punctuation.separator.php
     # https://wiki.php.net/rfc/typed_properties_v2
-    - match: (?=\b(?:public|private|protected|static)\b)
+    - match: (?=\b(?:var|public|private|protected|static)\b)
       push:
         - match: (?=\b(?:const|function)\b)
           pop: true
-        - match: \b(?:public|private|protected|static)\b
+        - match: \b(?:var|public|private|protected|static)\b
           scope: storage.modifier.php
-        - match: (?=(?:\?\s*)?{{identifier}})
-          set:
-            - match: '(?:(\?)\s*)?({{identifier}})'
-              captures:
-                1: storage.type.nullable.php
-                2: support.class.php
-              pop: true
-            - match: ''
-              pop: true
+        - match: '(?:(\?)\s*)?({{identifier}})'
+          captures:
+            1: storage.type.nullable.php
+            2: support.class.php
+          pop: true
+        # Exit on unexpected content
         - match: (?=\S)
           pop: true
     - include: statements

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -912,6 +912,26 @@ class B
 //   ^ - meta.use
 //    ^ storage.modifier
 
+    public static ?Foo $str = '';
+//  ^^^^^^ storage.modifier
+//         ^^^^^^ storage.modifier
+//                ^ storage.type.nullable
+//                 ^^^ support.class
+//                     ^ punctuation.definition.variable
+//                      ^^^ variable.other
+//                          ^ keyword.operator.assignment
+
+    public const STR_1 = '';
+//  ^^^^^^ storage.modifier
+//         ^^^^^ storage.modifier
+//               ^^^^^ constant
+//                     ^ keyword.operator.assignment
+
+    const STR_2 = '';
+//  ^^^^^ storage.modifier
+//        ^^^^^ constant
+//              ^ keyword.operator.assignment
+
     public function abc(callable $var, int $var2, string $var3)
 //                  ^^^ entity.name.function
 //                      ^ storage.type

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -181,6 +181,27 @@ function i(
 ) {};
 
 
+function array_values_from_keys($arr, $keys) {
+    return array_map(fn($x) => $arr[$x], $keys, fn($x) => $arr[$x]);
+//                   ^^ meta.function.arrow-function storage.type.function
+//                     ^ punctuation.section.group.begin
+//                      ^^ variable.parameter
+//                        ^ punctuation.section.group.end
+//                          ^^ punctuation.definition.arrow-function.php
+}
+
+$fn = fn($x) => fn($y) => $x * $y + $z;
+//    ^^ meta.function.arrow-function storage.type.function
+//      ^ punctuation.section.group.begin
+//       ^^ variable.parameter
+//         ^ punctuation.section.group.end
+//           ^^ punctuation.definition.arrow-function.php
+//              ^^ meta.function.arrow-function storage.type.function
+//                ^ punctuation.section.group.begin
+//                 ^^ variable.parameter
+//                   ^ punctuation.section.group.end
+//                     ^^ punctuation.definition.arrow-function.php
+
 $var = function(array $ar=array(), ClassName $cls) use ($var1, $var2) {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //     ^^^^^^^^ meta.function.closure

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1038,21 +1038,41 @@ $var = 0;
 $var2 = -123.456e10;
 //       ^^^^^^^^^^ constant.numeric.float.decimal
 
+$var2 = -12_3.45_6e1_0;
+//       ^^^^^^^^^^^^^ constant.numeric.float.decimal
+
 $var2 = -123.e10;
 //       ^^^^^^^ constant.numeric.float.decimal
+
+$var2 = -12_3.e1_0;
+//       ^^^^^^^^^ constant.numeric.float.decimal
 
 $var2 = -.123e10;
 //       ^^^^^^^ constant.numeric.float.decimal
 
+$var2 = -.12_3e1_0;
+//       ^^^^^^^^^ constant.numeric.float.decimal
+
 $var2 = -123e10;
 //       ^^^^^^ constant.numeric.float.decimal
+
+$var2 = -12_3e1_0;
+//       ^^^^^^^^ constant.numeric.float.decimal
 
 $var3 = 0x0f;
 //      ^^^^ constant.numeric.integer.hexadecimal
 //      ^^ punctuation.definition.numeric.hexadecimal
 
+$var3 = 0x0_f;
+//      ^^^^ constant.numeric.integer.hexadecimal
+//      ^^ punctuation.definition.numeric.hexadecimal
+
 $var4 = 0b0111;
 //      ^^^^^^ constant.numeric.integer.binary
+//      ^^ punctuation.definition.numeric.binary
+
+$var4 = 0b0_1_1_1;
+//      ^^^^^^^^^ constant.numeric.integer.binary
 //      ^^ punctuation.definition.numeric.binary
 
   foo_bar:

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -222,6 +222,17 @@ $var = function(array $ar=array(), ClassName $cls) use ($var1, $var2) {
 };
 // <- meta.function meta.block punctuation.section.block.end
 
+function foo(?stinrg ...$args) {}
+//           ^ storage.type.nullable
+//            ^^^^^^ support.class
+//                   ^^^ keyword.operator.spread
+//                      ^^^^^ variable.parameter
+
+$arr4 = ['a', ...$arr1, 'b', ...$arr2, 'c'];
+//            ^^^ keyword.operator.spread
+//               ^^^^^ variable.other
+//                           ^^^ keyword.operator.spread
+
 $array = [   ];
 //       ^ meta.array.empty.php punctuation.section.array.begin.php
 //           ^ meta.array.empty.php punctuation.section.array.end.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1066,6 +1066,9 @@ $a += .5;
 $a .= 1;
 // ^^ keyword.operator.assignment.augmented.php
 
+$a ??= 1;
+// ^^^ keyword.operator.assignment.augmented.php
+
 if ($a !== $b);
 //     ^^^ keyword.operator.comparison.php
 


### PR DESCRIPTION
PHP 7.4 has been feature-freezed so this PR will no longer add new things.

## PHP 7.4 New Syntaxes

- [X] [Arrow function](https://wiki.php.net/rfc/arrow_functions_v2)
- [X] [Null coalescing assignment operator `??=`](https://wiki.php.net/rfc/null_coalesce_equal_operator)
- [X] [Typed properties](https://wiki.php.net/rfc/typed_properties_v2)
- [X] [Spread Operator in Array Expression `...`](https://wiki.php.net/rfc/spread_operator_for_array)
- [X] [Numeric Literal Separator `_`](https://wiki.php.net/rfc/numeric_literal_separator)