### PR TITLE
[Ruby] Change color of %i and %I symbol array literal elements according to symbol color (#1879)

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1139,7 +1139,7 @@ contexts:
 
   late-strings:
     # literal capable of interpolation ()
-    - match: '%[QWI]?\('
+    - match: '%[QW]?\('
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
@@ -1150,7 +1150,7 @@ contexts:
         - include: escaped-char
         - include: nest-parens-i
     # "literal capable of interpolation []"
-    - match: '%[QWI]?\['
+    - match: '%[QW]?\['
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
@@ -1161,7 +1161,7 @@ contexts:
         - include: escaped-char
         - include: nest-brackets-i
     # literal capable of interpolation <>
-    - match: '%[QWI]?\<'
+    - match: '%[QW]?\<'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
@@ -1172,7 +1172,7 @@ contexts:
         - include: escaped-char
         - include: nest-ltgt-i
     # literal capable of interpolation -- {}
-    - match: '%[QWI]?\{'
+    - match: '%[QW]?\{'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.double.ruby.mod
@@ -1183,7 +1183,7 @@ contexts:
         - include: escaped-char
         - include: nest-curly-i
     # literal capable of interpolation -- wildcard
-    - match: '%[QWI]([^\w])'
+    - match: '%[QW]([^\w])'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
@@ -1202,8 +1202,72 @@ contexts:
           pop: true
         - include: interpolated-ruby
         - include: escaped-char
+    # literal capable of interpolation ()
+    - match: '%I\('
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
+        - match: \)
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - include: interpolated-ruby
+        - include: escaped-char
+        - include: nest-parens-i
+    # "literal capable of interpolation []"
+    - match: '%I\['
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
+        - match: '\]'
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - include: interpolated-ruby
+        - include: escaped-char
+        - include: nest-brackets-i
+    # literal capable of interpolation <>
+    - match: '%I\<'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
+        - match: \>
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - include: interpolated-ruby
+        - include: escaped-char
+        - include: nest-ltgt-i
+    # literal capable of interpolation -- {}
+    - match: '%I\{'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - meta_scope: meta.string.ruby string.quoted.double.ruby.mod
+        - match: '\}'
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - include: interpolated-ruby
+        - include: escaped-char
+        - include: nest-curly-i
+    # literal capable of interpolation -- wildcard
+    - match: '%I([^\w])'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - meta_scope: meta.string.ruby string.quoted.other.literal.upper.ruby
+        - match: \1
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - include: interpolated-ruby
+        - include: escaped-char
     # literal incapable of interpolation -- ()
-    - match: '%[qwsi]\('
+    - match: '%[qws]\('
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.lower.ruby
@@ -1214,7 +1278,7 @@ contexts:
           scope: constant.character.escape.ruby
         - include: nest-parens
     # literal incapable of interpolation -- <>
-    - match: '%[qwsi]\<'
+    - match: '%[qws]\<'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.lower.ruby
@@ -1225,7 +1289,7 @@ contexts:
           scope: constant.character.escape.ruby
         - include: nest-ltgt
     # literal incapable of interpolation -- []
-    - match: '%[qwsi]\['
+    - match: '%[qws]\['
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.lower.ruby
@@ -1236,7 +1300,7 @@ contexts:
           scope: constant.character.escape.ruby
         - include: nest-brackets
     # literal incapable of interpolation -- {}
-    - match: '%[qwsi]\{'
+    - match: '%[qws]\{'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.lower.ruby
@@ -1247,10 +1311,74 @@ contexts:
           scope: constant.character.escape.ruby
         - include: nest-curly
     # literal incapable of interpolation -- wildcard
-    - match: '%[qwsi]([^\w])'
+    - match: '%[qws]([^\w])'
       scope: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.ruby string.quoted.other.literal.lower.ruby
+        - match: \1
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        # Cant be named because its not necessarily an escape
+        - match: \\.
+    # symbol literal incapable of interpolation -- ()
+    - match: '%i\('
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - meta_scope: string.quoted.other.literal.lower.ruby
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - match: \)
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - match: \\\)|\\\\
+          scope: constant.character.escape.ruby
+        - include: nest-parens
+    # symbol literal incapable of interpolation -- <>
+    - match: '%i\<'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - meta_scope: string.quoted.other.literal.lower.ruby
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - match: \>
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - match: \\\>|\\\\
+          scope: constant.character.escape.ruby
+        - include: nest-ltgt
+    # symbol literal incapable of interpolation -- []
+    - match: '%i\['
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - meta_scope: string.quoted.other.literal.lower.ruby
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - match: '\]'
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - match: '\\\]|\\\\'
+          scope: constant.character.escape.ruby
+        - include: nest-brackets
+    # symbol literal incapable of interpolation -- {}
+    - match: '%i\{'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - meta_scope: string.quoted.other.literal.lower.ruby
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
+        - match: '\}'
+          scope: punctuation.definition.string.end.ruby
+          pop: true
+        - match: '\\\}|\\\\'
+          scope: constant.character.escape.ruby
+        - include: nest-curly
+    # symbol literal incapable of interpolation -- wildcard
+    - match: '%i([^\w])'
+      scope: punctuation.definition.string.begin.ruby
+      push:
+        - meta_scope: string.quoted.other.literal.lower.ruby
+        - match: '\w+'
+          scope: constant.other.symbol.ruby
         - match: \1
           scope: punctuation.definition.string.end.ruby
           pop: true

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -489,9 +489,9 @@ str = sprintf("%1$*2$s %2$d", "hello", -8)
 #      ^^^^^^^^^^^^^^^ meta.environment-variable.ruby
 #          ^^^^^^^^^^ meta.string.ruby meta.interpolation.ruby meta.string.ruby
 #                    ^^ meta.string.ruby meta.interpolation.ruby - string
