### PR TITLE
[Perl] Fix key constants

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -327,9 +327,8 @@ contexts:
   constants:
     - include: constants-numbers
     - include: constants-language
+    - include: constants-other
     - include: string
-    - match: \b\w+\s*(?==>)
-      scope: constant.other.key.perl
 
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
@@ -377,6 +376,10 @@ contexts:
       scope: constant.language.perl
     - match: \b(?:ARGV|ARGVOUT|STDERR|STDIN|STDOUT|DATA|IN|OUT){{break}}
       scope: constant.language.filehandle.perl
+
+  constants-other:
+    - match: \b\w+(?=\s*=>)
+      scope: constant.other.key.perl
     - match: \b[A-Z0-9_]+{{break}}
       scope: constant.other.perl
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -572,7 +572,8 @@ EOT
 #             ^^ keyword.accessor.arrow.perl
 #               ^^^ variable.function.member.perl
 #                  ^ punctuation.section.arguments.begin.perl
-#                   ^^^ constant.other.perl
+#                   ^^^ constant.other.key.perl
+#                      ^ - constant
 #                       ^^ keyword.operator.assignment.perl
 #                          ^^^^^^^ string.quoted.single.perl
 #                                 ^ punctuation.section.arguments.end.perl


### PR DESCRIPTION
This commit ...

1) excludes the space after a key from the `constant.other.key` scope.

   BEFORE:
   ```
   map(key => "value")
       ^^^^ constant.other.key
   ```

   AFTER:

   ```
   map(key => "value")
       ^^^ constant.other.key
          ^ - constant
   ```

2) groups the `constant.other` rules in the `constants-other` context.