### PR TITLE
[Python] Rename scope of assert keyword

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -97,7 +97,7 @@ contexts:
             - include: expressions
         - include: expressions
     - match: \b(assert)\b
-      scope: keyword.other.assert.python
+      scope: keyword.control.flow.assert.python
     - match: \b(del)\b
       scope: keyword.other.del.python
     - match: \b(print)\b(?! *([,.()\]}]))

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -518,6 +518,9 @@ def _():
         await something()
 #       ^^^^^ keyword.other.await
 
+    assert foo == bar
+#   ^^^^^^ keyword.control.flow.assert.python
+
     try:
 #   ^^^^ meta.statement.exception.try.python
 #   ^^^ keyword.control.exception.try.python


### PR DESCRIPTION
This commit scopes the `assert` keyword as `keyword.control.flow`.