### PR TITLE
[R] Improve numbers

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -45,13 +45,13 @@ contexts:
       scope: constant.language.r
     # complex imaginary
     - match: \b(0[xX])\h+(?:(i)|(I))\b
-      scope: constant.numeric.complex.imaginary.hexadecimal.r
+      scope: constant.numeric.imaginary.hexadecimal.r
       captures:
         1: punctuation.definition.numeric.hexadecimal.r
         2: storage.type.numeric.imaginary.r
         3: invalid.illegal.numeric.imaginary.r
     - match: (?:(\.)\d+|\b\d+(\.)?\d*){{exponent}}?(?:(i)|(I))\b
-      scope: constant.numeric.complex.imaginary.decimal.r
+      scope: constant.numeric.imaginary.decimal.r
       captures:
         1: punctuation.separator.decimal.r
         2: punctuation.separator.decimal.r

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -11,6 +11,7 @@ file_extensions:
 scope: source.r
 
 variables:
+  exponent: (?:[eE][-+]?\d+)
   var: '(?:[a-zA-Z._][a-zA-Z0-9._]*|`[^`]+`)'
 
 contexts:
@@ -42,22 +43,49 @@ contexts:
       scope: support.constant.misc.r
     - match: \b(TRUE|FALSE|NULL|NA|NA_integer_|NA_real_|NA_complex_|NA_character_|Inf|NaN)\b
       scope: constant.language.r
-    - match: \b0(x|X)[0-9a-fA-F]+i\b
-      scope: constant.numeric.imaginary.hexadecimal.r
-    - match: \b[0-9]+\.?[0-9]*(?:(e|E)(\+|-)?[0-9]+)?i\b
-      scope: constant.numeric.imaginary.decimal.r
-    - match: \.[0-9]+(?:(e|E)(\+|-)?[0-9]+)?i\b
-      scope: constant.numeric.imaginary.decimal.r
-    - match: \b0(x|X)[0-9a-fA-F]+L\b
+    # complex imaginary
+    - match: \b(0[xX])\h+(?:(i)|(I))\b
+      scope: constant.numeric.complex.imaginary.hexadecimal.r
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.r
+        2: storage.type.numeric.imaginary.r
+        3: invalid.illegal.numeric.imaginary.r
+    - match: (?:(\.)\d+|\b\d+(\.)?\d*){{exponent}}?(?:(i)|(I))\b
+      scope: constant.numeric.complex.imaginary.decimal.r
+      captures:
+        1: punctuation.separator.decimal.r
+        2: punctuation.separator.decimal.r
+        3: storage.type.numeric.imaginary.r
+        4: invalid.illegal.numeric.imaginary.r
+    # integers
+    - match: \b(0[xX])\h+(?:(L)|(l))\b
       scope: constant.numeric.integer.hexadecimal.r
-    - match: \b(?:[0-9]+\.?[0-9]*)L\b
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.r
+        2: storage.type.numeric.integer.r
+        3: invalid.illegal.numeric.integer.r
+    - match: \b\d+(\.)?\d*(?:(L)|(l))\b
       scope: constant.numeric.integer.decimal.r
-    - match: \b0(x|X)[0-9a-fA-F]+\b
+      captures:
+        1: punctuation.separator.decimal.r
+        2: storage.type.numeric.integer.r
+        3: invalid.illegal.numeric.integer.r
+    # floats
+    - match: \b(0[xX])\h+\b
       scope: constant.numeric.float.hexadecimal.r
-    - match: \b[0-9]+\.?[0-9]*(?:(e|E)(\+|-)?[0-9]+)?\b
+      captures:
+        1: punctuation.definition.numeric.hexadecimal.r
+    - match: |-
+        (?x:
+          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1, 1e1, 1e-1
+          \b\d+ (?: (\.) (?: \d* {{exponent}}? \b )? | {{exponent}}? \b )
+          # .1, .1e1, .1e-1
+          | (\.) \d+ {{exponent}}? \b
+        )
       scope: constant.numeric.float.decimal.r
-    - match: \.[0-9]+(?:(e|E)(\+|-)?[0-9]+)?\b
-      scope: constant.numeric.float.decimal.r
+      captures:
+        1: punctuation.separator.decimal.r
+        2: punctuation.separator.decimal.r
 
   general-variables:
     - match: '{{var}}'

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -48,28 +48,28 @@ contexts:
       scope: constant.numeric.imaginary.hexadecimal.r
       captures:
         1: punctuation.definition.numeric.hexadecimal.r
-        2: storage.type.numeric.imaginary.r
-        3: invalid.illegal.numeric.imaginary.r
+        2: storage.type.numeric.r
+        3: invalid.illegal.numeric.r
     - match: (?:(\.)\d+|\b\d+(\.)?\d*){{exponent}}?(?:(i)|(I))\b
       scope: constant.numeric.imaginary.decimal.r
       captures:
         1: punctuation.separator.decimal.r
         2: punctuation.separator.decimal.r
