### PR TITLE
[JavaScript] Improve scopes for textual operators

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1069,14 +1069,14 @@ contexts:
     - match: \+|\-
       scope: keyword.operator.arithmetic.js
     - match: (?:delete|typeof|void){{identifier_break}}
-      scope: keyword.operator.js
+      scope: keyword.operator.word.js
 
   binary-operators:
     - match: instanceof{{identifier_break}}
-      scope: keyword.operator.js
+      scope: keyword.operator.word.js
       push: expression-begin
     - match: in{{identifier_break}}
-      scope: keyword.operator.js
+      scope: keyword.operator.word.js
       push: expression-begin
     - match: '&&|\|\|'
       scope: keyword.operator.logical.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -708,7 +708,7 @@ for (var i = 0; i < 10; i++) {
 //  ^^^ keyword.control.loop
 //      ^^^^^^^^^^^^^^ meta.group
 //       ^ punctuation.separator.expression
-//           ^^ keyword.operator
+//           ^^ keyword.operator.word
 //                  ^ punctuation.separator.expression
 
     for (a[x in list];;) {}
@@ -716,7 +716,7 @@ for (var i = 0; i < 10; i++) {
 //  ^^^ keyword.control.loop
 //      ^^^^^^^^^^^^^^^^ meta.group
 //        ^^^^^^^^^^^ meta.brackets
-//           ^^ keyword.operator
+//           ^^ keyword.operator.word
 //                   ^ punctuation.separator.expression
 //                    ^ punctuation.separator.expression
 
@@ -1479,6 +1479,7 @@ new $Dollar();
 //  ^ variable.type.dollar punctuation.dollar
 
 void {
+//^^ keyword.operator.word
     'test1': [],
     'test2': new SomeObjectHash["default"],
 //               ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.constructor
@@ -1584,11 +1585,11 @@ a = /\//u + 0;
 
     x
     in y;
-//  ^^ keyword.operator
+//  ^^ keyword.operator.word
 
     x
     instanceof y;
-//  ^^^^^^^^^^ keyword.operator
+//  ^^^^^^^^^^ keyword.operator.word
 
 var π = 3.141592653
 //  ^ variable.other.readwrite


### PR DESCRIPTION
This PR applies the scope `keyword.operator.word` instead of just `keyword.operator` to `delete`, `typeof`, `void`, `instanceof`, `in`, so that they are picked up by color schemes that want to highlight textual operators differently from symbolic operators.
Reference: https://www.sublimetext.com/docs/3/scope_naming.html#keyword

Edit: @michaelblyons is something wrong with this (because you reacted with confused emoji)? This should have no effect for color schemes that highlight all operators the same, but those that want to differentiate between symbols and word operators don't have to add an extra rule for JavaScript. And it should comply with the scope naming guidelines now.