### PR TITLE
[Java] Fix lowercase inherit interface identifier

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -800,7 +800,7 @@ contexts:
     - include: inherited-object-type-reference-no-fqn
 
   inherited-object-type-reference-no-fqn:
-    - match: '{{classcase_id}}'
+    - match: (?!class|extends|implements|interface){{id}}
       scope: entity.other.inherited-class.java
       set: after-inherited-object-type-reference
     - include: any_POP

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -1598,6 +1598,16 @@ public class Generic<T> implements fully.qualified.Other<T> {
 }
 // <- punctuation.section.block.end.java
 
+public class Generic<T> extends iNtf implements iNterface<T> {
+//                              ^^^^ entity.other.inherited-class.java
+//                                              ^^^^^^^^^ entity.other.inherited-class.java
+//                                                       ^^^ meta.generic.java
+//                                                       ^ punctuation.definition.generic.begin.java
+//                                                        ^ support.class.java
+//                                                         ^ punctuation.definition.generic.end.java
+}
+// <- punctuation.section.block.end.java
+
 public class Bar {
   public void missingSemiColon() {
     boolean foo = foo


### PR DESCRIPTION
Fixes #1858

This PR is a local hotfix for issue #1858. If the identifier of an inherit class starts with a lowercase character, the rest of the class definition becomes broken. Therefore the methods aren't properly scoped and not part of the index.

#### Note:

Supporting lowercase here, would mean to support lowercase class identifiers in general to be complete, but this seems to be a bit more complicated.