### PR TITLE
[Python] Handle f-string escape sequences with other escapes

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1310,6 +1310,14 @@ contexts:
         2: constant.character.escape.unicode.32-bit-hex.python
         3: constant.character.escape.unicode.name.python
 
+  escaped-fstring-escape:
+    # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
+    - match: (\\)(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: invalid.deprecated.character.escape.python
+        2: constant.character.escape.python
+
   line-continuation-inside-string:
     - match: (\\)$\n?
       captures:
@@ -1387,8 +1395,13 @@ contexts:
     - match: \}
       scope: invalid.illegal.stray-brace.python
 
-  f-string-content-reset:
+  f-string-content-with-regex:
     # Same as f-string-content, but will reset the entire scope stack
+    # and has an additional match.
+    - match: \\(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: constant.character.escape.python
     - match: \{\{|\}\}
       scope: constant.character.escape.python
     - match: \{\s*\}
@@ -1555,9 +1568,9 @@ contexts:
             - match: '(?=""")'
               pop: true
             - include: line-continuation-inside-string
-            - include: f-string-content-reset
+            - include: f-string-content-with-regex
     # Triple-quoted f-string
-    - match: ((?i)f|f)(""")
+    - match: ([fF])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
@@ -1566,6 +1579,7 @@ contexts:
         - match: '"""'
           scope: punctuation.definition.string.begin.python
           set: after-expression
+        - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
         - include: f-string-content
@@ -1713,9 +1727,9 @@ contexts:
             - match: '(?="|\n)'
               pop: true
             - include: line-continuation-inside-string
-            - include: f-string-content-reset
+            - include: f-string-content-with-regex
     # Single-line f-string
-    - match: ((?i)f|f)(")
+    - match: ([fF])(")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
@@ -1724,6 +1738,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
         - include: line-continuation-inside-string
@@ -1870,7 +1885,7 @@ contexts:
             - match: (?=''')
               pop: true
             - include: line-continuation-inside-string
-            - include: f-string-content-reset
+            - include: f-string-content-with-regex
     # Triple-quoted f-string
     - match: ([fF])(''')
       captures:
@@ -1881,6 +1896,7 @@ contexts:
         - match: "'''"
           scope: punctuation.definition.string.begin.python
           set: after-expression
+        - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
         - include: f-string-content
@@ -2031,9 +2047,9 @@ contexts:
             - match: (?='|\n)
               pop: true
             - include: line-continuation-inside-string
-            - include: f-string-content-reset
+            - include: f-string-content-with-regex
     # Single-line f-string
-    - match: ((?i)f|f)(')
+    - match: ([fF])(')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
@@ -2042,6 +2058,7 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
         - include: line-continuation-inside-string

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -579,6 +579,18 @@ expr = fr"^\s*({label}|{notlabel})"
 #               ^^^^^ source.python.embedded meta.qualified-name.python meta.generic-name.python
 #                                ^ source.regexp.python meta.group.regexp punctuation.definition.group.end.regexp
 
+line = re.sub(rf" ?\{{\\i.?\}}({x})\{{\\i.?\}}", r"\1", line)
+#                  ^^^^^ constant.character.escape.backslash.regexp
+#                   ^^ constant.character.escape.python
+#                          ^^^ constant.character.escape.backslash.regexp
+#                           ^^ constant.character.escape.python
+#                              ^ punctuation.section.interpolation.begin.python
+
+f"\{{{x}\}} test"
+# ^ invalid.deprecated.character.escape.python
+#  ^^ constant.character.escape.python
+#    ^ punctuation.section.interpolation.begin.python
+
 f"{something}"
 #^^^^^^^^^^^^ meta.string.interpolated
 # <- storage.type.string


### PR DESCRIPTION
Previously, `\{{` imposed problems with both regex raw strings and
normal due to the `\{` being matched first and the final `{` then being
interpreted as the opening of an f-string. We now match the entire token
and scope it appropriately.

Before: ![2019-05-15_21-52-07](https://user-images.githubusercontent.com/931051/57806089-b3e0dc00-775e-11e9-99b1-8ed1bf83ee9e.png)

After: ![2019-05-15_21-59-21](https://user-images.githubusercontent.com/931051/57806093-b5aa9f80-775e-11e9-97b2-c31f92212db4.png)
