### PR TITLE
[C++/ObjC++] Highlight friend methods with body

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1226,23 +1226,31 @@ contexts:
       push: data-structures-modifier
     - include: expressions-minus-generic-type
 
+  data-structures-modifier-friend:
+    - match: (?=;)
+      pop: true
+    - match: '\{'
+      scope: punctuation.section.block.begin.c++
+      set:
+        - meta_scope: meta.block.c++
+        - match: '\}'
+          scope: punctuation.section.block.end.c++
+          pop: true
+        - include: statements
+    - include: expressions-minus-function-call
+
   data-structures-modifier:
     - match: '\bfriend\b'
       scope: storage.modifier.c++
       push:
-        - match: (?=;)
-          pop: true
-        - match: '\{'
-          scope: punctuation.section.block.begin.c++
-          set:
-            - meta_scope: meta.block.c++
-            - match: '\}'
-              scope: punctuation.section.block.end.c++
-              pop: true
-            - include: statements
+        - include: comments
         - match: '\b({{before_tag}})\b'
           scope: storage.type.c++
-        - include: expressions-minus-function-call
+          set: data-structures-modifier-friend
+        - match: '(?=\S)(?=[^;]+;)'
+          set: data-structures-modifier-friend
+        - match: '(?=\S)'
+          pop: true
     - include: comments
     - include: modifiers-parens
     - include: modifiers

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1672,9 +1672,9 @@ private:
     friend int func(int a, int b) {
 /*  ^ storage.modifier */
 /*         ^ storage.type */
-/*             ^ - entity.name.function */
+/*             ^ entity.name.function */
 /*             ^ - meta.function-call */
-/*                                ^ meta.class meta.block meta.block punctuation.section.block.begin */
+/*                                ^ meta.class meta.block meta.method meta.block punctuation.section.block.begin */
         int a = 1;
     }
 /*  ^ meta.class meta.block meta.block punctuation.section.block.end */
@@ -1685,6 +1685,13 @@ private:
 /*         ^ storage.type
 /*               ^^ punctuation.accessor */
 /*                 ^ - entity */
+
+    friend bool operator != (const X& lhs, const X& rhs) {
+    /*          ^^^^^^^^^^^ entity.name.function */
+        int a = 1;
+    }
+/*  ^ meta.class meta.block meta.block punctuation.section.block.end */
+/*   ^ - meta.class meta.block meta.block */
 
     #if 0
     /*  ^ constant.numeric */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1298,23 +1298,31 @@ contexts:
     - include: preprocessor-expressions
     - include: expressions-minus-generic-type
 
+  data-structures-modifier-friend:
+    - match: (?=;)
+      pop: true
+    - match: '\{'
+      scope: punctuation.section.block.begin.objc++
+      set:
+        - meta_scope: meta.block.objc++
+        - match: '\}'
+          scope: punctuation.section.block.end.objc++
+          pop: true
+        - include: statements
+    - include: expressions-minus-function-call
+
   data-structures-modifier:
     - match: '\bfriend\b'
       scope: storage.modifier.objc++
       push:
-        - match: (?=;)
-          pop: true
-        - match: '\{'
-          scope: punctuation.section.block.begin.objc++
-          set:
-            - meta_scope: meta.block.objc++
-            - match: '\}'
-              scope: punctuation.section.block.end.objc++
-              pop: true
-            - include: statements
+        - include: comments
         - match: '\b({{before_tag}})\b'
           scope: storage.type.objc++
-        - include: expressions-minus-function-call
+          set: data-structures-modifier-friend
+        - match: '(?=\S)(?=[^;]+;)'
+          set: data-structures-modifier-friend
+        - match: '(?=\S)'
+          pop: true
     - include: comments
     - include: modifiers-parens
     - include: modifiers

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1644,9 +1644,9 @@ private:
     friend int func(int a, int b) {
 /*  ^ storage.modifier */
 /*         ^ storage.type */
-/*             ^ - entity.name.function */
+/*             ^ entity.name.function */
 /*             ^ - meta.function-call */
-/*                                ^ meta.class meta.block meta.block punctuation.section.block.begin */
+/*                                ^ meta.class meta.block meta.method meta.block punctuation.section.block.begin */
         int a = 1;
     }
 /*  ^ meta.class meta.block meta.block punctuation.section.block.end */
@@ -1657,6 +1657,13 @@ private:
 /*         ^ storage.type
 /*               ^^ punctuation.accessor */
 /*                 ^ - entity */
+
+    friend bool operator != (const X& lhs, const X& rhs) {
+    /*          ^^^^^^^^^^^ entity.name.function */
+        int a = 1;
+    }
+/*  ^ meta.class meta.block meta.block punctuation.section.block.end */
+/*   ^ - meta.class meta.block meta.block */
 
     #if 0
     /*  ^ constant.numeric */


### PR DESCRIPTION
This PR aims to retry the attempt in #1083. 
More details can be seen in #2080. 

With this PR, friend methods **with body** is marked with `entity.name.function`, 
while other types of declarations remain untouched. 