### PR TITLE
[Python] Highlight inline expression operator :=

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -389,6 +389,7 @@ contexts:
         - match: \]
           scope: meta.item-access.python punctuation.section.brackets.end.python
           pop: true
+        - include: illegal-assignment-expression
         - match: ':'
           scope: punctuation.separator.slice.python
         - include: expression-in-a-group
@@ -520,9 +521,12 @@ contexts:
     - match: :=
       scope: keyword.operator.assignment.inline.python
 
-  assignments:
+  illegal-assignment-expression:
     - match: :=
       scope: invalid.illegal.not-allowed-here.python
+
+  assignments:
+    - include: illegal-assignment-expression
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
@@ -654,6 +658,7 @@ contexts:
             - meta_scope: meta.function.parameters.default-value.python
             - match: '(?=[,)])'
               set: [function-parameters, allow-unpack-operators]
+            - include: illegal-assignment-expression
             - include: expression-in-a-group
     - match: '(?=:)'
       set:
@@ -663,6 +668,7 @@ contexts:
             - meta_scope: meta.function.parameters.annotation.python
             - match: '(?=[,)=])'
               set: function-parameters
+            - include: illegal-assignment-expression
             - include: expression-in-a-group
     - include: function-parameters-tuple
     - include: illegal-names
@@ -708,6 +714,7 @@ contexts:
         - meta_content_scope: meta.function.annotation.return.python
         - match: ->
           scope: punctuation.separator.annotation.return.python
+        - include: illegal-assignment-expression
         - match: '(?=:)'
           set: function-after-parameters
         - include: line-continuation-or-pop
@@ -858,7 +865,8 @@ contexts:
         - match: '='
           scope: keyword.operator.assignment.python
           set:
-            - match: (?=\s*[,):])
+            - include: illegal-assignment-expression
+            - match: (?=[,):])
               pop: true
             - include: expression-in-a-group
         - include: illegal-names
@@ -876,7 +884,19 @@ contexts:
     - include: line-continuation-or-pop
     - match: '\:'
       scope: punctuation.section.function.begin.python
-      pop: true
+      set:
+        # clear meta_scope
+        - match: ''
+          set:
+            - meta_scope: meta.function.inline.body.python
+            - include: illegal-assignment-expression
+            # We don't know whether we are within a grouped
+            # or line-statement context at this point.
+            # If we're in a group, the underlying context will take over
+            # at the end of the line.
+            - match: (?=[,):])|$
+              pop: true
+            - include: expression-in-a-statement
     - match: ','
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
@@ -980,7 +1000,8 @@ contexts:
         - match: ','
           scope: punctuation.separator.set.python
           set: inside-set
-        - match: ':(?!=)'
+        - include: illegal-assignment-expression
+        - match: ':'
           scope: punctuation.separator.mapping.key-value.python
           set: inside-directory-value
         - include: inline-for
@@ -991,6 +1012,7 @@ contexts:
     - match: \}
       scope: punctuation.section.mapping.end.python
       set: after-expression
+    - include: illegal-assignment-expression
     - match: ':'
       scope: punctuation.separator.mapping.key-value.python
       set: inside-directory-value
@@ -1047,6 +1069,7 @@ contexts:
     - match: \}
       scope: punctuation.section.set.end.python
       set: after-expression
+    - include: illegal-assignment-expression
     - match: ':'
       scope: invalid.illegal.colon-inside-set.python
     - match: ','

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -64,7 +64,6 @@ variables:
     )*
 
 
-
 contexts:
   main:
     - include: statements
@@ -79,7 +78,7 @@ contexts:
     - include: assignments
     - match: ;
       scope: punctuation.terminator.statement.python
-    - include: line-expressions
+    - include: expression-as-a-statement
 
   line-statements:
     - include: imports
@@ -94,8 +93,8 @@ contexts:
           set:
             - meta_scope: meta.statement.raise.python
             - include: line-continuation-or-pop
