### PR TITLE
[XML] Highlight files starting with DOCTYPE as XML

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -13,11 +13,13 @@ file_extensions:
   - opml
   - svg
 first_line_match: |-
-    (?x)
-    ^(?:
-        <\?xml\s
-     |  \s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>
-     )
+    (?x:
+      ^(?:
+          <\?xml\s
+        | \s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>
+        | \s*<!DOCTYPE\s+(?!html\b)
+      )
+    )
 scope: text.xml
 variables:
   # The atomic part of a tag or attribute name without namespace separator `:`

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -17,7 +17,7 @@ first_line_match: |-
       ^(?:
           <\?xml\s
         | \s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>
-        | \s*<!DOCTYPE\s+(?!html[ \t\n\f>])
+        | \s*(?i:<!DOCTYPE\s+(?!html[ \t\n\f>]))
       )
     )
 scope: text.xml

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -17,7 +17,7 @@ first_line_match: |-
       ^(?:
           <\?xml\s
         | \s*<([\w-]+):Envelope\s+xmlns:\1\s*=\s*"http://schemas.xmlsoap.org/soap/envelope/"\s*>
-        | \s*<!DOCTYPE\s+(?!html\b)
+        | \s*<!DOCTYPE\s+(?!html[ \t\n\f>])
       )
     )
 scope: text.xml


### PR DESCRIPTION
Apply XML syntax to all files starting with `<!DOCTYPE >`, if it is not html. `<!DOCTYPE html>` is reserved for HTML syntax.

Sometimes the <?xml ...> prolog may be omitted in XML files which may also have an arbitary extension such as `*.ts` which is not associated to XML otherwise.