### PR TITLE
[JavaScript] Improve numbers

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -12,8 +12,8 @@ variables:
   oct_digit: '[0-7_]'
   dec_digit: '[0-9_]'
   hex_digit: '[\h_]'
-  integer: (?:0|[1-9]{{dec_digit}}*)
-  exponent: (?:[Ee](?:[-+]|(?![-+])){{dec_digit}}*)
+  dec_integer: (?:0|[1-9]{{dec_digit}}*)
+  dec_exponent: (?:[Ee](?:[-+]|(?![-+])){{dec_digit}}*)
 
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
@@ -1766,9 +1766,9 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          {{integer}} (?: (\.) {{dec_digit}}* {{exponent}}? | {{exponent}} )
+          {{dec_integer}} (?: (\.) {{dec_digit}}* {{dec_exponent}}? | {{dec_exponent}} )
           # .1, .1e1, .1e-1
-          | (\.) {{dec_digit}}+ {{exponent}}?
+          | (\.) {{dec_digit}}+ {{dec_exponent}}?
         ){{identifier_break}}
       scope: constant.numeric.float.decimal.js
       captures:
@@ -1802,7 +1802,7 @@ contexts:
         2: storage.type.numeric.js
       pop: true
 
-    - match: '{{integer}}(n|(?!\.)){{identifier_break}}'
+    - match: '{{dec_integer}}(n|(?!\.)){{identifier_break}}'
       scope: constant.numeric.integer.decimal.js
       captures:
         1: storage.type.numeric.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -8,6 +8,10 @@ file_extensions:
 first_line_match: ^#!\s*/.*\b(node|js)\b
 scope: source.js
 variables:
+  ddigits: (?:[0-9_]+)
+  ddigits0: (?:0|[1-9][0-9_]*)
+  exponent: (?:[Ee](?:[-+]|(?![-+]))[0-9_]*)
+
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
   identifier_part: (?:[_$\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]|{{identifier_escape}})
@@ -1755,56 +1759,55 @@ contexts:
         - include: object-property
 
   literal-number:
+    # floats
+    - match: |-
+        (?x:
+          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
+          {{ddigits0}} (?: (\.) {{ddigits}}? {{exponent}}? | {{exponent}} )
+          # .1, .1e1, .1e-1
+          | (\.) {{ddigits}} {{exponent}}?
+        ){{identifier_break}}
+      scope: constant.numeric.float.decimal.js
+      captures:
+        1: punctuation.separator.decimal.js
+        2: punctuation.separator.decimal.js
+      pop: true
+
+    # integers
     - match: '0[0-9]+{{identifier_break}}'
-      scope: constant.numeric.octal.js invalid.deprecated.numeric.octal.js
+      scope: constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
     - match: '(0[Xx])[0-9a-fA-F_]*(n)?{{identifier_break}}'
-      scope: constant.numeric.hexadecimal.js
+      scope: constant.numeric.integer.hexadecimal.js
       captures:
         1: punctuation.definition.numeric.hexadecimal.js
-        2: storage.type.numeric.bigint.js
+        2: storage.type.numeric.js
       pop: true
 
     - match: '(0[Oo])[0-7_]*(n)?{{identifier_break}}'
-      scope: constant.numeric.octal.js
+      scope: constant.numeric.integer.octal.js
       captures:
         1: punctuation.definition.numeric.octal.js
-        2: storage.type.numeric.bigint.js
+        2: storage.type.numeric.js
       pop: true
 
     - match: '(0[Bb])[0-1_]*(n)?{{identifier_break}}'
-      scope: constant.numeric.binary.js
+      scope: constant.numeric.integer.binary.js
       captures:
         1: punctuation.definition.numeric.binary.js
-        2: storage.type.numeric.bigint.js
+        2: storage.type.numeric.js
       pop: true
 
-    - match: '(?:0|[1-9][0-9_]*)(n){{identifier_break}}'
-      scope: constant.numeric.decimal.js
+    - match: '{{ddigits0}}(n|(?!\.)){{identifier_break}}'
+      scope: constant.numeric.integer.decimal.js
       captures:
