### PR TITLE
[Perl] Fix fully qualified sub routine identifier

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1117,7 +1117,7 @@ contexts:
   sub:
     - match: \bsub\b
       scope: storage.type.function.perl
-      push: [sub-meta, sub-path]
+      push: [sub-meta, sub-parameters, sub-path]
     # special functions which are executed at compile time
     # SEE: https://perldoc.perl.org/perlmod.html#BEGIN%2c-UNITCHECK%2c-CHECK%2c-INIT-and-END
     # NOTE: may not start with double colon when used without `sub` keyword
@@ -1132,35 +1132,36 @@ contexts:
     - include: immediately-pop
 
   sub-path:
-    # namespace
-    - match: (::)?({{identifier}})(?=::)
-      scope: meta.path.perl
+    - match: ({{identifier}})?(::)
       captures:
-        1: punctuation.accessor.double-colon.perl
-        2: support.class.perl
-    # function identifier
-    - match: '::'
-      scope: punctuation.accessor.double-colon.perl
+        1: support.class.perl
+        2: punctuation.accessor.double-colon.perl
       set:
         - meta_scope: meta.path.perl
+        - match: ({{identifier}})(::)
+          captures:
+            1: support.class.perl
+            2: punctuation.accessor.double-colon.perl
         - include: sub-name
+        - include: immediately-pop
     - include: sub-name
+    - include: comment-line
+    - match: (?=\S)
+      pop: true
 
   sub-name:
     # callback hook to auto load or destroy objects/functions
     - match: \b(AUTOLOAD|DESTROY){{break}}
       scope: entity.name.function.callback.perl
