### PR TITLE
[Ruby] Improve numbers

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -209,51 +209,46 @@ contexts:
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
     # numbers with decimal base prefix
-    - match: '\b(0[dD]){{ddigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
+    - match: '\b(0[dD]){{ddigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.decimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: storage.type.numeric.imaginary.ruby
-        5: invalid.illegal.numeric.rational.ruby
+        4: invalid.illegal.numeric.rational.ruby
     # numbers with hexadecimal base prefix
-    - match: '\b(0[xX]){{hdigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
+    - match: '\b(0[xX]){{hdigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: storage.type.numeric.imaginary.ruby
-        5: invalid.illegal.numeric.rational.ruby
+        4: invalid.illegal.numeric.rational.ruby
     # numbers with octal base prefix
-    - match: '\b(0[oO]?){{odigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
+    - match: '\b(0[oO]?){{odigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: storage.type.numeric.imaginary.ruby
-        5: invalid.illegal.numeric.rational.ruby
+        4: invalid.illegal.numeric.rational.ruby
     # numbers with binary base prefix
-    - match: '\b(0[bB]){{bdigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
+    - match: '\b(0[bB]){{bdigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: storage.type.numeric.imaginary.ruby
-        5: invalid.illegal.numeric.rational.ruby
-    # complex imaginary numbers: 1i, 1.i, 1.1i, 1.1.i, 1e1i, 1e1.i, 1.1e1i, 1.1e1.i, 1ri, 1r.i, 1.1ri, 1.1r.i
-    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(?:(r)|{{exponent}}(r)?)?(?:(\.i)|(i)(r)?)\b'
+        4: invalid.illegal.numeric.rational.ruby
+    # complex imaginary numbers: 1i, 1.1i, 1e1i, 1.1e1i, 1ri, 1.1ri
+    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(?:(r)|{{exponent}}(r)?)?(i)(r)?\b'
       scope: constant.numeric.complex.imaginary.ruby
       captures:
         1: punctuation.separator.decimal.ruby
         2: storage.type.numeric.rational.ruby
         3: invalid.illegal.numeric.rational.ruby
         4: storage.type.numeric.imaginary.ruby
-        5: storage.type.numeric.imaginary.ruby
-        6: invalid.illegal.numeric.rational.ruby
+        5: invalid.illegal.numeric.rational.ruby
     # rational numbers: 1r, 1.1r
     - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(r)'
       scope: constant.numeric.rational.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -203,14 +203,22 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b0[dD]\d(?:_?\d)*\b'
+    - match: '\b(0[dD])\d(?:_?\d)*\b'
       scope: constant.numeric.integer.decimal.ruby
-    - match: '\b0[xX]\h(?:_?\h)*\b'
+      captures:
+        1: punctuation.definition.numeric.decimal.ruby
+    - match: '\b(0[xX])\h(?:_?\h)*\b'
       scope: constant.numeric.integer.hexadecimal.ruby
-    - match: '\b0[oO]?[0-7](?:_?[0-7])*\b'
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.ruby
+    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*\b'
       scope: constant.numeric.integer.octal.ruby
-    - match: '\b0[bB][01](?:_?[01])*\b'
+      captures:
+        1: punctuation.definition.numeric.octal.ruby
+    - match: '\b(0[bB])[01](?:_?[01])*\b'
       scope: constant.numeric.integer.binary.ruby
+      captures:
+        1: punctuation.definition.numeric.binary.ruby
     - match: '\b\d(?:_?\d)*\.\d(?:_?\d)*r\b'
       scope: constant.numeric.float.rational.ruby
     - match: '\b\d(?:_?\d)*r\b'

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -247,7 +247,7 @@ contexts:
             # 1ri, 1.1ri, 1i, 1.1i | 1e1i, 1.1e1i
             (?: (\.) {{ddigits}} )? (?: (r) | {{exponent}}? )
             # 1.ri, 1.e1ri, 1.1e1ri | 1.i 1.e1i
-            |   (\.) (?: {{ddigits}}? {{exponent}}? (r) | ({{exponent}})? )
+            | (\.) (?: {{ddigits}}? {{exponent}}? (r) | ({{exponent}})? )
           )
         )(i)(r)?\b
       scope: constant.numeric.complex.imaginary.ruby
