### PR TITLE
[PHP] Remove nonexistent consts

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -830,9 +830,8 @@ contexts:
   constants:
     - match: |-
         \b(?xi:
-          BR | FALSE | NL | NO | NULL | OFF | ON | TAB |
-          TRUE | YES | __CLASS__ | __DIR__ | __FILE__ | __FUNCTION__ | __LINE__ | __METHOD__ |
-          __NAMESPACE__
+          TRUE | FALSE | NULL |
+          __CLASS__ | __DIR__ | __FILE__ | __FUNCTION__ | __LINE__ | __METHOD__ | __NAMESPACE__
         )\b
       scope: constant.language.php
     - match: (?=\\?{{identifier}}\\{{path}})


### PR DESCRIPTION
BR, NL, TAB, YES, NO, ON, OFF

These constants seem to be nonexistent. I cannot find docs mentioning them and they are just not working as built-in constants in PHP (tried PHP 5.3 and 7.4).