### PR TITLE
[Ruby] improve first line match

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -74,7 +74,11 @@ file_extensions:
   - thor
   - Thorfile
   - Vagrantfile
-first_line_match: ^#!\s*/.*\bj?ruby\b
+first_line_match: |-
+  (?xi:
+    ^\#! .* \bj?ruby\b |                # shebang
+    ^\# \s* -\*- [^*]* ruby [^*]* -\*-  # editorconfig
+  )
 scope: source.ruby
 variables:
   identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'


### PR DESCRIPTION
This commit applies the `first_line_match` pattern from Bash and Perl syntaxes to improve shebang and editorconfig support.