### PR TITLE
[HTML] Improve class/id attribute lists

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -404,7 +404,7 @@ contexts:
           captures:
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.script.html
-          set: 
+          set:
             - meta_scope: meta.tag.script.end.html
             - include: tag-end
             - include: tag-attributes
@@ -550,6 +550,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
+        - include: tag-attribute-value-separator
         - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
@@ -559,6 +560,7 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
+        - include: tag-attribute-value-separator
         - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
@@ -596,6 +598,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
+        - include: tag-attribute-value-separator
         - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
@@ -605,6 +608,7 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
+        - include: tag-attribute-value-separator
         - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
@@ -705,6 +709,12 @@ contexts:
     - include: tag-style-attribute
     - include: tag-event-attribute
     - include: tag-generic-attribute
+
+  tag-attribute-value-separator:
+    - match: (?=[{{ascii_space}}])
+      push:
+        - clear_scopes: 1 # clear `meta.class-name` or `meta.toc-list.id`
+        - include: else-pop
 
   tag-end:
     - match: '>'

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -521,6 +521,7 @@ contexts:
           pop: true
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
+        - include: entities
     - include: else-pop
 
   tag-class-attribute:
@@ -566,6 +567,7 @@ contexts:
           pop: true
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
+        - include: entities
     - include: else-pop
 
   tag-id-attribute:
@@ -611,6 +613,7 @@ contexts:
           pop: true
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
+        - include: entities
     - include: else-pop
 
   tag-style-attribute:

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -298,6 +298,13 @@ class="foo"></div>
         ##   ^^^^^^^ meta.attribute-with-value.id
         ##      ^^^^ string.unquoted meta.toc-list.id
 
+        <div id=My&#x49;d></div>
+        ##  ^ - meta.attribute-with-value.id
+        ##   ^^ entity.other.attribute-name.id
+        ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
+        ##      ^^^^^^^^^ string.unquoted meta.toc-list.id
+        ##        ^^^^^^ constant.character.entity.hexadecimal
+
         <div id='MyId2'></div>
         ##  ^ - meta.attribute-with-value.id
         ##   ^^^^^^^^^^ meta.attribute-with-value.id
@@ -321,6 +328,13 @@ class="foo"></div>
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##         ^^^^^^^^^^^^^ string.unquoted meta.class-name
+
+        <div class=element&#xAD;class></div>
+        ##  ^ - meta.attribute-with-value.class
+        ##   ^^^^^ entity.other.attribute-name.class
+        ##   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
+        ##         ^^^^^^^^^^^^^^^^^^ string.unquoted meta.class-name
+        ##                ^^^^^^ constant.character.entity.hexadecimal
 
         <div class='element-class'></div>
         ##  ^ - meta.attribute-with-value.class

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -323,6 +323,42 @@ class="foo"></div>
         ##       ^^^^^^^^^ meta.toc-list.id
         ##                ^ punctuation.definition.string.end - meta.toc-list.id
 
+        <div id=el-&foo;" bar&baz;></div>
+        ##  ^ - meta.attribute-with-value.id
+        ##   ^^ entity.other.attribute-name.id
+        ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
+        ##      ^^^^^^^^^ string.unquoted meta.toc-list.id
+        ##         ^^^^^ constant.character.entity.named
+        ##              ^ invalid.illegal.attribute-value.html
+        ##               ^ - meta.attribute-with-value - entity - constant - string - punctuation
+        ##                ^^^^^^^^ meta.attribute-with-value entity.other.attribute-name
+
+        <div id='el-&foo;" bar&baz;'></div>
+        ##  ^ - meta.attribute-with-value.id
+        ##   ^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id
+        ##   ^^ entity.other.attribute-name.id
+        ##      ^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+        ##      ^ punctuation.definition.string.begin - meta.toc-list.id
+        ##       ^^^^^^^^^ meta.toc-list.id
+        ##          ^^^^^ constant.character.entity
+        ##                ^ - meta.toc-list.id
+        ##                 ^^^^^^^^ meta.toc-list.id
+        ##                    ^^^^^ constant.character.entity
+        ##                         ^ punctuation.definition.string.end - meta.toc-list.id
+
+        <div id="el-&foo;' bar&baz;"></div>
+        ##  ^ - meta.attribute-with-value.id
+        ##   ^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id
+        ##   ^^ entity.other.attribute-name.id
+        ##      ^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+        ##      ^ punctuation.definition.string.begin - meta.toc-list.id
+        ##       ^^^^^^^^^ meta.toc-list.id
+        ##          ^^^^^ constant.character.entity
+        ##                ^ - meta.toc-list.id
+        ##                 ^^^^^^^^ meta.toc-list.id
+        ##                    ^^^^^ constant.character.entity
+        ##                         ^ punctuation.definition.string.end - meta.toc-list.id
+
         <div class=element-class></div>
         ##  ^ - meta.attribute-with-value.class
         ##   ^^^^^ entity.other.attribute-name.class