-        3: storage.type.numeric.imaginary.r
-        4: invalid.illegal.numeric.imaginary.r
+        3: storage.type.numeric.r
+        4: invalid.illegal.numeric.r
     # integers
     - match: \b(0[xX])\h+(?:(L)|(l))\b
       scope: constant.numeric.integer.hexadecimal.r
       captures:
         1: punctuation.definition.numeric.hexadecimal.r
-        2: storage.type.numeric.integer.r
-        3: invalid.illegal.numeric.integer.r
+        2: storage.type.numeric.r
+        3: invalid.illegal.numeric.r
     - match: \b\d+(\.)?\d*(?:(L)|(l))\b
       scope: constant.numeric.integer.decimal.r
       captures:
         1: punctuation.separator.decimal.r
-        2: storage.type.numeric.integer.r
-        3: invalid.illegal.numeric.integer.r
+        2: storage.type.numeric.r
+        3: invalid.illegal.numeric.r
     # floats
     - match: \b(0[xX])\h+\b
       scope: constant.numeric.float.hexadecimal.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -40,94 +40,94 @@ NaN
   0x1afi
 # ^^ punctuation.definition.numeric.hexadecimal.r
 # ^^^^^^ constant.numeric.imaginary.hexadecimal.r
-#      ^ storage.type.numeric.imaginary.r
+#      ^ storage.type.numeric.r
 
   0X1afi 0X1afI
 # ^^ punctuation.definition.numeric.hexadecimal.r
 # ^^^^^^ constant.numeric.imaginary.hexadecimal.r
-#      ^ storage.type.numeric.imaginary.r
+#      ^ storage.type.numeric.r
 #        ^^ punctuation.definition.numeric.hexadecimal.r
 #        ^^^^^^ constant.numeric.imaginary.hexadecimal.r
-#             ^ invalid.illegal.numeric.imaginary.r
+#             ^ invalid.illegal.numeric.r
 
   12i 12I
 # ^^^ constant.numeric.imaginary.decimal.r
-#   ^ storage.type.numeric.imaginary.r
+#   ^ storage.type.numeric.r
 #     ^^^ constant.numeric.imaginary.decimal.r
-#       ^ invalid.illegal.numeric.imaginary.r
+#       ^ invalid.illegal.numeric.r
 
   12.i 12.I
 # ^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#    ^ storage.type.numeric.imaginary.r
+#    ^ storage.type.numeric.r
 #      ^^^^ constant.numeric.imaginary.decimal.r
 #        ^ punctuation.separator.decimal.r
-#         ^ invalid.illegal.numeric.imaginary.r
+#         ^ invalid.illegal.numeric.r
 
   .345i
 # ^^^^^ constant.numeric.imaginary.decimal.r
 # ^ punctuation.separator.decimal.r
-#     ^ storage.type.numeric.imaginary.r
+#     ^ storage.type.numeric.r
 
   12.34e-12i
 # ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#          ^ storage.type.numeric.imaginary.r
+#          ^ storage.type.numeric.r
 
   12.34E-12i
 # ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#          ^ storage.type.numeric.imaginary.r
+#          ^ storage.type.numeric.r
 
   12.34e+12i
 # ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#          ^ storage.type.numeric.imaginary.r
+#          ^ storage.type.numeric.r
 
   12.34E+12i
 # ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#          ^ storage.type.numeric.imaginary.r
+#          ^ storage.type.numeric.r
 
   12.3456i 12.3456I
 # ^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
-#        ^ storage.type.numeric.imaginary.r
+#        ^ storage.type.numeric.r
 #          ^^^^^^^^ constant.numeric.imaginary.decimal.r
 #            ^ punctuation.separator.decimal.r
-#                 ^ invalid.illegal.numeric.imaginary.r
+#                 ^ invalid.illegal.numeric.r
 
 # integers
 
   0x1afL 0x1afl 0x1afx
 # ^^ punctuation.definition.numeric.hexadecimal.r
 # ^^^^^^ constant.numeric.integer.hexadecimal.r
-#      ^ storage.type.numeric.integer.r
+#      ^ storage.type.numeric.r
 #        ^^ punctuation.definition.numeric.hexadecimal.r
 #        ^^^^^^ constant.numeric.integer.hexadecimal.r
-#             ^ invalid.illegal.numeric.integer.r
+#             ^ invalid.illegal.numeric.r
 #               ^^^^^^ - constant
 
   0X1afL
 # ^^ punctuation.definition.numeric.hexadecimal.r
 # ^^^^^^ constant.numeric.integer.hexadecimal.r
