### PR TITLE
[JavaScript] Add optional chaining and nullish coalescing.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2337,7 +2337,7 @@ contexts:
       set: import-meta-expression-dot
 
   import-meta-expression-dot:
-    - match: '{{dot_accessor}}'
+    - match: \.
       scope: punctuation.accessor.js
       set:
         - match: meta{{identifier_break}}

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -815,7 +815,7 @@ contexts:
       pop: true
 
   decorator-expression-end:
-    - match: \.(?:(?!\?[\[(])\??)
+    - match: \.(?!\?[\[(])\??
       scope: punctuation.accessor.js
       push:
         - include: decorator-name
@@ -1235,7 +1235,7 @@ contexts:
       pop: true
 
   inherited-class-expression-end:
-    - match: \.(?:(?!\?[\[(])\??)
+    - match: \.(?!\?[\[(])\??
       scope: punctuation.accessor.js
       push:
         - include: inherited-class-name
@@ -1332,7 +1332,7 @@ contexts:
         - literal-variable-base
 
   expect-dot-accessor:
-    - match: \.(?:(?!\?[\[(])\??)
+    - match: \.(?!\?[\[(])\??
       scope: punctuation.accessor.js
       pop: true
     - include: else-pop
@@ -1811,7 +1811,7 @@ contexts:
         - literal-variable
 
   call-path:
-    - match: \.(?:(?!\?[\[(])\??)
+    - match: \.(?!\?[\[(])\??
       scope: punctuation.accessor.js
       push: object-property
     - include: else-pop
@@ -1911,7 +1911,7 @@ contexts:
     - match: Array{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-array
@@ -1922,7 +1922,7 @@ contexts:
     - match: ArrayBuffer{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-arraybuffer
@@ -1933,7 +1933,7 @@ contexts:
     - match: Atomics{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-atomics
@@ -1944,7 +1944,7 @@ contexts:
     - match: BigInt{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-bigint
@@ -1955,7 +1955,7 @@ contexts:
     - match: Date{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-date
@@ -1966,7 +1966,7 @@ contexts:
     - match: JSON{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-json
@@ -1977,7 +1977,7 @@ contexts:
     - match: Math{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-math
@@ -1988,7 +1988,7 @@ contexts:
     - match: Number{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-number
@@ -1999,7 +1999,7 @@ contexts:
     - match: Object{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-object
@@ -2010,7 +2010,7 @@ contexts:
     - match: Promise{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-promise
@@ -2021,7 +2021,7 @@ contexts:
     - match: Proxy{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-proxy
@@ -2032,7 +2032,7 @@ contexts:
     - match: Reflect{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-reflect
@@ -2043,7 +2043,7 @@ contexts:
     - match: String{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-string
@@ -2054,7 +2054,7 @@ contexts:
     - match: Symbol{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-symbol
@@ -2075,7 +2075,7 @@ contexts:
         )
       scope: support.class.builtin.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-typedarray
@@ -2184,7 +2184,7 @@ contexts:
     - match: console{{identifier_break}}
       scope: support.type.object.console.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set: builtin-console-properties
         - include: else-pop
@@ -2212,7 +2212,7 @@ contexts:
     - match: process{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-process
@@ -2227,7 +2227,7 @@ contexts:
     - match: module{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.(?:(?!\?[\[(])\??)
+        - match: \.(?!\?[\[(])\??
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-module
@@ -2330,7 +2330,7 @@ contexts:
       set: import-meta-expression-dot
 
   import-meta-expression-dot:
-    - match: \.(?:(?!\?[\[(])\??)
+    - match: \.(?!\?[\[(])\??
       scope: punctuation.accessor.js
       set:
         - match: meta{{identifier_break}}

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -91,6 +91,13 @@ variables:
       )
     ))
 
+  dot_accessor: |-
+    (?x: # Match . and .?, but not .?( or .?[
+      \.
+      (?! \? [\[(] )
+      \??
+    )
+
 contexts:
   main:
     - include: comments-top-level
@@ -815,7 +822,7 @@ contexts:
       pop: true
 
   decorator-expression-end:
-    - match: \.(?!\?[\[(])\??
+    - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       push:
         - include: decorator-name
@@ -1235,7 +1242,7 @@ contexts:
       pop: true
 
   inherited-class-expression-end:
-    - match: \.(?!\?[\[(])\??
+    - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       push:
         - include: inherited-class-name
@@ -1332,7 +1339,7 @@ contexts:
         - literal-variable-base
 
   expect-dot-accessor:
-    - match: \.(?!\?[\[(])\??
+    - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       pop: true
     - include: else-pop
@@ -1811,7 +1818,7 @@ contexts:
         - literal-variable
 
   call-path:
-    - match: \.(?!\?[\[(])\??
+    - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       push: object-property
     - include: else-pop
@@ -1911,7 +1918,7 @@ contexts:
     - match: Array{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-array
@@ -1922,7 +1929,7 @@ contexts:
     - match: ArrayBuffer{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-arraybuffer
@@ -1933,7 +1940,7 @@ contexts:
     - match: Atomics{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-atomics
@@ -1944,7 +1951,7 @@ contexts:
     - match: BigInt{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-bigint
@@ -1955,7 +1962,7 @@ contexts:
     - match: Date{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-date
@@ -1966,7 +1973,7 @@ contexts:
     - match: JSON{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-json
@@ -1977,7 +1984,7 @@ contexts:
     - match: Math{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-math
@@ -1988,7 +1995,7 @@ contexts:
     - match: Number{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-number
@@ -1999,7 +2006,7 @@ contexts:
     - match: Object{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-object
@@ -2010,7 +2017,7 @@ contexts:
     - match: Promise{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-promise
@@ -2021,7 +2028,7 @@ contexts:
     - match: Proxy{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-proxy
@@ -2032,7 +2039,7 @@ contexts:
     - match: Reflect{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-reflect
@@ -2043,7 +2050,7 @@ contexts:
     - match: String{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-string
@@ -2054,7 +2061,7 @@ contexts:
     - match: Symbol{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-symbol
@@ -2075,7 +2082,7 @@ contexts:
         )
       scope: support.class.builtin.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-typedarray
@@ -2184,7 +2191,7 @@ contexts:
     - match: console{{identifier_break}}
       scope: support.type.object.console.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set: builtin-console-properties
         - include: else-pop
@@ -2212,7 +2219,7 @@ contexts:
     - match: process{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-process
@@ -2227,7 +2234,7 @@ contexts:
     - match: module{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.(?!\?[\[(])\??
+        - match: '{{dot_accessor}}'
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-module
@@ -2330,7 +2337,7 @@ contexts:
       set: import-meta-expression-dot
 
   import-meta-expression-dot:
-    - match: \.(?!\?[\[(])\??
+    - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       set:
         - match: meta{{identifier_break}}

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -815,7 +815,7 @@ contexts:
       pop: true
 
   decorator-expression-end:
-    - match: \.
+    - match: \.(?:(?!\?[\[(])\??)
       scope: punctuation.accessor.js
       push:
         - include: decorator-name
@@ -850,13 +850,13 @@ contexts:
   left-expression-end:
     - include: expression-break
 
-    - include: property-access
-
     - match: (?=`)
       push: literal-string-template
 
-    - match: (?=\()
+    - match: (?=(?:\.\?)?\()
       push: function-call-arguments
+
+    - include: property-access
 
     - include: fallthrough
 
@@ -1078,7 +1078,7 @@ contexts:
     - match: in{{identifier_break}}
       scope: keyword.operator.js
       push: expression-begin
-    - match: '&&|\|\|'
+    - match: '&&|\|\||\?\?'
       scope: keyword.operator.logical.js
       push: expression-begin
     - match: '=(?![=>])'
@@ -1235,7 +1235,7 @@ contexts:
       pop: true
 
   inherited-class-expression-end:
-    - match: \.
+    - match: \.(?:(?!\?[\[(])\??)
       scope: punctuation.accessor.js
       push:
         - include: inherited-class-name
@@ -1332,7 +1332,7 @@ contexts:
         - literal-variable-base
 
   expect-dot-accessor:
-    - match: '\.'
+    - match: \.(?:(?!\?[\[(])\??)
       scope: punctuation.accessor.js
       pop: true
     - include: else-pop
@@ -1685,8 +1685,10 @@ contexts:
           push: expression
 
   function-call-arguments:
-    - match: \(
-      scope: punctuation.section.group.begin.js
+    - match: (\.\?)?(\()
+      captures:
+        1: punctuation.accessor.js
+        2: punctuation.section.group.begin.js
       set:
         - meta_scope: meta.group.js
         - match: \)
@@ -1705,8 +1707,10 @@ contexts:
         - include: expression-list
 
   property-access:
-    - match: '\['
-      scope: punctuation.section.brackets.begin.js
+    - match: (\.\?)?(\[)
+      captures:
+        1: punctuation.accessor.js
+        2: punctuation.section.brackets.begin.js
       push:
         - meta_scope: meta.brackets.js
         - match: '\]'
@@ -1715,10 +1719,10 @@ contexts:
         - match: (?=\S)
           push: expression
 
-    - match: \.
+    - match: \.(?:\?)?
       scope: punctuation.accessor.js
       push:
-        - match: '(?={{identifier}}\s*\()'
+        - match: '(?={{identifier}}\s*(?:\.\?)?\()'
           set:
             - call-method-meta
             - function-call-arguments
@@ -1793,13 +1797,13 @@ contexts:
       pop: true
 
   literal-call:
-    - match: (?={{identifier}}\s*\()
+    - match: (?={{identifier}}\s*(?:\.\?)?\()
       set:
         - call-function-meta
         - function-call-arguments
         - literal-variable
 
-    - match: (?={{identifier}}\s*(?:\.\s*{{identifier}}\s*)+\()
+    - match: (?={{identifier}}\s*(?:\.\s*{{identifier}}\s*)+(?:\.\?)?\()
       set:
         - call-method-meta
         - function-call-arguments
@@ -1807,7 +1811,7 @@ contexts:
         - literal-variable
 
   call-path:
-    - match: \.
+    - match: \.(?:(?!\?[\[(])\??)
       scope: punctuation.accessor.js
       push: object-property
     - include: else-pop
@@ -1846,7 +1850,7 @@ contexts:
       scope: support.class.js
       pop: true
 
-    - match: (?={{identifier}}\s*\()
+    - match: (?={{identifier}}\s*(?:\.\?)?\()
       set: call-function-name
 
     - include: literal-variable-base
@@ -1907,7 +1911,7 @@ contexts:
     - match: Array{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-array
@@ -1918,7 +1922,7 @@ contexts:
     - match: ArrayBuffer{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-arraybuffer
@@ -1929,7 +1933,7 @@ contexts:
     - match: Atomics{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-atomics
@@ -1940,7 +1944,7 @@ contexts:
     - match: BigInt{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-bigint
@@ -1951,7 +1955,7 @@ contexts:
     - match: Date{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-date
@@ -1962,7 +1966,7 @@ contexts:
     - match: JSON{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-json
@@ -1973,7 +1977,7 @@ contexts:
     - match: Math{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-math
@@ -1984,7 +1988,7 @@ contexts:
     - match: Number{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-number
@@ -1995,7 +1999,7 @@ contexts:
     - match: Object{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-object
@@ -2006,7 +2010,7 @@ contexts:
     - match: Promise{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-promise
@@ -2017,7 +2021,7 @@ contexts:
     - match: Proxy{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-proxy
@@ -2028,7 +2032,7 @@ contexts:
     - match: Reflect{{identifier_break}}
       scope: support.constant.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-reflect
@@ -2039,7 +2043,7 @@ contexts:
     - match: String{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-string
@@ -2050,7 +2054,7 @@ contexts:
     - match: Symbol{{identifier_break}}
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-symbol
@@ -2071,7 +2075,7 @@ contexts:
         )
       scope: support.class.builtin.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-ecma-typedarray
@@ -2180,7 +2184,7 @@ contexts:
     - match: console{{identifier_break}}
       scope: support.type.object.console.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set: builtin-console-properties
         - include: else-pop
@@ -2208,7 +2212,7 @@ contexts:
     - match: process{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-process
@@ -2223,7 +2227,7 @@ contexts:
     - match: module{{identifier_break}}
       scope: support.constant.node.js
       set:
-        - match: \.
+        - match: \.(?:(?!\?[\[(])\??)
           scope: punctuation.accessor.js
           set:
             - include: support-property-node-module
@@ -2270,7 +2274,7 @@ contexts:
 
     - include: support-property
 
-    - match: '(?={{identifier}}\s*\()'
+    - match: '(?={{identifier}}\s*(?:\.\?)?\()'
       set: call-method-name
 
     - include: object-property-base
@@ -2326,7 +2330,7 @@ contexts:
       set: import-meta-expression-dot
 
   import-meta-expression-dot:
-    - match: \.
+    - match: \.(?:(?!\?[\[(])\??)
       scope: punctuation.accessor.js
       set:
         - match: meta{{identifier_break}}

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1947,3 +1947,29 @@ debugger;
 debugger
 []
 // <- meta.sequence
+
+    a ?? b;
+//    ^^ keyword.operator.logical
+
+    a.?b.?c;
+//   ^^ punctuation.accessor
+//     ^ meta.property.object
+//      ^^ punctuation.accessor
+//        ^ meta.property.object
+
+    a.?[propName];
+//   ^^^^^^^^^^^^ meta.brackets
+//   ^^ punctuation.accessor
+//     ^ punctuation.section.brackets.begin
+
+    a.?();
+//  ^^^^^ meta.function-call
+//  ^ variable.function
+//   ^^^^ meta.group
+//   ^^ punctuation.accessor
+//     ^ punctuation.section.group.begin
+
+    a.b.?();
+//  ^^^^^^^ meta.function-call.method
+//    ^ variable.function
+//     


### PR DESCRIPTION
[Nullish coalescing](https://github.com/tc39/proposal-nullish-coalescing) (Stage 3)
[Optional chaining](https://github.com/tc39/proposal-optional-chaining) (Stage 3)

The regexp to match a dotted property access is now `\.(?!\?[\[(])\??`, which is regrettable.