### PR TITLE
Ruby rescue block, idiomatic Snippet

### DIFF
--- a/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
+++ b/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[${TM_SELECTED_TEXT/([\t ]*).*/$1/m}begin
 	${3:${TM_SELECTED_TEXT/(\A.*)|(.+)|\n\z/(?1:$0:(?2:\t$0))/g}}
-${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:Exception}${2/.+/ => /}${2:e}
+${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:StandardError}${2/.+/ => /}${2:e}
 ${TM_SELECTED_TEXT/([\t ]*).*/$1/m}	$0
 ${TM_SELECTED_TEXT/([\t ]*).*/$1/m}end
 ]]></content>

--- a/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
+++ b/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
@@ -1,11 +1,14 @@
 <snippet>
-	<content><![CDATA[${TM_SELECTED_TEXT/([\t ]*).*/$1/m}begin
-	${3:${TM_SELECTED_TEXT/(\A.*)|(.+)|\n\z/(?1:$0:(?2:\t$0))/g}}
-${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:Exception}${2/.+/ => /}${2:e}
-${TM_SELECTED_TEXT/([\t ]*).*/$1/m}	$0
+  <content><![CDATA[${TM_SELECTED_TEXT/([\t ]*).*/$1/m}begin
+  ${3:${TM_SELECTED_TEXT/(\A.*)|(.+)|\n\z/(?1:$0:(?2:\t$0))/g}}
+${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:StandardError}${2/.+/ => /}${2:e}
+${TM_SELECTED_TEXT/([\t ]*).*/$1/m} $0
 ${TM_SELECTED_TEXT/([\t ]*).*/$1/m}end
 ]]></content>
-	<tabTrigger>begin</tabTrigger>
-	<scope>source.ruby - comment</scope>
-	<description>begin … rescue … end</description>
+  <tabTrigger>begin</tabTrigger>
+  <scope>source.ruby - comment</scope>
+  <description>
+    # Rescue with StandardError as it is the idiomatic approach
+    begin … rescue … end
+  </description>
 </snippet>

--- a/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
+++ b/Ruby/Snippets/Wrap-in-Begin-Rescue-End.sublime-snippet
@@ -1,14 +1,11 @@
 <snippet>
-  <content><![CDATA[${TM_SELECTED_TEXT/([\t ]*).*/$1/m}begin
-  ${3:${TM_SELECTED_TEXT/(\A.*)|(.+)|\n\z/(?1:$0:(?2:\t$0))/g}}
-${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:StandardError}${2/.+/ => /}${2:e}
-${TM_SELECTED_TEXT/([\t ]*).*/$1/m} $0
+	<content><![CDATA[${TM_SELECTED_TEXT/([\t ]*).*/$1/m}begin
+	${3:${TM_SELECTED_TEXT/(\A.*)|(.+)|\n\z/(?1:$0:(?2:\t$0))/g}}
+${TM_SELECTED_TEXT/([\t ]*).*/$1/m}rescue ${1:Exception}${2/.+/ => /}${2:e}
+${TM_SELECTED_TEXT/([\t ]*).*/$1/m}	$0
 ${TM_SELECTED_TEXT/([\t ]*).*/$1/m}end
 ]]></content>
-  <tabTrigger>begin</tabTrigger>
-  <scope>source.ruby - comment</scope>
-  <description>
-    # Rescue with StandardError as it is the idiomatic approach
-    begin … rescue … end
-  </description>
+	<tabTrigger>begin</tabTrigger>
+	<scope>source.ruby - comment</scope>
+	<description>begin … rescue … end</description>
 </snippet>


### PR DESCRIPTION
* Don't trap Exception by default, but rather StandardError

If you rescue from Exception, you're unintentionally trapping Signals from the system like SIGQUIT