### PR TITLE
[ShellScript] Improve numbers

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1263,11 +1263,10 @@ contexts:
     # a number in that base. When specifying n, the digits greater than 9 are
     # represented by the lowercase letters, the uppercase letters, ‘@’, and ‘_’,
     # in that order.
-    - match: \b(\d+)(#)([a-zA-Z0-9@_]+)
+    - match: \b(\d+#)[a-zA-Z0-9@_]+
+      scope: constant.numeric.integer.other.shell
       captures:
-        1: constant.numeric.integer.decimal.base.shell
-        2: punctuation.definition.numeric.base.shell
-        3: constant.numeric.integer.generic-base.shell
+        1: punctuation.definition.numeric.other.shell
     # If base# is omitted, then base 10 is used.
     - match: \b\d+
       scope: constant.numeric.integer.decimal.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1239,8 +1239,8 @@ contexts:
 
   expression:
     # A leading ‘0x’ or ‘0X’ denotes hexadecimal.
-    - match: \b(?i)0x
-      scope: punctuation.definition.numeric.hexadecimal.shell
+    - match: \b0[xX]
+      scope: punctuation.definition.numeric.base.shell
       push:
         - meta_scope: constant.numeric.integer.hexadecimal.shell
         - match: '[g-zG-Z]'
@@ -1250,7 +1250,7 @@ contexts:
           pop: true
     # Constants with a leading 0 are interpreted as octal numbers.
     - match: \b0(?=[0-7])
-      scope: punctuation.definition.numeric.octal.shell
+      scope: punctuation.definition.numeric.base.shell
       push:
         - meta_scope: constant.numeric.integer.octal.shell
         - match: '[89]'
@@ -1266,7 +1266,7 @@ contexts:
     - match: \b(\d+#)[a-zA-Z0-9@_]+
       scope: constant.numeric.integer.other.shell
       captures:
-        1: punctuation.definition.numeric.other.shell
+        1: punctuation.definition.numeric.base.shell
     # If base# is omitted, then base 10 is used.
     - match: \b\d+
       scope: constant.numeric.integer.decimal.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1229,7 +1229,7 @@ exec >&${tee[1]} 2>&1
 # Misc. operators #
 ###################
 (( 0123456708 ))
-#  ^ constant.numeric.integer.octal punctuation.definition.numeric.octal
+#  ^ constant.numeric.integer.octal punctuation.definition.numeric.base
 #  ^^^^^^^^^ constant.numeric.integer.octal
 #           ^ constant.numeric.integer.octal invalid.illegal.not-an-octal-character
 (( 0 ))
@@ -1317,19 +1317,19 @@ exec >&${tee[1]} 2>&1
 #                     ^^^^^^^^^ meta.group.parens
 #                              ^^ - meta.group.parens
 (( 0xDEADBEEF 0xdeadbeef 0x1234567890abcdefg ))
-#  ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.hexadecimal
+#  ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.base
 #    ^^^^^^^^ constant.numeric.integer.hexadecimal
-#             ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.hexadecimal
+#             ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.base
 #               ^^^^^^^^ constant.numeric.integer.hexadecimal
-#                        ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.hexadecimal
+#                        ^^ constant.numeric.integer.hexadecimal punctuation.definition.numeric.base
 #                          ^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
 #                                          ^ constant.numeric.integer.hexadecimal invalid.illegal.not-a-hex-character
 (( 64#123@_ ))
 #  ^^^^^^^^ constant.numeric.integer.other
-#  ^^^ punctuation.definition.numeric.other
+#  ^^^ punctuation.definition.numeric.base
 (( 0x1f ))
 #  ^^^^ constant.numeric.integer.hexadecimal
-#  ^^ punctuation.definition.numeric.hexadecimal.shell
+#  ^^ punctuation.definition.numeric.base
 (( a * b ))
 #    ^ keyword.operator.arithmetic - keyword.operator.regexp
 ((a+=b))

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1325,11 +1325,11 @@ exec >&${tee[1]} 2>&1
 #                          ^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
 #                                          ^ constant.numeric.integer.hexadecimal invalid.illegal.not-a-hex-character
 (( 64#123@_ ))
-#  ^^ constant.numeric.integer.decimal.base
-#    ^ punctuation.definition.numeric.base
-#     ^^^^^ constant.numeric.integer.generic-base
+#  ^^^^^^^^ constant.numeric.integer.other
+#  ^^^ punctuation.definition.numeric.other
 (( 0x1f ))
 #  ^^^^ constant.numeric.integer.hexadecimal
+#  ^^ punctuation.definition.numeric.hexadecimal.shell
 (( a * b ))
 #    ^ keyword.operator.arithmetic - keyword.operator.regexp
 ((a+=b))


### PR DESCRIPTION
This PR renames `constant.numeric.integer.generic-base` to `constant.numeric.integer.other` and scopes the whole base part as punctuation to equalize with hexadecimal prefixes.