### PR TITLE
[Perl] Fix ${...} meta scope name

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1238,17 +1238,17 @@ contexts:
       push: maybe-item-access
     - match: ([\$\@\%])(\{)
       scope: punctuation.definition.variable.begin.perl
-      push:
-        - meta_scope: meta.braces.perl variable.other.readwrite.global.perl
-        - match: \}
-          scope: punctuation.definition.variable.end.perl
-          set:
-            - meta_content_scope: variable.other.readwrite.global.perl
-            - include: maybe-item-access
-        - include: blocks-nested
-        - include: brackets-nested
-        - include: groups-nested
-        - include: expressions
+      push: [maybe-item-access, variable-body, regexp-pop]
+
+  variable-body:
+    - meta_scope: meta.variable.perl
+    - match: \}
+      scope: punctuation.definition.variable.end.perl
+      pop: true
+    - include: blocks-nested
+    - include: brackets-nested
+    - include: groups-nested
+    - include: expressions
 
   maybe-item-access:
     # SEE: https://perldoc.perl.org/perllol.html

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -732,8 +732,22 @@ EOT
 #                       ^^ keyword.operator.assignment.perl
 #                          ^^^^^^^ string.quoted.single.perl
 #                                 ^ punctuation.section.arguments.end.perl
+  ${get_var_name()}
+# ^^^^^^^^^^^^^^^^^ meta.variable.perl
+# ^^ punctuation.definition.variable.begin.perl
+#   ^^^^^^^^^^^^ variable.function.perl
+#                 ^ punctuation.definition.variable.end.perl
+  ${/\w+$/g = $var}
+# ^^^^^^^^^^^^^^^^^ meta.variable.perl
+# ^^ punctuation.definition.variable.begin.perl
+#   ^ punctuation.section.generic.begin.perl
+#    ^^^^ string.regexp.perl
+#        ^ punctuation.section.generic.end.perl
+#         ^ constant.language.flags.regexp.perl
+#           ^ keyword.operator.assignment.perl
+#                 ^ punctuation.definition.variable.end.perl
   ${Foo::Bar::baz}
-# ^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^ meta.variable.perl
 # ^^ punctuation.definition.variable.begin.perl
 #   ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
@@ -742,23 +756,23 @@ EOT
 #             ^^^ variable.other.member.perl
 #                ^ punctuation.definition.variable.end.perl
   ${Foo::Bar::baz}[$var]
-# ^^^^^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^ meta.variable.perl
 #                 ^^^^^^ meta.item-access.perl
   ${
 #^ - variable
 # ^^ punctuation.definition.variable.begin.perl
-# ^^^ variable.other.readwrite.global.perl
+# ^^^ meta.variable.perl
     Foo::bar->baz()
-# <- variable.other.readwrite.global.perl
-#^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+# <- meta.variable.perl
+#^^^^^^^^^^^^^^^^^^^ meta.variable.perl
 #   ^^^ support.class.perl
 #      ^^ punctuation.accessor.double-colon.perl
 #        ^^^ variable.other.member.perl
 #           ^^ keyword.accessor.arrow.perl
 #             ^^^ variable.function.member.perl
   }
-# <- variable.other.readwrite.global.perl
-#^^ variable.other.readwrite.global.perl
+# <- meta.variable.perl
+#^^ meta.variable.perl
 # ^ punctuation.definition.variable.end.perl
 #  ^ - variable
   $::Config{'cf_email'}
@@ -814,11 +828,11 @@ EOT
 #           ^^^^ variable.other.readwrite.global.perl
 #               ^ punctuation.section.item-access.end.perl
   %{$foo{bar}{baz}} = 'excl';
-# ^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^^ meta.variable.perl
 #       ^^^^^^^^^^ meta.item-access.perl
 # ^^ punctuation.definition.variable.begin.perl
 #   ^ punctuation.definition.variable.perl
-#   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#   ^^^^ variable.other.readwrite.global.perl
 #       ^ punctuation.section.item-access.begin.perl
 #        ^^^ string.unquoted.perl
 #           ^ punctuation.section.item-access.end.perl
@@ -829,11 +843,11 @@ EOT
 #                     ^^^^^^ string.quoted.single.perl
 #                           ^ punctuation.terminator.statement.perl
   %{$foo{'bar'}{'bar'}} = 'excl';
-# ^^^^^^^^^^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+# ^^^^^^^^^^^^^^^^^^^^^ meta.variable.perl
 #       ^^^^^^^^^^^^^^ meta.item-access.perl
 # ^^ punctuation.definition.variable.begin.perl
 #   ^ punctuation.definition.variable.perl
-#   ^^^^ variable.other.readwrite.global.perl variable.other.readwrite.global.perl
+#   ^^^^ variable.other.readwrite.global.perl
 #       ^ punctuation.section.item-access.begin.perl
 #        ^^^^^ string.quoted.single.perl
 #             ^ punctuation.section.item-access.end.perl
@@ -859,7 +873,7 @@ EOT
   # add new columns to an existing row
   push @{ $AoA[0] }, "wilma", "betty";   # explicit deref
 # ^^^^ support.function.perl
-#      ^^^^^^^^^^^^ meta.braces.perl variable.other.readwrite.global.perl
+#      ^^^^^^^^^^^^ meta.variable.perl
 #         ^^^^ variable.other.readwrite.global.perl - meta.item-access
 #             ^^^ meta.item-access.perl
 #      ^^  punctuation.definition.variable.begin.perl


### PR DESCRIPTION
Up to this commit all `${...}` or `%{...}` tokens are scoped as `variable.other` while they contain ordinary expressions.

This commit...

1. replaces the scope by a `meta.variable` to avoid otherwise unmatched parts of the expressions being highlighted in a wrong way.
2. adds the `regexp-pop` context right after the opening punctuation in order to fix an issue with `/patter/flags` not being detected.

Note:
  This change is part to solve issue #2017