### PR TITLE
[Erlang] Fix quoted identifier lookahead

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -33,12 +33,15 @@ variables:
   # end of identifier lookahead
   # Note: avoid negative lookahead as it is 6-8% slower
   ident_break: (?={{ident_break_char}})
+  # a quoted identifier with possibly escaped single quote
+  # preceeded by an arbitary number of excaped backslashes
+  ident_quoted: \'((?:\\\\)*\\\'|[^''])*\'
   # an identifier can be an atom or a variable
   ident_unquoted: '[_A-Za-z]{{ident_char}}*'
   # all characters not being used to indicate a context change
   illegal_ident: '[^\s,:.;''(){}\[\]%=|/]+'
   # quoted/unquoted/macro identifier
-  ident: \?{,2}(?:{{ident_unquoted}}|\'.*?(?=[^\\])\')
+  ident: \?{,2}(?:{{ident_unquoted}}|{{ident_quoted}})
 
   # http://erlang.org/doc/reference_manual/macros.html#predefined-macros
   erlang_macros: |-

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -1630,6 +1630,34 @@ preprocessor_define_tests() -> .
 % <- punctuation.section.arguments.end.erlang
 %^ punctuation.terminator.clause.erlang
 
+-define(_get_stacktrace_(),
+        try exit('$get_stacktrace') catch exit:'$get_stacktrace':Stacktrace -> Stacktrace end).
+%       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.define.arguments.erlang
+%       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.exception.try.erlang
+%                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.exception.catch.erlang
+%                                                                                         ^^^ meta.exception.try.erlang
+%           ^^^^ meta.function-call.name.erlang
+%               ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang
+%       ^^^ keyword.control.exception.try.erlang
+%           ^^^^ support.function.erlang
+%               ^ punctuation.section.arguments.begin.erlang
+%                ^ punctuation.definition.atom.begin.erlang
+%                ^^^^^^^^^^^^^^^^^ constant.other.symbol.erlang
+%                                ^ punctuation.definition.atom.end.erlang
+%                                 ^ punctuation.section.arguments.end.erlang
+%                                   ^^^^^ keyword.control.exception.catch.erlang
+%                                         ^^^^ constant.language.exception.type.erlang
+%                                             ^ punctuation.separator.patterns.erlang
+%                                              ^ punctuation.definition.atom.begin.erlang
+%                                              ^^^^^^^^^^^^^^^^^ constant.other.symbol.erlang
+%                                                              ^ punctuation.definition.atom.end.erlang
+%                                                               ^ punctuation.separator.patterns.erlang
+%                                                                ^^^^^^^^^^ variable.other.erlang
+%                                                                           ^^ punctuation.separator.clause-head-body.erlang
+%                                                                              ^^^^^^^^^^ variable.other.erlang
+%                                                                                         ^^^ keyword.control.exception.end.erlang
+%           
+
 % directive-export tests
 
 preprocessor_export_tests() -> .


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/pull/1878#issuecomment-546978653

This PR improves the quoted identifier pattern as the old one caused the namespace lookahead to be triggered in the wrong place.

The following token was matched as `namespace` by the `(?={{ident}}\s*:[^:=])` lookahead pattern in the namespace context by accident:

    '$get_stacktrace') catch exit:'$get_stacktrace':

The new pattern makes sure to stop matching at the first unescaped single quote. Any number of escaped backslashes is allowed in front of it.

Note: This change has no impact on parsing performance.