### PR TITLE
[Perl] Improve numeric highlighting

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -395,9 +395,9 @@ contexts:
 
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
-    - match: 0b[01]+(?![\.\w+])
+    - match: 0b[01]+\b
       scope: constant.numeric.integer.binary.perl
-    - match: 0x[\h_]+(?![\.\w+])
+    - match: 0x[\h_]+\b
       scope: constant.numeric.integer.hexadecimal.perl
     - include: constants-numbers-float
     - include: constants-numbers-integer
@@ -415,7 +415,7 @@ contexts:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.float.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: (?:[-+]|\b)\d+\.\d+(?:e[-+]?\d+)?(?![\.\w+])
+    - match: \b\d+\.\d+(?:e[-+]?\d+)?\b
       scope: constant.numeric.float.decimal.perl
 
   constants-numbers-integer:
@@ -431,7 +431,7 @@ contexts:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: (?:[-+]|\b)\d+(?![\.\w+])
+    - match: \b\d+\b
       scope: constant.numeric.integer.decimal.perl
 
   constants-language:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -395,21 +395,6 @@ contexts:
 
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
-    # binary integers
-    - match: \b(0b)[01]+\b
-      scope: constant.numeric.integer.binary.perl
-      captures:
-        1: punctuation.definition.numeric.binary.perl
-    # hexadecimal integers
-    - match: \b(0x)[\h_]+\b
-      scope: constant.numeric.integer.hexadecimal.perl
-      captures:
-        1: punctuation.definition.numeric.hexadecimal.perl
-    # octal integers
-    - match: \b(0)[0-7]+\b
-      scope: constant.numeric.integer.octal.perl
-      captures:
-        1: punctuation.definition.numeric.octal.perl
     # decimal floats
     - match:  |-
         (?x:
@@ -471,6 +456,22 @@ contexts:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
+    # binary integers
+    - match: \b(0b)[01]+\b
+      scope: constant.numeric.integer.binary.perl
+      captures:
+        1: punctuation.definition.numeric.binary.perl
+    # hexadecimal integers
+    - match: \b(0x)[\h_]+\b
+      scope: constant.numeric.integer.hexadecimal.perl
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.perl
+    # octal integers
+    - match: \b(0)[0-7]+\b
+      scope: constant.numeric.integer.octal.perl
+      captures:
+        1: punctuation.definition.numeric.octal.perl
+    # decimal integers
     - match: \b\d+\b
       scope: constant.numeric.integer.decimal.perl
 

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -395,18 +395,22 @@ contexts:
 
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
+    # binary integers
     - match: (0b)[01]+\b
       scope: constant.numeric.integer.binary.perl
       captures:
         1: punctuation.definition.numeric.binary.perl
+    # hexadecimal integers
     - match: (0x)[\h_]+\b
       scope: constant.numeric.integer.hexadecimal.perl
       captures:
         1: punctuation.definition.numeric.hexadecimal.perl
-    - include: constants-numbers-float
-    - include: constants-numbers-integer
-
-  constants-numbers-float:
+    # octal integers
+    - match: \b(0)[0-7]+\b
+      scope: constant.numeric.integer.octal.perl
+      captures:
+        1: punctuation.definition.numeric.octal.perl
+    # decimal floats
     - match:  |-
         (?x:
           (") ( [-+]? (?:
@@ -454,8 +458,7 @@ contexts:
       captures:
         1: punctuation.separator.decimal.perl
         2: punctuation.separator.decimal.perl
-
-  constants-numbers-integer:
+    # decimal integers
     - match: (")([-+]?\d+)(")
       scope: string.quoted.double.perl
       captures:
@@ -468,10 +471,6 @@ contexts:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: \b(0)[0-7]+\b
-      scope: constant.numeric.integer.octal.perl
-      captures:
-        1: punctuation.definition.numeric.octal.perl
     - match: \b\d+\b
       scope: constant.numeric.integer.decimal.perl
 

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -396,12 +396,12 @@ contexts:
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
     # binary integers
-    - match: (0b)[01]+\b
+    - match: \b(0b)[01]+\b
       scope: constant.numeric.integer.binary.perl
       captures:
         1: punctuation.definition.numeric.binary.perl
     # hexadecimal integers
-    - match: (0x)[\h_]+\b
+    - match: \b(0x)[\h_]+\b
       scope: constant.numeric.integer.hexadecimal.perl
       captures:
         1: punctuation.definition.numeric.hexadecimal.perl
@@ -448,7 +448,7 @@ contexts:
     - match: |-
         (?x:
           (\.)\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
-              \d+ (?: (\.) (?: (?:
+            \b\d+ (?: (\.) (?: (?:
               \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
                       e[-+]?\d+\b )     |  # 1.e1 1.e-1 1.e+1
                       (?=[^.]))         |  # 1. (protect the .. operator)

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -406,43 +406,50 @@ contexts:
     - match:  |-
         (?x:
           (") ( [-+]? (?:
-          \.\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
-            \d+ (?: \. (?:
-            \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                    e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
-                    e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
+              \d+ (?: (\.) (?:
+              \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                      e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                      e[-+]?\d+ )      # 1e1 1e-1 1e+1
           ) ) (")
         )
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.float.decimal.perl
-        3: punctuation.definition.string.end.perl
+        3: punctuation.separator.decimal.perl
+        4: punctuation.separator.decimal.perl
+        5: punctuation.definition.string.end.perl
     - match:  |-
         (?x:
           (') ( [-+]? (?:
-          \.\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
-            \d+ (?: \. (?:
-            \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                    e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
-                    e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
+              \d+ (?: (\.) (?:
+              \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                      e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                      e[-+]?\d+ )      # 1e1 1e-1 1e+1
           ) ) (')
         )
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.float.decimal.perl
-        3: punctuation.definition.string.end.perl
+        3: punctuation.separator.decimal.perl
+        4: punctuation.separator.decimal.perl
+        5: punctuation.definition.string.end.perl
     - match: |-
         (?x:
-          \.\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
-            \d+ (?: \. (?: (?:
-            \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                    e[-+]?\d+\b )     |  # 1.e1 1.e-1 1.e+1
-                    (?=[^.]))         |  # 1. (protect the .. operator)
-                    e[-+]?\d+\b )        # 1e1 1e-1 1e+1
+          (\.)\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
+              \d+ (?: (\.) (?: (?:
+              \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                      e[-+]?\d+\b )     |  # 1.e1 1.e-1 1.e+1
+                      (?=[^.]))         |  # 1. (protect the .. operator)
+                      e[-+]?\d+\b )        # 1e1 1e-1 1e+1
         )
       scope: constant.numeric.float.decimal.perl
+      captures:
+        1: punctuation.separator.decimal.perl
+        2: punctuation.separator.decimal.perl
 
   constants-numbers-integer:
     - match: (")(?:([-+]?0[0-7]+)|([-+]?\d+))(")

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -399,11 +399,11 @@ contexts:
     - match:  |-
         (?ix:
           (") ( [-+]? (?:
-          (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
-              \d+ (?: (\.) (?:
-              \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                      e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
-                      e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          (\.)[\d_]+ (?: e[-+]?[\d_]+ )?  |  # .1 .1e1 .1e-1 .1e+1
+              [\d_]+ (?: (\.) (?:
+              [\d_]+ (?: e[-+]?[\d_]+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                         e[-+]?[\d_]+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                         e[-+]?[\d_]+ )      # 1e1 1e-1 1e+1
           ) ) (")
         )
       scope: string.quoted.double.perl
@@ -416,11 +416,11 @@ contexts:
     - match:  |-
         (?ix:
           (') ( [-+]? (?:
-          (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
-              \d+ (?: (\.) (?:
-              \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                      e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
-                      e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          (\.)[\d_]+ (?: e[-+]?[\d_]+ )?  |  # .1 .1e1 .1e-1 .1e+1
+              [\d_]+ (?: (\.) (?:
+              [\d_]+ (?: e[-+]?[\d_]+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                         e[-+]?[\d_]+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                         e[-+]?[\d_]+ )      # 1e1 1e-1 1e+1
           ) ) (')
         )
       scope: string.quoted.single.perl
@@ -432,32 +432,32 @@ contexts:
         5: punctuation.definition.string.end.perl
     - match: |-
         (?ix:
-          (\.)\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
-            \b\d+ (?: (\.) (?: (?:
-              \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
-                      e[-+]?\d+\b )     |  # 1.e1 1.e-1 1.e+1
-                      (?=[^.]))         |  # 1. (protect the .. operator)
-                      e[-+]?\d+\b )        # 1e1 1e-1 1e+1
+          (\.)[\d_]+ (?: e[-+]?[\d_]+   )? \b |  # .1 .1e1 .1e-1 .1e+1
+            \b[\d_]+ (?: (\.) (?: (?:
+              [\d_]+ (?: e[-+]?[\d_]+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                         e[-+]?[\d_]+\b )     |  # 1.e1 1.e-1 1.e+1
+                         (?=[^.]))            |  # 1. (protect the .. operator)
+                         e[-+]?[\d_]+\b )        # 1e1 1e-1 1e+1
         )
       scope: constant.numeric.float.decimal.perl
       captures:
         1: punctuation.separator.decimal.perl
         2: punctuation.separator.decimal.perl
     # decimal integers
-    - match: (")([-+]?\d+)(")
+    - match: (")([-+]?[\d_]+)(")
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: (')([-+]?\d+)(')
+    - match: (')([-+]?[\d_]+)(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
     # binary integers
-    - match: \b(0[bB])[01]+\b
+    - match: \b(0[bB])[01_]+\b
       scope: constant.numeric.integer.binary.perl
       captures:
         1: punctuation.definition.numeric.binary.perl
@@ -467,12 +467,12 @@ contexts:
       captures:
         1: punctuation.definition.numeric.hexadecimal.perl
     # octal integers
-    - match: \b(0)[0-7]+\b
+    - match: \b(0)[0-7_]+\b
       scope: constant.numeric.integer.octal.perl
       captures:
         1: punctuation.definition.numeric.octal.perl
     # decimal integers
-    - match: \b\d+\b
+    - match: \b[\d_]+\b
       scope: constant.numeric.integer.decimal.perl
 
   constants-language:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -395,10 +395,14 @@ contexts:
 
   constants-numbers:
     # SEE: http://perldoc.perl.org/perlnumber.html
-    - match: 0b[01]+\b
+    - match: (0b)[01]+\b
       scope: constant.numeric.integer.binary.perl
-    - match: 0x[\h_]+\b
+      captures:
+        1: punctuation.definition.numeric.binary.perl
+    - match: (0x)[\h_]+\b
       scope: constant.numeric.integer.hexadecimal.perl
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.perl
     - include: constants-numbers-float
     - include: constants-numbers-integer
 
@@ -452,22 +456,26 @@ contexts:
         2: punctuation.separator.decimal.perl
 
   constants-numbers-integer:
-    - match: (")(?:([-+]?0[0-7]+)|([-+]?\d+))(")
+    - match: (")(?:([-+]?(0)[0-7]+)|([-+]?\d+))(")
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.octal.perl
-        3: constant.numeric.integer.decimal.perl
-        4: punctuation.definition.string.end.perl
-    - match: (')(?:([-+]?0[0-7]+)|([-+]?\d+))(')
+        3: punctuation.definition.numeric.octal.perl
+        4: constant.numeric.integer.decimal.perl
+        5: punctuation.definition.string.end.perl
+    - match: (')(?:([-+]?(0)[0-7]+)|([-+]?\d+))(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.integer.octal.perl
-        3: constant.numeric.integer.decimal.perl
-        4: punctuation.definition.string.end.perl
-    - match: \b0[0-7]+\b
+        3: punctuation.definition.numeric.octal.perl
+        4: constant.numeric.integer.decimal.perl
+        5: punctuation.definition.string.end.perl
+    - match: \b(0)[0-7]+\b
       scope: constant.numeric.integer.octal.perl
+      captures:
+        1: punctuation.definition.numeric.octal.perl
     - match: \b\d+\b
       scope: constant.numeric.integer.decimal.perl
 

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -397,7 +397,7 @@ contexts:
     # SEE: http://perldoc.perl.org/perlnumber.html
     # decimal floats
     - match:  |-
-        (?x:
+        (?ix:
           (") ( [-+]? (?:
           (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
               \d+ (?: (\.) (?:
@@ -414,7 +414,7 @@ contexts:
         4: punctuation.separator.decimal.perl
         5: punctuation.definition.string.end.perl
     - match:  |-
-        (?x:
+        (?ix:
           (') ( [-+]? (?:
           (\.)\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
               \d+ (?: (\.) (?:
@@ -431,7 +431,7 @@ contexts:
         4: punctuation.separator.decimal.perl
         5: punctuation.definition.string.end.perl
     - match: |-
-        (?x:
+        (?ix:
           (\.)\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
             \b\d+ (?: (\.) (?: (?:
               \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
@@ -457,12 +457,12 @@ contexts:
         2: constant.numeric.integer.decimal.perl
         3: punctuation.definition.string.end.perl
     # binary integers
-    - match: \b(0b)[01]+\b
+    - match: \b(0[bB])[01]+\b
       scope: constant.numeric.integer.binary.perl
       captures:
         1: punctuation.definition.numeric.binary.perl
     # hexadecimal integers
-    - match: \b(0x)[\h_]+\b
+    - match: \b(0[xX])[\h_]+\b
       scope: constant.numeric.integer.hexadecimal.perl
       captures:
         1: punctuation.definition.numeric.hexadecimal.perl

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -456,22 +456,18 @@ contexts:
         2: punctuation.separator.decimal.perl
 
   constants-numbers-integer:
-    - match: (")(?:([-+]?(0)[0-7]+)|([-+]?\d+))(")
+    - match: (")([-+]?\d+)(")
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.octal.perl
-        3: punctuation.definition.numeric.octal.perl
-        4: constant.numeric.integer.decimal.perl
-        5: punctuation.definition.string.end.perl
-    - match: (')(?:([-+]?(0)[0-7]+)|([-+]?\d+))(')
+        2: constant.numeric.integer.decimal.perl
+        3: punctuation.definition.string.end.perl
+    - match: (')([-+]?\d+)(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.octal.perl
-        3: punctuation.definition.numeric.octal.perl
-        4: constant.numeric.integer.decimal.perl
-        5: punctuation.definition.string.end.perl
+        2: constant.numeric.integer.decimal.perl
+        3: punctuation.definition.string.end.perl
     - match: \b(0)[0-7]+\b
       scope: constant.numeric.integer.octal.perl
       captures:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -403,19 +403,45 @@ contexts:
     - include: constants-numbers-integer
 
   constants-numbers-float:
-    - match: (")([-+]?\d+\.\d+(?:e[-+]?\d+)?)(")
+    - match:  |-
+        (?x:
+          (") ( [-+]? (?:
+          \.\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
+            \d+ (?: \. (?:
+            \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                    e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                    e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          ) ) (")
+        )
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.float.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: (')([-+]?\d+\.\d+(?:e[-+]?\d+)?)(')
+    - match:  |-
+        (?x:
+          (') ( [-+]? (?:
+          \.\d+ (?: e[-+]?\d+ )?  |  # .1 .1e1 .1e-1 .1e+1
+            \d+ (?: \. (?:
+            \d+ (?: e[-+]?\d+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                    e[-+]?\d+ )?  |  # 1. 1.e1 1.e-1 1.e+1
+                    e[-+]?\d+ )      # 1e1 1e-1 1e+1
+          ) ) (')
+        )
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
         2: constant.numeric.float.decimal.perl
         3: punctuation.definition.string.end.perl
-    - match: \b\d+\.\d+(?:e[-+]?\d+)?\b
+    - match: |-
+        (?x:
+          \.\d+ (?: e[-+]?\d+   )? \b |  # .1 .1e1 .1e-1 .1e+1
+            \d+ (?: \. (?: (?:
+            \d+ (?: e[-+]?\d+   )? \b |  # 1.1 1.1e1 1.1e-1 1.1e+1
+                    e[-+]?\d+\b )     |  # 1.e1 1.e-1 1.e+1
+                    (?=[^.]))         |  # 1. (protect the .. operator)
+                    e[-+]?\d+\b )        # 1e1 1e-1 1e+1
+        )
       scope: constant.numeric.float.decimal.perl
 
   constants-numbers-integer:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -419,18 +419,22 @@ contexts:
       scope: constant.numeric.float.decimal.perl
 
   constants-numbers-integer:
-    - match: (")([-+]?\d+)(")
+    - match: (")(?:([-+]?0[0-7]+)|([-+]?\d+))(")
       scope: string.quoted.double.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.decimal.perl
-        3: punctuation.definition.string.end.perl
-    - match: (')([-+]?\d+)(')
+        2: constant.numeric.integer.octal.perl
+        3: constant.numeric.integer.decimal.perl
+        4: punctuation.definition.string.end.perl
+    - match: (')(?:([-+]?0[0-7]+)|([-+]?\d+))(')
       scope: string.quoted.single.perl
       captures:
         1: punctuation.definition.string.begin.perl
-        2: constant.numeric.integer.decimal.perl
-        3: punctuation.definition.string.end.perl
+        2: constant.numeric.integer.octal.perl
+        3: constant.numeric.integer.decimal.perl
+        4: punctuation.definition.string.end.perl
+    - match: \b0[0-7]+\b
+      scope: constant.numeric.integer.octal.perl
     - match: \b\d+\b
       scope: constant.numeric.integer.decimal.perl
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -893,6 +893,32 @@ EOT
   1.1-             # normal float
 # ^^^ constant.numeric.float.decimal.perl
 #    ^ keyword.operator.arithmetic.perl
+  .1               # normal float
+# ^^ constant.numeric.float.decimal.perl
+  -.1              # normal float
+# ^ keyword.operator.arithmetic.perl
+#  ^^ constant.numeric.float.decimal.perl
+  .1-              # normal float
+# ^^ constant.numeric.float.decimal.perl
+#   ^ keyword.operator.arithmetic.perl
+  1.               # normal float
+# ^^ constant.numeric.float.decimal.perl
+  -1.              # normal float
+# ^ keyword.operator.arithmetic.perl
+#  ^^ constant.numeric.float.decimal.perl
+  1.-              # normal float
+# ^^ constant.numeric.float.decimal.perl
+#   ^ keyword.operator.arithmetic.perl
+  1e5              # exponential notation
+# ^^^ constant.numeric.float.decimal.perl
+  -1e5             # exponential notation
+# ^ keyword.operator.arithmetic.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  1e5-             # exponential notation
+# ^^^ constant.numeric.float.decimal.perl
+#    ^ keyword.operator.arithmetic.perl
+  1.e5             # exponential notation
+# ^^^^ constant.numeric.float.decimal.perl
   12.34e56         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
   -12.34e-56       # exponential notation
@@ -918,9 +944,39 @@ EOT
   "-01234"          # number specified as a string
 # ^^^^^^^^ string.quoted.double.perl
 #  ^^^^^^ constant.numeric.integer.octal.perl
-  "-12.34e56"      # number specified as a string
-# ^^^^^^^^^^^ string.quoted.double.perl
-#  ^^^^^^^^^ constant.numeric.float.decimal.perl
+  "1.1"            # normal float
+# ^^^^^ string.quoted.double.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  "-1.1"           # normal float
+# ^^^^^^ string.quoted.double.perl
+#  ^^^^ constant.numeric.float.decimal.perl
+  ".1"             # normal float
+# ^^^^ string.quoted.double.perl
+#  ^^ constant.numeric.float.decimal.perl
+  "-.1"            # normal float
+# ^^^^^ string.quoted.double.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  "1."             # normal float
+# ^^^^ string.quoted.double.perl
+#  ^^ constant.numeric.float.decimal.perl
+  "-1."            # normal float
+# ^^^^^ string.quoted.double.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  "1e5"            # exponential notation
+# ^^^^^ string.quoted.double.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  "-1e5"           # exponential notation
+# ^^^^^^ string.quoted.double.perl
+#  ^^^^ constant.numeric.float.decimal.perl
+  "1.e5"           # exponential notation
+# ^^^^^^ string.quoted.double.perl
+#  ^^^^ constant.numeric.float.decimal.perl
+  "12.34e56"       # exponential notation
+# ^^^^^^^^^^ string.quoted.double.perl
+#  ^^^^^^^^ constant.numeric.float.decimal.perl
+  "-12.34e-56"     # exponential notation
+# ^^^^^^^^^^^^ string.quoted.double.perl
+#  ^^^^^^^^^^ constant.numeric.float.decimal.perl
   '0.00_01'
 #  ^^^^^^^ - constant.numeric
   '01bau'
@@ -1907,6 +1963,21 @@ _EOD_
 #     ^ punctuation.section.group.begin.perl
 #                           ^ punctuation.section.group.end.perl
 #                             ^ punctuation.section.block.begin.perl
+    break;
+#   ^^^^^ keyword.control.flow.break.perl
+  }
+# ^ punctuation.section.block.end.perl
+
+  for my $i (0..9) {
+# ^^^ keyword.control.loop.for.perl
+#     ^^ keyword.declaration.variable.perl
+#        ^^ variable.other.readwrite.global.perl
+#           ^ punctuation.section.group.begin.perl
+#            ^ constant.numeric.integer.decimal.perl
+#             ^^ keyword.operator.range.perl
+#               ^ constant.numeric.integer.decimal.perl
+#                ^ punctuation.section.group.end.perl
+#                  ^ punctuation.section.block.begin.perl
     break;
 #   ^^^^^ keyword.control.flow.break.perl
   }

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1033,7 +1033,7 @@ EOT
 #  ^^^^^^^^^^ constant.numeric.float.decimal.perl
 #     ^ punctuation.separator.decimal.perl
   '0.00_01'
-#  ^^^^^^^ - constant.numeric
+#  ^^^^^^^ constant.numeric.float.decimal.perl
   '01bau'
 #  ^^^^^ - constant.numeric
   __PACKAGE__

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -864,12 +864,12 @@ EOT
   0b1110011        # binary integer
 # ^^^^^^^^^ constant.numeric.integer.binary.perl
   01234            # octal integer
-# ^^^^^ constant.numeric.integer.decimal.perl
+# ^^^^^ constant.numeric.integer.octal.perl
   -01234            # octal integer
 # ^ keyword.operator.arithmetic.perl
-#  ^^^^^ constant.numeric.integer.decimal.perl
+#  ^^^^^ constant.numeric.integer.octal.perl
   01234-           # octal integer
-# ^^^^^ constant.numeric.integer.decimal.perl
+# ^^^^^ constant.numeric.integer.octal.perl
 #      ^ keyword.operator.arithmetic.perl
   0x1234           # hexadecimal integer
 # ^^^^^^ constant.numeric.integer.hexadecimal.perl
@@ -906,12 +906,21 @@ EOT
   12.34e+56-       # exponential notation
 # ^^^^^^^^^ constant.numeric.float.decimal.perl
 #          ^ keyword.operator.arithmetic.perl
-  "-12.34e56"      # number specified as a string
-# ^^^^^^^^^^^ string.quoted.double.perl
-#  ^^^^^^^^^ constant.numeric.float.decimal.perl
   "1234"           # number specified as a string
 # ^^^^^^ string.quoted.double.perl
 #  ^^^^ constant.numeric.integer.decimal.perl
+  "-1234"           # number specified as a string
+# ^^^^^^^ string.quoted.double.perl
+#  ^^^^^ constant.numeric.integer.decimal.perl
+  "01234"          # number specified as a string
+# ^^^^^^^ string.quoted.double.perl
+#  ^^^^^ constant.numeric.integer.octal.perl
+  "-01234"          # number specified as a string
+# ^^^^^^^^ string.quoted.double.perl
+#  ^^^^^^ constant.numeric.integer.octal.perl
+  "-12.34e56"      # number specified as a string
+# ^^^^^^^^^^^ string.quoted.double.perl
+#  ^^^^^^^^^ constant.numeric.float.decimal.perl
   '0.00_01'
 #  ^^^^^^^ - constant.numeric
   '01bau'

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -887,27 +887,36 @@ EOT
 #     ^^^^ constant.numeric.integer.hexadecimal.perl
   1.1              # normal float
 # ^^^ constant.numeric.float.decimal.perl
+#  ^ punctuation.separator.decimal.perl
   -1.1             # normal float
 # ^ keyword.operator.arithmetic.perl
 #  ^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   1.1-             # normal float
 # ^^^ constant.numeric.float.decimal.perl
+#  ^ punctuation.separator.decimal.perl
 #    ^ keyword.operator.arithmetic.perl
   .1               # normal float
+# ^ punctuation.separator.decimal.perl
 # ^^ constant.numeric.float.decimal.perl
   -.1              # normal float
 # ^ keyword.operator.arithmetic.perl
+#  ^ punctuation.separator.decimal.perl
 #  ^^ constant.numeric.float.decimal.perl
   .1-              # normal float
+# ^ punctuation.separator.decimal.perl
 # ^^ constant.numeric.float.decimal.perl
 #   ^ keyword.operator.arithmetic.perl
   1.               # normal float
 # ^^ constant.numeric.float.decimal.perl
+#  ^ punctuation.separator.decimal.perl
   -1.              # normal float
 # ^ keyword.operator.arithmetic.perl
 #  ^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   1.-              # normal float
 # ^^ constant.numeric.float.decimal.perl
+#  ^ punctuation.separator.decimal.perl
 #   ^ keyword.operator.arithmetic.perl
   1e5              # exponential notation
 # ^^^ constant.numeric.float.decimal.perl
@@ -919,18 +928,24 @@ EOT
 #    ^ keyword.operator.arithmetic.perl
   1.e5             # exponential notation
 # ^^^^ constant.numeric.float.decimal.perl
+#  ^ punctuation.separator.decimal.perl
   12.34e56         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   -12.34e-56       # exponential notation
 # ^ keyword.operator.arithmetic.perl
 #  ^^^^^^^^^ constant.numeric.float.decimal.perl
+#    ^ punctuation.separator.decimal.perl
   - 12.34e-56      # exponential notation
 # ^ keyword.operator.arithmetic.perl
 #   ^^^^^^^^^ constant.numeric.float.decimal.perl
+#     ^ punctuation.separator.decimal.perl
   12.34e+56        # exponential notation
 # ^^^^^^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   12.34e+56-       # exponential notation
 # ^^^^^^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
 #          ^ keyword.operator.arithmetic.perl
   "1234"           # number specified as a string
 # ^^^^^^ string.quoted.double.perl
@@ -947,21 +962,27 @@ EOT
   "1.1"            # normal float
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   "-1.1"           # normal float
 # ^^^^^^ string.quoted.double.perl
 #  ^^^^ constant.numeric.float.decimal.perl
+#    ^ punctuation.separator.decimal.perl
   ".1"             # normal float
 # ^^^^ string.quoted.double.perl
+#  ^ punctuation.separator.decimal.perl
 #  ^^ constant.numeric.float.decimal.perl
   "-.1"            # normal float
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   "1."             # normal float
 # ^^^^ string.quoted.double.perl
 #  ^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   "-1."            # normal float
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl
+#    ^ punctuation.separator.decimal.perl
   "1e5"            # exponential notation
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl
@@ -971,12 +992,15 @@ EOT
   "1.e5"           # exponential notation
 # ^^^^^^ string.quoted.double.perl
 #  ^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   "12.34e56"       # exponential notation
 # ^^^^^^^^^^ string.quoted.double.perl
 #  ^^^^^^^^ constant.numeric.float.decimal.perl
+#    ^ punctuation.separator.decimal.perl
   "-12.34e-56"     # exponential notation
 # ^^^^^^^^^^^^ string.quoted.double.perl
 #  ^^^^^^^^^^ constant.numeric.float.decimal.perl
+#     ^ punctuation.separator.decimal.perl
   '0.00_01'
 #  ^^^^^^^ - constant.numeric
   '01bau'

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -970,13 +970,10 @@ EOT
 #  ^^^^^ constant.numeric.integer.decimal.perl
   "01234"          # number specified as a string
 # ^^^^^^^ string.quoted.double.perl
-#  ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
-#   ^^^^ constant.numeric.integer.octal.perl - punctuation
+#  ^^^^^ constant.numeric.integer.decimal.perl - punctuation
   "-01234"          # number specified as a string
 # ^^^^^^^^ string.quoted.double.perl
-#  ^ constant.numeric.integer.octal.perl - punctuation
-#   ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
-#    ^^^^ constant.numeric.integer.octal.perl - punctuation
+#  ^^^^^^ constant.numeric.integer.decimal.perl - punctuation
   "1.1"            # normal float
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -831,6 +831,8 @@ EOT
 
   1234             # decimal integer
 # ^^^^ constant.numeric.integer.decimal.perl
+  12_4             # decimal integer
+# ^^^^ constant.numeric.integer.decimal.perl
   +1234            # decimal integer
 # ^ keyword.operator.arithmetic.perl
 #  ^^^^ constant.numeric.integer.decimal.perl
@@ -869,24 +871,24 @@ EOT
 #    ^ keyword.operator.concat.perl
 #     ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
 #       ^  constant.numeric.integer.binary.perl - punctuation
-  0b1110011        # binary integer
+  0b11__011        # binary integer
 # ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
 #   ^^^^^^^  constant.numeric.integer.binary.perl - punctuation
-  01234            # octal integer
+  01_34            # octal integer
 # ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
 #  ^^^^ constant.numeric.integer.octal.perl - punctuation
   -01234            # octal integer
 # ^ keyword.operator.arithmetic.perl
 #  ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
 #   ^^^^ constant.numeric.integer.octal.perl - punctuation
-  01234-           # octal integer
+  012_4-           # octal integer
 # ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
 #  ^^^^ constant.numeric.integer.octal.perl - punctuation
 #      ^ keyword.operator.arithmetic.perl
-  0x1234           # hexadecimal integer
+  0x_234           # hexadecimal integer
 # ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
 #   ^^^^ constant.numeric.integer.hexadecimal.perl - punctuation
-  0X1234           # hexadecimal integer
+  0X123_           # hexadecimal integer
 # ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
 #   ^^^^ constant.numeric.integer.hexadecimal.perl - punctuation
   0x9              # hexadecimal integer
@@ -958,7 +960,7 @@ EOT
   12.34e56         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
 #   ^ punctuation.separator.decimal.perl
-  12.34E56         # exponential notation
+  _2._4E_6         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
 #   ^ punctuation.separator.decimal.perl
   -12.34e-56       # exponential notation
@@ -976,7 +978,7 @@ EOT
 # ^^^^^^^^^ constant.numeric.float.decimal.perl
 #   ^ punctuation.separator.decimal.perl
 #          ^ keyword.operator.arithmetic.perl
-  "1234"           # number specified as a string
+  "12_4"           # number specified as a string
 # ^^^^^^ string.quoted.double.perl
 #  ^^^^ constant.numeric.integer.decimal.perl
   "-1234"           # number specified as a string

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -900,6 +900,9 @@ EOT
 #    ^ keyword.operator.concat.perl
 #     ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
 #       ^ constant.numeric.integer.hexadecimal.perl - punctuation
+  01.1             # normal float
+# ^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
   1.1              # normal float
 # ^^^ constant.numeric.float.decimal.perl
 #  ^ punctuation.separator.decimal.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -831,30 +831,81 @@ EOT
 
   1234             # decimal integer
 # ^^^^ constant.numeric.integer.decimal.perl
+  +1234            # decimal integer
+# ^ keyword.operator.arithmetic.perl
+#  ^^^^ constant.numeric.integer.decimal.perl
+  + 1234           # decimal integer
+# ^ keyword.operator.arithmetic.perl
+#   ^^^^ constant.numeric.integer.decimal.perl
+  1234+            # decimal integer
+# ^^^^ constant.numeric.integer.decimal.perl
+#     ^ keyword.operator.arithmetic.perl
   -1234            # decimal integer
-# ^^^^^ constant.numeric.integer.decimal.perl
+# ^ keyword.operator.arithmetic.perl
+#  ^^^^ constant.numeric.integer.decimal.perl
   - 1234           # decimal integer
 # ^ keyword.operator.arithmetic.perl
 #   ^^^^ constant.numeric.integer.decimal.perl
+  1234-            # decimal integer
+# ^^^^ constant.numeric.integer.decimal.perl
+#     ^ keyword.operator.arithmetic.perl
   0b0              # binary integer
 # ^^^ constant.numeric.integer.binary.perl
+  -0b0             # binary integer
+# ^ keyword.operator.arithmetic.perl
+#  ^^^ constant.numeric.integer.binary.perl
+  0b0-             # binary integer
+# ^^^ constant.numeric.integer.binary.perl
+#    ^ keyword.operator.arithmetic.perl
+  0b1.0b1
+# ^^^ constant.numeric.integer.binary.perl
+#    ^ keyword.operator.concat.perl
+#     ^^^ constant.numeric.integer.binary.perl
   0b1110011        # binary integer
 # ^^^^^^^^^ constant.numeric.integer.binary.perl
   01234            # octal integer
 # ^^^^^ constant.numeric.integer.decimal.perl
+  -01234            # octal integer
+# ^ keyword.operator.arithmetic.perl
+#  ^^^^^ constant.numeric.integer.decimal.perl
+  01234-           # octal integer
+# ^^^^^ constant.numeric.integer.decimal.perl
+#      ^ keyword.operator.arithmetic.perl
   0x1234           # hexadecimal integer
 # ^^^^^^ constant.numeric.integer.hexadecimal.perl
   0x9              # hexadecimal integer
 # ^^^ constant.numeric.integer.hexadecimal.perl
+  +0x9             # hexadecimal integer
+# ^ keyword.operator.arithmetic.perl
+#  ^^^ constant.numeric.integer.hexadecimal.perl
+  0x9-             # hexadecimal integer
+# ^^^ constant.numeric.integer.hexadecimal.perl
+#    ^ keyword.operator.arithmetic.perl
+  0x9.0x10         # hexadecimal integer
+# ^^^ constant.numeric.integer.hexadecimal.perl
+#    ^ keyword.operator.concat.perl
+#     ^^^^ constant.numeric.integer.hexadecimal.perl
+  1.1              # normal float
+# ^^^ constant.numeric.float.decimal.perl
+  -1.1             # normal float
+# ^ keyword.operator.arithmetic.perl
+#  ^^^ constant.numeric.float.decimal.perl
+  1.1-             # normal float
+# ^^^ constant.numeric.float.decimal.perl
+#    ^ keyword.operator.arithmetic.perl
   12.34e56         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
   -12.34e-56       # exponential notation
-# ^^^^^^^^^^ constant.numeric.float.decimal.perl
+# ^ keyword.operator.arithmetic.perl
+#  ^^^^^^^^^ constant.numeric.float.decimal.perl
   - 12.34e-56      # exponential notation
 # ^ keyword.operator.arithmetic.perl
 #   ^^^^^^^^^ constant.numeric.float.decimal.perl
   12.34e+56        # exponential notation
 # ^^^^^^^^^ constant.numeric.float.decimal.perl
+  12.34e+56-       # exponential notation
+# ^^^^^^^^^ constant.numeric.float.decimal.perl
+#          ^ keyword.operator.arithmetic.perl
   "-12.34e56"      # number specified as a string
 # ^^^^^^^^^^^ string.quoted.double.perl
 #  ^^^^^^^^^ constant.numeric.float.decimal.perl
@@ -1757,7 +1808,8 @@ sub AUTOLOAD () {}
 # ^^^^ entity.name.label.perl
 #     ^ punctuation.separator.perl
 #      ^^^^ keyword.control.flow.exit.perl
-#           ^^ constant.numeric.integer.decimal.perl
+#           ^ keyword.operator.arithmetic.perl
+#            ^ constant.numeric.integer.decimal.perl
 
 ###[ FUNCTION CALLS ]#########################################################
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -849,6 +849,9 @@ EOT
   1234-            # decimal integer
 # ^^^^ constant.numeric.integer.decimal.perl
 #     ^ keyword.operator.arithmetic.perl
+  0B0              # binary integer
+# ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#   ^  constant.numeric.integer.binary.perl - punctuation
   0b0              # binary integer
 # ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
 #   ^  constant.numeric.integer.binary.perl - punctuation
@@ -881,6 +884,9 @@ EOT
 #  ^^^^ constant.numeric.integer.octal.perl - punctuation
 #      ^ keyword.operator.arithmetic.perl
   0x1234           # hexadecimal integer
+# ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#   ^^^^ constant.numeric.integer.hexadecimal.perl - punctuation
+  0X1234           # hexadecimal integer
 # ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
 #   ^^^^ constant.numeric.integer.hexadecimal.perl - punctuation
   0x9              # hexadecimal integer
@@ -936,8 +942,10 @@ EOT
 # ^^ constant.numeric.float.decimal.perl
 #  ^ punctuation.separator.decimal.perl
 #   ^ keyword.operator.arithmetic.perl
-  1e5              # exponential notation
+  1e5 1E5          # exponential notation
 # ^^^ constant.numeric.float.decimal.perl
+#     ^^^ constant.numeric.float.decimal.perl
+#     ^^^ constant.numeric.float.decimal.perl
   -1e5             # exponential notation
 # ^ keyword.operator.arithmetic.perl
 #  ^^^ constant.numeric.float.decimal.perl
@@ -948,6 +956,9 @@ EOT
 # ^^^^ constant.numeric.float.decimal.perl
 #  ^ punctuation.separator.decimal.perl
   12.34e56         # exponential notation
+# ^^^^^^^^ constant.numeric.float.decimal.perl
+#   ^ punctuation.separator.decimal.perl
+  12.34E56         # exponential notation
 # ^^^^^^^^ constant.numeric.float.decimal.perl
 #   ^ punctuation.separator.decimal.perl
   -12.34e-56       # exponential notation

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -850,41 +850,56 @@ EOT
 # ^^^^ constant.numeric.integer.decimal.perl
 #     ^ keyword.operator.arithmetic.perl
   0b0              # binary integer
-# ^^^ constant.numeric.integer.binary.perl
+# ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#   ^  constant.numeric.integer.binary.perl - punctuation
   -0b0             # binary integer
 # ^ keyword.operator.arithmetic.perl
-#  ^^^ constant.numeric.integer.binary.perl
+#  ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#    ^  constant.numeric.integer.binary.perl - punctuation
   0b0-             # binary integer
-# ^^^ constant.numeric.integer.binary.perl
+# ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#   ^  constant.numeric.integer.binary.perl - punctuation
 #    ^ keyword.operator.arithmetic.perl
   0b1.0b1
-# ^^^ constant.numeric.integer.binary.perl
+# ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#   ^  constant.numeric.integer.binary.perl - punctuation
 #    ^ keyword.operator.concat.perl
-#     ^^^ constant.numeric.integer.binary.perl
+#     ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#       ^  constant.numeric.integer.binary.perl - punctuation
   0b1110011        # binary integer
-# ^^^^^^^^^ constant.numeric.integer.binary.perl
+# ^^ constant.numeric.integer.binary.perl punctuation.definition.numeric.binary.perl
+#   ^^^^^^^  constant.numeric.integer.binary.perl - punctuation
   01234            # octal integer
-# ^^^^^ constant.numeric.integer.octal.perl
+# ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
+#  ^^^^ constant.numeric.integer.octal.perl - punctuation
   -01234            # octal integer
 # ^ keyword.operator.arithmetic.perl
-#  ^^^^^ constant.numeric.integer.octal.perl
+#  ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
+#   ^^^^ constant.numeric.integer.octal.perl - punctuation
   01234-           # octal integer
-# ^^^^^ constant.numeric.integer.octal.perl
+# ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
+#  ^^^^ constant.numeric.integer.octal.perl - punctuation
 #      ^ keyword.operator.arithmetic.perl
   0x1234           # hexadecimal integer
-# ^^^^^^ constant.numeric.integer.hexadecimal.perl
+# ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#   ^^^^ constant.numeric.integer.hexadecimal.perl - punctuation
   0x9              # hexadecimal integer
-# ^^^ constant.numeric.integer.hexadecimal.perl
+# ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#   ^ constant.numeric.integer.hexadecimal.perl - punctuation
   +0x9             # hexadecimal integer
 # ^ keyword.operator.arithmetic.perl
-#  ^^^ constant.numeric.integer.hexadecimal.perl
+#  ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#    ^ constant.numeric.integer.hexadecimal.perl - punctuation
   0x9-             # hexadecimal integer
-# ^^^ constant.numeric.integer.hexadecimal.perl
+# ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#   ^ constant.numeric.integer.hexadecimal.perl - punctuation
 #    ^ keyword.operator.arithmetic.perl
   0x9.0x10         # hexadecimal integer
-# ^^^ constant.numeric.integer.hexadecimal.perl
+# ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#   ^ constant.numeric.integer.hexadecimal.perl - punctuation
 #    ^ keyword.operator.concat.perl
-#     ^^^^ constant.numeric.integer.hexadecimal.perl
+#     ^^ constant.numeric.integer.hexadecimal.perl punctuation.definition.numeric.hexadecimal.perl
+#       ^ constant.numeric.integer.hexadecimal.perl - punctuation
   1.1              # normal float
 # ^^^ constant.numeric.float.decimal.perl
 #  ^ punctuation.separator.decimal.perl
@@ -955,10 +970,13 @@ EOT
 #  ^^^^^ constant.numeric.integer.decimal.perl
   "01234"          # number specified as a string
 # ^^^^^^^ string.quoted.double.perl
-#  ^^^^^ constant.numeric.integer.octal.perl
+#  ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
+#   ^^^^ constant.numeric.integer.octal.perl - punctuation
   "-01234"          # number specified as a string
 # ^^^^^^^^ string.quoted.double.perl
-#  ^^^^^^ constant.numeric.integer.octal.perl
+#  ^ constant.numeric.integer.octal.perl - punctuation
+#   ^ constant.numeric.integer.octal.perl punctuation.definition.numeric.octal.perl
+#    ^^^^ constant.numeric.integer.octal.perl - punctuation
   "1.1"            # normal float
 # ^^^^^ string.quoted.double.perl
 #  ^^^ constant.numeric.float.decimal.perl


### PR DESCRIPTION
In PR #1912 the scope names were renamed to match the latest scope naming guidelines.

This PR is a result of further investigations about how Perl parses numbers.

The main intentions are:

1. add support for incomplete floating point numbers like `1.`, `.1` or `1e1`.
2. fix some edge cases with numbers followed by `+` or `.` operator, which are broken up to this commit. Need to avoid breaking the `..` range operator, though.
3. properly apply the `constant.numeric.integer.octal` scope to numbers beginning with `0`.

Furthermore this PR intends to create some kind of consistency with other languages like D, Go or Python with regards of scoping decimal punctuation or leading `0b`, `0x` and `0` in bin/hex/oct constants.