### PR TITLE
[SCALA] Proper parsing annotations in a class parameter list

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -569,6 +569,11 @@ contexts:
   class-type-parameter-list:
     - match: '\b(private|protected)\b'
       scope: storage.modifier.access.scala
+    - match: (?=@{{plainid}})
+      set:
+        - include: annotation
+        - match: '(?=\S)'
+          set: class-type-parameter-list
     - match: '(?=\()'
       set: class-parameter-list
     - match: '\['

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -182,21 +182,31 @@ contexts:
           set: annotation-parameters
     - match: '(@)({{alphaplainid}})'
       captures:
-        1: meta.annotation.scala punctuation.definition.annotation.scala
-        2: meta.annotation.identifier.scala variable.annotation.scala
+       1: meta.annotation.scala punctuation.definition.annotation.scala
+       2: meta.annotation.identifier.scala variable.annotation.scala
       push: annotation-parameters
 
   annotation-parameters:
     - meta_content_scope: meta.annotation.parameters.scala
+    - match: (?=\(\))
+      push:
+      - match: \(
+        scope: punctuation.section.arguments.annotation.begin.scala
+      - match: (?=\))
+        scope: punctuation.section.arguments.annotation.end.scala
+        pop: true
     - match: \(
       scope: punctuation.section.arguments.annotation.begin.scala
       push:
-        - match: ','
-          scope: punctuation.separator.arguments.annotation.scala
-        - match: \)
+        - match: (?=\))
           scope: punctuation.section.arguments.annotation.end.scala
           pop: true
+        - match: ','
+          scope: punctuation.separator.arguments.annotation.scala
         - include: main
+    - match: \)
+      scope: punctuation.section.arguments.annotation.end.scala
+      pop: true
     - match: \[
       scope: punctuation.section.arguments.annotation.begin.scala
       push:

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -182,8 +182,8 @@ contexts:
           set: annotation-parameters
     - match: '(@)({{alphaplainid}})'
       captures:
-       1: meta.annotation.scala punctuation.definition.annotation.scala
-       2: meta.annotation.identifier.scala variable.annotation.scala
+        1: meta.annotation.scala punctuation.definition.annotation.scala
+        2: meta.annotation.identifier.scala variable.annotation.scala
       push: annotation-parameters
 
   annotation-parameters:

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1329,12 +1329,30 @@ trait AlgebraF[F[_]] { type f[x] = Algebra[F,x] }
 //                     ^^^^ storage.type.scala
 //                               ^ keyword.operator.assignment.scala
 
+class Foo @Inject()(a: String)
+//         ^^^^^^ meta.annotation.identifier
+//                 ^- meta.annotation
+//                  ^ variable.parameter.scala
+
+class Foo @Inject() @Provided(scope = "test")(a: String)
+//         ^^^^^^ meta.annotation.identifier
+//                 ^- meta.annotation
+//                   ^^^^^^^ meta.annotation.identifier
+//                           ^^^^^^^ meta.annotation.parameters
+//                                           ^- meta.annotation
+//                                            ^ variable.parameter.scala
+
+class Foo @Inject(z = "a")(a: String)
+//         ^^^^^^ variable.annotation
+//                ^^^^^^^ meta.annotation.parameters
+//                         ^ variable.parameter.scala
+
 // annotation examples from: http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html
 @deprecated("Use D", "1.0") class C { ... }
 // <- meta.annotation
 // ^^ variable.annotation
 //            ^^ string
-//                        ^ meta.annotation
+//                       ^ meta.annotation
 //                         ^ - meta.annotation
 
 @transient @volatile var m: Int
@@ -1372,7 +1390,7 @@ trait Function0[@specialized(Unit, Int, Double) T] {
 //                                              ^ support.class
 //              ^ punctuation.definition.annotation
 //              ^ meta.annotation
-//                                            ^ meta.annotation.parameters
+//                                           ^ meta.annotation.parameters
 //                                             ^ - meta.annotation
 //                               ^ punctuation.separator.arguments.annotation
   def apply: T

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1347,6 +1347,12 @@ class Foo @Inject(z = "a")(a: String)
 //                ^^^^^^^ meta.annotation.parameters
 //                         ^ variable.parameter.scala
 
+class Foo[A] @Inject()(a: String)
+//        ^ support.class
+//            ^^^^^^ meta.annotation.identifier
+//                    ^- meta.annotation
+//                     ^ variable.parameter.scala
+
 // annotation examples from: http://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html
 @deprecated("Use D", "1.0") class C { ... }
 // <- meta.annotation


### PR DESCRIPTION
This a fix for annoying pink highlights, when class using annotations for a parameter list, for example:

```scala
class TestController @Inject()(controllerComponents: ControllerComponents) extends AbstractController(controllerComponents) with I18nSupport
```
Without that fix, `extends` and `with` have this illegal syntax hightlights.