### PR TITLE
[Ruby] Fix inline conditional keyword highlighting

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1190,8 +1190,9 @@ contexts:
   try-regex:
     # Generally for multiline regexes, one of the %r forms below will be used,
     # so we bail out if we can't find a second / on the current line
-    - match: /(?=(?!=).*/)
-      scope: punctuation.definition.string.begin.ruby
+    - match: \s*(/)(?=(?!=).*/)
+      captures:
+        1: punctuation.definition.string.begin.ruby
       push:
         - meta_scope: meta.string.regexp.ruby string.regexp.classic.ruby
         - match: (/)([eimnosux]*)
@@ -1200,7 +1201,7 @@ contexts:
             2: keyword.other.ruby
           pop: true
         - include: regex-sub
-    - match: $|(?=\S)
+    - match: ''
       pop: true
 
   regexes:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1281,3 +1281,13 @@ foo / "bar/bla"
 #                   ^ punctuation.definition.string.end.ruby
 #                    ^ punctuation.separator.sequence.ruby
 #                      ^^^ string.quoted.double.ruby
+
+# issue #2181
+foo << bar if baz.include?(x)
+#          ^^ keyword.control.ruby
+foo << bar.baz if baz.include?(x)
+#              ^^ keyword.control.ruby
+foo << bar.assert_match if baz.include?(x)
+#                       ^^ keyword.control.ruby
+foo << bar.to_s if baz.include?(x)
+#               ^^ keyword.control.ruby


### PR DESCRIPTION
Fixes #2181

In order to avoid the `{{identifier}}{{method_punctuation}}` in the `identifiers-accessors` context matching reserved words as method call the `try-regex` context needs to pop off without consuming any whitespace.

This issue was introduced for the `.to_s` method by PR #2017, but already existed for methods like `assert_match` if they were not followed by a regexp pattern.