### PR TITLE
[Lua] Update mapping matching

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -17,7 +17,7 @@ variables:
   metamethod: |- # http://lua-users.org/wiki/MetatableEvents
     (?x:__(?:
       # special
-      index|newindex|mode|call|tostring|len|i?pairs|gc
+      index|newindex|call|tostring|len|i?pairs|gc
       # math operators
       |unm|add|sub|mul|i?div|mod|pow|concat
       # bitwise operators
@@ -25,6 +25,8 @@ variables:
       # comparison
       |eq|lt|le
     ))
+  # __metatable and __mode don't use functions
+  metaproperty: (?:__(?:metatable|mode))
 
   identifier_start: (?:[A-Za-z_])
   identifier_char: (?:[A-Za-z0-9_])
@@ -338,6 +340,9 @@ contexts:
     - match: '{{identifier}}{{function_call_ahead}}'
       scope: meta.property.lua variable.function.lua
       pop: true
+    - match: '{{metaproperty}}'
+      scope: meta.property.lua support.other.metaproperty.lua
+      pop: true
     - match: '{{identifier}}'
       scope: meta.property.lua
       pop: true
@@ -542,6 +547,9 @@ contexts:
               pop: true
             - match: '{{metamethod}}'
               scope: entity.name.function.lua support.function.metamethod.lua
+              pop: true
+            - match: '{{metaproperty}}'
+              scope: string.unquoted.key.lua support.other.metaproperty.lua
               pop: true
             - match: '{{identifier}}'
               scope: string.unquoted.key.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -518,6 +518,9 @@ contexts:
           push:
             - clear_scopes: 1
             - meta_scope: meta.mapping.key.lua
+            - match: '{{identifier}}(?=\s*=\s*function\b)'
+              scope: entity.name.function.lua
+              pop: true
             - match: '{{identifier}}'
               scope: string.unquoted.key.lua
               pop: true

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -24,9 +24,9 @@ variables:
       |band|bor|bxor|bnot|shl|shr
       # comparison
       |eq|lt|le
-    ))
+    ){{identifier_break}})
   # __metatable and __mode don't use functions
-  metaproperty: (?:__(?:metatable|mode))
+  metaproperty: (?:__(?:metatable|mode){{identifier_break}})
 
   identifier_start: (?:[A-Za-z_])
   identifier_char: (?:[A-Za-z0-9_])

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -506,20 +506,29 @@ contexts:
         - match: \[(?!=*\[)
           scope: punctuation.section.brackets.begin.lua
           push:
-            - meta_scope: meta.brackets.lua
+            - clear_scopes: 1
+            - meta_scope: meta.mapping.key.lua meta.brackets.lua
             - match: \]
               scope: punctuation.section.brackets.end.lua
               pop: true
             - match: (?=\S)
               push: expression
 
-        - match: '{{identifier}}(?=\s*=)'
-          scope: meta.key.lua string.unquoted.key.lua
+        - match: (?={{identifier}}\s*=(?!=))
+          push:
+            - clear_scopes: 1
+            - meta_scope: meta.mapping.key.lua
+            - match: '{{identifier}}'
+              scope: string.unquoted.key.lua
+              pop: true
 
         - match: =(?!=)
-          scope: punctuation.separator.key-value.lua
-          push: expression
-
+          scope: meta.mapping.lua punctuation.separator.key-value.lua
+          push:
+            - - clear_scopes: 1
+              - meta_content_scope: meta.mapping.value.lua
+              - include: immediately-pop
+            - expression
         - match: (?=\S)
           push: expression
 

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -516,7 +516,7 @@ contexts:
         - match: '{{identifier}}(?=\s*=)'
           scope: meta.key.lua string.unquoted.key.lua
 
-        - match: =
+        - match: =(?!=)
           scope: punctuation.separator.key-value.lua
           push: expression
 

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -14,6 +14,17 @@ variables:
       and|break|do|elseif|else|end|for|goto|if|in|
       local|or|repeat|return|then|until|while
     ){{identifier_break}})
+  metamethod: |- # http://lua-users.org/wiki/MetatableEvents
+    (?x:__(?:
+      # special
+      index|newindex|mode|call|tostring|len|i?pairs|gc
+      # math operators
+      |unm|add|sub|mul|i?div|mod|pow|concat
+      # bitwise operators
+      |band|bor|bxor|bnot|shl|shr
+      # comparison
+      |eq|lt|le
+    ))
 
   identifier_start: (?:[A-Za-z_])
   identifier_char: (?:[A-Za-z0-9_])
@@ -132,6 +143,9 @@ contexts:
   function-name-property:
     - match: '{{identifier}}(?=\s*[.:])'
       scope: meta.property.lua
+      pop: true
+    - match: '{{metamethod}}'
+      scope: meta.property.lua entity.name.function.lua support.function.metamethod.lua
       pop: true
     - match: '{{identifier}}'
       scope: meta.property.lua entity.name.function.lua
@@ -315,6 +329,9 @@ contexts:
           push: expression
 
   property:
+    - match: '{{metamethod}}{{function_assignment_ahead}}'
+      scope: meta.property.lua entity.name.function.lua support.function.metamethod.lua
+      pop: true
     - match: '{{identifier}}{{function_assignment_ahead}}'
       scope: meta.property.lua entity.name.function.lua
       pop: true
@@ -518,8 +535,13 @@ contexts:
           push:
             - clear_scopes: 1
             - meta_scope: meta.mapping.key.lua
