### PR TITLE
[R] do not highlight builtin functions after $

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -18,6 +18,7 @@ contexts:
     - include: codesection
     - include: comments
     - include: constants
+    - include: accessor
     - include: operators
     - include: keywords
     - include: storage-types
@@ -116,6 +117,15 @@ contexts:
     - match: \bin\b
       scope: keyword.operator.word.r
 
+  accessor:
+    - match: '\$'
+      scope: keyword.accessor.dollar.r
+      push:
+        - include: function-calls
+        - include: general-variables
+        - match: ''
+          pop: true
+
   operators:
     # NOTE: sorted by length to ensure not to break ligatures
 
@@ -146,7 +156,7 @@ contexts:
       scope: keyword.operator.assignment.r
     - match: '[!&|<>]'
       scope: keyword.operator.logical.r
-    - match: '[$:~@]'
+    - match: '[:~@]'
       scope: keyword.other.r
     - match: ;
       scope: punctuation.terminator.semicolon.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -278,12 +278,11 @@ NaN
 #        ^^^ punctuation.accessor.colons.r
 #            ^^ punctuation.accessor.colons.r
 
-  ... : ~ @ $
+  ... : ~ @
 # ^^^ keyword.other.r
 #     ^ keyword.other.r
 #       ^ keyword.other.r
 #         ^ keyword.other.r
-#           ^ keyword.other.r
 
   foo.99 <- 1
 #    ^^^ - constant.numeric
@@ -449,3 +448,9 @@ a[[1, 2]]
 
 foo:::bar
 #  ^^^ punctuation.accessor.colons.r
+
+
+foo$update()
+#  ^ keyword.accessor.dollar.r
+#   ^^^^^^ meta.function-call.name.r variable.function.r
+#   ^^^^^^ - support.function.r


### PR DESCRIPTION
Functions and variables after the `$` sign should not be recognized as build-in functions.

Before
<img width="230" alt="Screen Shot 2019-11-06 at 12 56 11 AM" src="https://user-images.githubusercontent.com/1690993/68283355-3f616880-0030-11ea-9691-7202c772c2b4.png">



After
<img width="236" alt="Screen Shot 2019-11-06 at 12 55 20 AM" src="https://user-images.githubusercontent.com/1690993/68283284-2062d680-0030-11ea-8ea9-e712294691ce.png">
