### PR TITLE
[C/C++/ObjC/ObjC++] Exclude snippets from #include<...>

### DIFF
--- a/C++/Snippets/#ifndef-#define-#endif.sublime-snippet
+++ b/C++/Snippets/#ifndef-#define-#endif.sublime-snippet
@@ -4,5 +4,5 @@
 #define ${1:SYMBOL} ${2:value}
 #endif]]></content>
 	<tabTrigger>def</tabTrigger>
-	<scope>source.c, source.c++, source.objc, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/#ifndef-#define-#endif.sublime-snippet
+++ b/C++/Snippets/#ifndef-#define-#endif.sublime-snippet
@@ -4,5 +4,5 @@
 #define ${1:SYMBOL} ${2:value}
 #endif]]></content>
 	<tabTrigger>def</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/#include-(#inc angle).sublime-snippet
+++ b/C++/Snippets/#include-(#inc angle).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include &lt;…&gt;</description>
 	<content><![CDATA[include <${1:.h}>]]></content>
 	<tabTrigger>inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp;meta.preprocessor.incomplete</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; meta.preprocessor.incomplete  - comment - string</scope>
 </snippet>

--- a/C++/Snippets/#include-(#inc).sublime-snippet
+++ b/C++/Snippets/#include-(#inc).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include "…"</description>
 	<content><![CDATA[include "${1:${TM_FILENAME/\..+$/.h/}}"]]></content>
 	<tabTrigger>inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; meta.preprocessor.incomplete</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; meta.preprocessor.incomplete - comment - string</scope>
 </snippet>

--- a/C++/Snippets/#include-(inc angle).sublime-snippet
+++ b/C++/Snippets/#include-(inc angle).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include &lt;…&gt;</description>
 	<content><![CDATA[#include <${1:.h}>]]></content>
 	<tabTrigger>Inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/#include-(inc angle).sublime-snippet
+++ b/C++/Snippets/#include-(inc angle).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include &lt;…&gt;</description>
 	<content><![CDATA[#include <${1:.h}>]]></content>
 	<tabTrigger>Inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/#include-(inc).sublime-snippet
+++ b/C++/Snippets/#include-(inc).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include "…"</description>
 	<content><![CDATA[#include "${1:${TM_FILENAME/\..+$/.h/}}"]]></content>
 	<tabTrigger>inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/#include-(inc).sublime-snippet
+++ b/C++/Snippets/#include-(inc).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>#include "…"</description>
 	<content><![CDATA[#include "${1:${TM_FILENAME/\..+$/.h/}}"]]></content>
 	<tabTrigger>inc</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.incomplete - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
+++ b/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>$1.begin(), $1.end()</description>
 	<content><![CDATA[${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}begin(), ${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}end()]]></content>
 	<tabTrigger>beginend</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
+++ b/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>$1.begin(), $1.end()</description>
 	<content><![CDATA[${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}begin(), ${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}end()]]></content>
 	<tabTrigger>beginend</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/030-for-int-loop-(fori).sublime-snippet
+++ b/C++/Snippets/030-for-int-loop-(fori).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 }]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/030-for-int-loop-(fori).sublime-snippet
+++ b/C++/Snippets/030-for-int-loop-(fori).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 }]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/Enumeration.sublime-snippet
+++ b/C++/Snippets/Enumeration.sublime-snippet
@@ -5,5 +5,5 @@
 	$0
 };]]></content>
 	<tabTrigger>enum</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/Enumeration.sublime-snippet
+++ b/C++/Snippets/Enumeration.sublime-snippet
@@ -5,5 +5,5 @@
 	$0
 };]]></content>
 	<tabTrigger>enum</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/Typedef.sublime-snippet
+++ b/C++/Snippets/Typedef.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>Typedef</description>
 	<content><![CDATA[typedef ${1:int} ${2:MyCustomType};]]></content>
 	<tabTrigger>td</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/Typedef.sublime-snippet