-#      ^ storage.type.numeric.integer.r
+#      ^ storage.type.numeric.r
 
   12L 12l
 # ^^^ constant.numeric.integer.decimal.r
-#   ^ storage.type.numeric.integer.r
+#   ^ storage.type.numeric.r
 #     ^^^ constant.numeric.integer.decimal.r
-#       ^ invalid.illegal.numeric.integer.r
+#       ^ invalid.illegal.numeric.r
 
   12.L
 # ^^^^ constant.numeric.integer.decimal.r
 #   ^ punctuation.separator.decimal.r
-#    ^ storage.type.numeric.integer.r
+#    ^ storage.type.numeric.r
 
   12.000L
 # ^^^^^^^ constant.numeric.integer.decimal.r
 #   ^ punctuation.separator.decimal.r
-#       ^ storage.type.numeric.integer.r
+#       ^ storage.type.numeric.r
 
 # floats
 

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -39,61 +39,61 @@ NaN
 
   0x1afi
 # ^^ punctuation.definition.numeric.hexadecimal.r
-# ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+# ^^^^^^ constant.numeric.imaginary.hexadecimal.r
 #      ^ storage.type.numeric.imaginary.r
 
   0X1afi 0X1afI
 # ^^ punctuation.definition.numeric.hexadecimal.r
-# ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+# ^^^^^^ constant.numeric.imaginary.hexadecimal.r
 #      ^ storage.type.numeric.imaginary.r
 #        ^^ punctuation.definition.numeric.hexadecimal.r
-#        ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+#        ^^^^^^ constant.numeric.imaginary.hexadecimal.r
 #             ^ invalid.illegal.numeric.imaginary.r
 
   12i 12I
-# ^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^ constant.numeric.imaginary.decimal.r
 #   ^ storage.type.numeric.imaginary.r
-#     ^^^ constant.numeric.complex.imaginary.decimal.r
+#     ^^^ constant.numeric.imaginary.decimal.r
 #       ^ invalid.illegal.numeric.imaginary.r
 
   12.i 12.I
-# ^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #    ^ storage.type.numeric.imaginary.r
-#      ^^^^ constant.numeric.complex.imaginary.decimal.r
+#      ^^^^ constant.numeric.imaginary.decimal.r
 #        ^ punctuation.separator.decimal.r
 #         ^ invalid.illegal.numeric.imaginary.r
 
   .345i
-# ^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^ constant.numeric.imaginary.decimal.r
 # ^ punctuation.separator.decimal.r
 #     ^ storage.type.numeric.imaginary.r
 
   12.34e-12i
-# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #          ^ storage.type.numeric.imaginary.r
 
   12.34E-12i
-# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #          ^ storage.type.numeric.imaginary.r
 
   12.34e+12i
-# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #          ^ storage.type.numeric.imaginary.r
 
   12.34E+12i
-# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #          ^ storage.type.numeric.imaginary.r
 
   12.3456i 12.3456I
-# ^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^^^^^^^^ constant.numeric.imaginary.decimal.r
 #   ^ punctuation.separator.decimal.r
 #        ^ storage.type.numeric.imaginary.r
-#          ^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#          ^^^^^^^^ constant.numeric.imaginary.decimal.r
 #            ^ punctuation.separator.decimal.r
 #                 ^ invalid.illegal.numeric.imaginary.r
 

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -35,65 +35,146 @@ Inf
 NaN
 # <- constant.language.r
 
-  12L
+# complex imaginary
+
+  0x1afi
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+#      ^ storage.type.numeric.imaginary.r
+
+  0X1afi 0X1afI
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+#      ^ storage.type.numeric.imaginary.r
+#        ^^ punctuation.definition.numeric.hexadecimal.r
+#        ^^^^^^ constant.numeric.complex.imaginary.hexadecimal.r
+#             ^ invalid.illegal.numeric.imaginary.r
+
+  12i 12I
+# ^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ storage.type.numeric.imaginary.r
+#     ^^^ constant.numeric.complex.imaginary.decimal.r
+#       ^ invalid.illegal.numeric.imaginary.r
+
+  12.i 12.I
+# ^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#    ^ storage.type.numeric.imaginary.r
+#      ^^^^ constant.numeric.complex.imaginary.decimal.r
+#        ^ punctuation.separator.decimal.r
+#         ^ invalid.illegal.numeric.imaginary.r
+
+  .345i
+# ^^^^^ constant.numeric.complex.imaginary.decimal.r
+# ^ punctuation.separator.decimal.r
+#     ^ storage.type.numeric.imaginary.r
+
+  12.34e-12i
+# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#          ^ storage.type.numeric.imaginary.r
+
+  12.34E-12i
+# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#          ^ storage.type.numeric.imaginary.r
+
+  12.34e+12i
+# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#          ^ storage.type.numeric.imaginary.r
+
+  12.34E+12i
+# ^^^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#          ^ storage.type.numeric.imaginary.r
+
+  12.3456i 12.3456I
+# ^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#   ^ punctuation.separator.decimal.r
+#        ^ storage.type.numeric.imaginary.r
+#          ^^^^^^^^ constant.numeric.complex.imaginary.decimal.r
+#            ^ punctuation.separator.decimal.r
+#                 ^ invalid.illegal.numeric.imaginary.r
+
+# integers
+
+  0x1afL 0x1afl 0x1afx
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^^ constant.numeric.integer.hexadecimal.r
+#      ^ storage.type.numeric.integer.r
+#        ^^ punctuation.definition.numeric.hexadecimal.r
+#        ^^^^^^ constant.numeric.integer.hexadecimal.r
+#             ^ invalid.illegal.numeric.integer.r
+#               ^^^^^^ - constant
+
+  0X1afL
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^^ constant.numeric.integer.hexadecimal.r
+#      ^ storage.type.numeric.integer.r
+
+  12L 12l
 # ^^^ constant.numeric.integer.decimal.r
