### PR TITLE
[Git Formats/Git Commit] Add scope for rename punctuation "->"

### DIFF
--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -112,7 +112,16 @@ contexts:
         1: keyword.other.change-list.git.commit
         2: punctuation.separator.mapping.pair.change-list.git.commit
         3: string.unquoted.git.commit markup.inserted.file.git.commit
-    - match: \b({{copied}}|{{renamed}}|{{typechange}})\s*(:)\s*(.*)
+    - match: \b({{copied}}|{{renamed}})\s*(:)\s*((.+)\s+(->)\s+(.+))
+      scope: meta.change-list.git.commit
+      captures:
+        1: keyword.other.change-list.git.commit
+        2: punctuation.separator.mapping.pair.change-list.git.commit
+        3: string.unquoted.git.commit
+        4: markup.changed.file.name.git.commit
+        5: punctuation.separator.mapping.pair.path.git.commit
+        6: markup.changed.file.name.git.commit
+    - match: \b({{typechange}})\s*(:)\s*(.*)
       scope: meta.change-list.git.commit
       captures:
         1: keyword.other.change-list.git.commit

--- a/Git Formats/syntax_test_git_commit
+++ b/Git Formats/syntax_test_git_commit
@@ -183,6 +183,10 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #    ^^^^^^^^ keyword.other.change-list.git.commit
 #            ^ punctuation.separator.mapping.pair.change-list.git.commit
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.commit markup.changed.file.content.git.commit
+#    renamed:    gitconfig/old_name -> gitconfig/new_name
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit
+#                                   ^^ punctuation.separator.mapping.pair.path.git.commit
 #    deleted:    gitconfig/Symbol List.tmPreferences
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit
@@ -205,6 +209,10 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #    ^^^^^^^^ keyword.other.change-list.git.commit
 #            ^ punctuation.separator.mapping.pair.change-list.git.commit
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.commit markup.changed.file.content.git.commit
+#    renommé:    gitconfig/old_name -> gitconfig/new_name
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit
+#                                   ^^ punctuation.separator.mapping.pair.path.git.commit
 #    gelöscht:   gitconfig/Symbol List.tmPreferences
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit
@@ -227,6 +235,10 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #    ^^ keyword.other.change-list.git.commit
 #      ^ punctuation.separator.mapping.pair.change-list.git.commit
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.commit markup.changed.file.content.git.commit
+#    重命名:    gitconfig/old_name -> gitconfig/new_name
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit
+#                               ^^ punctuation.separator.mapping.pair.path.git.commit
 #    删除:         gitconfig/Symbol List.tmPreferences
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.change-list.git.commit


### PR DESCRIPTION
```
#   renamed:    old_file -> new_file
#                        ^^ punctuation.separator.mapping.pair.path.git.commit
```

This make it possible to make the `renamed:` (and `copied:`) line more readable by giving a dedicated scope to the `->` separator.

![image](https://user-images.githubusercontent.com/6594915/65402867-a0780880-de03-11e9-9142-0b979080ad9f.png)


---

`typechage:` has no `->`.

![image](https://user-images.githubusercontent.com/6594915/65536601-5774a100-df36-11e9-940e-31693c04bcc5.png)
