### PR TITLE
[Python] Octal string escapes accept **up to** 3 digits

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1295,7 +1295,7 @@ contexts:
             pop: true
 
   escaped-char:
-    - match: '(\\x\h{2})|(\\[0-7]{3})|(\\[\\"''abfnrtv])'
+    - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
       captures:
         1: constant.character.escape.hex.python
         2: constant.character.escape.octal.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -4,7 +4,7 @@
 # Strings and embedded syntaxes
 ###############################
 
-var = "\x00 \xaa \xAF \070 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE}"
+var = "\x00 \xaa \xAF \070 \0 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE}"
 #     ^ meta.string.python
 #      ^^^^ constant.character.escape.hex
 #           ^^^^ constant.character.escape.hex
@@ -19,14 +19,14 @@ var = "\x00 \xaa \xAF \070 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE
 #                                            ^^ constant.character.escape
 #                                               ^^ constant.character.escape
 #                                                  ^^ constant.character.escape
-#                                                     ^^^^^^ constant.character.escape.unicode
-#                                                            ^^^^^^^^^^ constant.character.escape.unicode
-#                                                                       ^^^^^^^^^ constant.character.escape.unicode
+#                                                     ^^ constant.character.escape
+#                                                        ^^^^^^ constant.character.escape.unicode
+#                                                               ^^^^^^^^^^ constant.character.escape.unicode
+#                                                                          ^^^^^^^^^ constant.character.escape.unicode
 
-invalid_escapes = "\.  \7 \-"
+invalid_escapes = "\.  \-"
 #                  ^^ invalid.deprecated.character.escape.python
 #                      ^^ invalid.deprecated.character.escape.python
-#                         ^^ invalid.deprecated.character.escape.python
 
 conn.execute("SELECT * FROM foobar")
 #              ^ meta.string.python keyword.other.DML.sql


### PR DESCRIPTION
Via https://docs.python.org/3/reference/lexical_analysis.html#literals.