-      set: sub-parameters
+      pop: true
     # special functions which are executed at compile time
     - match: \b(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
       scope: entity.name.function.prepocessor.perl
-      set: sub-parameters
+      pop: true
     # ordinary function identifier
     - match: (?!{{reserved_words}}){{identifier}}
       scope: entity.name.function.perl
-      set: sub-parameters
-    # anonymous sub routine with parameter list
-    - include: sub-parameters
+      pop: true
 
   sub-parameters:
     - match: (?=\()

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -55,8 +55,12 @@ variables:
     \b(?x:
       # control keywords
       default|else|elsif|given|if|unless|when|break|caller|continue|die|
-      do|dump|exit|goto|last|next|redo|return|wait|for|foreach|until|while
-    ){{break}}
+      do|dump|exit|goto|last|next|redo|return|wait|for|foreach|until|while|
+      # declaration keywords
+      local|my|no|our|package|require|state|sub|use|
+      # word operators
+      and|or|xor|as|cmp|eq|gt|ge|lt|le|ne|not
+    )\b
 
 contexts:
   main:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1117,69 +1117,86 @@ contexts:
   sub:
     - match: \bsub\b
       scope: storage.type.function.perl
-      push: sub-name
+      push: [sub-meta, sub-path]
     # special functions which are executed at compile time
     # SEE: https://perldoc.perl.org/perlmod.html#BEGIN%2c-UNITCHECK%2c-CHECK%2c-INIT-and-END
-    - match: \b(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
-      scope: meta.function.perl entity.name.function.prepocessor.perl
-      push: sub-expect-parameters
+    # NOTE: may not start with double colon when used without `sub` keyword
+    - match: (::)?(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
+      captures:
+        1: invalid.illegal.accessor.perl
+        2: entity.name.function.prepocessor.perl
+      push: [sub-meta, sub-parameters]
+
+  sub-meta:
+    - meta_scope: meta.function.perl
+    - include: immediately-pop
+
+  sub-path:
+    # namespace
+    - match: (::)?((?!{{reserved_words}}){{identifier}})(?=::)
+      scope: meta.path.perl
+      captures:
+        1: punctuation.accessor.double-colon.perl
+        2: support.class.perl
+    # function identifier
+    - match: '::'
+      scope: punctuation.accessor.double-colon.perl
+      set:
+        - meta_scope: meta.path.perl
+        - include: sub-name
+    - include: sub-name
 
   sub-name:
-    - meta_scope: meta.function.perl
     # callback hook to auto load or destroy objects/functions
     - match: \b(AUTOLOAD|DESTROY){{break}}
       scope: entity.name.function.callback.perl
-      set: sub-expect-parameters
+      set: sub-parameters
     # special functions which are executed at compile time
     - match: \b(BEGIN|CHECK|END|INIT|UNITCHECK){{break}}
       scope: entity.name.function.prepocessor.perl
-      set: sub-expect-parameters
-    # ordinary function identifier
-    - match: '{{identifier}}'
-      scope: entity.name.function.perl
-      set: sub-expect-parameters
-    - include: sub-expect-block
-
-  sub-expect-parameters:
-    - meta_content_scope: meta.function.perl
-    - match: (?=\()
       set: sub-parameters
-    - include: sub-expect-block
-    - match: \S
-      scope: invalid.illegal.function-name.perl
+    # ordinary function identifier
+    - match: (?!{{reserved_words}}){{identifier}}
+      scope: entity.name.function.perl
+      set: sub-parameters
+    # anonymous sub routine with parameter list
+    - include: sub-parameters
 
   sub-parameters:
-    - match: \(
-      scope: punctuation.section.group.begin.perl
+    - match: (?=\()
       set:
-        - meta_scope: meta.function.parameters.perl
-        - match: \)
-          scope: punctuation.section.group.end.perl
-          set: sub-expect-block
-        - match: '[\$\@\*;][^\s,\)]*'
-          scope: variable.parameter.perl
-        - include: expressions
+        - clear_scopes: 1
+        - match: \(
+          scope: punctuation.section.group.begin.perl
+          set:
+            - clear_scopes: 1
+            - meta_scope: meta.function.parameters.perl
+            - match: \)
+              scope: punctuation.section.group.end.perl
+              set: sub-block
+            - match: ([$@%*;])[^\s,\)]*
+              scope: variable.parameter.perl
+              captures:
+                1: punctuation.definition.variable.perl
+            - include: expressions
+    - include: sub-block
 
-  sub-expect-block:
-    - meta_content_scope: meta.function.perl
-    - include: comment-line
-    - include: term-pop
-    - match: $|(?=\{)
+  sub-block:
+    - match: \{
+      scope: punctuation.section.block.begin.perl
       set:
-        - match: \{
-          scope: punctuation.section.block.begin.perl
-          set: [sub-block-body, regexp-pop]
-        - include: comment-line
-        - include: comment-pod
-        - match: (?=\S)
-          pop: true
-
-  sub-block-body:
-    - meta_scope: meta.function.perl meta.block.perl
-    - match: \}
-      scope: punctuation.section.block.end.perl
+        - - meta_scope: meta.block.perl
+          - match: \}
+            scope: punctuation.section.block.end.perl
+            pop: true
+          - include: main
+        - regexp-pop
+    # don't break expressions after incomplete sub statement
+    - match: (?=;|{{reserved_words}})
       pop: true
-    - include: main
+    - include: comment-line
+    - match: \S
+      scope: invalid.illegal.function-name.perl
 
 ###[ VARIABLES ]##############################################################
 

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1133,7 +1133,7 @@ contexts:
 
   sub-path:
     # namespace
-    - match: (::)?((?!{{reserved_words}}){{identifier}})(?=::)
+    - match: (::)?({{identifier}})(?=::)
       scope: meta.path.perl
       captures:
         1: punctuation.accessor.double-colon.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1719,14 +1719,18 @@ sub name ($) {}
 #          ^ punctuation.section.group.end.perl - variable.parameter.perl
 sub ::name
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^ meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl
 #         ^ - entity - invalid
 sub ::name # comment
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^^^^^^^^^^ meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl
@@ -1734,7 +1738,9 @@ sub ::name # comment
 #          ^^^^^^^^^ comment.line.number-sign.perl
 sub ::name invalid
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^^^^^^^^^^ meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl
@@ -1742,7 +1748,9 @@ sub ::name invalid
 #          ^^^^^^^ invalid.illegal.function-name.perl
 sub ::name invalid # comment
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^^^^^^^^^^^^^^^^^^ meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl
@@ -1752,14 +1760,18 @@ sub ::name invalid # comment
 #                  ^^^^^^^^^ comment.line.number-sign.perl
 sub ::name;
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^ - meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl
 #         ^ punctuation.terminator.statement.perl
 sub ::name invalid;
 # <- meta.function.perl storage.type.function.perl
-#^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^ meta.function.perl meta.path.perl
+#         ^^^^^^^^ meta.function.perl - meta.path
 #^^ storage.type.function.perl
 #   ^^ punctuation.accessor.double-colon.perl
 #     ^^^^ entity.name.function.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1779,7 +1779,7 @@ sub ::name invalid;
 #                 ^ punctuation.terminator.statement.perl
 sub
 #^^^ meta.function.perl - meta.path
-  NS::name
+  if::name
 # ^^^^^^^^ meta.function.perl meta.path.perl
 # ^^ support.class
 #   ^^ punctuation.accessor.double-colon.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1436,11 +1436,28 @@ no strict;
 #       ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
   }
 # ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  ::BEGIN {
+# ^^^^^^^^ meta.function.perl - meta.block
+# ^^ invalid.illegal.accessor.perl
+#   ^^^^^ entity.name.function.prepocessor.perl
+#         ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
   sub BEGIN {
 # ^^^^^^^^^^ meta.function.perl - meta.block
 # ^^^ storage.type.function.perl
 #     ^^^^^ entity.name.function.prepocessor.perl
 #           ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub ::BEGIN {
+# ^^^^ meta.function.perl - meta.path.perl - meta.block
+#     ^^^^^^^ meta.function.perl meta.path.perl - meta.block
+#            ^ meta.function.perl - meta.path.perl - meta.block
+# ^^^ storage.type.function.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^^^ entity.name.function.prepocessor.perl
+#             ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
   }
 # ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
   CHECK {
@@ -1495,6 +1512,21 @@ no strict;
 #               ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
   }
 # ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
+  sub AUTOLOAD () {}
+# ^^^^^^^^^^^^^ meta.function.perl
+#              ^^ meta.function.parameters.perl
+#                ^^^ meta.function.perl
+# ^^^ storage.type.function.perl
+#     ^^^^^^^^ entity.name.function.callback.perl
+  sub ::AUTOLOAD () {}
+# ^^^^ meta.function.perl - meta.path
+#     ^^^^^^^^^^ meta.function.perl meta.path.perl - meta.function.parameters.perl
+#               ^ meta.function.perl - meta.function.parameters.perl - meta.path
+#                ^^ meta.function.parameters.perl - meta.function.perl - meta.path
+#                  ^^^ meta.function.perl - meta.function.parameters.perl - meta.path
+# ^^^ storage.type.function.perl
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^^^^^^ entity.name.function.callback.perl
 
 ###[ SUB ]####################################################################
 
@@ -1550,6 +1582,20 @@ sub name invalid;
 #   ^^^^ entity.name.function.perl
 #        ^^^^^^^ invalid.illegal.function-name.perl
 #               ^ punctuation.terminator.statement.perl
+sub
+# <- meta.function.perl storage.type.function.perl
+#^^ meta.function.perl storage.type.function.perl
+#  ^ - invalid
+  name
+# ^^^^ meta.function.perl entity.name.function.perl
+sub # comment
+# <- meta.function.perl storage.type.function.perl
+#^^ meta.function.perl storage.type.function.perl
+#  ^^^^^^^^^^ meta.function.perl
+#  ^ - comment - entity - keyword - invalid
+#   ^^^^^^^^^ comment.line.number-sign.perl
+  name
+# ^^^^ meta.function.perl entity.name.function.perl
 sub {
 # <- meta.function.perl storage.type.function.perl
 #^^^^^^^^^^ meta.function.perl
@@ -1634,7 +1680,6 @@ sub name ($arg, $arg) # comment
 # <- meta.function.perl punctuation.section.block.begin.perl
 }
 # <- meta.function.perl punctuation.section.block.end.perl
-
 sub name invalid ($arg, $arg) {
 # <- meta.function.perl storage.type.function.perl
 #^^^^^^^^^^^^^^^^ meta.function.perl - meta.function.parameters.perl
@@ -1672,12 +1717,145 @@ sub name ($) {}
 #        ^^^ meta.function.parameters.perl
 #         ^ variable.parameter.perl
 #          ^ punctuation.section.group.end.perl - variable.parameter.perl
-
-sub AUTOLOAD () {}
-#^^^^^^^^^^^^ meta.function.perl
-#            ^^ meta.function.parameters.perl
-#              ^^^ meta.function.perl
-#   ^^^^^^^^ entity.name.function.callback.perl
+sub ::name
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#         ^ - entity - invalid
+sub ::name # comment
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#         ^ - comment - entity - invalid
+#          ^^^^^^^^^ comment.line.number-sign.perl
+sub ::name invalid
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#         ^ - entity - invalid
+#          ^^^^^^^ invalid.illegal.function-name.perl
+sub ::name invalid # comment
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#         ^ - entity - invalid
+#          ^^^^^^^ invalid.illegal.function-name.perl
+#                 ^ - comment - entity - invalid
+#                  ^^^^^^^^^ comment.line.number-sign.perl
+sub ::name;
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#         ^ punctuation.terminator.statement.perl
+sub ::name invalid;
+# <- meta.function.perl storage.type.function.perl
+#^^^^^^^^^^^^^^^^^ meta.function.perl
+#^^ storage.type.function.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+#          ^^^^^^^ invalid.illegal.function-name.perl
+#                 ^ punctuation.terminator.statement.perl
+sub
+#^^^ meta.function.perl - meta.path
+  NS::name
+# ^^^^^^^^ meta.function.perl meta.path.perl
+# ^^ support.class
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^^^ entity.name.function.perl
+sub NS::name
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^ meta.function.perl meta.path.perl
+#   ^^ support.class
+#     ^^ punctuation.accessor.double-colon.perl
+#       ^^^^ entity.name.function.perl
+sub ::NS::name
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^ meta.function.perl meta.path.perl
+#   ^^ punctuation.accessor.double-colon.perl
+#     ^^ support.class
+#       ^^ punctuation.accessor.double-colon.perl
+#         ^^^^ entity.name.function.perl
+sub B::NS::name
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#          ^^^^ entity.name.function.perl
+sub B::NS::name invalid
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#              ^^^^^^^^ meta.function.perl - meta.path
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#          ^^^^ entity.name.function.perl
+#               ^^^^^^^ invalid.illegal.function-name.perl
+sub B::NS::name # comment
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#          ^^^^ entity.name.function.perl
+#               ^^^^^^^^^ comment.line.number-sign.perl
+sub B::NS::name() # comment
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#              ^^ meta.function.parameters.perl
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#          ^^^^ entity.name.function.perl
+#              ^ punctuation.section.group.begin.perl
+#               ^ punctuation.section.group.end.perl
+#                 ^^^^^^^^^ comment.line.number-sign.perl
+sub B::NS::name {
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#              ^^ meta.function.perl - meta.path
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#          ^^^^ entity.name.function.perl
+}
+# <- meta.function.perl meta.block.perl punctuation.section.block.end.perl
+sub
+#^^^ meta.function.perl - meta.path
+  B::NS::name
+# ^^^^^^^^^^^ meta.function.perl meta.path.perl
+#            ^^ meta.function.perl - meta.path
+# ^ support.class
+#  ^^ punctuation.accessor.double-colon.perl
+#    ^^ support.class
+#      ^^ punctuation.accessor.double-colon.perl
+#        ^^^^ entity.name.function.perl
+  (
+# ^ meta.function.parameters.perl punctuation.section.group.begin.perl
+    $arg,
+#   ^^^^ meta.function.parameters.perl variable.parameter.perl
+#       ^ meta.function.parameters.perl punctuation.separator.sequence.perl
+  )
+# ^ meta.function.parameters.perl punctuation.section.group.end.perl
+  {
+# ^ meta.function.perl meta.block.perl punctuation.section.block.begin.perl
+  }
+# ^ meta.function.perl meta.block.perl punctuation.section.block.end.perl
 
 ###[ CONTROL KEYWORDS ]#######################################################
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1815,6 +1815,27 @@ sub B::NS::name invalid
 #        ^^ punctuation.accessor.double-colon.perl
 #          ^^^^ entity.name.function.perl
 #               ^^^^^^^ invalid.illegal.function-name.perl
+sub B::NS ::invalid;
+#^^^ meta.function.perl - meta.path
+#   ^^^^^ meta.function.perl meta.path.perl
+#        ^^^^^^^^^^ meta.function.perl - meta.path
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ entity.name.function.perl
+#         ^^^^^^^^^ invalid.illegal.function-name.perl
+#                  ^ punctuation.terminator.statement.perl
+sub B::NS:: invalid {};
+#^^^ meta.function.perl - meta.path
+#   ^^^^^^^ meta.function.perl meta.path.perl
+#          ^^^^^^^^^^^ meta.function.perl - meta.path
+#   ^ support.class
+#    ^^ punctuation.accessor.double-colon.perl
+#      ^^ support.class
+#        ^^ punctuation.accessor.double-colon.perl
+#           ^^^^^^^ invalid.illegal.function-name.perl
+#                   ^ punctuation.section.block.begin.perl
+#                    ^ punctuation.section.block.end.perl
+#                     ^ punctuation.terminator.statement.perl
 sub B::NS::name # comment
 #^^^ meta.function.perl - meta.path
 #   ^^^^^^^^^^^ meta.function.perl meta.path.perl


### PR DESCRIPTION
Each variable or function identifier can consist of a fully qualified path.

Example:

    $NS1::NS2::variable
    NS1::NS2::function

The `NS` is expressed by the file path relative to the core library or can be extended by sub routine definitions.

Example:

    sub NS1::NS2::NS3::function { }

   A real life example can be found in <..>/core_perl/B/Debug.pm

Before this commit fully qualified subroutine identifiers are scoped `invalid.illegal`. This is fixed by this commit.

Note:

  The namespace part is currently scoped as `support.class`, because
  a) this is the scope being used in other situations as well
  b) the scope naming guidelines don't yet suggest a scope for that part.

   - C# uses `variable.other.namespace`.
   - The rewritten Erlang introduces `variable.namespace` because it fits best to the `entity.name.namespace` which is to be used for namespace definitions.
   - The proposed general `variable.qualifier` would probably the most general alternative as it is hard/impossible to distinguish namespace from class access. Would require `entity.name.qualifier` as definition counterpart then?

   c) All `support.class` scopes should be renamed in one commit later.