### PR TITLE
[Erlang] Remove special scoping of erlang atoms

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -164,7 +164,6 @@ contexts:
     - include: string
     - include: operator-unary
     - include: variable-anonymous
-    - include: variable-erlang
     - include: atom
 
   common:
@@ -1443,10 +1442,6 @@ contexts:
   variable-any:
     - match: \.{3}
       scope: variable.language.any.erlang
-
-  variable-erlang:
-    - match: erlang{{ident_break}}
-      scope: support.namespace.erlang
 
   variable-other:
     - match: '{{variable}}'

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -4397,7 +4397,7 @@ function_call_tests() ->
 % erlang is a special autoimported namespace
 
     erlang
-%   ^^^^^^ support.namespace.erlang
+%   ^^^^^^ meta.atom.erlang constant.other.symbol.erlang - meta.path - support.namespace
 
     erlang:
 %  ^ - meta.path


### PR DESCRIPTION
This commit removes the `variable-erlang` context, which was used to scope all `erlang` tokens as `variable.namespace`.

As a result the `erlang` token is scoped as ordinary atom if not followed by an accessor.

For the reason of change, please refer to:

  https://github.com/sublimehq/Packages/pull/1878#issuecomment-543071180