### PR TITLE
[C++] Add support for Javadoc style comments

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -204,6 +204,8 @@ contexts:
           - match: \*/
             scope: punctuation.definition.comment.c
             pop: true
+          - match: ^\s*\*(?!/)
+            scope: punctuation.definition.comment.c
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -204,7 +204,7 @@ contexts:
           - match: \*/
             scope: punctuation.definition.comment.c
             pop: true
-          - match: ^\s*(\*)?(?!/)
+          - match: ^\s*(\*)(?!/)
             captures:
               1: punctuation.definition.comment.c
     - include: early-expressions

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -204,8 +204,9 @@ contexts:
           - match: \*/
             scope: punctuation.definition.comment.c
             pop: true
-          - match: ^\s*\*(?!/)
-            scope: punctuation.definition.comment.c
+          - match: ^\s*(\*)?(?!/)
+            captures:
+              1: punctuation.definition.comment.c
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.c++

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -193,7 +193,7 @@ contexts:
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
     # Take care of comments just before a function definition.
-    - match: /\*\*?
+    - match: /\*
       scope: punctuation.definition.comment.c
       push:
         - - match: \s*(?=\w)

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -193,7 +193,7 @@ contexts:
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
     # Take care of comments just before a function definition.
-    - match: /\*
+    - match: /\*\*?
       scope: punctuation.definition.comment.c
       push:
         - - match: \s*(?=\w)

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2329,3 +2329,7 @@ void sayHi()
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
+
+/**
+      *
+/*    ^ comment.block.c punctuation.definition.comment.c */


### PR DESCRIPTION
Allows Javadoc style comments to be recognized in scope. Word wrapping depends on it to wrap comment blocks properly.