### PR TITLE
[JavaScript] Improve numbers parsing performance

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1809,19 +1809,19 @@ contexts:
       pop: true
 
     # illegal numbers
-    - match: 0[Xx]{{identifier_part}}+{{identifier_break}}
+    - match: 0[Xx]{{identifier_part}}+
       scope: invalid.illegal.numeric.hexadecimal.js
       pop: true
 
-    - match: 0[Bb]{{identifier_part}}+{{identifier_break}}
+    - match: 0[Bb]{{identifier_part}}+
       scope: invalid.illegal.numeric.binary.js
       pop: true
 
-    - match: 0{{identifier_part}}+{{identifier_break}}
+    - match: 0{{identifier_part}}+
       scope: invalid.illegal.numeric.octal.js
       pop: true
 
-    - match: '[1-9]{{identifier_part}}+{{identifier_break}}(?:\.{{identifier_part}}*{{identifier_break}})?'
+    - match: '[1-9]{{identifier_part}}+(?:\.{{identifier_part}}*)?'
       scope: invalid.illegal.numeric.decimal.js
       pop: true
 


### PR DESCRIPTION
This PR is to improve the parsing performance of numeric literals. It does not change any behavior.

The `{{identifier_break}}` is a negative lookahead of `{{identifier_part}}` and thus should not be required to ensure the boundaries of an illegal numeric literal.

### Note

I can't explain why, but this lookaheads even have a negative impact on parsing performance if the parsed code contains only valid numbers and therefore the context should be popped off before any of those rules is matched. (Or is it due to ST merging all rules to one single rule?)

### Benchmarks

before: 400ms
after: 334ms
result: -15%

10k lines of the following content:

    0b010100101 0b010100101 0b010100101 0x123af 0x123af 0x123af 0.002 123.42 123e10

Benchmarks with pure binary numbers even result in up to -24%!