### PR TITLE
[C#] include structs in symbol list

### DIFF
--- a/C#/Symbol List Structs.tmPreferences
+++ b/C#/Symbol List Structs.tmPreferences
@@ -11,10 +11,6 @@
 		<integer>1</integer>
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
-		<key>symbolTransformation</key>
-		<string>
-		s/^/struct /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Structs.tmPreferences
+++ b/C#/Symbol List Structs.tmPreferences
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Struct</string>
+	<key>scope</key>
+	<string>source.cs entity.name.struct</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^/struct /;
+		</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
I finally figured out why some of my types weren't in the Goto Symbol in Project… list: they are structs!

I went ahead and looked at the Classes and Interfaces files and added one for Structs, lo and behold it just worked and I know too little about Sublime development to know what effects this has, except that now I can finally jump around to my structs, so I thought I'd make a PR for it. 😬 

Let me know if there's something you need from me. ❤️ 👏 