### PR TITLE
[PHP] "var" is equivalent to "public"

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -623,28 +623,28 @@ contexts:
         - include: expressions
 
   function-use:
-      - meta_content_scope: meta.function.closure.use.php
-      - include: comments
-      - match: '\)'
-        scope: punctuation.section.group.end.php
-        set:
-          - meta_content_scope: meta.function.php
-          - match: '(?=:)'
-            set: function-return-type
-          - match: \{
-            scope: meta.block.php punctuation.section.block.begin.php
-            set: function-body
-          # Exit on unexpected content
-          - match: (?=\S)
-            pop: true
-      - match: '&'
-        scope: storage.modifier.reference.php
-      - match: '(\$+){{identifier}}'
-        scope: variable.parameter.php
-        captures:
-          1: punctuation.definition.variable.php
-      - match: ','
-        scope: punctuation.separator.php
+    - meta_content_scope: meta.function.closure.use.php
+    - include: comments
+    - match: '\)'
+      scope: punctuation.section.group.end.php
+      set:
+        - meta_content_scope: meta.function.php
+        - match: '(?=:)'
+          set: function-return-type
+        - match: \{
+          scope: meta.block.php punctuation.section.block.begin.php
+          set: function-body
+        # Exit on unexpected content
+        - match: (?=\S)
+          pop: true
+    - match: '&'
+      scope: storage.modifier.reference.php
+    - match: '(\$+){{identifier}}'
+      scope: variable.parameter.php
+      captures:
+        1: punctuation.definition.variable.php
+    - match: ','
+      scope: punctuation.separator.php
 
   function-return-type:
     - meta_content_scope: meta.function.return-type.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -210,7 +210,7 @@ contexts:
     - match: (?i)\s*\(\s*(array|real|double|float|int(eger)?|bool(ean)?|string|object|binary|unset)\s*\)
       captures:
         1: storage.type.php
-    - match: (?i)\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|clone|var|function|interface|object)\b
+    - match: (?i)\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|clone|function|interface|object)\b
       scope: storage.type.php
     - match: (?i)\b(parent|self)\b
       scope: variable.language.php
@@ -544,11 +544,11 @@ contexts:
     - include: statements
 
   function:
-    - match: (?i)(?=(?:\b(?:final|abstract|public|private|protected|static)\s+)*\bfunction\b\s*(&\s*)?{{identifier_start}})
+    - match: (?i)(?=(?:\b(?:final|abstract|var|public|private|protected|static)\s+)*\bfunction\b\s*(&\s*)?{{identifier_start}})
       push:
         - meta_content_scope: meta.function.php
         - include: comments
-        - match: '(?i)\b(final|abstract|public|private|protected|static)\b'
+        - match: '(?i)\b(final|abstract|var|public|private|protected|static)\b'
           scope: storage.modifier.php
         - match: (?i)\bfunction\b
           scope: storage.type.function.php
@@ -1134,7 +1134,7 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.end.php
           pop: true
-    - match: ^\s*\*\s*(@access)\s+((public|private|protected)|(.+))\s*$
+    - match: ^\s*\*\s*(@access)\s+((var|public|private|protected)|(.+))\s*$
       captures:
         1: keyword.other.phpdoc.php
         3: storage.modifier.php


### PR DESCRIPTION
The deprecated `var` keyword is equivalent to `public` so I think they should share the same scope.

https://www.php.net/manual/en/language.oop5.visibility.php

```
Note: The PHP 4 method of declaring a variable with the var keyword
is still supported for compatibility reasons (as a synonym for the
public keyword). In PHP 5 before 5.1.3, its usage would generate an
E_STRICT warning.
```