-            - match: '{{identifier}}(?=\s*=\s*function\b)'
+            - match: (?:({{metamethod}})|{{identifier}})(?=\s*=\s*function\b)
               scope: entity.name.function.lua
+              captures:
+                1: support.function.metamethod.lua
+              pop: true
+            - match: '{{metamethod}}'
+              scope: entity.name.function.lua support.function.metamethod.lua
               pop: true
             - match: '{{identifier}}'
               scope: string.unquoted.key.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -291,6 +291,10 @@
 --               ^^^^ variable.other.lua - meta.mapping.key
 --                    ^^ keyword.operator.comparison
 
+    {method = function ()
+--   ^^^^^^ meta.mapping.key.lua entity.name.function.lua
+     end}
+
 --PARENS
 
     (foo + bar);

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -268,14 +268,15 @@
 --              ^ punctuation.section.block.end
 
     {[a] = x, b = y};
---   ^^^ meta.brackets
+--  ^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
+--   ^^^ meta.mapping.key meta.brackets
 --   ^ punctuation.section.brackets.begin
 --    ^ variable.other
 --     ^ punctuation.section.brackets.end
 --       ^ punctuation.separator.key-value
---         ^ variable.other
---          ^ punctuation.separator.field
---            ^ meta.key string.unquoted.key
+--         ^ meta.mapping.value variable.other
+--          ^ meta.mapping.lua punctuation.separator.field
+--            ^ meta.mapping.key string.unquoted.key
 --              ^ punctuation.separator.key-value
 --                ^ meta.mapping variable.other
 
@@ -284,8 +285,10 @@
 --                          ^^^ meta.mapping.lua string.quoted.multiline.lua punctuation.definition.string.begin.lua
 
     {some = 2}, {some == 2}
---   ^^^^ string.unquoted.key.lua
+--   ^^^^ meta.mapping.key string.unquoted.key.lua
 --        ^ punctuation.separator.key-value.lua
+--          ^ meta.mapping.value constant.numeric.decimal
+--               ^^^^ variable.other.lua - meta.mapping.key
 --                    ^^ keyword.operator.comparison
 
 --PARENS

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -283,6 +283,11 @@
 --   ^^ meta.mapping.lua string.quoted.multiline.lua punctuation.definition.string.begin.lua
 --                          ^^^ meta.mapping.lua string.quoted.multiline.lua punctuation.definition.string.begin.lua
 
+    {some = 2}, {some == 2}
+--   ^^^^ string.unquoted.key.lua
+--        ^ punctuation.separator.key-value.lua
+--                    ^^ keyword.operator.comparison
+
 --PARENS
 
     (foo + bar);

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -300,6 +300,8 @@
 --   ^^^^^^ meta.mapping.key.lua entity.name.function.lua support.function.metamethod.lua
      not_method = some_var,
 --   ^^^^^^^^^^ meta.mapping.key.lua string.unquoted.key.lua - entity - support
+     __metatable = nil,
+--   ^^^^^^^^^^^ meta.mapping.key.lua string.unquoted.key.lua support.other.metaproperty.lua
  }
 
 --PARENS
@@ -312,6 +314,9 @@
     foo.bar;
 --     ^ punctuation.accessor
 --      ^^^ meta.property
+
+    foo.__mode = "kv";
+--      ^^^^^^ meta.property.lua support.other.metaproperty.lua
 
     foo:bar;
 --     ^ punctuation.accessor

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -291,9 +291,16 @@
 --               ^^^^ variable.other.lua - meta.mapping.key
 --                    ^^ keyword.operator.comparison
 
-    {method = function ()
---   ^^^^^^ meta.mapping.key.lua entity.name.function.lua
-     end}
+    {__index = function(i) end,
+--   ^^^^^^^ meta.mapping.key entity.name.function support.function.metamethod.lua
+     method = function ()
+--   ^^^^^^ meta.mapping.key.lua entity.name.function.lua - support
+     end,
+     __call = some_func,
+--   ^^^^^^ meta.mapping.key.lua entity.name.function.lua support.function.metamethod.lua
+     not_method = some_var,
+--   ^^^^^^^^^^ meta.mapping.key.lua string.unquoted.key.lua - entity - support
+ }
 
 --PARENS
 
@@ -410,6 +417,9 @@
 --                       ^^^^^ meta.group
 --                             ^^^ keyword.control.end
 
+    function foo.bar:__index (...) end
+--                   ^^^^^^^ meta.name.function meta.property.lua entity.name.function.lua support.function.metamethod.lua
+
     function foo
         .bar () end
 --      ^^^^^^^^^^^ meta.function
@@ -436,6 +446,9 @@
 
     foo.bar = function() end;
 --      ^^^ meta.property entity.name.function
+
+    foo.__call = function() end;
+--      ^^^^^^ meta.property.lua entity.name.function.lua support.function.metamethod.lua
 
     function (return) end;
 --            ^^^^^^ invalid.unexpected-keyword.lua


### PR DESCRIPTION
![img](https://cdn.discordapp.com/attachments/280157067396775936/618130799656435712/unknown.png)

Reported by @Resike on Discord.

While I was at it, I also implemented `meta.mapping.{key,value}`, as we established those as standards a while ago and as they are used in Python, JS (?) and JSON. It made sense to add to the PR because it would otherwise be conflicting.

And highlighting of metamethod and normal method assignments.