### PR TITLE
[Python] Improve numbers

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -33,8 +33,8 @@ variables:
   identifier_continue: '[[:alnum:]_]'
   identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
   identifier_constant: '\b(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
-  digit: (?:\d+(?:_\d+)*)
-  exponent: (?:[Ee][-+]?{{digit}})
+  digits: (?:\d+(?:_\d+)*)
+  exponent: (?:[eE][-+]?{{digits}})
   path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH)\b
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
@@ -457,10 +457,12 @@ contexts:
     # complex
     - match: |-
         (?x:
-                      (\.)  {{digit}}  {{exponent}}? |
-          \b{{digit}} (\.)? {{digit}}? {{exponent}}?
-        )([Jj])
-      scope: constant.numeric.complex.imaginary.python
+          # 1.j, 1.1j, 1.1e1j, 1.1e-1j, 1.e1j, 1.e-1 | 1e1j, 1e-1j
+          \b{{digits}} (\.)? {{digits}}? {{exponent}}?
+          # .1j, .1e1j, .1e-1j
+          | (\.) {{digits}} {{exponent}}?
+        )([jJ])
+      scope: constant.numeric.complex.imaginary.decimal.python
       captures:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python
@@ -468,8 +470,10 @@ contexts:
     # floating point
     - match: |-
         (?x:
-                          (\.) {{digit}}  {{exponent}}? |
-          \b{{digit}} (?: (\.) {{digit}}? {{exponent}}? | {{exponent}} )
+          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
+          \b{{digits}} (?: (\.) {{digits}}? {{exponent}}? | {{exponent}} )
+          # .1, .1e1, .1e-1
+          | (\.) {{digits}} {{exponent}}?
         )
       scope: constant.numeric.float.decimal.python
       captures:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -425,7 +425,7 @@ contexts:
       scope: constant.numeric.integer.hexadecimal.python
       captures:
         1: punctuation.definition.numeric.hexadecimal.python
-        2: storage.type.numeric.long.python
+        2: storage.type.numeric.python
     - match: \b(?i)(0x)(_?\h)+
       scope: constant.numeric.integer.hexadecimal.python
       captures:
@@ -435,7 +435,7 @@ contexts:
       scope: constant.numeric.integer.octal.python
       captures:
         1: punctuation.definition.integer.octal.python
-        2: storage.type.numeric.long.python
+        2: storage.type.numeric.python
     - match: \b(?i)(0)[0-7]+ # py2
       scope: constant.numeric.integer.octal.python
       captures:
@@ -449,7 +449,7 @@ contexts:
       scope: constant.numeric.integer.binary.python
       captures:
         1: punctuation.definition.numeric.binary.python
-        2: storage.type.numeric.long.python
+        2: storage.type.numeric.python
     - match: \b(?i)(0b)(_?[01])*
       scope: constant.numeric.integer.binary.python
       captures:
@@ -466,7 +466,7 @@ contexts:
       captures:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python
-        3: storage.type.numeric.imaginary.python
+        3: storage.type.numeric.python
     # floating point
     - match: |-
         (?x:
@@ -483,7 +483,7 @@ contexts:
     - match: \b(?i)(?:[1-9]\d*|0)(L)\b # py2
       scope: constant.numeric.integer.decimal.python
       captures:
-        1: storage.type.numeric.long.python
+        1: storage.type.numeric.python
     - match: \b(?i)([1-9][\d_]*|0)\b
       scope: constant.numeric.integer.decimal.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -462,7 +462,7 @@ contexts:
           # .1j, .1e1j, .1e-1j
           | (\.) {{digits}} {{exponent}}?
         )([jJ])
-      scope: constant.numeric.complex.imaginary.decimal.python
+      scope: constant.numeric.imaginary.decimal.python
       captures:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -33,7 +33,8 @@ variables:
   identifier_continue: '[[:alnum:]_]'
   identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
   identifier_constant: '\b(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
