### PR TITLE
[Ruby] Fix operators ligatures and scopes

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -100,6 +100,7 @@ contexts:
     - include: comments
     - include: data-section
     - include: heredocs
+    - include: punctuation
     - include: operators
     - include: identifiers-accessors
 
@@ -326,78 +327,85 @@ contexts:
     - match: \b(and|not|or)\b
       scope: keyword.operator.logical.ruby
       push: after-keyword
-    - match: '!+|&&|\|\||\^'
-      scope: keyword.operator.logical.ruby
-      push: after-operator
     - match: '\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\b(?![?!])|\bdefined\?|\bblock_given\?'
       scope: keyword.control.pseudo-method.ruby
 
   operators:
-    - match: '=>'
-      scope: punctuation.separator.key-value.ruby
+    - match: '>>'
+      scope: keyword.operator.other.ruby
       push: after-operator
-    - match: '<<=|%=|&=|\*=|\*\*=|\+=|\-=|\^=|\|{1,2}=|<<'
+    # note: `/=` is matched in the `regexes` context
+    - match: <<=|&&=|\|\|=|\*\*=|[-+*&|^]=|<<
       scope: keyword.operator.assignment.augmented.ruby
       push: after-operator
-    - match: '<=>|<(?!<|=)|>(?!<|=|>)|<=|>=|===|==|=~|!=|!~'
+    - match: <=>|===|<=|>=|==|=~|!=|!~|<|>
       scope: keyword.operator.comparison.ruby
       push: after-operator
-    - match: (%|&|\*\*|\*|\+|\-|/)
+    - match: \*\*|[-+*/%]
       scope: keyword.operator.arithmetic.ruby
       push: after-operator
-    - match: '='
+    - match: =
       scope: keyword.operator.assignment.ruby
       push: after-operator
-    - match: \||~|>>
-      scope: keyword.operator.other.ruby
+    - match: '!+|&&|\|\|'
+      scope: keyword.operator.logical.ruby
+      push: after-operator
+    - match: '[~&|^]'
+      scope: keyword.operator.bitwise.ruby
       push: after-operator
     - match: \?
       scope: keyword.operator.conditional.ruby
       push:
         # Handle hash-key-lookalike of identifier: in ternary
-        - match: '\s*{{identifier}}(:)(?!:)'
+        - match: \s*{{identifier}}(:)(?!:)
           captures:
             1: keyword.operator.conditional.ruby
+          set: after-operator
         - include: after-operator
-    - match: ':(?!:)'
+    - match: :(?!:)
       scope: keyword.operator.conditional.ruby
       push: after-operator
-    - match: \;
+    - match: \.\.\.?
+      scope: keyword.operator.range.ruby
+      push: after-operator
+
+  punctuation:
+    - match: =>
+      scope: punctuation.separator.key-value.ruby
+      push: after-operator
+    - match: ','
+      scope: punctuation.separator.sequence.ruby
+      push: after-operator
+    - match: ;
       scope: punctuation.terminator.statement.ruby
       push: after-operator
-    - match: ","
-      scope: punctuation.separator.ruby
-      push: after-operator
-    - match: '\['
+    - match: \[
       scope: punctuation.section.array.ruby
       push: after-operator
     - match: \(
       scope: punctuation.definition.group.begin.ruby
       push: after-operator
     # Opening { is handled by "block" context to try and detect parameters
-    - match: '\}'
+    - match: \}
       scope: punctuation.section.scope.ruby
-    - match: '\]'
+    - match: \]
       scope: punctuation.section.array.ruby
     - match: \)
       scope: punctuation.definition.group.end.ruby
-    - match: '\.\.\.?'
-      scope: keyword.operator.ruby
-      push: after-operator
 
   identifiers-accessors:
     # This consumes class/module access to prevent issues parsing : as part
     # of a ternary operator
-    - match: '(::)(?={{identifier}}{{method_punctuation}})'
-      scope: punctuation.accessor.ruby
+    - match: ::(?={{identifier}}{{method_punctuation}})
+      scope: punctuation.accessor.double-colon.ruby
       push:
         - include: well-known-methods
         - match: '{{identifier}}{{method_punctuation}}'
         - match: ''
           set: after-identifier
     # This consumes attribute access so we don't need a lookbehind for .
-    - match: '(\.)(?={{identifier}}{{method_punctuation}})'
-      scope: punctuation.accessor.ruby
+    - match: \.(?={{identifier}}{{method_punctuation}})
+      scope: punctuation.accessor.dot.ruby
       push:
         - include: well-known-methods
         - match: '{{identifier}}{{method_punctuation}}'
