### PR TITLE
[Lua] Include newline into comments

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -46,10 +46,13 @@ contexts:
         - match: \]\1\]
           scope: punctuation.definition.comment.end.lua
           pop: true
-    - match: (--).*
-      scope: comment.line.lua
-      captures:
-        1: punctuation.definition.comment.lua
+    - match: --
+      scope: punctuation.definition.comment.lua
+      push:
+        - meta_include_prototype: false
+        - meta_scope: comment.line.lua
+        - match: \n
+          pop: true
 
   end:
     - match: end{{identifier_break}}

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -3,22 +3,28 @@
 --COMMENTS
 
     -- Foo!
---  ^^^^^^^ comment.line
+-- ^ - comment
+--  ^^^^^^^^ comment.line
 --  ^^ punctuation.definition.comment
 
 
     --[[ Foo! ]]
+-- ^ - comment
 --  ^^^^^^^^^^^^ comment.block
 --  ^^^^ punctuation.definition.comment.begin
 --            ^^ punctuation.definition.comment.end
+--              ^ - comment
 
     --[=[ Foo! ]] ]=]
+-- ^ - comment
 --  ^^^^^^^^^^^^^^^^^ comment.block
 --  ^^^^^ punctuation.definition.comment.begin
 --             ^^ - punctuation
 --                ^^^ punctuation.definition.comment.end
+--                   ^ - comment
 
     --[=[
+-- ^ - comment
 --  ^^^^^ comment.block punctuation.definition.comment.begin
         ]]
 --      ^^^ comment.block - punctuation
@@ -30,6 +36,7 @@
 --      ^^ - punctuation
     ]=]
 --  ^^^ comment.block punctuation.definition.comment.end
+--     ^ - comment
 
 --VARIABLES
 


### PR DESCRIPTION
Fixes #2127

This commit ...

1. replaces the `capture` by pushing into a dedicated comment context as it is slightly faster and therefore already used in a couple of other syntax definitions.
2. includes the newline `\n` into the comment scope in order to fix the issue #2127 and avoid normal completions to be triggered at the end of a comment line.