+++ b/C++/Snippets/Typedef.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>Typedef</description>
 	<content><![CDATA[typedef ${1:int} ${2:MyCustomType};]]></content>
 	<tabTrigger>td</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/class-..-(class).sublime-snippet
+++ b/C++/Snippets/class-..-(class).sublime-snippet
@@ -1,5 +1,4 @@
 <snippet>
-	<name>Class</name>
 	<content><![CDATA[class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:name}}
 {
 public:
@@ -8,5 +7,5 @@ public:
 	$0
 };]]></content>
 	<tabTrigger>class</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/class-..-(class).sublime-snippet
+++ b/C++/Snippets/class-..-(class).sublime-snippet
@@ -7,5 +7,5 @@ public:
 	$0
 };]]></content>
 	<tabTrigger>class</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/do...while-loop-(do).sublime-snippet
+++ b/C++/Snippets/do...while-loop-(do).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 } while (${1:/* condition */});]]></content>
 	<tabTrigger>do</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/do...while-loop-(do).sublime-snippet
+++ b/C++/Snippets/do...while-loop-(do).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 } while (${1:/* condition */});]]></content>
 	<tabTrigger>do</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/forv.sublime-snippet
+++ b/C++/Snippets/forv.sublime-snippet
@@ -5,5 +5,5 @@
 	$0
 }]]></content>
 	<tabTrigger>forv</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/forv.sublime-snippet
+++ b/C++/Snippets/forv.sublime-snippet
@@ -5,5 +5,5 @@
 	$0
 }]]></content>
 	<tabTrigger>forv</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/fprintf.sublime-snippet
+++ b/C++/Snippets/fprintf.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>fprintf …</description>
 	<content><![CDATA[fprintf(${1:stderr}, "${2:%s}\\n"${2/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$3${2/([^%]|%%)*(%.)?.*/(?2:\);)/}]]></content>
 	<tabTrigger>fprintf</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/fprintf.sublime-snippet
+++ b/C++/Snippets/fprintf.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>fprintf …</description>
 	<content><![CDATA[fprintf(${1:stderr}, "${2:%s}\\n"${2/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$3${2/([^%]|%%)*(%.)?.*/(?2:\);)/}]]></content>
 	<tabTrigger>fprintf</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/if-..-(if).sublime-snippet
+++ b/C++/Snippets/if-..-(if).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 }]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/if-..-(if).sublime-snippet
+++ b/C++/Snippets/if-..-(if).sublime-snippet
@@ -5,5 +5,5 @@
 	${0:/* code */}
 }]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/main()-(int main).sublime-snippet
+++ b/C++/Snippets/main()-(int main).sublime-snippet
@@ -6,5 +6,5 @@
 	return 0;
 }]]></content>
 	<tabTrigger>main</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; entity.name.function - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; entity.name.function - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/main()-(int main).sublime-snippet
+++ b/C++/Snippets/main()-(int main).sublime-snippet
@@ -6,5 +6,5 @@
 	return 0;
 }]]></content>
 	<tabTrigger>main</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; entity.name.function</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) &amp; entity.name.function - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/main()-(main).sublime-snippet
+++ b/C++/Snippets/main()-(main).sublime-snippet
@@ -6,5 +6,5 @@
 	return 0;
 }]]></content>
 	<tabTrigger>main</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - entity.name.function</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - entity.name.function - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/main()-(main).sublime-snippet
+++ b/C++/Snippets/main()-(main).sublime-snippet
@@ -6,5 +6,5 @@
 	return 0;
 }]]></content>
 	<tabTrigger>main</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - entity.name.function - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - entity.name.function - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/namespace-..-(namespace).sublime-snippet
+++ b/C++/Snippets/namespace-..-(namespace).sublime-snippet
@@ -6,5 +6,5 @@
 }
 ]]></content>
 	<tabTrigger>ns</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/namespace-..-(namespace).sublime-snippet