-            - include: expressions
-        - include: expressions
+            - include: expression-in-a-statement
+        - include: expression-in-a-statement
     - match: \b(assert)\b
       scope: keyword.other.assert.python
     - match: \b(del)\b
@@ -112,8 +111,6 @@ contexts:
       scope: keyword.control.flow.continue.python
     - match: \b(pass)\b
       scope: keyword.control.flow.pass.python
-    - match: ':'
-      scope: punctuation.separator.annotation.variable.python
 
   imports:
     - match: \b(import)\b
@@ -215,11 +212,11 @@ contexts:
           set:
             - meta_content_scope: meta.statement.loop.for.python
             - include: line-continuation-or-pop
-            - match: ':'
+            - match: ':(?!=)'
               scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
               pop: true
-            - include: expressions
-        - match: ':'
+            - include: expression-in-a-statement
+        - match: ':(?!=)'
           scope: invalid.illegal.missing-in.python
           pop: true
         - include: target-list
@@ -235,7 +232,7 @@ contexts:
       push:
         - meta_scope: meta.statement.exception.catch.python
         - include: line-continuation-or-pop
-        - match: ':'
+        - match: ':(?!=)'
           scope: punctuation.section.block.exception.catch.python
           pop: true
         - match: '\bas\b'
@@ -253,19 +250,19 @@ contexts:
       push:
         - meta_scope: meta.statement.conditional.if.python
         - include: line-continuation-or-pop
-        - match: ':'
+        - match: ':(?!=)'
           scope: punctuation.section.block.conditional.if.python
           pop: true
-        - include: expressions
+        - include: expression-in-a-statement
     - match: \bwhile\b
       scope: keyword.control.loop.while.python
       push:
         - meta_scope: meta.statement.loop.while.python
         - include: line-continuation-or-pop
-        - match: ':'
+        - match: ':(?!=)'
           scope: punctuation.section.block.loop.while.python
           pop: true
-        - include: expressions
+        - include: expression-in-a-statement
     - match: \b(else)\b(?:\s*(:))?
       scope: meta.statement.conditional.else.python
       captures:
@@ -285,12 +282,12 @@ contexts:
       scope: keyword.control.conditional.elseif.python
       push:
         - meta_scope: meta.statement.conditional.elseif.python
-        - match: ':'
+        - match: ':(?!=)'
           scope: punctuation.section.block.conditional.elseif.python
           pop: true
         - match: $\n?
           pop: true
-        - include: line-expressions
+        - include: expression-in-a-statement
 
   with-body:
     - meta_scope: meta.statement.with.python
@@ -298,12 +295,12 @@ contexts:
     - match: \b(as)\b
       scope: keyword.control.flow.with.as.python
       set: with-as
-    - match: ':'
+    - match: ':(?!=)'
       scope: punctuation.section.block.with.python
       pop: true
     - match: ','
       scope: punctuation.separator.with-resources.python
-    - include: expressions
+    - include: expression-in-a-statement
 
   with-as:
     - meta_scope: meta.statement.with.python
@@ -343,16 +340,24 @@ contexts:
       scope: invalid.illegal.stray.brace.curly.python
     - include: line-continuation
 
-  line-expressions: # Always include this last!
+  # Always include these last and only one at a time!
+  expression-as-a-statement:
     - include: expressions-common
     - include: qualified-name
 
-  expressions: # Always include this last!
-    # Differs from the line scope in that invalid-name matches will pop the current context
-    # and matches accessors continued on a different line
+  expression-in-a-statement:
+    # Differs from expression-as-a-statement in that:
+    # - invalid-name matches will pop the current context
+    # - assignment expressions
     - include: expressions-common
     - include: illegal-names-pop
     - include: qualified-name
+    - include: assignment-expression
+
+  expression-in-a-group:  # Always include this last!
+    # Differs from expression-in-a-statement in that:
+    # - accessor matching continues into the next line
+    - include: expression-in-a-statement
     - match: '(\.) *(?={{identifier}})'
       captures:
         1: punctuation.accessor.dot.python
@@ -386,7 +391,7 @@ contexts:
           pop: true
         - match: ':'
           scope: punctuation.separator.slice.python
