### PR TITLE
[Lua] Update number patterns again

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -415,13 +415,13 @@ contexts:
       pop: true
 
   number:
-    - match: (0[Xx])\h*
+    - match: (0[Xx])\h*(?:\.\h*)?(?:[Pp][-+]?\d*)?
       scope: constant.numeric.hexadecimal.lua
       captures:
         1: punctuation.definition.numeric.hexadecimal.lua
       pop: true
 
-    - match: (\d+(?:\.\d+)?|\.\d+)([Ee][-+]?\d+)?
+    - match: (?:\d+(?:\.\d*)?|\.\d+)([Ee][-+]?\d+)?
       scope: constant.numeric.decimal.lua
       pop: true
 

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -67,6 +67,12 @@
     12.345;
 --  ^^^^^^ constant.numeric.decimal
 
+    1.;
+--  ^^ constant.numeric.decimal
+
+    .2;
+--  ^^ constant.numeric.decimal
+
     1e10;
 --  ^^^^ constant.numeric.decimal
 
@@ -82,6 +88,14 @@
 
     0XdeafBEEF42;
 --  ^^^^^^^^^^^^ constant.numeric.hexadecimal
+--  ^^ punctuation.definition.numeric.hexadecimal
+
+    0xa.bc;
+--  ^^^^^^ constant.numeric.hexadecimal
+--  ^^ punctuation.definition.numeric.hexadecimal
+
+    0x1p10;
+--  ^^^^^^ constant.numeric.hexadecimal
 --  ^^ punctuation.definition.numeric.hexadecimal
 
     'foo';
@@ -125,7 +139,7 @@
 --   ^^^^^ constant.character.escape.unicode
 --         ^^^^^^^^ constant.character.escape.unicode
 
-    '\z
+    '\z  
 --   ^^^^^ constant.character.escape - invalid
     ';
 
@@ -425,15 +439,6 @@
         2 + 2
     end
 -- ^^^^ meta.block
---  ^^^ keyword.control.end
-
-    if 2 > .2 then
---  ^^ keyword.control.conditional
---     ^ constant.numeric.decimal
---         ^^ constant.numeric.decimal
---            ^^^^ keyword.control.conditional
-
-    end
 --  ^^^ keyword.control.end
 
     do 2 + 2 end


### PR DESCRIPTION
Partly reverts and updates 61e2cd280231da90afe37d07f591084f51affd9f.
I also made `1.` a proper match because that works as well and removed capturing group.

See #1937.
