### PR TITLE
[Git] End gitconfig strings before newline

### DIFF
--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -211,7 +211,7 @@ contexts:
           pop: true
 
   line-end:
-    - match: $\n?
+    - match: $
       pop: true
 
   expect-line-end:

--- a/Git Formats/syntax_test_git_config
+++ b/Git Formats/syntax_test_git_config
@@ -357,6 +357,7 @@ stray-bracket]
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #           ^^^^ string.unquoted.value
 #                ^^^^^^^^^^^^^^^^^^ string.unquoted.value
+#                                  ^ - string
     sla = log --oneline --decorate --graph --all
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
@@ -370,6 +371,7 @@ stray-bracket]
 #                       ^^^^^^^^^^ string.unquoted.value
 #                                  ^^^^^^^ string.unquoted.value
 #                                          ^^^^^ string.unquoted.value
+#                                               ^ - string
    serve = !git daemon --reuseaddr --verbose  --base-path=. --export-all ./.git  # shell comment
 # <- meta.mapping
 #^^ meta.mapping


### PR DESCRIPTION
I have a background color tweak for `string` that makes the problem more obvious.