### PR TITLE
[JavaScript] Update control keyword scopes

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -315,23 +315,29 @@ contexts:
     - include: label
     - include: variable-declaration
 
-    - match: throw{{identifier_break}}
-      scope: keyword.control.trycatch.js
-      set: restricted-production
-
-    - match: (?:break|continue){{identifier_break}}
-      scope: keyword.control.loop.js
+    - match: break{{identifier_break}}
+      scope: keyword.control.flow.break.js
       set:
         - expect-semicolon
         - expect-label
 
-    - match: return{{identifier_break}}
-      scope: keyword.control.flow.js
-      set: restricted-production
+    - match: continue{{identifier_break}}
+      scope: keyword.control.flow.continue.js
+      set:
+        - expect-semicolon
+        - expect-label
 
     - match: debugger{{identifier_break}}
-      scope: keyword.other.debugger.js
+      scope: keyword.control.flow.debugger.js
       set: expect-semicolon
+
+    - match: return{{identifier_break}}
+      scope: keyword.control.flow.return.js
+      set: restricted-production
+
+    - match: throw{{identifier_break}}
+      scope: keyword.control.flow.throw.js
+      set: restricted-production
 
     - include: function-or-class-declaration
 
@@ -584,21 +590,21 @@ contexts:
 
   conditional:
     - match: switch{{identifier_break}}
-      scope: keyword.control.switch.js
+      scope: keyword.control.conditional.switch.js
       set:
         - switch-meta
         - switch-block
         - expect-parenthesized-expression
 
     - match: do{{identifier_break}}
-      scope: keyword.control.loop.js
+      scope: keyword.control.loop.do-while.js
       set:
         - do-while-meta
         - do-while-condition
         - block-scope
 
     - match: for{{identifier_break}}
-      scope: keyword.control.loop.js
+      scope: keyword.control.loop.for.js
       set:
         - for-meta
         - block-scope
@@ -606,46 +612,53 @@ contexts:
         - for-await
 
     - match: while{{identifier_break}}
-      scope: keyword.control.loop.js
+      scope: keyword.control.loop.while.js
       set:
         - while-meta
         - block-scope
         - expect-parenthesized-expression
 
     - match: with{{identifier_break}}
-      scope: keyword.control.with.js
+      scope: keyword.control.flow.with.js
       set:
         - with-meta
         - block-scope
         - expect-parenthesized-expression
 
-    - match: (?:else\s+if|if){{identifier_break}}
-      scope: keyword.control.conditional.js
+    - match: if{{identifier_break}}
+      scope: keyword.control.conditional.if.js
+      set:
+        - conditional-meta
+        - block-scope
+        - expect-parenthesized-expression
+
+    - match: else\s+if{{identifier_break}}
+      scope: keyword.control.conditional.elseif.js
       set:
         - conditional-meta
         - block-scope
         - expect-parenthesized-expression
 
     - match: else{{identifier_break}}
-      scope: keyword.control.conditional.js
+      scope: keyword.control.conditional.else.js
       set:
         - conditional-meta
         - block-scope
 
     - match: try{{identifier_break}}
-      scope: keyword.control.trycatch.js
+      scope: keyword.control.exception.try.js
       set:
         - try-meta
         - block-scope
 
     - match: finally{{identifier_break}}
-      scope: keyword.control.trycatch.js
+      scope: keyword.control.exception.finally.js
       set:
         - finally-meta
         - block-scope
 
     - match: catch{{identifier_break}}
-      scope: keyword.control.trycatch.js
+      scope: keyword.control.exception.catch.js
       set:
         - catch-meta
         - block-scope
@@ -702,7 +715,7 @@ contexts:
 
   for-await:
     - match: await{{identifier_break}}
-      scope: keyword.control.loop.js
+      scope: keyword.control.flow.await.js
       pop: true
     - include: else-pop
 
@@ -778,13 +791,13 @@ contexts:
       pop: true
 
     - match: case{{identifier_break}}
-      scope: keyword.control.switch.js
+      scope: keyword.control.conditional.case.js
       push:
         - expect-case-colon
         - expression
 
     - match: default{{identifier_break}}
-      scope: keyword.control.switch.js
+      scope: keyword.control.conditional.default.js
       push:
         - expect-case-colon
 
@@ -792,7 +805,7 @@ contexts:
 
   do-while-condition:
     - match: while{{identifier_break}}
-      scope: keyword.control.loop.js
+      scope: keyword.control.loop.while.js
       set: parenthesized-expression
     - include: else-pop
 
@@ -1159,7 +1172,7 @@ contexts:
 
   yield-expression:
     - match: yield{{identifier_break}}
-      scope: keyword.control.flow.js
+      scope: keyword.control.flow.yield.js
       set:
         - match: $
           pop: true
@@ -1171,7 +1184,7 @@ contexts:
 
   await-expression:
     - match: await{{identifier_break}}
