### PR TITLE
[Perl] variable reference operator

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1231,13 +1231,16 @@ contexts:
       captures:
         1: punctuation.definition.variable.perl
       push: maybe-item-access
-    - match: ([\$\@\%]#?)\w+\b
+    - match: (\\)?([\$\@\%]{1,3}#?)(\w+)\b
       scope: variable.other.readwrite.global.perl
       captures:
-        1: punctuation.definition.variable.perl
+        1: keyword.operator.reference.perl
+        2: punctuation.definition.variable.perl
       push: maybe-item-access
-    - match: ([\$\@\%])(\{)
-      scope: punctuation.definition.variable.begin.perl
+    - match: (\\)?([\$\@\%]{1,3}\{)
+      captures:
+        1: keyword.operator.reference.perl
+        2: punctuation.definition.variable.begin.perl
       push:
         - meta_scope: meta.braces.perl variable.other.readwrite.global.perl
         - match: \}

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -827,6 +827,14 @@ EOT
 #                             ^^^^^^^ string.quoted.double.perl
 #                                    ^ punctuation.terminator.statement.perl
 
+  \$foo
+# ^ keyword.operator.reference.perl
+#  ^ punctuation.definition.variable.perl
+# ^^^^^ variable.other.readwrite.global.perl
+  $@foo
+# ^^ punctuation.definition.variable.perl
+# ^^^^^ variable.other.readwrite.global.perl
+
 ###[ CONSTANTS ] #############################################################
 
   1234             # decimal integer


### PR DESCRIPTION
Scope `\` preceding user-defined variables. See https://perldoc.perl.org/perlref.html#Making-References

Also allow accessor chaining three-deep, and use `variable.language` rather than `variable.other.predefined`.