### PR TITLE
[Makefile] Fix "detect_indentation" setting overriding user settings

### DIFF
--- a/Makefile/Makefile.sublime-settings
+++ b/Makefile/Makefile.sublime-settings
@@ -1,4 +1,3 @@
 {
-	"translate_tabs_to_spaces": false,
-	"detect_indentation": true
+	"translate_tabs_to_spaces": false
 }


### PR DESCRIPTION
The default is already to detect indentation, so a user override should
be respected