### PR TITLE
[Markdown] Add link/ref/image attribute support

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -167,6 +167,11 @@ variables:
         (?i:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)
         (?:\s|$|/?>)
       )
+    ascii_space: '\t\n\f '
+    tag_attribute_name_start: (?=[^{{ascii_space}}=/>}])
+    tag_attribute_name_break: (?=[{{ascii_space}}=/>}])
+    tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
+    tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
     # code_fence_escape: |-
     #   (?x:
     #     ^         # the beginning of the line
@@ -570,7 +575,7 @@ contexts:
          )
       captures:
         1: meta.image.inline.markdown punctuation.definition.image.begin.markdown
-      push: [image-inline-after-text, image-link-text]
+      push: [image-inline-attr, image-inline-after-text, image-link-text]
   image-link-text:
     - meta_content_scope: meta.image.inline.description.markdown
     - include: link-text
@@ -608,6 +613,15 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+  image-inline-attr:
+    - match: '([ ]*)(\{)(?=[^}]*\})'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.attributes.begin.markdown
+      set:
+        - meta_scope: meta.image.inline.markdown
+        - include: tag-attributes
+    - include: immediately-pop
   image-ref:
     - match: |-
         (?x:
@@ -622,7 +636,7 @@ contexts:
         )
       captures:
         1: meta.image.reference.markdown punctuation.definition.image.begin.markdown
-      push: [image-ref-after-text, image-ref-text]
+      push: [image-ref-attr, image-ref-after-text, image-ref-text]
   image-ref-text:
     - meta_content_scope: meta.image.reference.description.markdown
     - include: link-text
@@ -637,6 +651,15 @@ contexts:
         3: punctuation.definition.constant.end.markdown
       scope: meta.image.reference.markdown
       pop: true
+  image-ref-attr:
+    - match: '([ ]*)(\{)(?=[^}]*\})'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.attributes.begin.markdown
+      set:
+        - meta_scope: meta.image.reference.markdown
+        - include: tag-attributes
+    - include: immediately-pop
   inline:
     - include: escape
     - include: ampersand
@@ -764,7 +787,7 @@ contexts:
         )
       captures:
         1: meta.link.inline.markdown punctuation.definition.link.begin.markdown
-      push: [link-inline-after-text, link-inline-link-text]
+      push: [link-inline-attr, link-inline-after-text, link-inline-link-text]
   link-inline-after-text:
     - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
       captures:
@@ -795,6 +818,15 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+  link-inline-attr:
+    - match: '([ ]*)(\{)(?=[^}]*\})'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.attributes.begin.markdown
+      set:
+        - meta_scope: meta.link.inline.markdown
+        - include: tag-attributes
+    - include: immediately-pop
   link-inline-link-text:
     - meta_content_scope: meta.link.inline.description.markdown
     - include: link-text-allow-image
@@ -815,7 +847,7 @@ contexts:
         )
       captures:
         1: meta.link.reference.markdown punctuation.definition.link.begin.markdown
-      push: [link-ref-after-text, link-ref-link-text]
+      push: [link-ref-attr, link-ref-after-text, link-ref-link-text]
   link-ref-link-text:
     - meta_content_scope: meta.link.reference.description.markdown
     - include: link-text-allow-image
@@ -830,6 +862,15 @@ contexts:
         3: punctuation.definition.constant.end.markdown
       scope: meta.link.reference.markdown
       pop: true
+  link-ref-attr:
+    - match: '([ ]*)(\{)(?=[^}]*\})'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.attributes.begin.markdown
+      set:
+        - meta_scope: meta.link.reference.markdown
+        - include: tag-attributes
+    - include: immediately-pop
   link-ref-literal:
     - match: |-
         (?x:
@@ -844,7 +885,7 @@ contexts:
         )
       captures:
         1: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
-      push: [link-ref-literal-after-text, link-ref-literal-link-text]
+      push: [link-ref-literal-attr, link-ref-literal-after-text, link-ref-literal-link-text]
   link-ref-literal-link-text:
     - meta_content_scope: meta.link.reference.literal.description.markdown
     - include: link-text-allow-image