-  digitpart: (?:\d(?:_?\d)*)
+  digit: (?:\d(?:_?\d)*)
+  exponent: (?:[Ee][-+]?{{digit}})
   path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH)\b
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
@@ -454,36 +455,26 @@ contexts:
       captures:
         1: punctuation.definition.numeric.binary.python
     # complex
-    - match: (?i){{digitpart}}?(\.){{digitpart}}(?:e[\-\+]?{{digitpart}})?(j) # mandatory fraction
-      scope: constant.numeric.complex.python
-      captures:
-        1: punctuation.separator.decimal.python
-        2: storage.type.numeric.complex.python
-    - match: \b(?i)(?:{{digitpart}}(?:(\.){{digitpart}}?)?|(\.){{digitpart}})(?:e[\-\+]?{{digitpart}})(j) # mandatory exponent
-      scope: constant.numeric.complex.python
+    - match: |-
+        (?x:
+                      (\.)  {{digit}}  {{exponent}}? |
+          \b{{digit}} (\.)? {{digit}}? {{exponent}}?
+        )([Jj])
+      scope: constant.numeric.complex.imaginary.python
       captures:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python
-        3: storage.type.numeric.complex.python
-    - match: (?i){{digitpart}}(\.)?(j) # mandatory digitpart
-      scope: constant.numeric.complex.python
-      captures:
-        1: punctuation.separator.decimal.python
-        2: storage.type.numeric.complex.python
+        3: storage.type.numeric.imaginary.python
     # floating point
-    - match: (?i){{digitpart}}?(\.){{digitpart}}(?:e[\-\+]?{{digitpart}})? # mandatory fraction
-      scope: constant.numeric.float.python
-      captures:
-        1: punctuation.separator.decimal.python
-    - match: \b(?i)(?:{{digitpart}}(?:(\.){{digitpart}}?)?|(\.){{digitpart}})(?:e[\-\+]?{{digitpart}}) # mandatory exponent
-      scope: constant.numeric.float.python
+    - match: |-
+        (?x:
+                          (\.) {{digit}}  {{exponent}}? |
+          \b{{digit}} (?: (\.) {{digit}}? {{exponent}}? | {{exponent}} )
+        )
+      scope: constant.numeric.float.decimal.python
       captures:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python
-    - match: (?i){{digitpart}}(\.) # mandatory digitpart
-      scope: constant.numeric.float.python
-      captures:
-        1: punctuation.separator.decimal.python
     # integer
     - match: \b(?i)(?:[1-9]\d*|0)(L)\b # py2
       scope: constant.numeric.integer.long.decimal.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -33,7 +33,7 @@ variables:
   identifier_continue: '[[:alnum:]_]'
   identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
   identifier_constant: '\b(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
-  digit: (?:\d(?:_?\d)*)
+  digit: (?:\d+(?:_\d+)*)
   exponent: (?:[Ee][-+]?{{digit}})
   path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -422,7 +422,7 @@ contexts:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
     # hexadecimal
     - match: \b(?i)(0x)\h*(L) # py2
-      scope: constant.numeric.integer.long.hexadecimal.python
+      scope: constant.numeric.integer.hexadecimal.python
       captures:
         1: punctuation.definition.numeric.hexadecimal.python
         2: storage.type.numeric.long.python
@@ -432,7 +432,7 @@ contexts:
         1: punctuation.definition.numeric.hexadecimal.python
     # octal
     - match: \b(?i)(0o?)(?=o|[0-7])[0-7]*(L) # py2
-      scope: constant.numeric.integer.long.octal.python
+      scope: constant.numeric.integer.octal.python
       captures:
         1: punctuation.definition.integer.octal.python
         2: storage.type.numeric.long.python
@@ -446,7 +446,7 @@ contexts:
         1: punctuation.definition.numeric.octal.python
     # binary
     - match: \b(?i)(0b)[01]*(L) # py2