@@ -407,8 +415,10 @@ contexts:
     - match: '{{identifier}}{{method_punctuation}}'
     # This consumes module/class accessor so we don't need a lookbehind for ::
       push: after-identifier
-    - match: '::|\.'
-      scope: punctuation.accessor.ruby
+    - match: \.
+      scope: punctuation.accessor.dot.ruby
+    - match: '::'
+      scope: punctuation.accessor.double-colon.ruby
 
   after-identifier:
     # Handles a : right after an identifier. In this case it can't be the

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -177,14 +177,11 @@ contexts:
       pop: true
 
   name-parts:
-    - match: '::'
-      scope: punctuation.accessor.ruby
-    - match: '\.'
-      scope: punctuation.accessor.ruby
-    - match: '({{identifier}})(::|\.)'
+    - match: ({{identifier}})?(?:(::)|(\.))
       captures:
         1: support.other.namespace.ruby
-        2: punctuation.accessor.ruby
+        2: punctuation.accessor.double-colon.ruby
+        3: punctuation.accessor.dot.ruby
     - match: '{{identifier}}'
 
   invalid:
@@ -456,7 +453,7 @@ contexts:
         - include: expressions
     - match: '(::)?(\b[[:upper:]]\w*)(?=((\.|::)[[:alpha:]_]|\[))'
       captures:
-        1: punctuation.accessor.ruby
+        1: punctuation.accessor.double-colon.ruby
         2: support.class.ruby
     - match: '\b[[:upper:]]\w*\b'
       scope: variable.other.constant.ruby
@@ -723,17 +720,18 @@ contexts:
         - match: '(self)(\.)({{identifier}}{{method_punctuation}}|===?|>[>=]?|<=>|<[<=]?|[%&`/\|]|\*\*?|=?~|[-+]@?|\[\]=?)'
           captures:
             1: variable.language.ruby
-            2: punctuation.accessor.ruby
+            2: punctuation.accessor.dot.ruby
             3: entity.name.function.ruby
           set: method-parameters-start
         - match: '===?|>[>=]?|<=>|<[<=]?|[%&`/\|]|\*\*?|=?~|[-+]@?|\[\]=?'
           scope: entity.name.function.ruby
           set: method-parameters-start
-        - match: '(?:({{identifier}})(::|\.))?{{identifier}}{{method_punctuation}}'
+        - match: '(?:({{identifier}})(?:(::)|(\.)))?{{identifier}}{{method_punctuation}}'
           scope: entity.name.function.ruby
           captures:
             1: support.other.namespace.ruby
-            2: punctuation.accessor.ruby
+            2: punctuation.accessor.double-colon.ruby
+            3: punctuation.accessor.dot.ruby
           set: method-parameters-start
         - match: '$'
           pop: true

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -263,16 +263,16 @@ module MyModule::OtherModule
 # <- keyword.control.module
 #      ^^^^^^^^^^^^^^^^^^^^^ entity.name.module
 #      ^^^^^^^^ support.other.namespace
-#              ^^ punctuation.accessor
+#              ^^ punctuation.accessor.double-colon
 end
 
 class ::MyModule::MyClass < MyModule::InheritedClass
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class
-#     ^^ punctuation.accessor
-#               ^^ punctuation.accessor
+#     ^^ punctuation.accessor.double-colon
+#               ^^ punctuation.accessor.double-colon
 #                         ^ punctuation.separator.inheritance
 #                           ^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
-#                                   ^^ punctuation.accessor
+#                                   ^^ punctuation.accessor.double-colon
 
   def my_method(param1, param2)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
@@ -286,7 +286,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
   def self.my_second_method *arg_without_parens # comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #     ^^^^ variable.language
-#         ^ punctuation.accessor
+#         ^ punctuation.accessor.dot
 #          ^^^^^^^^^^^^^^^^ entity.name.function
 #                           ^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #                           ^ keyword.operator.splat
@@ -297,7 +297,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
   def self.my_third_method(a, b="foo", c=[], d=foo(), *args)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #     ^^^^ variable.language
-#         ^ punctuation.accessor
+#         ^ punctuation.accessor.dot
 #          ^^^^^^^^^^^^^^^ entity.name.function
 #                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #                         ^ punctuation.definition.group.begin
@@ -374,7 +374,7 @@ def MyModule::module_method
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #   ^^^^^^^^^^^^^^^^^^^^^^^ entity.name.function
 #   ^^^^^^^^ support.other.namespace
-#           ^^ punctuation.accessor
+#           ^^ punctuation.accessor.double-colon
 
 end
 
@@ -384,12 +384,12 @@ def my_function
 end
 
 f = MyModule::MyClass.new
