### PR TITLE
[Perl] Add file extensions

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -3,11 +3,12 @@
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Perl
 file_extensions:
+  - pc
   - pl
   - pm
+  - pmc
   - pod
   - t
-  - PL
 first_line_match: |-
   (?x:
     ^\#! .* \bperl\b |                     # shebang


### PR DESCRIPTION
This commit adds

- `pc`   = was found in the core_perl/Win32API/File library
- `pmc`  = mentioned in https://perldoc.perl.org/functions/require.html
           The importer loads pmc files if present in place of a
           requested pm file.

and removes:

- `PL`   = duplicate of `pl`.