### PR TITLE
[Perl] Add unquoted hash keys highlighting

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1263,6 +1263,12 @@ contexts:
           - include: groups-nested
           - include: expressions
         - regexp-pop
+    - match: (\{)\s*({{identifier}})\s*(\})
+      scope: meta.item-access.perl
+      captures:
+        1: punctuation.section.item-access.begin.perl
+        2: string.unquoted.perl
+        3: punctuation.section.item-access.end.perl
     - match: \{
       scope: punctuation.section.item-access.begin.perl
       push:

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -767,6 +767,9 @@ EOT
 # ^ punctuation.definition.variable.perl
 #  ^^ punctuation.accessor.double-colon.perl
 #    ^^^^^^ support.class.perl
+#          ^ punctuation.section.item-access.begin.perl
+#           ^^^^^^^^^^ string.quoted.single.perl
+#                     ^ punctuation.section.item-access.end.perl
   -f
 # ^^ keyword.operator.filetest.perl
   -foo
@@ -816,6 +819,11 @@ EOT
 # ^^ punctuation.definition.variable.begin.perl
 #   ^ punctuation.definition.variable.perl
 #   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#       ^ punctuation.section.item-access.begin.perl
+#        ^^^ string.unquoted.perl
+#           ^ punctuation.section.item-access.end.perl
+#             ^^^ string.unquoted.perl
+#                ^ punctuation.section.item-access.end.perl
 #                 ^ punctuation.definition.variable.end.perl
 #                   ^ keyword.operator.assignment.perl
 #                     ^^^^^^ string.quoted.single.perl
@@ -826,6 +834,12 @@ EOT
 # ^^ punctuation.definition.variable.begin.perl
 #   ^ punctuation.definition.variable.perl
 #   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#       ^ punctuation.section.item-access.begin.perl
+#        ^^^^^ string.quoted.single.perl
+#             ^ punctuation.section.item-access.end.perl
+#              ^ punctuation.section.item-access.begin.perl
+#               ^^^^^ string.quoted.single.perl
+#                    ^ punctuation.section.item-access.end.perl
 #                     ^ punctuation.definition.variable.end.perl
 #                       ^ keyword.operator.assignment.perl
 #                         ^^^^^^ string.quoted.single.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -787,6 +787,39 @@ EOT
 #         ^^^^^ string.quoted.double.perl
 #             ^ punctuation.definition.string.end.perl
 #              ^ punctuation.terminator.statement.perl
+  $foo{bar}
+# ^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#     ^ punctuation.section.item-access.begin.perl
+#     ^^^^^ meta.item-access.perl
+#      ^^^ string.unquoted.perl
+#         ^ punctuation.section.item-access.end.perl
+  $foo{bar()}
+# ^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#     ^ punctuation.section.item-access.begin.perl
+#     ^^^^^ meta.item-access.perl
+#      ^^^ variable.function.perl
+#           ^ punctuation.section.item-access.end.perl
+  $foo{10 + $bar}
+# ^^^^ variable.other.readwrite.global.perl
+# ^ punctuation.definition.variable.perl
+#     ^ punctuation.section.item-access.begin.perl
+#     ^^^^^^^^^^^ meta.item-access.perl
+#      ^^ constant.numeric.integer.decimal.perl
+#         ^ keyword.operator.arithmetic.perl
+#           ^^^^ variable.other.readwrite.global.perl
+#               ^ punctuation.section.item-access.end.perl
+  %{$foo{bar}{baz}} = 'excl';
+# ^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+#       ^^^^^^^^^^ meta.item-access.perl
+# ^^ punctuation.definition.variable.begin.perl
+#   ^ punctuation.definition.variable.perl
+#   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#                 ^ punctuation.definition.variable.end.perl
+#                   ^ keyword.operator.assignment.perl
+#                     ^^^^^^ string.quoted.single.perl
+#                           ^ punctuation.terminator.statement.perl
   %{$foo{'bar'}{'bar'}} = 'excl';
 # ^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
 #       ^^^^^^^^^^^^^^ meta.item-access.perl


### PR DESCRIPTION
In order to access an item of a hash (dictionary), the caller can use an unquoted string as key.

In the other way round: The `item_key` in `$the_hash{item_key}` is a simple unquoted string.

Prior to this commit, the key was not scoped at all and would so as function/method call in the future.

_Note: This fix is one result of the discussion in issue #2017._