### PR TITLE
[Go] Templates String Updates

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -513,7 +513,7 @@ contexts:
          scope: keyword.operator.template.right.trim.go
        - match: "-\\s"
          scope: keyword.operator.template.left.trim.go
-       - match: ":="
+       - match: ":=|="
          scope: keyword.operator.assignment.go
        - match: \|
          scope: keyword.operator.template.pipe.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -529,7 +529,7 @@ contexts:
          scope: variable.other.template.go
        - match: \b(if|else|range|template|with|end|nil|define|block)\b
          scope: keyword.control.go
-       - match: \b(and|call|html|index|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
+       - match: \b(and|call|html|index|slice|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
          scope: variable.function.go support.function.builtin.go
        - include: match-comments
        - include: match-strings

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2875,5 +2875,9 @@ func template() {
     //                            ^^ variable.other.template
     //                               ^ keyword.operator.template.pipe
     //                                 ^^^^^^ support.function.builtin
+    t = "{{with $x := "output"}}{{$x = "new value"}}{{$x | printf "%q"}}{{end}}"
+    //                            ^ meta.interpolation.go variable.other.template.go punctuation.definition.variable.go
+    //                             ^ meta.interpolation.go variable.other.template.go
+    //                               ^ meta.interpolation.go keyword.operator.assignment.go
     t = "{{slice x 1 2}}"
     //     ^^^^^ meta.interpolation.go variable.function.go support.function.builtin.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2875,3 +2875,5 @@ func template() {
     //                            ^^ variable.other.template
     //                               ^ keyword.operator.template.pipe
     //                                 ^^^^^^ support.function.builtin
+    t = "{{slice x 1 2}}"
+    //     ^^^^^ meta.interpolation.go variable.function.go support.function.builtin.go


### PR DESCRIPTION
Two minor updates to template strings:

- New `slice` function [added in v1.13](https://golang.org/doc/go1.13#text/template).
- Re-assignment operator `=` [added in v1.11](https://golang.org/doc/go1.11#text/template).

> *Sidebar*: I added a test for the new `slice` function. Previously the only function being tested was `printf`. If we think there's value in testing all those template functions, I can add additional tests.