### PR TITLE
[Ruby] Fix interpolated require

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -455,13 +455,10 @@ contexts:
     - match: '\b(initialize|new|loop|include|extend|prepend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|module_function|public|protected|private)\b(?![?!])'
       scope: keyword.other.special-method.ruby
     - match: \b(require|require_relative|gem)\b
-      captures:
-        1: keyword.other.special-method.ruby
+      scope: keyword.other.special-method.ruby
       push:
         - meta_scope: meta.require.ruby
-        - match: $|(?=#)
-          captures:
-            1: keyword.other.special-method.ruby
+        - match: $|(?=[#}])
           pop: true
         - include: expressions
     # Conversion methods

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -60,6 +60,14 @@ str = sprintf("%1$*2$s %2$d", "hello", -8)
 #              ^^^^^^^ string.quoted.double.ruby constant.other.placeholder.ruby
 #                      ^^^^ string.quoted.double.ruby constant.other.placeholder.ruby
 
+  "#{MyParams.new.require(:filename)}"
+# ^ - meta.interpolation
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation - string
+#                                    ^ - meta.interpolation
+# ^ string.quoted.double.ruby punctuation.definition.string.begin.ruby
+#  ^^ punctuation.section.interpolation.begin.ruby
+#                                   ^ punctuation.section.interpolation.end.ruby
+#                                    ^ string.quoted.double.ruby punctuation.definition.string.end.ruby
   %I[#{ENV['APP_NAME']} apple orange]
 # ^^^ punctuation.definition.string.begin.ruby
 # ^^^ string.quoted.other.literal.upper.ruby


### PR DESCRIPTION
Fixes #2000

This commit causes the `require` context to pop off by `}` in addition to the end of a line in order to make it work properly within string interpolations.

It also removes some unnecessary captures.

_Note: Not sure why the method `require` pushes into a context to add a meta, while the other method's don't. Looks like all should be handled as `meta.function-call`._