-#                      ^^^^^^^ meta.string.ruby - meta.interpolation
+#                       ^^^^^ constant.other.symbol.ruby
 #                             ^^^^^^^^^^^^^^^^ meta.string.ruby meta.interpolation.ruby - string
-#                                             ^^^^^^^ meta.string.ruby - meta.interpolation
+#                                              ^^^^^^ constant.other.symbol.ruby
 # ^^^ punctuation.definition.string.begin.ruby
 # ^^^ string.quoted.other.literal.upper.ruby
 #    ^^ punctuation.section.interpolation.begin.ruby
@@ -1090,11 +1090,6 @@ class MyClass
 #         ^ support.class.ruby
 #                 ^ keyword.other.special-method.ruby
 
-  FIELDS = %i[a b c]
-# ^ meta.constant.ruby entity.name.constant.ruby
-#        ^ keyword.operator.assignment.ruby
-#          ^^^ punctuation.definition.string.begin.ruby
-#             ^^^^^ string.quoted.other.literal.lower.ruby
 
   A, B, C = :a, :b, :c
 # ^ meta.constant.ruby entity.name.constant.ruby
@@ -1119,6 +1114,49 @@ exit! 2
 #^^^^ support.function.builtin
 
 
+##################
+# Symbol literals
+##################
+
+  FIELDS = %i[a b c]
+# ^^^^^^ meta.constant.ruby entity.name.constant.ruby
+#        ^ keyword.operator.assignment.ruby
+#          ^^^ punctuation.definition.string.begin.ruby
+#             ^      constant.other.symbol.ruby
+#               ^    constant.other.symbol.ruby
+#                 ^  constant.other.symbol.ruby
+#                  ^  punctuation.definition.string.end.ruby
+
+  %i(a b c)
+# ^^^ punctuation.definition.string.begin.ruby
+#    ^      constant.other.symbol.ruby
+#      ^    constant.other.symbol.ruby
+#        ^  constant.other.symbol.ruby
+#         ^  punctuation.definition.string.end.ruby
+
+  %I[#{'a'} b #@c#@@d e]
+# ^^^ meta.string.ruby - meta.interpolation
+#    ^^ source.ruby meta.string.ruby meta.interpolation.ruby punctuation.section.interpolation.begin.ruby
+#      ^^^ meta.string.ruby meta.interpolation.ruby meta.string.ruby
+#         ^ source.ruby meta.string.ruby meta.interpolation.ruby punctuation.section.interpolation.end.ruby
+#           ^ constant.other.symbol.ruby
+#             ^^^^^^^ meta.string.ruby meta.interpolation.ruby - string
+#                     ^ constant.other.symbol.ruby
+#                      ^  punctuation.definition.string.end.ruby
+
+##################
+# String literals
+##################
+
+  %w[a b c]
+# ^^^ punctuation.definition.string.begin.ruby
+#    ^^^^^ string.quoted.other.literal.lower.ruby
+#         ^  punctuation.definition.string.end.ruby
+
+  %w(a b c)
+# ^^^ punctuation.definition.string.begin.ruby
+#    ^^^^^ string.quoted.other.literal.lower.ruby
+#         ^  punctuation.definition.string.end.ruby
 
 ##################
 # Tokens with Multiple Meanings


### PR DESCRIPTION
This is my first try to implement #1879. I checked that Rubymine behaves in the same way.

An open task would be to adopt changes into `syntax_test_ruby.rb`, but I'd do this only after someone acknowledged the way I did it and that it's okay.

Examples would be:
```
%I(asd foo#{1 + 1 + 'x'} bar)
%I[asd foo#{1 + 1 + 'x'} bar]
%I<asd foo#{1 + 1 + 'x'} bar>
%I!asd foo#{1 + 1 + 'x'} bar!

%i(asd foo bar)
%i[asd foo bar]
%i<asd foo bar>
%i!asd foo bar!
```
Since I haven't worked on syntax files yet I would appreciate any feedback.