### PR TITLE
[JSON] Improve scope for Javadoc style comments

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -49,6 +49,9 @@ contexts:
         - meta_include_prototype: false
         - match: \*/
           pop: true
+        - match: ^\s*(\*)?(?!/)
+          captures:
+            1: punctuation.definition.comment.json
     - match: /\*
       scope: punctuation.definition.comment.json
       push:

--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -49,7 +49,7 @@ contexts:
         - meta_include_prototype: false
         - match: \*/
           pop: true
-        - match: ^\s*(\*)?(?!/)
+        - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.json
     - match: /\*

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -79,4 +79,9 @@
 
   "ke//y": "value"
 //^^^^^^^ meta.mapping.key.json string.quoted.double.json - comment
+
+/**
+    *
+//  ^ meta.mapping.json comment.block.documentation.json punctuation.definition.comment.json
+*/
 }


### PR DESCRIPTION
Allow leading asterisks (excluding leading white space) in body of Javadoc style comments to be recognized as "punctuation.definition" scope. Default word wrapping will depend on it to wrap comment blocks properly.