### PR TITLE
[Rust] Restructure macro parsing

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -23,6 +23,14 @@ contexts:
     - match: '\${{identifier}}'
       scope: variable.other.rust
 
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  pop-immediately:
+    - match: ''
+      pop: true
+
   statements:
 
     - match: '(''{{identifier}})\s*(:)'
@@ -644,95 +652,111 @@ contexts:
             - include: type-any-identifier
 
   macro-block:
+    # This meta scope requires some juggling
     - meta_scope: meta.macro.rust
-    - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
-      pop: true
-    - match: '[\])]'
-      scope: punctuation.section.group.end.rust
-      pop: true
-    - match: '\{'
-      scope: punctuation.section.block.begin.rust
-      push:
-        - meta_scope: meta.block.rust
-        - match: '(?=\})'
+    - match: \{
+      scope: meta.block.rust punctuation.section.block.begin.rust
+      set:
+        - meta_content_scope: meta.macro.rust meta.block.rust
+        - match: \}
+          scope: meta.macro.rust meta.block.rust punctuation.section.block.end.rust
           pop: true
         - include: macro-block-contents
-    - match: '\['
-      scope: punctuation.section.group.begin.rust
-      push:
-        - meta_scope: meta.group.rust
-        - match: '(?=\])'
+    - match: \[
+      scope: meta.group.rust punctuation.section.group.begin.rust
+      set:
+        - meta_content_scope: meta.macro.rust meta.group.rust
+        - match: \]
+          scope: meta.macro.rust meta.group.rust punctuation.section.group.end.rust
           pop: true
         - include: macro-block-contents
-    - match: '\('
-      scope: punctuation.section.group.begin.rust
-      push:
-        - meta_scope: meta.group.rust
-        - match: '(?=\))'
+    - match: \(
+      scope: meta.group.rust punctuation.section.group.begin.rust
+      set:
+        - meta_content_scope: meta.macro.rust meta.group.rust
+        - match: \)
+          scope: meta.macro.rust meta.group.rust punctuation.section.group.end.rust
           pop: true
         - include: macro-block-contents
+    - include: else-pop
 
   macro-block-contents:
     - include: comments
