### PR TITLE
[Git Formats] Match hash in commit message

### DIFF
--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -75,6 +75,8 @@ contexts:
           pop: true
         - include: Git Common.sublime-syntax#references
         - include: signed-off
+        - match: '{{hash}}'
+          scope: constant.numeric.hex.hash.git.commit
 
   signed-off:
     - match: ^\s*(Signed-off-by)\s*(:)

--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -76,7 +76,7 @@ contexts:
         - include: Git Common.sublime-syntax#references
         - include: signed-off
         - match: '{{hash}}'
-          scope: constant.numeric.hex.hash.git.commit
+          scope: constant.other.hash.git.commit
 
   signed-off:
     - match: ^\s*(Signed-off-by)\s*(:)
@@ -146,7 +146,7 @@ contexts:
       scope: meta.command-list.git.commit
       captures:
         1: keyword.operator.git.commit
-        2: constant.numeric.hex.hash.git.commit
+        2: constant.other.hash.git.commit
         3: string.unquoted.subject.git.commit
 
   date-line:

--- a/Git Formats/syntax_test_git_commit
+++ b/Git Formats/syntax_test_git_commit
@@ -124,6 +124,9 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #                                   ^ punctuation.separator.email.git
 #                                          ^ punctuation.separator.domain.git
 #                                              ^ punctuation.definition.reference.email.end.git
+  This commit references a hash: 21dde213
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                                ^^^^^^^^ constant.numeric.hex.hash.git.commit
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
 # Please enter the commit message for your changes. Lines starting

--- a/Git Formats/syntax_test_git_commit
+++ b/Git Formats/syntax_test_git_commit
@@ -126,7 +126,7 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #                                              ^ punctuation.definition.reference.email.end.git
   This commit references a hash: 21dde213
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
-#                                ^^^^^^^^ constant.numeric.hex.hash.git.commit
+#                                ^^^^^^^^ constant.other.hash.git.commit
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
 # Please enter the commit message for your changes. Lines starting
@@ -148,17 +148,17 @@ This commit applies all changes required to satisfy the JSON format unittest.
 #    squash 26b2cc6 Fix: JSON resource format errors
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command-list.git.commit
 #    ^^^^^^ keyword.operator.git.commit
-#          ^ - keyword.operator.git.commit - constant.numeric.hex.hash.git.commit
-#           ^^^^^^^ constant.numeric.hex.hash.git.commit
-#                  ^ - constant.numeric.hex.hash.git.commit - string.unquoted.subject.git.commit
+#          ^ - keyword.operator.git.commit - constant.other.hash.git.commit
+#           ^^^^^^^ constant.other.hash.git.commit
+#                  ^ - constant.other.hash.git.commit - string.unquoted.subject.git.commit
 #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.subject.git.commit
 #                                                   ^ - string.unquoted.subject.git.commit
 #    fixup 8e9e7bc fixup! Fix: JSON resource format errors
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command-list.git.commit
 #    ^^^^^ keyword.operator.git.commit
-#         ^ - keyword.operator.git.commit - constant.numeric.hex.hash.git.commit
-#          ^^^^^^^ constant.numeric.hex.hash.git.commit
-#                 ^ - constant.numeric.hex.hash.git.commit - string.unquoted.subject.git.commit
+#         ^ - keyword.operator.git.commit - constant.other.hash.git.commit
+#          ^^^^^^^ constant.other.hash.git.commit
+#                 ^ - constant.other.hash.git.commit - string.unquoted.subject.git.commit
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.subject.git.commit
 #                                                         ^ - string.unquoted.subject.git.commit
 # No commands remaining.


### PR DESCRIPTION
I feel that hashes in commit messages deserve more attention than they do now (which is none at all), because they are frequently used to cross-reference commits.

I intended to use a `variable.other.hash` scope, because that's basically what hashes are used like (as references), but we already have `constant.numeric.hex.hash.git.commit` in the syntax definition, so I didn't change that. I totally could, if people are in favor of it, however.