### PR TITLE
[D] Improve numbers

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -13,17 +13,29 @@ variables:
   name_lookahead: '(?=\b{{name}}\b)'
   identifier_ref: '\.?\s*{{name}}(\s*\.\s*{{name}})*'
   string_postfix: '[cwd]?'
-  escape_sequence: '\\([''"?\\0abfnrtv]|x{{hex_char}}{2}|[0-7]{1,3}|u{{hex_char}}{4}|U{{hex_char}}{8}|&\w+;)'
-  hex_char: '[0-9a-fA-F]'
-  hex_or_under: '(?:{{hex_char}}|_)'
+  escape_sequence: '\\([''"?\\0abfnrtv]|x\h{2}|[0-7]{1,3}|u\h{4}|U\h{8}|&\w+;)'
 
-  number_lookahead: '(?=(\b|\.)[0-9])'
-  integer_lookahead: '(?=\b[0-9])'
+  # number lookaheads
+  number_lookahead: '(?=(\b|\.)\d)'
+  integer_lookahead: '(?=\b\d)'
+
+  # number digits
+  bin_digits: '(?:[01][01_]*)'
+  hex_digits: '(?:\h[\h_]*)'
+  dec_digits: '(?:\d[\d_]*)'
+  dec_integer: '(?:0_*|[1-9][0-9_]*)'
+
+  # number suffixes
+  imaginary_suffix: '[fFL]?i'
   integer_suffix: 'L[uU]|[uU]L|[LuU]'