-        - include: expressions
+        - include: expression-in-a-group
     # indirect function call following attribute access
     - include: function-calls
     # arbitrary attribute access
@@ -511,7 +516,15 @@ contexts:
         1: keyword.control.flow.yield.python
         2: keyword.control.flow.yield-from.python
 
+  assignment-expression:
+    - match: :=
+      scope: keyword.operator.assignment.inline.python
+
   assignments:
+    - match: :=
+      scope: invalid.illegal.not-allowed-here.python
+    - match: ':'
+      scope: punctuation.separator.annotation.variable.python
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
     - match: '=(?!=)'
@@ -592,7 +605,7 @@ contexts:
                     1: punctuation.accessor.dot.python
                 - match: ''
                   pop: true
-            - include: expressions
+            - include: expression-in-a-group
 
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\b'
@@ -641,7 +654,7 @@ contexts:
             - meta_scope: meta.function.parameters.default-value.python
             - match: '(?=[,)])'
               set: [function-parameters, allow-unpack-operators]
-            - include: expressions
+            - include: expression-in-a-group
     - match: '(?=:)'
       set:
         - match: ':'
@@ -650,7 +663,7 @@ contexts:
             - meta_scope: meta.function.parameters.annotation.python
             - match: '(?=[,)=])'
               set: function-parameters
-            - include: expressions
+            - include: expression-in-a-group
     - include: function-parameters-tuple
     - include: illegal-names
     - match: '{{identifier}}'
@@ -698,7 +711,7 @@ contexts:
         - match: '(?=:)'
           set: function-after-parameters
         - include: line-continuation-or-pop
-        - include: expressions
+        - include: expression-in-a-statement
     - match: ':'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: true
@@ -794,7 +807,7 @@ contexts:
               pop: true
             - match: ':'
               scope: punctuation.separator.slice.python
-            - include: expressions
+            - include: expression-in-a-group
 
   function-calls:
     - match: '(?=(\.\s*)?{{path}}\s*\()'
@@ -836,7 +849,7 @@ contexts:
       scope: punctuation.separator.arguments.python
       push: allow-unpack-operators
     - include: inline-for
-    - include: expressions
+    - include: expression-in-a-group
 
   keyword-arguments:
     - match: '(?={{identifier}}\s*=(?!=))'
@@ -847,7 +860,7 @@ contexts:
           set:
             - match: (?=\s*[,):])
               pop: true
-            - include: expressions
+            - include: expression-in-a-group
         - include: illegal-names
         - match: '{{identifier}}'
           scope: variable.parameter.python
@@ -886,7 +899,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.tuple.python
         - include: inline-for
-        - include: expressions
+        - include: expression-in-a-group
 
   tuples:
     # We don't know for certain, whether a parenthesized expression is a tuple,
@@ -912,7 +925,7 @@ contexts:
       scope: punctuation.separator.sequence.python
       push: allow-unpack-operators
     - include: inline-for
-    - include: expressions
+    - include: expression-in-a-group
 
   lists:
     - match: (\[)\s*(\])
@@ -934,7 +947,7 @@ contexts:
       scope: punctuation.separator.sequence.python
       push: allow-unpack-operators
     - include: inline-for
-    - include: expressions
+    - include: expression-in-a-group
 
   dictionaries-and-sets:
     # Dictionaries and set literals use the same punctuation,
@@ -967,11 +980,11 @@ contexts:
         - match: ','
           scope: punctuation.separator.set.python
           set: inside-set
-        - match: ':'
+        - match: ':(?!=)'
           scope: punctuation.separator.mapping.key-value.python
           set: inside-directory-value
         - include: inline-for
-        - include: expressions
+        - include: expression-in-a-group
 
   inside-dictionary:
     - meta_scope: meta.mapping.python
@@ -991,7 +1004,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.mapping.python
           pop: true
-        - include: expressions
+        - include: expression-in-a-group
     - include: comments
     - match: (?=\S)
       push:
