### PR TITLE
[Scala] Scope overhaul to better align with convention

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -810,10 +810,7 @@ contexts:
           scope: punctuation.separator.scala
         - match: '(?=[\n;])'
           pop: true
-        - match: '{{upperid}}'
-          scope: support.class.import.scala
         - match: '{{id}}'
-          scope: support.type.package.scala
         - match: \.
           scope: punctuation.accessor.dot.scala
         - match: '_'
@@ -829,10 +826,7 @@ contexts:
               scope: punctuation.separator.scala
             - match: '{{rightarrow}}'
               scope: keyword.operator.arrow.scala
-            - match: '{{upperid}}'
-              scope: support.class.import.scala
             - match: '{{id}}'
-              scope: support.type.package.scala
             - match: '_'
               scope: variable.language.underscore.scala
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -367,13 +367,15 @@ contexts:
         2: storage.type.class.scala
         3: entity.name.class.scala
       push: class-inheritance-extends
-    - match: '\b(package)\s+({{id}}(?:\.{{id}})*)\s*\{'
+    - match: '\b(package)\s+({{id}}(?:\.{{id}})*)\s*(\{)'
       captures:
         1: keyword.control.scala
         2: entity.name.namespace.scoped.scala
+        3: punctuation.section.block.begin.scala
       push:
         - meta_scope: meta.namespace.scala
         - match: '\}'
+          scope: punctuation.section.block.end.scala
           pop: true
         - include: main
     - match: '\b(package)\s+({{id}}(?:\.{{id}})*)'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -821,6 +821,8 @@ contexts:
             - match: "}"
               scope: punctuation.section.group.end.scala
               pop: true
+            - match: ','
+              scope: punctuation.separator.scala
             - match: '{{rightarrow}}'
               scope: keyword.operator.arrow.scala
             - match: '{{upperid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1582,6 +1582,8 @@ contexts:
       scope: keyword.declaration.scala
     - match: '[\.#]'
       scope: punctuation.accessor.scala
+    - match: ','
+      scope: punctuation.separator.scala
     # - include: literal-constants
     # - include: char-literal
     # - include: scala-symbol

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -503,6 +503,7 @@ contexts:
       scope: punctuation.definition.generic.begin.scala
       push: function-tparams-brackets
     - match: ':'
+      scope: punctuation.ascription.scala
       set: function-return-type-definition
     - match: '(?=[\{\};]|{{nonopchar}}?={{nonopchar}})'
       pop: true
@@ -569,7 +570,7 @@ contexts:
                   pop: true
         - include: main
     - match: ':'
-      scope: punctuation.separator.scala
+      scope: punctuation.ascription.scala
       set: function-return-type-definition
     - match: '\n'
       set: function-parameter-list-newline

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1003,8 +1003,8 @@ contexts:
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
-    - match: \b(?:eq|ne)\b
-      scope: keyword.operator.word.scala
+    - match: '[!=]=(?={{nonopchar}})|\b(?:eq|ne)\b'
+      scope: keyword.operator.comparison.scala
 
   late-keywords:
     - match: \bextends\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -36,10 +36,10 @@ variables:
       [:@\x{2190}\x{21D2}#]{{operator_character}}+
     )
 