-      scope: keyword.control.flow.js
+      scope: keyword.control.flow.await.js
 
   class:
     - match: class{{identifier_break}}

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -619,7 +619,7 @@ contexts:
         - expect-parenthesized-expression
 
     - match: with{{identifier_break}}
-      scope: keyword.control.flow.with.js
+      scope: keyword.control.import.with.js
       set:
         - with-meta
         - block-scope

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -274,7 +274,7 @@ function foo(){}/**/
 //              ^ - meta.function
 
 if (true)
-// <- keyword.control.conditional
+// <- keyword.control.conditional.if
 {
     bar()
 }
@@ -289,7 +289,7 @@ if (true)
 // <- comment.block.documentation punctuation.definition.comment.end
 
 /**
-    * 
+    *
 //  ^ comment.block.documentation.js punctuation.definition.comment.js
 */
 
@@ -662,6 +662,7 @@ var qux = 100;
 //^ - meta.block
 
 if (Infinity > qux) {
+// <- meta.conditional.js keyword.control.conditional.if
 // ^^^^^^^^^^^^^^^ meta.conditional
 //  ^^^^^^^^ constant.language.infinity
     a;
@@ -676,14 +677,14 @@ if(false){}/**/
 //         ^ - meta.conditional
 
 do {
-// <- meta.do-while
+// <- meta.do-while keyword.control.loop.do-while
 // ^ meta.block
     qux += 1
 //  ^^^^^^^^ meta.do-while meta.block
 } while(qux < 20);
 // <- meta.block
 // ^^^^^^^^^^^^^^ meta.do-while - meta.block
-// ^^^^ keyword.control.loop
+// ^^^^ keyword.control.loop.while
 //      ^^^^^^^^ meta.group
 
 do // Incomplete statement
@@ -691,7 +692,10 @@ do // Incomplete statement
 //  ^^ constant.numeric - meta.do-while
 
 do {} while (false)/**/
+// <- meta.do-while keyword.control.loop.do-while
+//^^^^^^^^^^^^^^^^^ meta.do-while.js
 //                 ^^ - meta.do-while
+//    ^^^^^ keyword.control.loop.while.js
 
 for (var i = 0; i < 10; i++) {
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
@@ -705,7 +709,7 @@ for (var i = 0; i < 10; i++) {
 
     for (; x in list;) {}
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^ meta.group
 //       ^ punctuation.separator.expression
 //           ^^ keyword.operator
@@ -713,7 +717,7 @@ for (var i = 0; i < 10; i++) {
 
     for (a[x in list];;) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^ meta.group
 //        ^^^^^^^^^^^ meta.brackets
 //           ^^ keyword.operator
@@ -725,33 +729,33 @@ for (var i = 0; i < 10; i++) {
 
     for (const x in list) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^^ meta.group
 //       ^^^^^ storage.type
 //               ^^ keyword.operator.word
 
     for (const x of list) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^^ meta.group
 //       ^^^^^ storage.type
 //               ^^ keyword.operator.word
 
     for (x in list) {}
 //  ^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^ meta.group
 //         ^^ keyword.operator.word
 
     for (x of list) {}
 //  ^^^^^^^^^^^^^^^^^^ meta.for
-//  ^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^ meta.group
 //         ^^ keyword.operator.word
 
     for await (const x of list) {}
-//  ^^^ keyword.control.loop
-//      ^^^^^ keyword.control.loop
+//  ^^^ keyword.control.loop.for
+//      ^^^^^ keyword.control.flow.await
 
 for
     42;
@@ -766,10 +770,10 @@ while (true)
 {
 // <- meta.block
     x = yield;
-//      ^^^^^ keyword.control.flow
+//      ^^^^^ keyword.control.flow.yield
 
     x = yield * 42;
-//      ^^^^^ keyword.control.flow
+//      ^^^^^ keyword.control.flow.yield
 //            ^ keyword.generator.asterisk
 
     x = yield
@@ -784,23 +788,23 @@ while (true)
 //  ^^ meta.brackets - meta.sequence
 
     y = await 42;
-//      ^^^^^ keyword.control.flow
+//      ^^^^^ keyword.control.flow.await
 
     y = yield await 42;
-//      ^^^^^ keyword.control.flow
-//            ^^^^^ keyword.control.flow
+//      ^^^^^ keyword.control.flow.yield
+//            ^^^^^ keyword.control.flow.await
 
     yield (parenthesized_expression);
-//  ^^^^^ keyword.control.flow
+//  ^^^^^ keyword.control.flow.yield
 
     yield `template`;
-//  ^^^^^ keyword.control.flow
+//  ^^^^^ keyword.control.flow.yield
 
     break;
-//  ^^^^^ keyword.control.loop
+//  ^^^^^ keyword.control.flow.break
 
     break foo;
-//  ^^^^^ keyword.control.loop
+//  ^^^^^ keyword.control.flow.break
 //        ^^^ variable.label
 
     break
@@ -818,10 +822,10 @@ while (true)
 //        ^^^^^^^^ invalid.illegal.identifier variable.label
 
     continue;
-//  ^^^^^^^^ keyword.control.loop
+//  ^^^^^^^^ keyword.control.flow.continue
 
     continue foo;
-//  ^^^^^^^^ keyword.control.loop
+//  ^^^^^^^^ keyword.control.flow.continue
 //           ^^^ variable.label
 
     continue
@@ -848,10 +852,11 @@ while(false){}/**/
 //            ^ - meta.while
 
 with (undefined) {
-// <- keyword.control.with
+// <- keyword.control.flow.with
 //^^^^^^^^^^ meta.with
 //    ^^^^^^^^^ constant.language.undefined
     return;
+//  ^^^^^^ meta.with.js meta.block.js keyword.control.flow.return
 }
 
 with // Incomplete statement
@@ -862,23 +867,25 @@ with(false){}/**/
 //           ^ - meta.with
 
 switch ($foo) {
+// <- meta.switch.js keyword.control.conditional.switch
 // ^^^^^^^^^^^^ meta.switch
+//^^^^ keyword.control.conditional.switch
 //      ^^^^ meta.group
 //            ^ meta.block punctuation.section.block.begin
     case foo:
-    // ^ meta.switch meta.block keyword.control.switch
+    // ^ meta.switch meta.block keyword.control.conditional.case
     //      ^ - punctuation.separator.key-value
         qux = 1;
         break;
-        // ^ keyword.control.loop
+        // ^ keyword.control.flow.break
     case "baz":
-    // ^ keyword.control.switch
+    // ^ keyword.control.conditional.case
     //        ^ - punctuation.separator.key-value string
         qux = 2;
         break;
-        // ^ keyword.control.loop
+        // ^ keyword.control.flow.break
     default:
-    // ^ meta.switch meta.block keyword.control.switch
+    // ^ meta.switch meta.block keyword.control.conditional.default
     //     ^ - punctuation.separator.key-value
         qux = 3;
 
@@ -892,26 +899,28 @@ switch ($foo) {
 
     case 0: {}
     case 1:
-//  ^^^^ keyword.control.switch
+//  ^^^^ keyword.control.conditional.case
 }
 // <- meta.block punctuation.section.block.end
 
 try {
-// <- meta.try keyword.control.trycatch
+// <- meta.try keyword.control.exception.try
 // ^^ meta.try
 //  ^ meta.block
     foobar = qux.bar();
 //  ^^^^^^^^^^^^^^^^^^^ meta.try meta.block
 } catch (e) {
 // <- meta.block
-// ^^^^^^^ meta.catch
+//^^^^^^^^^^^^ meta.catch
+//^^^^^ keyword.control.exception.catch
 //       ^ meta.group
 //          ^ meta.block
     foobar = 0
 //  ^^^^^^^^^^ meta.catch meta.block
 } finally {
 // <- meta.block
-// ^^^^^^^^ meta.finally
+//^^^^^^^^^^ meta.finally
+//^^^^^^^ keyword.control.exception.finally
 //        ^ meta.block
     foobar += 1
 //  ^^^^^^^^^^^ meta.finally meta.block
@@ -1920,7 +1929,7 @@ function yy (a, b) {
 
     12345e6_7_8;
 //  ^^^^^^^^^^^ constant.numeric.decimal
-    
+
     123.456e+789;
 //  ^^^^^^^^^^^^ constant.numeric.decimal
 
@@ -1942,7 +1951,7 @@ function yy (a, b) {
 //       ^^^ meta.property.object
 
 debugger;
-// <- keyword.other.debugger
+// <- keyword.control.flow.debugger.js
 
 debugger
 []

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -852,7 +852,7 @@ while(false){}/**/
 //            ^ - meta.while
 
 with (undefined) {
-// <- keyword.control.flow.with
+// <- keyword.control.import.with
 //^^^^^^^^^^ meta.with
 //    ^^^^^^^^^ constant.language.undefined
     return;

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1173,7 +1173,7 @@ __test!*test__ Issue 1163
 | <- punctuation.definition.raw.code-fence.begin
 |  ^^ constant.other.language-name
 for (var i = 0; i < 10; i++) {
-| ^ keyword.control.loop.js
+| ^ source.js keyword.control.loop
     console.log(i);
 }
 ```


### PR DESCRIPTION
This PR proposes to modify control structure keyword scope names to make them comply with the results of the discussion in issue #1228.

The goal is to make all default syntaxes use the same precise scopes for related keywords.

Notes:

The following keywords haven't been discussed yet:

1) `await`    -> `keyword.control.flow.await`
2) `debugger` -> `keyword.control.flow.debugger`
3) `with`     -> ~~`keyword.control.flow.with`~~ `keyword.control.import.with`

~~The `with` might need to use another scope though, as it has a slightly different meaning.~~