+#   ^ storage.type.numeric.integer.r
+#     ^^^ constant.numeric.integer.decimal.r
+#       ^ invalid.illegal.numeric.integer.r
+
+  12.L
+# ^^^^ constant.numeric.integer.decimal.r
+#   ^ punctuation.separator.decimal.r
+#    ^ storage.type.numeric.integer.r
+
+  12.000L
+# ^^^^^^^ constant.numeric.integer.decimal.r
+#   ^ punctuation.separator.decimal.r
+#       ^ storage.type.numeric.integer.r
+
+# floats
+
+  0x1af
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^ constant.numeric.float.hexadecimal.r
+
+  0X1af
+# ^^ punctuation.definition.numeric.hexadecimal.r
+# ^^^^^ constant.numeric.float.hexadecimal.r
 
   12
 # ^^ constant.numeric.float.decimal.r
 
-  0x1afL
-# ^^^^^^ constant.numeric.integer.hexadecimal.r
+  12.
+# ^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
-  0X1afL
-# ^^^^^^ constant.numeric.integer.hexadecimal.r
+  .3456
+# ^ punctuation.separator.decimal.r
+# ^^^^^ constant.numeric.float.decimal.r
 
-  0x1af
-# ^^^^^ constant.numeric.float.hexadecimal.r
-
-  0X1af
-# ^^^^^ constant.numeric.float.hexadecimal.r
-
-  99.99e-12
-# ^^^^^^^^^ constant.numeric.float.decimal.r
-
-  99.99E-12
-# ^^^^^^^^^ constant.numeric.float.decimal.r
-
-  99.99e+12
-# ^^^^^^^^^ constant.numeric.float.decimal.r
-
-  99.99E+12
-# ^^^^^^^^^ constant.numeric.float.decimal.r
-
-  99.9999
+  12.3456
 # ^^^^^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
- .9999
-# ^^^^ constant.numeric.float.decimal.r
+  12.34e-12
+# ^^^^^^^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
-  12i
-# ^^^ constant.numeric.imaginary.decimal.r
+  12.34E-12
+# ^^^^^^^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
-  0x1afi
-# ^^^^^^ constant.numeric.imaginary.hexadecimal.r
+  12.34e+12
+# ^^^^^^^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
-  0x1afi
-# ^^^^^^ constant.numeric.imaginary.hexadecimal.r
+  12.34E+12
+# ^^^^^^^^^ constant.numeric.float.decimal.r
+#   ^ punctuation.separator.decimal.r
 
-  99.99e-12i
-# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
+  12e34
+# ^^^^^ constant.numeric.float.decimal.r
 
-  99.99E-12i
-# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
-
-  99.99e+12i
-# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
-
-  99.99E+12i
-# ^^^^^^^^^^ constant.numeric.imaginary.decimal.r
-
-  99.9999i
-# ^^^^^^^^ constant.numeric.imaginary.decimal.r
+  12e-34
+# ^^^^^^ constant.numeric.float.decimal.r
 
   %*% %/% %% %o% %x% %:% %+%
 # ^^^ keyword.operator.arithmetic.r


### PR DESCRIPTION
This commit ...

1. adds punctuation scopes to numbers.
2. renames the imaginary numbers to `constant.numeric.complex.imaginary`
3. merges some rules to compensate performance impacts caused by the added capture groups required for (1).
4. makes use of character classes where appropriate (e.g.: [eE] )
5. removes some unnecessary escapes (e.g. (\+\-) => [-+])
6. adds a couple of test cases for the different types of numbers