-  # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #, <%, <:, :<, +, -}
+  # {{operator_character}}+ \ {:, =, =>, <-, @, ←, ⇒, #, <%, <:, :<}
   typeop: |-
     (?x:
-      [[^:=<@\x{2190}\x{21D2}#+\-]&&{{operator_character}}]{{operator_character}}*|
+      [[^:=<@\x{2190}\x{21D2}#]&&{{operator_character}}]{{operator_character}}*|
       =[[^>]&&{{operator_character}}]{{operator_character}}*|
       =>{{operator_character}}+|
       <(?!{{operator_character}}|[[:alpha:]])|
@@ -47,7 +47,7 @@ variables:
       <[:%\-]{{operator_character}}+|
       :[[^<]&&{{operator_character}}]+|
       :<{{operator_character}}+|
-      [@\x{2190}\x{21D2}#+\-]{{operator_character}}+
+      [@\x{2190}\x{21D2}#]{{operator_character}}+
     )
 
   idrest: '(?:(?:{{idcont}}|_(?=[^{{operator_character}}]))*(?:_{{operator_character}}+)?)'
@@ -1571,8 +1571,8 @@ contexts:
   delimited-type-expression:
     - include: annotation
     # kind-projector support
-    - match: '\?'
-      scope: variable.language.qmark.scala
+    - match: '\?|\*'
+      scope: variable.language.hole.scala
     # \x{03BB} = λ
     - match: '\bLambda\b|\x{03BB}'
       scope: keyword.operator.type-lambda.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -357,7 +357,7 @@ contexts:
     - match: '\b(var)\s+({{id}})'
       captures:
         1: storage.type.volatile.scala
-        2: entity.name.var.scala variable.other.readwrite.scala
+        2: variable.other.readwrite.scala
     - match: '\bval\b'
       scope: storage.type.stable.scala
       push: val-simple-body
@@ -1366,7 +1366,7 @@ contexts:
         - match: (?=\S)
           pop: true
     - match: '\b{{varid}}'
-      scope: entity.name.val.scala variable.other.constant.scala
+      scope: variable.other.constant.scala
     - match: \[
       push:
         - match: \]
@@ -1407,17 +1407,17 @@ contexts:
 
     # special form lookahead to prevent invalid operator ascription syntax
     - match: '(?:{{op}}|{{id}}_{{operator_character}}*):(?=\s+:|\s*=|\s*$)'
-      scope: entity.name.val.scala variable.other.constant.scala
+      scope: variable.other.constant.scala
       set: val-simple-body-tail
     - match: '({{op}}|{{id}}_{{operator_character}}*)(:)(?=\s)'
       captures:
-        1: entity.name.val.scala variable.other.constant.scala
+        1: variable.other.constant.scala
         2: invalid.ascription.following-operator.scala
       set: val-simple-ascription
 
     # an id followed by a type, or an =, or EOL
     - match: '{{id}}(?=\s*:{{nonopchar}}|\s*=|\s*$)'
-      scope: entity.name.val.scala variable.other.constant.scala
+      scope: variable.other.constant.scala
       set: val-simple-body-tail
     - match: (?=\S)
       set:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -18,7 +18,7 @@ variables:
   operator_character: '[\p{Sm}\p{So}[{{disallowed_as_operator}}&&[\x{20}-\x{7E}]]]'
   upper: '[$\p{Lu}]'
   # This is "letter", but without _ so we can ensure it is not last
-  idcont: '[$\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{Nl}0-9'']'
+  idcont: '[$\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{Nl}0-9]'
 
   # note the handling of ' characters in identifiers is somewhat conservative
   # TLS doesn't document this feature very well (read: at all), but this is how it's used
@@ -1172,14 +1172,13 @@ contexts:
 
   interpolated-vars-expressions:
     # we duplicate this pattern to encode a greedy ? on the [']
-    - match: '(\$)({{alphaid}})['']'
-      captures:
-        1: punctuation.definition.variable.scala variable.other.scala
-        2: variable.other.scala
-    - match: '(\$){{alphaid}}'
-      scope: variable.other.scala
-      captures:
-        1: punctuation.definition.variable.scala
+    - match: '\$(?={{alphaid}})'
+      scope: punctuation.definition.variable.scala variable.other.scala
+      push:
+        - clear_scopes: 1
+        - match: '{{alphaid}}'
+          scope: variable.other.scala
+          pop: true
     - match: '\$\{'
       scope: punctuation.definition.expression.scala
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -358,7 +358,7 @@ contexts:
       captures:
         1: storage.type.volatile.scala
         2: entity.name.var.scala variable.other.readwrite.scala
-    - match: '\b(?:val)\b'
+    - match: '\bval\b'
       scope: storage.type.stable.scala
       push: val-simple-body
     - match: '\b(package)\s+(object)\s+({{id}})'
@@ -384,13 +384,13 @@ contexts:
         1: keyword.control.scala
         2: entity.name.namespace.header.scala
     # what follows is identical to case-pattern, except it goes to case-body-first
-    - match: '\b(?:case)\b(?!\s+class\b)'
+    - match: '\bcase\b(?!\s+class\b)'
       scope: keyword.other.declaration.scala
       push:
         - meta_content_scope: meta.pattern.scala
         - match: '(?=\bclass\b)'
           pop: true
-        - match: '\b(?:if)\b'
+        - match: '\bif\b'
           scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
@@ -433,11 +433,11 @@ contexts:
 
   # this exists to clear the meta_scope from first or non-first
   case-pattern:
-    - match: '\b(?:case)\b'
+    - match: '\bcase\b'
       scope: keyword.other.declaration.scala
       set:
         - meta_content_scope: meta.pattern.scala
-        - match: '\b(?:if)\b'
+        - match: '\bif\b'
           scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
@@ -623,9 +623,9 @@ contexts:
         - match: '\)'
           scope: punctuation.section.group.end.scala
           pop: true
-        - match: '\b(?:val)\b'
+        - match: '\bval\b'
           scope: storage.type.scala
-        - match: '\b(?:var)\b'
+        - match: '\bvar\b'
           scope: storage.type.volatile.scala
         - match: '({{alphaid}})(?=\s*:)'
           captures:
@@ -798,7 +798,7 @@ contexts:
       set: class-inheritance-with
 
   imports:
-    - match: \b(?:import)\b
+    - match: \bimport\b
       scope: keyword.other.import.scala
       push:
         - meta_scope: meta.import.scala
@@ -842,7 +842,7 @@ contexts:
     - match: '{{op}}'   # no explicit scope, just pulling it out
 
   initialization:
-    - match: '\b(?:new)\b'
+    - match: '\bnew\b'
       scope: keyword.other.scala
       push: initialization-body
 
@@ -873,7 +873,7 @@ contexts:
           scope: punctuation.definition.generic.end.scala
           set: initialization-term-tail
         - include: delimited-type-expression
-    - match: '\b(?:with)\b'
+    - match: '\bwith\b'
       scope: keyword.declaration.scala
       set: initialization-body-allow-newline
     - match: '{{upperid}}'
@@ -962,7 +962,7 @@ contexts:
             (?:{{nonopchar}}|_)(<-|\x{2190}|=){{nonopchar}}
           )
       push:
-        - match: '\b(?:val)\b'
+        - match: '\bval\b'
           scope: storage.type.stable.scala
         - match: <-|\x{2190}|=
           scope: keyword.operator.assignment.scala
@@ -971,13 +971,13 @@ contexts:
         - include: main
     - include: main
   for-parens-body:
-    - match: '\b(?:if)\b'
+    - match: '\bif\b'
       scope: keyword.control.flow.scala
       push: for-parens-expr
     - match: '<-|\x{2190}|='
       scope: keyword.operator.assignment.scala
       push: for-parens-expr
-    - match: '\b(?:val)\b'
+    - match: '\bval\b'
       scope: storage.type.stable.scala
     - include: pattern-match
   for-parens-expr:
@@ -994,7 +994,7 @@ contexts:
       scope: keyword.control.flow.scala
     - match: \b(?:catch|finally|try)\b
       scope: keyword.control.exception.scala
-    - match: \b(?:macro)\b
+    - match: \bmacro\b
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
@@ -1016,7 +1016,7 @@ contexts:
       scope: storage.type.scala
     - match: \bvar\b
       scope: storage.type.volatile.scala
-    - match: \b(?:package)\b
+    - match: \bpackage\b
       scope: keyword.control.scala
 
   late-operators:
@@ -1577,9 +1577,9 @@ contexts:
     # \x{03BB} = λ
     - match: '\bLambda\b|\x{03BB}'
       scope: keyword.operator.type-lambda.scala
-    - match: '\b(?:type)\b'
+    - match: '\btype\b'
       scope: keyword.other.scala
-    - match: '\b(?:with)\b'
+    - match: '\bwith\b'
       scope: keyword.declaration.scala
     - match: '[\.#]'
       scope: punctuation.accessor.scala
@@ -1606,7 +1606,7 @@ contexts:
 
   # single-type is a type expression with semicolon inference
   single-type-expression-no-function:
-    - match: '\b(?:type)\b'
+    - match: '\btype\b'
       scope: keyword.other.scala
     - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
@@ -1642,7 +1642,7 @@ contexts:
   single-type-expression:
     - match: '(?=\bif\b)'   # for pattern matching
       pop: true
-    - match: '\b(?:type)\b'
+    - match: '\btype\b'
       scope: keyword.other.scala
     - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
@@ -1712,7 +1712,7 @@ contexts:
       captures:
         1: keyword.declaration.scala
       set: single-type-expression-no-function
-    - match: '\b(?:type)\b'
+    - match: '\btype\b'
       scope: invalid.keyword.type.in-tail-position.scala
     - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
@@ -1772,7 +1772,7 @@ contexts:
       captures:
         1: keyword.declaration.scala
       set: single-type-expression
-    - match: '\b(?:type)\b'
+    - match: '\btype\b'
       scope: invalid.keyword.type.in-tail-position.scala
     - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -784,26 +784,27 @@ contexts:
         - match: ',\n'    # TODO operator scoping for , and . in imports
         - match: '(?=[\n;])'
           pop: true
-        - match: '(?:{{id}}\.)+{{id}}?'
-          scope: variable.package.scala
+        - match: '{{upperid}}'
+          scope: support.class.import.scala
         - match: '{{id}}'
-          scope: variable.import.scala
+          scope: support.type.package.scala
+        - match: \.
+          scope: punctuation.accessor.dot.scala
         - match: '_'
           scope: variable.language.underscore.scala
         - match: "{"
+          scope: punctuation.section.group.begin.scala
           push:
             - meta_scope: meta.import.selector.scala
             - match: "}"
+              scope: punctuation.section.group.end.scala
               pop: true
-            - match: '({{id}})\s*({{rightarrow}})\s*({{id}})'
-              captures:
-                1: variable.import.renamed-from.scala
-                2: keyword.operator.arrow.scala
-                3: variable.import.renamed-to.scala
             - match: '{{rightarrow}}'
               scope: keyword.operator.arrow.scala
+            - match: '{{upperid}}'
+              scope: support.class.import.scala
             - match: '{{id}}'
-              scope: variable.import.scala
+              scope: support.type.package.scala
             - match: '_'
               scope: variable.language.underscore.scala
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -803,7 +803,11 @@ contexts:
       scope: keyword.other.import.scala
       push:
         - meta_scope: meta.import.scala
-        - match: ',\n'    # TODO operator scoping for , and . in imports
+        - match: '(,)[ \t]*\n'    # TODO real newline inference
+          captures:
+            1: punctuation.separator.scala
+        - match: ','
+          scope: punctuation.separator.scala
         - match: '(?=[\n;])'
           pop: true
         - match: '{{upperid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -347,7 +347,7 @@ contexts:
     - match: '\b(var)\s+({{id}})'
       captures:
         1: storage.type.volatile.scala
-        2: entity.name.var.scala
+        2: entity.name.var.scala variable.other.readwrite.scala
     - match: '\b(val)\b'
       captures:
         1: storage.type.stable.scala
@@ -1349,7 +1349,7 @@ contexts:
         - match: (?=\S)
           pop: true
     - match: '\b{{varid}}'
-      scope: entity.name.val.scala
+      scope: entity.name.val.scala variable.other.constant.scala
     - match: \[
       push:
         - match: \]
@@ -1390,17 +1390,17 @@ contexts:
 
     # special form lookahead to prevent invalid operator ascription syntax
     - match: '(?:{{op}}|{{id}}_{{operator_character}}*):(?=\s+:|\s*=|\s*$)'
-      scope: entity.name.val.scala
+      scope: entity.name.val.scala variable.other.constant.scala
       set: val-simple-body-tail
     - match: '({{op}}|{{id}}_{{operator_character}}*)(:)(?=\s)'
       captures:
-        1: entity.name.val.scala
+        1: entity.name.val.scala variable.other.constant.scala
         2: invalid.ascription.following-operator.scala
       set: val-simple-ascription
 
     # an id followed by a type, or an =, or EOL
     - match: '{{id}}(?=\s*:{{nonopchar}}|\s*=|\s*$)'
-      scope: entity.name.val.scala
+      scope: entity.name.val.scala variable.other.constant.scala
       set: val-simple-body-tail
     - match: (?=\S)
       set:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -491,6 +491,7 @@ contexts:
     - match: '(?=\()'
       set: function-parameter-list
     - match: '\['
+      scope: punctuation.definition.generic.begin.scala
       push: function-tparams-brackets
     - match: ':'
       set: function-return-type-definition
@@ -507,9 +508,12 @@ contexts:
       set: function-type-parameter-list
 
   function-tparams-brackets:
+    - meta_scope: meta.generic.scala
     - match: '\['
+      scope: punctuation.definition.generic.begin.scala
       push: function-tparams-brackets
     - match: '\]'
+      scope: punctuation.definition.generic.end.scala
       pop: true
     - include: type-constraints
     - include: delimited-type-expression
@@ -530,8 +534,10 @@ contexts:
 
   function-parameter-list:
     - match: '\('
+      scope: punctuation.section.group.begin.scala
       push:
         - match: '\)'
+          scope: punctuation.section.group.end.scala
           pop: true
         - match: '({{alphaid}})(?=\s*:)'
           captures:
@@ -572,6 +578,7 @@ contexts:
     - match: '(?=\()'
       set: class-parameter-list
     - match: '\['
+      scope: punctuation.definition.generic.begin.scala
       push: class-tparams-brackets
     - match: '(?=\b(extends|with)\b)'
       set: class-inheritance-extends
@@ -588,9 +595,12 @@ contexts:
       set: class-type-parameter-list
 
   class-tparams-brackets:
+    - meta_scope: meta.generic.scala
     - match: '\['
+      scope: punctuation.definition.generic.begin.scala
       push: class-tparams-brackets
     - match: '\]'
+      scope: punctuation.definition.generic.end.scala
       pop: true
     - match: '\b(this|super)\b'
       scope: variable.language.scala
@@ -599,8 +609,10 @@ contexts:
 
   class-parameter-list:
     - match: '\('
+      scope: punctuation.section.group.begin.scala
       push:
         - match: '\)'
+          scope: punctuation.section.group.end.scala
           pop: true
         - match: '\b(val)\b'
           scope: storage.type.scala
@@ -905,18 +917,22 @@ contexts:
       pop: true
 
   for-comprehension:
-    - match: '\b(for)\s*\{'
+    - match: '\b(for)\s*(\{)'
       captures:
         1: keyword.control.flow.scala
+        2: punctuation.section.block.begin.scala
       push:
         - match: '\}'
+          scope: punctuation.section.block.end.scala
           pop: true
         - include: for-braces-body
-    - match: '\b(for)\s*\('
+    - match: '\b(for)\s*(\()'
       captures:
         1: keyword.control.flow.scala
+        2: punctuation.section.group.begin.scala
       push:
         - match: '\)'
+          scope: punctuation.section.group.end.scala
           pop: true
         - include: for-parens-body
   for-braces-body:
@@ -1506,18 +1522,24 @@ contexts:
 
   base-type-expression-no-function:
     - match: \(
+      scope: punctuation.definition.group.begin.scala
       push:
         - match: \)
+          scope: punctuation.definition.group.end.scala
           pop: true
         - include: delimited-type-expression
     - match: \[
+      scope: punctuation.definition.generic.begin.scala
       push:
         - match: \]
+          scope: punctuation.definition.generic.end.scala
           pop: true
         - include: delimited-type-expression
     - match: \{
+      scope: punctuation.definition.block.begin.scala
       push:
         - match: \}
+          scope: punctuation.definition.block.end.scala
           pop: true
         - include: declarations
     - match: '_\s*\*'
@@ -1589,8 +1611,10 @@ contexts:
     - match: (?=@{{plainid}})
       set: single-type-expression-tail-no-function
     - match: \(
+      scope: punctuation.definition.generic.begin.scala
       set:
         - match: \)
+          scope: punctuation.definition.generic.end.scala
           set: single-type-expression-tail-no-function
         - include: delimited-type-expression
     - include: base-type-expression-no-function
@@ -1625,8 +1649,10 @@ contexts:
     - match: (?=@{{plainid}})
       set: single-type-expression-tail
     - match: \(
+      scope: punctuation.definition.group.begin.scala
       set:
         - match: \)
+          scope: punctuation.definition.group.end.scala
           set: single-type-expression-tail
         - include: delimited-type-expression
     - include: base-type-expression
@@ -1691,8 +1717,10 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail-no-function-type-expectation
     - match: '\{'
+      scope: punctuation.definition.block.begin.scala
       set:
         - match: \}
+          scope: punctuation.definition.block.end.scala
           set: single-type-expression-tail-no-function
         - include: main
     - match: '(?=\()'
@@ -1749,8 +1777,10 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail-type-expectation
     - match: '\{'
+      scope: punctuation.definition.block.begin.scala
       set:
         - match: \}
+          scope: punctuation.definition.block.end.scala
           set: single-type-expression-tail
         - include: main
     - match: '(?=\()'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -250,10 +250,10 @@ contexts:
     - include: lambda-declaration-base
 
   base-types:
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double|Any|AnyRef|AnyVal|Nothing)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double|Any|AnyRef|AnyVal|Nothing)\b
       scope: storage.type.primitive.scala
   literal-constants:
-    - match: \b(false|null|true)\b
+    - match: \b(?:false|null|true)\b
       scope: constant.language.scala
     # TODO negation
     # source: http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#floating-point-literals
@@ -282,10 +282,10 @@ contexts:
       scope: constant.language.scala
   base-constants:
     - include: literal-constants
-    - match: \b(this|super)\b
+    - match: \b(?:this|super)\b
       scope: variable.language.scala
     # base-types with try-dispatch followup
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
       push: try-dispatch
   constants:
@@ -322,7 +322,7 @@ contexts:
         1: storage.type.function.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
-    - match: '\b(case\s+)?(class|trait|object)(?:\s+({{id}}))'
+    - match: '\b(case\s+)?(class|trait|object)(\s+({{id}}))'
       scope: meta.class.identifier.scala
       captures:
         1: storage.type.class.scala
@@ -358,9 +358,8 @@ contexts:
       captures:
         1: storage.type.volatile.scala
         2: entity.name.var.scala variable.other.readwrite.scala
-    - match: '\b(val)\b'
-      captures:
-        1: storage.type.stable.scala
+    - match: '\b(?:val)\b'
+      scope: storage.type.stable.scala
       push: val-simple-body
     - match: '\b(package)\s+(object)\s+({{id}})'
       captures:
@@ -383,15 +382,14 @@ contexts:
         1: keyword.control.scala
         2: entity.name.namespace.header.scala
     # what follows is identical to case-pattern, except it goes to case-body-first
-    - match: '\b(case)\b(?!\s+class\b)'
+    - match: '\b(?:case)\b(?!\s+class\b)'
       scope: keyword.other.declaration.scala
       push:
         - meta_content_scope: meta.pattern.scala
         - match: '(?=\bclass\b)'
           pop: true
-        - match: '\b(if)\b'
-          captures:
-            1: keyword.control.flow.scala
+        - match: '\b(?:if)\b'
+          scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
               scope: storage.type.function.arrow.case.scala
@@ -433,13 +431,12 @@ contexts:
 
   # this exists to clear the meta_scope from first or non-first
   case-pattern:
-    - match: '\b(case)\b'
+    - match: '\b(?:case)\b'
       scope: keyword.other.declaration.scala
       set:
         - meta_content_scope: meta.pattern.scala
-        - match: '\b(if)\b'
-          captures:
-            1: keyword.control.flow.scala
+        - match: '\b(?:if)\b'
+          scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
               scope: storage.type.function.arrow.case.scala
@@ -492,7 +489,7 @@ contexts:
   # this is included when a single newline is found in a declaration
   # you should never push/set this context, only include
   decl-newline-double-check:
-    - match: '(?=[\{\}\)]|\b(case|class|def|val|var|trait|object|private|protected|for|while|if|final|sealed|implicit|type|import|override)\b)'
+    - match: '(?=[\{\}\)]|\b(?:case|class|def|val|var|trait|object|private|protected|for|while|if|final|sealed|implicit|type|import|override)\b)'
       pop: true
     - match: '\n'
       pop: true
@@ -583,14 +580,14 @@ contexts:
       set: function-parameter-list
 
   class-type-parameter-list:
-    - match: '\b(private|protected)\b'
+    - match: '\b(?:private|protected)\b'
       scope: storage.modifier.access.scala
     - match: '(?=\()'
       set: class-parameter-list
     - match: '\['
       scope: punctuation.definition.generic.begin.scala
       push: class-tparams-brackets
-    - match: '(?=\b(extends|with)\b)'
+    - match: '(?=\b(?:extends|with)\b)'
       set: class-inheritance-extends
     - match: '(?=\{)'
       set: class-pre-inheritance-early-initializer
@@ -612,7 +609,7 @@ contexts:
     - match: '\]'
       scope: punctuation.definition.generic.end.scala
       pop: true
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
     - include: type-constraints
     - include: delimited-type-expression
@@ -624,9 +621,9 @@ contexts:
         - match: '\)'
           scope: punctuation.section.group.end.scala
           pop: true
-        - match: '\b(val)\b'
+        - match: '\b(?:val)\b'
           scope: storage.type.scala
-        - match: '\b(var)\b'
+        - match: '\b(?:var)\b'
           scope: storage.type.volatile.scala
         - match: '({{alphaid}})(?=\s*:)'
           captures:
@@ -648,7 +645,7 @@ contexts:
                 - match: '(?=[=])'
                   pop: true
         - include: main
-    - match: '(?=\b(extends|with)\b)'
+    - match: '(?=\b(?:extends|with)\b)'
       set: class-inheritance-extends
     - match: '(?=\{)'
       set: class-pre-inheritance-early-initializer
@@ -671,7 +668,7 @@ contexts:
           scope: punctuation.section.braces.end.scala
           pop: true
         - include: main
-    - match: '(?=\b(extends|with)\b)'
+    - match: '(?=\b(?:extends|with)\b)'
       set: class-inheritance-extends
     - match: '(?=\S)'
       pop: true
@@ -746,7 +743,7 @@ contexts:
           scope: punctuation.section.brackets.end.scala
           pop: true
         - include: delimited-type-expression
-    - match: (?=\b(with|extends)\b)
+    - match: (?=\b(?:with|extends)\b)
       set: class-inheritance-with
     - match: (?=\{)
       set: class-inheritance-early-initializer
@@ -799,7 +796,7 @@ contexts:
       set: class-inheritance-with
 
   imports:
-    - match: \b(import)\b
+    - match: \b(?:import)\b
       scope: keyword.other.import.scala
       push:
         - meta_scope: meta.import.scala
@@ -843,7 +840,7 @@ contexts:
     - match: '{{op}}'   # no explicit scope, just pulling it out
 
   initialization:
-    - match: '\b(new)\b'
+    - match: '\b(?:new)\b'
       scope: keyword.other.scala
       push: initialization-body
 
@@ -874,7 +871,7 @@ contexts:
           scope: punctuation.definition.generic.end.scala
           set: initialization-term-tail
         - include: delimited-type-expression
-    - match: '\b(with)\b'
+    - match: '\b(?:with)\b'
       scope: keyword.declaration.scala
       set: initialization-body-allow-newline
     - match: '{{upperid}}'
@@ -963,7 +960,7 @@ contexts:
             (?:{{nonopchar}}|_)(<-|\x{2190}|=){{nonopchar}}
           )
       push:
-        - match: '\b(val)\b'
+        - match: '\b(?:val)\b'
           scope: storage.type.stable.scala
         - match: <-|\x{2190}|=
           scope: keyword.operator.assignment.scala
@@ -972,13 +969,13 @@ contexts:
         - include: main
     - include: main
   for-parens-body:
-    - match: '\b(if)\b'
+    - match: '\b(?:if)\b'
       scope: keyword.control.flow.scala
       push: for-parens-expr
     - match: '<-|\x{2190}|='
       scope: keyword.operator.assignment.scala
       push: for-parens-expr
-    - match: '\b(val)\b'
+    - match: '\b(?:val)\b'
       scope: storage.type.stable.scala
     - include: pattern-match
   for-parens-expr:
@@ -989,17 +986,17 @@ contexts:
     - include: main
 
   keywords:
-    - match: \b(return|throw)\b
+    - match: \b(?:return|throw)\b
       scope: keyword.control.flow.jump.scala
-    - match: \b(else|if|do|while|for|yield|match)\b
+    - match: \b(?:else|if|do|while|for|yield|match)\b
       scope: keyword.control.flow.scala
-    - match: \b(catch|finally|try)\b
+    - match: \b(?:catch|finally|try)\b
       scope: keyword.control.exception.scala
-    - match: \b(macro)\b
+    - match: \b(?:macro)\b
       scope: keyword.other.scala
     - match: \?\?\?
       scope: keyword.other.scala
-    - match: \b(eq|ne)\b
+    - match: \b(?:eq|ne)\b
       scope: keyword.operator.word.scala
 
   late-keywords:
@@ -1017,7 +1014,7 @@ contexts:
       scope: storage.type.scala
     - match: \bvar\b
       scope: storage.type.volatile.scala
-    - match: \b(package)\b
+    - match: \b(?:package)\b
       scope: keyword.control.scala
 
   late-operators:
@@ -1048,9 +1045,9 @@ contexts:
       scope: constant.other.symbol.scala
 
   storage-modifiers:
-    - match: '\b(private\[\S+\]|protected\[\S+\]|private|protected)\b'
+    - match: '\b(?:private\[\S+\]|protected\[\S+\]|private|protected)\b'
       scope: storage.modifier.access.scala
-    - match: \b(abstract|final|lazy|sealed|implicit|override)\b
+    - match: \b(?:abstract|final|lazy|sealed|implicit|override)\b
       scope: storage.modifier.other.scala
 
   # see http://www.scala-lang.org/docu/files/ScalaReference.pdf part 1.3.5-6 (page 18)
@@ -1578,9 +1575,9 @@ contexts:
     # \x{03BB} = λ
     - match: '\bLambda\b|\x{03BB}'
       scope: keyword.operator.type-lambda.scala
-    - match: '\b(type)\b'
+    - match: '\b(?:type)\b'
       scope: keyword.other.scala
-    - match: '\b(with)\b'
+    - match: '\b(?:with)\b'
       scope: keyword.declaration.scala
     - match: '[\.#]'
       scope: punctuation.accessor.scala
@@ -1591,9 +1588,9 @@ contexts:
     # - include: scala-symbol
     # - include: strings
     - include: base-types
-    - match: '\b(forSome)\b'
+    - match: '\b(?:forSome)\b'
       scope: keyword.declaration.scala
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
     - match: '(?={{keywords}})'
       pop: true
@@ -1607,14 +1604,14 @@ contexts:
 
   # single-type is a type expression with semicolon inference
   single-type-expression-no-function:
-    - match: '\b(type)\b'
+    - match: '\b(?:type)\b'
       scope: keyword.other.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
       set: single-type-expression-tail-no-function
-    - match: '\b(forSome)\b'
+    - match: '\b(?:forSome)\b'
       scope: keyword.declaration.scala
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
       set: single-type-expression-tail-no-function
     - match: '{{upperid}}'
@@ -1643,14 +1640,14 @@ contexts:
   single-type-expression:
     - match: '(?=\bif\b)'   # for pattern matching
       pop: true
-    - match: '\b(type)\b'
+    - match: '\b(?:type)\b'
       scope: keyword.other.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
       set: single-type-expression-tail
-    - match: '\b(forSome)\b'
+    - match: '\b(?:forSome)\b'
       scope: keyword.declaration.scala
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
       set: single-type-expression-tail
     - match: '{{upperid}}'
@@ -1713,14 +1710,14 @@ contexts:
       captures:
         1: keyword.declaration.scala
       set: single-type-expression-no-function
-    - match: '\b(type)\b'
+    - match: '\b(?:type)\b'
       scope: invalid.keyword.type.in-tail-position.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
       set: single-type-expression-tail-no-function-type-expectation
-    - match: '\b(forSome)\b'
+    - match: '\b(?:forSome)\b'
       scope: keyword.declaration.scala
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
       set: single-type-expression-tail-no-function-type-expectation
     - match: '{{upperid}}'
@@ -1773,14 +1770,14 @@ contexts:
       captures:
         1: keyword.declaration.scala
       set: single-type-expression
-    - match: '\b(type)\b'
+    - match: '\b(?:type)\b'
       scope: invalid.keyword.type.in-tail-position.scala
-    - match: \b(Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
+    - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double)\b
       scope: storage.type.primitive.scala
       set: single-type-expression-tail-type-expectation
-    - match: '\b(forSome)\b'
+    - match: '\b(?:forSome)\b'
       scope: keyword.declaration.scala
-    - match: '\b(this|super)\b'
+    - match: '\b(?:this|super)\b'
       scope: variable.language.scala
       set: single-type-expression-tail-type-expectation
     - match: '{{upperid}}'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -715,10 +715,10 @@ contexts:
       scope: entity.other.inherited-class.scala
       set: class-inheritance-extends-token-after
     - match: \(
-      scope: punctuation.section.parens.begin.scala
+      scope: punctuation.definition.parens.begin.scala
       set:
         - match: \)
-          scope: punctuation.section.parens.end.scala
+          scope: punctuation.definition.parens.end.scala
           set: class-inheritance-with
         - include: delimited-type-expression
     - match: '\n'
@@ -732,6 +732,7 @@ contexts:
       set: class-inheritance-extends-token
 
   class-inheritance-extends-token-after:
+    # we don't use punctuation.definition here because it's not part of the type anymore
     - match: \(
       scope: punctuation.section.parens.begin.scala
       push:
@@ -740,10 +741,10 @@ contexts:
           pop: true
         - include: main
     - match: \[
-      scope: punctuation.section.brackets.begin.scala
+      scope: punctuation.definition.generic.begin.scala
       push:
         - match: \]
-          scope: punctuation.section.brackets.end.scala
+          scope: punctuation.definition.generic.end.scala
           pop: true
         - include: delimited-type-expression
     - match: (?=\b(?:with|extends)\b)

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -217,8 +217,10 @@ contexts:
         - include: lambda-declaration
   lambda-declaration-base:
     - match: \(
+      scope: punctuation.section.group.begin.scala
       push:
         - match: \)
+          scope: punctuation.section.group.end.scala
           pop: true
         - include: lambda-declaration-parens
     - match: '{{id}}'
@@ -297,13 +299,18 @@ contexts:
       push: try-dispatch
   try-dispatch:
     - match: '\('
+      scope: punctuation.section.group.begin.scala
       push:
         - match: \)
+          scope: punctuation.section.group.end.scala
           pop: true
         - include: main
     - match: '\['
+      scope: punctuation.definition.generic.begin.scala
       push:
+        - meta_scope: meta.generic.scala
         - match: \]