@@ -999,7 +1012,7 @@ contexts:
         - meta_scope: meta.mapping.key.python
         - match: \s*(?=\}|,|:)
           pop: true
-        - include: expressions
+        - include: expression-in-a-group
 
   inside-directory-value:
     - meta_content_scope: meta.mapping.python
@@ -1019,7 +1032,7 @@ contexts:
         - match: ','
           scope: invalid.illegal.unexpected-comma.python
         - include: inline-for
-        - include: expressions
+        - include: expression-in-a-group
     - include: comments
     - match: (?=\S)
       push:
@@ -1027,7 +1040,7 @@ contexts:
         - meta_content_scope: meta.mapping.value.python
         - match: (?=\s*(\}|,|for\b))
           pop: true
-        - include: expressions
+        - include: expression-in-a-group
 
   inside-set:
     - meta_scope: meta.set.python
@@ -1046,9 +1059,9 @@ contexts:
         - match: ','
           scope: punctuation.separator.set.python
           pop: true
-        - include: expressions
+        - include: expression-in-a-group
     - include: inline-for
-    - include: expressions
+    - include: expression-in-a-group
 
   builtin-exceptions:
     - match: |-
@@ -1452,7 +1465,7 @@ contexts:
             - match: \\
               scope: invalid.illegal.backslash-in-fstring.python
             - include: inline-for
-            - include: expressions
+            - include: expression-in-a-group
 
   f-string-replacement-reset:
     # Same as f-string-replacement, but with clear_scopes: true
@@ -1483,7 +1496,7 @@ contexts:
             - match: \\
               scope: invalid.illegal.backslash-in-fstring.python
             - include: inline-for
-            - include: expressions
+            - include: expression-in-a-group
 
   string-quoted-double-block:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1360,5 +1360,73 @@ class Starship:
 #                                   ^ keyword.operator.assignment
 
 
+##################
+# Assignment Expressions
+##################
+
+# Examples from https://www.python.org/dev/peps/pep-0572/
+
+y := f(x)
+# ^^ invalid.illegal.not-allowed-here.python
+
+(y := f(x))
+#  ^^ keyword.operator.assignment.inline.python
+
+y0 = y1 := f(x)
+#       ^^ invalid.illegal.not-allowed-here.python
+
+y0 = (y1 := f(x))
+#        ^^ keyword.operator.assignment.inline.python
+
+foo(x=(y := f(x)))
+#        ^^ keyword.operator.assignment.inline.python
+
+if (match := pattern.search(data)) is not None:
+#         ^^ keyword.operator.assignment.inline.python
+    pass
+
+if tz := self._tzstr():
+#     ^^ keyword.operator.assignment.inline.python
+    s += tz
+
+while chunk := file.read(8192):
+#           ^^ keyword.operator.assignment.inline.python
+    process(chunk)
+
+[y := f(x), y**2, y**3]
+#  ^^ keyword.operator.assignment.inline.python
+
+filtered_data = [y for x in data if (y := f(x)) is not None]
+#                                      ^^ keyword.operator.assignment.inline.python
+
+def foo(answer=(p := 42)):
+#                 ^^ keyword.operator.assignment.inline.python
+
+lambda: (x := 1)
+#          ^^ keyword.operator.assignment.inline.python
+
+lambda line: (m := re.match(pattern, line)) and m.group(1) # Valid
+#               ^^ keyword.operator.assignment.inline.python
+
+f'{(x:=10)}'
+#    ^^ keyword.operator.assignment.inline.python
+
+f'{x:=10}'
+#   ^^ - keyword.operator.assignment.inline.python
+
+
+if any(len(longline := line) >= 100 for line in lines):
+#                   ^^ keyword.operator.assignment.inline.python
+    print("Extremely long line:", longline)
+
+# These are invalid, but we let linters handle them
+def foo(x: y:=f(x)) -> a:=None: pass
+foo(x = y := f(x))
+{a := 1: 2}
+{1, b := 2}
+[1][x:=0]
+def foo(answer = p := 42):  pass
+(lambda: x := 1)
+
 # <- - meta
 # ensure we're not leaking a context

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -236,13 +236,13 @@ def _():
 #          ^^^^ keyword.control.conditional.else
 
     c = lambda: pass
