### PR TITLE
[CSS] Add justify-content values

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -466,7 +466,7 @@ contexts:
               | (extra|semi|ultra)-(condensed|expanded)
               | farthest-(corner|side)?
               | fill(-box|-opacity)?
-              | filter|fixed|flat
+              | filter|first|fixed|flat
               | flex((-basis|-end|-grow|-shrink|-start)|box)?
               | flip|flood-color
               | font(-size(-adjust)?|-stretch|-weight)?
@@ -527,6 +527,7 @@ contexts:
               | run-in
               | ruby(-base|-text)?(-container)?
               | rtl|running|saturat(e|ion)|screen
+              | safe
               | scroll(-position|bar)?
               | separate|sepia
               | scale-down
@@ -537,7 +538,7 @@ contexts:
               | slashed-zero|slice
               | small(-caps|er)?
               | smooth|snap|solid|soft-light
-              | space(-around|-between)?
+              | space(-around|-between|-evenly)?
               | span|sRGB
               | stack(ed-fractions)?
               | start(ColorStr)?
@@ -560,7 +561,7 @@ contexts:
               | touch|traditional
               | transform(-origin)?
               | under(-edge|line)?
-              | unicase|unset|uppercase|upright
+              | unicase|unsafe|unset|uppercase|upright
               | use-(glyph-orientation|script)
               | verso
               | vertical(-align|-ideographic|-lr|-rl|-text)?

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -288,7 +288,11 @@ PROPERTY_DICT = {
     'ime-mode': ['auto', 'normal', 'active', 'inactive', 'disabled'],
     'isolation': ['auto', 'isolation'],
     'justify-content': [
-        'flex-start', 'flex-end', 'center', 'space-between', 'space-around'
+        'start', 'end', 'flex-start', 'flex-end', 'center', 'left', 'right',
+        'safe start', 'safe end', 'safe flex-start', 'safe flex-end', 'safe center', 'safe left', 'safe right',
+        'unsafe start', 'unsafe end', 'unsafe flex-start', 'unsafe flex-end', 'unsafe center', 'unsafe left', 'unsafe right',
+        'normal', 'baseline', 'first baseline', 'last baseline',
+        'space-between', 'space-around', 'space-evenly', 'stretch'
     ],
     'kerning': ['auto'],
     'left': ['<length>', '<percentage>', 'auto'],


### PR DESCRIPTION
Fixes #2046

This commit adds completions and highlighting for the `justify-content` values as documented at

  https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content