### PR TITLE
[XML] Add support for dtd/ent/mod files

### DIFF
--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -9,4 +9,4 @@ scope: text.xml.dtd
 
 contexts:
   main:
-    - include: scope:text.xml#dtd
+    - include: Packages/XML/XML.sublime-syntax#dtd

--- a/XML/DTD.sublime-syntax
+++ b/XML/DTD.sublime-syntax
@@ -1,0 +1,12 @@
+%YAML 1.2
+---
+name: DTD
+file_extensions:
+  - dtd
+  - ent
+  - mod
+scope: text.xml.dtd
+
+contexts:
+  main:
+    - include: scope:text.xml#dtd


### PR DESCRIPTION
_I know about the intention not to add further syntax definitions. Therefore this is just a proposal without a strong meaning about whether it is worth to add or not - but the effort is just too small to do it anyway._

The XML.sublime-syntax contains all we need for fully qualified support for dedicated DTD files.

This PR therefore proposes to expose these existing rules to enable Sublime Text to highlight doctype definition files and their subsets (*.ent, *.mod) out of the box.

Notes:

1. The test cases for doctype definitions are located in the syntax_test_xml.xml.
2. This file type seems not to be used by any officially listed 3rd party package at packagecontrol.io so far.