### PR TITLE
[Ruby] Rename numeric base scopes

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -209,21 +209,21 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.hexadecimal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
     - match: '\b(0[oO]?){{odigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.octal.ruby
       captures:
-        1: punctuation.definition.numeric.octal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # binary imaginary numbers: 0b1i, 0b1ri
     - match: '\b(0[bB]){{bdigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.binary.ruby
       captures:
-        1: punctuation.definition.numeric.binary.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
@@ -238,7 +238,7 @@ contexts:
         )\b
       scope: constant.numeric.imaginary.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.decimal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: punctuation.separator.decimal.ruby
         3: storage.type.numeric.ruby
         4: punctuation.separator.decimal.ruby
@@ -249,25 +249,25 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}(r)\b'
       scope: constant.numeric.rational.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.hexadecimal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # octal rational numbers: 0o1r, 01r
     - match: '\b(0[oO]?){{odigits}}(r)\b'
       scope: constant.numeric.rational.octal.ruby
       captures:
-        1: punctuation.definition.numeric.octal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # binary rational numbers: 0b1r
     - match: '\b(0[bB]){{bdigits}}(r)\b'
       scope: constant.numeric.rational.binary.ruby
       captures:
-        1: punctuation.definition.numeric.binary.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # decimal rational numbers: 0d1r, 1r, 1.1r
     - match: '\b(?:(0[dD])?{{ddigits}}|{{ddigits}}(\.){{ddigits}})(r)\b'
       scope: constant.numeric.rational.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.decimal.ruby
+        1: punctuation.definition.numeric.base.ruby
         2: punctuation.separator.decimal.ruby
         3: storage.type.numeric.ruby
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
@@ -281,22 +281,22 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.hexadecimal.ruby
+        1: punctuation.definition.numeric.base.ruby
     # octal integer numbers: 0o1, 01
     - match: '\b(0[oO]?){{odigits}}\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
-        1: punctuation.definition.numeric.octal.ruby
+        1: punctuation.definition.numeric.base.ruby
     # binary integer numbers: 0b1
     - match: '\b(0[bB]){{bdigits}}\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
-        1: punctuation.definition.numeric.binary.ruby
+        1: punctuation.definition.numeric.base.ruby
     # decimal integer numbers: 0d1, 1
     - match: '\b(0[dD])?{{ddigits}}\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.decimal.ruby
+        1: punctuation.definition.numeric.base.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -190,31 +190,31 @@ BAR
 #^^^^^ constant.numeric.integer.decimal
  0d170
 #^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
  0D170
 #^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
  0xAa
 #^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
  0XAa
 #^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
  0252
 #^^^^ constant.numeric.integer.octal
-#^ punctuation.definition.numeric.octal
+#^ punctuation.definition.numeric.base
  0o252
 #^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
  0O252
 #^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
  0b10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
  0B10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
  12.
 #^^ constant.numeric.integer.decimal
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
@@ -248,19 +248,19 @@ BAR
 #    ^ storage.type.numeric
  0d170r
 #^^^^^^ constant.numeric.rational.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
  0xAar
 #^^^^^ constant.numeric.rational.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
 #    ^ storage.type.numeric
  0o252r
 #^^^^^^ constant.numeric.rational.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
  0b10101010r
 #^^^^^^^^^^^ constant.numeric.rational.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
 #          ^ storage.type.numeric
 
  12i
@@ -293,40 +293,40 @@ BAR
 #    ^^ storage.type.numeric
  0d170i
 #^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
  0d170ri
 #^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
 #     ^^ storage.type.numeric
  0xAai
 #^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
 #    ^ storage.type.numeric
  0xAari
 #^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
 #    ^^ storage.type.numeric
  0o252i
 #^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
  0o252ri
 #^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
 #     ^^ storage.type.numeric
  0b10101010i
 #^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
 #          ^ storage.type.numeric
  0b10101010ri
 #^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
 #          ^^ storage.type.numeric
  12e3ri
 #^^^^^^ constant.numeric.imaginary.decimal
 #    ^ invalid.illegal.numeric
-#     ^ storage.type.numeric 
+#     ^ storage.type.numeric
  1.2e3ri
 #^^^^^^^ constant.numeric.imaginary.decimal
 # ^ punctuation.separator.decimal
@@ -352,22 +352,22 @@ BAR
 #      ^ invalid.illegal.numeric
  0d170ir
 #^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.decimal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
 #      ^ invalid.illegal.numeric
  0xAair
 #^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.hexadecimal
+#^^ punctuation.definition.numeric.base
 #    ^ storage.type.numeric
 #     ^ invalid.illegal.numeric
  0o252ir
 #^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.octal
+#^^ punctuation.definition.numeric.base
 #     ^ storage.type.numeric
 #      ^ invalid.illegal.numeric
  0b10101010ir
 #^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.binary
+#^^ punctuation.definition.numeric.base
 #          ^ storage.type.numeric
 #           ^ invalid.illegal.numeric
 


### PR DESCRIPTION
This commit renames the scopes for `0x`, `0b`, `0` numeric prefixes to `punctuation.definition.numeric.base`.