### PR TITLE
[Rust] Fix next_result handling for Cargo build errors

### DIFF
--- a/Rust/Cargo.sublime-build
+++ b/Rust/Cargo.sublime-build
@@ -1,10 +1,12 @@
 {
     "cmd": ["cargo", "build"],
-    "selector": "source.rust",
     "file_regex": "(?|, ([^,<\n]*\\.[A-z]{2}):([0-9]+)|[ \t]*-->[ \t]*([^<\n]*):([0-9]+):([0-9]+))",
     "syntax": "Packages/Rust/Cargo.sublime-syntax",
+    "keyfiles": ["Cargo.toml"],
+    "working_dir": "${folder:${project_path:${file_path}}}",
 
-    "variants": [
+    "variants":
+    [
         {
             "cmd": ["cargo", "run"],
             "name": "Run"


### PR DESCRIPTION
Paths in error messages are relative to the top-level directory, so ensure the
working_dir is set to that.

This also sets Cargo.sublime-build to be active when there's a Cargo.toml file,
rather than when editing Rust source code, which ensures it's an available build
system in more circumstances (e.g., when editing Cargo.toml)