+          scope: punctuation.definition.generic.end.scala
           pop: true
         - include: delimited-type-expression
     - match: '(?=[\S\n;])'
@@ -330,8 +337,11 @@ contexts:
         - match: '(?=[\n;\}\)\]])'
           pop: true
         - match: '\['
+          scope: punctuation.definition.generic.begin.scala
           push:
+            - meta_scope: meta.generic.scala
             - match: '\]'
+              scope: punctuation.definition.generic.end.scala
               pop: true
             - include: type-constraints
             - include: delimited-type-expression
@@ -1582,6 +1592,7 @@ contexts:
     - match: '{{upperid}}'
       scope: support.class.scala
     - match: _
+      scope: variable.language.underscore.scala
     - match: '{{typeid}}'
       scope: support.type.scala
     - include: base-type-expression

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -834,6 +834,8 @@ contexts:
   # it would be incorrect to scope operators specially, since they are just identifiers
   # by pulling them out HERE though and refusing to scope them, we emulate lookbehind
   operators:
+    - match: ;
+      scope: punctuation.terminator.scala
     - match: '{{op}}(?=[\(\[])'   # no explicit scope, just pulling it out
       push: try-dispatch
     - match: '{{op}}'   # no explicit scope, just pulling it out
@@ -1531,6 +1533,9 @@ contexts:
         - include: nested-pattern-match
 
   base-type-expression-no-function:
