### PR TITLE
[C#] Improve numbers

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -16,18 +16,11 @@ variables:
   bin_op: '(?:\+|->|-|\*|/|%|\|\||&&|\||&|\^|<<|>>|=>|<=|<|>=|>|==|!=|\?\?)'
   unary_op: '(?:\+\+|--|-|~|!|&|\*)'
 
-  # digit separators
-  digit_separators: '(?:(?:_+[0-9]+)*)'
-
-  # integers
-  hex_numeral: '(0[xX])_*\h+(?:_+\h+)*'
-  binary_numeral: '(0[bB])_*[01]+(?:_+[01]+)*'
-  decimal_numeral: '(0|[1-9][0-9]*{{digit_separators}})((?i:ul|lu|u|l)?)'
-
-  # floating point numbers
-  exponent: '[eE][+\-]?[0-9]+{{digit_separators}}'
-  floating_point: '([0-9]+{{digit_separators}}(?={{floating_point_suffix}}|[.Ee])(?:\.[0-9]+{{digit_separators}})?(?:{{exponent}})?)({{floating_point_suffix}}?)'
-  floating_point_suffix: '[fFdDmM]'
+  # numbers
+  dec_digits: (?:[\d_]*\d)
+  dec_exponent: (?:[eE][-+]??{{dec_digits}})
+  float_suffix: '[fFdDmM]'
+  integer_suffix: '[uU][lL]?|[lL][uU]?'
 
   # characters
   unicode_char: '(?:\\u\h{4}|\\U\h{8})'
@@ -133,10 +126,10 @@ contexts:
         1: keyword.other.preprocessor.cs
         2: keyword.other.preprocessor.cs
       push: option_done
-    - match: '\b(line)\s+([0-9]*)\s+((").*("))?'
+    - match: '\b(line)\s+(\d*)\s+((").*("))?'
       captures:
         1: keyword.other.preprocessor.cs
-        2: constant.numeric.cs
+        2: constant.numeric.integer.decimal.cs
         3: string.quoted.double.cs
         4: punctuation.definition.string.begin.cs
         5: punctuation.definition.string.end.cs
@@ -150,8 +143,8 @@ contexts:
           scope: punctuation.definition.string.begin.cs
           push:
             - meta_scope: string.quoted.double.hash.cs
-            - match: '[0-9a-fA-F-]+'
-              scope: constant.numeric.cs
+            - match: '[-\h]+'
+              scope: constant.numeric.integer.hexadecimal.cs
             - match: '}"'
               scope: punctuation.definition.string.end.cs
               pop: true
@@ -1537,22 +1530,24 @@ contexts:
     - match: (')[^']+(')
       scope: invalid.illegal.not_a_char.cs
     # numbers
-    - match: '{{hex_numeral}}'
+    - match: (0[xX])[\h_]*\h
       scope: constant.numeric.integer.hexadecimal.cs
       captures:
-        1: punctuation.definition.numeric.hexadecimal.cs
-    - match: '{{binary_numeral}}'
+        1: punctuation.definition.numeric.base.cs
+    - match: (0[bB])[01_]*[01]
       scope: constant.numeric.integer.binary.cs
       captures:
-        1: punctuation.definition.numeric.binary.cs
-    - match: '{{floating_point}}'
+        1: punctuation.definition.numeric.base.cs
+    - match: '{{dec_digits}}(?:(?:(?:(\.){{dec_digits}}){{dec_exponent}}?|{{dec_exponent}})({{float_suffix}})?|({{float_suffix}}))'
+      scope: constant.numeric.float.decimal.cs
       captures:
-        1: constant.numeric.float.decimal.cs
+        1: punctuation.separator.decimal.cs
         2: storage.type.numeric.cs
-    - match: '{{decimal_numeral}}'
+        3: storage.type.numeric.cs
+    - match: (?:0|[1-9]{{dec_digits}}?)({{integer_suffix}})?
+      scope: constant.numeric.integer.decimal.cs
       captures:
-        1: constant.numeric.integer.decimal.cs
-        2: storage.type.numeric.cs
+        1: storage.type.numeric.cs
     # strings
     - match: '"'
       scope: punctuation.definition.string.begin.cs
@@ -1569,7 +1564,7 @@ contexts:
     - match: '(\{)(\d+)'
       captures:
         1: punctuation.definition.placeholder.begin.cs
-        2: constant.numeric.cs
+        2: constant.numeric.integer.decimal.cs
       push: string_placeholder
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
@@ -1626,7 +1621,7 @@ contexts:
       scope: constant.other.placeholder.cs
       captures:
         1: punctuation.definition.placeholder.begin.cs
-        2: constant.numeric.cs invalid.illegal.unclosed-string-placeholder.cs
+        2: constant.numeric.integer.decimal.cs invalid.illegal.unclosed-string-placeholder.cs
 
   inside_string_placeholder:
     - match: '(\})(\}(?!\}))?'
@@ -1655,7 +1650,7 @@ contexts:
     - match: '\s*(?:(,)\s*(-?\d+)\s*)?'
       captures:
         1: punctuation.separator.arguments.cs
-        2: constant.numeric.formatting.cs
+        2: constant.numeric.integer.decimal.formatting.cs
     - match: ':(?=")'
       scope: invalid.illegal.unclosed-string-placeholder.cs
       pop: true
@@ -1677,7 +1672,7 @@ contexts:
     - match: '\s*(?:(,)\s*(-?\d+)\s*)?'
       captures:
         1: punctuation.separator.arguments.cs
-        2: constant.numeric.formatting.cs
+        2: constant.numeric.integer.decimal.formatting.cs
     - match: ':(?="(?!"))'
       scope: invalid.illegal.unclosed-string-placeholder.cs
       pop: true
@@ -1711,7 +1706,7 @@ contexts:
     - match: '(\{)(\d+)'
       captures:
         1: punctuation.definition.placeholder.begin.cs
-        2: constant.numeric.cs
+        2: constant.numeric.integer.decimal.cs
       push: long_string_placeholder
     - match: '"'
       scope: punctuation.definition.string.end.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -26,7 +26,7 @@ class Foo {
 ///     ^^^ storage.type
 ///         ^ - entity.name
 ///           ^ keyword.operator.assignment
-///             ^^ constant.numeric
+///             ^^ constant.numeric.integer.decimal
 ///               ^ punctuation.terminator
 
         // simple nested function
@@ -138,23 +138,26 @@ class Foo {
 ///                       ^^^ variable.function
 ///                          ^^^ meta.group meta.group
 ///                          ^ punctuation.section.group.begin
-///                           ^ constant.numeric
+///                           ^ constant.numeric.integer.decimal
 ///                            ^ punctuation.section.group.end
 ///                             ^ punctuation.section.group.end
 
         // https://github.com/dotnet/roslyn/pull/2950
         int bin = 0b1001_1010_0001_0100;
 ///               ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-///               ^^ punctuation.definition.numeric.binary
+///               ^^ punctuation.definition.numeric.base
         int hex = 0x1b_a0_44_fe;
 ///               ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-///               ^^ punctuation.definition.numeric.hexadecimal
+///               ^^ punctuation.definition.numeric.base
         int dec = 33_554_432;
 ///               ^^^^^^^^^^ constant.numeric.integer.decimal
         int weird = 1_2__3___4____5_____6______7_______8________9;
 ///                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.decimal
         double real = 1_000.111_1e-1_000;
 ///                   ^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal
+///                        ^ punctuation.separator.decimal.cs
+        double real = 1_000e-1_000;
+///                   ^^^^^^^^^^^^ constant.numeric.float.decimal
         double dbl = 33_554_432.5_2;
 ///                  ^^^^^^^^^^^^^^ constant.numeric.float.decimal
         long lng = 33_554_4321L;
@@ -163,15 +166,15 @@ class Foo {
         bin = _0b1001_1010_0001_0100;
 ///           ^^^^^^^^^^^^^^^^^^^^^^ variable.other
         bin = 0b1001_1010_0001_0100_;
-///                                ^ - constant.numeric
+///                                ^ - constant.numeric.integer.binary
         bin = 0b_1001_1010_0001_0100;
-///           ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric
+///           ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
         bin = 0b__1001__1010__0001__0_1_0_0;
-///           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric
+///           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
         hex = _0x1b_a0_44_fe;
 ///           ^^^^^^^^^^^^^^ variable.other
         hex = 0x_1b_a0_44_fe;
-///           ^^^^^^^^^^^^^^ constant.numeric
+///           ^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
         int abc = _123;
 ///               ^^^^ variable.other
 
@@ -185,7 +188,7 @@ class Foo {
 ///                                 ^ punctuation.accessor.dot
 ///                                  ^^^^ variable.other
 ///                                       ^^ keyword.operator
-///                                          ^ constant.numeric
+///                                          ^ constant.numeric.integer.decimal
 ///                                           ^ punctuation.separator.case-statement
                 Console.WriteLine($"The shape: {sh.GetType().Name} with no dimensions");
                 break;
@@ -197,7 +200,7 @@ class Foo {
 ///                           ^^^^ keyword.control.switch.case.when
 ///                                ^^^^^^^ variable.other
 ///                                        ^^ keyword.operator
-///                                           ^ constant.numeric
+///                                           ^ constant.numeric.integer.decimal
 ///                                            ^ punctuation.separator.case-statement
             case Shape<Shape> shape when shape.Area > 0:
 ///         ^^^^ keyword.control.switch.case
@@ -211,7 +214,7 @@ class Foo {
 ///                                           ^ punctuation.accessor.dot
 ///                                            ^^^^ variable.other
 ///                                                 ^ keyword.operator
-///                                                   ^ constant.numeric
+///                                                   ^ constant.numeric.integer.decimal
 ///                                                    ^ punctuation.separator.case-statement
         }
 
@@ -439,7 +442,7 @@ class Foo {
 ///                                            ^ meta.group.tuple punctuation.section.group.begin
 ///                                             ^^^^^^^^^^^^^^^^ meta.function.anonymous
 ///                                                             ^ punctuation.separator.tuple - meta.function.anonymous
-///                                                               ^ constant.numeric.float.decimal
+///                                                               ^ constant.numeric.integer.decimal
 ///                                                                ^ punctuation.accessor.dot
 ///                                                                 ^^^^^^^^ variable.function
 ///                                                                         ^ punctuation.section.group.begin

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -65,12 +65,12 @@ string interpolated = $"inner {t.Word,-30} {t.Responsibility,8:F2} {{";
 ///                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
 ///                            ^ variable.other
 ///                                  ^ punctuation.separator
-///                                   ^^^ constant.numeric
+///                                   ^^^ constant.numeric.integer.decimal
 ///                                      ^ punctuation.section.interpolation.end
 ///                                        ^ punctuation.section.interpolation.begin
 ///                                         ^ variable.other
 ///                                                         ^ punctuation.separator
-///                                                          ^ constant.numeric
+///                                                          ^ constant.numeric.integer.decimal
 ///                                                           ^ punctuation.separator
 ///                                                            ^^ constant.other.format-spec
 ///                                                                ^^ constant.character.escape
@@ -103,7 +103,7 @@ string unclosed_interpolation = $"inner {
 
 string unclosed_interpolation = $"inner {2}
 ///                                     ^ punctuation.section.interpolation.begin.cs
-///                                      ^ constant.numeric
+///                                      ^ constant.numeric.integer.decimal.cs
 ///                                       ^ punctuation.section.interpolation.end.cs
 ///                                        ^ invalid.illegal.unclosed-string.cs
 

--- a/C#/tests/syntax_test_Operators.cs
+++ b/C#/tests/syntax_test_Operators.cs
@@ -57,10 +57,10 @@ A?.B?.C?[0] == E;
 ///       ^ punctuation.terminator
 
     var c = 5 * 4;
-///         ^ constant.numeric
+///         ^ constant.numeric.integer.decimal
 ///           ^ keyword.operator
 ///           ^ - keyword.operator.pointer
-///             ^ constant.numeric
+///             ^ constant.numeric.integer.decimal
 
     x >>= y
 ///   ^^^ keyword.operator

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -13,7 +13,7 @@ using System;
 #pragma checksum "file.cs" "{3673e4ca-6098-4ec1-890f-8fceb2a794a2}" "{012345678AB}" // New checksum
 //       ^ keyword.other.preprocessor
 //                 ^ stirng.quoted.double
-//                                     ^ constant.numeric
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
 
 #region
 /// ^^ meta.preprocessor keyword.other.preprocessor

--- a/C#/tests/syntax_test_c#.cs
+++ b/C#/tests/syntax_test_c#.cs
@@ -149,52 +149,64 @@ public class Coo
 class Syntax
 {
     public decimal decimal1 = 1.0m;
-    //                        ^^^  constant.numeric
+    //                        ^^^^ constant.numeric.float.decimal
+    //                         ^ punctuation.separator.decimal.cs
     //                           ^ storage.type.numeric
     public decimal decimal2 = 2.0M;
-    //                        ^^^  constant.numeric
+    //                        ^^^^ constant.numeric.float.decimal
+    //                         ^ punctuation.separator.decimal.cs
     //                           ^ storage.type.numeric
     public double double1 = 1.0d;
-    //                      ^^^  constant.numeric
+    //                      ^^^^ constant.numeric.float.decimal
+    //                       ^ punctuation.separator.decimal.cs
     //                         ^ storage.type.numeric
     public double double2 = 2.0D;
-    //                      ^^^  constant.numeric
+    //                      ^^^^ constant.numeric.float.decimal
+    //                       ^ punctuation.separator.decimal.cs
     //                         ^ storage.type.numeric
+    public double double3 = 2D;
+    //                      ^^ constant.numeric.float.decimal
+    //                       ^ storage.type.numeric
     public float float1 = 1.0f;
-    //                    ^^^  constant.numeric
+    //                    ^^^^ constant.numeric.float.decimal
+    //                     ^ punctuation.separator.decimal.cs
     //                       ^ storage.type.numeric
     public float float2 = 2.0F;
-    //                    ^^^  constant.numeric
+    //                    ^^^^ constant.numeric.float.decimal
+    //                     ^ punctuation.separator.decimal.cs
+    //                       ^ storage.type.numeric
+    public double double3 = 2f;
+    //                      ^^ constant.numeric.float.decimal
     //                       ^ storage.type.numeric
     public long long1 = 1l;
-    //                  ^  constant.numeric
+    //                  ^^ constant.numeric
     //                   ^ storage.type.numeric
     public long long2 = 2L;
-    //                  ^  constant.numeric
+    //                  ^^ constant.numeric
     //                   ^ storage.type.numeric
     public ulong ulong1 = 1ul;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong2 = 2UL;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong3 = 3lu;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong4 = 4LU;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong5 = 5uL;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong6 = 6Ul;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong7 = 7lU;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong ulong8 = 8Lu;
-    //                    ^   constant.numeric
+    //                    ^^^ constant.numeric
     //                     ^^ storage.type.numeric
     public ulong bad = 1UU;
     //                   ^ - storage.type.numeric


### PR DESCRIPTION
This commit ...

1. applies the scope naming guidelines to all numeric literals
2. removes some numeral variables which are used only once and introduces some of those from other syntaxes
4. Improves the floating point pattern by avoiding lookaheads for parsing performance reasons.
   
   Parsing performance increases by about 7%.