### PR TITLE
[Python] Add support for some new syntax in Python 3.8

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -624,6 +624,13 @@ contexts:
     - match: ','
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
+    - match: /
+      scope: storage.modifier.positional-args-only.python
+      push:
+        - match: (?=[,)])
+          pop: true
+        - match: \S
+          scope: invalid.illegal.expected-comma.python
     - match: '(?==)'
       set:
         - match: '='

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1411,6 +1411,8 @@ contexts:
           pop: true
         - match: '![ars]'
           scope: storage.modifier.conversion.python
+        - match: =
+          scope: storage.modifier.debug.python
         - match: ':'
           push:
             - meta_scope: meta.format-spec.python constant.other.format-spec.python
@@ -1423,7 +1425,7 @@ contexts:
         - match: ''
           push:
             - meta_content_scope: source.python.embedded
-            - match: (?=![^=]|:|\})
+            - match: (?==?(![^=]|:|\}))
               pop: true
             - match: \\
               scope: invalid.illegal.backslash-in-fstring.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -729,6 +729,15 @@ def foo(arg: int = 0, (x: float, y=20) = (0.0, "default")):
 #                                                       ^ punctuation.section.sequence.end.python
     pass
 
+def name(p1, p2=None, /, p_or_kw=None, *, kw): pass
+#                     ^ storage.modifier.positional-args-only.python
+#                      ^ punctuation.separator.parameters.python
+#                                      ^ keyword.operator.unpacking.sequence.python
+def name(p1, p2, /): pass
+#                ^ storage.modifier.positional-args-only.python
+#                 ^ punctuation.section.parameters.end.python
+
+
 ##################
 # Class definitions
 ##################

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -634,6 +634,33 @@ F""" {} {\} }
 #           ^ invalid.illegal.stray-brace
 """
 
+# Most of these were inspired by
+# https://github.com/python/cpython/commit/9a4135e939bc223f592045a38e0f927ba170da32
+f'{x=:}'
+#   ^ storage.modifier.debug.python
+f'{x=:.2f}'
+#   ^ storage.modifier.debug.python
+f'{x=!r}'
+#   ^ storage.modifier.debug.python
+f'{x=!a}'
+#   ^ storage.modifier.debug.python
+f'{x=!s:*^20}'
+#   ^ storage.modifier.debug.python
+#    ^^ storage.modifier.conversion.python
+#      ^^^^^ meta.format-spec.python
+f'{"Σ"=}'
+#     ^ storage.modifier.debug.python
+f'{0==1}'
+#   ^^ -storage.modifier.debug.python
+f'{0!=1}'
+#    ^ -storage.modifier.debug.python
+f'{0<=1}'
+#    ^ -storage.modifier.debug.python
+f'{0>=1}'
+#    ^ -storage.modifier.debug.python
+f'{f(a="3=")}'
+#     ^^^^ -storage.modifier.debug.python
+
 f" {
 %   ^ invalid.illegal.unclosed-string
    # TODO make this test pass


### PR DESCRIPTION
[Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html) will include the following syntax changes:

- [x] `f'{expr=}'` expands to the text of the expression, an equal sign, then the repr of the evaluated expression (https://bugs.python.org/issue36817)
- [x] Positional-Only Parameters (https://www.python.org/dev/peps/pep-0570/)
- [ ] Assignment Expressions (https://www.python.org/dev/peps/pep-0572/)

I skipped assignment expressions for now because they are a tad bit more involved and ideally I'd like to see some consensus on #1842 regarding the scope names I should use for the identifiers that are assigned to. Because the assignments are inline, it would seem useful for those to be highlighted differently compared to normal variable usages.
Anyway, here are the small changes I've done so far.

The final release is [scheduled for 2019-10-21](https://www.python.org/dev/peps/pep-0569/).