### PR TITLE
[Git Formats] Add Git Log settings

### DIFF
--- a/Git Formats/Git Log.sublime-settings
+++ b/Git Formats/Git Log.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // Ensure not to modify a git log due to the following settings
+    // being set `true` in the User/Preferences.sublime-settings
+    "ensure_newline_at_eof_on_save": false,
+    "trim_trailing_white_space_on_save": false,
+}


### PR DESCRIPTION
This PR proposes to add a syntax specific settings file for the `Git Log` to prevent such files from being modified upon saving due to

    "ensure_newline_at_eof_on_save": true,
    "trim_trailing_white_space_on_save": true,

being set in the User/Preferences.sublime-settings

Git indents the git commit messages by 4 spaces including empty lines. Therefore empty commit message lines always contain 4 space characters which are deleted if "ensure_newline_at_eof_on_save": true is set and a gitlog file is saved.