### PR TITLE
[Java] Remove quotation marks from match patterns

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -421,7 +421,7 @@ contexts:
       scope: punctuation.definition.comment.java
       push:
         - meta_scope: comment.line.double-slash.java
-        - match: $\n?
+        - match: \n
           pop: true
         - match: (?=%>)
           pop: true

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -20,17 +20,17 @@ variables:
   before_fqn: (?={{lowercase_id}}\s*\.)
 
   # utility lookaround
-  lambda_lookahead: '(?:\(.*\)|{{id}})\s*->'
+  lambda_lookahead: (?:\(.*\)|{{id}})\s*->
 
 contexts:
   prototype:
-    - match: '(?=%>)'
+    - match: (?=%>)
       pop: true
     - include: comments
     - include: illegal-keywords
 
   any_POP:
-    - match: '(?=\S)'
+    - match: (?=\S)
       pop: true
 
   immediate_POP:
@@ -155,7 +155,7 @@ contexts:
     - include: object-types
 
   annotations:
-    - match: '@'
+    - match: \@
       scope: punctuation.definition.annotation.java
       push:
         - - meta_scope: meta.annotation.java
@@ -387,11 +387,11 @@ contexts:
     - include: code-block-include
     - include: parens
   code-block-include:
-    - match: "{"
+    - match: \{
       scope: punctuation.section.block.begin.java
       push:
         - meta_scope: meta.block.java
-        - match: "}"
+        - match: \}
           scope: punctuation.section.block.end.java
           pop: true
         - include: code-block
@@ -423,7 +423,7 @@ contexts:
         - meta_scope: comment.line.double-slash.java
         - match: $\n?
           pop: true
-        - match: '(?=%>)'
+        - match: (?=%>)
           pop: true
   constants-and-special-vars:
     - match: \b(true|false|null)\b
@@ -639,7 +639,7 @@ contexts:
 
   before-next-field:
     # Prevent style from being removed from whole file when making a new expression
-    - match: '(?=\b(?:{{storage_modifiers}}|{{primitives}}|void)\b)'
+    - match: (?=\b(?:{{storage_modifiers}}|{{primitives}}|void)\b)
       pop: true
 
   method:
@@ -663,11 +663,11 @@ contexts:
           pop: true
     - include: throws
     - include: annotation-default
-    - match: "{"
+    - match: \{
       scope: punctuation.section.block.begin.java
       set:
         - meta_scope: meta.method.java meta.method.body.java
-        - match: "}"
+        - match: \}
           scope: punctuation.section.block.end.java
           pop: true
         - include: code-block
@@ -892,7 +892,7 @@ contexts:
     - include: punctuation-separator-comma
 
   lambdas:
-    - match: '(?={{lambda_lookahead}})'
+    - match: (?={{lambda_lookahead}})
       push: lambda-params
 
   lambda-params:
@@ -971,15 +971,15 @@ contexts:
       scope: keyword.operator.assignment.java
       push:
         - meta_scope: meta.assignment.rhs.java
-        - match: '(?=;|\)|\}|,)'
+        - match: (?=;|\)|\}|,)
           pop: true
         - include: code
   static-code-block:
-    - match: "{"
+    - match: \{
       scope: punctuation.section.block.begin.java
       push:
         - meta_scope: meta.static.body.java
-        - match: "}"
+        - match: \}
           scope: punctuation.section.block.end.java
           pop: true
         - include: code-block
@@ -987,7 +987,7 @@ contexts:
     - match: \b{{storage_modifiers}}\b
       scope: storage.modifier.java
   stray-braces:
-    - match: '\}'
+    - match: \}
       scope: invalid.illegal.stray-brace-end
   stray-parens:
     - match: \)


### PR DESCRIPTION
This PR proposes to remove some remaining quotation marks from the match patterns because most of them are already unquoted.

This PR does not change functionality, but is only for consistent code style.