### PR TITLE
[CSS] Fix missing string punctuation within local()

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1014,6 +1014,7 @@ contexts:
           - meta_scope: meta.group.css
           - match: '(?=\))'
             pop: true
+          - include: literal-string
           - include: unquoted-string
 
       # Transform Functions

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -983,6 +983,18 @@
   src: local(Gentium-Bold);
 /*     ^^^^^              support.function.font-face.css */
 /*           ^^^^^^^^^^^^ string.unquoted.css            */
+
+  src: local('Gentium-Bold');
+/*     ^^^^^              support.function.font-face.css          */
+/*           ^^^^^^^^^^^^^^ string.quoted.single.css              */
+/*           ^ punctuation.definition.string.begin.css            */
+/*                        ^ punctuation.definition.string.end.css */
+
+  src: local("Gentium-Bold");
+/*     ^^^^^              support.function.font-face.css          */
+/*           ^^^^^^^^^^^^^^ string.quoted.double.css              */
+/*           ^ punctuation.definition.string.begin.css            */
+/*                        ^ punctuation.definition.string.end.css */
 }
 
 @font-face {


### PR DESCRIPTION
According to [https://drafts.csswg.org/css-fonts-3/#descdef-src](https://drafts.csswg.org/css-fonts-3/#descdef-src) the font face name within `local()` can optionally be enclosed in quotes.

```css
@font-face {
    font-family: 'Ubuntu';
    src: local('Ubuntu Regular'),
         url('Ubuntu-Regular.ttf') format('truetype');
}

@font-face {
    font-family: "Ubuntu";
    src: local("Ubuntu Regular"),
         url("Ubuntu-Regular.ttf") format("truetype");
}
```

Before:
![before](https://user-images.githubusercontent.com/6579999/62415820-25c71400-b630-11e9-96ba-4b47b9a2737e.png)

After:
![after](https://user-images.githubusercontent.com/6579999/62415825-2d86b880-b630-11e9-87e3-5815ca05055c.png)
