### PR TITLE
[Git Formats] Rename the remaining hash constants

### DIFF
--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -17,7 +17,7 @@ contexts:
       scope: meta.header.git.commit markup.raw.block.git.log
       captures:
         1: keyword.other.commit.git.log
-        2: constant.numeric.hex.hash.git.log
+        2: constant.other.hash.git.log
       embed: commit-header
       escape: (?=^commit\s)
 

--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -103,10 +103,10 @@ contexts:
     - match: Rebase\s+({{hash}})(?:(..)({{hash}}))?.+({{hash}}).*
       scope: meta.rebase-msg.git.rebase markup.heading.git.rebase
       captures:
-        1: constant.numeric.hex.hash.git.rebase
+        1: constant.other.hash.git.rebase
         2: punctuation.separator.commit-range.git.rebase
-        3: constant.numeric.hex.hash.git.rebase
-        4: constant.numeric.hex.hash.git.rebase
+        3: constant.other.hash.git.rebase
+        4: constant.other.hash.git.rebase
 
 ##[ COMMITS ]##########################################################
 
@@ -144,7 +144,7 @@ contexts:
 
   commit-hash:
     - match: '{{hash}}' # e.g. d284bb2
-      scope: constant.numeric.hex.hash.git.rebase
+      scope: constant.other.hash.git.rebase
       pop: true
     - include: line-end
     - match: \S+

--- a/Git Formats/syntax_test_git_log
+++ b/Git Formats/syntax_test_git_log
@@ -3,7 +3,7 @@ commit e2077c6e006acfd2f060aef03c4ef8f89c4db362
 # <- meta.header.git.commit markup.raw.block.git.log keyword.other.commit.git.log
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.git.commit markup.raw.block.git.log
 #^^^^^ keyword.other.commit.git.log
-#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.hash.git.log
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.log
 Author: username <user-name.last@host.com>
 # <- meta.header.git.commit markup.raw.block.git.log keyword.other.header.git.log
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.git.commit markup.raw.block.git.log

--- a/Git Formats/syntax_test_git_rebase
+++ b/Git Formats/syntax_test_git_rebase
@@ -3,66 +3,66 @@
 pick d284bb2 Initial commit
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                           ^ -meta.commit
+#                           ^ - meta.commit
 # <- keyword.operator.commit.pick
 #^^^ keyword.operator.commit.pick
-#   ^ -storage.type.commit
-#    ^^^^^^^ constant.numeric.hex.hash
-#           ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#   ^ - storage.type.commit
+#    ^^^^^^^ constant.other.hash
+#           ^ - constant.other.hash -meta.subject.git.commit
 #            ^^^^^^^^^^^^^^ meta.subject.git.commit
-#                          ^ -meta.subject.git.commit
+#                          ^ - meta.subject.git.commit
 p 6746220 Second pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                                         ^ -meta.commit
+#                                         ^ - meta.commit
 # <- keyword.operator.commit.pick
-#^ -keyword.operator.commit
-# ^^^^^^^ constant.numeric.hex.hash
-#        ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#^ - keyword.operator.commit
+# ^^^^^^^ constant.other.hash
+#        ^ - constant.other.hash -meta.subject.git.commit
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                        ^ -meta.subject.git.commit
-#                ^^^^ -keyword
+#                                        ^ - meta.subject.git.commit
+#                ^^^^ - keyword
    p 6746220 Third pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                                            ^ -meta.commit
-# ^ -keyword.operator.commit
+#                                            ^ - meta.commit
+# ^ - keyword.operator.commit
 #  ^ keyword.operator.commit.pick
-#   ^ -keyword.operator.commit -constant.numeric.hex.hash
-#    ^^^^^^^ constant.numeric.hex.hash
-#           ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#   ^ - keyword.operator.commit -constant.other.hash
+#    ^^^^^^^ constant.other.hash
+#           ^ - constant.other.hash -meta.subject.git.commit
 #            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                          ^ -meta.subject.git.commit
-#                  ^^^^ -keyword
+#                                          ^ - meta.subject.git.commit
+#                  ^^^^ - keyword
 puck 6746220 Invalid command
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- invalid.illegal.command-expected
 #^^^ invalid.illegal.command-expected
-#   ^ -storage.type.commit -invalid.illegal.command-expected
-#    ^^^^^^^ constant.numeric.hex.hash
-#           ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#   ^ - storage.type.commit -invalid.illegal.command-expected
+#    ^^^^^^^ constant.other.hash
+#           ^ - constant.other.hash -meta.subject.git.commit
 #            ^^^^^^^^^^^^^^^ meta.subject.git.commit
 p 6746x20 Invalid hash # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- keyword.operator.commit.pick
-#^ -storage.type.commit
+#^ - storage.type.commit
 # ^^^^^^^ invalid.illegal.hash-expected
-#        ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#        ^ - constant.other.hash -meta.subject.git.commit
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                  ^ -meta.subject.git.commit
+#                                  ^ - meta.subject.git.commit
 a 6746x20 Invalid command and hash # no comment (#403)
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- invalid.illegal.command-expected
-#^ -storage.type.commit
+#^ - storage.type.commit
 # ^^^^^^^ invalid.illegal.hash-expected
-#        ^ -constant.numeric.hex.hash -meta.subject.git.commit
+#        ^ - constant.other.hash -meta.subject.git.commit
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
 #                                                ^ punctuation.definition.reference.issue.git
 #                                                ^^^^ meta.reference.issue.git constant.other.reference.issue.git
-#                                                     ^ -meta.subject.git.commit
+#                                                     ^ - meta.subject.git.commit
   # p 6746220 Second pick commit # no comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
   d d284bb2 Drop commit
@@ -89,10 +89,10 @@ a 6746x20 Invalid command and hash # no comment (#403)
 # Rebase 9e73d21..6746220 onto 9e73d21 (2 commands)
 # <- comment.line punctuation.definition.comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line meta.rebase-msg
-#        ^^^^^^^ constant.numeric.hex.hash
+#        ^^^^^^^ constant.other.hash
 #               ^^ punctuation.separator.commit-range
-#                 ^^^^^^^ constant.numeric.hex.hash
-#                              ^^^^^^^ constant.numeric.hex.hash
+#                 ^^^^^^^ constant.other.hash
+#                              ^^^^^^^ constant.other.hash
 #
 # Commands:
 #^^^^^^^^^^^ comment.line.git.rebase


### PR DESCRIPTION
This commit renames the remaining scopes to `constant.other.hash` as it was introduced by commit 71aeb9ad2812bbd4bc8cf6e139e963d7a37b7dd8.