### PR TITLE
[D] Fix multiple values in case statement not being parsed correctly

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1406,12 +1406,12 @@ contexts:
     - include: not-whitespace-illegal-pop
 
   value-list:
-    - match: '(?=\)|}|]|;)'
+    - match: '(?=\)|}|]|;|:)'
       pop: true
     - match: '(?=\S)'
       set: [value-list-after, value]
   value-list-after:
-    - match: '(?=\)|}|]|;)'
+    - match: '(?=\)|}|]|;|:)'
       pop: true
     - match: ','
       scope: punctuation.separator.sequence.d
@@ -2004,7 +2004,7 @@ contexts:
           set: [switch-after, value]
     - match: '\bcase\b'
       scope: keyword.control.flow.d
-      push: [case-after, value]
+      push: [case-after, value-list]
     - match: '\bdefault\b'
       scope: keyword.control.flow.d
       push:

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2058,6 +2058,14 @@ extern(1)
   //       ^^ keyword.operator.arithmetic.d
   //          ^ constant.numeric.integer.d
   //           ^ punctuation.separator.case-statement.d
+    case 2, "foo":
+  //^^^^ keyword.control.flow.d
+  //     ^ constant.numeric.integer.d
+  //      ^ punctuation.separator.sequence.d
+  //        ^ meta.string.d string.quoted.double.d punctuation.definition.string.begin.d
+  //         ^^^^ meta.string.d string.quoted.double.d
+  //             ^ punctuation.separator.case-statement.d
+  //^^^^^^^^^^^^^^ meta.block.d
     case 2: .. case 4:
   //^^^^ keyword.control.flow.d
   //     ^ constant.numeric.integer.d


### PR DESCRIPTION
Example:
```d
switch (str) {
    case "foo", "bar":
        break;
}
```