### PR TITLE
[Perl] Restrict whitespace surrounding namespace accessors

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -16,7 +16,7 @@ first_line_match: |-
 scope: source.perl
 
 variables:
-  break: (?!\w|\s*::)
+  break: \b(?!::)
   identifier: '\b[_[:alpha:]]\w*\b'
   module: '\b[_[:upper:]]\w*\b'
   member: '\b[_[:lower:]]\w*\b'
@@ -282,7 +282,7 @@ contexts:
     #      http://perldoc.perl.org/perlmodlib.html#Pragmatic-Modules
     - match: |-
         \b(?x:
-           attributes|autodie(?:\s*::\s*(?:exception(?:\s*::\s*system)|hints|skip))?|autouse
+           attributes|autodie(?:::(?:exception(?:::system)|hints|skip))?|autouse
           |base|bigint|bignum|bigrat|blib|bytes
           |charnames|constant
           |diagnostics
@@ -298,7 +298,7 @@ contexts:
           |threads|threads::shared
           |utf8
           |vars|vmsish
-          |warnings|warnings\s*::\s*register){{break}}
+          |warnings|warnings::register){{break}}
       scope: storage.modifier.perl
 
 ###[ EXPRESSIONS ]############################################################
@@ -656,26 +656,26 @@ contexts:
 ###[ CLASSES ]################################################################
 
   class:
-    - match: '{{module}}(?=\s*(?:::|[#;]|$))'
+    - match: '{{module}}(?=(?:::|\s*[#;]|\s*$))'
       scope: support.class.perl
       push: class-members-pop
 
   class-members-pop:
     # nested class
