### PR TITLE
[Go] Numeric Literal Updates (v1.13)

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -450,22 +450,18 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: '(0[xX]){{hdigits}}([pP])([+-])?{{ddigits}}(i)?'
+    - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
-        2: punctuation.section.exponent.go
-        3: keyword.operator.go
-        4: storage.type.numeric.go
+        2: storage.type.numeric.go
     # Hex float literal, with fraction
-    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}([pP])([+-])?{{ddigits}}(i)?'
+    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.separator.decimal.go
-        3: punctuation.section.exponent.go
-        4: keyword.operator.go
-        5: storage.type.numeric.go
+        3: storage.type.numeric.go
 
   match-integers:
     - include: match-octal-integer

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -432,16 +432,13 @@ contexts:
 
   match-floats:
     # Integer, no fraction, exponent
-    - match: '{{ddigits}}({{exponent}}){{ddigits}}'
+    - match: '{{ddigits}}{{exponent}}{{ddigits}}'
       scope: constant.numeric.float.go
-      captures:
-        1: punctuation.separator.exponent.go
     # Integer, fraction, optional exponent
-    - match: '{{ddigits}}(\.){{ddigits}}(?:({{exponent}}){{ddigits}})?'
+    - match: '{{ddigits}}(\.){{ddigits}}(?:{{exponent}}{{ddigits}})?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.decimal.go
-        2: punctuation.separator.exponent.go
     # Dot without fraction
     - match: \d+\.(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -449,12 +449,6 @@ contexts:
         3: punctuation.section.exponent.go
         4: keyword.operator.go
         5: storage.type.numeric.imaginary.go
-    # Hex float literal, no fraction, missing exponent digits
-    - match: (0[xX])\h+([pP])([\+\-])?
-      scope: invalid.illegal.go
-    # Hex float literal, with fraction, missing exponent digits
-    - match: (0[xX])\h*(\.)\h*([pP])([\+\-])?
-      scope: invalid.illegal.go
 
   match-integers:
     - include: match-octal-integer
@@ -474,8 +468,6 @@ contexts:
       captures:
         1: punctuation.definition.numeric.octal.go
         2: storage.type.numeric.imaginary.go
-    - match: 0[oO]
-      scope: invalid.illegal.go
 
   match-hex-integer:
     - match: (0[Xx])(?:_)?\h+(?:_\h+)*(i)?
@@ -490,8 +482,6 @@ contexts:
       captures:
         1: punctuation.definition.numeric.binary.go
         2: storage.type.numeric.imaginary.go
-    - match: 0[bB]
-      scope: invalid.illegal.go
 
   match-decimal-integer:
     - match: \d+(?:_\d+)*

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -433,7 +433,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: (0[x|X])(?:_)?\h+(?:_\h+)*([p|P])([\+|\-])?\d+(?:_\d+)*(i)?
+    - match: (0[xX])(?:_)?\h+(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -441,7 +441,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: (0[x|X])(?:_)?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([p|P])([\+|\-])?\d+(?:_\d+)*(i)?
+    - match: (0[xX])(?:_)?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -450,10 +450,10 @@ contexts:
         4: keyword.operator.go
         5: storage.type.numeric.imaginary.go
     # Hex float literal, no fraction, missing exponent digits
-    - match: (0[x|X])\h+([p|P])([\+|\-])?
+    - match: (0[xX])\h+([pP])([\+\-])?
       scope: invalid.illegal.go
     # Hex float literal, with fraction, missing exponent digits
-    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?
+    - match: (0[xX])\h*(\.)\h*([pP])([\+\-])?
       scope: invalid.illegal.go
 
   match-integers:
@@ -469,12 +469,12 @@ contexts:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[o|O])(?:_)?[0-7]+(?:_[0-7]+)*(i)?
+    - match: (0[oO])(?:_)?[0-7]+(?:_[0-7]+)*(i)?
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
         2: storage.type.numeric.imaginary.go
-    - match: 0[o|O]
+    - match: 0[oO]
       scope: invalid.illegal.go
 
   match-hex-integer:
@@ -485,12 +485,12 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
-    - match: (0[b|B])[_]?[1|0]+(?:_[0|1]+)*(i)?
+    - match: (0[bB])[_]?[01]+(?:_[01]+)*(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go
         2: storage.type.numeric.imaginary.go
-    - match: 0[b|B]
+    - match: 0[bB]
       scope: invalid.illegal.go
 
   match-decimal-integer:

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -433,10 +433,10 @@ contexts:
   match-floats:
     # Integer, no fraction, exponent
     - match: '{{ddigits}}{{exponent}}{{ddigits}}'
-      scope: constant.numeric.float.go
+      scope: constant.numeric.float.decimal.go
     # Integer, fraction, optional exponent
     - match: '{{ddigits}}(\.){{ddigits}}(?:{{exponent}}{{ddigits}})?'
-      scope: constant.numeric.float.go
+      scope: constant.numeric.float.decimal.go
       captures:
         1: punctuation.separator.decimal.go
     # Dot without fraction
@@ -447,13 +447,13 @@ contexts:
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
     - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)?'
-      scope: constant.numeric.float.go
+      scope: constant.numeric.float.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: storage.type.numeric.go
     # Hex float literal, with fraction
     - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}(i)?'
-      scope: constant.numeric.float.go
+      scope: constant.numeric.float.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.separator.decimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -412,6 +412,7 @@ contexts:
       scope: invalid.deprecated.go
     # Dot without integer
     - match: \.\d+(?:{{exponent}}\d+)?i
+      scope: invalid.deprecated.go
 
   match-floats:
     # Integer, no fraction, exponent