-  integer_float_suffix: '[fF]i?|i'
-  float_suffix: '[fFL]i?|i'
-  float_exponent: '[eE][+\-]?[0-9]+'
-  hex_float_exponent: '[pP][+\-]?[0-9]+'
+  integer_float_suffix: '[fFL]'
+  float_suffix: '[fF]'
+
+  # number exponents
+  exponent: '[-+]??\d+'
+  dec_exponent: '(?:[eE]{{exponent}})'
+  hex_exponent: '(?:[pP]{{exponent}})'
+
   character_lookahead: (?=')
   string_lookahead: '(?=`|[rxq]?"|q{)'
 
@@ -182,74 +194,103 @@ contexts:
     - include: integer-opt
     - include: not-whitespace-illegal-pop
   integer-opt:
-    - match: '\b(0|[1-9][0-9_]*)({{integer_suffix}})?\b'
+    - match: '(0[bB])(_?){{bin_digits}}({{integer_suffix}})?'
+      scope: constant.numeric.integer.binary.d
       captures:
-        1: constant.numeric.integer.d
-        2: storage.type.integer.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: storage.type.numeric.d
       pop: true
-    - match: '\b(0[bB])([01][01_]*)({{integer_suffix}})?\b'
+    - match: '(0[xX])(_?){{hex_digits}}({{integer_suffix}})?'
+      scope: constant.numeric.integer.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.binary.d
-        2: constant.numeric.integer.binary.d
-        3: storage.type.integer.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: storage.type.numeric.d
       pop: true
-    - match: '\b(0[xX])({{hex_char}}(?:_|{{hex_char}})*)({{integer_suffix}})?\b'
+    - match: '{{dec_integer}}({{integer_suffix}})?'
+      scope: constant.numeric.integer.decimal.d
       captures:
-        1: punctuation.definition.numeric.hexadecimal.d
-        2: constant.numeric.integer.hexadecimal.d
-        3: storage.type.integer.d
+        1: storage.type.numeric.d
       pop: true
 
   floating-point:
     - include: floating-point-opt
     - include: not-whitespace-illegal-pop
   floating-point-opt:
-    - match: '\b(0[xX])({{hex_or_under}}*\.?{{hex_or_under}}+)({{hex_float_exponent}})({{float_suffix}})?\b'
+    # decimal imaginary numbers
+    - match: '{{dec_integer}}?(?:(\.){{dec_digits}}?)?{{dec_exponent}}?({{imaginary_suffix}})'
+      scope: constant.numeric.imaginary.decimal.d
       captures:
-        1: punctuation.definition.numeric.hexadecimal.d
-        2: constant.numeric.float.hexadecimal.d
-        3: constant.numeric.float.hexadecimal.d
-        4: storage.type.float.d
+        1: punctuation.separator.decimal.d
+        2: storage.type.numeric.d
       pop: true
-    - match: '\b(0|[1-9][0-9_]*)({{integer_float_suffix}})\b'
+    # decimal floats
+    - match: |-
+        (?x:
+          {{dec_integer}}
+          (?:
+            (?:
+              (\.)
+              (?:
+                # 1.1, 1.1e1, 1.1e-1, 1.1f, 1.1e1f, 1.1e-1f, 1.1L, 1.1e1L, 1.1e-1L
+                {{dec_digits}} {{dec_exponent}}?
+                # 1.e1, 1.e-1, 1.e1f, 1.e-1f, 1.e1L, 1.e-1L
+                | {{dec_exponent}}
+                # 1., 1.f, 1.L # but not `..` or method/attribute access
+                | (?!\.|\s*[[:alpha:]_]) )
+              # 1e1 1e1f 1e1L
+              | {{dec_exponent}}
+            ) ({{integer_float_suffix}})?
+            # 1f
+            | ({{float_suffix}})
+          )
+          # .1, .1e1, .1e-1, .1f, .1e1f, .1e-1f, .1L, .1e1L, .1e-1L
+          | (\.) {{dec_digits}} {{dec_exponent}}? ({{integer_float_suffix}})?
+        )
+      scope: constant.numeric.float.decimal.d
       captures:
-        1: constant.numeric.float.d
-        2: storage.type.float.d
+        1: punctuation.separator.decimal.d
+        2: storage.type.numeric.d
+        3: storage.type.numeric.d
+        4: punctuation.separator.decimal.d
+        5: storage.type.numeric.d
       pop: true
-    - match: '\b(0[bB])([01][01_]*)({{integer_float_suffix}})\b'
+
+    # hexadecimal imaginary numbers
+    - match: (0[xX])(_?){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}?({{imaginary_suffix}})
+      scope: constant.numeric.imaginary.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.binary.d
-        2: constant.numeric.float.binary.d
-        3: storage.type.float.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: punctuation.separator.decimal.d
+        4: storage.type.numeric.d
       pop: true
-    - match: '\b(0[xX])({{hex_char}}{{hex_or_under}}*)({{hex_float_exponent}})({{integer_float_suffix}})\b'
+    # hexadecimal floats
+    - match: (0[xX])(_?){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}({{integer_float_suffix}})?
+      scope: constant.numeric.float.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.hexadecimal.d
-        2: constant.numeric.float.hexadecimal.d
-        3: storage.type.float.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: punctuation.separator.decimal.d
+        4: storage.type.numeric.d
       pop: true
-    - match: '\b([0-9][0-9_]*\.[0-9][0-9_]*)({{float_exponent}})?({{float_suffix}})?\b'
+
+    # binary imaginary numbers
+    - match: (0[bB])(_?){{bin_digits}}({{imaginary_suffix}})
+      scope: constant.numeric.imaginary.binary.d
       captures:
-        1: constant.numeric.float.d
-        2: constant.numeric.float.d
-        3: storage.type.float.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: storage.type.numeric.d
       pop: true
-    - match: '\b([0-9][0-9_]*\.(?!\.|\s*[a-zA-Z]))({{float_suffix}})?'
+    # binary floats
+    - match: (0[bB])(_?){{bin_digits}}({{float_suffix}})
+      scope: constant.numeric.float.binary.d
       captures:
-        1: constant.numeric.float.d
-        2: storage.type.float.d
-      pop: true
-    - match: '(\.[0-9][0-9_]*)({{float_exponent}})?({{float_suffix}})?\b'
-      captures:
-        1: constant.numeric.float.d
-        2: constant.numeric.float.d
-        3: storage.type.float.d
-      pop: true
-    - match: '\b([0-9][0-9_]*)({{float_exponent}})({{float_suffix}})?\b'
-      captures:
-        1: constant.numeric.float.d
-        2: constant.numeric.float.d
-        3: storage.type.float.d
+        1: punctuation.definition.numeric.base.d
+        2: invalid.illegal.numeric.d
+        3: storage.type.numeric.d
       pop: true
 
   character-in:
@@ -325,7 +366,7 @@ contexts:
             1: punctuation.definition.string.end.d
             2: storage.type.string.d
           pop: true
-        - match: '{{hex_char}}\s*{{hex_char}}'
+        - match: '\h\s*\h'
           scope: constant.character.escape.d
         - match: '\S'
           scope: invalid.illegal.unknown-escape.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -139,7 +139,7 @@ auto tokenString = q{
 //  ^^^^ variable.language.d
 //       ^^ keyword.d
 //              ^^^^ storage.type.d
-//                        ^^ constant.numeric.integer.d
+//                        ^^ constant.numeric.integer.decimal.d
     /*}*/
 //  ^^^^^^ meta.string.d
 //  ^^ punctuation.definition.comment.d
@@ -173,79 +173,129 @@ c = ''';
 //  ^^ invalid.illegal.d
 
 auto dec = 2_0__000;
-//         ^^^^^^^^ constant.numeric.integer.d
+//         ^^^^^^^^ constant.numeric.integer.decimal.d
 dec = 1L;
-//    ^ constant.numeric.integer.d
-//     ^ storage.type.integer.d
+//    ^^ constant.numeric.integer.decimal.d
+//     ^ storage.type.numeric.d
 dec = 1u;
-//    ^ constant.numeric.integer.d
-//     ^ storage.type.integer.d
+//    ^^ constant.numeric.integer.decimal.d
+//     ^ storage.type.numeric.d
 dec = 1U;
-//    ^ constant.numeric.integer.d
-//     ^ storage.type.integer.d
+//    ^^ constant.numeric.integer.decimal.d
+//     ^ storage.type.numeric.d
 dec = 1Lu;
-//    ^ constant.numeric.integer.d
-//     ^^ storage.type.integer.d
+//    ^^^ constant.numeric.integer.decimal.d
+//     ^^ storage.type.numeric.d
 dec = 1LU;
-//    ^ constant.numeric.integer.d
-//     ^^ storage.type.integer.d
+//    ^^^ constant.numeric.integer.decimal.d
+//     ^^ storage.type.numeric.d
 dec = 1uL;
-//    ^ constant.numeric.integer.d
-//     ^^ storage.type.integer.d
+//    ^^^ constant.numeric.integer.decimal.d
+//     ^^ storage.type.numeric.d
 dec = 1UL;
-//    ^ constant.numeric.integer.d
-//     ^^ storage.type.integer.d
+//    ^^^ constant.numeric.integer.decimal.d
+//     ^^ storage.type.numeric.d
 auto bin = 0b1;
-//         ^^ punctuation.definition.numeric.binary.d
-//           ^ constant.numeric.integer.binary.d
+//         ^^ punctuation.definition.numeric.base.d
+//         ^^^ constant.numeric.integer.binary.d
 bin = 0b10__1;
-//    ^^ punctuation.definition.numeric.binary.d
-//      ^^^^^ constant.numeric.integer.binary.d
+//    ^^ punctuation.definition.numeric.base.d
+//    ^^^^^^^ constant.numeric.integer.binary.d
 bin = 0B1;
-//    ^^ punctuation.definition.numeric.binary.d
-//      ^ constant.numeric.integer.binary.d
+//    ^^ punctuation.definition.numeric.base.d
+//    ^^^ constant.numeric.integer.binary.d
 auto hex = 0xFf;
-//         ^^ punctuation.definition.numeric.hexadecimal.d
-//           ^^ constant.numeric.integer.hexadecimal.d
+//         ^^ punctuation.definition.numeric.base.d
+//         ^^^^ constant.numeric.integer.hexadecimal.d
 hex = 0x012_3;
-//    ^^ punctuation.definition.numeric.hexadecimal.d
-//      ^^^^^ constant.numeric.integer.hexadecimal.d
+//    ^^ punctuation.definition.numeric.base.d
+//    ^^^^^^^ constant.numeric.integer.hexadecimal.d
 hex = 0X1;
-//    ^^ punctuation.definition.numeric.hexadecimal.d
-//      ^ constant.numeric.integer.hexadecimal.d
+//    ^^ punctuation.definition.numeric.base.d
+//    ^^^ constant.numeric.integer.hexadecimal.d
+
+imag = 123_45i + 0_.1_i + 12_.e1i;
+//     ^^^^^^^ constant.numeric.imaginary.decimal.d
+//           ^ storage.type.numeric.d
+//             ^ keyword.operator.arithmetic.d
+//               ^^^^^^ constant.numeric.imaginary.decimal.d
+//                 ^ punctuation.separator.decimal.d
+//                    ^ storage.type.numeric.d
+//                        ^^^^^^^ constant.numeric.imaginary.decimal.d
+//                           ^ punctuation.separator.decimal.d
+//                              ^ storage.type.numeric.d
+imag = 23134723__742e1i;
+//     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.decimal.d
+//                    ^ storage.type.numeric.d
+imag = 0x_3472389742f_i;
+//     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.d
+//     ^^ punctuation.definition.numeric.base.d
+//       ^ invalid.illegal.numeric.d
+//                    ^ storage.type.numeric.d
+imag = 0x_34723897p-34i;
+//     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.d
+//     ^^ punctuation.definition.numeric.base.d
+//       ^ invalid.illegal.numeric.d
+//                    ^ storage.type.numeric.d
+imag = 0x347._23897p-34i;
+//     ^^^^^ constant.numeric.integer.hexadecimal.d
+//     ^^ punctuation.definition.numeric.base.d
+//          ^ punctuation.accessor.dot.d
+//           ^^^^^^^ variable.other.d
+//                  ^ keyword.operator.arithmetic.d
+//                   ^^^ constant.numeric.imaginary.decimal.d
+imag = 0b_0100_010_00_i;
+//     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.binary.d
+//     ^^ punctuation.definition.numeric.base.d
+//       ^ invalid.illegal.numeric.d
+//                    ^ storage.type.numeric.d
 
 auto f = 0_.0_;
-//       ^^^ constant.numeric.float.d
+//       ^^^^^ constant.numeric.float.decimal.d
+//         ^ punctuation.separator.decimal.d
 f = 0_.;
-//  ^^ constant.numeric.float.d
+//  ^^^ constant.numeric.float.decimal.d
+//    ^ punctuation.separator.decimal.d
 f = .123_1243;
-//  ^^^^^^^^^ constant.numeric.float.d
-f = 2313472389742e1i;
-//  ^^^^^^^^^^^^^^^ constant.numeric.float.d
-//                 ^ storage.type.float.d
+//  ^ punctuation.separator.decimal.d
+//  ^^^^^^^^^ constant.numeric.float.decimal.d
+f = ._123_1243 + 1._123;
+//  ^ punctuation.accessor.dot.d
+//   ^^^^^^^^^ variable.other.d
+//             ^ keyword.operator.arithmetic.d
+//               ^ constant.numeric.integer.decimal.d
+//                ^ punctuation.accessor.dot.d
+//                 ^^^^ variable.other.d
 f = 3423.2e-45;
-//  ^^^^^^^^^ constant.numeric.float.d
+//  ^^^^^^^^^^ constant.numeric.float.decimal.d
+//      ^ punctuation.separator.decimal.d
+f = 2.e-45;
+//  ^^^^^^ constant.numeric.float.decimal.d
+//   ^ punctuation.separator.decimal.d
 f = .4E+4L;
-//  ^^^^^ constant.numeric.float.d
-//       ^ storage.type.float.d
+//  ^ punctuation.separator.decimal.d
+//  ^^^^^^ constant.numeric.float.decimal.d
+//       ^ storage.type.numeric.d
 f =  1f;
-//   ^ constant.numeric.float.d
-//    ^ storage.type.float.d
+//   ^^ constant.numeric.float.decimal.d
+//    ^ storage.type.numeric.d
 f = 0x123p2f;
-//  ^^ punctuation.definition.numeric.hexadecimal.d
-//    ^^^^^ constant.numeric.float.hexadecimal.d
-//         ^ storage.type.float.d
+//  ^^ punctuation.definition.numeric.base.d
+//  ^^^^^^^^ constant.numeric.float.hexadecimal.d
+//         ^ storage.type.numeric.d
 f = 0b10101101f;
-//  ^^ punctuation.definition.numeric.binary.d
-//    ^^^^^^^^ constant.numeric.float.binary.d
-//            ^ storage.type.float.d
+//  ^^ punctuation.definition.numeric.base.d
+//  ^^^^^^^^^^^ constant.numeric.float.binary.d
+//            ^ storage.type.numeric.d
 f = 0x.1aFp2;
-//  ^^ punctuation.definition.numeric.hexadecimal.d
-//    ^^^^^^ constant.numeric.float.hexadecimal.d
+//  ^^ punctuation.definition.numeric.base.d
+//  ^^^^^^^^ constant.numeric.float.hexadecimal.d
+//    ^ punctuation.separator.decimal.d
 f = 0xF.AP-2f;
-//  ^^ punctuation.definition.numeric.hexadecimal.d
-//    ^^^^^^ constant.numeric.float.hexadecimal.d
-//          ^ storage.type.float.d
+//  ^^ punctuation.definition.numeric.base.d
+//  ^^^^^^^^^ constant.numeric.float.hexadecimal.d
+//     ^ punctuation.separator.decimal.d
+//          ^ storage.type.numeric.d
 
   @foo:
 //^ punctuation.definition.annotation.begin.d
@@ -262,8 +312,8 @@ f = 0xF.AP-2f;
 //              ^^^^^^^^^ meta.function-call.d
 //              ^^^ meta.path.d storage.type.d
 //                 ^ punctuation.section.parens.begin.d
-//                  ^ constant.numeric.integer.d
-//                     ^ constant.numeric.integer.d
+//                  ^ constant.numeric.integer.decimal.d
+//                     ^ constant.numeric.integer.decimal.d
 //                      ^ punctuation.section.parens.end.d
 //                       ^^^^^^^^^ storage.modifier.d
   static shared const immutable final __gshared nothrow pure ref
@@ -295,13 +345,13 @@ extern(1)
 //^^^^^ keyword.other.alignment.d
 //      ^^^^^ keyword.other.alignment.d
 //           ^ punctuation.section.parens.begin.d
-//            ^ constant.numeric.integer.d
+//            ^ constant.numeric.integer.decimal.d
 //             ^ punctuation.section.parens.end.d
 //               ^^^^^ keyword.other.alignment.d
 //                    ^ punctuation.section.parens.begin.d
 //                     ^^^ variable.other.d
 //                         ^ keyword.operator.arithmetic.d
-//                           ^ constant.numeric.integer.d
+//                           ^ constant.numeric.integer.decimal.d
 //                            ^ punctuation.section.parens.end.d
   deprecated
 //^^^^^^^^^^ keyword.other.deprecated.d
@@ -488,7 +538,7 @@ extern(1)
 //          ^ punctuation.section.brackets.end.d
 //            ^ variable.other.d
 //              ^ keyword.operator.assignment.d
-//                ^^^ constant.numeric.integer.d
+//                ^^^ constant.numeric.integer.decimal.d
 //                   ^ punctuation.terminator.d
   bar* some_long_Name;
 //^^^ variable.other.d
@@ -499,14 +549,14 @@ extern(1)
 //^^^^ storage.modifier.d
 //     ^^^ variable.other.d
 //         ^ keyword.operator.assignment.d
-//           ^ constant.numeric.integer.d
+//           ^ constant.numeric.integer.decimal.d
 //            ^ punctuation.terminator.d
   auto
 //^^^^ storage.modifier.d
   asjfaisdjaksdjaklsjdnaskjjks = 3;
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.other.d
 //                             ^ keyword.operator.assignment.d
-//                               ^ constant.numeric.integer.d
+//                               ^ constant.numeric.integer.decimal.d
 //                                ^ punctuation.terminator.d
   char[] buffer_, encoded_;
 //^^^^ storage.type.d
@@ -654,7 +704,7 @@ extern(1)
   //^^^^^^^^^ meta.enum.d
   //^^^ entity.name.constant.d
   //    ^ keyword.operator.assignment.d
-  //      ^ constant.numeric.integer.d
+  //      ^ constant.numeric.integer.decimal.d
   //       ^ punctuation.separator.sequence.d
     1
   //^ meta.enum.d invalid.illegal.d
@@ -669,7 +719,7 @@ extern(1)
 //               ^ punctuation.section.block.begin.d
 //                 ^ entity.name.constant.d
 //                   ^ keyword.operator.assignment.d
-//                     ^^ constant.numeric.integer.d
+//                     ^^ constant.numeric.integer.decimal.d
 //                        ^ punctuation.section.block.end.d
   enum : foo[string] { TEST }
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum.d
@@ -689,7 +739,7 @@ extern(1)
 //       ^^^ storage.type.d
 //           ^ entity.name.constant.d
 //             ^ keyword.operator.assignment.d
-//               ^^ constant.numeric.integer.d
+//               ^^ constant.numeric.integer.decimal.d
 //                 ^ punctuation.separator.sequence.d
     Foo // f
 //  ^^^^^^^^^ meta.enum.d
@@ -704,7 +754,7 @@ extern(1)
 //^^^^ storage.type.enum.d keyword.declaration.enum.d
 //     ^ entity.name.enum.d
 //       ^ keyword.operator.assignment.d
-//         ^^ constant.numeric.integer.d
+//         ^^ constant.numeric.integer.decimal.d
 //           ^ punctuation.terminator.d
   enum f(x, int t) = cast(x)t;
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum.d
@@ -731,7 +781,7 @@ extern(1)
 //          ^ punctuation.section.brackets.end.d
 //            ^^^ entity.name.enum.d
 //                ^ keyword.operator.assignment.d
-//                  ^^ constant.numeric.integer.d
+//                  ^^ constant.numeric.integer.decimal.d
 //                    ^ punctuation.terminator.d
   enum fool
 //^^^^^^^^^^ meta.enum.d
@@ -747,15 +797,15 @@ extern(1)
 //     ^^^^ storage.type.d
 //          ^ entity.name.enum.d
 //            ^ keyword.operator.assignment.d
-//              ^ constant.numeric.integer.d
+//              ^ constant.numeric.integer.decimal.d
 //               ^ punctuation.separator.sequence.d
 //                 ^ entity.name.enum.d
 //                   ^ keyword.operator.assignment.d
-//                     ^ constant.numeric.integer.d
+//                     ^ constant.numeric.integer.decimal.d
 //                      ^ punctuation.separator.sequence.d
 //                        ^^^^^^^^^^^^ entity.name.enum.d
 //                                     ^ keyword.operator.assignment.d
-//                                       ^ constant.numeric.integer.d
+//                                       ^ constant.numeric.integer.decimal.d
 //                                        ^ punctuation.terminator.d
   enum immutable(Char)[] seqBefore = "[";
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum.d
@@ -785,17 +835,17 @@ extern(1)
   //^^^^^^^^^^^^ meta.enum.d
   //^ entity.name.enum.d
   //  ^ keyword.operator.assignment.d
-  //    ^ constant.numeric.integer.d
+  //    ^ constant.numeric.integer.decimal.d
   //      ^^ keyword.operator.bitwise.d
-  //         ^ constant.numeric.integer.d
+  //         ^ constant.numeric.integer.decimal.d
   //          ^ punctuation.separator.sequence.d
     b = 1 << 3;
   //^^^^^^^^^^^ meta.enum.d
   //^ entity.name.enum.d
   //  ^ keyword.operator.assignment.d
-  //    ^ constant.numeric.integer.d
+  //    ^ constant.numeric.integer.decimal.d
   //      ^^ keyword.operator.bitwise.d
-  //         ^ constant.numeric.integer.d
+  //         ^ constant.numeric.integer.decimal.d
   //          ^ punctuation.terminator.d
   enum foo
 //^^^^^^^^^ meta.enum.d
@@ -805,7 +855,7 @@ extern(1)
   //^^^^^^^^ meta.enum.d
   //^^^ entity.name.enum.d
   //    ^ keyword.operator.assignment.d
-  //      ^ constant.numeric.integer.d
+  //      ^ constant.numeric.integer.decimal.d
   //       ^ punctuation.terminator.d
   enum Attr;
 //^^^^^^^^^^ meta.enum.d
@@ -835,7 +885,7 @@ extern(1)
   version(1):
 //^^^^^^^ keyword.control.conditional.d
 //       ^ punctuation.section.parens.begin.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //         ^ punctuation.section.parens.end.d
 //          ^ punctuation.separator.d
 
@@ -867,7 +917,7 @@ extern(1)
   debug = 2;
 //^^^^^ keyword.control.conditional.d
 //      ^ keyword.operator.assignment.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //         ^ punctuation.terminator.d
   version = foo;
 //^^^^^^^ keyword.control.conditional.d
@@ -878,16 +928,16 @@ extern(1)
 //^^^^^^^ keyword.control.conditional.d
    = 5;
 // ^ keyword.operator.assignment.d
-//   ^ constant.numeric.integer.d
+//   ^ constant.numeric.integer.decimal.d
 //    ^ punctuation.terminator.d
   int foo = true;
   static if (12 + 5):
 //^^^^^^ storage.modifier.d
 //       ^^ keyword.control.conditional.d
 //          ^ punctuation.section.parens.begin.d
-//           ^^ constant.numeric.integer.d
+//           ^^ constant.numeric.integer.decimal.d
 //              ^ keyword.operator.arithmetic.d
-//                ^ constant.numeric.integer.d
+//                ^ constant.numeric.integer.decimal.d
 //                 ^ punctuation.section.parens.end.d
 //                  ^ punctuation.separator.d
   static if (true) {} else {}
@@ -904,7 +954,7 @@ extern(1)
 //^^^^^^ storage.modifier.d
 //       ^^ keyword.control.conditional.d
 //          ^ punctuation.section.parens.begin.d
-//           ^ constant.numeric.integer.d
+//           ^ constant.numeric.integer.decimal.d
 //            ^ punctuation.section.parens.end.d
 //              ^ punctuation.section.block.begin.d
   } else static if (1) {
@@ -913,7 +963,7 @@ extern(1)
 //       ^^^^^^ storage.modifier.d
 //              ^^ keyword.control.conditional.d
 //                 ^ punctuation.section.parens.begin.d
-//                  ^ constant.numeric.integer.d
+//                  ^ constant.numeric.integer.decimal.d
 //                   ^ punctuation.section.parens.end.d
 //                     ^ punctuation.section.block.begin.d
   }
@@ -930,7 +980,7 @@ extern(1)
   //                ^^^ storage.type.d
   //                    ^ variable.parameter.d
   //                     ^ punctuation.separator.sequence.d
-  //                       ^^^ constant.numeric.integer.d
+  //                       ^^^ constant.numeric.integer.decimal.d
   //                          ^ punctuation.section.parens.end.d
   //                            ^ punctuation.section.block.begin.d
   //                             ^
@@ -943,14 +993,14 @@ extern(1)
 //^^^^^^ keyword.other.assert.d
 //       ^^^^^^ keyword.other.assert.d
 //             ^ punctuation.section.parens.begin.d
-//              ^^ constant.numeric.integer.d
+//              ^^ constant.numeric.integer.decimal.d
 //                ^ punctuation.section.parens.end.d
 //                 ^ punctuation.terminator.d
   static assert(12, "foobar");
 //^^^^^^ keyword.other.assert.d
 //       ^^^^^^ keyword.other.assert.d
 //             ^ punctuation.section.parens.begin.d
-//              ^^ constant.numeric.integer.d
+//              ^^ constant.numeric.integer.decimal.d
 //                ^ punctuation.separator.sequence.d
 //                  ^^^^^^^^ string.quoted.double.d
 //                          ^ punctuation.section.parens.end.d
@@ -1095,11 +1145,11 @@ extern(1)
 //                    ^ variable.parameter.d
 //                      ^ keyword.operator.assignment.d
 //                        ^ punctuation.section.brackets.begin.d
-//                         ^ constant.numeric.integer.d
+//                         ^ constant.numeric.integer.decimal.d
 //                          ^ punctuation.separator.sequence.d
-//                            ^ constant.numeric.integer.d
+//                            ^ constant.numeric.integer.decimal.d
 //                             ^ punctuation.separator.sequence.d
-//                               ^ constant.numeric.integer.d
+//                               ^ constant.numeric.integer.decimal.d
 //                                ^ punctuation.section.brackets.end.d
 //                                 ^ punctuation.section.group.end.d
 //                                   ^^ meta.function.d meta.block.d
@@ -1308,7 +1358,7 @@ extern(1)
   //^^^^^^ meta.function-call.d
   //^^^ meta.path.d variable.function.d
   //   ^ punctuation.section.parens.begin.d
-  //    ^ constant.numeric.integer.d
+  //    ^ constant.numeric.integer.decimal.d
   //     ^ punctuation.section.parens.end.d
   //      ^ punctuation.terminator.d
   }
@@ -1375,11 +1425,11 @@ extern(1)
 //^^^^ meta.function.d entity.name.function.constructor.d
 //    ^^^^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
-//     ^ constant.numeric.integer.d
+//     ^ constant.numeric.integer.decimal.d
 //      ^ punctuation.separator.sequence.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //         ^ punctuation.separator.sequence.d
-//           ^ constant.numeric.integer.d
+//           ^ constant.numeric.integer.decimal.d
 //            ^ punctuation.section.group.end.d
 //             ^ meta.function.d punctuation.terminator.d
   this(T)(T foo);
@@ -1436,7 +1486,7 @@ extern(1)
   invariant(0, "test") {
 //^^^^^^^^^ keyword.other.invariant.d
 //         ^ punctuation.section.parens.begin.d
-//          ^ constant.numeric.integer.d
+//          ^ constant.numeric.integer.decimal.d
 //           ^ punctuation.separator.sequence.d
 //             ^^^^^^ string.quoted.double.d
 //                   ^ punctuation.section.parens.end.d
@@ -1561,7 +1611,7 @@ extern(1)
   if (2) {
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //     ^ punctuation.section.parens.end.d
 //       ^ punctuation.section.block.begin.d
   }
@@ -1569,7 +1619,7 @@ extern(1)
   if (1) {} else {}
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //     ^ punctuation.section.parens.end.d
 //       ^ punctuation.section.block.begin.d
 //        ^ punctuation.section.block.end.d
@@ -1580,33 +1630,33 @@ extern(1)
   if (1) {} else 1;
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //     ^ punctuation.section.parens.end.d
 //       ^ punctuation.section.block.begin.d
 //        ^ punctuation.section.block.end.d
 //          ^^^^ keyword.control.conditional.d
-//               ^ constant.numeric.integer.d
+//               ^ constant.numeric.integer.decimal.d
 
   while (2) 1;
 //^^^^^ keyword.control.loop.d
 //      ^ punctuation.section.parens.begin.d
-//       ^ constant.numeric.integer.d
+//       ^ constant.numeric.integer.decimal.d
 //        ^ punctuation.section.parens.end.d
-//          ^ constant.numeric.integer.d
+//          ^ constant.numeric.integer.decimal.d
   while (2)
 //^^^^^ keyword.control.loop.d
 //      ^ punctuation.section.parens.begin.d
-//       ^ constant.numeric.integer.d
+//       ^ constant.numeric.integer.decimal.d
 //        ^ punctuation.section.parens.end.d
   {
 //^ punctuation.section.block.begin.d
     do 2;
   //^^ keyword.control.loop.d
-  //   ^ constant.numeric.integer.d
+  //   ^ constant.numeric.integer.decimal.d
     while (3);
   //^^^^^ keyword.control.loop.d
   //      ^ punctuation.section.parens.begin.d
-  //       ^ constant.numeric.integer.d
+  //       ^ constant.numeric.integer.decimal.d
   //        ^ punctuation.section.parens.end.d
     do
   //^^ keyword.control.loop.d
@@ -1616,18 +1666,18 @@ extern(1)
   //^ punctuation.section.block.end.d
   //  ^^^^^ keyword.control.loop.d
   //        ^ punctuation.section.parens.begin.d
-  //         ^ constant.numeric.integer.d
+  //         ^ constant.numeric.integer.decimal.d
   //          ^ punctuation.section.parens.end.d
   }
 //^ punctuation.section.block.end.d
   for (1; 2; 3) {
 //^^^ keyword.control.loop.d
 //    ^ punctuation.section.parens.begin.d
-//     ^ constant.numeric.integer.d
+//     ^ constant.numeric.integer.decimal.d
 //      ^ punctuation.terminator.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //         ^ punctuation.terminator.d
-//           ^ constant.numeric.integer.d
+//           ^ constant.numeric.integer.decimal.d
 //            ^ punctuation.section.parens.end.d
 //              ^ punctuation.section.block.begin.d
   }
@@ -1638,7 +1688,7 @@ extern(1)
 //    ^^^ storage.type.d
 //        ^ variable.other.d
 //         ^^ punctuation.terminator.d
-//           ^^ constant.numeric.integer.d
+//           ^^ constant.numeric.integer.decimal.d
 //             ^ punctuation.section.parens.end.d
 //               ^ punctuation.section.block.begin.d
   }
@@ -1677,7 +1727,7 @@ extern(1)
 //                  ^ punctuation.section.parens.begin.d
 //                   ^^^ storage.type.d
 //                      ^ punctuation.section.parens.end.d
-//                       ^ constant.numeric.integer.d
+//                       ^ constant.numeric.integer.decimal.d
 //                        ^ punctuation.terminator.d
 //                         ^ punctuation.section.parens.end.d
 //                           ^ punctuation.section.block.begin.d
@@ -1688,9 +1738,9 @@ extern(1)
 //         ^^^ storage.type.d
 //             ^ variable.parameter.d
 //              ^ punctuation.separator.sequence.d
-//                ^ constant.numeric.integer.d
+//                ^ constant.numeric.integer.decimal.d
 //                 ^^ keyword.operator.slice.d
-//                   ^ constant.numeric.integer.d
+//                   ^ constant.numeric.integer.decimal.d
 //                    ^ punctuation.section.parens.end.d
 //                      ^ punctuation.section.block.begin.d
     foreach_reverse (int a; 2) {
@@ -1699,7 +1749,7 @@ extern(1)
   //                 ^^^ storage.type.d
   //                     ^ variable.parameter.d
   //                      ^ punctuation.separator.sequence.d
-  //                        ^ constant.numeric.integer.d
+  //                        ^ constant.numeric.integer.decimal.d
   //                         ^ punctuation.section.parens.end.d
   //                           ^ punctuation.section.block.begin.d
     }
@@ -1736,7 +1786,7 @@ extern(1)
 //      ^ punctuation.terminator.d
   return 2;
 //^^^^^^ keyword.control.flow.d
-//       ^ constant.numeric.integer.d
+//       ^ constant.numeric.integer.decimal.d
 //        ^ punctuation.terminator.d
   goto foo;
 //^^^^ keyword.control.flow.d
@@ -1753,34 +1803,34 @@ extern(1)
   goto case 2;
 //^^^^ keyword.control.flow.d
 //     ^^^^ keyword.control.flow.d
-//          ^ constant.numeric.integer.d
+//          ^ constant.numeric.integer.decimal.d
 //           ^ punctuation.terminator.d
 
   with (2) {}
 //^^^^ keyword.other.with.d
 //     ^ punctuation.section.parens.begin.d
-//      ^ constant.numeric.integer.d
+//      ^ constant.numeric.integer.decimal.d
 //       ^ punctuation.section.parens.end.d
 //         ^ punctuation.section.block.begin.d
 //          ^ punctuation.section.block.end.d
   with (2) 3;
 //^^^^ keyword.other.with.d
 //     ^ punctuation.section.parens.begin.d
-//      ^ constant.numeric.integer.d
+//      ^ constant.numeric.integer.decimal.d
 //       ^ punctuation.section.parens.end.d
-//         ^ constant.numeric.integer.d
+//         ^ constant.numeric.integer.decimal.d
 
   synchronized (3) {}
 //^^^^^^^^^^^^ keyword.other.synchronized.d
 //             ^ punctuation.section.parens.begin.d
-//              ^ constant.numeric.integer.d
+//              ^ constant.numeric.integer.decimal.d
 //               ^ punctuation.section.parens.end.d
 //                 ^ punctuation.section.block.begin.d
 //                  ^ punctuation.section.block.end.d
   synchronized(3);
 //^^^^^^^^^^^^ keyword.other.synchronized.d
 //            ^ punctuation.section.parens.begin.d
-//             ^ constant.numeric.integer.d
+//             ^ constant.numeric.integer.decimal.d
 //              ^ punctuation.section.parens.end.d
 
   try {
@@ -1812,7 +1862,7 @@ extern(1)
 //^ punctuation.section.block.end.d
   throw 3;
 //^^^^^ keyword.control.flow.exception.d
-//      ^ constant.numeric.integer.d
+//      ^ constant.numeric.integer.decimal.d
 
   scope (exit) {}
 //^^^^^ keyword.control.flow.d
@@ -1833,7 +1883,7 @@ extern(1)
 //     ^ punctuation.section.parens.begin.d
 //      ^^^^^^^ keyword.control.flow.d
 //             ^ punctuation.section.parens.end.d
-//               ^ constant.numeric.integer.d
+//               ^ constant.numeric.integer.decimal.d
 
   asm {
 //^^^ keyword.declaration.asm.d
@@ -1858,13 +1908,13 @@ extern(1)
 //    ^ keyword.operator.assignment.d
 //      ^^^ keyword.operator.word.d
 //          ^ punctuation.section.parens.begin.d
-//           ^^ constant.numeric.integer.d
+//           ^^ constant.numeric.integer.decimal.d
 //             ^ punctuation.separator.sequence.d
 //               ^^^^^ string.quoted.double.d
 //                    ^ punctuation.section.parens.end.d
 //                      ^^^^^^ storage.type.d
 //                            ^ punctuation.section.brackets.begin.d
-//                             ^^ constant.numeric.integer.d
+//                             ^^ constant.numeric.integer.decimal.d
 //                               ^ punctuation.section.brackets.end.d
 //                                ^ punctuation.section.parens.begin.d
 //                                 ^^^^^ string.quoted.double.d
@@ -1872,7 +1922,7 @@ extern(1)
 //                                        ^^^^^ string.quoted.double.d
 //                                             ^ punctuation.section.parens.end.d
 //                                              ^ punctuation.section.brackets.begin.d
-//                                               ^^ constant.numeric.integer.d
+//                                               ^^ constant.numeric.integer.decimal.d
 //                                                 ^ punctuation.section.brackets.end.d
 //                                                  ^ punctuation.terminator.d
   i = new Foo();
@@ -1887,15 +1937,15 @@ extern(1)
   new(1, 2, 3) string[12];
 //^^^ keyword.operator.word.d
 //   ^ punctuation.section.parens.begin.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //     ^ punctuation.separator.sequence.d
-//       ^ constant.numeric.integer.d
+//       ^ constant.numeric.integer.decimal.d
 //        ^ punctuation.separator.sequence.d
-//          ^ constant.numeric.integer.d
+//          ^ constant.numeric.integer.decimal.d
 //           ^ punctuation.section.parens.end.d
 //             ^^^^^^ storage.type.d
 //                   ^ punctuation.section.brackets.begin.d
-//                    ^^ constant.numeric.integer.d
+//                    ^^ constant.numeric.integer.decimal.d
 //                      ^ punctuation.section.brackets.end.d
 //                       ^ punctuation.terminator.d
   auto c = new class (12) T, Bar {
@@ -1906,7 +1956,7 @@ extern(1)
 //             ^^^^^^^^^^^^^^^^^^^^ meta.class.d
 //             ^^^^^ storage.type.class.d keyword.declaration.class.d
 //                   ^ punctuation.section.parens.begin.d
-//                    ^^ constant.numeric.integer.d
+//                    ^^ constant.numeric.integer.decimal.d
 //                      ^ punctuation.section.parens.end.d
 //                        ^ storage.type.d
 //                         ^ punctuation.separator.sequence.d
@@ -1953,7 +2003,7 @@ extern(1)
     //^^^^^^ keyword.control.flow.d
     //       ^^^ meta.path.d variable.other.d
     //           ^ keyword.operator.arithmetic.d
-    //             ^ constant.numeric.integer.d
+    //             ^ constant.numeric.integer.decimal.d
     //              ^ punctuation.terminator.d
     }
   //^ meta.class.d meta.block.d meta.function.d meta.block.d punctuation.section.block.end.d
@@ -1968,19 +2018,19 @@ extern(1)
 //         ^ punctuation.section.parens.end.d
 //           ^ keyword.operator.assignment.d
 //             ^ punctuation.section.group.begin.d
-//              ^^ constant.numeric.integer.d
+//              ^^ constant.numeric.integer.decimal.d
 //                 ^^ keyword.operator.arithmetic.d
-//                    ^ constant.numeric.integer.d
+//                    ^ constant.numeric.integer.decimal.d
 //                     ^ punctuation.section.group.end.d
 //                       ^ keyword.operator.arithmetic.d
-//                         ^ constant.numeric.integer.d
+//                         ^ constant.numeric.integer.decimal.d
 //                           ^ keyword.operator.arithmetic.d
 //                             ^ punctuation.section.group.begin.d
-//                              ^ constant.numeric.integer.d
+//                              ^ constant.numeric.integer.decimal.d
 //                               ^^ keyword.operator.arithmetic.d
 //                                  ^ keyword.operator.arithmetic.d
 //                                    ^^ keyword.operator.arithmetic.d
-//                                      ^ constant.numeric.integer.d
+//                                      ^ constant.numeric.integer.decimal.d
 //                                       ^ punctuation.section.group.end.d
 //                                         ^ keyword.operator.concatenation.d
 //                                           ^^^^^ string.quoted.double.d
@@ -1992,9 +2042,9 @@ extern(1)
 //       ^ keyword.operator.assignment.d
 //         ^^^ meta.path.d variable.other.d
 //             ^ keyword.operator.ternary.d
-//               ^^ constant.numeric.integer.d
+//               ^^ constant.numeric.integer.decimal.d
 //                  ^ keyword.operator.ternary.d
-//                    ^^ constant.numeric.integer.d
+//                    ^^ constant.numeric.integer.decimal.d
 //                      ^ punctuation.terminator.d
 
   foreach (ref a; foo) {}
@@ -2012,11 +2062,11 @@ extern(1)
 //^^^ storage.type.d
 //    ^ variable.other.d
 //      ^ keyword.operator.assignment.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //         ^ punctuation.separator.sequence.d
 //           ^ variable.other.d
 //             ^ keyword.operator.assignment.d
-//               ^ constant.numeric.integer.d
+//               ^ constant.numeric.integer.decimal.d
 //                ^ punctuation.terminator.d
 
   a = "foo", b = "bar";
@@ -2037,9 +2087,9 @@ extern(1)
 //           ^ keyword.operator.assignment.d
 //             ^ punctuation.section.brackets.begin.d
     1: 2,
-  //^ constant.numeric.integer.d
+  //^ constant.numeric.integer.decimal.d
   // ^ punctuation.separator.mapping.key-value.d
-  //   ^ constant.numeric.integer.d
+  //   ^ constant.numeric.integer.decimal.d
   //    ^ punctuation.separator.sequence.d
     "foo",
   //^^^^^ string.quoted.double.d
@@ -2053,21 +2103,21 @@ extern(1)
   switch (2 * 3)
 //^^^^^^ keyword.control.flow.d
 //       ^ punctuation.section.parens.begin.d
-//        ^ constant.numeric.integer.d
+//        ^ constant.numeric.integer.decimal.d
 //          ^ keyword.operator.arithmetic.d
-//            ^ constant.numeric.integer.d
+//            ^ constant.numeric.integer.decimal.d
 //             ^ punctuation.section.parens.end.d
   {
 //^ punctuation.section.block.begin.d
     case 2 ^^ 2:
   //^^^^ keyword.control.flow.d
-  //     ^ constant.numeric.integer.d
+  //     ^ constant.numeric.integer.decimal.d
   //       ^^ keyword.operator.arithmetic.d
-  //          ^ constant.numeric.integer.d
+  //          ^ constant.numeric.integer.decimal.d
   //           ^ punctuation.separator.case-statement.d
     case 2, "foo":
   //^^^^ keyword.control.flow.d
-  //     ^ constant.numeric.integer.d
+  //     ^ constant.numeric.integer.decimal.d
   //      ^ punctuation.separator.sequence.d
   //        ^ meta.string.d string.quoted.double.d punctuation.definition.string.begin.d
   //         ^^^^ meta.string.d string.quoted.double.d
@@ -2075,11 +2125,11 @@ extern(1)
   //^^^^^^^^^^^^^^ meta.block.d
     case 2: .. case 4:
   //^^^^ keyword.control.flow.d
-  //     ^ constant.numeric.integer.d
+  //     ^ constant.numeric.integer.decimal.d
   //      ^ punctuation.separator.case-statement.d
   //        ^^ keyword.operator.d
   //           ^^^^ keyword.control.flow.d
-  //                ^ constant.numeric.integer.d
+  //                ^ constant.numeric.integer.decimal.d
   //                 ^ punctuation.separator.case-statement.d
     default:
   //^^^^^^^ keyword.control.flow.d
@@ -2162,7 +2212,7 @@ extern(1)
   typeof(2) a(typeof('f') b);
 //^^^^^^ keyword.other.d
 //      ^ punctuation.section.parens.begin.d
-//       ^ constant.numeric.integer.d
+//       ^ constant.numeric.integer.decimal.d
 //        ^ punctuation.section.parens.end.d
 //          ^ meta.function.d entity.name.function.d
 //           ^^^^^^^^^^^^^^^ meta.function.parameters.d
@@ -2188,14 +2238,14 @@ extern(1)
 //   ^^^^^^^^^^^^^ meta.function.d
 //   ^^^^^^^^ storage.modifier.d
 //            ^^ storage.type.function.d keyword.declaration.function.lambda.d
-//               ^ constant.numeric.integer.d
+//               ^ constant.numeric.integer.decimal.d
 //                ^ punctuation.terminator.d
   (a => 2);
 //^ punctuation.section.group.begin.d
 // ^^^^^^ meta.function.d
 // ^ variable.parameter.d
 //   ^^ storage.type.function.d keyword.declaration.function.lambda.d
-//      ^ constant.numeric.integer.d
+//      ^ constant.numeric.integer.decimal.d
 //       ^ punctuation.section.group.end.d
 //        ^ punctuation.terminator.d
   (foo) @trusted => foo(3);
@@ -2208,7 +2258,7 @@ extern(1)
 //                  ^^^^^^ meta.function-call.d
 //                  ^^^ variable.function.d
 //                     ^ punctuation.section.parens.begin.d
-//                      ^ constant.numeric.integer.d
+//                      ^ constant.numeric.integer.decimal.d
 //                       ^ punctuation.section.parens.end.d
 //                        ^ punctuation.terminator.d
   (foo..., bar) @safe {};
@@ -2410,32 +2460,32 @@ extern(1)
 //                                                        ^ punctuation.terminator.d
 
   3 != 3 && "s" !in [2];
-//^ constant.numeric.integer.d
+//^ constant.numeric.integer.decimal.d
 //  ^^ keyword.operator.comparison.d
-//     ^ constant.numeric.integer.d
+//     ^ constant.numeric.integer.decimal.d
 //       ^^ keyword.operator.logical.d
 //          ^^^ string.quoted.double.d
 //              ^^^ keyword.operator.comparison.d
 //                  ^ punctuation.section.brackets.begin.d
-//                   ^ constant.numeric.integer.d
+//                   ^ constant.numeric.integer.decimal.d
 //                    ^ punctuation.section.brackets.end.d
 //                     ^ punctuation.terminator.d
   j ^^= 11;
 //^ variable.other.d
 //  ^^^ keyword.operator.assignment.d
-//      ^^ constant.numeric.integer.d
+//      ^^ constant.numeric.integer.decimal.d
 //        ^ punctuation.terminator.d
   k ^^ 11 == j;
 //^ variable.other.d
 //  ^^ keyword.operator.arithmetic.d
-//     ^^ constant.numeric.integer.d
+//     ^^ constant.numeric.integer.decimal.d
 //        ^^ keyword.operator.comparison.d
 //           ^ variable.other.d
 //            ^ punctuation.terminator.d
   x *= 12345;
 //^ variable.other.d
 //  ^^ keyword.operator.assignment.d
-//     ^^^^^ constant.numeric.integer.d
+//     ^^^^^ constant.numeric.integer.decimal.d
 //          ^ punctuation.terminator.d
   foo();
 //^^^^^ meta.function-call.d
@@ -2446,7 +2496,7 @@ extern(1)
   a != 2;
 //^ variable.other.d
 //  ^^ keyword.operator.comparison.d
-//     ^ constant.numeric.integer.d
+//     ^ constant.numeric.integer.decimal.d
 //      ^ punctuation.terminator.d
 
   .AliasSeq!(immutable char, int);
@@ -2521,9 +2571,9 @@ extern(1)
 //                          ^ punctuation.section.brackets.begin.d
 //                           ^ punctuation.section.brackets.end.d
 //                            ^ punctuation.section.parens.begin.d
-//                             ^^^^ constant.numeric.integer.d
+//                             ^^^^ constant.numeric.integer.decimal.d
 //                                  ^ keyword.operator.arithmetic.d
-//                                    ^ constant.numeric.integer.d
+//                                    ^ constant.numeric.integer.decimal.d
 //                                     ^ punctuation.section.parens.end.d
 //                                      ^ punctuation.terminator.d
 
@@ -2604,7 +2654,7 @@ extern(1)
 //^^^^^ meta.function-call.d
 //^^^ meta.path.d variable.function.d
 //   ^ keyword.operator.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //      ^^^ variable.other.d
 //         ^ punctuation.terminator.d
 
@@ -2620,7 +2670,7 @@ extern(1)
   a * 2;
 //^ meta.path.d variable.other.d
 //  ^ keyword.operator.arithmetic.d
-//    ^ constant.numeric.integer.d
+//    ^ constant.numeric.integer.decimal.d
 //     ^ punctuation.terminator.d
   void* foo() {}
 //^^^^ storage.type.d
@@ -2733,7 +2783,7 @@ extern(1)
 //      ^ punctuation.section.block.begin.d
 //        ^ entity.name.label.d
 //         ^ punctuation.separator.d
-//           ^ constant.numeric.integer.d
+//           ^ constant.numeric.integer.decimal.d
 //            ^ punctuation.separator.sequence.d
 //              ^ variable.other.d
 //               ^ punctuation.separator.mapping.key-value.d
@@ -2743,11 +2793,11 @@ extern(1)
 //  ^^^^^^^^^^^^^^^ meta.block.d
 //  ^ variable.other.d
 //   ^ punctuation.separator.mapping.key-value.d
-//     ^ constant.numeric.integer.d
+//     ^ constant.numeric.integer.decimal.d
 //      ^ meta.path.d punctuation.accessor.dot.d
 //       ^^^^ meta.function-call.d meta.path.d variable.function.d
 //           ^ meta.function-call.d punctuation.section.parens.begin.d
-//            ^^ meta.function-call.d constant.numeric.integer.d
+//            ^^ meta.function-call.d constant.numeric.integer.decimal.d
 //              ^ meta.function-call.d punctuation.section.parens.end.d
 //                ^ punctuation.section.block.end.d
 //                 ^ meta.path.d punctuation.accessor.dot.d
@@ -2756,3 +2806,14 @@ extern(1)
 //                     ^ punctuation.section.parens.begin.d
 //                      ^ punctuation.section.parens.end.d
 //                       ^ punctuation.terminator.d
+
+    s = 5._method(12._);
+//      ^ constant.numeric.integer.decimal.d
+//       ^ meta.path.d punctuation.accessor.dot.d
+//        ^^^^^^^ meta.function-call.d meta.path.d variable.function.d
+//               ^ meta.function-call.d punctuation.section.parens.begin.d
+//                ^^ meta.function-call.d constant.numeric.integer.decimal.d
+//                  ^ meta.function-call.d meta.path.d punctuation.accessor.dot.d
+//                   ^ meta.function-call.d meta.path.d variable.other.d
+//                    ^ meta.function-call.d punctuation.section.parens.end.d
+//                     ^ punctuation.terminator.d

--- a/D/tests/syntax_test_old.d
+++ b/D/tests/syntax_test_old.d
@@ -21,7 +21,7 @@ shared int b = 5000;
 //              ^ constant.numeric
 
 int c = 0x0;
-//      ^^ punctuation.definition.numeric.hexadecimal
+//      ^^ punctuation.definition.numeric.base
 //        ^ constant.numeric
 int d = 0x0_00;
 //          ^ constant.numeric


### PR DESCRIPTION
This commit applies the latest numeric scope naming guidelines.

1. scope number literals  `constant.numeric.[imaginary|integer|float].[binary|decimal|hexadecimal]
2. scope number suffixes `storage.type.numeric`
3. scope number prefixes `punctuation.definition.numeric.base`
4. add/rename variables for several number patterns as done in the other syntaxes as well.
5. add test cases for imaginary numbers and some possible tricky edge cases especially with floating point numbers with trailing `.`

_Benchmark:_

Parsing performance improved by 4%.

10k lines of:

    2_0__000; 1L; 1u; 1U; 1Lu; 1LU; 1uL; 1UL; 0b1; 0b10__1; 0B1; 0xFf; 0x012_3; 0X1; 0_.0_; 0_.;.123_1243; 2313472389742e1i; 3423.2e-45;.4E+4L; 1f; 0x123p2f; 0b10101101f; 0x.1aFp2; 0xF.AP-2f;