### PR TITLE
[RestructuredText] Improve handling of directives, verbatim, and comments

### DIFF
--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -24,10 +24,6 @@ contexts:
         4: punctuation.separator.key-value.restructuredtext
       push:
         - match: '^(?!\1[ \t])'
-          captures:
-            2: meta.directive.restructuredtext
-            3: punctuation.definition.directive.restructuredtext
-            4: punctuation.separator.key-value.restructuredtext
           pop: true
         - include: scope:text.html.basic
     - match: '(\.\.)\s[A-z][A-z0-9-_]+(::)\s*$'
@@ -44,9 +40,6 @@ contexts:
       push:
         - meta_scope: meta.raw.block.restructuredtext
         - match: '^(?=\1[^\s]+)'
-          captures:
-            2: markup.raw.restructuredtext
-            3: punctuation.definition.raw.restructuredtext
           pop: true
         - match: .+
           scope: markup.raw.restructuredtext

--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -16,7 +16,7 @@ contexts:
           pop: true
         - include: inline
   inline:
-    - match: '^(\s*)((\.\.)\sraw(::)) html'
+    - match: '^(\s*)((\.\.)\s+raw(::)) html'
       comment: directives.html
       captures:
         2: meta.directive.restructuredtext
@@ -27,7 +27,7 @@ contexts:
           pop: true
         - meta_content_scope: text.html.basic
         - include: scope:text.html.basic
-    - match: '^(\s*)((\.\.)\s[A-z][A-z0-9\-_]+(::))\s*'
+    - match: '^(\s*)((\.\.)\s+[A-z][A-z0-9\-_]+(::))\s*'
       comment: directives
       captures:
         2: meta.other.directive.restructuredtext

--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -9,37 +9,42 @@ file_extensions:
 scope: text.restructuredtext
 contexts:
   main:
-    - match: '^([ \t]*)(?=\S)'
+    - match: '^(?=(\s*)\S)'
       push:
         - meta_content_scope: meta.paragraph.restructuredtext
         - match: ^(?!\1(?=\S))
           pop: true
         - include: inline
   inline:
-    - match: '^([ \t]*)((\.\.)\sraw(::)) html'
+    - match: '^(\s*)((\.\.)\sraw(::)) html'
       comment: directives.html
       captures:
         2: meta.directive.restructuredtext
         3: punctuation.definition.directive.restructuredtext
         4: punctuation.separator.key-value.restructuredtext
       push:
-        - match: '^(?!\1[ \t])'
+        - match: '^(?!\1\s+)(?=\s*\S+)'
           pop: true
+        - meta_content_scope: text.html.basic
         - include: scope:text.html.basic
-    - match: '(\.\.)\s[A-z][A-z0-9-_]+(::)\s*$'
+    - match: '^(\s*)((\.\.)\s[A-z][A-z0-9\-_]+(::))\s*'
       comment: directives
-      scope: meta.other.directive.restructuredtext
       captures:
-        1: punctuation.definition.directive.restructuredtext
-        2: punctuation.separator.key-value.restructuredtext
-    - match: '^([ \t]*).*?((::))'
+        2: meta.other.directive.restructuredtext
+        3: punctuation.definition.directive.restructuredtext
+        4: punctuation.separator.key-value.restructuredtext
+      push:
+        - match: '^(?!\1\s+)(?=\s*\S+)'
+          pop: true
+        - include: inline
+    - match: '^(\s*).*?((::))'
       comment: verbatim blocks
       captures:
         2: markup.raw.restructuredtext
         3: punctuation.definition.raw.restructuredtext
       push:
         - meta_scope: meta.raw.block.restructuredtext
-        - match: '^(?=\1[^\s]+)'
+        - match: '^(?!\1\s+)(?=\s*\S+)'
           pop: true
         - match: .+
           scope: markup.raw.restructuredtext
@@ -183,11 +188,11 @@ contexts:
       scope: markup.heading.restructuredtext
       captures:
         1: punctuation.definition.heading.restructuredtext
