### PR TITLE
[YAML] Improve numbers

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -134,7 +134,7 @@ variables:
     )
   _type_timestamp: |- # http://yaml.org/type/timestamp.html
     (?x:
-        \d{4} (-) \d{2} (-) \d{2}        # (y-m-d)
+        \d{4} (-) \d{2} (-) \d{2}       # (y-m-d)
       | \d{4}                           # (year)
         (-) \d{1,2}                     # (month)
         (-) \d{1,2}                     # (day)

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -526,7 +526,7 @@ contexts:
       captures:
         1: keyword.control.flow.block-scalar.literal.yaml
         2: keyword.control.flow.block-scalar.folded.yaml
-        3: constant.numeric.indentation-indicator.yaml
+        3: constant.numeric.integer.decimal.indentation-indicator.yaml
         4: storage.modifier.chomping-indicator.yaml
       push:
         - meta_include_prototype: false

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -119,32 +119,32 @@ variables:
     )
   _type_int: |- # http://yaml.org/type/int.html
     (?x:
-        [-+]? 0b [0-1_]+ # (base 2)
-      | [-+]? 0  [0-7_]+ # (base 8)
-      | [-+]? (?: 0|[1-9][0-9_]*) # (base 10)
-      | [-+]? 0x [0-9a-fA-F_]+ # (base 16)
-      | [-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+ # (base 60)
+        ([-+]? (0b) [0-1_]+) # (base 2)
+      | ([-+]? (0)  [0-7_]+) # (base 8)
+      | ([-+]? (?: 0|[1-9][0-9_]*)) # (base 10)
+      | ([-+]? (0x) [0-9a-fA-F_]+) # (base 16)
+      | ([-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+) # (base 60)
     )
   _type_float: |- # http://yaml.org/type/float.html
     (?x:
-        [-+]? (?: [0-9] [0-9_]*)? \. [0-9.]* (?: [eE] [-+] [0-9]+)? # (base 10)
-      | [-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \. [0-9_]* # (base 60)
-      | [-+]? \. (?: inf|Inf|INF) # (infinity)
-      |       \. (?: nan|NaN|NAN) # (not a number)
+        ([-+]? (?: [0-9] [0-9_]*)? (\.) [0-9.]* (?: [eE] [-+] [0-9]+)?) # (base 10)
+      | ([-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ (\.) [0-9_]*) # (base 60)
+      | ([-+]? (\.) (?: inf|Inf|INF)) # (infinity)
+      | (      (\.) (?: nan|NaN|NAN)) # (not a number)
     )
   _type_timestamp: |- # http://yaml.org/type/timestamp.html
     (?x:
-        \d{4} - \d{2} - \d{2}           # (y-m-d)
+        \d{4} (-) \d{2} (-) \d{2}        # (y-m-d)
       | \d{4}                           # (year)
-        - \d{1,2}                       # (month)
-        - \d{1,2}                       # (day)
+        (-) \d{1,2}                     # (month)
+        (-) \d{1,2}                     # (day)
         (?: [Tt] | [ \t]+) \d{1,2}      # (hour)
-        : \d{2}                         # (minute)
-        : \d{2}                         # (second)
-        (?: \.\d*)?                     # (fraction)
+        (:) \d{2}                       # (minute)
+        (:) \d{2}                       # (second)
+        (?: (\.)\d*)?                   # (fraction)
         [ \t]*
         (?:
-          Z | [-+] \d{1,2} (?: :\d{1,2})?
+          Z | [-+] \d{1,2} (?: (:)\d{1,2})?
         )?                              # (time zone)
     )
 
@@ -332,11 +332,44 @@ contexts:
       captures: # &implicit_type_captures
         1: constant.language.null.yaml
         2: constant.language.boolean.yaml
-        3: constant.numeric.integer.yaml
-        4: constant.numeric.float.yaml
-        5: constant.other.timestamp.yaml
-        6: constant.language.value.yaml
-        7: constant.language.merge.yaml
+        # binary integer
+        4: constant.numeric.integer.binary.yaml
+        5: punctuation.definition.numeric.base.yaml
+        # octal integer
+        6: constant.numeric.integer.octal.yaml
+        7: punctuation.definition.numeric.base.yaml
+        # decimal integer
+        8: constant.numeric.integer.decimal.yaml
+        # hexadecimal integer
+        9: constant.numeric.integer.hexadecimal.yaml
+        10: punctuation.definition.numeric.base.yaml
+        # other integer
+        11: constant.numeric.integer.other.yaml
+        # decimal float
+        13: constant.numeric.float.decimal.yaml
+        14: punctuation.separator.decimal.yaml
+        # other float
+        15: constant.numeric.float.other.yaml
+        16: punctuation.separator.decimal.yaml
+        # infinity float
+        17: constant.numeric.float.other.yaml
+        18: punctuation.separator.decimal.yaml
+        # not a number
+        19: constant.numeric.float.other.yaml
+        20: punctuation.separator.decimal.yaml
+        # timestamp
+        21: constant.other.timestamp.yaml
+        22: punctuation.separator.date.yaml
+        23: punctuation.separator.date.yaml
+        24: punctuation.separator.date.yaml
+        25: punctuation.separator.date.yaml
+        26: punctuation.separator.time.yaml
+        27: punctuation.separator.time.yaml
+        28: punctuation.separator.time.yaml
+        29: punctuation.separator.time.yaml
+        # constants
+        30: constant.language.value.yaml
+        31: constant.language.merge.yaml
 
   flow-scalar-plain-out-implicit-type:
     - match: |
@@ -347,11 +380,44 @@ contexts:
         # Alias does not work, see https://github.com/SublimeTextIssues/Core/issues/967
         1: constant.language.null.yaml
         2: constant.language.boolean.yaml
-        3: constant.numeric.integer.yaml
-        4: constant.numeric.float.yaml
-        5: constant.other.timestamp.yaml
-        6: constant.language.value.yaml
-        7: constant.language.merge.yaml
+        # binary integer
+        4: constant.numeric.integer.binary.yaml
+        5: punctuation.definition.numeric.base.yaml
+        # octal integer
+        6: constant.numeric.integer.octal.yaml
+        7: punctuation.definition.numeric.base.yaml
+        # decimal integer
+        8: constant.numeric.integer.decimal.yaml
+        # hexadecimal integer
+        9: constant.numeric.integer.hexadecimal.yaml
+        10: punctuation.definition.numeric.base.yaml
+        # other integer
+        11: constant.numeric.integer.other.yaml
+        # decimal float
+        13: constant.numeric.float.decimal.yaml
+        14: punctuation.separator.decimal.yaml
+        # other float
+        15: constant.numeric.float.other.yaml
+        16: punctuation.separator.decimal.yaml
+        # infinity float
+        17: constant.numeric.float.other.yaml
+        18: punctuation.separator.decimal.yaml
+        # not a number
+        19: constant.numeric.float.other.yaml
+        20: punctuation.separator.decimal.yaml
+        # timestamp
+        21: constant.other.timestamp.yaml
+        22: punctuation.separator.date.yaml
+        23: punctuation.separator.date.yaml
+        24: punctuation.separator.date.yaml
+        25: punctuation.separator.date.yaml
+        26: punctuation.separator.time.yaml
+        27: punctuation.separator.time.yaml
+        28: punctuation.separator.time.yaml
+        29: punctuation.separator.time.yaml
+        # constants
+        30: constant.language.value.yaml
+        31: constant.language.merge.yaml
 
   flow-scalar-plain-out:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -18,11 +18,11 @@
 
 - >1
 # ^ keyword.control.flow.block-scalar
-#  ^ constant.numeric.indentation-indicator
+#  ^ constant.numeric.integer.decimal.indentation-indicator
 
 - |1-
 # ^ keyword.control.flow.block-scalar
-#  ^ constant.numeric.indentation-indicator
+#  ^ constant.numeric.integer.decimal.indentation-indicator
 #   ^ storage.modifier.chomping-indicator
 
 # Headers and content ################

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -38,34 +38,43 @@
 ## http://yaml.org/type/int.html
 
 - [0b0, +0b1_0_1, -0b1, ~, 0b, 0b2, 0b1 abc
-#  ^^^                                      constant.numeric.integer
-#       ^^^^^^^^                            constant.numeric.integer
-#                 ^^^^                      constant.numeric.integer
+#  ^^^                                      constant.numeric.integer.binary
+#  ^^                                       punctuation.definition.numeric.base
+#       ^^^^^^^^                            constant.numeric.integer.binary
+#        ^^                                 punctuation.definition.numeric.base
+#                 ^^^^                      constant.numeric.integer.binary
+#                  ^^                       punctuation.definition.numeric.base
 #                          ^^^^^^^^^^^^^^^^ -constant
 
    01, +0_761, -07, ~, 09, 0123 f
-#  ^^                             constant.numeric.integer
-#      ^^^^^^                     constant.numeric.integer
-#              ^^^                constant.numeric.integer
+#  ^^                             constant.numeric.integer.octal
+#  ^                              punctuation.definition.numeric.base
+#      ^^^^^^                     constant.numeric.integer.octal
+#       ^                         punctuation.definition.numeric.base
+#              ^^^                constant.numeric.integer.octal
+#               ^                 punctuation.definition.numeric.base
 #                      ^^^^^^^^^^ -constant
 
    0, +1, -12_345, ~, 3 not a number
-#  ^                                 constant.numeric.integer
-#     ^^                             constant.numeric.integer
-#         ^^^^^^^                    constant.numeric.integer
+#  ^                                 constant.numeric.integer.decimal
+#     ^^                             constant.numeric.integer.decimal
+#         ^^^^^^^                    constant.numeric.integer.decimal
 #                     ^^^^^^^^^^^^^^ -constant
 
    0x0, +0x12_34_56, -0xabcdef, ~, 0xyz, 0x,
-#  ^^^                                      constant.numeric.integer
-#       ^^^^^^^^^^^                         constant.numeric.integer
-#                    ^^^^^^^^^              constant.numeric.integer
+#  ^^^                                      constant.numeric.integer.hexadecimal
+#  ^^                                       punctuation.definition.numeric.base
+#       ^^^^^^^^^^^                         constant.numeric.integer.hexadecimal
+#        ^^                                 punctuation.definition.numeric.base
+#                    ^^^^^^^^^              constant.numeric.integer.hexadecimal
+#                     ^^                    punctuation.definition.numeric.base
 #                                  ^^^^^^^^ -constant
 
 # Note: pyyaml does not handle hexagesimal literals correctly (for linting purposes)
    1:20, +1:9, -1_234:59:00, ~, 1:60, :60, 1:2 s
-#  ^^^^                                          constant.numeric.integer
-#        ^^^^                                    constant.numeric.integer
-#              ^^^^^^^^^^^^                      constant.numeric.integer
+#  ^^^^                                          constant.numeric.integer.other
+#        ^^^^                                    constant.numeric.integer.other
+#              ^^^^^^^^^^^^                      constant.numeric.integer.other
 #                               ^^^^^^^^^^^^^^^^ -constant
   ]
 
@@ -74,18 +83,26 @@
 ## http://yaml.org/type/float.html
 
 - [0.1, +.293, -1_123.e-3, 2.234.567, ~, 0.1 f
-#  ^^^                                         constant.numeric.float
-#       ^^^^^                                  constant.numeric.float
-#              ^^^^^^^^^^                      constant.numeric.float
-#                          ^^^^^^^^^           constant.numeric.float
+#  ^^^                                         constant.numeric.float.decimal
+#   ^                                          punctuation.separator.decimal
+#       ^^^^^                                  constant.numeric.float.decimal
+#        ^                                     punctuation.separator.decimal
+#              ^^^^^^^^^^                      constant.numeric.float.decimal
+#                    ^                         punctuation.separator.decimal
+#                          ^^^^^^^^^           constant.numeric.float.decimal
+#                           ^                  punctuation.separator.decimal
 #                                        ^^^^^ -constant
    .inf, +.INF, -.Inf, ~, .inF, .inf .inf
-#  ^^^^                                   constant.numeric.float
-#        ^^^^^                            constant.numeric.float
-#               ^^^^^                     constant.numeric.float
+#  ^^^^                                   constant.numeric.float.other
+#  ^                                      punctuation.separator.decimal
+#        ^^^^^                            constant.numeric.float.other
+#         ^                               punctuation.separator.decimal
+#               ^^^^^                     constant.numeric.float.other
+#                ^                        punctuation.separator.decimal
 #                         ^^^^^^^^^^^^^^^ -constant
    .NaN, ~, .Nan,
-#  ^^^^          constant.numeric.float
+#  ^^^^          constant.numeric.float.other
+#  ^                                      punctuation.separator.decimal
 #           ^^^^ -constant
 ]
 
@@ -94,11 +111,34 @@
 ## http://yaml.org/type/timestamp.html
 
 - [2015-08-15, 2015-08-15 1:20:30.123, 2015-08-15T12:20:30.123-9:00, 2015-08-15 1:20:30.123 Z, 2001-12-14 21:59:43.10 -5]
-#  ^^^^^^^^^^                                                                                 constant.other.timestamp
-#              ^^^^^^^^^^^^^^^^^^^^^^                                                         constant.other.timestamp
-#                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                           constant.other.timestamp
+#  ^^^^^^^^^^ constant.other.timestamp
+#      ^ punctuation.separator.date
+#         ^ punctuation.separator.date
+#              ^^^^^^^^^^^^^^^^^^^^^^ constant.other.timestamp
+#                  ^ punctuation.separator.date
+#                     ^ punctuation.separator.date
+#                          ^ punctuation.separator.time
+#                             ^ punctuation.separator.time
+#                                ^ punctuation.separator.time
+#                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.timestamp
+#                                          ^ punctuation.separator.date
+#                                             ^ punctuation.separator.date
+#                                                   ^ punctuation.separator.time
+#                                                      ^ punctuation.separator.time
+#                                                         ^ punctuation.separator.time
+#                                                               ^ punctuation.separator.time
 #                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.timestamp
+#                                                                        ^ punctuation.separator.date
+#                                                                           ^ punctuation.separator.date
+#                                                                                ^ punctuation.separator.time
+#                                                                                   ^ punctuation.separator.time
+#                                                                                      ^ punctuation.separator.time
 #                                                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.timestamp
+#                                                                                                  ^ punctuation.separator.date
+#                                                                                                     ^ punctuation.separator.date
+#                                                                                                           ^ punctuation.separator.time
+#                                                                                                              ^ punctuation.separator.time
+#                                                                                                                 ^ punctuation.separator.time
 
 
 ##############################################################################
@@ -114,14 +154,20 @@
 
 true: false
 #^^^        constant.language.boolean
-#   ^       punctuation
+#   ^       punctuation.separator.key-value.mapping
 #     ^^^^^ constant.language.boolean
 3.e-3: 3.e+3
-#^^^^        constant.numeric.float
-#    ^       punctuation
-#      ^^^^^ constant.numeric.float
+#^^^^        constant.numeric.float.decimal
+#^           punctuation.separator.decimal
+#    ^       punctuation.separator.key-value.mapping
+#      ^^^^^ constant.numeric.float.decimal
 {.NaN: 2, 2: 2015-08-15}
-#^^^^                   constant.numeric.float
-#      ^                constant.numeric.integer
-#         ^             constant.numeric.integer
+#^^^^                   constant.numeric.float.other
+#    ^                  punctuation.separator.key-value.mapping
+#      ^                constant.numeric.integer.decimal
+#       ^               punctuation.separator.mapping
+#         ^             constant.numeric.integer.decimal
+#          ^            punctuation.separator.key-value.mapping
 #            ^^^^^^^^^^ constant.other.timestamp
+#                ^      punctuation.separator.date
+#                   ^   punctuation.separator.date


### PR DESCRIPTION
This commit adds some capturing groups to the existing numeric literal match patterns in order to distinguish the types (int/float/...) and to add scopes for the separators.