### PR TITLE
[Erlang] Improve numbers

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1766,48 +1766,47 @@ contexts:
 
   number:
     # http://erlang.org/doc/reference_manual/data_types.html#number
-    - match: \d+(\.)\d+(([eE])[-+]?\d+)?\b
+    - match: \d+(\.)\d+([eE][-+]?\d+)?\b
       scope: constant.numeric.float.decimal.erlang
       captures:
         1: punctuation.separator.decimal.erlang
-        3: punctuation.definition.exponent.erlang
     - match: |-
-        (?x:(2(\#)[0-1]+)       # binary
-          | (8(\#)[0-7]+)       # octal
-          | (10(\#)[0-9]+)      # decimal
-          | (16(\#)[\da-fA-F]+) # hexadecimal
-          | (3(\#)[0-2]+
-          |  4(\#)[0-3]+
-          |  5(\#)[0-4]+
-          |  6(\#)[0-5]+
-          |  7(\#)[0-6]+
-          |  9(\#)[0-8]+
-          |  11(\#)[\daA]+
-          |  12(\#)[\da-bA-B]+
-          |  13(\#)[\da-cA-C]+
-          |  14(\#)[\da-dA-D]+
-          |  15(\#)[\da-eA-E]+
-          |  17(\#)[\da-gA-G]+
-          |  18(\#)[\da-hA-H]+
-          |  19(\#)[\da-iA-I]+
-          |  20(\#)[\da-jA-J]+
-          |  21(\#)[\da-kA-K]+
-          |  22(\#)[\da-lA-L]+
-          |  23(\#)[\da-mA-M]+
-          |  24(\#)[\da-nA-N]+
-          |  25(\#)[\da-oA-O]+
-          |  26(\#)[\da-pA-P]+
-          |  27(\#)[\da-qA-Q]+
-          |  28(\#)[\da-rA-R]+
-          |  29(\#)[\da-sA-S]+
-          |  30(\#)[\da-tA-T]+
-          |  31(\#)[\da-uA-U]+
-          |  32(\#)[\da-vA-V]+
-          |  33(\#)[\da-wA-W]+
-          |  34(\#)[\da-xA-X]+
-          |  35(\#)[\da-yA-Y]+
-          |  36(\#)[\da-zA-Z]+) # other
-          | (\d+(\#)\S+)        # illegal
+        (?x:((2\#)[0-1]+)       # binary
+          | ((8\#)[0-7]+)       # octal
+          | ((10\#)[0-9]+)      # decimal
+          | ((16\#)[\da-fA-F]+) # hexadecimal
+          | ((3\#)[0-2]+
+          |  (4\#)[0-3]+
+          |  (5\#)[0-4]+
+          |  (6\#)[0-5]+
+          |  (7\#)[0-6]+
+          |  (9\#)[0-8]+
+          |  (11\#)[\daA]+
+          |  (12\#)[\da-bA-B]+
+          |  (13\#)[\da-cA-C]+
+          |  (14\#)[\da-dA-D]+
+          |  (15\#)[\da-eA-E]+
+          |  (17\#)[\da-gA-G]+
+          |  (18\#)[\da-hA-H]+
+          |  (19\#)[\da-iA-I]+
+          |  (20\#)[\da-jA-J]+
+          |  (21\#)[\da-kA-K]+
+          |  (22\#)[\da-lA-L]+
+          |  (23\#)[\da-mA-M]+
+          |  (24\#)[\da-nA-N]+
+          |  (25\#)[\da-oA-O]+
+          |  (26\#)[\da-pA-P]+
+          |  (27\#)[\da-qA-Q]+
+          |  (28\#)[\da-rA-R]+
+          |  (29\#)[\da-sA-S]+
+          |  (30\#)[\da-tA-T]+
+          |  (31\#)[\da-uA-U]+
+          |  (32\#)[\da-vA-V]+
+          |  (33\#)[\da-wA-W]+
+          |  (34\#)[\da-xA-X]+
+          |  (35\#)[\da-yA-Y]+
+          |  (36\#)[\da-zA-Z]+) # other
+          | ((\d+\#)\S+)        # illegal
         )\b
       captures:
         1: constant.numeric.integer.binary.erlang

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -698,67 +698,64 @@ numbers_test() -> .
     2.3e3
 %   ^^^^^ constant.numeric.float.decimal.erlang
 %    ^ punctuation.separator.decimal.erlang
-%      ^ punctuation.definition.exponent.erlang
 
     2.3e+3
 %   ^^^^^^ constant.numeric.float.decimal.erlang
 %    ^ punctuation.separator.decimal.erlang
-%      ^ punctuation.definition.exponent.erlang
 
     2.3e-3
 %   ^^^^^^ constant.numeric.float.decimal.erlang
 %    ^ punctuation.separator.decimal.erlang
-%      ^ punctuation.definition.exponent.erlang
 
     1#0
 %   ^^^ invalid.illegal.integer.erlang
-%    ^ punctuation.definition.numeric.base.erlang
+%   ^^ punctuation.definition.numeric.base.erlang
 
     2#01 2#012
 %   ^^^^ constant.numeric.integer.binary.erlang
-%    ^ punctuation.definition.numeric.base.erlang
+%   ^^ punctuation.definition.numeric.base.erlang
 %        ^^^^^ invalid.illegal.integer.erlang
-%         ^ punctuation.definition.numeric.base.erlang
+%        ^^ punctuation.definition.numeric.base.erlang
 
     3#012 3#123
 %   ^^^^^ constant.numeric.integer.other.erlang
-%    ^ punctuation.definition.numeric.base.erlang
+%   ^^ punctuation.definition.numeric.base.erlang
 %         ^^^^^ invalid.illegal.integer.erlang
-%          ^ punctuation.definition.numeric.base.erlang
+%         ^^ punctuation.definition.numeric.base.erlang
 
     4#0123 4#1234
 %   ^^^^^^ constant.numeric.integer.other.erlang
-%    ^ punctuation.definition.numeric.base.erlang
+%   ^^ punctuation.definition.numeric.base.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
-%           ^ punctuation.definition.numeric.base.erlang
+%          ^^ punctuation.definition.numeric.base.erlang
 
     8#0723 8#1834
 %   ^^^^^^ constant.numeric.integer.octal.erlang
-%    ^ punctuation.definition.numeric.base.erlang
+%   ^^ punctuation.definition.numeric.base.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
-%           ^ punctuation.definition.numeric.base.erlang
+%          ^^ punctuation.definition.numeric.base.erlang
 
     10#0943 10#183A
 %   ^^^^^^^ constant.numeric.integer.decimal.erlang
-%     ^ punctuation.definition.numeric.base.erlang
+%   ^^^ punctuation.definition.numeric.base.erlang
 %           ^^^^^^ invalid.illegal.integer.erlang
-%             ^ punctuation.definition.numeric.base.erlang
+%           ^^^ punctuation.definition.numeric.base.erlang
 
     16#0F2B 16#F8G4
 %   ^^^^^^^ constant.numeric.integer.hexadecimal.erlang
-%     ^ punctuation.definition.numeric.base.erlang
+%   ^^^ punctuation.definition.numeric.base.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
-%             ^ punctuation.definition.numeric.base.erlang
+%           ^^^ punctuation.definition.numeric.base.erlang
 
     35#0Y2B 35#F8Z4
 %   ^^^^^^^ constant.numeric.integer.other.erlang
-%     ^ punctuation.definition.numeric.base.erlang
+%   ^^^ punctuation.definition.numeric.base.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
-%             ^ punctuation.definition.numeric.base.erlang
+%           ^^^ punctuation.definition.numeric.base.erlang
 
     37#ABC
 %   ^^^^^^ invalid.illegal.integer.erlang
-%     ^ punctuation.definition.numeric.base.erlang
+%   ^^^ punctuation.definition.numeric.base.erlang
 
 % String tests
 


### PR DESCRIPTION
This commit

1. removes the punctuation scope from the `e` exponent character
2. scopes the whole base part of integers as `punctuation.definition.numeric.base`.

_Note:_

When I saw the `punctuation.definition.numeric.base` scope I wondered whether it was a good general scope name for all kinds of numeric prefixes like `0x`, 0b`, etc.

Most syntaxes use specialized scopes like `punctuation.definition.numeric.hexadecimal`.

Thoughts?