+++ b/C++/Snippets/namespace-..-(namespace).sublime-snippet
@@ -6,5 +6,5 @@
 }
 ]]></content>
 	<tabTrigger>ns</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/printf-..-(printf).sublime-snippet
+++ b/C++/Snippets/printf-..-(printf).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>printf …</description>
 	<content><![CDATA[printf("${1:%s}\\n"${1/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$2${1/([^%]|%%)*(%.)?.*/(?2:\);)/}]]></content>
 	<tabTrigger>printf</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/printf-..-(printf).sublime-snippet
+++ b/C++/Snippets/printf-..-(printf).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>printf …</description>
 	<content><![CDATA[printf("${1:%s}\\n"${1/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$2${1/([^%]|%%)*(%.)?.*/(?2:\);)/}]]></content>
 	<tabTrigger>printf</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/read-file-(readF).sublime-snippet
+++ b/C++/Snippets/read-file-(readF).sublime-snippet
@@ -9,5 +9,5 @@ if (FILE${TM_C_POINTER: *}fp = fopen(${1:"filename"}, "r"))
 	fclose(fp);
 }]]></content>
 	<tabTrigger>readfile</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/read-file-(readF).sublime-snippet
+++ b/C++/Snippets/read-file-(readF).sublime-snippet
@@ -9,5 +9,5 @@ if (FILE${TM_C_POINTER: *}fp = fopen(${1:"filename"}, "r"))
 	fclose(fp);
 }]]></content>
 	<tabTrigger>readfile</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/std-map-(map).sublime-snippet
+++ b/C++/Snippets/std-map-(map).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>std::map</description>
 	<content><![CDATA[std::map<${1:key}, ${2:value}> map$0;]]></content>
 	<tabTrigger>map</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/std-map-(map).sublime-snippet
+++ b/C++/Snippets/std-map-(map).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>std::map</description>
 	<content><![CDATA[std::map<${1:key}, ${2:value}> map$0;]]></content>
 	<tabTrigger>map</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/std-vector-(v).sublime-snippet
+++ b/C++/Snippets/std-vector-(v).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>std::vector</description>
 	<content><![CDATA[std::vector<${1:char}> v$0;]]></content>
 	<tabTrigger>vector</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/std-vector-(v).sublime-snippet
+++ b/C++/Snippets/std-vector-(v).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>std::vector</description>
 	<content><![CDATA[std::vector<${1:char}> v$0;]]></content>
 	<tabTrigger>vector</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/struct.sublime-snippet
+++ b/C++/Snippets/struct.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 };]]></content>
 	<tabTrigger>struct</tabTrigger>
-	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/struct.sublime-snippet
+++ b/C++/Snippets/struct.sublime-snippet
@@ -1,9 +1,8 @@
 <snippet>
-	<name>Struct</name>
 	<content><![CDATA[struct ${1:${TM_FILENAME/(.+)\..+|.*/$/:name}}
 {
 	$0
 };]]></content>
 	<tabTrigger>struct</tabTrigger>
-	<scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<scope>(source.c | source.objc | source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>

--- a/C++/Snippets/template-typename-..-(template).sublime-snippet
+++ b/C++/Snippets/template-typename-..-(template).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>template &lt;typename ${1:_InputIter}&gt;</description>
 	<content><![CDATA[template <typename ${1:_InputIter}>]]></content>
 	<tabTrigger>tp</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
 </snippet>

--- a/C++/Snippets/template-typename-..-(template).sublime-snippet
+++ b/C++/Snippets/template-typename-..-(template).sublime-snippet
@@ -2,5 +2,5 @@
 	<description>template &lt;typename ${1:_InputIter}&gt;</description>
 	<content><![CDATA[template <typename ${1:_InputIter}>]]></content>
 	<tabTrigger>tp</tabTrigger>
-	<scope>source.c++, source.objc++</scope>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include</scope>
 </snippet>


### PR DESCRIPTION
Fixes #2055

Prevent snippets from being added to the completions when the caret is within an include directive.