### PR TITLE
[Matlab] Fix transpose highlight following fields

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -29,6 +29,7 @@ contexts:
     - match: ({{id}})(\.)({{id}})
       captures:
         2: punctuation.accessor.dot.matlab
+      push: transpose_post_parens
   all_matlab_comments:
     - match: (%%).*$\n?
       scope: comment.double.percentage.matlab

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -173,6 +173,12 @@ a = a' % is the conjugate and transpose
 a = a.' % is the transpose
 %   ^ -keyword.operator.transpose.matlab
 %    ^^ keyword.operator.transpose.matlab
+c = a.b' % is the conjugate and transpose of the field b of structure a
+%    ^ punctuation.accessor.dot.matlab
+%      ^ keyword.operator.transpose.matlab
+c = a.b.' % is the transpose of the field b of structure a
+%    ^ punctuation.accessor.dot.matlab
+%      ^^ keyword.operator.transpose.matlab
 x = a[3]' + b(4)' % is the conjugate and transpose
 %       ^ keyword.operator.transpose.matlab
 %               ^ keyword.operator.transpose.matlab


### PR DESCRIPTION
Fix #1647.

This pull request adds a check for a transpose comma after fields of structures using dot notation `a.b'` to prevent false highlighting as a string, see [this comment](https://github.com/sublimehq/Packages/issues/1647#issuecomment-483157721). Previously, the rule of the context `transpose` did not apply to `a.b'` because it requires a variable name (`{{id}}`) preceding the transpose comma, but `a.b` was already matched by the rule of context `members`. Therefore I included the transpose comma check, which is already used after parens/brackets/braces, to matches of the form `a.b`.

Detecting the transpose comma will also work for nested structures of the form `a.b.c`, `a.b.c.d` etc. now, even though these are not entirely matched by the context `members`.