### PR TITLE
[R] Remove .S file extension

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -5,8 +5,6 @@ name: R
 file_extensions:
   - R
   - r
-  - s
-  - S
   - Rprofile
 scope: source.r
 


### PR DESCRIPTION
Fixes #1935

The `.S` file extension is used by assembly code, which causes them to be highlighted as R by accident.