### PR TITLE
[LaTeX] Rewrite citation matches

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -659,24 +659,41 @@ contexts:
   references:
     - match: |-
         (?x)
-        (
-          (\\)
-          (?:
-            [cC]ite(?:author|title|year|date|url|t|p|alt|alp|text|yearpar)?
-          | (?:[pP]aren|foot|[tT]ext|[sS]mart|super|[aA]|no|full|footfull)cite|footcitetext
-          )
-          \*?
+        (\\)
+        (?:
+          # biblatex commands
+          #   http://mirrors.ibiblio.org/CTAN/macros/latex/exptl/biblatex/doc/biblatex.pdf section 3.8
+          # commands with multicite variant
+            (?:[aA]uto|foot|[pP]aren|[sS]mart|super|[tT]ext)cites?
+          | [Cc]ites?
+          | footcitetexts?
+          # text commands
+          | [cC]ite(?:author)
+          | cite(?:title|year|date)
+          | citeurl
+          # special
+          | (?:[aA]|no|full|footfull)cites?
+          | [vV]olcites?
+          | (?:[pPfFsStTaA]|ft)volcites?
+          | (?:[pPf]?n|N)otecite
+          # non-biblatex
+          | [aA]cite
+          | [cC]ite(?:t|p|alt|alp|text|yearpar)
         )\b
+        # For simplicity with using \b, we match a star for all variants
+        \*?
+      scope: support.function.cite.latex keyword.other.cite.latex
       captures:
-        1: support.function.cite.latex keyword.other.cite.latex
-        2: punctuation.definition.backslash.latex
+        1: punctuation.definition.backslash.latex
       push:
         - meta_scope: meta.function.citation.latex
         - include: general-optional-arguments
         - match: '\{'
           scope: punctuation.definition.group.brace.begin.latex
-          set:
-            - meta_scope: meta.function.citation.latex meta.group.brace.latex
+          # Some commands, e.g. \parencites, allow multiple [][]{} argument sequences,
+          # so we `push` instead of `set`.
+          push:
+            - meta_scope: meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.citation.latex
             - match: '\}'

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -124,6 +124,27 @@
 %           ^ support.function
 %
 
+\parencite[Propositon~1]{Ref}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+%          ^ meta.group.bracket.latex
+%                         ^ constant.other.citation.latex
+
+\parencites[Proposition~1]{Firstref}[p.~2]{SecondRef}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+%           ^ meta.group.bracket.latex
+%                          ^ constant.other.citation.latex
+%                                     ^ meta.group.bracket.latex
+%                                          ^ constant.other.citation.latex
+
+\Citeauthor*[]{ref}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+%          ^ support.function.cite.latex
+%           ^ meta.group.bracket.latex
+%              ^ constant.other.citation.latex
+
 
 % URL COMMAND
 


### PR DESCRIPTION
- Add multi-cite variants and a couple other supported by biblatex.
- Allow multiple sets of []{} parameter blocks for multi-cite.
  Just add them to all so we don't have to duplicate the entire match.
- Add a test for star variant and ensure they work.
- Add a reference to biblatex's doc.
- Remove an unnecessary capture group.

Closes #1813.
Fixes #1762.