### PR TITLE
[PHP] Fix JavaScript heredocs.

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -884,13 +884,9 @@ contexts:
           scope: punctuation.section.embedded.begin.php punctuation.definition.string.php
           captures:
             1: keyword.operator.heredoc.php
-          push:
-            - meta_scope: meta.embedded.js
-            - meta_content_scope: source.js
-            - match: (?=^\s*JAVASCRIPT\b)
-              pop: true
-            - include: interpolation
-            - include: scope:source.js
+          embed: heredoc-javascript
+          embed_scope: meta.embedded.js source.js
+          escape: (?=^\s*JAVASCRIPT\b)
         - match: <<<\s*('JAVASCRIPT')\s*$\n?
           scope: meta.embedded.js punctuation.section.embedded.begin.php punctuation.definition.string.php
           captures:
@@ -953,6 +949,12 @@ contexts:
             - meta_scope: string.unquoted.nowdoc.php
             - match: (?=^\s*\2\b)
               pop: true
+  heredoc-javascript:
+    - meta_include_prototype: false
+    - match: ''
+      push: scope:source.js
+      with_prototype:
+        - include: interpolation
   instantiation:
     # anonymous class ( http://php.net/manual/en/language.oop5.anonymous.php )
     - match: '(?i)(new)\s+(class)\b\s*'

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1244,6 +1244,8 @@ var foo = 1;
 $var
 // <- variable.other.php
 //^^ variable.other.php
+    ($var)
+//   ^^^^ variable.other.php
 JAVASCRIPT;
 // <- punctuation.section.embedded.end keyword.operator.heredoc
 


### PR DESCRIPTION
It looks like the language-specific heredocs in PHP are a bit brittle. I've fixed the JavaScript one here because it was breaking #2011. The rest of these should probably be fixed as well, but I'm not familiar with the PHP syntax.