+    - match: ;
+      scope: punctuation.terminator.scala
+      pop: true
     - match: \(
       scope: punctuation.definition.group.begin.scala
       push:

--- a/Scala/Symbols-val.tmPreferences
+++ b/Scala/Symbols-val.tmPreferences
@@ -4,7 +4,7 @@
   <key>name</key>
   <string>Symbols (val)</string>
   <key>scope</key>
-  <string>source.scala entity.name.val</string>
+  <string>source.scala variable.other.constant</string>
   <key>settings</key>
   <dict>
     <key>showInSymbolList</key>

--- a/Scala/Symbols-var.tmPreferences
+++ b/Scala/Symbols-var.tmPreferences
@@ -4,7 +4,7 @@
   <key>name</key>
   <string>Symbols (var)</string>
   <key>scope</key>
-  <string>source.scala entity.name.var</string>
+  <string>source.scala variable.other.readwrite</string>
   <key>settings</key>
   <dict>
     <key>showInSymbolList</key>

--- a/Scala/Symbols.tmPreferences
+++ b/Scala/Symbols.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala entity.name.val, source.scala entity.name.type, source.scala entity.name.namespace.scoped</string>
+	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala variable.other.constant, source.scala entity.name.type, source.scala entity.name.namespace.scoped</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>

--- a/Scala/Symbols.tmPreferences
+++ b/Scala/Symbols.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala variable.other.constant, source.scala entity.name.type, source.scala entity.name.namespace.scoped</string>
+	<string>source.scala entity.name.function, source.scala entity.name.class, source.scala variable.other.constant, source.scala variable.other.readwrite, source.scala entity.name.type, source.scala entity.name.namespace.scoped</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -945,6 +945,9 @@ import foo
 // <- meta.import.scala
 //     ^^^ support.type.package.scala
 
+import foo, bar
+//        ^ punctuation.separator.scala
+
 import foo; import bar
 //     ^^^ support.type.package.scala
 //          ^^^^^^ keyword.other.import.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -149,7 +149,9 @@ object Foo
 
   type Foo[A, B, C] = Bar
 //         ^ support.class
+//          ^ punctuation.separator.scala
 //            ^ support.class
+//             ^ punctuation.separator.scala
 //               ^ support.class
 //                  ^ keyword.operator.assignment.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -87,6 +87,8 @@ def foo(a: Int, b: Bar): Baz = 42
 
    def foo(implicit bar: Int): Unit
 //         ^^^^^^^^ storage.modifier.other
+//                     ^ punctuation.ascription.scala
+//                           ^ punctuation.ascription.scala
 
    val foo: Unit; 42
 // ^^^ storage.type.stable.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -624,7 +624,10 @@ type Foo = Bar[A] forSome { type A }
      back <- Traverse[Option]
 //   ^^^^ variable.parameter
 //           ^^^^^^^^ support.constant
+//                   ^^^^^^^^ meta.generic.scala
+//                   ^ punctuation.definition.generic.begin.scala
 //                    ^^^^^^ support.class
+//                          ^ punctuation.definition.generic.end.scala
        .traverse[Free, Stuff](res) { r => }
 //      ^^^^^^^^ - entity.name
 //                            ^^^ - entity.name
@@ -635,14 +638,16 @@ type Foo = Bar[A] forSome { type A }
   val baseSettings: Seq[Def.Setting[_]] = _
 //    ^^^^^^^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                  ^^^ support.class
-//                                  ^ - keyword
+//                                  ^ variable.language.underscore.scala - keyword
 
   for {
     r <- blah
   } yield r.copy(foo = a)
 //        ^ - entity.name
 //          ^^^^ - entity.name
+//              ^ punctuation.section.group.begin.scala
 //               ^^^ - entity.name
+//                      ^ punctuation.section.group.end.scala
 
   {
     case foo.Bar => 42
@@ -783,8 +788,10 @@ type Foo >: Bar
 //   ^ variable.parameter
 
    { (a, b) => ??? }
-//    ^ variable.parameter
-//       ^ variable.parameter
+//   ^ punctuation.section.group.begin.scala
+//    ^ variable.parameter.scala
+//       ^ variable.parameter.scala
+//        ^ punctuation.section.group.end.scala
 
    { a: Int => ??? }
 //   ^ variable.parameter
@@ -1683,7 +1690,9 @@ new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
 
 type =?>[A] = Any
 //   ^^^ entity.name.type.scala
-
+//      ^^^ meta.generic.scala
+//      ^ punctuation.definition.generic.begin.scala
+//        ^ punctuation.definition.generic.end.scala
   val x: Foo @> Bar
 //           ^^ support.type.scala
 

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1315,8 +1315,15 @@ def foo(a: String*, b: (Int => String)*, c: Int*): Negative*
 //                                             ^ keyword.operator.varargs.scala
 //                                                         ^ support.type.scala - keyword
 
-def foo(a: Int * String): Unit
-//             ^ support.type.scala - keyword
+def foo[A[_] <: B](a: Int * String): Unit
+//     ^ punctuation.definition.generic.begin.scala
+//       ^ punctuation.definition.generic.begin.scala
+//         ^ punctuation.definition.generic.end.scala
+//               ^ punctuation.definition.generic.end.scala
+//     ^^^^^^^^^^^ meta.generic.scala
+//                ^ punctuation.section.group.begin.scala
+//                                ^ punctuation.section.group.end.scala
+//                        ^ support.type.scala - keyword
 
 class Foo(a: String*)
 //                 ^ keyword.operator.varargs.scala
@@ -1335,6 +1342,7 @@ trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 @deprecated("Use D", "1.0") class C { ... }
 // <- meta.annotation
 // ^^ variable.annotation
+//         ^ meta.annotation.parameters.scala punctuation.section.arguments.annotation.begin.scala
 //            ^^ string
 //                        ^ meta.annotation
 //                         ^ - meta.annotation
@@ -1618,10 +1626,18 @@ new Monad[Catenable] with Traverse
 //                        ^^^^^^^^ support.class.scala
 
    final class A
-   final class B
+   final class B[A[_] <: B](a: B)
 // ^^^^^ storage.modifier.other.scala
 //       ^^^^^ storage.type.class.scala
 //             ^ entity.name.class.scala
+//              ^^^^^^^^^^^ meta.generic.scala
+//              ^ punctuation.definition.generic.begin.scala
+//                ^ punctuation.definition.generic.begin.scala
+//                  ^ punctuation.definition.generic.end.scala
+//                    ^^ keyword.operator.bound.scala
+//                        ^ punctuation.definition.generic.end.scala
+//                         ^ punctuation.section.group.begin.scala
+//                              ^ punctuation.section.group.end.scala
 
 abc match {
   case $foo(bar) => ()
@@ -1712,8 +1728,10 @@ import scalaz._
 // ^^^^^^ support.constant.scala
 
    for {
+//     ^ punctuation.section.block.begin.scala
        _ <_
    } yield true
+// ^ punctuation.section.block.end.scala
 //   ^^^^^ keyword.control.flow.scala
 
    x: ResourceError \/ Resource
@@ -1724,6 +1742,16 @@ import scalaz._
    type TS1 = trans.TransSpec1
    import library._
 // ^^^^^^ - support.type
+
+  type Foo = Thing { val a: Int }
+  //               ^ punctuation.definition.block.begin.scala
+  //                            ^ punctuation.definition.block.end.scala
+
+  type Foo = (Bar op (Baz))
+  //         ^ punctuation.definition.group.begin.scala
+  //                 ^ punctuation.definition.group.begin.scala
+  //                     ^ punctuation.definition.group.end.scala
+  //                      ^ punctuation.definition.group.end.scala
 
    def identity: CFId
    override final def equals(other: Any): Boolean
@@ -1739,6 +1767,7 @@ import scalaz._
 //               ^^^^^ variable.language.scala
 
 a match {
+//      ^ punctuation.section.block.begin.scala
   case x: b if Foo =>
 //          ^^ keyword.control.flow.scala
 //             ^^^ support.constant.scala
@@ -1830,12 +1859,14 @@ for {
 }
 
 for (_<- fu; _← fu; _= fu)
+//  ^ punctuation.section.group.begin.scala
 //   ^ variable.language.underscore.scala
 //    ^^ keyword.operator.assignment.scala
 //           ^ variable.language.underscore.scala
 //            ^ keyword.operator.assignment.scala
 //                  ^ variable.language.underscore.scala
 //                   ^ keyword.operator.assignment.scala
+//                       ^ punctuation.section.group.end.scala
 
    raw"foo\nbar\rbaz"
 // ^^^ string.quoted.raw.interpolated.scala support.function.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -994,8 +994,8 @@ for {} yield ()
 foo: m.type
 //     ^^^^ keyword.other.scala
 
-   ==
-// ^^ - keyword
+   ===
+// ^^^ - keyword
 
 offset >= 0
 //     ^^ - keyword
@@ -1069,10 +1069,10 @@ val (foo, bar) = ???
 //      ^ punctuation.separator.scala
 
 foo eq bar
-//  ^^ keyword.operator.word.scala
+//  ^^ keyword.operator.comparison.scala
 
 foo ne bar
-//  ^^ keyword.operator.word.scala
+//  ^^ keyword.operator.comparison.scala
 
 new Config()
 //        ^^ - constant
@@ -2116,3 +2116,15 @@ val (firstA :: firstB :: Nil) :: (secondA :: secondB :: Nil) :: Nil = results
    42d
 // ^^^ constant.numeric.float.scala
 //   ^ storage.type.numeric.scala
+
+foo == bar
+//  ^^ keyword.operator.comparison.scala
+
+foo != bar
+//  ^^ keyword.operator.comparison.scala
+
+foo eq bar
+//  ^^ keyword.operator.comparison.scala
+
+foo ne bar
+//  ^^ keyword.operator.comparison.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -24,10 +24,11 @@ def foo: Baz = 42
 //           ^ keyword.operator.assignment.scala
 //             ^^ constant.numeric.integer.scala
 
-def foo: Baz => Bar = 42
+def foo: Baz => Bar = 42;
 //       ^^^ support.class
 //              ^^^ support.class
 //                  ^ keyword.operator.assignment.scala
+//                      ^ punctuation.terminator.scala
 
 
 def foo(a: Int, b: Bar): Baz = 42
@@ -84,10 +85,12 @@ def foo(a: Int, b: Bar): Baz = 42
    def foo(implicit bar: Int): Unit
 //         ^^^^^^^^ storage.modifier.other
 
-   val foo: Unit
+   val foo: Unit; 42
 // ^^^ storage.type.stable.scala
 //     ^^^ entity.name.val
 //          ^^^^ storage.type.primitive.scala
+//              ^ punctuation.terminator.scala
+//                ^^ constant.numeric.integer.scala
 
    var foo: Unit
 // ^^^ storage.type.volatile.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -264,7 +264,7 @@ type Foo = Bar[A] forSome { type A }
 
    f"formatted: x: $x%+,.3f ca"
 // ^ support.function
-//                  ^ variable.other.scala
+//                  ^ variable.other.scala - string
 //                   ^^^^^^ constant.other.formatting.scala
 
    f"formatted: date: $x%T "
@@ -1710,14 +1710,8 @@ val x: = 42
    IO
 // ^^ support.constant.scala
 
-val foo' = 42
-//  ^^^^ entity.name.val.scala variable.other.constant.scala
-
-val foo'' = 42
-//  ^^^^^ entity.name.val.scala variable.other.constant.scala
-
-def foo' = ()
-//  ^^^^ entity.name.function.scala
+val a' = 42
+//   ^ - entity.name
 
 val ' = 42
 //  ^ - entity.name

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -16,8 +16,6 @@ package fubar {
 import fubar.{Unit, Foo}
 // ^^^ keyword.other.import
 // <- meta.import.scala
-//     ^^^^^ support.type.package.scala
-//            ^^^^ support.class.import.scala
 //                ^ punctuation.separator.scala
 
 def foo: Baz = 42
@@ -943,36 +941,27 @@ class Foo(a: A :: B)
 
 import foo
 // <- meta.import.scala
-//     ^^^ support.type.package.scala
 
 import foo, bar
 //        ^ punctuation.separator.scala
 
 import foo; import bar
-//     ^^^ support.type.package.scala
+//        ^ punctuation.terminator.scala
 //          ^^^^^^ keyword.other.import.scala
-//                 ^^^ support.type.package.scala
 
 import foo.bar
-//     ^^^ support.type.package.scala
 //        ^ punctuation.accessor.dot.scala
-//         ^^^ support.type.package.scala
 
 import foo.{bar, bar => baz, bar=>baz}
 //         ^^^^^^^^^^^^^^^^^ meta.import.selector.scala
-//          ^^^ support.type.package.scala
-//               ^^^ support.type.package.scala
 //                   ^^ keyword.operator.arrow.scala
-//                      ^^^ support.type.package.scala
-//                           ^^^ support.type.package.scala
 //                              ^^ keyword.operator.arrow.scala
-//                                ^^^ support.type.package.scala
 
 
 import foo.{
    bar => bin
-// ^^^ support.type.package.scala
-//        ^^^ support.type.package.scala
+// ^^^ meta.import.scala
+//        ^^^ meta.import.scala
 }
 
 import foo._
@@ -1551,7 +1540,6 @@ var foo: Thing =42
 class Foo extends Bar with {
    import Thing._
 // ^^^^^^ keyword.other.import.scala
-//        ^^^^^ support.class.import.scala
 }
 
 class Foo extends Bar.Baz with bin.Baz
@@ -1740,11 +1728,11 @@ type Foo = Monad[Lambda[α => OptionT[IO, α]]]
 
 import scalaz._,
    Scalaz._
-// ^^^^^^ meta.import.scala support.class.import.scala
+// ^^^^^^ meta.import.scala
 
 import scalaz._
    Scalaz._
-// ^^^^^^ support.constant.scala
+// ^^^^^^ support.constant.scala - meta.import
 
    for {
 //     ^ punctuation.section.block.begin.scala
@@ -1966,7 +1954,7 @@ s"testing '$foo' bar"
    new DataCodec {
      import PreciseKeys._
 //   ^^^^^^ meta.import.scala keyword.other.import.scala
-//          ^^^^^^^^^^^ meta.import.scala support.class.import.scala
+//          ^^^^^^^^^^^ meta.import.scala
 //                     ^ meta.import.scala punctuation.accessor.dot.scala
 //                      ^ meta.import.scala variable.language.underscore.scala
    } foo

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -8,8 +8,10 @@ package fubar
 package fubar {
 // ^^^^ keyword.control.scala
 //      ^^^^^ entity.name.namespace.scoped.scala
+//            ^ punctuation.section.block.begin.scala
 // <- meta.namespace.scala
-}
+   }
+// ^ punctuation.section.block.end.scala
 
 import fubar.{Unit, Foo}
 // ^^^ keyword.other.import

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -91,7 +91,7 @@ def foo(a: Int, b: Bar): Baz = 42
 
    var foo: Unit
 // ^^^ storage.type.volatile.scala
-//     ^^^ entity.name.var
+//     ^^^ entity.name.var variable.other.readwrite.scala
 //          ^^^^ storage.type.primitive.scala
 
    class Foo[A](a: Bar) extends Baz with Bin
@@ -633,7 +633,7 @@ type Foo = Bar[A] forSome { type A }
 
 
   val baseSettings: Seq[Def.Setting[_]] = _
-//    ^^^^^^^^^^^^ entity.name.val.scala
+//    ^^^^^^^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                  ^^^ support.class
 //                                  ^ - keyword
 
@@ -665,30 +665,30 @@ type Foo = Bar[A] forSome { type A }
 //        ^^^ support.type.scala
 
    val foo_::: abc
-//     ^^^^^^ entity.name.val.scala
+//     ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //           ^ invalid.ascription.following-operator.scala
 
    val ::: abc
 //       ^ invalid.ascription.following-operator.scala
 
    val :: : abc
-//     ^^ entity.name.val.scala
+//     ^^ entity.name.val.scala variable.other.constant.scala
 //        ^ - invalid
 
   val foo_:::: = 42
-//    ^^^^^^^^ entity.name.val.scala
+//    ^^^^^^^^ entity.name.val.scala variable.other.constant.scala
 //           ^ - invalid
 
   val :::: = 42
-//    ^^^^ entity.name.val.scala
+//    ^^^^ entity.name.val.scala variable.other.constant.scala
 //       ^ - invalid
 
    val foo_: : abc
-//     ^^^^^ entity.name.val.scala
+//     ^^^^^ entity.name.val.scala variable.other.constant.scala
 //         ^ - invalid
 //           ^ - invalid
    val foo_:: : abc
-//     ^^^^^^ entity.name.val.scala
+//     ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //          ^ - invalid
 //            ^ - invalid
 
@@ -1058,7 +1058,7 @@ new Config()
 //        ^^ - constant
 
 val A: Foo = stuff
-//  ^ entity.name.val.scala
+//  ^ entity.name.val.scala variable.other.constant.scala
 
 type Maybe[A] = { type Inner = A; def x: Int }
 //                                ^^ storage.type.function.scala
@@ -1115,8 +1115,8 @@ xs: Foo with Bar
 }
 
 val Stuff(thing, other) = ???
-//        ^^^^^ entity.name.val.scala
-//               ^^^^^ entity.name.val.scala
+//        ^^^^^ entity.name.val.scala variable.other.constant.scala
+//               ^^^^^ entity.name.val.scala variable.other.constant.scala
 
    x: List[Int] => ()
 // ^ variable.parameter.scala
@@ -1548,9 +1548,9 @@ final case class
 }
 
   val ~ = 42
-//    ^ entity.name.val.scala
+//    ^ entity.name.val.scala variable.other.constant.scala
   val \/- = 42
-//    ^^^ entity.name.val.scala
+//    ^^^ entity.name.val.scala variable.other.constant.scala
 
 type ~[+A] = A
 //     ^ keyword.operator
@@ -1699,10 +1699,10 @@ val x: = 42
 // ^^ support.constant.scala
 
 val foo' = 42
-//  ^^^^ entity.name.val.scala
+//  ^^^^ entity.name.val.scala variable.other.constant.scala
 
 val foo'' = 42
-//  ^^^^^ entity.name.val.scala
+//  ^^^^^ entity.name.val.scala variable.other.constant.scala
 
 def foo' = ()
 //  ^^^^ entity.name.function.scala
@@ -1796,14 +1796,14 @@ tail: _ *
 
     val Message(
       Address(from),
-//            ^^^^ entity.name.val.scala
+//            ^^^^ entity.name.val.scala variable.other.constant.scala
       Address(to),
-//            ^^ entity.name.val.scala
+//            ^^ entity.name.val.scala variable.other.constant.scala
       subject,
-//    ^^^^^^^ entity.name.val.scala
+//    ^^^^^^^ entity.name.val.scala variable.other.constant.scala
       Content(tpe, value)) = m
-//            ^^^ entity.name.val.scala
-//                 ^^^^^ entity.name.val.scala
+//            ^^^ entity.name.val.scala variable.other.constant.scala
+//                 ^^^^^ entity.name.val.scala variable.other.constant.scala
 
 {
   case Foo() =>
@@ -1962,7 +1962,7 @@ type Foo = (Bar, Baz) => Result
   case _: NumberFormatException =>
     val col = foo
 //  ^^^ storage.type.stable.scala
-//      ^^^ entity.name.val.scala
+//      ^^^ entity.name.val.scala variable.other.constant.scala
 //          ^ keyword.operator.assignment.scala
   case _: (NumberFormatException => Bar) => Bar
   //                                ^^^ support.class.scala
@@ -2025,21 +2025,21 @@ class Foo(bar: Baz)
 //           ^ punctuation.ascription.scala
 
 val firstA :: firstB :: Nil = results
-//  ^^^^^^ entity.name.val.scala
+//  ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //         ^^ - entity
-//            ^^^^^^ entity.name.val.scala
+//            ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                   ^^ - entity
 //                      ^^^ support.constant.scala - entity
 
 val (firstA :: firstB :: Nil) :: (secondA :: secondB :: Nil) :: Nil = results
-//   ^^^^^^ entity.name.val.scala
+//   ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //          ^^ - entity
-//             ^^^^^^ entity.name.val.scala
+//             ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                    ^^ - entity
 //                       ^^^ support.constant.scala - entity
-//                                ^^^^^^^ entity.name.val.scala
+//                                ^^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                                        ^^ - entity
-//                                            ^^^^^^ entity.name.val.scala
+//                                            ^^^^^^ entity.name.val.scala variable.other.constant.scala
 //                                                      ^^^ support.constant.scala - entity
 //                                                           ^^ - entity
 //                                                              ^^^ support.constant.scala - entity

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1325,17 +1325,17 @@ def foo(a: String*, b: (Int => String)*, c: Int*): Negative*
 //               ^ keyword.operator.varargs.scala
 //                                    ^ keyword.operator.varargs.scala
 //                                             ^ keyword.operator.varargs.scala
-//                                                         ^ support.type.scala - keyword
+//                                                         ^ - support
 
-def foo[A[_] <: B](a: Int * String): Unit
+def foo[A[_] <: B](a: Int + String): Unit
 //     ^ punctuation.definition.generic.begin.scala
 //       ^ punctuation.definition.generic.begin.scala
 //         ^ punctuation.definition.generic.end.scala
 //               ^ punctuation.definition.generic.end.scala
 //     ^^^^^^^^^^^ meta.generic.scala
 //                ^ punctuation.section.group.begin.scala
-//                                ^ punctuation.section.group.end.scala
 //                        ^ support.type.scala - keyword
+//                                ^ punctuation.section.group.end.scala
 
 class Foo(a: String*)
 //                 ^ keyword.operator.varargs.scala
@@ -1719,7 +1719,10 @@ val ' = 42
 //  ^ - entity.name
 
 type Foo = Monad[OptionT[IO, ?]]
-//                           ^ variable.language.qmark.scala
+//                           ^ variable.language.hole.scala
+
+type Foo = Monad[OptionT[IO, *]]
+//                           ^ variable.language.hole.scala
 
 type Foo = Monad[λ[α => OptionT[IO, α]]]
 //               ^ keyword.operator.type-lambda.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -92,14 +92,14 @@ def foo(a: Int, b: Bar): Baz = 42
 
    val foo: Unit; 42
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.val
+//     ^^^ variable.other.constant.scala
 //          ^^^^ storage.type.primitive.scala
 //              ^ punctuation.terminator.scala
 //                ^^ constant.numeric.integer.scala
 
    var foo: Unit
 // ^^^ storage.type.volatile.scala
-//     ^^^ entity.name.var variable.other.readwrite.scala
+//     ^^^ variable.other.readwrite.scala
 //          ^^^^ storage.type.primitive.scala
 
    class Foo[A](a: Bar) extends Baz with Bin
@@ -514,7 +514,7 @@ type Foo = Bar[A] forSome { type A }
 
    val abc @ `abc`
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.val
+//     ^^^ variable.other.constant.scala
 //         ^ keyword.operator.at.scala
 //           ^ punctuation.definition.identifier.scala
 //               ^ punctuation.definition.identifier.scala
@@ -525,7 +525,7 @@ type Foo = Bar[A] forSome { type A }
 
    val ble @ `abc` = _
 // ^^^ storage.type.stable.scala
-//     ^^^ entity.name.val
+//     ^^^ variable.other.constant.scala
 //         ^ keyword.operator.at.scala
 //           ^^^^^ - entity.name
 //                 ^ keyword.operator.assignment.scala
@@ -646,17 +646,17 @@ type Foo = Bar[A] forSome { type A }
 
 
   val baseSettings: Seq[Def.Setting[_]] = _
-//    ^^^^^^^^^^^^ entity.name.val.scala variable.other.constant.scala
+//    ^^^^^^^^^^^^ variable.other.constant.scala
 //                  ^^^ support.class
 //                                  ^ variable.language.underscore.scala - keyword
 
   for {
     r <- blah
   } yield r.copy(foo = a)
-//        ^ - entity.name
-//          ^^^^ - entity.name
+//        ^ - variable
+//          ^^^^ - variable
 //              ^ punctuation.section.group.begin.scala
-//               ^^^ - entity.name
+//               ^^^ - variable
 //                      ^ punctuation.section.group.end.scala
 
   {
@@ -669,52 +669,52 @@ type Foo = Bar[A] forSome { type A }
   }
 
    val Foo = 42
-//     ^^^ entity.name.val
+//     ^^^ variable.other.constant.scala
 
    val * = 42
-//     ^ entity.name.val
+//     ^ variable.other.constant.scala
 
    val *: abc = 42
-//     ^ entity.name.val
+//     ^ variable.other.constant.scala
 //      ^ invalid.ascription.following-operator.scala
 //        ^^^ support.type.scala
 
    val foo_::: abc
-//     ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//     ^^^^^^ variable.other.constant.scala
 //           ^ invalid.ascription.following-operator.scala
 
    val ::: abc
 //       ^ invalid.ascription.following-operator.scala
 
    val :: : abc
-//     ^^ entity.name.val.scala variable.other.constant.scala
-//        ^ - invalid
+//     ^^ variable.other.constant.scala
+//        ^ punctuation.ascription.scala - invalid
 
   val foo_:::: = 42
-//    ^^^^^^^^ entity.name.val.scala variable.other.constant.scala
+//    ^^^^^^^^ variable.other.constant.scala
 //           ^ - invalid
 
   val :::: = 42
-//    ^^^^ entity.name.val.scala variable.other.constant.scala
+//    ^^^^ variable.other.constant.scala
 //       ^ - invalid
 
    val foo_: : abc
-//     ^^^^^ entity.name.val.scala variable.other.constant.scala
+//     ^^^^^ variable.other.constant.scala
 //         ^ - invalid
 //           ^ - invalid
    val foo_:: : abc
-//     ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//     ^^^^^^ variable.other.constant.scala
 //          ^ - invalid
 //            ^ - invalid
 
    val * : abc = 42
-//     ^ entity.name.val
+//     ^ variable.other.constant.scala
 //       ^ punctuation.ascription.scala - invalid
 //         ^^^ support.type.scala
 
    val (Foo, x) = 42
 //      ^^^ support.constant.scala
-//           ^ entity.name.val
+//           ^ variable.other.constant.scala
 
 {
   Set[Foo[A, A] forSome { type A }, A]
@@ -1006,7 +1006,7 @@ offset >= 0
 }
 
 val chunk #: h = ???
-//           ^ entity.name.val
+//           ^ variable.other.constant.scala
 
 for {
   if things >= stuff
@@ -1078,7 +1078,7 @@ new Config()
 //        ^^ - constant
 
 val A: Foo = stuff
-//  ^ entity.name.val.scala variable.other.constant.scala
+//  ^ variable.other.constant.scala
 
 type Maybe[A] = { type Inner = A; def x: Int }
 //                                ^^ storage.type.function.scala
@@ -1135,8 +1135,8 @@ xs: Foo with Bar
 }
 
 val Stuff(thing, other) = ???
-//        ^^^^^ entity.name.val.scala variable.other.constant.scala
-//               ^^^^^ entity.name.val.scala variable.other.constant.scala
+//        ^^^^^ variable.other.constant.scala
+//               ^^^^^ variable.other.constant.scala
 
    x: List[Int] => ()
 // ^ variable.parameter.scala
@@ -1568,9 +1568,9 @@ final case class
 }
 
   val ~ = 42
-//    ^ entity.name.val.scala variable.other.constant.scala
+//    ^ variable.other.constant.scala
   val \/- = 42
-//    ^^^ entity.name.val.scala variable.other.constant.scala
+//    ^^^ variable.other.constant.scala
 
 type ~[+A] = A
 //     ^ keyword.operator
@@ -1815,14 +1815,14 @@ tail: _ *
 
     val Message(
       Address(from),
-//            ^^^^ entity.name.val.scala variable.other.constant.scala
+//            ^^^^ variable.other.constant.scala
       Address(to),
-//            ^^ entity.name.val.scala variable.other.constant.scala
+//            ^^ variable.other.constant.scala
       subject,
-//    ^^^^^^^ entity.name.val.scala variable.other.constant.scala
+//    ^^^^^^^ variable.other.constant.scala
       Content(tpe, value)) = m
-//            ^^^ entity.name.val.scala variable.other.constant.scala
-//                 ^^^^^ entity.name.val.scala variable.other.constant.scala
+//            ^^^ variable.other.constant.scala
+//                 ^^^^^ variable.other.constant.scala
 
 {
   case Foo() =>
@@ -1981,7 +1981,7 @@ type Foo = (Bar, Baz) => Result
   case _: NumberFormatException =>
     val col = foo
 //  ^^^ storage.type.stable.scala
-//      ^^^ entity.name.val.scala variable.other.constant.scala
+//      ^^^ variable.other.constant.scala
 //          ^ keyword.operator.assignment.scala
   case _: (NumberFormatException => Bar) => Bar
   //                                ^^^ support.class.scala
@@ -2044,21 +2044,21 @@ class Foo(bar: Baz)
 //           ^ punctuation.ascription.scala
 
 val firstA :: firstB :: Nil = results
-//  ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//  ^^^^^^ variable.other.constant.scala
 //         ^^ - entity
-//            ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//            ^^^^^^ variable.other.constant.scala
 //                   ^^ - entity
 //                      ^^^ support.constant.scala - entity
 
 val (firstA :: firstB :: Nil) :: (secondA :: secondB :: Nil) :: Nil = results
-//   ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//   ^^^^^^ variable.other.constant.scala
 //          ^^ - entity
-//             ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//             ^^^^^^ variable.other.constant.scala
 //                    ^^ - entity
 //                       ^^^ support.constant.scala - entity
-//                                ^^^^^^^ entity.name.val.scala variable.other.constant.scala
+//                                ^^^^^^^ variable.other.constant.scala
 //                                        ^^ - entity
-//                                            ^^^^^^ entity.name.val.scala variable.other.constant.scala
+//                                            ^^^^^^ variable.other.constant.scala
 //                                                      ^^^ support.constant.scala - entity
 //                                                           ^^ - entity
 //                                                              ^^^ support.constant.scala - entity

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1469,12 +1469,12 @@ class Foo extends Bar(42)
 //                      ^ punctuation.section.parens.end.scala
 
 class Foo extends (Int => String)
-//                ^ punctuation.section.parens.begin.scala
-//                              ^ punctuation.section.parens.end.scala
+//                ^ punctuation.definition.parens.begin.scala
+//                              ^ punctuation.definition.parens.end.scala
 
 class Foo extends Bar[Int]
-//                   ^ punctuation.section.brackets.begin.scala
-//                       ^ punctuation.section.brackets.end.scala
+//                   ^ punctuation.definition.generic.begin.scala
+//                       ^ punctuation.definition.generic.end.scala
 
    object Underscore_
 // ^^^^^^ storage.type.class.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -14,8 +14,8 @@ package fubar {
 import fubar.{Unit, Foo}
 // ^^^ keyword.other.import
 // <- meta.import.scala
-//     ^^^^^ variable.package.scala
-//            ^^^^ variable.import.scala
+//     ^^^^^ support.type.package.scala
+//            ^^^^ support.class.import.scala
 
 def foo: Baz = 42
 //^ storage.type.function.scala
@@ -926,31 +926,33 @@ class Foo(a: A :: B)
 
 import foo
 // <- meta.import.scala
-//     ^^^ variable.import.scala
+//     ^^^ support.type.package.scala
 
 import foo; import bar
-//     ^^^ variable.import.scala
+//     ^^^ support.type.package.scala
 //          ^^^^^^ keyword.other.import.scala
-//                 ^^^ variable.import.scala
+//                 ^^^ support.type.package.scala
 
 import foo.bar
-//     ^^^^^^^ variable.package.scala
+//     ^^^ support.type.package.scala
+//        ^ punctuation.accessor.dot.scala
+//         ^^^ support.type.package.scala
 
 import foo.{bar, bar => baz, bar=>baz}
 //         ^^^^^^^^^^^^^^^^^ meta.import.selector.scala
-//          ^^^ variable.import.scala
-//               ^^^ variable.import.renamed-from.scala
+//          ^^^ support.type.package.scala
+//               ^^^ support.type.package.scala
 //                   ^^ keyword.operator.arrow.scala
-//                      ^^^ variable.import.renamed-to.scala
-//                           ^^^ variable.import.renamed-from.scala
+//                      ^^^ support.type.package.scala
+//                           ^^^ support.type.package.scala
 //                              ^^ keyword.operator.arrow.scala
-//                                ^^^ variable.import.renamed-to.scala
+//                                ^^^ support.type.package.scala
 
 
 import foo.{
    bar => bin
-// ^^^ variable.import.renamed-from.scala
-//        ^^^ variable.import.renamed-to.scala
+// ^^^ support.type.package.scala
+//        ^^^ support.type.package.scala
 }
 
 import foo._
@@ -1521,7 +1523,7 @@ var foo: Thing =42
 class Foo extends Bar with {
    import Thing._
 // ^^^^^^ keyword.other.import.scala
-//        ^^^^^ variable.package.scala
+//        ^^^^^ support.class.import.scala
 }
 
 class Foo extends Bar.Baz with bin.Baz
@@ -1703,7 +1705,7 @@ type Foo = Monad[Lambda[α => OptionT[IO, α]]]
 
 import scalaz._,
    Scalaz._
-// ^^^^^^^ meta.import.scala variable.package.scala
+// ^^^^^^ meta.import.scala support.class.import.scala
 
 import scalaz._
    Scalaz._
@@ -1914,7 +1916,8 @@ s"testing '$foo' bar"
    new DataCodec {
      import PreciseKeys._
 //   ^^^^^^ meta.import.scala keyword.other.import.scala
-//          ^^^^^^^^^^^^ meta.import.scala variable.package.scala
+//          ^^^^^^^^^^^ meta.import.scala support.class.import.scala
+//                     ^ meta.import.scala punctuation.accessor.dot.scala
 //                      ^ meta.import.scala variable.language.underscore.scala
    } foo
    bar

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -16,6 +16,7 @@ import fubar.{Unit, Foo}
 // <- meta.import.scala
 //     ^^^^^ support.type.package.scala
 //            ^^^^ support.class.import.scala
+//                ^ punctuation.separator.scala
 
 def foo: Baz = 42
 //^ storage.type.function.scala


### PR DESCRIPTION
This changes loads of stuff. I'm sorry for the mega PR. I kept the commits granular so you can see in a bit more fine-grained fashion what changed, but I can squish a lot of it together. This mostly boils down to making the scoping of most constructs align more consistently with other modes. In particular, I relied on JavaScript and C# as the primary canon, though I also looked at Java (NB: the Java mode scopes imports inconsistently and still has some unfortunate bugs).

Some big ticket bullets:

- I changed `val` and `var` scoping. They used to use `entity.name`, and now they use `variable.other`, so as to be consistent with JavaScript. I went back and forth on this *a lot*, because `val` is not materially different from a no-argument `def` in Scala, and they are conventionally used entirely interchangeably. For that reason, `val` and `var` are both included in the project symbol index. This indexing strategy has turned out to be a very good balance in practice on both small and large codebases, but it also puts the Scala mode in a unique position of attempting to scope the construct consistently and index it inconsistently. My solution to this was to scope the construct consistently with C# and JavaScript, but I added `variable.other.constant` and `variable.other.readwrite` to the symbol set. This is quite unusual, but I decided that unconventional indexing was better than unconventional scoping.
  + As a note, I'm happy to re-explain in detail why it is that `val` and `var` are indexed (if you recall, we discussed this at length several years ago). I would also be happy to entertain removing `var` from the index, though in practice I haven't found its presence to be a problem in any sense, and it *feels* better to not have to care about the difference between `val` and `var` while navigating.
- Loads and loads of punctuation scopes. I hadn't been using a color scheme which scoped punctuation, and that caused a lot of oversights. I believe I caught everything now. There's a bit of subtlety between `punctuation.definition` and `punctuation.section`, and I tried to be as reasonable as I could be. I tried to be particularly careful about this given the special coloring that Mariana gives to `punctuation.definition`.
  + As an aside, it makes me sad that `punctuation.separator` and `punctuation.accessor` are given special treatment by Mariana, but `punctuation.ascription` is not. I understand why, but it feels a bit odd in practice, and unfortunately the `:` operator in Scala just doesn't fit into any of these other buckets.
- Imports are completely redone and now are entirely uniform with C# and entirely *not* uniform with Java. The one wart I left here is scoping of `package` declarations, which are currently using `entity.name.namespace` for the *entire* fully-qualified name, dots-included. This is highly inconsistent, but I can't fix it without changing symbol indexing for this construct, since Scala supports fully-qualified *scoped* packages (similar to namespaces in C#, but with full qualification). That full qualification needs to be part of the symbol set, but that in turn means that we either need to *not* index `entity.name.namespace` and instead index some `meta` scope which covers the entities and the punctuation, *or* we need to scope the whole thing and the `.`s end up scoped as `entity.name` rather than `punctuation.accessor`. Right now I'm doing the latter, but I'm open to the former.
- Most Scala operators are entirely free-form and we can't scope them any more than we can scope random functions, but `!=` and `==` are special magic and cannot be overridden, and thus I feel justified in giving them scoping which is more uniform with other languages of more restricted operator sets. We were already doing this for `eq` and `ne` (also special magic), though there were some bugs.
- Some random bug fixes that I found

Fixes #1986