-#       ^^^^^^^ meta.function.inline
+#       ^^^^^^^^^^^^ meta.function.inline
 #       ^^^^^^ storage.type.function.inline
 #             ^ punctuation.section.function.begin
-#               ^^^^ keyword
+#               ^^^^ invalid.illegal.name.python
 
     _(lambda x, y: 10)
-#     ^^^^^^^^^^^^ meta.function.inline
+#     ^^^^^^^^^^^^^^^ meta.function.inline
 #     ^^^^^^ storage.type.function.inline
 #           ^^^^^ meta.function.inline.parameters
 #            ^ variable.parameter
@@ -252,13 +252,14 @@ def _():
 
     lambda \
         a, \
-        b=2: pass
-#       ^^^^ meta.function.inline
+        b=2: True
+#       ^^^^^^^^^ meta.function.inline
 #        ^ keyword.operator.assignment
 #          ^ punctuation.section.function.begin
-#            ^^^^ keyword
+#           ^^^^^ meta.function.inline.body
+#            ^^^^ constant.language.python
 
-    lambda as, in=2: pass
+    lambda as, in=2: 0
 #          ^^ invalid.illegal.name
 #              ^^ invalid.illegal.name
 
@@ -273,9 +274,10 @@ def _():
     lambda x
 #   ^^^^^^ storage.type.function.inline
 
-    lambda (x, y): pass
-#   ^^^^^^^^^^^^^^ meta.function.inline.python
-#         ^^^^^^^ meta.function.inline.parameters.python
+    lambda (x, y): 0
+#   ^^^^^^^^^^^^^^^^ meta.function.inline
+#         ^^^^^^^^ meta.function.inline.parameters.python
+#                 ^^ meta.function.inline.body.python
 #          ^^^^^^ meta.group.python
 #          ^ punctuation.section.group.begin.python
 #           ^ variable.parameter.python
@@ -283,7 +285,6 @@ def _():
 #              ^ variable.parameter.python
 #               ^ punctuation.section.group.end.python
 #                ^ punctuation.section.function.begin.python
-#                  ^^^^ keyword.control.flow.pass.python
     lambda (
 #   ^^^^^^^^^ meta.function.inline.python
 #         ^^^ meta.function.inline.parameters.python
@@ -1419,14 +1420,25 @@ if any(len(longline := line) >= 100 for line in lines):
 #                   ^^ keyword.operator.assignment.inline.python
     print("Extremely long line:", longline)
 
-# These are invalid, but we let linters handle them
+# These are all invalid. We could let linters handle them,
+# but these weren't hard to implement.
 def foo(x: y:=f(x)) -> a:=None: pass
-foo(x = y := f(x))
+#           ^^ invalid.illegal.not-allowed-here.python
+#                       ^^ invalid.illegal.not-allowed-here.python
+foo(x = y := f(x), y=x:=2)
+#         ^^ invalid.illegal.not-allowed-here.python
+#                     ^^ invalid.illegal.not-allowed-here.python
 {a := 1: 2}
+#  ^^ invalid.illegal.not-allowed-here.python
 {1, b := 2}
+#     ^^ invalid.illegal.not-allowed-here.python
 [1][x:=0]
+#    ^^ invalid.illegal.not-allowed-here.python
 def foo(answer = p := 42):  pass
+#                  ^^ invalid.illegal.not-allowed-here.python
 (lambda: x := 1)
+#          ^^ invalid.illegal.not-allowed-here.python
+
 
 # <- - meta
 # ensure we're not leaking a context


### PR DESCRIPTION
Formalized in https://www.python.org/dev/peps/pep-0572/ and included in Python 3.8, to be released [later this month](https://www.python.org/dev/peps/pep-0569/). This is the final syntax change required for 3.8 support.

Tests should be self-explanatory. While I was at it, I added a meta scope for lambda bodies and added invalid highlighting for various known locations.