### PR TITLE
[CSS] Fix selector symbol index

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -788,6 +788,8 @@ contexts:
             - match: '\]'
               scope: punctuation.definition.entity.css
               pop: true
+        - match: ','
+          scope: punctuation.separator.sequence.css
 
   # Pseudo Elements
   # https://drafts.csswg.org/selectors-4/#pseudo-elements

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -733,7 +733,7 @@ contexts:
         - include: property-values
 
   selector:
-    - match: '\s*(?=[:.*#a-zA-Z\[])'
+    - match: (?=[:.*#a-zA-Z\[])
       push:
         - meta_scope: meta.selector.css
         - match: "(?=[/@{)])"

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -48,11 +48,15 @@
 /*  ^   punctuation.definition.entity.css  */
 /*   ^^ entity.other.attribute-name.id.css */
 
-    html {}
+    html, h1 {}
 /*^^ - meta.selector.css  */
-/*  ^^^^^ meta.selector.css */
-/*       ^^ - meta.selector.css  */
+/*  ^^^^^^^^^ meta.selector.css */
+/*           ^^ - meta.selector.css  */
 /*  ^^^^ entity.name.tag.css */
+/*      ^ punctuation.separator.sequence.css */
+/*        ^^ entity.name.tag.css */
+/*           ^ punctuation.section.property-list.css */
+/*            ^ punctuation.section.property-list.css */
 
     @charset "UTF-8";
 /*  ^^^^^^^^^^^^^^^^ meta.at-rule.charset.css */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -35,15 +35,23 @@
 /* < punctuation.section.property-list.css */
 
     .classname {}
+/*^^ - meta.selector.css  */
 /*  ^^^^^^^^^^^ meta.selector.css */
+/*             ^^ - meta.selector.css  */
 /*  ^          punctuation.definition.entity.css     */
 /*   ^^^^^^^^^ entity.other.attribute-name.class.css */
 
     #id {}
+/*^^ - meta.selector.css  */
+/*  ^^^^ meta.selector.css */
+/*      ^^ - meta.selector.css  */
 /*  ^   punctuation.definition.entity.css  */
 /*   ^^ entity.other.attribute-name.id.css */
 
     html {}
+/*^^ - meta.selector.css  */
+/*  ^^^^^ meta.selector.css */
+/*       ^^ - meta.selector.css  */
 /*  ^^^^ entity.name.tag.css */
 
     @charset "UTF-8";
@@ -361,12 +369,16 @@
 
 /* Test Functional Pseudo Class Meta Scopes */
 .test:nth-child(even) {}
+/*^^^^^^^^^^^^^^^^^^^^ meta.selector.css                     */
+/*                    ^ - meta.selector.css                  */
 /*   ^^^^^^^^^^^^^^^^ meta.function-call.css                 */
 /*             ^^^^^^ meta.group.css                         */
 /*             ^      punctuation.definition.group.begin.css */
 /*                  ^ punctuation.definition.group.end.css   */
 
 .test-pseudo-classes:nth-child(2):hover {}
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.css                */
+/*                                      ^ - meta.selector.css             */
 /*                   ^^^^^^^^^          entity.other.pseudo-class.css     */
 /*                             ^        constant.numeric.css              */
 /*                               ^      punctuation.definition.entity.css */


### PR DESCRIPTION
Fixes #2057

This commit modifies the `meta.selector` lookahead in order to exclude leading whitespace.

Whitespace between entities and after the last one keep untouched.