### PR TITLE
[JavaScript] Signs aren't part of numeric literals

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1727,32 +1727,32 @@ contexts:
         - include: object-property
 
   literal-number:
-    - match: '[+-]?0[0-9]+{{identifier_break}}'
+    - match: '0[0-9]+{{identifier_break}}'
       scope: constant.numeric.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
-    - match: '[+-]?(0[Xx])[0-9a-fA-F_]*(n)?{{identifier_break}}'
+    - match: '(0[Xx])[0-9a-fA-F_]*(n)?{{identifier_break}}'
       scope: constant.numeric.hexadecimal.js
       captures:
         1: punctuation.definition.numeric.hexadecimal.js
         2: storage.type.numeric.bigint.js
       pop: true
 
-    - match: '[+-]?(0[Oo])[0-7_]*(n)?{{identifier_break}}'
+    - match: '(0[Oo])[0-7_]*(n)?{{identifier_break}}'
       scope: constant.numeric.octal.js
       captures:
         1: punctuation.definition.numeric.octal.js
         2: storage.type.numeric.bigint.js
       pop: true
 
-    - match: '[+-]?(0[Bb])[0-1_]*(n)?{{identifier_break}}'
+    - match: '(0[Bb])[0-1_]*(n)?{{identifier_break}}'
       scope: constant.numeric.binary.js
       captures:
         1: punctuation.definition.numeric.binary.js
         2: storage.type.numeric.bigint.js
       pop: true
 
-    - match: '[+-]?(?:0|[1-9][0-9_]*)(n){{identifier_break}}'
+    - match: '(?:0|[1-9][0-9_]*)(n){{identifier_break}}'
       scope: constant.numeric.decimal.js
       captures:
         1: storage.type.numeric.bigint.js
@@ -1760,7 +1760,6 @@ contexts:
 
     - match: |-
         (?x)
-        [-+]?
         (
           (?:0|[1-9][0-9_]*)
           (?:\.[0-9_]*|(?!\.))
@@ -1772,23 +1771,23 @@ contexts:
       scope: constant.numeric.decimal.js
       pop: true
 
-    - match: '[+-]?0[Xx]{{identifier_part}}+{{identifier_break}}'
+    - match: '0[Xx]{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.numeric.hexadecimal.js
       pop: true
 
-    - match: '[+-]?0[Oo]{{identifier_part}}+{{identifier_break}}'
+    - match: '0[Oo]{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.numeric.octal.js
       pop: true
 
-    - match: '[+-]?0[Bb]{{identifier_part}}+{{identifier_break}}'
+    - match: '0[Bb]{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.numeric.binary.js
       pop: true
 
-    - match: '[+-]?0{{identifier_part}}+{{identifier_break}}'
+    - match: '0{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.numeric.octal.js
       pop: true
 
-    - match: '[+-]?[1-9]{{identifier_part}}+{{identifier_break}}(?:\.{{identifier_part}}*{{identifier_break}})?'
+    - match: '[1-9]{{identifier_part}}+{{identifier_break}}(?:\.{{identifier_part}}*{{identifier_break}})?'
       scope: invalid.illegal.numeric.decimal.js
       pop: true
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1848,10 +1848,12 @@ function yy (a, b) {
 //       ^^^ meta.property.object
 
     +123;
-//  ^^^^ constant.numeric.decimal - keyword
+//  ^ keyword.operator.arithmetic
+//   ^^^ constant.numeric.decimal - keyword
 
     -123;
-//  ^^^^ constant.numeric.decimal - keyword
+//  ^ keyword.operator.arithmetic
+//   ^^^ constant.numeric.decimal - keyword
 
     + 123;
 //  ^ keyword.operator.arithmetic


### PR DESCRIPTION
Since #1552, preceding signs are scoped as part of numeric literals. This is wrong. I have no idea why I thought that that was correct. I can only plead temporary insanity. This PR restores order.