### PR TITLE
[Python] Fix raw f-block-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1609,7 +1609,6 @@ contexts:
           with_prototype:
             - match: '(?=""")'
               pop: true
-            - include: line-continuation-inside-string
             - include: f-string-content-with-regex
     # Triple-quoted f-string
     - match: ([fF])(""")
@@ -1926,7 +1925,6 @@ contexts:
           with_prototype:
             - match: (?=''')
               pop: true
-            - include: line-continuation-inside-string
             - include: f-string-content-with-regex
     # Triple-quoted f-string
     - match: ([fF])(''')

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1366,6 +1366,10 @@ contexts:
       scope: invalid.illegal.unclosed-string.python
       set: after-expression
 
+  line-continuation-inside-block-string:
+    - match: \\$
+      scope: punctuation.separator.continuation.line.python
+
   constant-placeholder:
     - match: |- # printf style
         (?x)
@@ -1620,6 +1624,7 @@ contexts:
         - match: '"""'
           scope: punctuation.definition.string.begin.python
           set: after-expression
+        - include: line-continuation-inside-block-string
         - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
@@ -1642,6 +1647,7 @@ contexts:
               with_prototype:
                 - match: '(?=""")'
                   pop: true
+                - include: line-continuation-inside-block-string
                 - include: escaped-unicode-char
                 - include: escaped-char
                 - include: constant-placeholder
@@ -1651,6 +1657,7 @@ contexts:
             - match: '"""'
               scope: punctuation.definition.string.end.python
               set: after-expression
+            - include: line-continuation-inside-block-string
             - include: escaped-unicode-char
             - include: escaped-char
             - include: constant-placeholder
@@ -1664,6 +1671,7 @@ contexts:
         - match: '"""'
           scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-block-string
         - include: escaped-char
         - include: constant-placeholder
 
@@ -1936,6 +1944,7 @@ contexts:
         - match: "'''"
           scope: punctuation.definition.string.begin.python
           set: after-expression
+        - include: line-continuation-inside-block-string
         - include: escaped-fstring-escape
         - include: escaped-unicode-char
         - include: escaped-char
@@ -1958,6 +1967,7 @@ contexts:
               with_prototype:
                 - match: (?=''')
                   pop: true
+                - include: line-continuation-inside-block-string
                 - include: escaped-unicode-char
                 - include: escaped-char
                 - include: constant-placeholder
@@ -1967,6 +1977,7 @@ contexts:
             - match: "'''"
               scope: punctuation.definition.string.end.python
               set: after-expression
+            - include: line-continuation-inside-block-string
             - include: escaped-unicode-char
             - include: escaped-char
             - include: constant-placeholder
@@ -1980,6 +1991,7 @@ contexts:
         - match: "'''"
           scope: punctuation.definition.string.end.python
           set: after-expression
+        - include: line-continuation-inside-block-string
         - include: escaped-char
         - include: constant-placeholder
 

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -646,6 +646,10 @@ F""" {} {\} }
 #           ^ invalid.illegal.stray-brace
 """
 
+fr'''
+#    ^ - invalid
+'''
+
 # Most of these were inspired by
 # https://github.com/python/cpython/commit/9a4135e939bc223f592045a38e0f927ba170da32
 f'{x=:}'

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -136,10 +136,14 @@ string = """
 
 string = """
 #        ^^^ string.quoted.double.block - string string
+\
+# <- punctuation.separator.continuation.line.python
 """
 
 string = r"""
 #         ^^^ meta.string.python string.quoted.double.block
+\
+# <- - punctuation
 """
 
 string = r"""


### PR DESCRIPTION
Multi-line raw f-strings had an invalid line continuation context included.
Whil I was at it, I noticed that we didn't highlight line contiuations for block strings at all, so I added that.

Reported in https://forum.sublimetext.com/t/python-multiline-f-string-r-string-syntax-highlighting/47471.