### PR TITLE
[Diff] Add syntax specific setting to enforce tabs

### DIFF
--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"translate_tabs_to_spaces": false
+}

--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"translate_tabs_to_spaces": false
+	"trim_trailing_white_space_on_save": false
 }

--- a/Diff/diff.py
+++ b/Diff/diff.py
@@ -52,7 +52,9 @@ class DiffFilesCommand(sublime_plugin.WindowCommand):
             v.set_name(os.path.basename(files[1]) + " -> " + os.path.basename(files[0]))
             v.set_scratch(True)
             v.assign_syntax('Packages/Diff/Diff.sublime-syntax')
+            v.settings().set('translate_tabs_to_spaces', False)
             v.run_command('append', {'characters': difftxt})
+            v.settings().erase('translate_tabs_to_spaces')
 
     def is_visible(self, files):
         return len(files) == 2
@@ -100,7 +102,9 @@ class DiffChangesCommand(sublime_plugin.TextCommand):
             v.assign_syntax('Packages/Diff/Diff.sublime-syntax')
             v.settings().set('word_wrap', self.view.settings().get('word_wrap'))
 
+        v.settings().set('translate_tabs_to_spaces', False)
         v.run_command('append', {'characters': difftxt})
+        v.settings().erase('translate_tabs_to_spaces')
 
         if not use_buffer:
             win.run_command("show_panel", {"panel": "output.unsaved_changes"})


### PR DESCRIPTION
This adds a `Diff.sublime-settings` file that reinforces that the default  setting for `translate_tabs_to_spaces` in Diff files should be `false` unless the user specifically overrides it.

The rationale here is that the `diff_files` and `diff_changes` commands provided by the package use `append` to add the computed diff to the `view`/`panel`; thus if the user enables `translate_tabs_to_spaces` in their user preferences, diff output will always be portrayed with spaces regardless of the input file.

I think the expectation when computing a diff would be that both the context lines and the changed lines be represented as in the original files; translating tabs to spaces in this case can potentially distort the diff and make it harder to see what exactly has changed.

Making sure that this setting is disabled in a diff unless the user takes a deliberate action to do so still allows for this behaviour to remain if the user wants it.