@@ -277,7 +277,7 @@ contexts:
         \b(?x:
           {{ddigits}} (?:
             # 1e1, 1.1e1
-            (?: (\.)     {{ddigits}}  )?  {{exponent}} \b
+            (?: (\.) {{ddigits}} )? {{exponent}}\b
             # 1., 1.1, 1.e1
             | (\.) (?: {{ddigits}}\b | ({{exponent}})\b )?
           )

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -203,8 +203,28 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b(0[xX]\h(_?\h)*|\d(_?\d)*(\.(?![^[:space:][:digit:]])(_?\d)*)?([eE][-+]?\d(_?\d)*)?|0[bB][01]+)\b'
-      scope: constant.numeric.ruby
+    - match: '\b0[dD]\d(_?\d)*\b'
+      scope: constant.numeric.integer.decimal.ruby
+    - match: '\b0[xX]\h(_?\h)*\b'
+      scope: constant.numeric.integer.hexadecimal.ruby
+    - match: '\b0[oO]?[0-7](_?[0-7])*\b'
+      scope: constant.numeric.integer.octal.ruby
+    - match: '\b0[bB][01](_?[01])*\b'
+      scope: constant.numeric.integer.binary.ruby
+    - match: '\b\d(_?\d)*\.\d(_?\d)*r\b'
+      scope: constant.numeric.float.rational.ruby
+    - match: '\b\d(_?\d)*r\b'
+      scope: constant.numeric.integer.rational.ruby
+    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?r?i\b'
+      scope: constant.numeric.complex.imaginary.ruby
+    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?ir\b'
+      scope: invalid.illegal.ruby
+    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?[eE][-+]?\d(_?\d)*\b'
+      scope: constant.numeric.float.ruby
+    - match: '\b\d(_?\d)*\.(\d(_?\d)*\b)?'
+      scope: constant.numeric.float.ruby
+    - match: '\b\d(_?\d)*\b'
+      scope: constant.numeric.integer.ruby
     - match: ":'"
       scope: punctuation.definition.constant.ruby
       push:

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -208,63 +208,98 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    # numbers with decimal base prefix
-    - match: '\b(0[dD]){{ddigits}}(r)?(?:(i)(r)?)?\b'
-      scope: constant.numeric.integer.decimal.ruby
-      captures:
-        1: punctuation.definition.numeric.decimal.ruby
-        2: storage.type.numeric.rational.ruby
-        3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
-    # numbers with hexadecimal base prefix
-    - match: '\b(0[xX]){{hdigits}}(r)?(?:(i)(r)?)?\b'
-      scope: constant.numeric.integer.hexadecimal.ruby
+    # hexadecimal imaginary numbers: 0xAi, 0xAri
+    - match: '\b(0[xX]){{hdigits}}(r?i)(r)?\b'
+      scope: constant.numeric.imaginary.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
-        2: storage.type.numeric.rational.ruby
-        3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
-    # numbers with octal base prefix
-    - match: '\b(0[oO]?){{odigits}}(r)?(?:(i)(r)?)?\b'
-      scope: constant.numeric.integer.octal.ruby
+        2: storage.type.numeric.ruby
+        3: invalid.illegal.numeric.ruby
+    # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
+    - match: '\b(0[oO]?){{odigits}}(r?i)(r)?\b'
+      scope: constant.numeric.imaginary.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
-        2: storage.type.numeric.rational.ruby
-        3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
-    # numbers with binary base prefix
-    - match: '\b(0[bB]){{bdigits}}(r)?(?:(i)(r)?)?\b'
-      scope: constant.numeric.integer.binary.ruby
+        2: storage.type.numeric.ruby
+        3: invalid.illegal.numeric.ruby
+    # binary imaginary numbers: 0b1i, 0b1ri
+    - match: '\b(0[bB]){{bdigits}}(r?i)(r)?\b'
+      scope: constant.numeric.imaginary.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
-        2: storage.type.numeric.rational.ruby
-        3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
-    # complex imaginary numbers: 1i, 1.1i, 1e1i, 1.1e1i, 1ri, 1.1ri
-    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(?:(r)|{{exponent}}(r)?)?(i)(r)?\b'
-      scope: constant.numeric.complex.imaginary.ruby
+        2: storage.type.numeric.ruby
+        3: invalid.illegal.numeric.ruby
+    # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
+    - match: |-
+        \b(?x:
+          (?:
+            # 0d1i, 0d1ri, 1i, 1ri | 1.1i, 1.1ri
+            (?: (0[dD])? {{ddigits}} | {{ddigits}} (\.) {{ddigits}} ) (r?i)
+            # 1e1i, 1.1e1i
+            | {{ddigits}} (?: (\.) {{ddigits}} )? {{exponent}} (r)? (i)
+          ) (r)?
+        )\b
+      scope: constant.numeric.imaginary.decimal.ruby
       captures:
-        1: punctuation.separator.decimal.ruby
-        2: storage.type.numeric.rational.ruby
-        3: invalid.illegal.numeric.rational.ruby
-        4: storage.type.numeric.imaginary.ruby
-        5: invalid.illegal.numeric.rational.ruby
-    # rational numbers: 1r, 1.1r
-    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(r)'
-      scope: constant.numeric.rational.ruby
+        1: punctuation.definition.numeric.decimal.ruby
+        2: punctuation.separator.decimal.ruby
+        3: storage.type.numeric.ruby
+        4: punctuation.separator.decimal.ruby
+        5: invalid.illegal.numeric.ruby
+        6: storage.type.numeric.ruby
+        7: invalid.illegal.numeric.ruby
+    # hexadecimal rational numbers: 0xAr
+    - match: '\b(0[xX]){{hdigits}}(r)\b'
+      scope: constant.numeric.rational.hexadecimal.ruby
       captures:
-        1: punctuation.separator.decimal.ruby
-        2: storage.type.numeric.rational.ruby
-    # floating point numbers: 1.1, 1e1, 1.1e1
+        1: punctuation.definition.numeric.hexadecimal.ruby
+        2: storage.type.numeric.ruby
+    # octal rational numbers: 0o1r, 01r
+    - match: '\b(0[oO]?){{odigits}}(r)\b'
+      scope: constant.numeric.rational.octal.ruby
+      captures:
+        1: punctuation.definition.numeric.octal.ruby
+        2: storage.type.numeric.ruby
+    # binary rational numbers: 0b1r
+    - match: '\b(0[bB]){{bdigits}}(r)\b'
+      scope: constant.numeric.rational.binary.ruby
+      captures:
+        1: punctuation.definition.numeric.binary.ruby
+        2: storage.type.numeric.ruby
+    # decimal rational numbers: 0d1r, 1r, 1.1r
+    - match: '\b(?:(0[dD])?{{ddigits}}|{{ddigits}}(\.){{ddigits}})(r)\b'
+      scope: constant.numeric.rational.decimal.ruby
+      captures:
+        1: punctuation.definition.numeric.decimal.ruby
+        2: punctuation.separator.decimal.ruby
+        3: storage.type.numeric.ruby
+    # decimal floating point numbers: 1.1, 1e1, 1.1e1
     - match: '\b{{ddigits}}(?:(\.){{ddigits}}|(?:(\.){{ddigits}})?{{exponent}}(r)?)\b'
       scope: constant.numeric.float.decimal.ruby
       captures:
         1: punctuation.separator.decimal.ruby
         2: punctuation.separator.decimal.ruby
         3: invalid.illegal.numeric.rational.ruby
-    # integer numbers
-    - match: '\b{{ddigits}}\b'
+    # hexadecimal integer numbers: 0xA
+    - match: '\b(0[xX]){{hdigits}}\b'
+      scope: constant.numeric.integer.hexadecimal.ruby
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.ruby
+    # octal integer numbers: 0o1, 01
+    - match: '\b(0[oO]?){{odigits}}\b'
+      scope: constant.numeric.integer.octal.ruby
+      captures:
+        1: punctuation.definition.numeric.octal.ruby
+    # binary integer numbers: 0b1
+    - match: '\b(0[bB]){{bdigits}}\b'
+      scope: constant.numeric.integer.binary.ruby
+      captures:
+        1: punctuation.definition.numeric.binary.ruby
+    # decimal integer numbers: 0d1, 1
+    - match: '\b(0[dD])?{{ddigits}}\b'
       scope: constant.numeric.integer.decimal.ruby
+      captures:
+        1: punctuation.definition.numeric.decimal.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -69,8 +69,11 @@ file_extensions:
 first_line_match: ^#!\s*/.*\bj?ruby\b
 scope: source.ruby
 variables:
-  digit: (?:\d(?:_?\d)*)
-  exponent: (?:[Ee][-+]?{{digit}})
+  bdigits: (?:[01]+(?:_[01]+)*)
+  ddigits: (?:\d+(?:_\d+)*)
+  hdigits: (?:\h+(?:_\h+)*)
+  odigits: (?:[0-7]+(?:_[0-7]+)*)
+  exponent: (?:[Ee][-+]?{{ddigits}})
   heredoc_type_css: (?:[[:upper:]_]_)?CSS
   heredoc_type_html: (?:[[:upper:]_]_)?HTML
   heredoc_type_js: (?:[[:upper:]_]_)?(?:JS|JAVASCRIPT)
@@ -206,7 +209,7 @@ contexts:
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
     # numbers with decimal base prefix
-    - match: '\b(0[dD]){{digit}}(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[dD]){{ddigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.decimal.ruby
@@ -214,7 +217,7 @@ contexts:
         3: storage.type.numeric.imaginary.ruby
         4: invalid.illegal.numeric.rational.ruby
     # numbers with hexadecimal base prefix
-    - match: '\b(0[xX])\h(?:_?\h)*(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[xX]){{hdigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
@@ -222,7 +225,7 @@ contexts:
         3: storage.type.numeric.imaginary.ruby
         4: invalid.illegal.numeric.rational.ruby
     # numbers with octal base prefix
-    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[oO]?){{odigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
@@ -230,7 +233,7 @@ contexts:
         3: storage.type.numeric.imaginary.ruby
         4: invalid.illegal.numeric.rational.ruby
     # numbers with binary base prefix
-    - match: '\b(0[bB])[01](?:_?[01])*(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[bB]){{bdigits}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
@@ -240,11 +243,11 @@ contexts:
     # complex imaginary numbers
     - match: |-
         \b(?x:
-          {{digit}} (?:
+          {{ddigits}} (?:
             # 1ri, 1.1ri, 1i, 1.1i | 1e1i, 1.1e1i
-            (?: (\.) {{digit}} )? (?: (r) | {{exponent}}? )
+            (?: (\.) {{ddigits}} )? (?: (r) | {{exponent}}? )
             # 1.ri, 1.e1ri, 1.1e1ri | 1.i 1.e1i
-            |   (\.) (?: {{digit}}? {{exponent}}? (r) | ({{exponent}})? )
+            |   (\.) (?: {{ddigits}}? {{exponent}}? (r) | ({{exponent}})? )
           )
         )(i)(r)?\b
       scope: constant.numeric.complex.imaginary.ruby
@@ -260,7 +263,7 @@ contexts:
     - match: |-
         \b(?x:
           # 1.r | 1r, 1.1r, 1.e1r, 1.1e1r
-          {{digit}} (?: (\.) (r) | (?: (\.) {{digit}}? ({{exponent}})? )? (r) )
+          {{ddigits}} (?: (\.) (r) | (?: (\.) {{ddigits}}? ({{exponent}})? )? (r) )
         )\b
       scope: constant.numeric.rational.ruby
       captures:
@@ -272,11 +275,11 @@ contexts:
     # floating point numbers
     - match: |-
         \b(?x:
-          {{digit}} (?:
+          {{ddigits}} (?:
             # 1e1, 1.1e1
-            (?: (\.)     {{digit}}  )?  {{exponent}} \b
+            (?: (\.)     {{ddigits}}  )?  {{exponent}} \b
             # 1., 1.1, 1.e1
-            |   (\.) (?: {{digit}}\b | ({{exponent}})\b )?
+            | (\.) (?: {{ddigits}}\b | ({{exponent}})\b )?
           )
         )
       scope: constant.numeric.float.ruby
@@ -285,7 +288,7 @@ contexts:
         2: punctuation.separator.decimal.ruby
         3: invalid.illegal.numeric.exponent.ruby
     # integer decimal
-    - match: '\b{{digit}}\b'
+    - match: '\b{{ddigits}}\b'
       scope: constant.numeric.integer.ruby
     # Quoted symbols
     - match: ":'"

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -219,12 +219,19 @@ contexts:
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
-    - match: '\b\d(?:_?\d)*\.\d(?:_?\d)*r\b'
+    - match: '\b\d(?:_?\d)*\.\d(?:_?\d)*(r)\b'
       scope: constant.numeric.float.rational.ruby
-    - match: '\b\d(?:_?\d)*r\b'
+      captures:
+        1: storage.type.numeric.rational.ruby
+    - match: '\b\d(?:_?\d)*(r)\b'
       scope: constant.numeric.integer.rational.ruby
-    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?r?i\b'
+      captures:
+        1: storage.type.numeric.rational.ruby
+    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(r)?(i)\b'
       scope: constant.numeric.complex.imaginary.ruby
+      captures:
+        1: storage.type.numeric.rational.ruby
+        2: storage.type.numeric.imaginary.ruby
     - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?ir\b'
       scope: invalid.illegal.ruby
     - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?[eE][-+]?\d(?:_?\d)*\b'

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -205,33 +205,38 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    # numbers with 'ir' suffix are invalid
-    - match: '\b(?:{{digit}}(?:\.{{digit}})?{{exponent}}?|0[dDxXoObB]?\h(?:_?\h)*)ir\b'
-      scope: invalid.illegal.ruby
-    - match: '\b(0[dD]){{digit}}(r)?(i)?\b'
+    # numbers with decimal base prefix
+    - match: '\b(0[dD]){{digit}}(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.decimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-    - match: '\b(0[xX])\h(?:_?\h)*(r)?(i)?\b'
+        4: invalid.illegal.numeric.rational.ruby
+    # numbers with hexadecimal base prefix
+    - match: '\b(0[xX])\h(?:_?\h)*(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*(r)?(i)?\b'
+        4: invalid.illegal.numeric.rational.ruby
+    # numbers with octal base prefix
+    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-    - match: '\b(0[bB])[01](?:_?[01])*(r)?(i)?\b'
+        4: invalid.illegal.numeric.rational.ruby
+    # numbers with binary base prefix
+    - match: '\b(0[bB])[01](?:_?[01])*(r)?(?:(i)(r)?)?\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
+        4: invalid.illegal.numeric.rational.ruby
     # complex imaginary numbers
     - match: |-
         \b(?x:
@@ -241,7 +246,7 @@ contexts:
             # 1.ri, 1.e1ri, 1.1e1ri | 1.i 1.e1i
             |   (\.) (?: {{digit}}? {{exponent}}? (r) | ({{exponent}})? )
           )
-        )(i)\b
+        )(i)(r)?\b
       scope: constant.numeric.complex.imaginary.ruby
       captures:
         1: punctuation.separator.decimal.ruby
@@ -250,6 +255,7 @@ contexts:
         4: invalid.illegal.numeric.rational.ruby
         5: invalid.illegal.numeric.exponent.ruby
         6: storage.type.numeric.imaginary.ruby
+        7: invalid.illegal.numeric.rational.ruby
     # rational numbers
     - match: |-
         \b(?x:
@@ -265,14 +271,14 @@ contexts:
         5: storage.type.numeric.rational.ruby
     # floating point numbers
     - match: |-
-       \b(?x:
+        \b(?x:
           {{digit}} (?:
             # 1e1, 1.1e1
             (?: (\.)     {{digit}}  )?  {{exponent}} \b
             # 1., 1.1, 1.e1
             |   (\.) (?: {{digit}}\b | ({{exponent}})\b )?
           )
-       )
+        )
       scope: constant.numeric.float.ruby
       captures:
         1: punctuation.separator.decimal.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -276,17 +276,16 @@ contexts:
     - match: |-
         \b(?x:
           {{ddigits}} (?:
-            # 1e1, 1.1e1
-            (?: (\.) {{ddigits}} )? {{exponent}}\b
-            # 1., 1.1, 1.e1
-            | (\.) (?: {{ddigits}}\b | ({{exponent}})\b )?
+            # 1.1, 1.1e1, 1.e1
+            (\.) (?: {{ddigits}} {{exponent}}? | ({{exponent}}) )
+            # 1e1
+            | {{exponent}}
           )
-        )
+        )\b
       scope: constant.numeric.float.ruby
       captures:
         1: punctuation.separator.decimal.ruby
-        2: punctuation.separator.decimal.ruby
-        3: invalid.illegal.numeric.exponent.ruby
+        2: invalid.illegal.numeric.exponent.ruby
     # integer decimal
     - match: '\b{{ddigits}}\b'
       scope: constant.numeric.integer.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -209,84 +209,65 @@ contexts:
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
     # numbers with decimal base prefix
-    - match: '\b(0[dD]){{ddigits}}(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[dD]){{ddigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.decimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
+        4: storage.type.numeric.imaginary.ruby
+        5: invalid.illegal.numeric.rational.ruby
     # numbers with hexadecimal base prefix
-    - match: '\b(0[xX]){{hdigits}}(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[xX]){{hdigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
+        4: storage.type.numeric.imaginary.ruby
+        5: invalid.illegal.numeric.rational.ruby
     # numbers with octal base prefix
-    - match: '\b(0[oO]?){{odigits}}(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[oO]?){{odigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
+        4: storage.type.numeric.imaginary.ruby
+        5: invalid.illegal.numeric.rational.ruby
     # numbers with binary base prefix
-    - match: '\b(0[bB]){{bdigits}}(r)?(?:(i)(r)?)?\b'
+    - match: '\b(0[bB]){{bdigits}}(r)?(?:(\.i)|(i)(r)?)?\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
         2: storage.type.numeric.rational.ruby
         3: storage.type.numeric.imaginary.ruby
-        4: invalid.illegal.numeric.rational.ruby
-    # complex imaginary numbers
-    - match: |-
-        \b(?x:
-          {{ddigits}} (?:
-            # 1ri, 1.1ri, 1i, 1.1i | 1e1i, 1.1e1i
-            (?: (\.) {{ddigits}} )? (?: (r) | {{exponent}}? )
-            # 1.ri, 1.e1ri, 1.1e1ri | 1.i 1.e1i
-            | (\.) (?: {{ddigits}}? {{exponent}}? (r) | ({{exponent}})? )
-          )
-        )(i)(r)?\b
+        4: storage.type.numeric.imaginary.ruby
+        5: invalid.illegal.numeric.rational.ruby
+    # complex imaginary numbers: 1i, 1.i, 1.1i, 1.1.i, 1e1i, 1e1.i, 1.1e1i, 1.1e1.i, 1ri, 1r.i, 1.1ri, 1.1r.i
+    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(?:(r)|{{exponent}}(r)?)?(?:(\.i)|(i)(r)?)\b'
       scope: constant.numeric.complex.imaginary.ruby
       captures:
         1: punctuation.separator.decimal.ruby
         2: storage.type.numeric.rational.ruby
-        3: punctuation.separator.decimal.ruby
-        4: invalid.illegal.numeric.rational.ruby
-        5: invalid.illegal.numeric.exponent.ruby
-        6: storage.type.numeric.imaginary.ruby
-        7: invalid.illegal.numeric.rational.ruby
-    # rational numbers
-    - match: |-
-        \b(?x:
-          # 1.r | 1r, 1.1r, 1.e1r, 1.1e1r
-          {{ddigits}} (?: (\.) (r) | (?: (\.) {{ddigits}}? ({{exponent}})? )? (r) )
-        )\b
+        3: invalid.illegal.numeric.rational.ruby
+        4: storage.type.numeric.imaginary.ruby
+        5: storage.type.numeric.imaginary.ruby
+        6: invalid.illegal.numeric.rational.ruby
+    # rational numbers: 1r, 1.1r
+    - match: '\b{{ddigits}}(?:(\.){{ddigits}})?(r)'
       scope: constant.numeric.rational.ruby
       captures:
         1: punctuation.separator.decimal.ruby
-        2: invalid.illegal.numeric.rational.ruby
-        3: punctuation.separator.decimal.ruby
-        4: invalid.illegal.numeric.exponent.ruby
-        5: storage.type.numeric.rational.ruby
-    # floating point numbers
-    - match: |-
-        \b(?x:
-          {{ddigits}} (?:
-            # 1.1, 1.1e1, 1.e1
-            (\.) (?: {{ddigits}} {{exponent}}? | ({{exponent}}) )
-            # 1e1
-            | {{exponent}}
-          )
-        )\b
+        2: storage.type.numeric.rational.ruby
+    # floating point numbers: 1.1, 1e1, 1.1e1
+    - match: '\b{{ddigits}}(?:(\.){{ddigits}}|(?:(\.){{ddigits}})?{{exponent}}(r)?)\b'
       scope: constant.numeric.float.ruby
       captures:
         1: punctuation.separator.decimal.ruby
-        2: invalid.illegal.numeric.exponent.ruby
-    # integer decimal
+        2: punctuation.separator.decimal.ruby
+        3: invalid.illegal.numeric.rational.ruby
+    # integer numbers
     - match: '\b{{ddigits}}\b'
       scope: constant.numeric.integer.ruby
     # Quoted symbols

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -203,27 +203,27 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b0[dD]\d(_?\d)*\b'
+    - match: '\b0[dD]\d(?:_?\d)*\b'
       scope: constant.numeric.integer.decimal.ruby
-    - match: '\b0[xX]\h(_?\h)*\b'
+    - match: '\b0[xX]\h(?:_?\h)*\b'
       scope: constant.numeric.integer.hexadecimal.ruby
-    - match: '\b0[oO]?[0-7](_?[0-7])*\b'
+    - match: '\b0[oO]?[0-7](?:_?[0-7])*\b'
       scope: constant.numeric.integer.octal.ruby
-    - match: '\b0[bB][01](_?[01])*\b'
+    - match: '\b0[bB][01](?:_?[01])*\b'
       scope: constant.numeric.integer.binary.ruby
-    - match: '\b\d(_?\d)*\.\d(_?\d)*r\b'
+    - match: '\b\d(?:_?\d)*\.\d(?:_?\d)*r\b'
       scope: constant.numeric.float.rational.ruby
-    - match: '\b\d(_?\d)*r\b'
+    - match: '\b\d(?:_?\d)*r\b'
       scope: constant.numeric.integer.rational.ruby
-    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?r?i\b'
+    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?r?i\b'
       scope: constant.numeric.complex.imaginary.ruby
-    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?ir\b'
+    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?ir\b'
       scope: invalid.illegal.ruby
-    - match: '\b\d(_?\d)*(\.\d(_?\d)*)?[eE][-+]?\d(_?\d)*\b'
+    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?[eE][-+]?\d(?:_?\d)*\b'
       scope: constant.numeric.float.ruby
-    - match: '\b\d(_?\d)*\.(\d(_?\d)*\b)?'
+    - match: '\b\d(?:_?\d)*\.(?:\d(?:_?\d)*\b)?'
       scope: constant.numeric.float.ruby
-    - match: '\b\d(_?\d)*\b'
+    - match: '\b\d(?:_?\d)*\b'
       scope: constant.numeric.integer.ruby
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -203,41 +203,68 @@ contexts:
       scope: constant.language.ruby
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
-    - match: '\b(0[dD])\d(?:_?\d)*\b'
+    # numbers with 'ir' suffix are invalid
+    - match: '\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][-+]?\d(?:_?\d)*)?|0[dDxXoObB]?\h(?:_?\h)*)ir\b'
+      scope: invalid.illegal.ruby
+    - match: '\b(0[dD])\d(?:_?\d)*(r)?(i)?\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.decimal.ruby
-    - match: '\b(0[xX])\h(?:_?\h)*\b'
+        2: storage.type.numeric.rational.ruby
+        3: storage.type.numeric.imaginary.ruby
+    - match: '\b(0[xX])\h(?:_?\h)*(r)?(i)?\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.hexadecimal.ruby
-    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*\b'
+        2: storage.type.numeric.rational.ruby
+        3: storage.type.numeric.imaginary.ruby
+    - match: '\b(0[oO]?)[0-7](?:_?[0-7])*(r)?(i)?\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.octal.ruby
-    - match: '\b(0[bB])[01](?:_?[01])*\b'
+        2: storage.type.numeric.rational.ruby
+        3: storage.type.numeric.imaginary.ruby
+    - match: '\b(0[bB])[01](?:_?[01])*(r)?(i)?\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.binary.ruby
-    - match: '\b\d(?:_?\d)*\.\d(?:_?\d)*(r)\b'
-      scope: constant.numeric.float.rational.ruby
-      captures:
-        1: storage.type.numeric.rational.ruby
-    - match: '\b\d(?:_?\d)*(r)\b'
-      scope: constant.numeric.integer.rational.ruby
-      captures:
-        1: storage.type.numeric.rational.ruby
-    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(r)?(i)\b'
+        2: storage.type.numeric.rational.ruby
+        3: storage.type.numeric.imaginary.ruby
+    # 1.1e1i, 1e1i
+    - match: '\b\d(?:_?\d)*(?:(\.)\d(?:_?\d)*)?[eE][-+]?\d(?:_?\d)*(i)\b'
       scope: constant.numeric.complex.imaginary.ruby
       captures:
-        1: storage.type.numeric.rational.ruby
+        1: punctuation.separator.decimal.ruby
         2: storage.type.numeric.imaginary.ruby
-    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?ir\b'
-      scope: invalid.illegal.ruby
-    - match: '\b\d(?:_?\d)*(?:\.\d(?:_?\d)*)?[eE][-+]?\d(?:_?\d)*\b'
+    # 1.1ri, 1.1i, 1ri, 1i
+    - match: '\b\d(?:_?\d)*(?:(\.)\d(?:_?\d)*)?(r)?(i)\b'
+      scope: constant.numeric.complex.imaginary.ruby
+      captures:
+        1: punctuation.separator.decimal.ruby
+        2: storage.type.numeric.rational.ruby
+        3: storage.type.numeric.imaginary.ruby
+    # 1.i
+    - match: '\b\d(?:_?\d)*(\.)(i)\b'
+      scope: constant.numeric.complex.imaginary.ruby
+      captures:
+        1: punctuation.separator.decimal.ruby
+        2: storage.type.numeric.imaginary.ruby
+    # 1.1r, 1r
+    - match: '\b\d(?:_?\d)*(?:(\.)\d(?:_?\d)*)?(r)\b'
+      scope: constant.numeric.rational.ruby
+      captures:
+        1: punctuation.separator.decimal.ruby
+        2: storage.type.numeric.rational.ruby
+    # 1.1e1, 1e1
+    - match: '\b\d(?:_?\d)*(?:(\.)\d(?:_?\d)*)?[eE][-+]?\d(?:_?\d)*\b'
       scope: constant.numeric.float.ruby
-    - match: '\b\d(?:_?\d)*\.(?:\d(?:_?\d)*\b)?'
+      captures:
+        1: punctuation.separator.decimal.ruby
+    # 1.1, 1.
+    - match: '\b\d(?:_?\d)*(\.)(?:\d(?:_?\d)*\b)?'
       scope: constant.numeric.float.ruby
+      captures:
+        1: punctuation.separator.decimal.ruby
     - match: '\b\d(?:_?\d)*\b'
       scope: constant.numeric.integer.ruby
     - match: ":'"

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -257,14 +257,14 @@ contexts:
         2: storage.type.numeric.rational.ruby
     # floating point numbers: 1.1, 1e1, 1.1e1
     - match: '\b{{ddigits}}(?:(\.){{ddigits}}|(?:(\.){{ddigits}})?{{exponent}}(r)?)\b'
-      scope: constant.numeric.float.ruby
+      scope: constant.numeric.float.decimal.ruby
       captures:
         1: punctuation.separator.decimal.ruby
         2: punctuation.separator.decimal.ruby
         3: invalid.illegal.numeric.rational.ruby
     # integer numbers
     - match: '\b{{ddigits}}\b'
-      scope: constant.numeric.integer.ruby
+      scope: constant.numeric.integer.decimal.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -191,10 +191,12 @@ BAR
 
  12.34
 #^^^^^ constant.numeric.float
+#  ^ punctuation.separator.decimal
  1234e-2
 #^^^^^^^ constant.numeric.float
  1.234E1
 #^^^^^^^ constant.numeric.float
+# ^ punctuation.separator.decimal
 
  0d170
 #^^^^^ constant.numeric.integer.decimal
@@ -203,22 +205,10 @@ BAR
 #^^^^^ constant.numeric.integer.decimal
 #^^ punctuation.definition.numeric.decimal
 
- 0xaa
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
  0xAa
 #^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
- 0xAA
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
- 0Xaa
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
  0XAa
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
- 0XaA
 #^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
 
@@ -240,10 +230,11 @@ BAR
 #^^ punctuation.definition.numeric.binary
 
  12r         #=> (12/1)
-#^^^ constant.numeric.integer.rational
+#^^^ constant.numeric.rational
 #  ^ storage.type.numeric.rational
  12.3r       #=> (123/10)
-#^^^^^ constant.numeric.float.rational
+#^^^^^ constant.numeric.rational
+#  ^ punctuation.separator.decimal
 #    ^ storage.type.numeric.rational
 
  1i          #=> (0+1i)
@@ -252,11 +243,33 @@ BAR
 
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary
+#  ^ punctuation.separator.decimal
 #    ^ storage.type.numeric.rational
 #     ^ storage.type.numeric.imaginary
 
  12.3ir      #=> syntax error
 #^^^^^^ invalid.illegal - constant.numeric
+
+ 1.2e3i
+#^^^^^^ constant.numeric.complex.imaginary
+# ^ punctuation.separator.decimal
+#     ^ storage.type.numeric.imaginary
+
+ 0xAAr
+#^^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
+#    ^ storage.type.numeric.rational
+
+ 0xAAi
+#^^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
+#    ^ storage.type.numeric.imaginary
+
+ 0xAAri
+#^^^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
+#    ^ storage.type.numeric.rational
+#     ^ storage.type.numeric.imaginary
 
  1.
 # ^ constant.numeric.float - punctuation.accessor

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -250,63 +250,33 @@ BAR
  1i          #=> (0+1i)
 #^^ constant.numeric.complex.imaginary
 # ^ storage.type.numeric.imaginary
- 1.i         #=> (0+1i)
-#^^^ constant.numeric.complex.imaginary
-# ^^ storage.type.numeric.imaginary
  1.0i        #=> (0+1.0i)
 #^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
 #   ^ storage.type.numeric.imaginary
- 1.0.i       #=> (0+1.0i)
-#^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#   ^^ storage.type.numeric.imaginary
  12e3i       #=> (0+12000.0i)
 #^^^^^ constant.numeric.complex.imaginary
 #    ^ storage.type.numeric.imaginary
- 12e3.i      #=> (0+12000.0i)
-#^^^^^^ constant.numeric.complex.imaginary
-#    ^^ storage.type.numeric.imaginary
  12e-3i      #=> (0+0.012i)
 #^^^^^^ constant.numeric.complex.imaginary
 #     ^ storage.type.numeric.imaginary
- 12e-3.i     #=> (0+0.012i)
-#^^^^^^^ constant.numeric.complex.imaginary
-#     ^^ storage.type.numeric.imaginary
  1.2e3i      #=> (0+1200.0i)
 #^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
 #     ^ storage.type.numeric.imaginary
- 1.2e3.i     #=> (0+1200.0i)
-#^^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#     ^^ storage.type.numeric.imaginary
  1.2e-3i     #=> (0+0.0012i)
 #^^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
 #      ^ storage.type.numeric.imaginary
- 1.2e-3.i    #=> (0+0.0012i)
-#^^^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#      ^^ storage.type.numeric.imaginary
  12ri        #=> (0+(12/1)*i)
 #^^^^ constant.numeric.complex.imaginary
 #  ^ storage.type.numeric.rational
 #   ^ storage.type.numeric.imaginary
- 12r.i       #=> (0+(12/1)*i)
-#^^^^^ constant.numeric.complex.imaginary
-#  ^ storage.type.numeric.rational
-#   ^^ storage.type.numeric.imaginary
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary
 #  ^ punctuation.separator.decimal
 #    ^ storage.type.numeric.rational
 #     ^ storage.type.numeric.imaginary
- 12.3r.i     #=> (0+(123/10)*i)
-#^^^^^^^ constant.numeric.complex.imaginary
-#  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric.rational
-#     ^^ storage.type.numeric.imaginary
  12e3ri      #=> syntax error
 #^^^^^^ constant.numeric.complex.imaginary
 #    ^ invalid.illegal.numeric.rational

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -188,10 +188,10 @@ BAR
 #^^^^ constant.numeric.integer
  1_234
 #^^^^^ constant.numeric.integer
+ 1.          #=> dot after integer indicates method call
+#^ constant.numeric.integer
+# ^ punctuation.accessor - constant.numeric
 
- 1.
-#^^ constant.numeric.float
-# ^ punctuation.separator.decimal
  12.34
 #^^^^^ constant.numeric.float
 #  ^ punctuation.separator.decimal

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -240,6 +240,14 @@ BAR
  1i          #=> (0+1i)
 #^^ constant.numeric.complex.imaginary
 # ^ storage.type.numeric.imaginary
+ 1.i         #=> (0+1i)
+#^^^ constant.numeric.complex.imaginary
+# ^ punctuation.separator.decimal
+#  ^ storage.type.numeric.imaginary
+ 1.0i        #=> (0+1.0i)
+#^^^^ constant.numeric.complex.imaginary
+# ^ punctuation.separator.decimal
+#   ^ storage.type.numeric.imaginary
 
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -188,55 +188,68 @@ BAR
 #^^^^ constant.numeric.integer 
  1_234
 #^^^^^ constant.numeric.integer
- 
+
  12.34
 #^^^^^ constant.numeric.float
  1234e-2
 #^^^^^^^ constant.numeric.float
  1.234E1
 #^^^^^^^ constant.numeric.float
- 
+
  0d170
 #^^^^^ constant.numeric.integer.decimal
+#^^ punctuation.definition.numeric.decimal
  0D170
 #^^^^^ constant.numeric.integer.decimal
- 
+#^^ punctuation.definition.numeric.decimal
+
  0xaa
 #^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
  0xAa
 #^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
  0xAA
 #^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
  0Xaa
 #^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
  0XAa
 #^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
  0XaA
 #^^^^ constant.numeric.integer.hexadecimal
- 
+#^^ punctuation.definition.numeric.hexadecimal
+
  0252
 #^^^^ constant.numeric.integer.octal
+#^ punctuation.definition.numeric.octal
  0o252
 #^^^^^ constant.numeric.integer.octal
+#^^ punctuation.definition.numeric.octal
  0O252
 #^^^^^ constant.numeric.integer.octal
- 
+#^^ punctuation.definition.numeric.octal
+
  0b10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
+#^^ punctuation.definition.numeric.binary
  0B10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
- 
+#^^ punctuation.definition.numeric.binary
+
  12r         #=> (12/1)
 #^^^ constant.numeric.integer.rational
  12.3r       #=> (123/10)
 #^^^^^ constant.numeric.float.rational
- 
+
  1i          #=> (0+1i)
 #^^ constant.numeric.complex.imaginary 
- 
+
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary
- 
+
  12.3ir      #=> syntax error
 #^^^^^^ invalid.illegal - constant.numeric
 

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -188,7 +188,7 @@ BAR
 #^^^^ constant.numeric.integer
  1_234
 #^^^^^ constant.numeric.integer
- 1.          #=> dot after integer indicates method call
+ 1.
 #^ constant.numeric.integer
 # ^ punctuation.accessor - constant.numeric
 
@@ -200,14 +200,13 @@ BAR
  1.234E1
 #^^^^^^^ constant.numeric.float
 # ^ punctuation.separator.decimal
- 12.e1
+ 12e3r       #=> syntax error
 #^^^^^ constant.numeric.float
-#  ^ punctuation.separator.decimal
-#   ^^ invalid.illegal.numeric.exponent
- 12.e-1
-#^^^^^ constant.numeric.float
-#  ^ punctuation.separator.decimal
-#   ^^^ invalid.illegal.numeric.exponent
+#    ^ invalid.illegal.numeric.rational
+ 1.2e3r      #=> syntax error
+#^^^^^^ constant.numeric.float
+# ^ punctuation.separator.decimal
+#     ^ invalid.illegal.numeric.rational
 
  0d170
 #^^^^^ constant.numeric.integer.decimal
@@ -243,9 +242,6 @@ BAR
  12r         #=> (12/1)
 #^^^ constant.numeric.rational
 #  ^ storage.type.numeric.rational
- 12.r        #=> illegal
-#^^^^ constant.numeric.rational
-#   ^ invalid.illegal.numeric.rational
  12.3r       #=> (123/10)
 #^^^^^ constant.numeric.rational
 #  ^ punctuation.separator.decimal
@@ -256,69 +252,92 @@ BAR
 # ^ storage.type.numeric.imaginary
  1.i         #=> (0+1i)
 #^^^ constant.numeric.complex.imaginary
-#  ^ storage.type.numeric.imaginary
- 1.0i        #=> (0+1i)
+# ^^ storage.type.numeric.imaginary
+ 1.0i        #=> (0+1.0i)
 #^^^^ constant.numeric.complex.imaginary
+# ^ punctuation.separator.decimal
 #   ^ storage.type.numeric.imaginary
- 1.e3i       #=> incomplete
+ 1.0.i       #=> (0+1.0i)
 #^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
-#  ^^ invalid.illegal.numeric.exponent
+#   ^^ storage.type.numeric.imaginary
+ 12e3i       #=> (0+12000.0i)
+#^^^^^ constant.numeric.complex.imaginary
 #    ^ storage.type.numeric.imaginary
- 1.e-3i      #=> incomplete
+ 12e3.i      #=> (0+12000.0i)
+#^^^^^^ constant.numeric.complex.imaginary
+#    ^^ storage.type.numeric.imaginary
+ 12e-3i      #=> (0+0.012i)
+#^^^^^^ constant.numeric.complex.imaginary
+#     ^ storage.type.numeric.imaginary
+ 12e-3.i     #=> (0+0.012i)
+#^^^^^^^ constant.numeric.complex.imaginary
+#     ^^ storage.type.numeric.imaginary
+ 1.2e3i      #=> (0+1200.0i)
 #^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
-#  ^^^ invalid.illegal.numeric.exponent
 #     ^ storage.type.numeric.imaginary
- 1.2e3i      #=> (0+1200i)
-#^^^^^^ constant.numeric.complex.imaginary
+ 1.2e3.i     #=> (0+1200.0i)
+#^^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
-#     ^ storage.type.numeric.imaginary
+#     ^^ storage.type.numeric.imaginary
  1.2e-3i     #=> (0+0.0012i)
 #^^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
 #      ^ storage.type.numeric.imaginary
- 12e3i       #=> (0+12000i)
-#^^^^^ constant.numeric.complex.imaginary
-#    ^ storage.type.numeric.imaginary
- 12e-3i      #=> (0+0.012i)
-#^^^^^^ constant.numeric.complex.imaginary
-#     ^ storage.type.numeric.imaginary
- 12.3ir      #=> illegal
-#^^^^^^ constant.numeric.complex.imaginary
-#  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric.imaginary
-#     ^ invalid.illegal.numeric.rational
-
- 12ri        #=> (0+(12/3)*i)
+ 1.2e-3.i    #=> (0+0.0012i)
+#^^^^^^^^ constant.numeric.complex.imaginary
+# ^ punctuation.separator.decimal
+#      ^^ storage.type.numeric.imaginary
+ 12ri        #=> (0+(12/1)*i)
 #^^^^ constant.numeric.complex.imaginary
 #  ^ storage.type.numeric.rational
 #   ^ storage.type.numeric.imaginary
- 12.ri       #=> illegal
+ 12r.i       #=> (0+(12/1)*i)
 #^^^^^ constant.numeric.complex.imaginary
-#  ^ punctuation.separator.decimal
-#   ^ invalid.illegal.numeric.rational
-#    ^ storage.type.numeric.imaginary
+#  ^ storage.type.numeric.rational
+#   ^^ storage.type.numeric.imaginary
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary
 #  ^ punctuation.separator.decimal
 #    ^ storage.type.numeric.rational
 #     ^ storage.type.numeric.imaginary
- 1.e3ri      #=> illegal, incomplete
+ 12.3r.i     #=> (0+(123/10)*i)
+#^^^^^^^ constant.numeric.complex.imaginary
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric.rational
+#     ^^ storage.type.numeric.imaginary
+ 12e3ri      #=> syntax error
 #^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
 #    ^ invalid.illegal.numeric.rational
-#     ^ storage.type.numeric.imaginary
- 1.2e3ri     #=> illegal
+#     ^ storage.type.numeric.imaginary 
+ 1.2e3ri     #=> syntax error
 #^^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
 #     ^ invalid.illegal.numeric.rational
 #      ^ storage.type.numeric.imaginary
- 1.2e-3ri    #=> illegal
+ 12ir        #=> syntax error
+#^^^^ constant.numeric.complex.imaginary
+#  ^ storage.type.numeric.imaginary
+#   ^ invalid.illegal.numeric.rational
+ 12.3ir      #=> syntax error
+#^^^^^^ constant.numeric.complex.imaginary
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric.imaginary
+#     ^ invalid.illegal.numeric.rational
+ 1.2e3ir     #=> syntax error
 #^^^^^^^ constant.numeric.complex.imaginary
 # ^ punctuation.separator.decimal
+#     ^ storage.type.numeric.imaginary
 #      ^ invalid.illegal.numeric.rational
-#       ^ storage.type.numeric.imaginary
+ 12e3ir      #=> syntax error
+#^^^^^^ constant.numeric.complex.imaginary
+#    ^ storage.type.numeric.imaginary
+#     ^ invalid.illegal.numeric.rational
+
+ 12.ir
+#  ^^^ - constant.numeric - storage.type.numeric - invalid.illegal
+#  ^ punctuation.accessor
 
  0xAAr
 #^^^^^ constant.numeric.integer.hexadecimal
@@ -333,7 +352,7 @@ BAR
 #^^ punctuation.definition.numeric.hexadecimal
 #    ^ storage.type.numeric.rational
 #     ^ storage.type.numeric.imaginary
- 0xAAir
+ 0xAAir      #=> syntax error
 #^^^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
 #    ^ storage.type.numeric.imaginary

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -181,6 +181,69 @@ BAR
 #  ^ - meta.string - string.unquoted
 
 ##################
+# Numbers
+##################
+
+ 1234
+#^^^^ constant.numeric.integer 
+ 1_234
+#^^^^^ constant.numeric.integer
+ 
+ 12.34
+#^^^^^ constant.numeric.float
+ 1234e-2
+#^^^^^^^ constant.numeric.float
+ 1.234E1
+#^^^^^^^ constant.numeric.float
+ 
+ 0d170
+#^^^^^ constant.numeric.integer.decimal
+ 0D170
+#^^^^^ constant.numeric.integer.decimal
+ 
+ 0xaa
+#^^^^ constant.numeric.integer.hexadecimal
+ 0xAa
+#^^^^ constant.numeric.integer.hexadecimal
+ 0xAA
+#^^^^ constant.numeric.integer.hexadecimal
+ 0Xaa
+#^^^^ constant.numeric.integer.hexadecimal
+ 0XAa
+#^^^^ constant.numeric.integer.hexadecimal
+ 0XaA
+#^^^^ constant.numeric.integer.hexadecimal
+ 
+ 0252
+#^^^^ constant.numeric.integer.octal
+ 0o252
+#^^^^^ constant.numeric.integer.octal
+ 0O252
+#^^^^^ constant.numeric.integer.octal
+ 
+ 0b10101010
+#^^^^^^^^^^ constant.numeric.integer.binary
+ 0B10101010
+#^^^^^^^^^^ constant.numeric.integer.binary
+ 
+ 12r         #=> (12/1)
+#^^^ constant.numeric.integer.rational
+ 12.3r       #=> (123/10)
+#^^^^^ constant.numeric.float.rational
+ 
+ 1i          #=> (0+1i)
+#^^ constant.numeric.complex.imaginary 
+ 
+ 12.3ri      #=> (0+(123/10)*i)
+#^^^^^^ constant.numeric.complex.imaginary
+ 
+ 12.3ir      #=> syntax error
+#^^^^^^ invalid.illegal - constant.numeric
+
+ 1.
+# ^ constant.numeric.float - punctuation.accessor
+
+##################
 # Strings
 ##################
 
@@ -436,7 +499,7 @@ Symbol === :foo
 #       ^^ constant.character.ruby
 #         ^ - constant
 #          ^ keyword.operator.conditional.ruby
-#           ^^ constant.numeric.ruby
+#           ^^ constant.numeric.integer.ruby
   ?a ?A ?あ ?abc ?a0
 #^ - constant
 # ^ punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -185,26 +185,26 @@ BAR
 ##################
 
  1234
-#^^^^ constant.numeric.integer
+#^^^^ constant.numeric.integer.decimal
  1_234
-#^^^^^ constant.numeric.integer
+#^^^^^ constant.numeric.integer.decimal
  1.
-#^ constant.numeric.integer
+#^ constant.numeric.integer.decimal
 # ^ punctuation.accessor - constant.numeric
 
  12.34
-#^^^^^ constant.numeric.float
+#^^^^^ constant.numeric.float.decimal
 #  ^ punctuation.separator.decimal
  1234e-2
-#^^^^^^^ constant.numeric.float
+#^^^^^^^ constant.numeric.float.decimal
  1.234E1
-#^^^^^^^ constant.numeric.float
+#^^^^^^^ constant.numeric.float.decimal
 # ^ punctuation.separator.decimal
  12e3r       #=> syntax error
-#^^^^^ constant.numeric.float
+#^^^^^ constant.numeric.float.decimal
 #    ^ invalid.illegal.numeric.rational
  1.2e3r      #=> syntax error
-#^^^^^^ constant.numeric.float
+#^^^^^^ constant.numeric.float.decimal
 # ^ punctuation.separator.decimal
 #     ^ invalid.illegal.numeric.rational
 
@@ -584,7 +584,7 @@ Symbol === :foo
 #       ^^ constant.character.ruby
 #         ^ - constant
 #          ^ keyword.operator.conditional.ruby
-#           ^^ constant.numeric.integer.ruby
+#           ^^ constant.numeric.integer.decimal.ruby
   ?a ?A ?あ ?abc ?a0
 #^ - constant
 # ^ punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -188,40 +188,18 @@ BAR
 #^^^^ constant.numeric.integer.decimal
  1_234
 #^^^^^ constant.numeric.integer.decimal
- 1.
-#^ constant.numeric.integer.decimal
-# ^ punctuation.accessor - constant.numeric
-
- 12.34
-#^^^^^ constant.numeric.float.decimal
-#  ^ punctuation.separator.decimal
- 1234e-2
-#^^^^^^^ constant.numeric.float.decimal
- 1.234E1
-#^^^^^^^ constant.numeric.float.decimal
-# ^ punctuation.separator.decimal
- 12e3r       #=> syntax error
-#^^^^^ constant.numeric.float.decimal
-#    ^ invalid.illegal.numeric.rational
- 1.2e3r      #=> syntax error
-#^^^^^^ constant.numeric.float.decimal
-# ^ punctuation.separator.decimal
-#     ^ invalid.illegal.numeric.rational
-
  0d170
 #^^^^^ constant.numeric.integer.decimal
 #^^ punctuation.definition.numeric.decimal
  0D170
 #^^^^^ constant.numeric.integer.decimal
 #^^ punctuation.definition.numeric.decimal
-
  0xAa
 #^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
  0XAa
 #^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
-
  0252
 #^^^^ constant.numeric.integer.octal
 #^ punctuation.definition.numeric.octal
@@ -231,102 +209,167 @@ BAR
  0O252
 #^^^^^ constant.numeric.integer.octal
 #^^ punctuation.definition.numeric.octal
-
  0b10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
 #^^ punctuation.definition.numeric.binary
  0B10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
 #^^ punctuation.definition.numeric.binary
-
- 12r         #=> (12/1)
-#^^^ constant.numeric.rational
-#  ^ storage.type.numeric.rational
- 12.3r       #=> (123/10)
-#^^^^^ constant.numeric.rational
-#  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric.rational
-
- 1i          #=> (0+1i)
-#^^ constant.numeric.complex.imaginary
-# ^ storage.type.numeric.imaginary
- 1.0i        #=> (0+1.0i)
-#^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#   ^ storage.type.numeric.imaginary
- 12e3i       #=> (0+12000.0i)
-#^^^^^ constant.numeric.complex.imaginary
-#    ^ storage.type.numeric.imaginary
- 12e-3i      #=> (0+0.012i)
-#^^^^^^ constant.numeric.complex.imaginary
-#     ^ storage.type.numeric.imaginary
- 1.2e3i      #=> (0+1200.0i)
-#^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#     ^ storage.type.numeric.imaginary
- 1.2e-3i     #=> (0+0.0012i)
-#^^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#      ^ storage.type.numeric.imaginary
- 12ri        #=> (0+(12/1)*i)
-#^^^^ constant.numeric.complex.imaginary
-#  ^ storage.type.numeric.rational
-#   ^ storage.type.numeric.imaginary
- 12.3ri      #=> (0+(123/10)*i)
-#^^^^^^ constant.numeric.complex.imaginary
-#  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric.rational
-#     ^ storage.type.numeric.imaginary
- 12e3ri      #=> syntax error
-#^^^^^^ constant.numeric.complex.imaginary
-#    ^ invalid.illegal.numeric.rational
-#     ^ storage.type.numeric.imaginary 
- 1.2e3ri     #=> syntax error
-#^^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#     ^ invalid.illegal.numeric.rational
-#      ^ storage.type.numeric.imaginary
- 12ir        #=> syntax error
-#^^^^ constant.numeric.complex.imaginary
-#  ^ storage.type.numeric.imaginary
-#   ^ invalid.illegal.numeric.rational
- 12.3ir      #=> syntax error
-#^^^^^^ constant.numeric.complex.imaginary
-#  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric.imaginary
-#     ^ invalid.illegal.numeric.rational
- 1.2e3ir     #=> syntax error
-#^^^^^^^ constant.numeric.complex.imaginary
-# ^ punctuation.separator.decimal
-#     ^ storage.type.numeric.imaginary
-#      ^ invalid.illegal.numeric.rational
- 12e3ir      #=> syntax error
-#^^^^^^ constant.numeric.complex.imaginary
-#    ^ storage.type.numeric.imaginary
-#     ^ invalid.illegal.numeric.rational
-
+ 12.
+#^^ constant.numeric.integer.decimal
+#  ^ punctuation.accessor - constant.numeric - invalid.illegal
  12.ir
-#  ^^^ - constant.numeric - storage.type.numeric - invalid.illegal
-#  ^ punctuation.accessor
+#^^ constant.numeric.integer.decimal
+#  ^ punctuation.accessor - constant.numeric - invalid.illegal
+#   ^^ - constant.numeric - invalid.illegal - storage.type.numeric
 
- 0xAAr
-#^^^^^ constant.numeric.integer.hexadecimal
+ 12.34
+#^^^^^ constant.numeric.float.decimal
+#  ^ punctuation.separator.decimal
+ 1234e-2
+#^^^^^^^ constant.numeric.float.decimal
+ 1.234E1
+#^^^^^^^ constant.numeric.float.decimal
+# ^ punctuation.separator.decimal
+ 12e3r
+#^^^^^ constant.numeric.float.decimal
+#    ^ invalid.illegal.numeric
+ 1.2e3r
+#^^^^^^ constant.numeric.float.decimal
+# ^ punctuation.separator.decimal
+#     ^ invalid.illegal.numeric
+
+ 12r
+#^^^ constant.numeric.rational.decimal
+#  ^ storage.type.numeric
+ 12.3r
+#^^^^^ constant.numeric.rational.decimal
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric
+ 0d170r
+#^^^^^^ constant.numeric.rational.decimal
+#^^ punctuation.definition.numeric.decimal
+#     ^ storage.type.numeric
+ 0xAar
+#^^^^^ constant.numeric.rational.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
-#    ^ storage.type.numeric.rational
- 0xAAi
-#^^^^^ constant.numeric.integer.hexadecimal
+#    ^ storage.type.numeric
+ 0o252r
+#^^^^^^ constant.numeric.rational.octal
+#^^ punctuation.definition.numeric.octal
+#     ^ storage.type.numeric
+ 0b10101010r
+#^^^^^^^^^^^ constant.numeric.rational.binary
+#^^ punctuation.definition.numeric.binary
+#          ^ storage.type.numeric
+
+ 12i
+#^^^ constant.numeric.imaginary.decimal
+#  ^ storage.type.numeric
+ 12.3i
+#^^^^^ constant.numeric.imaginary.decimal
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric
+ 12e3i
+#^^^^^ constant.numeric.imaginary.decimal
+#    ^ storage.type.numeric
+ 12e-3i
+#^^^^^^ constant.numeric.imaginary.decimal
+#     ^ storage.type.numeric
+ 1.2e3i
+#^^^^^^ constant.numeric.imaginary.decimal
+# ^ punctuation.separator.decimal
+#     ^ storage.type.numeric
+ 1.2e-3i
+#^^^^^^^ constant.numeric.imaginary.decimal
+# ^ punctuation.separator.decimal
+#      ^ storage.type.numeric
+ 12ri
+#^^^^ constant.numeric.imaginary.decimal
+#  ^^ storage.type.numeric
+ 12.3ri
+#^^^^^^ constant.numeric.imaginary.decimal
+#  ^ punctuation.separator.decimal
+#    ^^ storage.type.numeric
+ 0d170i
+#^^^^^^ constant.numeric.imaginary.decimal
+#^^ punctuation.definition.numeric.decimal
+#     ^ storage.type.numeric
+ 0d170ri
+#^^^^^^^ constant.numeric.imaginary.decimal
+#^^ punctuation.definition.numeric.decimal
+#     ^^ storage.type.numeric
+ 0xAai
+#^^^^^ constant.numeric.imaginary.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
-#    ^ storage.type.numeric.imaginary
- 0xAAri
-#^^^^^^ constant.numeric.integer.hexadecimal
+#    ^ storage.type.numeric
+ 0xAari
+#^^^^^^ constant.numeric.imaginary.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
-#    ^ storage.type.numeric.rational
-#     ^ storage.type.numeric.imaginary
- 0xAAir      #=> syntax error
-#^^^^^^ constant.numeric.integer.hexadecimal
+#    ^^ storage.type.numeric
+ 0o252i
+#^^^^^^ constant.numeric.imaginary.octal
+#^^ punctuation.definition.numeric.octal
+#     ^ storage.type.numeric
+ 0o252ri
+#^^^^^^^ constant.numeric.imaginary.octal
+#^^ punctuation.definition.numeric.octal
+#     ^^ storage.type.numeric
+ 0b10101010i
+#^^^^^^^^^^^ constant.numeric.imaginary.binary
+#^^ punctuation.definition.numeric.binary
+#          ^ storage.type.numeric
+ 0b10101010ri
+#^^^^^^^^^^^^ constant.numeric.imaginary.binary
+#^^ punctuation.definition.numeric.binary
+#          ^^ storage.type.numeric
+ 12e3ri
+#^^^^^^ constant.numeric.imaginary.decimal
+#    ^ invalid.illegal.numeric
+#     ^ storage.type.numeric 
+ 1.2e3ri
+#^^^^^^^ constant.numeric.imaginary.decimal
+# ^ punctuation.separator.decimal
+#     ^ invalid.illegal.numeric
+#      ^ storage.type.numeric
+ 12ir
+#^^^^ constant.numeric.imaginary.decimal
+#  ^ storage.type.numeric
+#   ^ invalid.illegal.numeric
+ 12.3ir
+#^^^^^^ constant.numeric.imaginary.decimal
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric
+#     ^ invalid.illegal.numeric
+ 12e3ir
+#^^^^^^ constant.numeric.imaginary.decimal
+#    ^ storage.type.numeric
+#     ^ invalid.illegal.numeric
+ 1.2e3ir
+#^^^^^^^ constant.numeric.imaginary.decimal
+# ^ punctuation.separator.decimal
+#     ^ storage.type.numeric
+#      ^ invalid.illegal.numeric
+ 0d170ir
+#^^^^^^^ constant.numeric.imaginary.decimal
+#^^ punctuation.definition.numeric.decimal
+#     ^ storage.type.numeric
+#      ^ invalid.illegal.numeric
+ 0xAair
+#^^^^^^ constant.numeric.imaginary.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
-#    ^ storage.type.numeric.imaginary
-#     ^ invalid.illegal.numeric.rational
+#    ^ storage.type.numeric
+#     ^ invalid.illegal.numeric
+ 0o252ir
+#^^^^^^^ constant.numeric.imaginary.octal
+#^^ punctuation.definition.numeric.octal
+#     ^ storage.type.numeric
+#      ^ invalid.illegal.numeric
+ 0b10101010ir
+#^^^^^^^^^^^^ constant.numeric.imaginary.binary
+#^^ punctuation.definition.numeric.binary
+#          ^ storage.type.numeric
+#           ^ invalid.illegal.numeric
 
 ##################
 # Strings

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -284,6 +284,11 @@ BAR
  12e-3i      #=> (0+0.012i)
 #^^^^^^ constant.numeric.complex.imaginary
 #     ^ storage.type.numeric.imaginary
+ 12.3ir      #=> illegal
+#^^^^^^ constant.numeric.complex.imaginary
+#  ^ punctuation.separator.decimal
+#    ^ storage.type.numeric.imaginary
+#     ^ invalid.illegal.numeric.rational
 
  12ri        #=> (0+(12/3)*i)
 #^^^^ constant.numeric.complex.imaginary
@@ -315,24 +320,24 @@ BAR
 #      ^ invalid.illegal.numeric.rational
 #       ^ storage.type.numeric.imaginary
 
- 12.3ir      #=> syntax error
-#^^^^^^ invalid.illegal - constant.numeric
-
  0xAAr
 #^^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
 #    ^ storage.type.numeric.rational
-
  0xAAi
 #^^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
 #    ^ storage.type.numeric.imaginary
-
  0xAAri
 #^^^^^^ constant.numeric.integer.hexadecimal
 #^^ punctuation.definition.numeric.hexadecimal
 #    ^ storage.type.numeric.rational
 #     ^ storage.type.numeric.imaginary
+ 0xAAir
+#^^^^^^ constant.numeric.integer.hexadecimal
+#^^ punctuation.definition.numeric.hexadecimal
+#    ^ storage.type.numeric.imaginary
+#     ^ invalid.illegal.numeric.rational
 
 ##################
 # Strings

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -241,14 +241,19 @@ BAR
 
  12r         #=> (12/1)
 #^^^ constant.numeric.integer.rational
+#  ^ storage.type.numeric.rational
  12.3r       #=> (123/10)
 #^^^^^ constant.numeric.float.rational
+#    ^ storage.type.numeric.rational
 
  1i          #=> (0+1i)
-#^^ constant.numeric.complex.imaginary 
+#^^ constant.numeric.complex.imaginary
+# ^ storage.type.numeric.imaginary
 
  12.3ri      #=> (0+(123/10)*i)
 #^^^^^^ constant.numeric.complex.imaginary
+#    ^ storage.type.numeric.rational
+#     ^ storage.type.numeric.imaginary
 
  12.3ir      #=> syntax error
 #^^^^^^ invalid.illegal - constant.numeric


### PR DESCRIPTION
This PR

1. Fixes #2126
   I used the scope ~~`constant.numeric.integer.rational.ruby` for e.g. `12r` and `constant.numeric.float.rational.ruby` for `12.3r`~~ `constant.numeric.rational.ruby` for e.g. `12r` and `12.3r`.
2. Fixes numbers with decimal or octal prefix, which are not highlighted currently
3. ~~Changes the dot in e.g. `1.` to be included in the number, instead of having the scope `punctuation.accessor` (which is wrong in my opinion)~~
4. Applies more specific scopes `integer`, `float`, `decimal`, `binary`, `octal`, `hexadecimal` instead of just `constant.numeric.ruby`

Notice: What is the purpose of the negative lookahead `(?![^[:space:][:digit:]])`, which is currently used in the regex after a decimal dot? I don't see any benefit from it, so I deleted it. In case it was to allow something like `1.`, it didn't work anyway, because there is still a word boundary `\b` required at the end.

The examples in the syntax test file were taken from https://ruby-doc.org/core-2.6.3/doc/syntax/literals_rdoc.html#label-Numbers