### PR TITLE
[Rust] Improve scope for Javadoc style comments

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -927,7 +927,7 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.rust
           pop: true
-        - match: ^\s*(\*)?(?!/)
+        - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.rust
         - include: block-comments

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -927,6 +927,9 @@ contexts:
         - match: \*/
           scope: punctuation.definition.comment.rust
           pop: true
+        - match: ^\s*(\*)?(?!/)
+          captures:
+            1: punctuation.definition.comment.rust
         - include: block-comments
     - match: /\*
       scope: punctuation.definition.comment.rust

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -19,6 +19,11 @@ Block doc comments
 // ^^^^^^^^^^^^^^^^^^ comment.block.documentation comment.block
 */
 
+/**
+    *
+//  ^ comment.block.documentation.rust punctuation.definition.comment.rust 
+*/
+
 let c = 'c';
 // <- storage.type
 //    ^ keyword.operator.assignment


### PR DESCRIPTION
Allow leading asterisks (excluding leading white space) in body of Javadoc style comments to be recognized as "punctuation.definition" scope. Default word wrapping will depend on it to wrap comment blocks properly.