### PR TITLE
[C#] Removed type prefixes from symbol list

### DIFF
--- a/C#/Symbol List Classes.tmPreferences
+++ b/C#/Symbol List Classes.tmPreferences
@@ -11,10 +11,6 @@
 		<integer>1</integer>
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
-		<key>symbolTransformation</key>
-		<string>
-		s/^/class /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Enums.tmPreferences
+++ b/C#/Symbol List Enums.tmPreferences
@@ -11,10 +11,6 @@
 		<integer>1</integer>
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
-		<key>symbolTransformation</key>
-		<string>
-		s/^/enum /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Interfaces.tmPreferences
+++ b/C#/Symbol List Interfaces.tmPreferences
@@ -11,10 +11,6 @@
 		<integer>1</integer>
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
-		<key>symbolTransformation</key>
-		<string>
-		s/^/interface /;
-		</string>
 	</dict>
 </dict>
 </plist>

--- a/C#/Symbol List Namespace.tmPreferences
+++ b/C#/Symbol List Namespace.tmPreferences
@@ -9,8 +9,6 @@
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
-		<key>symbolTransformation</key>
-		<string>s/^/namespace /;</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
As discussed in #2001 this PR removes the `class`, `enum`, `interface`, and `namespace` prefixes inserted via symbol transformation. It's nice to have but really something that should be taken care of by Sublime Text in a more coherent manner.

🙅‍♂ **Before**
<img width="1351" alt="Screenshot 2019-08-04 at 17 49 18" src="https://user-images.githubusercontent.com/385582/62426167-b4e03480-b6e1-11e9-8c71-d27338d5325e.png">

🙆‍♂ **After**
<img width="1351" alt="Screenshot 2019-08-04 at 17 51 05" src="https://user-images.githubusercontent.com/385582/62426169-ba3d7f00-b6e1-11e9-9da6-6db33099fee9.png">
