### PR TITLE
[Matlab] Fix imaginary number scoped as invalid (#2111)

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -109,8 +109,8 @@ contexts:
     - include: all_matlab_keywords
     - include: all_matlab_comments
     - include: variable
-    - include: variable_invalid
     - include: number
+    - include: variable_invalid
     - include: operators
     - match: \.\.\.
       scope: punctuation.separator.continuation.matlab

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -157,8 +157,9 @@ end
 % <- constant.numeric.matlab
 1e1
 % <- constant.numeric.matlab
-1i
+1i - (4i)
 % <- constant.numeric.matlab
+%     ^^ constant.numeric.matlab
 1j
 % <- constant.numeric.matlab
 1e2j


### PR DESCRIPTION
Simple reorder of context fix the issue.
Add corresponding test.

Fix issue #2111 