### PR TITLE
[JavaScript] Improve scope for Javadoc style comments

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -110,7 +110,7 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.end.js
           pop: true
-        - match: ^\s*(\*)?(?!/)
+        - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.js
     - match: /\*

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -110,6 +110,9 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.end.js
           pop: true
+        - match: ^\s*(\*)?(?!/)
+          captures:
+            1: punctuation.definition.comment.js
     - match: /\*
       scope: punctuation.definition.comment.begin.js
       push:

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -276,6 +276,11 @@ if (true)
 */
 // <- comment.block.documentation punctuation.definition.comment.end
 
+/**
+    * 
+//  ^ comment.block.documentation.js punctuation.definition.comment.js
+*/
+
 /*
 // <- comment.block punctuation.definition.comment
 */


### PR DESCRIPTION
Allow leading asterisks (excluding leading white space) in body of Javadoc style comments to be recognized as "punctuation.definition" scope. Default word wrapping will depend on it to wrap comment blocks properly.