### PR TITLE
[RestructuredText] Add support for sphinx `math` directives and roles

### DIFF
--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -27,6 +27,17 @@ contexts:
           pop: true
         - meta_content_scope: text.html.basic
         - include: scope:text.html.basic
+    - match: '^(\s*)((\.\.)\s+math(::))\s*'
+      comment: directives.math
+      captures:
+        2: meta.directive.restructuredtext
+        3: punctuation.definition.directive.restructuredtext
+        4: punctuation.separator.key-value.restructuredtext
+      push:
+        - match: '^(?!\1\s+)(?=\s*\S+)'
+          pop: true
+        - meta_content_scope: text.tex.latex meta.environment.math.block.restructuredtext
+        - include: scope:text.tex.latex#math-content
     - match: '^(\s*)((\.\.)\s+[A-z][A-z0-9\-_]+(::))\s*'
       comment: directives
       captures:
@@ -77,6 +88,17 @@ contexts:
       scope: markup.underline.substitution.restructuredtext
       captures:
         1: punctuation.definition.substitution.restructuredtext
+    - match: (:math:)(`)
+      comment: links `...`_ or `...`__
+      captures:
+        1: support.function.role.builtin.restructuredtext
+        2: punctuation.definition.interpreted.restructuredtext
+      push:
+        - match: '`'
+          scope: punctuation.definition.interpreted.restructuredtext
+          pop: true
+        - meta_content_scope: text.tex.latex meta.environment.math.inline.restructuredtext
+        - include: scope:text.tex.latex#math-content
     - match: \b(\w+)(_)\b
       comment: links `...`_ or `...`__
       scope: meta.link.reference

--- a/RestructuredText/reStructuredText.sublime-syntax
+++ b/RestructuredText/reStructuredText.sublime-syntax
@@ -89,7 +89,7 @@ contexts:
       captures:
         1: punctuation.definition.substitution.restructuredtext
     - match: (:math:)(`)
-      comment: links `...`_ or `...`__
+      comment: embedded math-mode latex, https://docutils.sourceforge.io/docs/ref/rst/directives.html#math
       captures:
         1: support.function.role.builtin.restructuredtext
         2: punctuation.definition.interpreted.restructuredtext

--- a/RestructuredText/syntax_test_restructuredtext.rst
+++ b/RestructuredText/syntax_test_restructuredtext.rst
@@ -135,3 +135,18 @@ Not verbatim
 
     </b>
 ..  ^^^^ text.html.basic
+
+.. math::
+
+    \sum_{i=0}^N x_i^2
+..  ^^^^ text.tex.latex support.function.math.tex
+..  ^^^^^^^^^^^^^^^^^^^ text.tex.latex meta.environment.math.block.restructuredtext
+
+
+:test:
+
+   :math:`\alpha + \beta`
+.. ^^^^^^ support.function.role.builtin.restructuredtext
+..       ^ punctuation.definition.interpreted.restructuredtext
+..        ^^^^^^^^^^^^^^ text.tex.latex meta.environment.math.inline.restructuredtext
+..                      ^ punctuation.definition.interpreted.restructuredtext


### PR DESCRIPTION
These are treated as being embedded latex math of the right type (block/inline).

Notably, this makes them compatible with the inline preview rendering of the LaTeXTools plugin.

These are specifix to Sphinx, but represent:
* A frequent use case of rST
* One of the few things that `math` is likely to be defined as anyway

Notes on scope names:
- `support.function.role.builtin.restructuredtext` is a compromise between getting colored under the default highlighter while indicating the rst term for the `` :name:`text` `` construct
- `punctuation.definition.interpreted.restructuredtext` is used elsewhere in this file for backticks
- Including `text.tex.latex` as a root scope for embedded latex is enough to encourage the LaTeXTools plugin to get involved. Strictly, this would work without any syntax embedded at all, but having LaTeX highlighting feels natural here

---

To actually work for LaTeX previews, this needs https://github.com/SublimeText/LaTeXTools/pull/1438