### PR TITLE
[R] Add support for named code sections

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -16,6 +16,7 @@ variables:
 contexts:
   main:
     - include: roxygen
+    - include: codesection
     - include: comments
     - include: constants
     - include: operators
@@ -29,8 +30,15 @@ contexts:
     - include: function-calls
     - include: general-variables
 
+  codesection:
+    - match: ^\s*(\#+)\s*(.+?)\s*[-=#]{4,}$\n?
+      scope: comment.line.number-sign.r
+      captures:
+        1: punctuation.definition.comment.r
+        2: entity.name.section.r
+
   comments:
-    - match: "#"
+    - match: \#+
       scope: punctuation.definition.comment.r
       push:
         - meta_scope: comment.line.number-sign.r

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -31,11 +31,11 @@ contexts:
     - include: general-variables
 
   codesection:
-    - match: ^\s*(\#+)\s*(.+?)\s*[-=#]{4,}$\n?
-      scope: comment.line.number-sign.r
+    - match: ^\s*((\#+)\s*(.+?)\s*(?:-{4,}|={4,}|#{4,})[ \t]*$\n?)
       captures:
-        1: punctuation.definition.comment.r
-        2: entity.name.section.r
+        1: comment.line.number-sign.r
+        2: punctuation.definition.comment.r
+        3: entity.name.section.r
 
   comments:
     - match: \#+

--- a/R/Symbol List - Sections.tmPreferences
+++ b/R/Symbol List - Sections.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Sections</string>
+	<key>scope</key>
+	<string>entity.name.section.r</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+	</dict>
+</dict>
+</plist>

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -1,25 +1,26 @@
 # SYNTAX TEST "Packages/R/R.sublime-syntax"
 
 # comment
-# ^^^^^^^ comment.line.number-sign.r
+# ^^^^^^^^ comment.line.number-sign.r
 
 # no section ---
-# ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+# ^^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
 
 # section 1 ----
 #^ comment.line.number-sign.r - entity
 # ^^^^^^^^^ entity.name.section.r
-#          ^^^^^ comment.line.number-sign.r - entity
+#          ^^^^^^ comment.line.number-sign.r - entity
 
 ## section 1.1 ----
 #^^ comment.line.number-sign.r - entity
 #  ^^^^^^^^^^^ entity.name.section.r
-#             ^^^^^ comment.line.number-sign.r - entity
+#             ^^^^^^ comment.line.number-sign.r - entity
 
-#### section 1.1.1 ----
-#^^^^ comment.line.number-sign.r - entity
-#    ^^^^^^^^^^^^^ entity.name.section.r
-#                 ^^^^^ comment.line.number-sign.r - entity
+  #### section 1.1.1 ----
+#^ - comment
+# ^^^^^ comment.line.number-sign.r - entity
+#      ^^^^^^^^^^^^^ entity.name.section.r
+#                   ^^^^^^ comment.line.number-sign.r - entity
 
 # no section ===
 # ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
@@ -27,35 +28,38 @@
 # section 2 ====
 #^ comment.line.number-sign.r - entity
 # ^^^^^^^^^ entity.name.section.r
-#          ^^^^^ comment.line.number-sign.r - entity
+#          ^^^^^^ comment.line.number-sign.r - entity
 
 ## section 2.1 ====
 #^^ comment.line.number-sign.r - entity
 #  ^^^^^^^^^^^ entity.name.section.r
-#             ^^^^^ comment.line.number-sign.r - entity
+#             ^^^^^^ comment.line.number-sign.r - entity
 
 #### section 2.1.1 ====
 #^^^^ comment.line.number-sign.r - entity
 #    ^^^^^^^^^^^^^ entity.name.section.r
-#                 ^^^^^ comment.line.number-sign.r - entity
+#                 ^^^^^^ comment.line.number-sign.r - entity
 
 # no section ###
-# ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+# ^^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+
+# no section -=#=-
+# ^^^^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
 
 # section 3 ####
 #^ comment.line.number-sign.r - entity
 # ^^^^^^^^^ entity.name.section.r
-#          ^^^^^ comment.line.number-sign.r - entity
+#          ^^^^^^ comment.line.number-sign.r - entity
 
 ## section 3.1 ####
 #^^ comment.line.number-sign.r - entity
 #  ^^^^^^^^^^^ entity.name.section.r
-#             ^^^^^ comment.line.number-sign.r - entity
+#             ^^^^^^ comment.line.number-sign.r - entity
 
 #### section 3.1.1 ####
 #^^^^ comment.line.number-sign.r - entity
 #    ^^^^^^^^^^^^^ entity.name.section.r
-#                 ^^^^^ comment.line.number-sign.r - entity
+#                 ^^^^^^ comment.line.number-sign.r - entity
 
 # constants
 pi

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -3,6 +3,60 @@
 # comment
 # ^^^^^^^ comment.line.number-sign.r
 
+# no section ---
+# ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+
+# section 1 ----
+#^ comment.line.number-sign.r - entity
+# ^^^^^^^^^ entity.name.section.r
+#          ^^^^^ comment.line.number-sign.r - entity
+
+## section 1.1 ----
+#^^ comment.line.number-sign.r - entity
+#  ^^^^^^^^^^^ entity.name.section.r
+#             ^^^^^ comment.line.number-sign.r - entity
+
+#### section 1.1.1 ----
+#^^^^ comment.line.number-sign.r - entity
+#    ^^^^^^^^^^^^^ entity.name.section.r
+#                 ^^^^^ comment.line.number-sign.r - entity
+
+# no section ===
+# ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+
+# section 2 ====
+#^ comment.line.number-sign.r - entity
+# ^^^^^^^^^ entity.name.section.r
+#          ^^^^^ comment.line.number-sign.r - entity
+
+## section 2.1 ====
+#^^ comment.line.number-sign.r - entity
+#  ^^^^^^^^^^^ entity.name.section.r
+#             ^^^^^ comment.line.number-sign.r - entity
+
+#### section 2.1.1 ====
+#^^^^ comment.line.number-sign.r - entity
+#    ^^^^^^^^^^^^^ entity.name.section.r
+#                 ^^^^^ comment.line.number-sign.r - entity
+
+# no section ###
+# ^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
+
+# section 3 ####
+#^ comment.line.number-sign.r - entity
+# ^^^^^^^^^ entity.name.section.r
+#          ^^^^^ comment.line.number-sign.r - entity
+
+## section 3.1 ####
+#^^ comment.line.number-sign.r - entity
+#  ^^^^^^^^^^^ entity.name.section.r
+#             ^^^^^ comment.line.number-sign.r - entity
+
+#### section 3.1.1 ####
+#^^^^ comment.line.number-sign.r - entity
+#    ^^^^^^^^^^^^^ entity.name.section.r
+#                 ^^^^^ comment.line.number-sign.r - entity
+
 # constants
 pi
 # <- support.constant.misc.r


### PR DESCRIPTION
[R] Add support for named code sections

The issue was filed at:
https://forum.sublimetext.com/t/r-named-sections-not-taken-by-sublime/46891

The function is described at:
https://support.rstudio.com/hc/en-us/articles/200484568-Code-Folding-and-Sections

Notes:

As all `#` in front of a section are scoped as `punctuation.` the same is done for normal comments to keep their look synced.