### PR TITLE
[XML] Add associations for MSBuild file extensions

### DIFF
--- a/XML/XML.sublime-settings
+++ b/XML/XML.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"hidden_extensions": ["rss", "sublime-snippet", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae", "csproj"]
+	"hidden_extensions": ["rss", "sublime-snippet", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences", "dae", "csproj", "fsproj", "sqlproj", "vbproj", "vcproj", "vcxproj", "props", "targets" ]
 }


### PR DESCRIPTION
Files with the following extensions can be considered Xml files by default (and it's currently tedious to set syntax manually for each file or change defaults for each MSBuild extension if you happen to work with such project files).

| Extension | Description |
| --- | --- |
| `fsproj` | F# project file |
| `vbproj` | VB.NET project file |
| `shproj` | Shared project file |
| `vcxproj` | Visual C++ project file |
| `sqlproj` | SQL project file |
| `props` | MSBuild properties file |
| `targets` | MSBuild targets file |