### PR TITLE
[Rust] Swap assignment and comparison order.

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -247,11 +247,11 @@ contexts:
   operators:
     - match: \.{2,3}
       scope: keyword.operator.range.rust
-    - match: '[!<>=]=|[<>]'
-      scope: keyword.operator.comparison.rust
     - match: '(?:[-+%/*^&|]|<<|>>)?='
       scope: keyword.operator.assignment.rust
       push: after-operator
+    - match: '[!<>=]=|[<>]'
+      scope: keyword.operator.comparison.rust
     - match: '&&|\|\||!'
       scope: keyword.operator.logical.rust
     - match: '[-+%/*]'


### PR DESCRIPTION
This change fixes ligatures rendering.

Before Sublime grouped them like this <[<=], which ended up using <= ligature instead of more specific <<=.