### PR TITLE
[Makefile] improve first line match

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -21,7 +21,11 @@ file_extensions:
   - OCamlMakefile
   - mak
   - mk
-first_line_match: ^#!\s*/usr/bin/make\b
+first_line_match: |-
+  (?xi:
+    ^\#! .* \bmake\b |                     # shebang
+    ^\# \s* -\*- [^*]* makefile [^*]* -\*- # editorconfig
+  )
 scope: source.makefile
 #-------------------------------------------------------------------------------
 variables:


### PR DESCRIPTION
This commit applies the `first_line_match` pattern from Bash and Perl syntaxes to improve shebang and editorconfig support.