@@ -858,6 +899,15 @@ contexts:
         1: punctuation.definition.constant.begin.markdown
         2: punctuation.definition.constant.end.markdown
       pop: true
+  link-ref-literal-attr:
+    - match: '([ ]*)(\{)(?=[^}]*\})'
+      captures:
+        1: invalid.illegal.whitespace.markdown
+        2: punctuation.definition.attributes.begin.markdown
+      set:
+        - meta_scope: meta.link.reference.literal.markdown
+        - include: tag-attributes
+    - include: immediately-pop
   link-ref-footnote:
     - match: |-
         (?x:
@@ -1369,6 +1419,61 @@ contexts:
       captures:
         1: invalid.illegal.expected-eol.markdown
       pop: true
+
+###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################
+
+  tag-attributes:
+    - match: \}
+      scope: punctuation.definition.attributes.end.markdown
+      pop: true
+    - match: \,
+      scope: punctuation.separator.mapping.pair.markdown
+    - match: '{{tag_attribute_name_start}}'
+      push: [tag-attr-meta, tag-attr-equals, tag-attr-name]
+
+  tag-attr-name:
+    - meta_scope: entity.other.attribute-name.markdown
+    - match: '{{tag_attribute_name_break}}'
+      pop: true
+    - match: '["''`<]'
+      scope: invalid.illegal.attribute-name.markdown
+
+  tag-attr-meta:
+    - meta_scope: meta.attribute-with-value.markdown
+    - include: immediately-pop
+
+  tag-attr-equals:
+    - match: =
+      scope: punctuation.separator.key-value.markdown
+      set: tag-attr-value
+    - include: else-pop
+
+  tag-attr-value:
+    - match: \"
+      scope: punctuation.definition.string.begin.markdown
+      set:
+        - meta_scope: string.quoted.double.markdown
+        - match: \"
+          scope: punctuation.definition.string.end.markdown
+          pop: true
+    - match: \'
+      scope: punctuation.definition.string.begin.markdown
+      set:
+        - meta_scope: string.quoted.single.markdown
+        - match: \'
+          scope: punctuation.definition.string.end.markdown
+          pop: true
+    - match: '{{tag_unquoted_attribute_start}}'
+      set:
+        - meta_scope: string.unquoted.markdown
+        - match: '{{tag_unquoted_attribute_break}}'
+          pop: true
+        - match: '["''`<]'
+          scope: invalid.illegal.attribute-value.markdown
+    - include: else-pop
+
+###[ TABLE ]##################################################################
+
   table:
     - match: ^(?={{table_first_row}})
       push:
@@ -1414,3 +1519,13 @@ contexts:
                       scope: invalid.deprecated.unescaped-backticks.markdown
                     - include: inline
                     - include: scope:text.html.basic
+
+###[ PROTOTYPES ]#############################################################
+
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  immediately-pop:
+    - match: ''
+      pop: true

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1423,6 +1423,9 @@ contexts:
 ###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################
 
   tag-attributes:
+    # https://kramdown.gettalong.org/syntax.html#span-ials
+    # https://michelf.ca/projects/php-markdown/extra/
+    # https://pandoc.org/MANUAL.html#extension-link_attributes
     - match: \}
       scope: punctuation.definition.attributes.end.markdown
       pop: true

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -40,19 +40,25 @@ underlined heading followed by another one that should be treated as a normal pa
 
 Paragraph of text that should be scoped as meta.paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
