### PR TITLE
[C++/ObjC++] Fix #2042, generic has no form like '<<'

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -40,12 +40,13 @@ variables:
   non_angle_brackets: '(?=<<|<=)'
 
   regular: '[^(){}&;*^%=<>-]*'
+  regular_plus: '[^(){}&;*^%=<>-]+'
   paren_open: (?:\(
   paren_close: '\))?'
-  generic_open: (?:<
-  generic_close: '>)?'
+  generic_open: (?:{{regular_plus}}(?:<
+  generic_close: '>)?)?'
   balance_parentheses: '{{regular}}{{paren_open}}{{regular}}{{paren_close}}{{regular}}'
-  generic_lookahead: <{{regular}}{{generic_open}}{{regular}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
+  generic_lookahead: <{{generic_open}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
 
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2352,6 +2352,9 @@ void sayHi()
 /*       ^^^ meta.brackets */
 /*       ^ punctuation.section.brackets.begin */
 /*         ^ punctuation.section.brackets.end */
+
+    std::cout << ">> Hi!\n";
+/*            ^^ keyword.operator.arithmetic.c */
 }
 
 /////////////////////////////////////////////

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -28,12 +28,13 @@ variables:
   non_angle_brackets: '(?=<<|<=)'
 
   regular: '[^(){}&;*^%=<>-]*'
+  regular_plus: '[^(){}&;*^%=<>-]+'
   paren_open: (?:\(
   paren_close: '\))?'
-  generic_open: (?:<
-  generic_close: '>)?'
+  generic_open: (?:{{regular_plus}}(?:<
+  generic_close: '>)?)?'
   balance_parentheses: '{{regular}}{{paren_open}}{{regular}}{{paren_close}}{{regular}}'
-  generic_lookahead: <{{regular}}{{generic_open}}{{regular}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
+  generic_lookahead: <{{generic_open}}{{generic_open}}{{regular}}{{generic_close}}\s*{{generic_close}}{{balance_parentheses}}>
 
   data_structures_forward_decl_lookahead: '(\s+{{macro_identifier}})*\s*(:\s*({{path_lookahead}}|{{visibility_modifiers}}|,|\s|<[^;]*>)+)?;'
   non_func_keywords: 'if|for|switch|while|decltype|sizeof|__declspec|__attribute__|typeid|alignof|alignas|static_assert'

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -2323,6 +2323,9 @@ void sayHi()
 /*       ^^^ meta.brackets */
 /*       ^ punctuation.section.brackets.begin */
 /*         ^ punctuation.section.brackets.end */
+
+    std::cout << ">> Hi!\n";
+/*            ^^ keyword.operator.arithmetic.c */
 }
 
 /////////////////////////////////////////////


### PR DESCRIPTION
generic_lookahead should not include patterns like '<<', '<<<', which causes bugs like #2042.