@@ -432,7 +433,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: (0[x|X])\h+([p|P])([\+|\-])?\d+(i)?
+    - match: (0[x|X])(?:_)?\h+(?:_\h+)*([p|P])([\+|\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -440,7 +441,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?\d+(i)?
+    - match: (0[x|X])(?:_)?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([p|P])([\+|\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -88,10 +88,10 @@ variables:
 
   # Matches a digit with any number of numeric separators, while
   # not allowing a numeric separator as the last or first character.
-  ddigit: (?:\d+(?:_\d+)*)
+  ddigits: (?:\d+(?:_\d+)*)
 
-  # Hexideciaml counterpart to ddigit.
-  hdigit: (?:\h+(?:_\h+)*)
+  # Hexideciaml counterpart to ddigits.
+  hdigits: (?:\h+(?:_\h+)*)
 
 contexts:
   main:
@@ -408,7 +408,7 @@ contexts:
 
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
-    - match: '{{ddigit}}(?:(\.){{ddigit}})?(?:({{exponent}}){{ddigit}})?(i)'
+    - match: '{{ddigits}}(?:(\.){{ddigits}})?(?:({{exponent}}){{ddigits}})?(i)'
       scope: constant.numeric.imaginary.go
       captures:
         1: punctuation.separator.decimal.go
@@ -423,12 +423,12 @@ contexts:
 
   match-floats:
     # Integer, no fraction, exponent
-    - match: '{{ddigit}}({{exponent}}){{ddigit}}'
+    - match: '{{ddigits}}({{exponent}}){{ddigits}}'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.exponent.go
     # Integer, fraction, optional exponent
-    - match: '{{ddigit}}(\.){{ddigit}}(?:({{exponent}}){{ddigit}})?'
+    - match: '{{ddigits}}(\.){{ddigits}}(?:({{exponent}}){{ddigits}})?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.decimal.go
@@ -440,7 +440,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: '(0[xX])_?{{hdigit}}([pP])([\+\-])?{{ddigit}}(i)?'
+    - match: '(0[xX])_?{{hdigits}}([pP])([\+\-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -448,7 +448,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?{{ddigit}}(i)?'
+    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -477,7 +477,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-hex-integer:
-    - match: (0[Xx])_?{{hdigit}}(i)?
+    - match: (0[Xx])_?{{hdigits}}(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -491,7 +491,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-decimal-integer:
-    - match: '{{ddigit}}'
+    - match: '{{ddigits}}'
       scope: constant.numeric.integer.go
 
   # https://golang.org/ref/spec#Rune_literals

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -86,6 +86,10 @@ variables:
 
   exponent: '[Ee][+-]?'
 
+  # Matches a digit with any number of numeric separators, while
+  # not allowing a numeric separator as the last or first character.
+  ddigit: (?:\d+(?:_\d+)*)
+
 contexts:
   main:
     - include: match-any
@@ -401,7 +405,7 @@ contexts:
 
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
-    - match: \d+(?:_\d+)*(?:(\.)\d+(?:_\d+)*)?(?:({{exponent}})\d+(?:_\d+)*)?(i)
+    - match: '{{ddigit}}(?:(\.){{ddigit}})?(?:({{exponent}}){{ddigit}})?(i)'
       scope: constant.numeric.imaginary.go
       captures:
         1: punctuation.separator.decimal.go
@@ -416,12 +420,12 @@ contexts:
 
   match-floats:
     # Integer, no fraction, exponent
-    - match: \d+(?:_\d+)*({{exponent}})\d+(?:_\d+)*
+    - match: '{{ddigit}}({{exponent}}){{ddigit}}'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.exponent.go
     # Integer, fraction, optional exponent
-    - match: \d+(?:_\d+)*(\.)\d+(?:_\d+)*(?:({{exponent}})\d+(?:_\d+)*)?
+    - match: '{{ddigit}}(\.){{ddigit}}(?:({{exponent}}){{ddigit}})?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.decimal.go
@@ -433,7 +437,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: (0[xX])_?\h+(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
+    - match: '(0[xX])_?\h+(?:_\h+)*([pP])([\+\-])?{{ddigit}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -441,7 +445,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: (0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
+    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?{{ddigit}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -484,7 +488,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-decimal-integer:
-    - match: \d+(?:_\d+)*
+    - match: '{{ddigit}}'
       scope: constant.numeric.integer.go
 
   # https://golang.org/ref/spec#Rune_literals

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -483,10 +483,11 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
-    - match: (0[b|B])[1|0]+
+    - match: (0[b|B])[1|0]+(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go
+        2: storage.type.numeric.imaginary.go
     - match: 0[b|B]
       scope: invalid.illegal.go
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -433,7 +433,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: (0[xX])(?:_)?\h+(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
+    - match: (0[xX])_?\h+(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -441,7 +441,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: (0[xX])(?:_)?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
+    - match: (0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?\d+(?:_\d+)*(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -457,27 +457,27 @@ contexts:
     - include: match-decimal-integer
 
   match-octal-integer:
-    - match: (0)(?:_)?[0-7]+(?:_[0-7]+)*(?=\D)
+    - match: (0)_?[0-7]+(?:_[0-7]+)*(?=\D)
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[oO])(?:_)?[0-7]+(?:_[0-7]+)*(i)?
+    - match: (0[oO])_?[0-7]+(?:_[0-7]+)*(i)?
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
         2: storage.type.numeric.imaginary.go
 
   match-hex-integer:
-    - match: (0[Xx])(?:_)?\h+(?:_\h+)*(i)?
+    - match: (0[Xx])_?\h+(?:_\h+)*(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
-    - match: (0[bB])[_]?[01]+(?:_[01]+)*(i)?
+    - match: (0[bB])_?[01]+(?:_[01]+)*(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -484,7 +484,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
-    - match: (0[b|B])[1|0]+(i)?
+    - match: (0[b|B])[_]?[1|0]+(?:_[0|1]+)*(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -90,7 +90,7 @@ variables:
   # not allowing a numeric separator as the last or first character.
   ddigits: (?:\d+(?:_\d+)*)
 
-  # Hexideciaml counterpart to ddigits.
+  # Hexadeciaml counterpart to ddigits.
   hdigits: (?:\h+(?:_\h+)*)
 
 contexts:
@@ -477,7 +477,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-hex-integer:
-    - match: (0[Xx])_?{{hdigits}}(i)?
+    - match: (0[xX])_?{{hdigits}}(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -480,7 +480,7 @@ contexts:
 
   match-hex-integer:
     - match: (0[xX]){{hdigits}}(i)?
-      scope: constant.numeric.hex.go
+      scope: constant.numeric.integer.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -91,7 +91,7 @@ variables:
   ddigits: (?:\d+(?:_\d+)*)
 
   # Hexadeciaml counterpart to ddigits.
-  hdigits: (?:\h+(?:_\h+)*)
+  hdigits: _?(?:\h+(?:_\h+)*)
 
 contexts:
   main:
@@ -440,7 +440,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: '(0[xX])_?{{hdigits}}([pP])([\+\-])?{{ddigits}}(i)?'
+    - match: '(0[xX]){{hdigits}}([pP])([+-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -448,7 +448,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([\+\-])?{{ddigits}}(i)?'
+    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([+-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -477,7 +477,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-hex-integer:
-    - match: (0[xX])_?{{hdigits}}(i)?
+    - match: (0[xX]){{hdigits}}(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -426,13 +426,21 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
         2: punctuation.separator.exponent.go
-    # Hex float literal, no decimal
+    # Hex float literal, no fraction
     - match: (0[x|X])\h+([p|P])([\+|\-])?\d+
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.section.exponent.go
         3: keyword.operator.go
+    # Hex float literal, with fraction
+    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?\d+
+      scope: constant.numeric.float.go
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.go
+        2: punctuation.separator.decimal.go
+        3: punctuation.section.exponent.go
+        4: keyword.operator.go
     # Dot without fraction
     - match: \d+\.(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -494,7 +494,7 @@ contexts:
 
   match-decimal-integer:
     - match: '{{ddigits}}'
-      scope: constant.numeric.integer.go
+      scope: constant.numeric.integer.decimal.go
 
   # https://golang.org/ref/spec#Rune_literals
   match-runes:
@@ -1144,7 +1144,7 @@ contexts:
       set:
         - include: pop-on-terminator
         - match: \biota\b
-          scope: constant.numeric.integer.go
+          scope: constant.numeric.integer.decimal.go
         - include: match-any
 
   pop-var-type-and-or-assignment:

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -412,7 +412,6 @@ contexts:
       scope: invalid.deprecated.go
     # Dot without integer
     - match: \.\d+(?:{{exponent}}\d+)?i
-      scope: invalid.deprecated.go
 
   match-floats:
     # Integer, no fraction, exponent
@@ -433,20 +432,22 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: (0[x|X])\h+([p|P])([\+|\-])?\d+
+    - match: (0[x|X])\h+([p|P])([\+|\-])?\d+(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.section.exponent.go
         3: keyword.operator.go
+        4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?\d+
+    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?\d+(i)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.separator.decimal.go
         3: punctuation.section.exponent.go
         4: keyword.operator.go
+        5: storage.type.numeric.imaginary.go
     # Hex float literal, no fraction, missing exponent digits
     - match: (0[x|X])\h+([p|P])([\+|\-])?
       scope: invalid.illegal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -96,6 +96,9 @@ variables:
   # Octal counterpart to ddigits.
   odigits: _?(?:[0-7]+(?:_[0-7]+)*)
 
+  # Binary counterpart to ddigits.
+  bdigits: _?(?:[01]+(?:_[01]+)*)
+
 contexts:
   main:
     - include: match-any
@@ -487,7 +490,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
-    - match: (0[bB])_?[01]+(?:_[01]+)*(i)?
+    - match: (0[bB]){{bdigits}}(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -419,11 +419,11 @@ contexts:
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
     - match: '{{ddigits}}(?:(\.){{ddigits}})?(?:({{exponent}}){{ddigits}})?(i)'
-      scope: constant.numeric.complex.imaginary.go
+      scope: constant.numeric.imaginary.go
       captures:
         1: punctuation.separator.decimal.go
         2: punctuation.separator.exponent.go
-        3: storage.type.numeric.imaginary.go
+        3: storage.type.numeric.go
     # Dot without fraction
     - match: \d+\.(?:{{exponent}}\d+)?i
       scope: invalid.deprecated.go
@@ -456,7 +456,7 @@ contexts:
         1: punctuation.definition.numeric.hexadecimal.go
         2: punctuation.section.exponent.go
         3: keyword.operator.go
-        4: storage.type.numeric.imaginary.go
+        4: storage.type.numeric.go
     # Hex float literal, with fraction
     - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}([pP])([+-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
@@ -465,7 +465,7 @@ contexts:
         2: punctuation.separator.decimal.go
         3: punctuation.section.exponent.go
         4: keyword.operator.go
-        5: storage.type.numeric.imaginary.go
+        5: storage.type.numeric.go
 
   match-integers:
     - include: match-octal-integer
@@ -484,21 +484,21 @@ contexts:
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
-        2: storage.type.numeric.imaginary.go
+        2: storage.type.numeric.go
 
   match-hex-integer:
     - match: (0[xX]){{hdigits}}(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
-        2: storage.type.numeric.imaginary.go
+        2: storage.type.numeric.go
 
   match-binary-integer:
     - match: (0[bB]){{bdigits}}(i)?
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go
-        2: storage.type.numeric.imaginary.go
+        2: storage.type.numeric.go
 
   match-decimal-integer:
     - match: '{{ddigits}}'

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -449,13 +449,13 @@ contexts:
     - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)?'
       scope: constant.numeric.float.hexadecimal.go
       captures:
-        1: punctuation.definition.numeric.hexadecimal.go
+        1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go
     # Hex float literal, with fraction
     - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}(i)?'
       scope: constant.numeric.float.hexadecimal.go
       captures:
-        1: punctuation.definition.numeric.hexadecimal.go
+        1: punctuation.definition.numeric.base.go
         2: punctuation.separator.decimal.go
         3: storage.type.numeric.go
 
@@ -469,27 +469,27 @@ contexts:
     - match: (0){{odigits}}(?=\D)
       scope: constant.numeric.octal.go
       captures:
-        1: punctuation.definition.numeric.octal.go
+        1: punctuation.definition.numeric.base.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
     - match: (0[oO]){{odigits}}(i)?
       scope: constant.numeric.octal.go
       captures:
-        1: punctuation.definition.numeric.octal.go
+        1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go
 
   match-hex-integer:
     - match: (0[xX]){{hdigits}}(i)?
       scope: constant.numeric.hex.go
       captures:
-        1: punctuation.definition.numeric.hexadecimal.go
+        1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go
 
   match-binary-integer:
     - match: (0[bB]){{bdigits}}(i)?
       scope: constant.numeric.binary.go
       captures:
-        1: punctuation.definition.numeric.binary.go
+        1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go
 
   match-decimal-integer:

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -487,7 +487,7 @@ contexts:
 
   match-binary-integer:
     - match: (0[bB]){{bdigits}}(i)?
-      scope: constant.numeric.binary.go
+      scope: constant.numeric.integer.binary.go
       captures:
         1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -476,10 +476,11 @@ contexts:
       scope: invalid.illegal.go
 
   match-hex-integer:
-    - match: (0[Xx])\h+
+    - match: (0[Xx])\h+(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
+        2: storage.type.numeric.imaginary.go
 
   match-binary-integer:
     - match: (0[b|B])[1|0]+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -418,12 +418,11 @@ contexts:
 
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
-    - match: '{{ddigits}}(?:(\.){{ddigits}})?(?:({{exponent}}){{ddigits}})?(i)'
+    - match: '{{ddigits}}(?:(\.){{ddigits}})?(?:{{exponent}}{{ddigits}})?(i)'
       scope: constant.numeric.imaginary.go
       captures:
         1: punctuation.separator.decimal.go
-        2: punctuation.separator.exponent.go
-        3: storage.type.numeric.go
+        2: storage.type.numeric.go
     # Dot without fraction
     - match: \d+\.(?:{{exponent}}\d+)?i
       scope: invalid.deprecated.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -467,10 +467,11 @@ contexts:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[o|O])[0-7]+
+    - match: (0[o|O])[0-7]+(i)?
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
+        2: storage.type.numeric.imaginary.go
     - match: 0[o|O]
       scope: invalid.illegal.go
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -493,7 +493,7 @@ contexts:
       scope: invalid.illegal.go
 
   match-decimal-integer:
-    - match: \d+
+    - match: \d+(?:_\d+)*
       scope: constant.numeric.integer.go
 
   # https://golang.org/ref/spec#Rune_literals

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -426,6 +426,12 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
         2: punctuation.separator.exponent.go
+    # Dot without fraction
+    - match: \d+\.(?:{{exponent}}\d+)?
+      scope: invalid.deprecated.go
+    # Dot without integer
+    - match: \.\d+(?:{{exponent}}\d+)?
+      scope: invalid.deprecated.go
     # Hex float literal, no fraction
     - match: (0[x|X])\h+([p|P])([\+|\-])?\d+
       scope: constant.numeric.float.go
@@ -441,12 +447,12 @@ contexts:
         2: punctuation.separator.decimal.go
         3: punctuation.section.exponent.go
         4: keyword.operator.go
-    # Dot without fraction
-    - match: \d+\.(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
-    # Dot without integer
-    - match: \.\d+(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
+    # Hex float literal, no fraction, missing exponent digits
+    - match: (0[x|X])\h+([p|P])([\+|\-])?
+      scope: invalid.illegal.go
+    # Hex float literal, with fraction, missing exponent digits
+    - match: (0[x|X])\h*(\.)\h*([p|P])([\+|\-])?
+      scope: invalid.illegal.go
 
   match-integers:
     - include: match-octal-integer

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -426,6 +426,13 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
         2: punctuation.separator.exponent.go
+    # Hex float literal, no decimal
+    - match: (0[x|X])\h+([p|P])([\+|\-])?\d+
+      scope: constant.numeric.float.go
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.go
+        2: punctuation.section.exponent.go
+        3: keyword.operator.go
     # Dot without fraction
     - match: \d+\.(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -90,6 +90,9 @@ variables:
   # not allowing a numeric separator as the last or first character.
   ddigit: (?:\d+(?:_\d+)*)
 
+  # Hexideciaml counterpart to ddigit.
+  hdigit: (?:\h+(?:_\h+)*)
+
 contexts:
   main:
     - include: match-any
@@ -437,7 +440,7 @@ contexts:
     - match: \.\d+(?:{{exponent}}\d+)?
       scope: invalid.deprecated.go
     # Hex float literal, no fraction
-    - match: '(0[xX])_?\h+(?:_\h+)*([pP])([\+\-])?{{ddigit}}(i)?'
+    - match: '(0[xX])_?{{hdigit}}([pP])([\+\-])?{{ddigit}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
@@ -474,7 +477,7 @@ contexts:
         2: storage.type.numeric.imaginary.go
 
   match-hex-integer:
-    - match: (0[Xx])_?\h+(?:_\h+)*(i)?
+    - match: (0[Xx])_?{{hdigit}}(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -409,7 +409,7 @@ contexts:
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
     - match: '{{ddigits}}(?:(\.){{ddigits}})?(?:({{exponent}}){{ddigits}})?(i)'
-      scope: constant.numeric.imaginary.go
+      scope: constant.numeric.complex.imaginary.go
       captures:
         1: punctuation.separator.decimal.go
         2: punctuation.separator.exponent.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -462,13 +462,13 @@ contexts:
     - include: match-decimal-integer
 
   match-octal-integer:
-    - match: (0)[0-7]+(?=\D)
+    - match: (0)(?:_)?[0-7]+(?:_[0-7]+)*(?=\D)
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[o|O])[0-7]+(i)?
+    - match: (0[o|O])(?:_)?[0-7]+(?:_[0-7]+)*(i)?
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -90,8 +90,12 @@ variables:
   # not allowing a numeric separator as the last or first character.
   ddigits: (?:\d+(?:_\d+)*)
 
-  # Hexadeciaml counterpart to ddigits.
+  # Hexadecimal counterpart to ddigits.
   hdigits: _?(?:\h+(?:_\h+)*)
+
+  # Same as hdigits, except the leading hex character
+  # coefficient is optional in this case.
+  ohdigits: _?(?:\h*(?:_\h+)*)
 
   # Octal counterpart to ddigits.
   odigits: _?(?:[0-7]+(?:_[0-7]+)*)
@@ -454,7 +458,7 @@ contexts:
         3: keyword.operator.go
         4: storage.type.numeric.imaginary.go
     # Hex float literal, with fraction
-    - match: '(0[xX])_?\h*(?:_\h+)*(\.)\h*(?:_\h+)*([pP])([+-])?{{ddigits}}(i)?'
+    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}([pP])([+-])?{{ddigits}}(i)?'
       scope: constant.numeric.float.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -467,13 +467,13 @@ contexts:
 
   match-octal-integer:
     - match: (0){{odigits}}(?=\D)
-      scope: constant.numeric.octal.go
+      scope: constant.numeric.integer.octal.go
       captures:
         1: punctuation.definition.numeric.base.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
     - match: (0[oO]){{odigits}}(i)?
-      scope: constant.numeric.octal.go
+      scope: constant.numeric.integer.octal.go
       captures:
         1: punctuation.definition.numeric.base.go
         2: storage.type.numeric.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -458,6 +458,8 @@ contexts:
       scope: constant.numeric.binary.go
       captures:
         1: punctuation.definition.numeric.binary.go
+    - match: 0[b|B]
+      scope: invalid.illegal.go
 
   match-decimal-integer:
     - match: \d+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -436,6 +436,7 @@ contexts:
   match-integers:
     - include: match-octal-integer
     - include: match-hex-integer
+    - include: match-binary-integer
     - include: match-decimal-integer
 
   match-octal-integer:
@@ -451,6 +452,12 @@ contexts:
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
+
+  match-binary-integer:
+    - match: (0[b|B])[1|0]+
+      scope: constant.numeric.binary.go
+      captures:
+        1: punctuation.definition.numeric.binary.go
 
   match-decimal-integer:
     - match: \d+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -477,7 +477,7 @@ contexts:
       scope: invalid.illegal.go
 
   match-hex-integer:
-    - match: (0[Xx])\h+(i)?
+    - match: (0[Xx])(?:_)?\h+(?:_\h+)*(i)?
       scope: constant.numeric.hex.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -401,7 +401,7 @@ contexts:
 
   match-imaginary:
     # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
-    - match: \d+(?:(\.)\d+)?(?:({{exponent}})\d+)?(i)
+    - match: \d+(?:_\d+)*(?:(\.)\d+(?:_\d+)*)?(?:({{exponent}})\d+(?:_\d+)*)?(i)
       scope: constant.numeric.imaginary.go
       captures:
         1: punctuation.separator.decimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -415,12 +415,12 @@ contexts:
 
   match-floats:
     # Integer, no fraction, exponent
-    - match: \d+({{exponent}})\d+
+    - match: \d+(?:_\d+)*({{exponent}})\d+(?:_\d+)*
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.exponent.go
     # Integer, fraction, optional exponent
-    - match: \d+(\.)\d+(?:({{exponent}})\d+)?
+    - match: \d+(?:_\d+)*(\.)\d+(?:_\d+)*(?:({{exponent}})\d+(?:_\d+)*)?
       scope: constant.numeric.float.go
       captures:
         1: punctuation.separator.decimal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -450,6 +450,8 @@ contexts:
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
+    - match: 0[o|O]
+      scope: invalid.illegal.go
 
   match-hex-integer:
     - match: (0[Xx])\h+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -446,6 +446,10 @@ contexts:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
+    - match: (0[o|O])[0-7]+
+      scope: constant.numeric.octal.go
+      captures:
+        1: punctuation.definition.numeric.octal.go
 
   match-hex-integer:
     - match: (0[Xx])\h+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -412,6 +412,7 @@ contexts:
   match-literals:
     - include: match-imaginary
     - include: match-floats
+    - include: match-deprecated
     - include: match-integers
     - include: match-runes
     - include: match-strings
@@ -423,12 +424,6 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
         2: storage.type.numeric.go
-    # Dot without fraction
-    - match: \d+\.(?:{{exponent}}\d+)?i
-      scope: invalid.deprecated.go
-    # Dot without integer
-    - match: \.\d+(?:{{exponent}}\d+)?i
-      scope: invalid.deprecated.go
 
   match-floats:
     # Integer, no fraction, exponent
@@ -439,12 +434,6 @@ contexts:
       scope: constant.numeric.float.decimal.go
       captures:
         1: punctuation.separator.decimal.go
-    # Dot without fraction
-    - match: \d+\.(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
-    # Dot without integer
-    - match: \.\d+(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
     # Hex float literal, no fraction
     - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)?'
       scope: constant.numeric.float.hexadecimal.go
@@ -458,6 +447,11 @@ contexts:
         1: punctuation.definition.numeric.base.go
         2: punctuation.separator.decimal.go
         3: storage.type.numeric.go
+
+  match-deprecated:
+    # Dot without fraction or dot without integer.
+    - match: (?:\d+\.|\.\d+)(?:{{exponent}}\d+)?i?
+      scope: invalid.deprecated.go
 
   match-integers:
     - include: match-octal-integer

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -93,6 +93,9 @@ variables:
   # Hexadeciaml counterpart to ddigits.
   hdigits: _?(?:\h+(?:_\h+)*)
 
+  # Octal counterpart to ddigits.
+  odigits: _?(?:[0-7]+(?:_[0-7]+)*)
+
 contexts:
   main:
     - include: match-any
@@ -464,13 +467,13 @@ contexts:
     - include: match-decimal-integer
 
   match-octal-integer:
-    - match: (0)_?[0-7]+(?:_[0-7]+)*(?=\D)
+    - match: (0){{odigits}}(?=\D)
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[oO])_?[0-7]+(?:_[0-7]+)*(i)?
+    - match: (0[oO]){{odigits}}(i)?
       scope: constant.numeric.octal.go
       captures:
         1: punctuation.definition.numeric.octal.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -424,6 +424,38 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
         2: storage.type.numeric.go
+    # Hex float literal, no fraction
+    - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)'
+      scope: constant.numeric.imaginary.hexadecimal.go
+      captures:
+        1: punctuation.definition.numeric.base.go
+        2: storage.type.numeric.go
+    # Hex float literal, with fraction
+    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}(i)'
+      scope: constant.numeric.imaginary.hexadecimal.go
+      captures:
+        1: punctuation.definition.numeric.base.go
+        2: punctuation.separator.decimal.go
+        3: storage.type.numeric.go
+    # Hex integers.
+    - match: (0[xX]){{hdigits}}(i)
+      scope: constant.numeric.imaginary.hexadecimal.go
+      captures:
+        1: punctuation.definition.numeric.base.go
+        2: storage.type.numeric.go
+    # Octal numbers.
+    - match: (0[oO]){{odigits}}(i)
+      scope: constant.numeric.imaginary.octal.go
+      captures:
+        1: punctuation.definition.numeric.base.go
+        2: storage.type.numeric.go
+    # Binary numbers.
+    - match: (0[bB]){{bdigits}}(i)
+      scope: constant.numeric.imaginary.binary.go
+      captures:
+        1: punctuation.definition.numeric.base.go
+        2: storage.type.numeric.go
+
 
   match-floats:
     # Integer, no fraction, exponent
@@ -435,18 +467,16 @@ contexts:
       captures:
         1: punctuation.separator.decimal.go
     # Hex float literal, no fraction
-    - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}(i)?'
+    - match: '(0[xX]){{hdigits}}[pP][+-]?{{ddigits}}'
       scope: constant.numeric.float.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.base.go
-        2: storage.type.numeric.go
     # Hex float literal, with fraction
-    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}(i)?'
+    - match: '(0[xX]){{ohdigits}}(\.){{ohdigits}}[pP][+-]?{{ddigits}}'
       scope: constant.numeric.float.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.base.go
         2: punctuation.separator.decimal.go
-        3: storage.type.numeric.go
 
   match-deprecated:
     # Dot without fraction or dot without integer.
@@ -466,25 +496,22 @@ contexts:
         1: punctuation.definition.numeric.base.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
-    - match: (0[oO]){{odigits}}(i)?
+    - match: (0[oO]){{odigits}}
       scope: constant.numeric.integer.octal.go
       captures:
         1: punctuation.definition.numeric.base.go
-        2: storage.type.numeric.go
 
   match-hex-integer:
-    - match: (0[xX]){{hdigits}}(i)?
+    - match: (0[xX]){{hdigits}}
       scope: constant.numeric.integer.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.base.go
-        2: storage.type.numeric.go
 
   match-binary-integer:
-    - match: (0[bB]){{bdigits}}(i)?
+    - match: (0[bB]){{bdigits}}
       scope: constant.numeric.integer.binary.go
       captures:
         1: punctuation.definition.numeric.base.go
-        2: storage.type.numeric.go
 
   match-decimal-integer:
     - match: '{{ddigits}}'

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1778,6 +1778,15 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                ^ keyword.operator.go
 //                 ^^^^^^^^ constant.numeric.octal.go
 
+    0o660; 0O061; -0o02;
+//  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//    ^^^ constant.numeric.octal.go
+//         ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//           ^^^ constant.numeric.octal.go
+//                ^ keyword.operator.go
+//                 ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                   ^^ constant.numeric.octal.go
+
     08; 09;
 //  ^^ invalid.illegal.go
 //      ^^ invalid.illegal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2021,6 +2021,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 //                                ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
 
+    0b1011i; 0B00001i;
+//  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//    ^^^^ constant.numeric.binary.go
+//        ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//           ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//             ^^^^^ constant.numeric.binary.go
+//                  ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+
 // ## Runes
 
     ' '

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2005,6 +2005,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                  ^^^^^^ invalid.deprecated.go
 //                          ^^^^^^ invalid.deprecated.go
 
+    0o6i; 0O35i;
+//  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//    ^ constant.numeric.octal.go
+//     ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//        ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//          ^^ constant.numeric.octal.go
+//            ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+
 // ## Runes
 
     ' '

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1820,17 +1820,17 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ### Binary
 
     0b1011; 0B00001; -0b1; 0b_1; 0B1_0;
-//  ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//    ^^^^ constant.numeric.binary.go
-//          ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//            ^^^^^ constant.numeric.binary.go
+//  ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//    ^^^^ constant.numeric.integer.binary.go
+//          ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//            ^^^^^ constant.numeric.integer.binary.go
 //                   ^ keyword.operator.go
-//                    ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//                      ^ constant.numeric.binary.go
-//                         ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//                           ^^ constant.numeric.binary.go
-//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//                                 ^^^ constant.numeric.binary.go
+//                    ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                      ^ constant.numeric.integer.binary.go
+//                         ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                           ^^ constant.numeric.integer.binary.go
+//                               ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                                 ^^^ constant.numeric.integer.binary.go
 
 // ## Floats
 
@@ -2049,18 +2049,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                               ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
-//  ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//    ^^^^ constant.numeric.binary.go
-//        ^ constant.numeric.binary.go storage.type.numeric.go
-//           ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//             ^^^^^ constant.numeric.binary.go
-//                  ^ constant.numeric.binary.go storage.type.numeric.go
-//                     ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//                       ^^^^^ constant.numeric.binary.go
-//                            ^ constant.numeric.binary.go storage.type.numeric.go
-//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
-//                                 ^^^^^^ constant.numeric.binary.go
-//                                       ^ constant.numeric.binary.go storage.type.numeric.go
+//  ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//    ^^^^ constant.numeric.integer.binary.go
+//        ^ constant.numeric.integer.binary.go storage.type.numeric.go
+//           ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//             ^^^^^ constant.numeric.integer.binary.go
+//                  ^ constant.numeric.integer.binary.go storage.type.numeric.go
+//                     ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                       ^^^^^ constant.numeric.integer.binary.go
+//                            ^ constant.numeric.integer.binary.go storage.type.numeric.go
+//                               ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                                 ^^^^^^ constant.numeric.integer.binary.go
+//                                       ^ constant.numeric.integer.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
 //  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1832,28 +1832,28 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## Floats
 
     000.000; 123.456; .0; 1.;
-//  ^^^^^^^ constant.numeric.float.go
+//  ^^^^^^^ constant.numeric.float.decimal.go
 //     ^ punctuation.separator.decimal.go
-//           ^^^ constant.numeric.float.go
+//           ^^^ constant.numeric.float.decimal.go
 //              ^ punctuation.separator.decimal.go
-//               ^^^ constant.numeric.float.go
+//               ^^^ constant.numeric.float.decimal.go
 //                    ^^ invalid.deprecated.go
 //                        ^^ invalid.deprecated.go
 
     0_1.0_1; 1_23.4_6;
-//  ^^^
-//     ^ constant.numeric.float.go punctuation.separator.decimal.go
-//      ^^^ constant.numeric.float.go
-//           ^^^^ constant.numeric.float.go
-//               ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                ^^^ constant.numeric.float.go
+//  ^^^ constant.numeric.float.decimal.go
+//     ^ punctuation.separator.decimal.go
+//      ^^^ constant.numeric.float.decimal.go
+//           ^^^^ constant.numeric.float.decimal.go
+//               ^ punctuation.separator.decimal.go
+//                ^^^ constant.numeric.float.decimal.go
 
     -000.000; -123.456; -.0; -1.;
 //  ^ keyword.operator.go
-//   ^^^^^^^ constant.numeric.float.go
+//   ^^^^^^^ constant.numeric.float.decimal.go
 //      ^ punctuation.separator.decimal.go
 //            ^ keyword.operator.go
-//             ^^^^^^^ constant.numeric.float.go
+//             ^^^^^^^ constant.numeric.float.decimal.go
 //                ^ punctuation.separator.decimal.go
 //                      ^ keyword.operator.go
 //                       ^^ invalid.deprecated.go
@@ -1861,40 +1861,40 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                            ^^ invalid.deprecated.go
 
     0e+0; 0E+0; 0.0e+0; 0.0E+0; 123.456e+789;
-//  ^^^^ constant.numeric.float.go
-//        ^^^^ constant.numeric.float.go
-//              ^ constant.numeric.float.go
-//               ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                ^^^^ constant.numeric.float.go
-//                      ^ constant.numeric.float.go
-//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                        ^^^^ constant.numeric.float.go
-//                              ^^^ constant.numeric.float.go
-//                                 ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                                  ^^^^^^^^ constant.numeric.float.go
+//  ^^^^ constant.numeric.float.decimal.go
+//        ^^^^ constant.numeric.float.decimal.go
+//              ^ constant.numeric.float.decimal.go
+//               ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                ^^^^ constant.numeric.float.decimal.go
+//                      ^ constant.numeric.float.decimal.go
+//                       ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                        ^^^^ constant.numeric.float.decimal.go
+//                              ^^^ constant.numeric.float.decimal.go
+//                                 ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                                  ^^^^^^^^ constant.numeric.float.decimal.go
 
     1_2e+0; 1E+0_1; 0.1_2e2; 1_23.4_56e+78_9;
-//  ^^^^^^ constant.numeric.float.go
-//          ^^^^^^ constant.numeric.float.go
-//                  ^ constant.numeric.float.go
-//                   ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                    ^^^^^ constant.numeric.float.go
-//                           ^^^^ constant.numeric.float.go
-//                               ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                                ^^^^^^^^^^ constant.numeric.float.go
+//  ^^^^^^ constant.numeric.float.decimal.go
+//          ^^^^^^ constant.numeric.float.decimal.go
+//                  ^ constant.numeric.float.decimal.go
+//                   ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                    ^^^^^ constant.numeric.float.decimal.go
+//                           ^^^^ constant.numeric.float.decimal.go
+//                               ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                                ^^^^^^^^^^ constant.numeric.float.decimal.go
 
     0e-0; 0E-0; 0.0e-0; 0.0E-0; 123.456e-789;
-//  ^^^^ constant.numeric.float.go
-//        ^^^^ constant.numeric.float.go
-//              ^ constant.numeric.float.go
-//               ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                ^^^^ constant.numeric.float.go
-//                      ^ constant.numeric.float.go
-//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                        ^^^^ constant.numeric.float.go
-//                              ^^^ constant.numeric.float.go
-//                                 ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                                  ^^^^^^^^ constant.numeric.float.go
+//  ^^^^ constant.numeric.float.decimal.go
+//        ^^^^ constant.numeric.float.decimal.go
+//              ^ constant.numeric.float.decimal.go
+//               ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                ^^^^ constant.numeric.float.decimal.go
+//                      ^ constant.numeric.float.decimal.go
+//                       ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                        ^^^^ constant.numeric.float.decimal.go
+//                              ^^^ constant.numeric.float.decimal.go
+//                                 ^ constant.numeric.float.decimal.go punctuation.separator.decimal.go
+//                                  ^^^^^^^^ constant.numeric.float.decimal.go
 
     0.e+0; .0e+0; 0.e-0; .0e-0;
 //  ^^^^^ invalid.deprecated.go
@@ -1903,60 +1903,60 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^^^^^ invalid.deprecated.go
 
     0x1p-2; 0X1P+2; 0x1p2;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^^^ constant.numeric.float.go
-//          ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//            ^^^^ constant.numeric.float.go
-//                  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                    ^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^ constant.numeric.float.hexadecimal.go
+//          ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//            ^^^^ constant.numeric.float.hexadecimal.go
+//                  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                    ^^^ constant.numeric.float.hexadecimal.go
 
     0x_1p-2; 0X1_1P+2; 0x_1p2_1;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^^^^ constant.numeric.float.go
-//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//             ^^^^^^ constant.numeric.float.go
-//                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                       ^^^^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^^ constant.numeric.float.hexadecimal.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//             ^^^^^^ constant.numeric.float.hexadecimal.go
+//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                       ^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x1.0P-1021; 0X1.0p-1021;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^ constant.numeric.float.go
-//     ^ constant.numeric.float.go punctuation.separator.decimal.go
-//      ^^^^^^^ constant.numeric.float.go
-//               ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                 ^ constant.numeric.float.go
-//                  ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                   ^^^^^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^ constant.numeric.float.hexadecimal.go
+//     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//      ^^^^^^^ constant.numeric.float.hexadecimal.go
+//               ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                 ^ constant.numeric.float.hexadecimal.go
+//                  ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//                   ^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x_1_1.0_7P-1_021;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^^^ constant.numeric.float.go
-//        ^ constant.numeric.float.go punctuation.separator.decimal.go
-//         ^^^^^^^^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^ constant.numeric.float.hexadecimal.go
+//        ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//         ^^^^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x2.p10; 0x1.Fp+0; 0X.8p-0;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^ constant.numeric.float.go
-//     ^ constant.numeric.float.go punctuation.separator.decimal.go
-//      ^^^ constant.numeric.float.go
-//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//             ^ constant.numeric.float.go
-//              ^ constant.numeric.float.go punctuation.separator.decimal.go
-//               ^^^^ constant.numeric.float.go
-//                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                        ^^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^ constant.numeric.float.hexadecimal.go
+//     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//      ^^^ constant.numeric.float.hexadecimal.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//             ^ constant.numeric.float.hexadecimal.go
+//              ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//               ^^^^ constant.numeric.float.hexadecimal.go
+//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                       ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//                        ^^^^ constant.numeric.float.hexadecimal.go
 
     0x_2.p1_0; 0x1.F_Ap+0;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^ constant.numeric.float.go
-//      ^ constant.numeric.float.go punctuation.separator.decimal.go
-//       ^^^^ constant.numeric.float.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.float.hexadecimal.go
+//      ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//       ^^^^ constant.numeric.float.hexadecimal.go
 //           ^ punctuation.terminator.go
-//             ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//               ^ constant.numeric.float.go
-//                ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                 ^^^^^^ constant.numeric.float.go
+//             ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//               ^ constant.numeric.float.hexadecimal.go
+//                ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//                 ^^^^^^ constant.numeric.float.hexadecimal.go
 
 // ## Imaginary
 
@@ -2060,25 +2060,25 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                       ^ constant.numeric.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^^^ constant.numeric.float.go
-//        ^ constant.numeric.float.go storage.type.numeric.go
-//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//             ^^^^^^^^^ constant.numeric.float.go
-//                      ^ constant.numeric.float.go storage.type.numeric.go
-//                         ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                           ^^^^^^ constant.numeric.float.go
-//                                 ^ constant.numeric.float.go storage.type.numeric.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^ constant.numeric.float.hexadecimal.go
+//        ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//             ^^^^^^^^^ constant.numeric.float.hexadecimal.go
+//                      ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
+//                         ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                           ^^^^^^ constant.numeric.float.hexadecimal.go
+//                                 ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
-//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^^^^ constant.numeric.float.go
-//         ^ constant.numeric.float.go storage.type.numeric.go
-//            ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//              ^^^ constant.numeric.float.go
-//                 ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                  ^^^^^^^^^^ constant.numeric.float.go
-//                            ^ constant.numeric.float.go storage.type.numeric.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^^ constant.numeric.float.hexadecimal.go
+//         ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
+//            ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//              ^^^ constant.numeric.float.hexadecimal.go
+//                 ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
+//                  ^^^^^^^^^^ constant.numeric.float.hexadecimal.go
+//                            ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
 
 // ## Runes
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1762,13 +1762,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ### Decimal
 
-    0; 123456789; -0; -123456789;
+    0; 123456789; -0; -123456789; 1777_000_000;
 //  ^ constant.numeric.integer.go
 //     ^^^^^^^^^ constant.numeric.integer.go
 //                ^ keyword.operator.go
 //                 ^ constant.numeric.integer.go
 //                    ^ keyword.operator.go
 //                     ^^^^^^^^^ constant.numeric.integer.go
+//                                ^^^^^^^^^^^^ constant.numeric.integer.go
 
 // ### Octal
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -896,20 +896,20 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     map[[0]typ][0]typ
 //  ^^^ storage.type.keyword.map.go
-//       ^ constant.numeric.integer.go
+//       ^ constant.numeric.integer.decimal.go
 //         ^^^ storage.type.go
-//              ^ constant.numeric.integer.go
+//              ^ constant.numeric.integer.decimal.go
 //                ^^^ storage.type.go
 
     map[/**/ [0] /**/ typ /**/ ] /**/ [0] /**/ typ
 //  ^^^ storage.type.keyword.map.go
 //      ^^^^ comment.block.go
-//            ^ constant.numeric.integer.go
+//            ^ constant.numeric.integer.decimal.go
 //               ^^^^ comment.block.go
 //                    ^^^ storage.type.go
 //                        ^^^^ comment.block.go
 //                               ^^^^ comment.block.go
-//                                     ^ constant.numeric.integer.go
+//                                     ^ constant.numeric.integer.decimal.go
 //                                        ^^^^ comment.block.go
 //                                             ^^^ storage.type.go
 
@@ -1176,7 +1176,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
         field [0]typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^ meta.type.go punctuation.section.brackets.begin.go
-//             ^ meta.type.go constant.numeric.integer.go
+//             ^ meta.type.go constant.numeric.integer.decimal.go
 //              ^ meta.type.go punctuation.section.brackets.end.go
 //               ^^^ meta.type.go storage.type.go
     }
@@ -1186,7 +1186,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     [0]typ
 //  ^ punctuation.section.brackets.begin.go
-//   ^ constant.numeric.integer.go
+//   ^ constant.numeric.integer.decimal.go
 //    ^ punctuation.section.brackets.end.go
 //     ^^^ storage.type.go
 
@@ -1198,7 +1198,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     [0]typ ident
 //  ^ punctuation.section.brackets.begin.go
-//   ^ constant.numeric.integer.go
+//   ^ constant.numeric.integer.decimal.go
 //    ^ punctuation.section.brackets.end.go
 //     ^^^ storage.type.go
 //         ^^^^^ variable.other.go
@@ -1233,7 +1233,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //   ^^^^ comment.block.go
      /**/ 0 /**/ ] /**/ typ
 //   ^^^^ comment.block.go
-//        ^ constant.numeric.integer.go
+//        ^ constant.numeric.integer.decimal.go
 //          ^^^^ comment.block.go
 //                 ^^^^ comment.block.go
 //                      ^^^ storage.type.go
@@ -1440,7 +1440,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^^^ storage.type.keyword.const.go
 //        ^ variable.language.blank.go
 //          ^ keyword.operator.assignment.go
-//            ^^ constant.numeric.integer.go
+//            ^^ constant.numeric.integer.decimal.go
 
     /**/ const
 //  ^^^^ comment.block.go
@@ -1453,7 +1453,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                      ^^^^ comment.block.go
 //                           ^ keyword.operator.assignment.go
 //                             ^^^^ comment.block.go
-//                                  ^^^^ constant.numeric.integer.go
+//                                  ^^^^ constant.numeric.integer.decimal.go
 //                                       ^^^^ comment.block.go
 
     const ident, ident = 10, 20
@@ -1497,9 +1497,9 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                          ^^^^ comment.block.go
 //                               ^ keyword.operator.assignment.go
 //                                 ^^^^ comment.block.go
-//                                      ^^^^ constant.numeric.integer.go
+//                                      ^^^^ constant.numeric.integer.decimal.go
 //                                           ^ keyword.operator.go
-//                                             ^^^^ constant.numeric.integer.go
+//                                             ^^^^ constant.numeric.integer.decimal.go
 //                                                  ^^^^ comment.block.go
 
         /**/ ident /**/ = /**/ ident + 100 /**/
@@ -1510,7 +1510,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                        ^^^^ comment.block.go
 //                             ^^^^^ variable.other.go
 //                                   ^ keyword.operator.go
-//                                     ^^^ constant.numeric.integer.go
+//                                     ^^^ constant.numeric.integer.decimal.go
 //                                         ^^^^ comment.block.go
 
         /**/ ident /**/
@@ -1530,9 +1530,9 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^^^^ variable.other.constant.declaration.go
 //            ^^^ storage.type.go
 //                ^ keyword.operator.assignment.go
-//                  ^^ constant.numeric.integer.go
+//                  ^^ constant.numeric.integer.decimal.go
 //                    ^ punctuation.separator.go
-//                      ^^ constant.numeric.integer.go
+//                      ^^ constant.numeric.integer.decimal.go
 
         ident,
 //      ^^^^^ variable.other.constant.declaration.go
@@ -1569,20 +1569,20 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^^^^ variable.other.constant.declaration.go
 //            ^ keyword.operator.assignment.go
         10
-//      ^^ constant.numeric.integer.go
+//      ^^ constant.numeric.integer.decimal.go
 
         ident =
 //      ^^^^^ variable.other.constant.declaration.go
 //            ^ keyword.operator.assignment.go
         iota + iota
-//      ^^^^ constant.numeric.integer.go
+//      ^^^^ constant.numeric.integer.decimal.go
 //           ^ keyword.operator.go
-//             ^^^^ constant.numeric.integer.go
+//             ^^^^ constant.numeric.integer.decimal.go
 
         iota = iota
 //      ^^^^ variable.other.constant.declaration.go
 //           ^ keyword.operator.assignment.go
-//             ^^^^ constant.numeric.integer.go
+//             ^^^^ constant.numeric.integer.decimal.go
     )
 
     const ident typ = ident +
@@ -1627,7 +1627,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^^ storage.type.keyword.var.go
 //          ^^^^ variable.declaration.go
 //               ^ keyword.operator.assignment.go
-//                 ^ constant.numeric.integer.go
+//                 ^ constant.numeric.integer.decimal.go
         var _ = iota
 //      ^^^ storage.type.keyword.var.go
 //          ^ variable.language.blank.go
@@ -1654,7 +1654,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                      ^^^^ comment.block.go
 //                           ^ keyword.operator.assignment.go
 //                             ^^^^ comment.block.go
-//                                  ^^ constant.numeric.integer.go
+//                                  ^^ constant.numeric.integer.decimal.go
 //                                     ^^^^ comment.block.go
 
     var ident, ident = 10, 20
@@ -1702,7 +1702,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                            ^^^^ comment.block.go
 //                                                 ^ keyword.operator.go
 //                                                   ^^^^ comment.block.go
-//                                                        ^^ constant.numeric.integer.go
+//                                                        ^^ constant.numeric.integer.decimal.go
 //                                                           ^^^^ comment.block.go
 
         /**/ ident /**/ = /**/ ident + 20 /**/
@@ -1713,7 +1713,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                        ^^^^ comment.block.go
 //                             ^^^^^ variable.other.go
 //                                   ^ keyword.operator.go
-//                                     ^^ constant.numeric.integer.go
+//                                     ^^ constant.numeric.integer.decimal.go
 //                                        ^^^^ comment.block.go
 
         ident,
@@ -1763,13 +1763,13 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ### Decimal
 
     0; 123456789; -0; -123456789; 1777_000_000;
-//  ^ constant.numeric.integer.go
-//     ^^^^^^^^^ constant.numeric.integer.go
+//  ^ constant.numeric.integer.decimal.go
+//     ^^^^^^^^^ constant.numeric.integer.decimal.go
 //                ^ keyword.operator.go
-//                 ^ constant.numeric.integer.go
+//                 ^ constant.numeric.integer.decimal.go
 //                    ^ keyword.operator.go
-//                     ^^^^^^^^^ constant.numeric.integer.go
-//                                ^^^^^^^^^^^^ constant.numeric.integer.go
+//                     ^^^^^^^^^ constant.numeric.integer.decimal.go
+//                                ^^^^^^^^^^^^ constant.numeric.integer.decimal.go
 
 // ### Octal
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1862,48 +1862,39 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     0e+0; 0E+0; 0.0e+0; 0.0E+0; 123.456e+789;
 //  ^^^^ constant.numeric.float.go
-//   ^^ punctuation.separator.exponent.go
 //        ^^^^ constant.numeric.float.go
-//         ^^ punctuation.separator.exponent.go
-//              ^^^^^^ constant.numeric.float.go
-//                      ^^^^^^ constant.numeric.float.go
-//                       ^ punctuation.separator.decimal.go
-//                         ^^ punctuation.separator.exponent.go
-//                           ^ constant.numeric.float.go
-//                            ^ punctuation.terminator.go
-//                              ^^^^^^^^^^^^ constant.numeric.float.go
-//                                 ^ punctuation.separator.decimal.go
-//                                     ^^ punctuation.separator.exponent.go
+//              ^ constant.numeric.float.go
+//               ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                ^^^^ constant.numeric.float.go
+//                      ^ constant.numeric.float.go
+//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                        ^^^^ constant.numeric.float.go
+//                              ^^^ constant.numeric.float.go
+//                                 ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                                  ^^^^^^^^ constant.numeric.float.go
 
     1_2e+0; 1E+0_1; 0.1_2e2; 1_23.4_56e+78_9;
-//  ^^^ constant.numeric.float.go
-//     ^^ constant.numeric.float.go punctuation.separator.exponent.go
-//       ^ constant.numeric.float.go
-//          ^ constant.numeric.float.go
-//           ^^ constant.numeric.float.go punctuation.separator.exponent.go
-//             ^^^ constant.numeric.float.go
-//                  ^^^^^ constant.numeric.float.go
-//                       ^ constant.numeric.float.go punctuation.separator.exponent.go
-//                        ^ constant.numeric.float.go
-//                           ^^^^^^^^^ constant.numeric.float.go
-//                                    ^^ constant.numeric.float.go punctuation.separator.exponent.go
-//                                      ^^^^ constant.numeric.float.go
+//  ^^^^^^ constant.numeric.float.go
+//          ^^^^^^ constant.numeric.float.go
+//                  ^ constant.numeric.float.go
+//                   ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                    ^^^^^ constant.numeric.float.go
+//                           ^^^^ constant.numeric.float.go
+//                               ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                                ^^^^^^^^^^ constant.numeric.float.go
 
     0e-0; 0E-0; 0.0e-0; 0.0E-0; 123.456e-789;
 //  ^^^^ constant.numeric.float.go
-//   ^^ punctuation.separator.exponent.go
 //        ^^^^ constant.numeric.float.go
-//         ^^ punctuation.separator.exponent.go
-//           ^ constant.numeric.float.go
-//              ^^^^^^ constant.numeric.float.go
-//               ^ punctuation.separator.decimal.go
-//                 ^^ punctuation.separator.exponent.go
-//                      ^^^^^^ constant.numeric.float.go
-//                       ^ punctuation.separator.decimal.go
-//                         ^^ punctuation.separator.exponent.go
-//                              ^^^^^^^^^^^^ constant.numeric.float.go
-//                                 ^ punctuation.separator.decimal.go
-//                                     ^^ punctuation.separator.exponent.go
+//              ^ constant.numeric.float.go
+//               ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                ^^^^ constant.numeric.float.go
+//                      ^ constant.numeric.float.go
+//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                        ^^^^ constant.numeric.float.go
+//                              ^^^ constant.numeric.float.go
+//                                 ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                                  ^^^^^^^^ constant.numeric.float.go
 
     0.e+0; .0e+0; 0.e-0; .0e-0;
 //  ^^^^^ invalid.deprecated.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1872,6 +1872,21 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                 ^ punctuation.separator.decimal.go
 //                                     ^^ punctuation.separator.exponent.go
 
+    0x1p-2; 0X1P+2; 0x1p2;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.float.go
+//      ^ constant.numeric.float.go keyword.operator.go
+//       ^ constant.numeric.float.go
+//          ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//            ^ constant.numeric.float.go
+//             ^ constant.numeric.float.go punctuation.section.exponent.go
+//              ^ constant.numeric.float.go keyword.operator.go
+//               ^ constant.numeric.float.go
+//                  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//                    ^ constant.numeric.float.go
+//                     ^ constant.numeric.float.go punctuation.section.exponent.go
+//                      ^ constant.numeric.float.go
+
     0.e+0; .0e+0; 0.e-0; .0e-0;
 //  ^^^^^ invalid.deprecated.go
 //         ^^^^^ invalid.deprecated.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1192,7 +1192,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     [0x10]typ
 //  ^ punctuation.section.brackets.begin.go
-//   ^^^^ constant.numeric.hex.go
+//   ^^^^ constant.numeric.integer.hexadecimal.go
 //       ^ punctuation.section.brackets.end.go
 //        ^^^ storage.type.go
 
@@ -1806,16 +1806,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ### Hex
 
     0x0; 0x0123456789ABCDEFabcdef; -0x0123456789ABCDEFabcdef;
-//  ^^^ constant.numeric.hex.go
-//       ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
+//  ^^^ constant.numeric.integer.hexadecimal.go
+//       ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
 //                                 ^ keyword.operator.go
-//                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
+//                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
 
     0x_0; 0x012_3456_7_8_9ABCDEFabcd_ef;
-//  ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
-//    ^^ constant.numeric.hex.go
-//        ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
+//  ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//    ^^ constant.numeric.integer.hexadecimal.go
+//        ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
 
 // ### Binary
 
@@ -2038,15 +2038,15 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^ constant.numeric.integer.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
-//  ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
-//    ^ constant.numeric.hex.go
-//     ^ constant.numeric.hex.go storage.type.numeric.go
-//        ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
-//          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
-//                                ^ constant.numeric.hex.go storage.type.numeric.go
-//                                   ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
-//                                     ^^^^^^^^^^ constant.numeric.hex.go
-//                                               ^ constant.numeric.hex.go storage.type.numeric.go
+//  ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//    ^ constant.numeric.integer.hexadecimal.go
+//     ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
+//        ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
+//                                ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
+//                                   ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//                                     ^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
+//                                               ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1773,17 +1773,21 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ### Octal
 
-    00; 01234567; -01234567;
+    00; 01234567; -01234567; 0_0; 012_45;
 //  ^^ constant.numeric.octal.go
 //      ^^^^^^^^ constant.numeric.octal.go
 //                ^ keyword.operator.go
 //                 ^^^^^^^^ constant.numeric.octal.go
+//                           ^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                            ^^ constant.numeric.octal.go
+//                                ^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                                 ^^^^^ constant.numeric.octal.go
 
     08; 09;
 //  ^^ invalid.illegal.go
 //      ^^ invalid.illegal.go
 
-    0o660; 0O061; -0o02;
+    0o660; 0O061; -0o02; 0o_660; 0O0_6_1;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //    ^^^ constant.numeric.octal.go
 //         ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
@@ -1791,6 +1795,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                ^ keyword.operator.go
 //                 ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //                   ^^ constant.numeric.octal.go
+//                       ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                         ^^^^ constant.numeric.octal.go
+//                               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                                 ^^^^^ constant.numeric.octal.go
 
     0o; 0O;
 //  ^^ invalid.illegal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2023,7 +2023,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ## Imaginary
 
-    000i; 100i; -100i;
+    000i; 100i; -100i; 1_1i;
 //  ^^^^ constant.numeric.imaginary.go
 //     ^ storage.type.numeric.imaginary.go
 //        ^^^^ constant.numeric.imaginary.go
@@ -2031,8 +2031,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //              ^ keyword.operator.go
 //               ^^^^ constant.numeric.imaginary.go
 //                  ^ storage.type.numeric.imaginary.go
+//                     ^^^ constant.numeric.imaginary.go
+//                        ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
 
-    123.456i; -123.456i;
+    123.456i; -123.456i; 1_23.45_6i;
 //  ^^^^^^^^ constant.numeric.imaginary.go
 //     ^ punctuation.separator.decimal.go
 //         ^ storage.type.numeric.imaginary.go
@@ -2040,6 +2042,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //             ^^^^^^^^ constant.numeric.imaginary.go
 //                ^ punctuation.separator.decimal.go
 //                    ^ storage.type.numeric.imaginary.go
+//                       ^^^^ constant.numeric.imaginary.go
+//                           ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                            ^^^^ constant.numeric.imaginary.go
+//                                ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
 
     1e+2i; 1e-2i; 1.2e+3i; 1.2e-3i; 1E+2i; 1E-2i; 1.2E+3i; 1.2E-3i;
 //  ^^^^^ constant.numeric.imaginary.go
@@ -2071,29 +2077,54 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                            ^^ punctuation.separator.exponent.go
 //                                                               ^ storage.type.numeric.imaginary.go
 
-    0o6i; 0O35i;
+        1_1e+2_1i; 1.2_1E-3_5i;
+//      ^^^ constant.numeric.imaginary.go
+//         ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
+//           ^^^ constant.numeric.imaginary.go
+//              ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
+//                 ^^^^^ constant.numeric.imaginary.go
+//                      ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
+//                        ^^^ constant.numeric.imaginary.go
+//                           ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
+
+    0o6i; 0O35i; 0o_6i; 0O3_5i;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //    ^ constant.numeric.octal.go
 //     ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
 //        ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //          ^^ constant.numeric.octal.go
 //            ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                 ^^ constant.numeric.octal.go
+//                   ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//                      ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                        ^^^ constant.numeric.octal.go
+//                           ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
 
-    0x0i; 0x0123456789ABCDEFabcdefi;
+    0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
 //  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.hex.go
 //     ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
 //        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
 //          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 //                                ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+//                                   ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//                                     ^^^^^^^^^^ constant.numeric.hex.go
+//                                               ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
 
-    0b1011i; 0B00001i;
+    0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //    ^^^^ constant.numeric.binary.go
 //        ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
 //           ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //             ^^^^^ constant.numeric.binary.go
 //                  ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//                     ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                       ^^^^^ constant.numeric.binary.go
+//                            ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                                 ^^^^^^ constant.numeric.binary.go
+//                                       ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
@@ -2105,6 +2136,22 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                         ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //                           ^^^^^^ constant.numeric.float.go
 //                                 ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+
+    0x_1p-2i; 0x1_4.0_5P-102_1i;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.float.go
+//      ^ constant.numeric.float.go punctuation.section.exponent.go
+//       ^ constant.numeric.float.go keyword.operator.go
+//        ^ constant.numeric.float.go
+//         ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//            ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//              ^^^ constant.numeric.float.go
+//                 ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                  ^^^ constant.numeric.float.go
+//                     ^ constant.numeric.float.go punctuation.section.exponent.go
+//                      ^ constant.numeric.float.go keyword.operator.go
+//                       ^^^^^ constant.numeric.float.go
+//                            ^ constant.numeric.float.go storage.type.numeric.imaginary.go
 
 // ## Runes
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1790,6 +1790,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                 ^ keyword.operator.go
 //                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 
+// ### Binary
+
+    0b1011; 0B00001;
+//  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//    ^^^^ constant.numeric.binary.go
+//          ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//            ^^^^^ constant.numeric.binary.go
+
 // ## Floats
 
     000.000; 123.456; .0; 1.;

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1800,10 +1800,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //                                 ^^^^^ constant.numeric.octal.go
 
-    0o; 0O;
-//  ^^ invalid.illegal.go
-//      ^^ invalid.illegal.go
-
 // ### Hex
 
     0x0; 0x0123456789ABCDEFabcdef; -0x0123456789ABCDEFabcdef;
@@ -1832,10 +1828,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^^ constant.numeric.binary.go
 //                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //                                 ^^^ constant.numeric.binary.go
-
-    0b; 0B;
-//  ^^ invalid.illegal.go
-//      ^^ invalid.illegal.go
 
 // ## Floats
 
@@ -1950,11 +1942,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                         ^ constant.numeric.float.go punctuation.section.exponent.go
 //                          ^^^ constant.numeric.float.go
 
-    0x1p-; 0X1P+; 0x1p;
-//  ^^^^^ invalid.illegal.go
-//         ^^^^^ invalid.illegal.go
-//                ^^^^ invalid.illegal.go
-
     0x1.0P-1021; 0X1.0p-1021;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.float.go
@@ -2013,13 +2000,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                    ^ constant.numeric.float.go punctuation.section.exponent.go
 //                     ^ constant.numeric.float.go keyword.operator.go
 //                      ^ constant.numeric.float.go
-
-    0x1.0P-; 0X1.0p-; 0x2.p; 0x1.Fp; 0X.8p-;
-//  ^^^^^^^ invalid.illegal.go
-//           ^^^^^^^ invalid.illegal.go
-//                    ^^^^^ invalid.illegal.go
-//                           ^^^^^^ invalid.illegal.go
-//                                   ^^^^^^ invalid.illegal.go
 
 // ## Imaginary
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2013,6 +2013,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^ constant.numeric.octal.go
 //            ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
 
+    0x0i; 0x0123456789ABCDEFabcdefi;
+//  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//    ^ constant.numeric.hex.go
+//     ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+//        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
+//                                ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+
 // ## Runes
 
     ' '

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2004,118 +2004,118 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## Imaginary
 
     000i; 100i; -100i; 1_1i;
-//  ^^^^ constant.numeric.complex.imaginary.go
-//     ^ storage.type.numeric.imaginary.go
-//        ^^^^ constant.numeric.complex.imaginary.go
-//           ^ storage.type.numeric.imaginary.go
+//  ^^^^ constant.numeric.imaginary.go
+//     ^ storage.type.numeric.go
+//        ^^^^ constant.numeric.imaginary.go
+//           ^ storage.type.numeric.go
 //              ^ keyword.operator.go
-//               ^^^^ constant.numeric.complex.imaginary.go
-//                  ^ storage.type.numeric.imaginary.go
-//                     ^^^ constant.numeric.complex.imaginary.go
-//                        ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
+//               ^^^^ constant.numeric.imaginary.go
+//                  ^ storage.type.numeric.go
+//                     ^^^ constant.numeric.imaginary.go
+//                        ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     123.456i; -123.456i; 1_23.45_6i;
-//  ^^^^^^^^ constant.numeric.complex.imaginary.go
+//  ^^^^^^^^ constant.numeric.imaginary.go
 //     ^ punctuation.separator.decimal.go
-//         ^ storage.type.numeric.imaginary.go
+//         ^ storage.type.numeric.go
 //            ^ keyword.operator.go
-//             ^^^^^^^^ constant.numeric.complex.imaginary.go
+//             ^^^^^^^^ constant.numeric.imaginary.go
 //                ^ punctuation.separator.decimal.go
-//                    ^ storage.type.numeric.imaginary.go
-//                       ^^^^ constant.numeric.complex.imaginary.go
-//                           ^ constant.numeric.complex.imaginary.go punctuation.separator.decimal.go
-//                            ^^^^ constant.numeric.complex.imaginary.go
-//                                ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
+//                    ^ storage.type.numeric.go
+//                       ^^^^ constant.numeric.imaginary.go
+//                           ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                            ^^^^ constant.numeric.imaginary.go
+//                                ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     1e+2i; 1e-2i; 1.2e+3i; 1.2e-3i; 1E+2i; 1E-2i; 1.2E+3i; 1.2E-3i;
-//  ^^^^^ constant.numeric.complex.imaginary.go
+//  ^^^^^ constant.numeric.imaginary.go
 //   ^^ punctuation.separator.exponent.go
-//      ^ storage.type.numeric.imaginary.go
-//         ^^^^^ constant.numeric.complex.imaginary.go
+//      ^ storage.type.numeric.go
+//         ^^^^^ constant.numeric.imaginary.go
 //          ^^ punctuation.separator.exponent.go
-//             ^ storage.type.numeric.imaginary.go
-//                ^^^^^^^ constant.numeric.complex.imaginary.go
+//             ^ storage.type.numeric.go
+//                ^^^^^^^ constant.numeric.imaginary.go
 //                 ^ punctuation.separator.decimal.go
 //                   ^^ punctuation.separator.exponent.go
-//                      ^ storage.type.numeric.imaginary.go
-//                         ^^^^^^^ constant.numeric.complex.imaginary.go
+//                      ^ storage.type.numeric.go
+//                         ^^^^^^^ constant.numeric.imaginary.go
 //                          ^ punctuation.separator.decimal.go
 //                            ^^ punctuation.separator.exponent.go
-//                               ^ storage.type.numeric.imaginary.go
-//                                  ^^^^^ constant.numeric.complex.imaginary.go
+//                               ^ storage.type.numeric.go
+//                                  ^^^^^ constant.numeric.imaginary.go
 //                                   ^^ punctuation.separator.exponent.go
-//                                      ^ storage.type.numeric.imaginary.go
-//                                         ^^^^^ constant.numeric.complex.imaginary.go
+//                                      ^ storage.type.numeric.go
+//                                         ^^^^^ constant.numeric.imaginary.go
 //                                          ^^ punctuation.separator.exponent.go
-//                                             ^ storage.type.numeric.imaginary.go
-//                                                ^^^^^^^ constant.numeric.complex.imaginary.go
+//                                             ^ storage.type.numeric.go
+//                                                ^^^^^^^ constant.numeric.imaginary.go
 //                                                 ^ punctuation.separator.decimal.go
 //                                                   ^^ punctuation.separator.exponent.go
-//                                                      ^ storage.type.numeric.imaginary.go
-//                                                         ^^^^^^^ constant.numeric.complex.imaginary.go
+//                                                      ^ storage.type.numeric.go
+//                                                         ^^^^^^^ constant.numeric.imaginary.go
 //                                                          ^ punctuation.separator.decimal.go
 //                                                            ^^ punctuation.separator.exponent.go
-//                                                               ^ storage.type.numeric.imaginary.go
+//                                                               ^ storage.type.numeric.go
 
         1_1e+2_1i; 1.2_1E-3_5i;
-//      ^^^ constant.numeric.complex.imaginary.go
-//         ^^ constant.numeric.complex.imaginary.go punctuation.separator.exponent.go
-//           ^^^ constant.numeric.complex.imaginary.go
-//              ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
-//                 ^^^^^ constant.numeric.complex.imaginary.go
-//                      ^^ constant.numeric.complex.imaginary.go punctuation.separator.exponent.go
-//                        ^^^ constant.numeric.complex.imaginary.go
-//                           ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
+//      ^^^ constant.numeric.imaginary.go
+//         ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
+//           ^^^ constant.numeric.imaginary.go
+//              ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                 ^^^^^ constant.numeric.imaginary.go
+//                      ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
+//                        ^^^ constant.numeric.imaginary.go
+//                           ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //    ^ constant.numeric.octal.go
-//     ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//     ^ constant.numeric.octal.go storage.type.numeric.go
 //        ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //          ^^ constant.numeric.octal.go
-//            ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//            ^ constant.numeric.octal.go storage.type.numeric.go
 //               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //                 ^^ constant.numeric.octal.go
-//                   ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//                   ^ constant.numeric.octal.go storage.type.numeric.go
 //                      ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //                        ^^^ constant.numeric.octal.go
-//                           ^ constant.numeric.octal.go storage.type.numeric.imaginary.go
+//                           ^ constant.numeric.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
 //  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.hex.go
-//     ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+//     ^ constant.numeric.hex.go storage.type.numeric.go
 //        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
 //          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
-//                                ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+//                                ^ constant.numeric.hex.go storage.type.numeric.go
 //                                   ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
 //                                     ^^^^^^^^^^ constant.numeric.hex.go
-//                                               ^ constant.numeric.hex.go storage.type.numeric.imaginary.go
+//                                               ^ constant.numeric.hex.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //    ^^^^ constant.numeric.binary.go
-//        ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//        ^ constant.numeric.binary.go storage.type.numeric.go
 //           ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //             ^^^^^ constant.numeric.binary.go
-//                  ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//                  ^ constant.numeric.binary.go storage.type.numeric.go
 //                     ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //                       ^^^^^ constant.numeric.binary.go
-//                            ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//                            ^ constant.numeric.binary.go storage.type.numeric.go
 //                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //                                 ^^^^^^ constant.numeric.binary.go
-//                                       ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+//                                       ^ constant.numeric.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^^^^ constant.numeric.float.go
-//        ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//        ^ constant.numeric.float.go storage.type.numeric.go
 //           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //             ^^^^^^^^^ constant.numeric.float.go
-//                      ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//                      ^ constant.numeric.float.go storage.type.numeric.go
 //                         ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //                           ^^^^^^ constant.numeric.float.go
-//                                 ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//                                 ^ constant.numeric.float.go storage.type.numeric.go
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
@@ -2123,7 +2123,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^ constant.numeric.float.go punctuation.section.exponent.go
 //       ^ constant.numeric.float.go keyword.operator.go
 //        ^ constant.numeric.float.go
-//         ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//         ^ constant.numeric.float.go storage.type.numeric.go
 //            ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //              ^^^ constant.numeric.float.go
 //                 ^ constant.numeric.float.go punctuation.separator.decimal.go
@@ -2131,7 +2131,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ constant.numeric.float.go punctuation.section.exponent.go
 //                      ^ constant.numeric.float.go keyword.operator.go
 //                       ^^^^^ constant.numeric.float.go
-//                            ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//                            ^ constant.numeric.float.go storage.type.numeric.go
 
 // ## Runes
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1872,6 +1872,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                 ^ punctuation.separator.decimal.go
 //                                     ^^ punctuation.separator.exponent.go
 
+    0.e+0; .0e+0; 0.e-0; .0e-0;
+//  ^^^^^ invalid.deprecated.go
+//         ^^^^^ invalid.deprecated.go
+//                ^^^^^ invalid.deprecated.go
+//                       ^^^^^ invalid.deprecated.go
+
     0x1p-2; 0X1P+2; 0x1p2;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^^ constant.numeric.float.go
@@ -1886,6 +1892,11 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                    ^ constant.numeric.float.go
 //                     ^ constant.numeric.float.go punctuation.section.exponent.go
 //                      ^ constant.numeric.float.go
+
+    0x1p-; 0X1P+; 0x1p;
+//  ^^^^^ invalid.illegal.go
+//         ^^^^^ invalid.illegal.go
+//                ^^^^ invalid.illegal.go
 
     0x1.0P-1021; 0X1.0p-1021;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
@@ -1903,7 +1914,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ constant.numeric.float.go keyword.operator.go
 //                      ^^^^ constant.numeric.float.go
 
-    0x2.p10; 0x1.Fp+0; 0X.8p-0
+    0x2.p10; 0x1.Fp+0; 0X.8p-0;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.float.go
 //     ^ constant.numeric.float.go punctuation.separator.decimal.go
@@ -1923,12 +1934,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                          ^ constant.numeric.float.go keyword.operator.go
 //                           ^ constant.numeric.float.go
 
-
-    0.e+0; .0e+0; 0.e-0; .0e-0;
-//  ^^^^^ invalid.deprecated.go
-//         ^^^^^ invalid.deprecated.go
-//                ^^^^^ invalid.deprecated.go
-//                       ^^^^^ invalid.deprecated.go
+    0x1.0P-; 0X1.0p-; 0x2.p; 0x1.Fp; 0X.8p-;
+//  ^^^^^^^ invalid.illegal.go
+//           ^^^^^^^ invalid.illegal.go
+//                    ^^^^^ invalid.illegal.go
+//                           ^^^^^^ invalid.illegal.go
+//                                   ^^^^^^ invalid.illegal.go
 
 // ## Imaginary
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1804,9 +1804,15 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                 ^ keyword.operator.go
 //                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 
+    0x_0; 0x012_3456_7_8_9ABCDEFabcd_ef;
+//  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.hex.go
+//        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
+
 // ### Binary
 
-    0b1011; 0B00001; -0b1; 0b_1; 0B_1_0;
+    0b1011; 0B00001; -0b1; 0b_1; 0B1_0;
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //    ^^^^ constant.numeric.binary.go
 //          ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
@@ -1817,7 +1823,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                         ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //                           ^^ constant.numeric.binary.go
 //                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
-//                                 ^^^^ constant.numeric.binary.go
+//                                 ^^^ constant.numeric.binary.go
 
     0b; 0B;
 //  ^^ invalid.illegal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1806,7 +1806,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ### Binary
 
-    0b1011; 0B00001; -0b1
+    0b1011; 0B00001; -0b1; 0b_1; 0B_1_0;
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //    ^^^^ constant.numeric.binary.go
 //          ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
@@ -1814,6 +1814,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                   ^ keyword.operator.go
 //                    ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //                      ^ constant.numeric.binary.go
+//                         ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                           ^^ constant.numeric.binary.go
+//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                                 ^^^^ constant.numeric.binary.go
 
     0b; 0B;
 //  ^^ invalid.illegal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1792,11 +1792,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ### Binary
 
-    0b1011; 0B00001;
+    0b1011; 0B00001; -0b1
 //  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //    ^^^^ constant.numeric.binary.go
 //          ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //            ^^^^^ constant.numeric.binary.go
+//                   ^ keyword.operator.go
+//                    ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                      ^ constant.numeric.binary.go
+
+    0b; 0B;
+//  ^^ invalid.illegal.go
+//      ^^ invalid.illegal.go
 
 // ## Floats
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2004,68 +2004,68 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## Imaginary
 
     000i; 100i; -100i; 1_1i;
-//  ^^^^ constant.numeric.imaginary.go
+//  ^^^^ constant.numeric.complex.imaginary.go
 //     ^ storage.type.numeric.imaginary.go
-//        ^^^^ constant.numeric.imaginary.go
+//        ^^^^ constant.numeric.complex.imaginary.go
 //           ^ storage.type.numeric.imaginary.go
 //              ^ keyword.operator.go
-//               ^^^^ constant.numeric.imaginary.go
+//               ^^^^ constant.numeric.complex.imaginary.go
 //                  ^ storage.type.numeric.imaginary.go
-//                     ^^^ constant.numeric.imaginary.go
-//                        ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
+//                     ^^^ constant.numeric.complex.imaginary.go
+//                        ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
 
     123.456i; -123.456i; 1_23.45_6i;
-//  ^^^^^^^^ constant.numeric.imaginary.go
+//  ^^^^^^^^ constant.numeric.complex.imaginary.go
 //     ^ punctuation.separator.decimal.go
 //         ^ storage.type.numeric.imaginary.go
 //            ^ keyword.operator.go
-//             ^^^^^^^^ constant.numeric.imaginary.go
+//             ^^^^^^^^ constant.numeric.complex.imaginary.go
 //                ^ punctuation.separator.decimal.go
 //                    ^ storage.type.numeric.imaginary.go
-//                       ^^^^ constant.numeric.imaginary.go
-//                           ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
-//                            ^^^^ constant.numeric.imaginary.go
-//                                ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
+//                       ^^^^ constant.numeric.complex.imaginary.go
+//                           ^ constant.numeric.complex.imaginary.go punctuation.separator.decimal.go
+//                            ^^^^ constant.numeric.complex.imaginary.go
+//                                ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
 
     1e+2i; 1e-2i; 1.2e+3i; 1.2e-3i; 1E+2i; 1E-2i; 1.2E+3i; 1.2E-3i;
-//  ^^^^^ constant.numeric.imaginary.go
+//  ^^^^^ constant.numeric.complex.imaginary.go
 //   ^^ punctuation.separator.exponent.go
 //      ^ storage.type.numeric.imaginary.go
-//         ^^^^^ constant.numeric.imaginary.go
+//         ^^^^^ constant.numeric.complex.imaginary.go
 //          ^^ punctuation.separator.exponent.go
 //             ^ storage.type.numeric.imaginary.go
-//                ^^^^^^^ constant.numeric.imaginary.go
+//                ^^^^^^^ constant.numeric.complex.imaginary.go
 //                 ^ punctuation.separator.decimal.go
 //                   ^^ punctuation.separator.exponent.go
 //                      ^ storage.type.numeric.imaginary.go
-//                         ^^^^^^^ constant.numeric.imaginary.go
+//                         ^^^^^^^ constant.numeric.complex.imaginary.go
 //                          ^ punctuation.separator.decimal.go
 //                            ^^ punctuation.separator.exponent.go
 //                               ^ storage.type.numeric.imaginary.go
-//                                  ^^^^^ constant.numeric.imaginary.go
+//                                  ^^^^^ constant.numeric.complex.imaginary.go
 //                                   ^^ punctuation.separator.exponent.go
 //                                      ^ storage.type.numeric.imaginary.go
-//                                         ^^^^^ constant.numeric.imaginary.go
+//                                         ^^^^^ constant.numeric.complex.imaginary.go
 //                                          ^^ punctuation.separator.exponent.go
 //                                             ^ storage.type.numeric.imaginary.go
-//                                                ^^^^^^^ constant.numeric.imaginary.go
+//                                                ^^^^^^^ constant.numeric.complex.imaginary.go
 //                                                 ^ punctuation.separator.decimal.go
 //                                                   ^^ punctuation.separator.exponent.go
 //                                                      ^ storage.type.numeric.imaginary.go
-//                                                         ^^^^^^^ constant.numeric.imaginary.go
+//                                                         ^^^^^^^ constant.numeric.complex.imaginary.go
 //                                                          ^ punctuation.separator.decimal.go
 //                                                            ^^ punctuation.separator.exponent.go
 //                                                               ^ storage.type.numeric.imaginary.go
 
         1_1e+2_1i; 1.2_1E-3_5i;
-//      ^^^ constant.numeric.imaginary.go
-//         ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
-//           ^^^ constant.numeric.imaginary.go
-//              ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
-//                 ^^^^^ constant.numeric.imaginary.go
-//                      ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
-//                        ^^^ constant.numeric.imaginary.go
-//                           ^ constant.numeric.imaginary.go storage.type.numeric.imaginary.go
+//      ^^^ constant.numeric.complex.imaginary.go
+//         ^^ constant.numeric.complex.imaginary.go punctuation.separator.exponent.go
+//           ^^^ constant.numeric.complex.imaginary.go
+//              ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
+//                 ^^^^^ constant.numeric.complex.imaginary.go
+//                      ^^ constant.numeric.complex.imaginary.go punctuation.separator.exponent.go
+//                        ^^^ constant.numeric.complex.imaginary.go
+//                           ^ constant.numeric.complex.imaginary.go storage.type.numeric.imaginary.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1778,6 +1778,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                ^ keyword.operator.go
 //                 ^^^^^^^^ constant.numeric.octal.go
 
+    08; 09;
+//  ^^ invalid.illegal.go
+//      ^^ invalid.illegal.go
+
     0o660; 0O061; -0o02;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //    ^^^ constant.numeric.octal.go
@@ -1787,7 +1791,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                 ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //                   ^^ constant.numeric.octal.go
 
-    08; 09;
+    0o; 0O;
 //  ^^ invalid.illegal.go
 //      ^^ invalid.illegal.go
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1991,20 +1991,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                            ^^ punctuation.separator.exponent.go
 //                                                               ^ storage.type.numeric.imaginary.go
 
-    0.i; .0i; -0.i; -.0i;
-//  ^^^ invalid.deprecated.go
-//       ^^^ invalid.deprecated.go
-//            ^ keyword.operator.go
-//             ^^^ invalid.deprecated.go
-//                  ^ keyword.operator.go
-//                   ^^^ invalid.deprecated.go
-
-    0.e+0i; .0e+0i; 0.e-0i; .0e-0i;
-//  ^^^^^^ invalid.deprecated.go
-//          ^^^^^^ invalid.deprecated.go
-//                  ^^^^^^ invalid.deprecated.go
-//                          ^^^^^^ invalid.deprecated.go
-
     0o6i; 0O35i;
 //  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
 //    ^ constant.numeric.octal.go
@@ -2028,6 +2014,17 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //           ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
 //             ^^^^^ constant.numeric.binary.go
 //                  ^ constant.numeric.binary.go storage.type.numeric.imaginary.go
+
+    0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^ constant.numeric.float.go
+//        ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//             ^^^^^^^^^ constant.numeric.float.go
+//                      ^ constant.numeric.float.go storage.type.numeric.imaginary.go
+//                         ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//                           ^^^^^^ constant.numeric.float.go
+//                                 ^ constant.numeric.float.go storage.type.numeric.imaginary.go
 
 // ## Runes
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1848,6 +1848,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                    ^^ invalid.deprecated.go
 //                        ^^ invalid.deprecated.go
 
+    0_1.0_1; 1_23.4_6;
+//  ^^^
+//     ^ constant.numeric.float.go punctuation.separator.decimal.go
+//      ^^^ constant.numeric.float.go
+//           ^^^^ constant.numeric.float.go
+//               ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                ^^^ constant.numeric.float.go
+
     -000.000; -123.456; -.0; -1.;
 //  ^ keyword.operator.go
 //   ^^^^^^^ constant.numeric.float.go
@@ -1874,6 +1882,20 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                              ^^^^^^^^^^^^ constant.numeric.float.go
 //                                 ^ punctuation.separator.decimal.go
 //                                     ^^ punctuation.separator.exponent.go
+
+    1_2e+0; 1E+0_1; 0.1_2e2; 1_23.4_56e+78_9;
+//  ^^^ constant.numeric.float.go
+//     ^^ constant.numeric.float.go punctuation.separator.exponent.go
+//       ^ constant.numeric.float.go
+//          ^ constant.numeric.float.go
+//           ^^ constant.numeric.float.go punctuation.separator.exponent.go
+//             ^^^ constant.numeric.float.go
+//                  ^^^^^ constant.numeric.float.go
+//                       ^ constant.numeric.float.go punctuation.separator.exponent.go
+//                        ^ constant.numeric.float.go
+//                           ^^^^^^^^^ constant.numeric.float.go
+//                                    ^^ constant.numeric.float.go punctuation.separator.exponent.go
+//                                      ^^^^ constant.numeric.float.go
 
     0e-0; 0E-0; 0.0e-0; 0.0E-0; 123.456e-789;
 //  ^^^^ constant.numeric.float.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2024,64 +2024,62 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
-//  ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
-//    ^ constant.numeric.integer.octal.go
-//     ^ constant.numeric.integer.octal.go storage.type.numeric.go
-//        ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
-//          ^^ constant.numeric.integer.octal.go
-//            ^ constant.numeric.integer.octal.go storage.type.numeric.go
-//               ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
-//                 ^^ constant.numeric.integer.octal.go
-//                   ^ constant.numeric.integer.octal.go storage.type.numeric.go
-//                      ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
-//                        ^^^ constant.numeric.integer.octal.go
-//                           ^ constant.numeric.integer.octal.go storage.type.numeric.go
+//  ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//    ^ constant.numeric.imaginary.octal.go
+//     ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
+//        ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//          ^^ constant.numeric.imaginary.octal.go
+//            ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
+//               ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//                 ^^ constant.numeric.imaginary.octal.go
+//                   ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
+//                      ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//                        ^^^ constant.numeric.imaginary.octal.go
+//                           ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
-//  ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
-//    ^ constant.numeric.integer.hexadecimal.go
-//     ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
-//        ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
-//          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
-//                                ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
-//                                   ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
-//                                     ^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
-//                                               ^ constant.numeric.integer.hexadecimal.go storage.type.numeric.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//    ^ constant.numeric.imaginary.hexadecimal.go
+//     ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
+//        ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
+//                                ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
+//                                   ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//                                     ^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
+//                                               ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
-//  ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
-//    ^^^^ constant.numeric.integer.binary.go
-//        ^ constant.numeric.integer.binary.go storage.type.numeric.go
-//           ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
-//             ^^^^^ constant.numeric.integer.binary.go
-//                  ^ constant.numeric.integer.binary.go storage.type.numeric.go
-//                     ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
-//                       ^^^^^ constant.numeric.integer.binary.go
-//                            ^ constant.numeric.integer.binary.go storage.type.numeric.go
-//                               ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
-//                                 ^^^^^^ constant.numeric.integer.binary.go
-//                                       ^ constant.numeric.integer.binary.go storage.type.numeric.go
+//  ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//    ^^^^ constant.numeric.imaginary.binary.go
+//        ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
+//           ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//             ^^^^^ constant.numeric.imaginary.binary.go
+//                  ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
+//                     ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//                       ^^^^^ constant.numeric.imaginary.binary.go
+//                            ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
+//                               ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//                                 ^^^^^^ constant.numeric.imaginary.binary.go
+//                                       ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
-//    ^^^^ constant.numeric.float.hexadecimal.go
-//        ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
-//             ^^^^^^^^^ constant.numeric.float.hexadecimal.go
-//                      ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//                         ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
-//                           ^^^^^^ constant.numeric.float.hexadecimal.go
-//                                 ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//    ^^^^ constant.numeric.imaginary.hexadecimal.go
+//        ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
+//           ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//             ^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
+//                      ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
+//                         ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//                           ^^^^^^ constant.numeric.imaginary.hexadecimal.go
+//                                 ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
-//    ^^^^^ constant.numeric.float.hexadecimal.go
-//         ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//            ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
-//              ^^^ constant.numeric.float.hexadecimal.go
-//                 ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
-//                  ^^^^^^^^^^ constant.numeric.float.hexadecimal.go
-//                            ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//    ^^^^^ constant.numeric.imaginary.hexadecimal.go
+//         ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
+//            ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//              ^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
+//                            ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 
 // ## Runes
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1887,6 +1887,43 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ constant.numeric.float.go punctuation.section.exponent.go
 //                      ^ constant.numeric.float.go
 
+    0x1.0P-1021; 0X1.0p-1021;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^ constant.numeric.float.go
+//     ^ constant.numeric.float.go punctuation.separator.decimal.go
+//      ^ constant.numeric.float.go
+//       ^ constant.numeric.float.go punctuation.section.exponent.go
+//        ^ constant.numeric.float.go keyword.operator.go
+//         ^^^^ constant.numeric.float.go
+//               ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//                 ^ constant.numeric.float.go
+//                  ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                   ^ constant.numeric.float.go
+//                    ^ constant.numeric.float.go punctuation.section.exponent.go
+//                     ^ constant.numeric.float.go keyword.operator.go
+//                      ^^^^ constant.numeric.float.go
+
+    0x2.p10; 0x1.Fp+0; 0X.8p-0
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^ constant.numeric.float.go
+//     ^ constant.numeric.float.go punctuation.separator.decimal.go
+//      ^ constant.numeric.float.go punctuation.section.exponent.go
+//       ^^ constant.numeric.float.go
+//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//             ^ constant.numeric.float.go
+//              ^ constant.numeric.float.go punctuation.separator.decimal.go
+//               ^ constant.numeric.float.go
+//                ^ constant.numeric.float.go punctuation.section.exponent.go
+//                 ^ constant.numeric.float.go keyword.operator.go
+//                  ^ constant.numeric.float.go
+//                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//                       ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                        ^ constant.numeric.float.go
+//                         ^ constant.numeric.float.go punctuation.section.exponent.go
+//                          ^ constant.numeric.float.go keyword.operator.go
+//                           ^ constant.numeric.float.go
+
+
     0.e+0; .0e+0; 0.e-0; .0e-0;
 //  ^^^^^ invalid.deprecated.go
 //         ^^^^^ invalid.deprecated.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1934,6 +1934,22 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ constant.numeric.float.go punctuation.section.exponent.go
 //                      ^ constant.numeric.float.go
 
+    0x_1p-2; 0X1_1P+2; 0x_1p2_1;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.float.go
+//      ^ constant.numeric.float.go punctuation.section.exponent.go
+//       ^ constant.numeric.float.go keyword.operator.go
+//        ^ constant.numeric.float.go
+//           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//             ^^^ constant.numeric.float.go
+//                ^ constant.numeric.float.go punctuation.section.exponent.go
+//                 ^ constant.numeric.float.go keyword.operator.go
+//                  ^ constant.numeric.float.go
+//                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//                       ^^ constant.numeric.float.go
+//                         ^ constant.numeric.float.go punctuation.section.exponent.go
+//                          ^^^ constant.numeric.float.go
+
     0x1p-; 0X1P+; 0x1p;
 //  ^^^^^ invalid.illegal.go
 //         ^^^^^ invalid.illegal.go
@@ -1955,6 +1971,15 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ constant.numeric.float.go keyword.operator.go
 //                      ^^^^ constant.numeric.float.go
 
+    0x_1_1.0_7P-1_021;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^^^ constant.numeric.float.go
+//        ^ constant.numeric.float.go punctuation.separator.decimal.go
+//         ^^^ constant.numeric.float.go
+//            ^ constant.numeric.float.go punctuation.section.exponent.go
+//             ^ constant.numeric.float.go keyword.operator.go
+//              ^^^^^ constant.numeric.float.go
+
     0x2.p10; 0x1.Fp+0; 0X.8p-0;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.float.go
@@ -1974,6 +1999,20 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                         ^ constant.numeric.float.go punctuation.section.exponent.go
 //                          ^ constant.numeric.float.go keyword.operator.go
 //                           ^ constant.numeric.float.go
+
+    0x_2.p1_0; 0x1.F_Ap+0;
+//  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//    ^^ constant.numeric.float.go
+//      ^ constant.numeric.float.go punctuation.separator.decimal.go
+//       ^ constant.numeric.float.go punctuation.section.exponent.go
+//        ^^^ constant.numeric.float.go
+//             ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
+//               ^ constant.numeric.float.go
+//                ^ constant.numeric.float.go punctuation.separator.decimal.go
+//                 ^^^ constant.numeric.float.go
+//                    ^ constant.numeric.float.go punctuation.section.exponent.go
+//                     ^ constant.numeric.float.go keyword.operator.go
+//                      ^ constant.numeric.float.go
 
     0x1.0P-; 0X1.0p-; 0x2.p; 0x1.Fp; 0X.8p-;
 //  ^^^^^^^ invalid.illegal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1913,93 +1913,59 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     0x1p-2; 0X1P+2; 0x1p2;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^ constant.numeric.float.go
-//      ^ constant.numeric.float.go keyword.operator.go
-//       ^ constant.numeric.float.go
+//    ^^^^ constant.numeric.float.go
 //          ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//            ^ constant.numeric.float.go
-//             ^ constant.numeric.float.go punctuation.section.exponent.go
-//              ^ constant.numeric.float.go keyword.operator.go
-//               ^ constant.numeric.float.go
+//            ^^^^ constant.numeric.float.go
 //                  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                    ^ constant.numeric.float.go
-//                     ^ constant.numeric.float.go punctuation.section.exponent.go
-//                      ^ constant.numeric.float.go
+//                    ^^^ constant.numeric.float.go
 
     0x_1p-2; 0X1_1P+2; 0x_1p2_1;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^ constant.numeric.float.go
-//      ^ constant.numeric.float.go punctuation.section.exponent.go
-//       ^ constant.numeric.float.go keyword.operator.go
-//        ^ constant.numeric.float.go
+//    ^^^^^ constant.numeric.float.go
 //           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//             ^^^ constant.numeric.float.go
-//                ^ constant.numeric.float.go punctuation.section.exponent.go
-//                 ^ constant.numeric.float.go keyword.operator.go
-//                  ^ constant.numeric.float.go
+//             ^^^^^^ constant.numeric.float.go
 //                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//                       ^^ constant.numeric.float.go
-//                         ^ constant.numeric.float.go punctuation.section.exponent.go
-//                          ^^^ constant.numeric.float.go
+//                       ^^^^^^ constant.numeric.float.go
 
     0x1.0P-1021; 0X1.0p-1021;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.float.go
 //     ^ constant.numeric.float.go punctuation.separator.decimal.go
-//      ^ constant.numeric.float.go
-//       ^ constant.numeric.float.go punctuation.section.exponent.go
-//        ^ constant.numeric.float.go keyword.operator.go
-//         ^^^^ constant.numeric.float.go
+//      ^^^^^^^ constant.numeric.float.go
 //               ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //                 ^ constant.numeric.float.go
 //                  ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                   ^ constant.numeric.float.go
-//                    ^ constant.numeric.float.go punctuation.section.exponent.go
-//                     ^ constant.numeric.float.go keyword.operator.go
-//                      ^^^^ constant.numeric.float.go
+//                   ^^^^^^^ constant.numeric.float.go
 
     0x_1_1.0_7P-1_021;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^^^^ constant.numeric.float.go
 //        ^ constant.numeric.float.go punctuation.separator.decimal.go
-//         ^^^ constant.numeric.float.go
-//            ^ constant.numeric.float.go punctuation.section.exponent.go
-//             ^ constant.numeric.float.go keyword.operator.go
-//              ^^^^^ constant.numeric.float.go
+//         ^^^^^^^^^^ constant.numeric.float.go
 
     0x2.p10; 0x1.Fp+0; 0X.8p-0;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^ constant.numeric.float.go
 //     ^ constant.numeric.float.go punctuation.separator.decimal.go
-//      ^ constant.numeric.float.go punctuation.section.exponent.go
-//       ^^ constant.numeric.float.go
+//      ^^^ constant.numeric.float.go
 //           ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //             ^ constant.numeric.float.go
 //              ^ constant.numeric.float.go punctuation.separator.decimal.go
-//               ^ constant.numeric.float.go
-//                ^ constant.numeric.float.go punctuation.section.exponent.go
-//                 ^ constant.numeric.float.go keyword.operator.go
-//                  ^ constant.numeric.float.go
+//               ^^^^ constant.numeric.float.go
 //                     ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //                       ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                        ^ constant.numeric.float.go
-//                         ^ constant.numeric.float.go punctuation.section.exponent.go
-//                          ^ constant.numeric.float.go keyword.operator.go
-//                           ^ constant.numeric.float.go
+//                        ^^^^ constant.numeric.float.go
 
     0x_2.p1_0; 0x1.F_Ap+0;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //    ^^ constant.numeric.float.go
 //      ^ constant.numeric.float.go punctuation.separator.decimal.go
-//       ^ constant.numeric.float.go punctuation.section.exponent.go
-//        ^^^ constant.numeric.float.go
+//       ^^^^ constant.numeric.float.go
+//           ^ punctuation.terminator.go
 //             ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //               ^ constant.numeric.float.go
 //                ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                 ^^^ constant.numeric.float.go
-//                    ^ constant.numeric.float.go punctuation.section.exponent.go
-//                     ^ constant.numeric.float.go keyword.operator.go
-//                      ^ constant.numeric.float.go
+//                 ^^^^^^ constant.numeric.float.go
 
 // ## Imaginary
 
@@ -2119,18 +2085,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
 //  ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
-//    ^^ constant.numeric.float.go
-//      ^ constant.numeric.float.go punctuation.section.exponent.go
-//       ^ constant.numeric.float.go keyword.operator.go
-//        ^ constant.numeric.float.go
+//    ^^^^^ constant.numeric.float.go
 //         ^ constant.numeric.float.go storage.type.numeric.go
 //            ^^ constant.numeric.float.go punctuation.definition.numeric.hexadecimal.go
 //              ^^^ constant.numeric.float.go
 //                 ^ constant.numeric.float.go punctuation.separator.decimal.go
-//                  ^^^ constant.numeric.float.go
-//                     ^ constant.numeric.float.go punctuation.section.exponent.go
-//                      ^ constant.numeric.float.go keyword.operator.go
-//                       ^^^^^ constant.numeric.float.go
+//                  ^^^^^^^^^^ constant.numeric.float.go
 //                            ^ constant.numeric.float.go storage.type.numeric.go
 
 // ## Runes

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1778,9 +1778,9 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^^^^^^^ constant.numeric.octal.go
 //                ^ keyword.operator.go
 //                 ^^^^^^^^ constant.numeric.octal.go
-//                           ^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                           ^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                            ^^ constant.numeric.octal.go
-//                                ^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                                ^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                                 ^^^^^ constant.numeric.octal.go
 
     08; 09;
@@ -1788,16 +1788,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^ invalid.illegal.go
 
     0o660; 0O061; -0o02; 0o_660; 0O0_6_1;
-//  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//  ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //    ^^^ constant.numeric.octal.go
-//         ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//         ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //           ^^^ constant.numeric.octal.go
 //                ^ keyword.operator.go
-//                 ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                 ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                   ^^ constant.numeric.octal.go
-//                       ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                       ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                         ^^^^ constant.numeric.octal.go
-//                               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                               ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                                 ^^^^^ constant.numeric.octal.go
 
 // ### Hex
@@ -1809,24 +1809,24 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 
     0x_0; 0x012_3456_7_8_9ABCDEFabcd_ef;
-//  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
 //    ^^ constant.numeric.hex.go
-//        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//        ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 
 // ### Binary
 
     0b1011; 0B00001; -0b1; 0b_1; 0B1_0;
-//  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//  ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //    ^^^^ constant.numeric.binary.go
-//          ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//          ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //            ^^^^^ constant.numeric.binary.go
 //                   ^ keyword.operator.go
-//                    ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                    ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //                      ^ constant.numeric.binary.go
-//                         ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                         ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //                           ^^ constant.numeric.binary.go
-//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //                                 ^^^ constant.numeric.binary.go
 
 // ## Floats
@@ -1903,57 +1903,57 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^^^^^ invalid.deprecated.go
 
     0x1p-2; 0X1P+2; 0x1p2;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^^^ constant.numeric.float.hexadecimal.go
-//          ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//          ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //            ^^^^ constant.numeric.float.hexadecimal.go
-//                  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //                    ^^^ constant.numeric.float.hexadecimal.go
 
     0x_1p-2; 0X1_1P+2; 0x_1p2_1;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^^^^ constant.numeric.float.hexadecimal.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //             ^^^^^^ constant.numeric.float.hexadecimal.go
-//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //                       ^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x1.0P-1021; 0X1.0p-1021;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^ constant.numeric.float.hexadecimal.go
 //     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //      ^^^^^^^ constant.numeric.float.hexadecimal.go
-//               ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//               ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //                 ^ constant.numeric.float.hexadecimal.go
 //                  ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                   ^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x_1_1.0_7P-1_021;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^^^ constant.numeric.float.hexadecimal.go
 //        ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //         ^^^^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x2.p10; 0x1.Fp+0; 0X.8p-0;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^ constant.numeric.float.hexadecimal.go
 //     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //      ^^^ constant.numeric.float.hexadecimal.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //             ^ constant.numeric.float.hexadecimal.go
 //              ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //               ^^^^ constant.numeric.float.hexadecimal.go
-//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //                       ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                        ^^^^ constant.numeric.float.hexadecimal.go
 
     0x_2.p1_0; 0x1.F_Ap+0;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^ constant.numeric.float.hexadecimal.go
 //      ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //       ^^^^ constant.numeric.float.hexadecimal.go
 //           ^ punctuation.terminator.go
-//             ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//             ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //               ^ constant.numeric.float.hexadecimal.go
 //                ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                 ^^^^^^ constant.numeric.float.hexadecimal.go
@@ -2021,60 +2021,60 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
-//  ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//  ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //    ^ constant.numeric.octal.go
 //     ^ constant.numeric.octal.go storage.type.numeric.go
-//        ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//        ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //          ^^ constant.numeric.octal.go
 //            ^ constant.numeric.octal.go storage.type.numeric.go
-//               ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//               ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                 ^^ constant.numeric.octal.go
 //                   ^ constant.numeric.octal.go storage.type.numeric.go
-//                      ^^ constant.numeric.octal.go punctuation.definition.numeric.octal.go
+//                      ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
 //                        ^^^ constant.numeric.octal.go
 //                           ^ constant.numeric.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
-//  ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
 //    ^ constant.numeric.hex.go
 //     ^ constant.numeric.hex.go storage.type.numeric.go
-//        ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//        ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
 //          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
 //                                ^ constant.numeric.hex.go storage.type.numeric.go
-//                                   ^^ constant.numeric.hex.go punctuation.definition.numeric.hexadecimal.go
+//                                   ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go
 //                                     ^^^^^^^^^^ constant.numeric.hex.go
 //                                               ^ constant.numeric.hex.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
-//  ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//  ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //    ^^^^ constant.numeric.binary.go
 //        ^ constant.numeric.binary.go storage.type.numeric.go
-//           ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//           ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //             ^^^^^ constant.numeric.binary.go
 //                  ^ constant.numeric.binary.go storage.type.numeric.go
-//                     ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                     ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //                       ^^^^^ constant.numeric.binary.go
 //                            ^ constant.numeric.binary.go storage.type.numeric.go
-//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.binary.go
+//                               ^^ constant.numeric.binary.go punctuation.definition.numeric.base.go
 //                                 ^^^^^^ constant.numeric.binary.go
 //                                       ^ constant.numeric.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^^^ constant.numeric.float.hexadecimal.go
 //        ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //             ^^^^^^^^^ constant.numeric.float.hexadecimal.go
 //                      ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//                         ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//                         ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //                           ^^^^^^ constant.numeric.float.hexadecimal.go
 //                                 ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //    ^^^^^ constant.numeric.float.hexadecimal.go
 //         ^ constant.numeric.float.hexadecimal.go storage.type.numeric.go
-//            ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.hexadecimal.go
+//            ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
 //              ^^^ constant.numeric.float.hexadecimal.go
 //                 ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                  ^^^^^^^^^^ constant.numeric.float.hexadecimal.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1774,31 +1774,34 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ### Octal
 
     00; 01234567; -01234567; 0_0; 012_45;
-//  ^^ constant.numeric.octal.go
-//      ^^^^^^^^ constant.numeric.octal.go
+//  ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//   ^ constant.numeric.integer.octal.go
+//      ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//       ^^^^^^^ constant.numeric.integer.octal.go
 //                ^ keyword.operator.go
-//                 ^^^^^^^^ constant.numeric.octal.go
-//                           ^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                            ^^ constant.numeric.octal.go
-//                                ^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                                 ^^^^^ constant.numeric.octal.go
+//                 ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                  ^^^^^^^ constant.numeric.integer.octal.go
+//                           ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                            ^^ constant.numeric.integer.octal.go
+//                                ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                                 ^^^^^ constant.numeric.integer.octal.go
 
     08; 09;
 //  ^^ invalid.illegal.go
 //      ^^ invalid.illegal.go
 
     0o660; 0O061; -0o02; 0o_660; 0O0_6_1;
-//  ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//    ^^^ constant.numeric.octal.go
-//         ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//           ^^^ constant.numeric.octal.go
+//  ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//    ^^^ constant.numeric.integer.octal.go
+//         ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//           ^^^ constant.numeric.integer.octal.go
 //                ^ keyword.operator.go
-//                 ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                   ^^ constant.numeric.octal.go
-//                       ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                         ^^^^ constant.numeric.octal.go
-//                               ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                                 ^^^^^ constant.numeric.octal.go
+//                 ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                   ^^ constant.numeric.integer.octal.go
+//                       ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                         ^^^^ constant.numeric.integer.octal.go
+//                               ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                                 ^^^^^ constant.numeric.integer.octal.go
 
 // ### Hex
 
@@ -2021,18 +2024,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
-//  ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//    ^ constant.numeric.octal.go
-//     ^ constant.numeric.octal.go storage.type.numeric.go
-//        ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//          ^^ constant.numeric.octal.go
-//            ^ constant.numeric.octal.go storage.type.numeric.go
-//               ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                 ^^ constant.numeric.octal.go
-//                   ^ constant.numeric.octal.go storage.type.numeric.go
-//                      ^^ constant.numeric.octal.go punctuation.definition.numeric.base.go
-//                        ^^^ constant.numeric.octal.go
-//                           ^ constant.numeric.octal.go storage.type.numeric.go
+//  ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//    ^ constant.numeric.integer.octal.go
+//     ^ constant.numeric.integer.octal.go storage.type.numeric.go
+//        ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//          ^^ constant.numeric.integer.octal.go
+//            ^ constant.numeric.integer.octal.go storage.type.numeric.go
+//               ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                 ^^ constant.numeric.integer.octal.go
+//                   ^ constant.numeric.integer.octal.go storage.type.numeric.go
+//                      ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                        ^^^ constant.numeric.integer.octal.go
+//                           ^ constant.numeric.integer.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
 //  ^^ constant.numeric.hex.go punctuation.definition.numeric.base.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1994,43 +1994,39 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     1e+2i; 1e-2i; 1.2e+3i; 1.2e-3i; 1E+2i; 1E-2i; 1.2E+3i; 1.2E-3i;
-//  ^^^^^ constant.numeric.imaginary.go
-//   ^^ punctuation.separator.exponent.go
-//      ^ storage.type.numeric.go
-//         ^^^^^ constant.numeric.imaginary.go
-//          ^^ punctuation.separator.exponent.go
-//             ^ storage.type.numeric.go
-//                ^^^^^^^ constant.numeric.imaginary.go
-//                 ^ punctuation.separator.decimal.go
-//                   ^^ punctuation.separator.exponent.go
-//                      ^ storage.type.numeric.go
-//                         ^^^^^^^ constant.numeric.imaginary.go
-//                          ^ punctuation.separator.decimal.go
-//                            ^^ punctuation.separator.exponent.go
-//                               ^ storage.type.numeric.go
-//                                  ^^^^^ constant.numeric.imaginary.go
-//                                   ^^ punctuation.separator.exponent.go
-//                                      ^ storage.type.numeric.go
-//                                         ^^^^^ constant.numeric.imaginary.go
-//                                          ^^ punctuation.separator.exponent.go
-//                                             ^ storage.type.numeric.go
-//                                                ^^^^^^^ constant.numeric.imaginary.go
-//                                                 ^ punctuation.separator.decimal.go
-//                                                   ^^ punctuation.separator.exponent.go
-//                                                      ^ storage.type.numeric.go
-//                                                         ^^^^^^^ constant.numeric.imaginary.go
-//                                                          ^ punctuation.separator.decimal.go
-//                                                            ^^ punctuation.separator.exponent.go
-//                                                               ^ storage.type.numeric.go
+//  ^^^^ constant.numeric.imaginary.go
+//      ^ constant.numeric.imaginary.go storage.type.numeric.go
+//       ^ punctuation.terminator.go
+//         ^^^^ constant.numeric.imaginary.go
+//             ^ constant.numeric.imaginary.go storage.type.numeric.go
+//              ^ punctuation.terminator.go
+//                ^ constant.numeric.imaginary.go
+//                 ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                  ^^^^ constant.numeric.imaginary.go
+//                      ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                         ^ constant.numeric.imaginary.go
+//                          ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                           ^^^^ constant.numeric.imaginary.go
+//                               ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                                  ^^^^ constant.numeric.imaginary.go
+//                                      ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                                         ^^^^ constant.numeric.imaginary.go
+//                                             ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                                                ^ constant.numeric.imaginary.go
+//                                                 ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                                                  ^^^^ constant.numeric.imaginary.go
+//                                                      ^ constant.numeric.imaginary.go storage.type.numeric.go
+//                                                         ^ constant.numeric.imaginary.go
+//                                                          ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                                                           ^^^^ constant.numeric.imaginary.go
+//                                                               ^ constant.numeric.imaginary.go storage.type.numeric.go
 
         1_1e+2_1i; 1.2_1E-3_5i;
-//      ^^^ constant.numeric.imaginary.go
-//         ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
-//           ^^^ constant.numeric.imaginary.go
+//      ^^^^^^^^ constant.numeric.imaginary.go
 //              ^ constant.numeric.imaginary.go storage.type.numeric.go
-//                 ^^^^^ constant.numeric.imaginary.go
-//                      ^^ constant.numeric.imaginary.go punctuation.separator.exponent.go
-//                        ^^^ constant.numeric.imaginary.go
+//                 ^ constant.numeric.imaginary.go
+//                  ^ constant.numeric.imaginary.go punctuation.separator.decimal.go
+//                   ^^^^^^^^ constant.numeric.imaginary.go
 //                           ^ constant.numeric.imaginary.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;


### PR DESCRIPTION
Adds the following numeric literal updates [introduced in v1.13](https://golang.org/doc/go1.13#language) — all of these changes were part of [recent number literal proposal](https://github.com/golang/proposal/blob/master/design/19308-number-literals.md):

- [Binary integer literals](https://golang.org/ref/spec#Integer_literals).
- [Octal integer literals](https://golang.org/ref/spec#Integer_literals) behind a new (additional) prefix.
- [Hexadecimal floating-point literals](https://golang.org/ref/spec#Floating-point_literals).
- [Imaginary literals](https://golang.org/ref/spec#Imaginary_literals) can now be used with any numeric literal.
- [Numeric separators](https://github.com/golang/proposal/blob/master/design/19308-number-literals.md#digit-separators) can be used in any numeric literal.