-    - match: '\('
-      scope: punctuation.section.group.begin.rust
-      push: macro-matcher
-    - match: ';'
+    - match: (?=\()
+      push:
+        - macro-terminator
+        - macro-body
+        - macro-match-operator
+        - macro-matcher
 
   macro-matcher:
-    - meta_include_prototype: false
-    - meta_scope: meta.group.rust
-    - match: '\)'
-      scope: punctuation.section.group.end.rust
-      set: macro-match-operator
-    - match: '(\$)(\()'
-      captures:
-        1: keyword.operator.rust
-        2: punctuation.section.group.begin.rust
-      push:
-        - match: '(\))[^*+]?([*+])'
-          captures:
-            1: punctuation.section.group.end.rust
-            2: keyword.operator.rust
+    - match: \(
+      scope: punctuation.section.group.begin.rust
+      set:
+        - meta_include_prototype: false
+        - meta_scope: meta.group.macro-matcher.rust
+        - match: \)
+          scope: punctuation.section.group.end.rust
           pop: true
+        - match: ((\$)\()
+          captures:
+            1: punctuation.section.group.begin.rust
+            2: keyword.operator.rust
+          push:
+            - meta_scope: meta.group.rust
+            - meta_include_prototype: false
+            - match: (\))(?:\s*[^*+]?\s*([*+]))?
+              captures:
+                1: punctuation.section.group.end.rust
+                2: keyword.operator.rust
+              pop: true
+            - include: macro-metavariable
         - include: macro-metavariable
-    - include: macro-metavariable
 
   macro-match-operator:
-    - match: '=>'
+    - match: =>
       scope: keyword.operator.rust
-    - match: '\{'
+      pop: true
+    - include: else-pop
+
+  macro-body:
+    - match: \{
       scope: punctuation.section.block.begin.rust
       set:
-        - meta_scope: meta.block.rust
-        - match: '\}'
+        - meta_scope: meta.block.macro-body.rust
+        - match: \}
           scope: punctuation.section.block.end.rust
           pop: true
         - include: statements
-    - match: '\('
+    - match: \(
       scope: punctuation.section.group.begin.rust
       set:
-        - meta_scope: meta.group.rust
-        - match: '\)'
+        - meta_scope: meta.group.macro-body.rust
+        - match: \)
           scope: punctuation.section.group.end.rust
           pop: true
         - include: statements
-    - match: '\['
+    - match: \[
       scope: punctuation.section.group.begin.rust
       set:
-        - meta_scope: meta.group.rust
-        - match: '\]'
+        - meta_scope: meta.group.macro-body.rust
+        - match: \]
           scope: punctuation.section.group.end.rust
           pop: true
         - include: statements
+    - include: else-pop
 
   macro-metavariable:
     - match: '(\${{identifier}})(:)(ident|path|expr|ty|pat|stmt|block|item|meta|tt)'
       captures:
-        1: variable.parameter.rust
+        1: variable.parameter.macro.rust
         2: punctuation.separator.rust
         3: storage.type.rust
+
+  macro-terminator:
+    - match: ;|,
+      scope: punctuation.terminator.macro-matcher.rust
+    - include: else-pop
 
   impl-definition:
     - meta_scope: meta.impl.rust

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -929,34 +929,47 @@ macro_rules! alternate_group (
 )
 
 macro_rules! kleene_star {
+// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.macro.rust - meta.macro.rust meta.macro.rust
+//                       ^ meta.block.rust punctuation.section.block.begin.rust
     ($($arg:tt)+) => (
-//   ^ meta.macro meta.block meta.group keyword.operator
-//    ^ meta.macro meta.block meta.group punctuation.section.group.begin
-//     ^^^^ meta.macro meta.block meta.group variable.other
-//         ^^^^^ meta.macro meta.block meta.group
-//              ^ meta.macro meta.block meta.group punctuation.section.group.end
-//                ^ meta.macro meta.block keyword.operator
+//  ^^^^^^^^^^^^^^^^^^ meta.macro meta.block
+//  ^^^^^^^^^^^^^ meta.group.macro-matcher
+//   ^^^^^^^^^^ meta.group.macro-matcher meta.group
+//   ^^ punctuation.section.group.begin
+//   ^ keyword.operator
+//     ^^^^ variable.parameter.macro.rust
+//          ^^ storage.type.rust
+//             ^ keyword.operator.rust
+//              ^ meta.group punctuation.section.group.end
+//                ^^ keyword.operator
+//                   ^ meta.group.macro-body.rust punctuation.section.group.begin.rust
         println!($($arg));
     ),
     ($($arg:tt)*) => (
-//     ^^^^ meta.macro meta.block meta.group variable.other
-//         ^^^^^ meta.macro meta.block meta.group
-//              ^ meta.macro meta.block meta.group punctuation.section.group.end
-//                ^ meta.macro meta.block keyword.operator
+//  ^^^^^^^^^^^^^ meta.macro meta.block meta.group.macro-matcher
+//     ^^^^ variable.parameter.macro.rust
+//                ^^ meta.macro meta.block keyword.operator
         println!($($arg)*);
+//                 ^^^^ variable.other.rust
+//               ^^^^^^^^^ meta.macro.rust meta.block.rust meta.group.macro-body.rust meta.group.rust
     ),
-    ($($arg:tt);+) => (
-//     ^^^^ meta.macro meta.block meta.group variable.other
-//         ^^^^^^ meta.macro meta.block meta.group
-//               ^ meta.macro meta.block meta.group punctuation.section.group.end
-//                 ^ meta.macro meta.block keyword.operator
+    ($($arg:tt) ; +) => (
+//  ^^^^^^^^^^^^^^^^ meta.macro meta.block meta.group.macro-matcher
+//     ^^^^ variable.parameter.macro.rust
+//                   ^^ meta.macro meta.block keyword.operator
         println!($($arg));
     ),
     ($($arg:tt),*) => (
-//     ^^^^ meta.macro meta.block meta.group variable.other
-//         ^^^^^^ meta.macro meta.block meta.group
-//               ^ meta.macro meta.block meta.group punctuation.section.group.end
-//                 ^ meta.macro meta.block keyword.operator
+//  ^^^^^^^^^^^^^^ meta.macro meta.block meta.group.macro-matcher
+//     ^^^^ variable.parameter.macro.rust
+//                 ^^ meta.macro meta.block keyword.operator
+        println!($($arg)*);
+    ),
+
+// incomplete blocks
+    ($($arg:tt),*) ,
+//                 ^ meta.macro.rust meta.block.rust punctuation.terminator.macro-matcher.rust
+    ($($x:tt),*) => ($x) ,
         println!($($arg)*);
     )
 }


### PR DESCRIPTION
- Use a deterministic approach by pushing all expected tokens at once.
- Clean up closing punctuation matches to make them easier to
  understand.
- Recover from unmatched tokens more gracevully through 'else-pop'
  context.
- Accept whitespace around multi-match separator (Rust compiles fine
  with them).
- Add more details to scope names.
- Match comma as macro matcher separator.

Fixes #2014.

Before:
![2019-07-23_20-55-26](https://user-images.githubusercontent.com/931051/61739331-829f1080-ad8c-11e9-89ce-4b7617939ab2.png)


After:
![2019-07-23_20-55-07](https://user-images.githubusercontent.com/931051/61739329-829f1080-ad8c-11e9-8b0f-2a8ee060f5bc.png)

```rust
#[macro_export]
macro_rules! vec {
    ( $( $x:expr ) , * ) => {
        {
            let mut v = Vec::new();
            $(v.push($x);)*
            v
        }
    };
}

#[macro_export]
macro_rules! test [($($x:tt),*) => ($x)];

fn main() {
    let v = vec![1, 2, 3];
    println!("{:#?}", v);
}
```