-#           ^^ punctuation.accessor
+#           ^^ punctuation.accessor.double-colon
 
 def f.my_instance_method
 #^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #   ^^^^^^^^^^^^^^^^^^^^ entity.name.function
-#    ^ punctuation.accessor
+#    ^ punctuation.accessor.dot
 end
 
 class MyClass
@@ -466,7 +466,7 @@ puts 1 ? foo:bar
 
 puts 1 ? foo::baz:bar
 #      ^ keyword.operator.conditional
-#           ^^ punctuation.accessor
+#           ^^ punctuation.accessor.double-colon
 #             ^^^ - constant.other.symbol
 #                ^ keyword.operator.conditional
 

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -105,6 +105,97 @@ module: 'module'
 # ^^^^^ constant.other.symbol
 
 ##################
+# Operators
+##################
+
+  ,
+# ^ punctuation.separator.sequence.ruby
+  ;
+# ^ punctuation.terminator.statement.ruby
+  .
+# ^ punctuation.accessor.dot.ruby
+  ::
+# ^^ punctuation.accessor.double-colon.ruby
+  <<=
+# ^^^ keyword.operator.assignment.augmented.ruby
+  &&=
+# ^^^ keyword.operator.assignment.augmented.ruby
+  ||=
+# ^^^ keyword.operator.assignment.augmented.ruby
+  **=
+# ^^^ keyword.operator.assignment.augmented.ruby
+  +=
+# ^^ keyword.operator.assignment.augmented.ruby
+  -=
+# ^^ keyword.operator.assignment.augmented.ruby
+  *=
+# ^^ keyword.operator.assignment.augmented.ruby
+  /=
+# ^^ keyword.operator.assignment.augmented.ruby
+  &=
+# ^^ keyword.operator.assignment.augmented.ruby
+  |=
+# ^^ keyword.operator.assignment.augmented.ruby
+  ^=
+# ^^ keyword.operator.assignment.augmented.ruby
+  <<
+# ^^ keyword.operator.assignment.augmented.ruby
+  >>
+# ^^ keyword.operator.other.ruby
+  +
+# ^ keyword.operator.arithmetic.ruby
+  -
+# ^ keyword.operator.arithmetic.ruby
+  *
+# ^ keyword.operator.arithmetic.ruby
+  **
+# ^^ keyword.operator.arithmetic.ruby
+  /
+# ^ keyword.operator.arithmetic.ruby
+  %
+# ^ keyword.operator.arithmetic.ruby
+  !~
+# ^^ keyword.operator.comparison.ruby
+  =~
+# ^^ keyword.operator.comparison.ruby
+  <=>
+# ^^^ keyword.operator.comparison.ruby
+  ==
+# ^^ keyword.operator.comparison.ruby
+  !=
+# ^^ keyword.operator.comparison.ruby
+  >=
+# ^^ keyword.operator.comparison.ruby
+  <=
+# ^^ keyword.operator.comparison.ruby
+  >
+# ^ keyword.operator.comparison.ruby
+  <
+# ^ keyword.operator.comparison.ruby
+  &&
+# ^^ keyword.operator.logical.ruby
+  ||
+# ^^ keyword.operator.logical.ruby
+  !
+# ^ keyword.operator.logical.ruby
+  ?
+# ^ keyword.operator.conditional.ruby
+  :
+# ^ keyword.operator.conditional.ruby
+  ~
+# ^ keyword.operator.bitwise.ruby
+  &
+# ^ keyword.operator.bitwise.ruby
+  |
+# ^ keyword.operator.bitwise.ruby
+  ^
+# ^ keyword.operator.bitwise.ruby
+  ..
+# ^^ keyword.operator.range.ruby
+  ...
+# ^^^ keyword.operator.range.ruby
+
+##################
 # Blocks
 ##################
 
@@ -318,9 +409,9 @@ class MyClass
 
   A, B, C = :a, :b, :c
 # ^ meta.constant.ruby entity.name.constant.ruby
-#  ^ punctuation.separator.ruby
+#  ^ punctuation.separator.sequence.ruby
 #    ^ meta.constant.ruby entity.name.constant.ruby
-#     ^ punctuation.separator.ruby
+#     ^ punctuation.separator.sequence.ruby
 #       ^ meta.constant.ruby entity.name.constant.ruby
 end
 


### PR DESCRIPTION
Fixes #1387

This commit

1) sorts rules to correctly match all operators. This fixes some operators not being replaced by ligatures.
2) tweaks scope names a little bit.
   a) `|` and `~` are bitwise operators
   b) `..` is scoped `keyword.operator.range`