### PR TITLE
[Git Formats] Embed commit message into git log

### DIFF
--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -18,11 +18,8 @@ contexts:
       captures:
         1: keyword.other.commit.git.log
         2: constant.numeric.hex.hash.git.log
-      push: commit-header
-      with_prototype:
-        # make sure to pop off stack for next commit
-        - match: ^(?=commit)
-          pop: true
+      embed: commit-header
+      escape: (?=^commit\s)
 
   commit-header:
     # All header attributes are mappings of `key: value` format.
@@ -39,4 +36,7 @@ contexts:
         - match: \n
           pop: true
         - include: Git Common.sublime-syntax#email
-    - include: Git Commit.sublime-syntax
+    # using push instead of include as workaround for
+    # https://github.com/SublimeTextIssues/Core/issues/2395
+    - match: ^
+      push: Git Commit.sublime-syntax


### PR DESCRIPTION
This PR proposes to use the `embed` command instead of `push with_prototype` to include the Git Commit.sublime-syntax into Git Log.sublime-syntax

It is a performance tweak (about 5% faster).

**Note:**
  
It contains a workaround for 

  https://github.com/SublimeTextIssues/Core/issues/2395

as the `Git Commit.sublime-syntax` "sets away from main", which causes the `escape` command to be ignored with all current builds of ST3.