-    - match: \s*(::)\s*({{module}})
+    - match: (::)({{module}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: support.class.perl
       push: maybe-item-access
     # member function
-    - match: \s*(::)\s*(({{member}})\s*)(?=\()
+    - match: (::)(({{member}})\s*)(?=\()
       captures:
         1: punctuation.accessor.double-colon.perl
         2: meta.function-call.name.perl
         3: variable.function.member.perl
       set: function-call-arguments
     # member variable
-    - match: \s*(::)\s*({{identifier}})
+    - match: (::)({{identifier}})
       captures:
         1: punctuation.accessor.double-colon.perl
         2: variable.other.member.perl
@@ -1218,7 +1218,7 @@ contexts:
       push: maybe-item-access
     # $Module::SubModule::member
     # $::SubModule::member
-    - match: ([\$\@\%]#?)({{module}})?(?=\s*::)
+    - match: ([\$\@\%]#?)({{module}})?(?=::)
       captures:
         1: punctuation.definition.variable.perl
         2: support.class.perl

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -621,14 +621,6 @@ EOT
 #       ^^^ support.class.perl
 #          ^^ punctuation.accessor.double-colon.perl
 #            ^^^ variable.other.member.perl
-  $Foo :: Bar :: baz
-# ^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
-# ^ punctuation.definition.variable.perl
-#  ^^^ support.class.perl
-#      ^^ punctuation.accessor.double-colon.perl
-#         ^^^ support.class.perl
-#             ^^ punctuation.accessor.double-colon.perl
-#                ^^^ variable.other.member.perl
   $Foo::Bar::baz[4]
 # ^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
@@ -686,15 +678,6 @@ EOT
 #                  ^ punctuation.section.item-access.begin.perl
 #                  ^^^^ meta.item-access.perl
 #                     ^ punctuation.section.item-access.end.perl
-  $Foo :: Bar -> $baz
-# ^^^^^^^^^^^ variable.other.readwrite.global.perl
-# ^ punctuation.definition.variable.perl
-#  ^^^ support.class.perl
-#      ^^ punctuation.accessor.double-colon.perl
-#         ^^^ support.class.perl
-#             ^^ keyword.accessor.arrow.perl - variable
-#                ^^^^ variable.other.readwrite.global.perl
-#                ^ punctuation.definition.variable.perl
   $Foo::Bar::baz()
 # ^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
 # ^ punctuation.definition.variable.perl
@@ -705,17 +688,6 @@ EOT
 #            ^^^ meta.function-call.name.perl variable.function.member.perl
 #               ^ meta.function-call.arguments.perl punctuation.section.arguments.begin.perl
 #                ^ meta.function-call.arguments.perl punctuation.section.arguments.end.perl
-  $Foo :: Bar :: baz ()
-# ^^^^^^^^^^^^^^^^^^^^^ variable.other.readwrite.global.perl
-# ^ punctuation.definition.variable.perl
-#  ^^^ support.class.perl
-#      ^^ punctuation.accessor.double-colon.perl
-#         ^^^ support.class.perl
-#             ^^ punctuation.accessor.double-colon.perl
-#                ^^^^ meta.function-call.name.perl
-#                ^^^ variable.function.member.perl
-#                    ^ meta.function-call.arguments.perl punctuation.section.arguments.begin.perl
-#                     ^ meta.function-call.arguments.perl punctuation.section.arguments.end.perl
   $c = C::Scan->new(KEY => 'value')
 #               ^^^ meta.function-call.name.perl
 #                  ^^^^^^^^^^^^^^^^ meta.function-call.arguments.perl
@@ -1366,17 +1338,6 @@ eval { require Mail::Send; };
 #      ^^^^^^^^^^^^^^^^^^ meta.import.require.perl
 #                        ^^^^ - meta.import.require.perl
 #      ^^^^^^^ keyword.control.import.require.perl
-eval { require Mail :: Send; };
-#<- support.function.perl
-#^^^ support.function.perl
-#    ^ punctuation.section.block.begin.perl
-#      ^^^^^^^^^^^^^^^^^^^^ meta.import.require.perl
-#              ^^^^ support.class.perl
-#                  ^^^^ - support.class
-#                   ^^ punctuation.accessor.double-colon.perl
-#                      ^^^^ support.class.perl
-#                          ^^^^ - meta.import.require.perl
-#      ^^^^^^^ keyword.control.import.require.perl
 use strict;
 # <- meta.use.perl keyword.control.import.use.perl
 #^^^^^^^^^ meta.use.perl
@@ -1412,15 +1373,15 @@ use File::data;
 #       ^^ punctuation.accessor.double-colon.perl
 #         ^^^^ variable.other.member.perl
 #             ^ punctuation.terminator.statement.perl
-use warnings :: register File :: data;
+use warnings::register File::data;
 # <- meta.use.perl keyword.control.import.use.perl
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.use.perl
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.use.perl
 #^^ keyword.control.import.use.perl
-#   ^^^^^^^^^^^^^^^^^^^^ storage.modifier.perl
-#                        ^^^^ support.class.perl
-#                             ^^ punctuation.accessor.double-colon.perl
-#                                ^^^^ variable.other.member.perl
-#                                    ^ punctuation.terminator.statement.perl
+#   ^^^^^^^^^^^^^^^^^^ storage.modifier.perl
+#                      ^^^^ support.class.perl
+#                          ^^ punctuation.accessor.double-colon.perl
+#                            ^^^^ variable.other.member.perl
+#                                ^ punctuation.terminator.statement.perl
 no strict;
 # <- meta.no.perl keyword.declaration.no.perl
 #^^^^^^^^ meta.no.perl
@@ -1696,7 +1657,7 @@ sub AUTOLOAD () {}
   default:word
 # ^^^^^^^ - keyword.control
   default :: word
-# ^^^^^^^ - keyword.control
+# ^^^^^^^ keyword.control.conditional.default.perl
   default::word
 # ^^^^^^^ - keyword.control
   else -> word
@@ -1712,7 +1673,7 @@ sub AUTOLOAD () {}
   else:word
 # ^^^^ - keyword.control
   else :: word
-# ^^^^ - keyword.control
+# ^^^^ keyword.control.conditional.else.perl
   else::word
 # ^^^^ - keyword.control
   elsif


### PR DESCRIPTION
A fully qualified identifier must not contain whitespace. Hence the accessor `::` must not be surrounded by them as well.

It was supported up to this point in order to improve the writing experience by not breaking identifiers during writing.

This will cause conflicts with parsing/scoping fully qualified identifiers in future changes an therefore needs to be restricted.

The test cases containing whitespace surrounded accessors are removed for the moment as properly handling such situations is part of a future change.