-    - match: ^(\.\.)
+    - match: ^(\s*)(\.\.)
       comment: comment
       captures:
-        1: punctuation.definition.comment.restructuredtext
+        2: punctuation.definition.comment.restructuredtext
       push:
         - meta_scope: comment.line.double-dot.restructuredtext
-        - match: '^(?=\S)'
+        - match: '^(?!\1\s+)(?=\s*\S+)'
           pop: true

--- a/RestructuredText/syntax_test_restructuredtext.rst
+++ b/RestructuredText/syntax_test_restructuredtext.rst
@@ -13,6 +13,13 @@
 ..
   a multi-line comment ends at the first character in the
   first column
+This is not a comment
+.. <- meta.paragraph.restructuredtext
+
+.. multi line comments can contain blank lines.
+
+ These are still part of the comment if they're indented.
+.. <- comment.line.double-dot.restructuredtext
 
 Some text
 .. <- meta.paragraph.restructuredtext
@@ -60,3 +67,69 @@ This is *italic*.
 
 this is **bold**.
 ..      ^^^^^^^^ markup.bold.restructuredtext
+
+
+Directive tests
+--------------
+
+.. not possible to test a multi-line directive, since comments cannot appear
+.. mid-directive
+
+.. note:: Single line note
+.. <- punctuation.definition.directive.restructuredtext
+.. ^^^^ meta.other.directive.restructuredtext
+..     ^^ punctuation.separator.key-value.restructuredtext
+
+.. note::
+
+    Outer note
+
+    .. note:: inner Single line note
+    .. <- punctuation.definition.directive.restructuredtext
+    .. ^^^^ meta.other.directive.restructuredtext
+    ..     ^^ punctuation.separator.key-value.restructuredtext
+
+
+Verbatim tests
+--------------
+
+::
+
+    Verbatim
+..  ^^^^^^^^ meta.raw.block.restructuredtext
+
+Can start with other text::
+
+    Verbatim
+..  ^^^^^^^^ meta.raw.block.restructuredtext
+
+.. blank lines should not cause scopes to be left
+
+::
+
+    Verbatim
+
+    Also Verbatim
+..  ^^^^^^^^^^^^^ meta.raw.block.restructuredtext
+
+::
+
+    Verbatim
+
+      Also Verbatim
+..    ^^^^^^^^^^^^^ meta.raw.block.restructuredtext
+
+
+::
+
+    Verbatim
+
+Not verbatim
+.. <- meta.paragraph.restructuredtext
+
+.. raw:: html
+    <b>
+    Blank lines are fine
+
+    </b>
+..  ^^^^ text.html.basic

--- a/RestructuredText/syntax_test_restructuredtext.rst
+++ b/RestructuredText/syntax_test_restructuredtext.rst
@@ -72,19 +72,21 @@ this is **bold**.
 Directive tests
 --------------
 
-.. not possible to test a multi-line directive, since comments cannot appear
-.. mid-directive
+.. note that comments within multiline directives must be indented, else they
+   convert the contents of that directive into a comment
 
 .. note:: Single line note
 .. <- punctuation.definition.directive.restructuredtext
 .. ^^^^ meta.other.directive.restructuredtext
 ..     ^^ punctuation.separator.key-value.restructuredtext
 
-.. note::
+..     note::
+    .. ^^^^ meta.other.directive.restructuredtext
+    ..     ^^ punctuation.separator.key-value.restructuredtext
 
     Outer note
 
-    .. note:: inner Single line note
+    .. note:: Inner single line note
     .. <- punctuation.definition.directive.restructuredtext
     .. ^^^^ meta.other.directive.restructuredtext
     ..     ^^ punctuation.separator.key-value.restructuredtext


### PR DESCRIPTION
This:
* Allows comments to start at columns other than the first
* Allows blank lines to appear in comments, directives, and verbatim blocks

---

My eventual goal here is to allow:
* Latex environments to be embedded in sphinx RsT `.. math::` blocks
* RsT blocks to be embedded in python docstrings