-      scope: constant.numeric.integer.long.binary.python
+      scope: constant.numeric.integer.binary.python
       captures:
         1: punctuation.definition.numeric.binary.python
         2: storage.type.numeric.long.python
@@ -477,7 +477,7 @@ contexts:
         2: punctuation.separator.decimal.python
     # integer
     - match: \b(?i)(?:[1-9]\d*|0)(L)\b # py2
-      scope: constant.numeric.integer.long.decimal.python
+      scope: constant.numeric.integer.decimal.python
       captures:
         1: storage.type.numeric.long.python
     - match: \b(?i)([1-9][\d_]*|0)\b

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1199,13 +1199,13 @@ decimal = 1234567890 + 9876543210L + -1 + -42L * 0000
 #                                                ^^^^ constant.numeric.integer
 
 floating = 0.1 - .1 * 10e-20 - 0.0e2 % 2.
-#          ^^^ constant.numeric.float.python
+#          ^^^ constant.numeric.float.decimal.python
 #                ^ punctuation.separator.decimal.python
-#                ^^ constant.numeric.float.python
-#                     ^^^^^^ constant.numeric.float.python
+#                ^^ constant.numeric.float.decimal.python
+#                     ^^^^^^ constant.numeric.float.decimal.python
 #                               ^ punctuation.separator.decimal.python
-#                              ^^^^^ constant.numeric.float.python
-#                                      ^^ constant.numeric.float.python
+#                              ^^^^^ constant.numeric.float.decimal.python
+#                                      ^^ constant.numeric.float.decimal.python
 #                                       ^ punctuation.separator.decimal.python
 
 binary = 0b1010011 | 0b0110110L
@@ -1253,17 +1253,17 @@ illegal = 1LL << 08 | 0b010203 | 0xAbraCadabra
 #                                    ^^^^^^^^^ - constant.numeric
 
 amount = 10_000_000.0_2e2_0 + .e2 + 2_2._2
-#        ^^^^^^^^^^^^^^^^^^ constant.numeric.float
+#        ^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal.python
 #                  ^ punctuation.separator.decimal.python
 #                             ^^^ - constant
 #                                       ^^ - constant
 
 very_complex = 23_2.2e2_0J + 2_1j
-#              ^^^^^^^^^^^ constant.numeric.complex.python
+#              ^^^^^^^^^^^ constant.numeric.complex.imaginary.python
 #                  ^ punctuation.separator.decimal.python
-#                            ^^^^ constant.numeric.complex.python
-#                        ^ storage.type.numeric.complex.python
-#                               ^ storage.type.numeric.complex.python
+#                            ^^^^ constant.numeric.complex.imaginary.python
+#                        ^ storage.type.numeric.imaginary.python
+#                               ^ storage.type.numeric.imaginary.python
 
 addr = 0xCAFE_F00D
 #      ^^^^^^^^^^^ constant.numeric

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1259,9 +1259,9 @@ amount = 10_000_000.0_2e2_0 + .e2 + 2_2._2
 #                                       ^^ - constant
 
 very_complex = 23_2.2e2_0J + 2_1j
-#              ^^^^^^^^^^^ constant.numeric.complex.imaginary.python
+#              ^^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.python
 #                  ^ punctuation.separator.decimal.python
-#                            ^^^^ constant.numeric.complex.imaginary.python
+#                            ^^^^ constant.numeric.complex.imaginary.decimal.python
 #                        ^ storage.type.numeric.imaginary.python
 #                               ^ storage.type.numeric.imaginary.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1259,9 +1259,9 @@ amount = 10_000_000.0_2e2_0 + .e2 + 2_2._2
 #                                       ^^ - constant
 
 very_complex = 23_2.2e2_0J + 2_1j
-#              ^^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.python
+#              ^^^^^^^^^^^ constant.numeric.imaginary.decimal.python
 #                  ^ punctuation.separator.decimal.python
