### PR TITLE
[JavaScript] Use proper scopes for interpolation in template strings.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -937,18 +937,18 @@ contexts:
       scope: punctuation.definition.string.begin.js
       set:
         - meta_include_prototype: false
-        - meta_scope: meta.string.js string.template.js
+        - meta_scope: meta.string.js string.quoted.other.js
         - match: "`"
           scope: punctuation.definition.string.end.js
           pop: true
         - match: '\$\{'
-          scope: punctuation.definition.template-expression.begin.js
+          scope: punctuation.section.interpolation.begin.js
           push:
             - clear_scopes: 1
-            - meta_scope: meta.template.expression.js
-            - meta_content_scope: source.js.embedded.expression
+            - meta_scope: meta.interpolation.js
+            - meta_content_scope: source.js.embedded
             - match: '\}'
-              scope: punctuation.definition.template-expression.end.js
+              scope: punctuation.section.interpolation.end.js
               pop: true
             - match: (?=\S)
               push: expression

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -386,20 +386,24 @@ tag`Hello ${ a + b } world\nanother ${expression}.`;
 // <- variable.function.tagged-template
 // ^ punctuation.definition.string.begin
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
-// ^^^^^^^ string.template
-//        ^ punctuation.definition.template-expression.begin
+// ^^^^^^^ string.quoted.other
+//        ^^^^^^^^^^ meta.interpolation - string
+//        ^ punctuation.section.interpolation.begin
 //           ^ variable.other.readwrite
 //             ^ keyword.operator.arithmetic
-//               ^ meta.template.expression source.js.embedded.expression
-//                 ^ punctuation.definition.template-expression.end
-//                  ^^^^^^^^^^^^^^^^ string.template
+//               ^ source.js.embedded
+//                 ^ punctuation.section.interpolation.end
+//                  ^^^^^^^^^^^^^^^^ string.quoted.other
 //                        ^ constant.character.escape
-//                                               ^^ string.template
+//                                  ^^^^^^^^^^^^^ meta.interpolation - string
+//                                  ^^ punctuation.section.interpolation.begin
+//                                              ^ punctuation.section.interpolation.end
+//                                               ^^ string.quoted.other
 //                                                ^ punctuation.definition.string.end
 
 tag `template`;
 // <- variable.function.tagged-template
-//  ^^^^^^^^^^ meta.string string.template
+//  ^^^^^^^^^^ meta.string string.quoted.other
 
 x ? y // y is a template tag!
 `template` : z;
@@ -1749,12 +1753,12 @@ var query = {
 
 var str = `Hello, ${name}!`;
 //        ^^^^^^^^^^^^^^^^^ meta.string
-//        ^^^^^^^^ string.template
-//                ^^^^^^^ meta.template.expression - string
-//                       ^^ string.template
-//                ^^ punctuation.definition.template-expression.begin
-//                  ^^^^ source.js.embedded.expression variable.other.readwrite
-//                      ^ punctuation.definition.template-expression.end
+//        ^^^^^^^^ string.quoted.other
+//                ^^^^^^^ meta.interpolation - string
+//                       ^^ string.quoted.other
+//                ^^ punctuation.section.interpolation.begin
+//                  ^^^^ source.js.embedded variable.other.readwrite
+//                      ^ punctuation.section.interpolation.end
 
 function yy (a, b) {
 // ^^^^^^^^^^^^^^^^^ meta.function


### PR DESCRIPTION
- `string.template` → `string.quoted.other`
- `punctuation.definition.template-expression` → `punctuation.section.interpolation`
- `meta.template.expression` → `meta.interpolation`