-        1: storage.type.numeric.bigint.js
+        1: storage.type.numeric.js
       pop: true
 
-    - match: |-
-        (?x)
-        (
-          (?:0|[1-9][0-9_]*)
-          (?:\.[0-9_]*|(?!\.))
-          |
-          \.[0-9_]+
-        )
-        (?:[Ee](?:[+-]|(?![-+]))[0-9_]*)?
-        {{identifier_break}}
-      scope: constant.numeric.decimal.js
-      pop: true
-
+    # illegal numbers
     - match: '0[Xx]{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.numeric.hexadecimal.js
-      pop: true
-
-    - match: '0[Oo]{{identifier_part}}+{{identifier_break}}'
-      scope: invalid.illegal.numeric.octal.js
       pop: true
 
     - match: '0[Bb]{{identifier_part}}+{{identifier_break}}'

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1784,21 +1784,21 @@ contexts:
     - match: (0[Xx]){{hex_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.hexadecimal.js
       captures:
-        1: punctuation.definition.numeric.hexadecimal.js
+        1: punctuation.definition.numeric.base.js
         2: storage.type.numeric.js
       pop: true
 
     - match: (0[Oo]){{oct_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.octal.js
       captures:
-        1: punctuation.definition.numeric.octal.js
+        1: punctuation.definition.numeric.base.js
         2: storage.type.numeric.js
       pop: true
 
     - match: (0[Bb]){{bin_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.binary.js
       captures:
-        1: punctuation.definition.numeric.binary.js
+        1: punctuation.definition.numeric.base.js
         2: storage.type.numeric.js
       pop: true
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -8,9 +8,12 @@ file_extensions:
 first_line_match: ^#!\s*/.*\b(node|js)\b
 scope: source.js
 variables:
-  ddigits: (?:[0-9_]+)
-  ddigits0: (?:0|[1-9][0-9_]*)
-  exponent: (?:[Ee](?:[-+]|(?![-+]))[0-9_]*)
+  bin_digit: '[01_]'
+  oct_digit: '[0-7_]'
+  dec_digit: '[0-9_]'
+  hex_digit: '[\h_]'
+  integer: (?:0|[1-9]{{dec_digit}}*)
+  exponent: (?:[Ee](?:[-+]|(?![-+])){{dec_digit}}*)
 
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
@@ -1763,9 +1766,9 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          {{ddigits0}} (?: (\.) {{ddigits}}? {{exponent}}? | {{exponent}} )
+          {{integer}} (?: (\.) {{dec_digit}}* {{exponent}}? | {{exponent}} )
           # .1, .1e1, .1e-1
-          | (\.) {{ddigits}} {{exponent}}?
+          | (\.) {{dec_digit}}+ {{exponent}}?
         ){{identifier_break}}
       scope: constant.numeric.float.decimal.js
       captures:
@@ -1774,47 +1777,47 @@ contexts:
       pop: true
 
     # integers
-    - match: '0[0-9]+{{identifier_break}}'
+    - match: 0{{dec_digit}}+{{identifier_break}}
       scope: constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
-    - match: '(0[Xx])[0-9a-fA-F_]*(n)?{{identifier_break}}'
+    - match: (0[Xx]){{hex_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.hexadecimal.js
       captures:
         1: punctuation.definition.numeric.hexadecimal.js
         2: storage.type.numeric.js
       pop: true
 
-    - match: '(0[Oo])[0-7_]*(n)?{{identifier_break}}'
+    - match: (0[Oo]){{oct_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.octal.js
       captures:
         1: punctuation.definition.numeric.octal.js
         2: storage.type.numeric.js
       pop: true
 
-    - match: '(0[Bb])[0-1_]*(n)?{{identifier_break}}'
+    - match: (0[Bb]){{bin_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.binary.js
       captures:
         1: punctuation.definition.numeric.binary.js
         2: storage.type.numeric.js
       pop: true
 
-    - match: '{{ddigits0}}(n|(?!\.)){{identifier_break}}'
+    - match: '{{integer}}(n|(?!\.)){{identifier_break}}'
       scope: constant.numeric.integer.decimal.js
       captures:
         1: storage.type.numeric.js
       pop: true
 
     # illegal numbers
-    - match: '0[Xx]{{identifier_part}}+{{identifier_break}}'
+    - match: 0[Xx]{{identifier_part}}+{{identifier_break}}
       scope: invalid.illegal.numeric.hexadecimal.js
       pop: true
 
-    - match: '0[Bb]{{identifier_part}}+{{identifier_break}}'
+    - match: 0[Bb]{{identifier_part}}+{{identifier_break}}
       scope: invalid.illegal.numeric.binary.js
       pop: true
 
-    - match: '0{{identifier_part}}+{{identifier_break}}'
+    - match: 0{{identifier_part}}+{{identifier_break}}
       scope: invalid.illegal.numeric.octal.js
       pop: true
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1848,24 +1848,24 @@ function yy (a, b) {
 // Integers
 
     123_456_789_0n;
-//  ^^^^^^^^^^^^^^ constant.numeric.decimal
-//               ^ storage.type.numeric.bigint
+//  ^^^^^^^^^^^^^^ constant.numeric.integer.decimal
+//               ^ storage.type.numeric
 
     0;
-//  ^ constant.numeric.decimal
+//  ^ constant.numeric.integer.decimal
 
     123 .foo;
-//  ^^^ constant.numeric.decimal
+//  ^^^ constant.numeric.integer.decimal
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 
     +123;
 //  ^ keyword.operator.arithmetic
-//   ^^^ constant.numeric.decimal - keyword
+//   ^^^ constant.numeric.integer.decimal - keyword
 
     -123;
 //  ^ keyword.operator.arithmetic
-//   ^^^ constant.numeric.decimal - keyword
+//   ^^^ constant.numeric.integer.decimal - keyword
 
     + 123;
 //  ^ keyword.operator.arithmetic
@@ -1874,7 +1874,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     0123456789;
-//  ^^^^^^^^^^ constant.numeric.octal invalid.deprecated.numeric.octal
+//  ^^^^^^^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
 
     0123456789xyz;
 //  ^^^^^^^^^^^^^ invalid.illegal.numeric.octal
@@ -1890,33 +1890,33 @@ function yy (a, b) {
 //             ^^^ invalid.illegal.illegal-identifier
 
     0b0110_1001_1001_0110n;
-//  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.binary
+//  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
 //  ^^ punctuation.definition.numeric.binary
-//                       ^ storage.type.numeric.bigint
+//                       ^ storage.type.numeric
 
     0o0123_4567n;
-//  ^^^^^^^^^^^^ constant.numeric.octal
+//  ^^^^^^^^^^^^ constant.numeric.integer.octal
 //  ^^ punctuation.definition.numeric.octal
-//             ^ storage.type.numeric.bigint
+//             ^ storage.type.numeric
 
     0x01_23_45_67_89_ab_CD_efn;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hexadecimal
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
 //  ^^ punctuation.definition.numeric.hexadecimal
-//                           ^ storage.type.numeric.bigint
+//                           ^ storage.type.numeric
 
     0B0; 0O0; 0X0;
-//  ^^^ constant.numeric.binary
-//       ^^^ constant.numeric.octal
-//            ^^^ constant.numeric.hexadecimal
+//  ^^^ constant.numeric.integer.binary
+//       ^^^ constant.numeric.integer.octal
+//            ^^^ constant.numeric.integer.hexadecimal
 
     0b1.foo;
 //  ^^^^^^^ - invalid
-//  ^^^ constant.numeric.binary
+//  ^^^ constant.numeric.integer.binary
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
-//  ^^^ constant.numeric.binary
+//  ^^^ constant.numeric.integer.binary
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 
@@ -1927,21 +1927,26 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.decimal
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ constant.numeric.decimal
+//  ^^^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^^^^^^^ constant.numeric.decimal
+//  ^^^^^^^^^^^ constant.numeric.float.decimal
 
     123.456e+789;
-//  ^^^^^^^^^^^^ constant.numeric.decimal
+//  ^^^^^^^^^^^^ constant.numeric.float.decimal
+//     ^ punctuation.separator.decimal
 
     .123E-7_8_9;
-//  ^^^^^^^^^^^ constant.numeric.decimal
+//  ^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^ punctuation.separator.decimal
 
     0123.45;
+//  ^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
+//      ^ punctuation.accessor
 //       ^^ invalid.illegal - constant.numeric
 
     123.4foo;
@@ -1951,7 +1956,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ constant.numeric.decimal
+//  ^^^^ constant.numeric.float.decimal
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1891,32 +1891,37 @@ function yy (a, b) {
 
     0b0110_1001_1001_0110n;
 //  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.binary
+//  ^^ punctuation.definition.numeric.base
 //                       ^ storage.type.numeric
 
     0o0123_4567n;
 //  ^^^^^^^^^^^^ constant.numeric.integer.octal
-//  ^^ punctuation.definition.numeric.octal
+//  ^^ punctuation.definition.numeric.base
 //             ^ storage.type.numeric
 
     0x01_23_45_67_89_ab_CD_efn;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-//  ^^ punctuation.definition.numeric.hexadecimal
+//  ^^ punctuation.definition.numeric.base
 //                           ^ storage.type.numeric
 
     0B0; 0O0; 0X0;
 //  ^^^ constant.numeric.integer.binary
+//  ^^ punctuation.definition.numeric.base
 //       ^^^ constant.numeric.integer.octal
+//       ^^ punctuation.definition.numeric.base
 //            ^^^ constant.numeric.integer.hexadecimal
+//            ^^ punctuation.definition.numeric.base
 
     0b1.foo;
 //  ^^^^^^^ - invalid
 //  ^^^ constant.numeric.integer.binary
+//  ^^ punctuation.definition.numeric.base
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
 //  ^^^ constant.numeric.integer.binary
+//  ^^ punctuation.definition.numeric.base
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -26,7 +26,7 @@ const [ x, [a, b], z] = value;
 const [ x = 42, y = [a, b, c] ] = value;
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //        ^ keyword.operator.assignment
-//          ^^ meta.binding.destructuring.sequence.js constant.numeric.decimal.js
+//          ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
 //                ^ keyword.operator.assignment
 //                  ^^^^^^^^^ meta.sequence
 //                   ^ variable.other.readwrite - meta.binding.name
@@ -105,7 +105,7 @@ function f ([ x, [a, b], z]) {}
 function f ([ x = 42, y = [a, b, c] ]) {}
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //              ^ keyword.operator.assignment
-//                ^^ meta.binding.destructuring.sequence.js constant.numeric.decimal.js
+//                ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
 //                      ^ keyword.operator.assignment
 //                        ^^^^^^^^^ meta.sequence
 //                         ^ variable.other.readwrite - meta.binding.name
@@ -165,7 +165,7 @@ let f = ([ x = 42, y = [a, b, c] ]) => {};
 //  ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //           ^ keyword.operator.assignment
-//             ^^ meta.binding.destructuring.sequence.js constant.numeric.decimal.js
+//             ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
 //                   ^ keyword.operator.assignment
 //                     ^^^^^^^^^ meta.sequence
 //                      ^ variable.other.readwrite - meta.binding.name


### PR DESCRIPTION
This PR

1. uses `storage.type.numeric` scope for numeric literal suffixes.
2. adds more detailed `constant.numeric.[integer|float]` scopes.

Note:

1. The 2nd change required to change the pattern for floating point numbers and its order in the context in order to correctly distinguish between integers and floats.
2. The 1st rule being used to match illegal octal numbers is removed as its function is handled by the 2nd illegal octal rule.
3. The changes don't have an impact on parsing performance.