-#                            ^^^^ constant.numeric.complex.imaginary.decimal.python
+#                            ^^^^ constant.numeric.imaginary.decimal.python
 #                        ^ storage.type.numeric.imaginary.python
 #                               ^ storage.type.numeric.imaginary.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1191,7 +1191,7 @@ raise KeyError() from z
 
 decimal = 1234567890 + 9876543210L + -1 + -42L * 0000
 #         ^^^^^^^^^^ constant.numeric.integer.decimal.python
-#                      ^^^^^^^^^^^ constant.numeric.integer.long.decimal.python
+#                      ^^^^^^^^^^^ constant.numeric.integer.decimal.python
 #                                ^ storage.type.numeric.long.python
 #                                    ^ keyword.operator.arithmetic.python - constant.numeric
 #                                         ^ keyword.operator.arithmetic.python - constant.numeric
@@ -1211,7 +1211,7 @@ floating = 0.1 - .1 * 10e-20 - 0.0e2 % 2.
 binary = 0b1010011 | 0b0110110L
 #        ^^^^^^^^^ constant.numeric.integer.binary.python
 #        ^^ punctuation.definition.numeric.binary.python
-#                    ^^^^^^^^^^ constant.numeric.integer.long.binary.python
+#                    ^^^^^^^^^^ constant.numeric.integer.binary.python
 #                    ^^ punctuation.definition.numeric.binary.python
 #                             ^ storage.type.numeric.long.python
 
@@ -1219,7 +1219,7 @@ octal = 0o755 ^ 0o644L
 #       ^^^^^ constant.numeric.integer.octal.python
 #       ^^ punctuation.definition.numeric.octal.python
 #                    ^ storage.type.numeric.long.python
-#               ^^^^^^ constant.numeric.integer.long.octal.python
+#               ^^^^^^ constant.numeric.integer.octal.python
 #               ^^ punctuation.definition.integer.octal.python
 
 old_style_octal = 010 + 007 - 012345670L
@@ -1227,14 +1227,14 @@ old_style_octal = 010 + 007 - 012345670L
 #                 ^ punctuation.definition.numeric.octal.python
 #                       ^^^ constant.numeric.integer.octal.python
 #                       ^ punctuation.definition.numeric.octal.python
-#                             ^^^^^^^^^^ constant.numeric.integer.long.octal.python
+#                             ^^^^^^^^^^ constant.numeric.integer.octal.python
 #                             ^ punctuation.definition.integer.octal.python
 #                                      ^ storage.type.numeric.long.python
 
 hexadecimal = 0x100af - 0XDEADF00L
 #             ^^^^^^^ constant.numeric.integer.hexadecimal.python
 #             ^^ punctuation.definition.numeric.hexadecimal.python
-#                       ^^^^^^^^^^ constant.numeric.integer.long.hexadecimal.python
+#                       ^^^^^^^^^^ constant.numeric.integer.hexadecimal.python
 #                       ^^ punctuation.definition.numeric.hexadecimal.python
 #                                ^ storage.type.numeric.long.python
 
@@ -1243,7 +1243,7 @@ unintuitive = 0B101 + 0O101 + 10l
 #             ^^ punctuation.definition.numeric.binary.python
 #                     ^^^^^ constant.numeric.integer.octal.python
 #                     ^^ punctuation.definition.numeric.octal.python
-#                             ^^^ constant.numeric.integer.long.decimal.python
+#                             ^^^ constant.numeric.integer.decimal.python
 #                               ^ storage.type.numeric.long.python
 
 illegal = 1LL << 08 | 0b010203 | 0xAbraCadabra

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1192,10 +1192,10 @@ raise KeyError() from z
 decimal = 1234567890 + 9876543210L + -1 + -42L * 0000
 #         ^^^^^^^^^^ constant.numeric.integer.decimal.python
 #                      ^^^^^^^^^^^ constant.numeric.integer.decimal.python
