### PR TITLE
[Go] Fix unclosed {{ string highlighting

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -498,7 +498,7 @@ contexts:
         - include: match-fmt
 
   match-template-string:
-   - match: "{{"
+   - match: '{{(?=.*}})'
      scope: punctuation.section.interpolation.begin.go
      push:
        - meta_scope: meta.interpolation.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2772,6 +2772,8 @@ every function individually.
 Templates
 */
 func template() {
+    t := "\{{ foo }} bar }} {{baz} foo {{baz "
+    //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
     t := "{{.Count}} items are made of {{.Material}}"
     //    ^^^^^^^^^^ meta.interpolation
     //    ^^ punctuation.section.interpolation.begin


### PR DESCRIPTION
Fixes #2008

This commit adds a lookahead to avoid matching a string after `{{` as interpolation, if not followed by `}}` in the same line.

Note:

Any character - even quotation marks - are allowed within the interpolation, because an interpolation can contain quoted strings as well.