### PR TITLE
[D] Add support for Javadoc style comment

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -146,7 +146,7 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.d
           pop: true
-        - match: ^\s*(\*)?(?!/)
+        - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.d
     - match: (///?).*$\n?
@@ -162,7 +162,7 @@ contexts:
         - match: \+/
           scope: punctuation.definition.comment.d
           pop: true
-        - match: ^\s*(\+)?(?!/)
+        - match: ^\s*(\+)(?!/)
           captures:
             1: punctuation.definition.comment.d
         - include: nested-comment

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -146,6 +146,8 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.d
           pop: true
+        - match: ^\s*\*(?!/)
+          scope: punctuation.definition.comment.d
     - match: (///?).*$\n?
       scope: comment.line.double-slash.d
       captures:
@@ -159,6 +161,8 @@ contexts:
         - match: \+/
           scope: punctuation.definition.comment.d
           pop: true
+        - match: ^\s*\+(?!/)
+          scope: punctuation.definition.comment.d
         - include: nested-comment
 
   number-in:

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -146,8 +146,9 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.d
           pop: true
-        - match: ^\s*\*(?!/)
-          scope: punctuation.definition.comment.d
+        - match: ^\s*(\*)?(?!/)
+          captures:
+            1: punctuation.definition.comment.d
     - match: (///?).*$\n?
       scope: comment.line.double-slash.d
       captures:
@@ -161,8 +162,9 @@ contexts:
         - match: \+/
           scope: punctuation.definition.comment.d
           pop: true
-        - match: ^\s*\+(?!/)
-          scope: punctuation.definition.comment.d
+        - match: ^\s*(\+)?(?!/)
+          captures:
+            1: punctuation.definition.comment.d
         - include: nested-comment
 
   number-in:

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -32,6 +32,16 @@ module foo.a.b1_3;
   +/
 //^^ comment.block.nested.d punctuation.definition.comment.d
 
+ /++
+      +
+//    ^ comment.block.nested.d punctuation.definition.comment.d
+ +/
+
+ /**
+      *
+//    ^ comment.block.d punctuation.definition.comment.d
+ */
+
 auto wysiwyg = r"f// \n\";
 //             ^^^^^^^^^^ meta.string.d string.quoted.double.raw.d
 //             ^ storage.modifier.string.d


### PR DESCRIPTION
Leading asterisk/plus in multi line comment will now be treated as
punctuation definition. Word wrapping depends on it to wrap comment blocks properly.