-#                                ^ storage.type.numeric.long.python
+#                                ^ storage.type.numeric.python
 #                                    ^ keyword.operator.arithmetic.python - constant.numeric
 #                                         ^ keyword.operator.arithmetic.python - constant.numeric
-#                                            ^ storage.type.numeric.long.python
+#                                            ^ storage.type.numeric.python
 #                                                ^^^^ constant.numeric.integer
 
 floating = 0.1 - .1 * 10e-20 - 0.0e2 % 2.
@@ -1213,12 +1213,12 @@ binary = 0b1010011 | 0b0110110L
 #        ^^ punctuation.definition.numeric.binary.python
 #                    ^^^^^^^^^^ constant.numeric.integer.binary.python
 #                    ^^ punctuation.definition.numeric.binary.python
-#                             ^ storage.type.numeric.long.python
+#                             ^ storage.type.numeric.python
 
 octal = 0o755 ^ 0o644L
 #       ^^^^^ constant.numeric.integer.octal.python
 #       ^^ punctuation.definition.numeric.octal.python
-#                    ^ storage.type.numeric.long.python
+#                    ^ storage.type.numeric.python
 #               ^^^^^^ constant.numeric.integer.octal.python
 #               ^^ punctuation.definition.integer.octal.python
 
@@ -1229,14 +1229,14 @@ old_style_octal = 010 + 007 - 012345670L
 #                       ^ punctuation.definition.numeric.octal.python
 #                             ^^^^^^^^^^ constant.numeric.integer.octal.python
 #                             ^ punctuation.definition.integer.octal.python
-#                                      ^ storage.type.numeric.long.python
+#                                      ^ storage.type.numeric.python
 
 hexadecimal = 0x100af - 0XDEADF00L
 #             ^^^^^^^ constant.numeric.integer.hexadecimal.python
 #             ^^ punctuation.definition.numeric.hexadecimal.python
 #                       ^^^^^^^^^^ constant.numeric.integer.hexadecimal.python
 #                       ^^ punctuation.definition.numeric.hexadecimal.python
-#                                ^ storage.type.numeric.long.python
+#                                ^ storage.type.numeric.python
 
 unintuitive = 0B101 + 0O101 + 10l
 #             ^^^^^ constant.numeric.integer.binary.python
@@ -1244,7 +1244,7 @@ unintuitive = 0B101 + 0O101 + 10l
 #                     ^^^^^ constant.numeric.integer.octal.python
 #                     ^^ punctuation.definition.numeric.octal.python
 #                             ^^^ constant.numeric.integer.decimal.python
-#                               ^ storage.type.numeric.long.python
+#                               ^ storage.type.numeric.python
 
 illegal = 1LL << 08 | 0b010203 | 0xAbraCadabra
 #           ^ - constant.numeric
@@ -1262,8 +1262,8 @@ very_complex = 23_2.2e2_0J + 2_1j
 #              ^^^^^^^^^^^ constant.numeric.imaginary.decimal.python
 #                  ^ punctuation.separator.decimal.python
 #                            ^^^^ constant.numeric.imaginary.decimal.python
-#                        ^ storage.type.numeric.imaginary.python
-#                               ^ storage.type.numeric.imaginary.python
+#                        ^ storage.type.numeric.python
+#                               ^ storage.type.numeric.python
 
 addr = 0xCAFE_F00D
 #      ^^^^^^^^^^^ constant.numeric


### PR DESCRIPTION
This PR proposes to ...

1. rename some scope names to comply with the recent changes to the scope naming guidelines.
2. merges the float and imaginary match rules in order to improve parsing performance by about 14%. The solution is borrowed from Perl and adapted to Python.

EDIT:

Another banchmark even shows up to 30% improvement. The test case consists of some more complicated numbers.

```
12_34_5.1_23_45e+10 12_34_5.1_23_45e+10 12_34_5.1_23_45e+10 12_34_5.1_23_45e+10
```
