### PR TITLE
[JavaScript] Scope builtin errors as support.class.builtin.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2053,7 +2053,7 @@ contexts:
       scope: support.class.builtin.js
       pop: true
     - match: (?:Eval|Range|Reference|Syntax|Type|URI)?Error{{identifier_break}}
-      scope: support.class.error.js
+      scope: support.class.builtin.js
       pop: true
 
     - match: (?:eval|isFinite|isNaN|parseFloat|parseInt|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent){{identifier_break}}

--- a/JavaScript/tests/syntax_test_js_support_builtin.js
+++ b/JavaScript/tests/syntax_test_js_support_builtin.js
@@ -13,7 +13,7 @@
 //  ^^^^^ support.function
 
     new Error();
-//      ^^^^^ support.class.error
+//      ^^^^^ support.class.builtin
 
     Array;
 //  ^^^^^ support.class.builtin
@@ -75,19 +75,19 @@
 //  ^^^^^^^ support.class.builtin
 
     Error;
-//  ^^^^^ support.class.error
+//  ^^^^^ support.class.builtin
     EvalError;
-//  ^^^^^^^^^ support.class.error
+//  ^^^^^^^^^ support.class.builtin
     RangeError;
-//  ^^^^^^^^^^ support.class.error
+//  ^^^^^^^^^^ support.class.builtin
     ReferenceError;
-//  ^^^^^^^^^^^^^^ support.class.error
+//  ^^^^^^^^^^^^^^ support.class.builtin
     SyntaxError;
-//  ^^^^^^^^^^^ support.class.error
+//  ^^^^^^^^^^^ support.class.builtin
     TypeError;
-//  ^^^^^^^^^ support.class.error
+//  ^^^^^^^^^ support.class.builtin
     URIError;
-//  ^^^^^^^^ support.class.error
+//  ^^^^^^^^ support.class.builtin
 
     Atomics;
 //  ^^^^^^^ support.constant.builtin


### PR DESCRIPTION
Fix #1980.

The `.error` scope doesn't seem useful (it's not standard), so I removed it when adding `.builtin`.