-A [link](https://example.com), *italic text* and **bold**.
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
+A [link](https://example.com){ :_attr = value }, *italic text* and **bold**.
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
 | ^ punctuation.definition.link.begin
 |      ^ punctuation.definition.link.end
 |       ^ punctuation.definition.metadata
 |        ^^^^^^^^^^^^^^^^^^^ markup.underline.link
 |                           ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^ markup.italic
-|                              ^ punctuation.definition.italic
-|                                          ^ punctuation.definition.italic
-|                                                ^^ punctuation.definition.bold
-|                                                ^^^^^^^^ markup.bold
-|                                                      ^^ punctuation.definition.bold
+|                            ^ punctuation.definition.attributes.begin.markdown
+|                              ^^^^^^^^^^^^^^ meta.attribute-with-value.markdown
+|                              ^^^^^^ entity.other.attribute-name.markdown
+|                                     ^ punctuation.separator.key-value.markdown
+|                                       ^^^^^ string.unquoted.markdown
+|                                             ^ punctuation.definition.attributes.end.markdown
+|                                                ^^^^^^^^^^^^^ markup.italic
+|                                                ^ punctuation.definition.italic
+|                                                            ^ punctuation.definition.italic
+|                                                                  ^^ punctuation.definition.bold
+|                                                                  ^^^^^^^^ markup.bold
+|                                                                        ^^ punctuation.definition.bold
 
 Inline `code sample`.
 |      ^^^^^^^^^^^^^ markup.raw.inline
@@ -67,16 +73,44 @@ Here is a [](https://example.com).
 |            ^^^^^^^^^^^^^^^^^^^ markup.underline.link
 |                               ^ punctuation.definition.metadata
 
+Here is a [](https://example.com){_attr="value"}.
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
+|         ^ punctuation.definition.link.begin
+|          ^ punctuation.definition.link.end
+|           ^ punctuation.definition.metadata
+|            ^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                               ^ punctuation.definition.metadata
+|                                ^ punctuation.definition.attributes.begin.markdown
+|                                 ^^^^^^^^^^^^^ meta.attribute-with-value.markdown
+|                                 ^^^^^ entity.other.attribute-name.markdown
+|                                      ^ punctuation.separator.key-value.markdown
+|                                       ^^^^^^^ string.quoted.double.markdown
+|                                              ^ punctuation.definition.attributes.end.markdown
+
 Here is a [reference link][name].
 |         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
 |                         ^ punctuation.definition.constant.begin
 |                          ^^^^ constant.other.reference.link
 |                              ^ punctuation.definition.constant.end
 
-Here is a [blank reference link][].
-|         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
+Here is a [reference link][name]{_attr='value' :att2}.
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
+|                         ^ punctuation.definition.constant.begin
+|                          ^^^^ constant.other.reference.link
+|                              ^ punctuation.definition.constant.end
+|                               ^ punctuation.definition.attributes.begin.markdown
+|                                ^^^^^ entity.other.attribute-name.markdown
+|                                     ^ punctuation.separator.key-value.markdown
+|                                      ^^^^^^^ string.quoted.single.markdown
+|                                              ^^^^^ entity.other.attribute-name.markdown
+|                                                   ^ punctuation.definition.attributes.end.markdown
+
+Here is a [blank reference link][]{}.
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
 |                               ^ punctuation.definition.constant.begin
 |                                ^ punctuation.definition.constant.end
+|                                 ^ punctuation.definition.attributes.begin.markdown
+|                                  ^ punctuation.definition.attributes.end.markdown
 
 Here is a ![](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
@@ -85,6 +119,21 @@ Here is a ![](https://example.com/cat.gif).
 |            ^ punctuation.definition.metadata
 |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
 |                                        ^ punctuation.definition.metadata
+
+Here is a ![](https://example.com/cat.gif){_at"r=value :att2}.
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
+|          ^ punctuation.definition.image.begin
+|           ^ punctuation.definition.image.end - string
+|            ^ punctuation.definition.metadata
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                        ^ punctuation.definition.metadata
+|                                         ^ punctuation.definition.attributes.begin.markdown
+|                                          ^^^^^ entity.other.attribute-name.markdown
+|                                             ^ invalid.illegal.attribute-name.markdown
+|                                               ^ punctuation.separator.key-value.markdown
+|                                                ^^^^^ string.unquoted.markdown
+|                                                      ^^^^^ entity.other.attribute-name.markdown
+|                                                           ^ punctuation.definition.attributes.end.markdown
 
 Here is a ![Image Alt Text](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline


### PR DESCRIPTION
Fixes #2117

This PR adds support for attributes. The implementation is borrowed from the HTML.sublime-syntax.

The different styles of attribute names (with or without `:`) are not handled in a special way.