### PR TITLE
[Markdown] Support Pandoc's fenced code block format

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -104,6 +104,7 @@ variables:
             (~){3,}    #   3 or more tildas
             (?![^~]*~) #   not followed by any more tildas on the same line
           )
+          (?:\s*\{\.)? # Pandoc's notation: https://pandoc.org/MANUAL.html#fenced-code-blocks
           \s*          # allow for whitespace between code block start and info string
         )
     fenced_code_block_trailing_infostring_characters: |-
@@ -112,6 +113,8 @@ variables:
             \s*        # any whitespace, or ..
           |
             \s[^`]*    # any characters (except backticks), separated by whitespace ...
+          |
+            \}         # Pandoc's notation: https://pandoc.org/MANUAL.html#fenced-code-blocks
           )
           $\n?         # ... until EOL
         )

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1179,6 +1179,16 @@ for (var i = 0; i < 10; i++) {
 ```
 | <- punctuation.definition.raw.code-fence.end
 
+``` {.js}
+| <- punctuation.definition.raw.code-fence.begin
+|     ^^ constant.other.language-name
+for (var i = 0; i < 10; i++) {
+| ^ keyword.control.loop.js
+    console.log(i);
+}
+```
+| <- punctuation.definition.raw.code-fence.end
+
 ```testing``123```
 | <- punctuation.definition.raw.begin
 |         ^^ - punctuation


### PR DESCRIPTION
Support syntax highlight for Pandoc's fenced code block notation.

~~~~~~
``` {.bash}
CLIST=$(schroot -l | sed -n 's,^source:\(.*\-sbuild\)$,\1,p')
for ins in $CLIST; do sbuild-update -udcar $ins; done
```
~~~~~~

This is the first time that I see this kind of fenced code block notation though... but it's quite easy to support it from the current syntax definition.

References:

- https://pandoc.org/MANUAL.html#fenced-code-blocks
- https://forum.sublimetext.com/t/markdown-syntax-highlighting-misses-soem-code-blocks/45514