@@ -353,6 +389,42 @@ class="foo"></div>
         ##         ^ punctuation.definition.string.begin - meta.class-name
         ##          ^^^^^^^^^^^^^ meta.class-name
         ##                       ^ punctuation.definition.string.end - meta.class-name
+
+        <div class=el-&foo;" bar&baz;></div>
+        ##  ^ - meta.attribute-with-value.class
+        ##   ^^^^^ entity.other.attribute-name.class
+        ##   ^^^^^^^^^^^^^^^ meta.attribute-with-value.class
+        ##         ^^^^^^^^^ string.unquoted meta.class-name
+        ##            ^^^^^ constant.character.entity.named
+        ##                 ^ invalid.illegal.attribute-value.html
+        ##                  ^ - meta.attribute-with-value - entity - constant - string - punctuation
+        ##                   ^^^^^^^^ meta.attribute-with-value entity.other.attribute-name
+
+        <div class='el-&foo;" bar&baz;'></div>
+        ##  ^ - meta.attribute-with-value.class
+        ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
+        ##   ^^^^^ entity.other.attribute-name.class
+        ##         ^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+        ##         ^ punctuation.definition.string.begin - meta.class-name
+        ##          ^^^^^^^^^ meta.class-name
+        ##             ^^^^^ constant.character.entity
+        ##                   ^ - meta.class-name
+        ##                    ^^^^^^^^ meta.class-name
+        ##                       ^^^^^ constant.character.entity
+        ##                            ^ punctuation.definition.string.end - meta.class-name
+
+        <div class="el-&foo;' bar&baz;"></div>
+        ##  ^ - meta.attribute-with-value.class
+        ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
+        ##   ^^^^^ entity.other.attribute-name.class
+        ##         ^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+        ##         ^ punctuation.definition.string.begin - meta.class-name
+        ##          ^^^^^^^^^ meta.class-name
+        ##             ^^^^^ constant.character.entity
+        ##                   ^ - meta.class-name
+        ##                    ^^^^^^^^ meta.class-name
+        ##                       ^^^^^ constant.character.entity
+        ##                            ^ punctuation.definition.string.end - meta.class-name
 
         <div style="width: 100%"></div>
         ##  ^ - meta.attribute-with-value.style


### PR DESCRIPTION
This PR attempts to support a fix for https://github.com/SublimeTextIssues/Core/issues/2960

It includes 2 major changes.

1. Add support for entity highlighting in unquoted attribute values according to [whatwg.org / 12.2.5.38 Attribute value (unquoted) state](https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-value-(quoted)-state)
2. Split the `meta.class-name` and `meta.toc-list.id` tokens by spaces in order to make the meta-scopes represent a single class or id only. This change makes it possible to target each class/id individually.

_Note: This PR does not add a `punctuation.separator.sequence` for the space between the classes or ids, because it is unclear, whether a space should really be scoped as punctuation._

## Example

```html
<html>
<head>
    <style type="text/css">
        #MyId {
            font-size: 33pt;
        }
        .el-ment\' {
            font-weight: bold;
        }
    </style>
</head>
<body>

    <div id=My&#x49;d class="el-m&#x65;nt'">hello</div>
</body>
</html>
```

## Screenshot

![grafik](https://user-images.githubusercontent.com/16542113/64486032-52baa800-d228-11e9-97cb-246c6405029d.png)
