### PR TITLE
[C/C++/ObjC/ObjC++] Improve numbers

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -20,6 +20,21 @@ file_extensions:
 first_line_match: '-\*- C\+\+ -\*-'
 scope: source.c++
 variables:
+  # number digits
+  dec_digits: '(?:\d(?:[\d'']*\d)?)'
+
+  # number exponents
+  dec_exponent: '(?:[eE][-+]??{{dec_digits}})'
+  hex_exponent: '(?:[pP][-+]??{{dec_digits}})'
+
+  # number suffixes
+  # note: nearly everything can be defined as suffix via `operator` keyword
+  #  see: https://en.cppreference.com/w/cpp/numeric/complex/operator%22%22i
+  dec_suffix: '(?:[a-zA-Z_][[:alnum:]_]*|(?=[^[:alnum:]_'']))'
+  hex_suffix: '(?:[g-zG-Z_][[:alnum:]_]*|(?=[^[:alnum:]_'']))'
+  float_suffix: '[fF]'
+  integer_suffix: '[lL]{1,2}[uU]?|[uU][lL]{0,2}'
+
   identifier: \b[[:alpha:]_][[:alnum:]_]*\b # upper and lowercase
   macro_identifier: \b[[:upper:]_][[:upper:][:digit:]_]{2,}\b # only uppercase, at least 3 chars
   path_lookahead: '(?:::\s*)?(?:{{identifier}}\s*::\s*)*(?:template\s+)?{{identifier}}'
@@ -130,39 +145,97 @@ contexts:
           scope: punctuation.definition.string.end.c++
           pop: true
 
-  unique-numbers:
+  numbers:
+    # https://en.cppreference.com/w/cpp/language/floating_literal
+
+    # decimal floats
     - match: |-
-        (?x)
-        (?:
-        # floats
+        (?x:
+          \b{{dec_digits}}
           (?:
-          (?:\b\d(?:[\d']*\d)?\.\d(?:[\d']*\d)?|\B\.\d(?:[\d']*\d)?)(?:[Ee][+-]?\d(?:[\d']*\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\w*))?\b
-          |
-          (?:\b\d(?:[\d']*\d)?\.)(?:\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\w*))\b|(?:[Ee][+-]?\d(?:[\d']*\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\w*))?\b)
-          |
-          \b\d(?:[\d']*\d)?(?:[Ee][+-]?\d(?:[\d']*\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\w*))?\b
+            (?:
+              (\.)
+              (?:
+                # 1.1, 1.1e1, 1.1e-1, 1.1f, 1.1e1f, 1.1e-1f, 1.1L, 1.1e1L, 1.1e-1L
+                {{dec_digits}} {{dec_exponent}}?
+                # 1.e1, 1.e-1, 1.e1f, 1.e-1f, 1.e1L, 1.e-1L
+                | {{dec_exponent}}
+                # 1., 1.f, 1.L # but not `..`
+                | (?!\.)
+              )
+              # 1e1 1e1f 1e1L
+              | {{dec_exponent}}
+            ) ({{dec_suffix}})?
+            # 1f
+            | ({{float_suffix}})
           )
-        |
-        # ints
-          \b(?:
-          (?:
-          # dec
-          [1-9](?:[\d']*\d)?
-          |
-          # oct
-          0(?:[0-7']*[0-7])?
-          |
-          # hex
-          0[Xx][\da-fA-F](?:[\da-fA-F']*[\da-fA-F])?
-          |
-          # bin
-          0[Bb][01](?:[01']*[01])?
-          )
-          # int suffixes
-          (?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\w*))?)\b
+          # .1, .1e1, .1e-1, .1f, .1e1f, .1e-1f, .1L, .1e1L, .1e-1L
+          | (\.) {{dec_digits}} {{dec_exponent}}? ({{dec_suffix}})?
         )
-        (?!\.) # Number must not be followed by a decimal point
-      scope: constant.numeric.c++
+      scope: constant.numeric.float.decimal.c++
+      captures:
+        1: punctuation.separator.decimal.c++
+        2: storage.type.numeric.c++
+        3: storage.type.numeric.c++
+        4: punctuation.separator.decimal.c++
+        5: storage.type.numeric.c++
+
+    # hexadecimal float (C99)
+    - match: \b0[xX](?=[[:alnum:]_''.]+?[pP])
+      scope: punctuation.definition.numeric.base.c++
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.float.hexadecimal.c++
+        - match: '{{hex_exponent}}'
+          pop: true
+        - match: \.
+          scope: punctuation.separator.decimal.c++
+        - match: \H
+          scope: invalid.illegal.numeric.digit.c++
+
+    # https://en.cppreference.com/w/c/language/integer_constant
+
+    # binary integer
+    - match: \b0[bB]
+      scope: punctuation.definition.numeric.base.c++
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.binary.c++
+        - include: decimal-suffix
+        - match: '[2-9]'
+          scope: invalid.illegal.numeric.digit.c++
+    # hexadecimal integer
+    - match: \b0[xX]
+      scope: punctuation.definition.numeric.base.c++
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.hexadecimal.c++
+        - include: hexadecimal-suffix
+    # octal integer
+    - match: \b0(?=[\d''])
+      scope: punctuation.definition.numeric.base.c++
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.octal.c++
+        - include: decimal-suffix
+        - match: '[89]'
+          scope: invalid.illegal.numeric.digit.c++
+    # decimal integer
+    - match: \b\d+
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.decimal.c++
+        - include: decimal-suffix
+
+  decimal-suffix:
+    - match: '{{dec_suffix}}'
+      scope: storage.type.numeric.c++
+      pop: true
+
+  hexadecimal-suffix:
+    - match: '{{hex_suffix}}'
+      scope: storage.type.numeric.c++
+      pop: true
 
   identifiers:
     - match: '(?:(::)\s*)?{{identifier}}\s*(::)\s*'
@@ -358,10 +431,6 @@ contexts:
   strings:
     - include: unique-strings
     - include: scope:source.c#strings
-
-  numbers:
-    - include: unique-numbers
-    - include: scope:source.c#numbers
 
   ## C++-specific contexts
 
@@ -1036,7 +1105,7 @@ contexts:
     - match: '&'
       scope: keyword.operator.c++
     - match: \b0\b
-      scope: constant.numeric.c++
+      scope: constant.numeric.integer.decimal.c++
     - match: \b(default|delete)\b
       scope: storage.modifier.c++
     - match: '(?=\{)'
@@ -1502,7 +1571,7 @@ contexts:
     - match: '&'
       scope: keyword.operator.c++
     - match: \b0\b
-      scope: constant.numeric.c++
+      scope: constant.numeric.integer.decimal.c++
     - match: \b(default|delete)\b
       scope: storage.modifier.c++
     - match: '(?=:)'
@@ -1575,7 +1644,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1601,7 +1670,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1645,7 +1714,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1672,7 +1741,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1777,7 +1846,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1803,7 +1872,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++
         2: keyword.control.import.c++
-        3: constant.numeric.preprocessor.c++
+        3: constant.numeric.integer.decimal.c++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -2021,7 +2090,7 @@ contexts:
     # Captures the namespace macro idiom
     - match: '\b(namespace)\s+(?={{path_lookahead}}\s*\{)'
       scope: meta.namespace.c++
-      captures: 
+      captures:
         1: keyword.control.c++
       push:
         - meta_content_scope: meta.namespace.c++ entity.name.namespace.c++

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -9,6 +9,15 @@ first_line_match: "-[*]-( Mode:)? C -[*]-"
 scope: source.c
 
 variables:
+  # number exponents
+  dec_exponent: '(?:[eE][-+]??\d+)'
+  hex_exponent: '(?:[pP][-+]??\d+)'
+
+  # number suffixes
+  dec_suffix: '[a-zA-Z_][[:alnum:]_]*'
+  hex_suffix: '[g-zG-Z_][[:alnum:]_]*'
+  integer_suffix: '[lL]{1,2}[uU]?|[uU][lL]{0,2}'
+
   identifier: \b[[:alpha:]_][[:alnum:]_]*\b # upper and lowercase
   macro_identifier: \b[[:upper:]_][[:upper:][:digit:]_]{2,}\b # only uppercase, at least 3 chars
   control_keywords: 'break|case|continue|default|do|else|for|goto|if|_Pragma|return|switch|while'
@@ -169,8 +178,80 @@ contexts:
       scope: support.type.mac-classic.c
 
   numbers:
-    - match: '\b((0(x|X)[0-9a-fA-F]*(\.[0-9a-fA-F]+p-?\d+)?)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([fF]|(l{1,2}|L{1,2})[uU]?|[uU](l{0,2}|L{0,2}))?\b'
-      scope: constant.numeric.c
+    # https://en.cppreference.com/w/c/language/floating_constant
+
+    # decimal floats
+    - match: |-
+        (?x:
+          \b\d+
+          (?:
+            (?: (\.) (?: \d+ {{dec_exponent}}? | {{dec_exponent}} | (?=[^.])) | {{dec_exponent}} )
+            (?: ([fFlL])\b | ({{dec_suffix}})? ) | ([fF])\b
+          )
+          | (\.) \d+ {{dec_exponent}}? (?: ([fFlL])\b | ({{dec_suffix}})? )
+        )
+      scope: constant.numeric.float.decimal.c
+      captures:
+        1: punctuation.separator.decimal.c
+        2: storage.type.numeric.c
+        3: invalid.illegal.numeric.suffix.c
+        4: storage.type.numeric.c
+        5: punctuation.separator.decimal.c
+        6: storage.type.numeric.c
+        7: invalid.illegal.numeric.suffix.c
+    # hexadecimal float (C99)
+    - match: \b0[xX](?=[[:alnum:].]+?[pP])
+      scope: punctuation.definition.numeric.base.c
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.float.hexadecimal.c
+        - match: '{{hex_exponent}}\b'
+          pop: true
+        - match: \.
+          scope: punctuation.separator.decimal.c
+        - match: \H
+          scope: invalid.illegal.numeric.digit.c
+
+    # https://en.cppreference.com/w/c/language/integer_constant
+
+    # hexadecimal integer
+    - match: \b0[xX]
+      scope: punctuation.definition.numeric.base.c
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.hexadecimal.c
+        - include: hexadecimal-suffix
+    # octal integer
+    - match: \b0(?=\d)
+      scope: punctuation.definition.numeric.base.c
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.octal.c
+        - match: '[89]'
+          scope: invalid.illegal.numeric.digit.c
+        - include: decimal-suffix
+    # decimal integer
+    - match: \b\d+
+      push:
+        - meta_include_prototype: false
+        - meta_scope: constant.numeric.integer.decimal.c
+        - include: decimal-suffix
+
+  decimal-suffix:
+    - match: (?:{{integer_suffix}})?\b
+      scope: storage.type.numeric.c
+      pop: true
+    - match: '{{dec_suffix}}'
+      scope: invalid.illegal.numeric.suffix.c
+      pop: true
+
+  hexadecimal-suffix:
+    - match: (?:{{integer_suffix}})?\b
+      scope: storage.type.numeric.c
+      pop: true
+    - match: '{{hex_suffix}}'
+      scope: invalid.illegal.numeric.suffix.c
+      pop: true
 
   operators:
     - match: (?:\+\+|--)
@@ -302,7 +383,6 @@ contexts:
     - include: preprocessor-expressions
     - include: comments
     - include: case-default
-    - include: access
     - include: typedef
     - include: keywords-parens
     - include: keywords
@@ -314,6 +394,7 @@ contexts:
     - include: block
     - include: variables
     - include: constants
+    - include: access
     - match: ','
       scope: punctuation.separator.c
     - match: '\)|\}'
@@ -712,7 +793,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -738,7 +819,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -782,7 +863,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -809,7 +890,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -914,7 +995,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -940,7 +1021,7 @@ contexts:
       captures:
         1: meta.preprocessor.c
         2: keyword.control.import.c
-        3: constant.numeric.preprocessor.c
+        3: constant.numeric.integer.decimal.c
       push:
         - match: ^\s*(#\s*endif)\b
           captures:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -639,34 +639,242 @@ func_call(foo
 // Numeric Constants
 /////////////////////////////////////////////
 
+dec0 = 0;
+/*     ^ constant.numeric.integer.decimal */
+/*      ^ punctuation.terminator - constant */
 dec1 = 1234567890;
-/*     ^ constant.numeric */
-/*              ^ constant.numeric */
+/*     ^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^ punctuation.terminator - constant */
 
 dec2 = 1234567890f;
-/*     ^ constant.numeric */
-/*               ^ constant.numeric */
+/*     ^^^^^^^^^^^ constant.numeric.float.decimal */
+/*               ^ storage.type.numeric */
+/*                ^ punctuation.terminator - constant */
 
-dec2 = 1234567890L;
-/*     ^ constant.numeric */
-/*               ^ constant.numeric */
+dec3 = 1234567890L;
+/*     ^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^ storage.type.numeric */
+/*                ^ punctuation.terminator - constant */
 
-dec2 = 1234567890ul;
-/*     ^ constant.numeric */
-/*                ^ constant.numeric */
+dec4 = 1234567890ul;
+/*     ^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^ storage.type.numeric */
+/*                 ^ punctuation.terminator - constant */
 
-dec4 = 1234567890Lu;
-/*     ^ constant.numeric */
-/*                ^ constant.numeric */
+dec5 = 1234567890Lu;
+/*     ^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^ storage.type.numeric */
+/*                 ^ punctuation.terminator - constant */
 
-dec3 = 1234567890LLU;
-/*     ^ constant.numeric */
-/*                 ^ constant.numeric */
+dec6 = 1234567890LLU;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^^ storage.type.numeric */
+/*                  ^ punctuation.terminator - constant */
 
-dec3 = 1234567890uLL;
-/*     ^ constant.numeric */
-/*                 ^ constant.numeric */
+dec7 = 1234567890uLL;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^^ storage.type.numeric */
+/*                  ^ punctuation.terminator - constant */
 
+dec8 = 1'234_567'890s0f;
+/*     ^ constant.numeric.integer.decimal */
+/*      ^^^^^^^^^ string.quoted.single */
+/*               ^^^^^^ constant.numeric.integer.decimal */
+/*                  ^^^ invalid.illegal.numeric.suffix */
+/*                     ^ punctuation.terminator - constant */
+
+oct1 = 01234567;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^ punctuation.terminator - constant */
+
+oct2 = 01234567L;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^ storage.type.numeric */
+/*              ^ punctuation.terminator - constant */
+
+oct3 = 01234567LL;
+/*     ^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^^ storage.type.numeric */
+/*               ^ punctuation.terminator - constant */
+
+oct4 = 01234567ulL;
+/*     ^^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^^^ storage.type.numeric */
+/*                ^ punctuation.terminator - constant */
+
+oct2 = 01284967Z0L;
+/*     ^^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*        ^ invalid.illegal.numeric.digit */
+/*          ^ invalid.illegal.numeric.digit */
+/*             ^^^ invalid.illegal.numeric.suffix */
+/*                ^ punctuation.terminator - constant */
+
+hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
+/*     ^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^^^^ constant.numeric.integer.hexadecimal */
+/*         ^^ punctuation.definition.numeric.base */
+/*            ^ storage.type.numeric */
+/*              ^^^^^^ constant.numeric.integer.hexadecimal */
+/*              ^^ punctuation.definition.numeric.base */
+/*                 ^^^ storage.type.numeric */
+/*                     ^^^^^^ constant.numeric.integer.hexadecimal */
+/*                     ^^ punctuation.definition.numeric.base */
+/*                        ^^^ storage.type.numeric */
+/*                            ^^^^ constant.numeric.integer.hexadecimal */
+/*                            ^^ punctuation.definition.numeric.base */
+/*                               ^ storage.type.numeric */
+/*                                 ^^ constant.numeric.integer.hexadecimal */
+/*                                 ^^ punctuation.definition.numeric.base */
+/*                                   ^^^ string.quoted.single */
+/*                                      ^^^^^^ constant.numeric.integer.decimal */
+/*                                        ^^^^ invalid.illegal.numeric.suffix */
+/*                                            ^ punctuation.terminator - constant */
+
+hex2 = 0xc1.01AbFp-1;
+/*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^ punctuation.separator.decimal */
+/*                  ^ punctuation.terminator - constant */
+
+f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^^ constant.numeric.float.decimal */
+/*       ^ punctuation.separator.decimal */
+/*           ^ keyword.operator.arithmetic */
+/*            ^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.separator.decimal */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                      ^ storage.type.numeric */
+/*                       ^ keyword.operator.arithmetic */
+/*                        ^^^^^^ constant.numeric.float.decimal */
+/*                         ^ punctuation.separator.decimal */
+/*                             ^ storage.type.numeric */
+/*                              ^ keyword.operator.arithmetic */
+/*                               ^^^^^^^ constant.numeric.float.decimal */
+/*                                ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ keyword.operator.arithmetic */
+/*                                       ^^^^ constant.numeric.float.decimal */
+/*                                        ^ punctuation.separator.decimal */
+/*                                          ^ storage.type.numeric */
+/*                                           ^ keyword.operator.arithmetic */
+/*                                            ^^^^^^ constant.numeric.float.decimal */
+/*                                             ^ punctuation.separator.decimal */
+/*                                                 ^ storage.type.numeric */
+/*                                                  ^ keyword.operator.arithmetic */
+/*                                                   ^^^^^^^ constant.numeric.float.decimal */
+/*                                                    ^ punctuation.separator.decimal */
+/*                                                         ^ storage.type.numeric */
+/*                                                          ^ punctuation.terminator - constant */
+
+f = 1.e1+1.e-1+1.e1f+1.e-1f+1.e1L+1.e-1L;
+/*  ^^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*      ^ keyword.operator.arithmetic */
+/*       ^^^^^ constant.numeric.float.decimal */
+/*        ^ punctuation.separator.decimal */
+/*            ^ keyword.operator.arithmetic */
+/*             ^^^^^ constant.numeric.float.decimal */
+/*              ^ punctuation.separator.decimal */
+/*                 ^ storage.type.numeric */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^ constant.numeric.float.decimal */
+/*                           ^ punctuation.separator.decimal */
+/*                              ^ storage.type.numeric */
+/*                               ^ keyword.operator.arithmetic */
+/*                                ^^^^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ punctuation.terminator - constant */
+
+f = 1.+1.f+1.L+1..;
+/*  ^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^ constant.numeric.float.decimal */
+/*      ^ punctuation.separator.decimal */
+/*       ^ storage.type.numeric */
+/*        ^ keyword.operator.arithmetic */
+/*         ^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*           ^ storage.type.numeric */
+/*            ^ keyword.operator.arithmetic */
+/*             ^ constant.numeric.integer.decimal */
+/*              ^^ invalid.illegal.syntax */
+/*                ^ punctuation.terminator - constant */
+
+f = 1e1+1e1f+1e1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^ constant.numeric.float.decimal */
+/*         ^ storage.type.numeric */
+/*          ^ keyword.operator.arithmetic */
+/*           ^^^^ constant.numeric.float.decimal */
+/*              ^ storage.type.numeric */
+/*               ^ punctuation.terminator - constant */
+
+f = .1+.1e1+.1e-1+.1f+.1e1f+.1e-1f+.1L+.1e1L+.1e-1L;
+/*  ^^ constant.numeric.float.decimal */
+/*  ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^^ constant.numeric.float.decimal */
+/*     ^ punctuation.separator.decimal */
+/*         ^ keyword.operator.arithmetic */
+/*          ^^^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*               ^ keyword.operator.arithmetic */
+/*                ^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ keyword.operator.arithmetic */
+/*                    ^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^^ constant.numeric.float.decimal */
+/*                          ^ punctuation.separator.decimal */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                   ^ storage.type.numeric */
+/*                                    ^ keyword.operator.arithmetic */
+/*                                     ^^^^^ constant.numeric.float.decimal */
+/*                                     ^ punctuation.separator.decimal */
+/*                                         ^ storage.type.numeric */
+/*                                          ^ keyword.operator.arithmetic */
+/*                                           ^^^^^^ constant.numeric.float.decimal */
+/*                                           ^ punctuation.separator.decimal */
+/*                                                ^ storage.type.numeric */
+/*                                                 ^ punctuation.terminator - constant */
+
+f = 1.0suff+1.suff*.0suff/{1suff}
+/*  ^^^ constant.numeric.float.decimal - invalid */
+/*     ^^^^ constant.numeric.float.decimal invalid.illegal.numeric.suffix */
+/*         ^ keyword.operator.arithmetic */
+/*          ^^ constant.numeric.float.decimal - invalid */
+/*            ^^^^ constant.numeric.float.decimal invalid.illegal.numeric.suffix */
+/*                ^ keyword.operator */
+/*                 ^^ constant.numeric.float.decimal - invalid */
+/*                   ^^^^ constant.numeric.float.decimal invalid.illegal.numeric.suffix */
+/*                       ^ keyword.operator.arithmetic */
+/*                        ^ punctuation.section.block.begin */
+/*                         ^ constant.numeric.integer.decimal - invalid */
+/*                          ^^^^ constant.numeric.integer.decimal invalid.illegal.numeric.suffix */
+/*                              ^ punctuation.section.block.end */
 
 scanf("%ms %as %*[, ]", &buf);
 /*     ^^^ constant.other.placeholder */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -396,7 +396,7 @@ using Alias = Foo;
 
 using Alias
   = NewLineFoo;
-/*^ - entity.name */ 
+/*^ - entity.name */
 
 template <typename T>
 using TemplateAlias = Foo<T>;
@@ -429,7 +429,7 @@ class MyClass : public CrtpClass<MyClass>
 {
     using typename CrtpClass<MyClass>::PointerType;
 /*  ^ keyword.control */
-/*        ^ storage.modifier */ 
+/*        ^ storage.modifier */
     using CrtpClass<
 /*  ^ keyword.control */
         MyClass>::method;
@@ -965,135 +965,266 @@ std::cout << __LINE__ << '\n';
 /////////////////////////////////////////////
 
 dec1 = 1234567890;
-/*     ^ constant.numeric */
-/*              ^ constant.numeric */
+/*     ^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^ punctuation.terminator - constant */
 
 dec2 = 1'924'013;
-/*     ^ constant.numeric */
-/*             ^ constant.numeric */
+/*     ^^^^^^^^^ constant.numeric.integer.decimal */
+/*              ^ punctuation.terminator - constant */
 
 dec3 = 124ul;
-/*     ^ constant.numeric */
-/*         ^ constant.numeric */
+/*     ^^^^^ constant.numeric.integer.decimal */
+/*        ^^ storage.type.numeric */
+/*          ^ punctuation.terminator - constant */
 
 dec4 = 9'204lu;
-/*     ^ constant.numeric */
-/*           ^ constant.numeric */
+/*     ^^^^^^^ constant.numeric.integer.decimal */
+/*          ^^ storage.type.numeric */
+/*            ^ punctuation.terminator - constant */
 
 dec5 = 2'354'202'076LL;
-/*     ^ constant.numeric */
-/*                   ^ constant.numeric */
+/*     ^^^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*                  ^^ storage.type.numeric */
+/*                    ^ punctuation.terminator - constant */
 
-int oct1 = 01234567;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+oct1 = 0123_567;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*         ^^^^ storage.type.numeric */
+/*             ^ punctuation.terminator - constant */
 
-int oct2 = 014'70;
-/*         ^ constant.numeric */
-/*              ^ constant.numeric */
+oct2 = 014'70;
+/*     ^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*           ^ punctuation.terminator - constant */
 
-int hex1 = 0x1234567890ABCDEF;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex1 = 0x1234567890ABCDEF;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex2 = 0X1234567890ABCDEF;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex2 = 0X1234567890ABCDEF;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex3 = 0x1234567890abcdef;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex3 = 0x1234567890abcdef;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex4 = 0xA7'45'8C'38;
-/*         ^ constant.numeric */
-/*                     ^ constant.numeric */
+hex4 = 0xA7'45'8C'38;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                  ^ punctuation.terminator - constant */
 
-int bin1 = 0b010110;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+hex5 = 0x0+0xFL+0xaull+0xallu+0xfu+0xf'12_4_uz;
+/*     ^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^^^^ constant.numeric.integer.hexadecimal */
+/*         ^^ punctuation.definition.numeric.base */
+/*            ^ storage.type.numeric */
+/*              ^^^^^^ constant.numeric.integer.hexadecimal */
+/*              ^^ punctuation.definition.numeric.base */
+/*                 ^^^ storage.type.numeric */
+/*                     ^^^^^^ constant.numeric.integer.hexadecimal */
+/*                     ^^ punctuation.definition.numeric.base */
+/*                        ^^^ storage.type.numeric */
+/*                            ^^^^ constant.numeric.integer.hexadecimal */
+/*                            ^^ punctuation.definition.numeric.base */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*                                 ^^ punctuation.definition.numeric.base */
+/*                                       ^^^^^ storage.type.numeric */
+/*                                            ^ punctuation.terminator - constant */
 
-int bin2 = 0B010010;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+hex2 = 0xc1.01AbFp-1;
+/*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^ punctuation.separator.decimal */
+/*                  ^ punctuation.terminator - constant */
 
-int bin3 = 0b1001'1101'0010'1100;
-/*         ^ constant.numeric */
-/*                             ^ constant.numeric */
+bin1 = 0b010110;
+/*     ^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*             ^ punctuation.terminator - constant */
 
-units1 = 134h;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+bin2 = 0B010010;
+/*     ^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*             ^ punctuation.terminator - constant */
 
-units2 = 147min;
-/*       ^ constant.numeric */
-/*            ^ constant.numeric */
+bin3 = 0b1001'1101'0010'1100;
+/*     ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*                          ^ punctuation.terminator - constant */
 
-units3 = 357s;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^^ constant.numeric.float.decimal */
+/*       ^ punctuation.separator.decimal */
+/*           ^ keyword.operator.arithmetic */
+/*            ^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.separator.decimal */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                      ^ storage.type.numeric */
+/*                       ^ keyword.operator.arithmetic */
+/*                        ^^^^^^ constant.numeric.float.decimal */
+/*                         ^ punctuation.separator.decimal */
+/*                             ^ storage.type.numeric */
+/*                              ^ keyword.operator.arithmetic */
+/*                               ^^^^^^^ constant.numeric.float.decimal */
+/*                                ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ keyword.operator.arithmetic */
+/*                                       ^^^^ constant.numeric.float.decimal */
+/*                                        ^ punctuation.separator.decimal */
+/*                                          ^ storage.type.numeric */
+/*                                           ^ keyword.operator.arithmetic */
+/*                                            ^^^^^^ constant.numeric.float.decimal */
+/*                                             ^ punctuation.separator.decimal */
+/*                                                 ^ storage.type.numeric */
+/*                                                  ^ keyword.operator.arithmetic */
+/*                                                   ^^^^^^^ constant.numeric.float.decimal */
+/*                                                    ^ punctuation.separator.decimal */
+/*                                                         ^ storage.type.numeric */
+/*                                                          ^ punctuation.terminator - constant */
 
-units4 = 234_custom;
-/*       ^ constant.numeric */
-/*                ^ constant.numeric */
+f = 1.e1+1.e-1+1.e1f+1.e-1f+1.e1L+1.e-1L;
+/*  ^^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*      ^ keyword.operator.arithmetic */
+/*       ^^^^^ constant.numeric.float.decimal */
+/*        ^ punctuation.separator.decimal */
+/*            ^ keyword.operator.arithmetic */
+/*             ^^^^^ constant.numeric.float.decimal */
+/*              ^ punctuation.separator.decimal */
+/*                 ^ storage.type.numeric */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^ constant.numeric.float.decimal */
+/*                           ^ punctuation.separator.decimal */
+/*                              ^ storage.type.numeric */
+/*                               ^ keyword.operator.arithmetic */
+/*                                ^^^^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ punctuation.terminator - constant */
 
-fixed1 = 123.456;
-/*       ^ constant.numeric */
-/*             ^ constant.numeric */
+f = 1.+1.f+1.L+1..;
+/*  ^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^ constant.numeric.float.decimal */
+/*      ^ punctuation.separator.decimal */
+/*       ^ storage.type.numeric */
+/*        ^ keyword.operator.arithmetic */
+/*         ^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*           ^ storage.type.numeric */
+/*            ^ keyword.operator.arithmetic */
+/*             ^ constant.numeric.integer.decimal */
+/*              ^^ invalid.illegal.syntax */
+/*                ^ punctuation.terminator - constant */
 
-fixed2 = 12.;
-/*       ^ constant.numeric */
-/*         ^ constant.numeric */
+f = 1e1+1e1f+1e1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^ constant.numeric.float.decimal */
+/*         ^ storage.type.numeric */
+/*          ^ keyword.operator.arithmetic */
+/*           ^^^^ constant.numeric.float.decimal */
+/*              ^ storage.type.numeric */
+/*               ^ punctuation.terminator - constant */
 
-fixed3 = .35;
-/*       ^ constant.numeric */
-/*         ^ constant.numeric */
+f = .1+.1e1+.1e-1+.1f+.1e1f+.1e-1f+.1L+.1e1L+.1e-1L;
+/*  ^^ constant.numeric.float.decimal */
+/*  ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^^ constant.numeric.float.decimal */
+/*     ^ punctuation.separator.decimal */
+/*         ^ keyword.operator.arithmetic */
+/*          ^^^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*               ^ keyword.operator.arithmetic */
+/*                ^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ keyword.operator.arithmetic */
+/*                    ^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^^ constant.numeric.float.decimal */
+/*                          ^ punctuation.separator.decimal */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                   ^ storage.type.numeric */
+/*                                    ^ keyword.operator.arithmetic */
+/*                                     ^^^^^ constant.numeric.float.decimal */
+/*                                     ^ punctuation.separator.decimal */
+/*                                         ^ storage.type.numeric */
+/*                                          ^ keyword.operator.arithmetic */
+/*                                           ^^^^^^ constant.numeric.float.decimal */
+/*                                           ^ punctuation.separator.decimal */
+/*                                                ^ storage.type.numeric */
+/*                                                 ^ punctuation.terminator - constant */
 
-fixed4 = 1'843'290.245'123;
-/*       ^ constant.numeric */
-/*                       ^ constant.numeric */
+f = 1'843'290.245'123;
+/*  ^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal */
+/*           ^ punctuation.separator.decimal */
+/*                   ^ punctuation.terminator - constant */
 
-fixed5 = 0.3f;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+f = 2'837e1'000;
+/*  ^^^^^^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.terminator - constant */
 
-fixed6 = 0.82L;
-/*       ^ constant.numeric */
-/*           ^ constant.numeric */
+f = 23e-1'000;
+/*  ^^^^^^^^^ constant.numeric.float.decimal */
+/*           ^ punctuation.terminator - constant */
 
-float sci1 = 1.23e10;
-/*           ^ constant.numeric */
-/*                 ^ constant.numeric */
+units1 = 134h + 123.45h;
+/*       ^^^^ constant.numeric.integer.decimal */
+/*          ^ storage.type.numeric */
+/*           ^^^ - constant */
+/*              ^^^^^^^ constant.numeric.float.decimal */
+/*                 ^ punctuation.separator.decimal */
+/*                    ^ storage.type.numeric */
+/*                     ^ punctuation.terminator - constant */
 
-float sci2 = 13e5;
-/*           ^ constant.numeric */
-/*              ^ constant.numeric */
+units2 = 147min + 147.min;
+/*       ^^^^^^ constant.numeric.integer.decimal */
+/*          ^^^ storage.type.numeric */
+/*             ^^^ - constant */
+/*                ^^^^^^^ constant.numeric.float.decimal */
+/*                   ^ punctuation.separator.decimal */
+/*                    ^^^ storage.type.numeric */
+/*                       ^ punctuation.terminator - constant */
 
-float sci3 = 14.23e+14;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
+units3 = 357s + 34.7s;
+/*       ^^^^ constant.numeric.integer.decimal */
+/*          ^ storage.type.numeric */
+/*           ^^^ - constant */
+/*              ^^^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ punctuation.terminator - constant */
 
-float sci4 = 14e+14;
-/*           ^ constant.numeric */
-/*                ^ constant.numeric */
-
-float sci5 = 18.84e-12;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
-
-float sci6 = 46e-14;
-/*           ^ constant.numeric */
-/*                ^ constant.numeric */
-
-float sci7 = 2'837e1'000;
-/*           ^ constant.numeric */
-/*                     ^ constant.numeric */
-
-float sci8 = 23e-1'000;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
-
-double sci_hex = 0xc1.01AbFp-1;
-/*               ^^^^^^^^^^^^^ constant.numeric */
+units4 = 234_custom + 10e-1_custom;
+/*       ^^^^^^^^^^ constant.numeric.integer.decimal */
+/*          ^^^^^^^ storage.type.numeric */
+/*                 ^^^ - constant */
+/*                    ^^^^^^^^^^^^ constant.numeric.float.decimal */
+/*                         ^^^^^^^ storage.type.numeric */
+/*                                ^ punctuation.terminator - constant */
 
 /////////////////////////////////////////////
 // Functions
@@ -1407,7 +1538,7 @@ void func() {
 /*                                                   ^ string */
 }
 
-using namespace 
+using namespace
 /* <- keyword.control */
 /*    ^ keyword.control */
 
@@ -2098,7 +2229,7 @@ enum class Namespace::MyEnum
 };
 
 class Namespace::
-MyClass MACRO1 
+MyClass MACRO1
 /* <- entity.name.class */
 /*      ^ - entity.name */
 {

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -225,8 +225,7 @@ contexts:
     - include: scope:source.c#strings
 
   numbers:
-    - include: scope:source.c++#unique-numbers
-    - include: scope:source.c#numbers
+    - include: scope:source.c++#numbers
 
   ##########################################
   # Directly from Objective-C.sublime-syntax
@@ -379,7 +378,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -405,7 +404,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1637,7 +1636,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1663,7 +1662,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1707,7 +1706,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1734,7 +1733,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1839,7 +1838,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1865,7 +1864,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++
         2: keyword.control.import.objc++
-        3: constant.numeric.preprocessor.objc++
+        3: constant.numeric.integer.decimal.objc++
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -2083,7 +2082,7 @@ contexts:
     # Captures the namespace macro idiom
     - match: '\b(namespace)\s+(?={{path_lookahead}}\s*\{)'
       scope: meta.namespace.objc++
-      captures: 
+      captures:
         1: keyword.control.objc++
       push:
         - meta_content_scope: meta.namespace.objc++ entity.name.namespace.objc++

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -1094,7 +1094,7 @@ contexts:
     - match: '&'
       scope: keyword.operator.objc++
     - match: \b0\b
-      scope: constant.numeric.objc++
+      scope: constant.numeric.integer.decimal.objc++
     - match: \b(default|delete)\b
       scope: storage.modifier.objc++
     - match: '(?=\{)'
@@ -1563,7 +1563,7 @@ contexts:
     - match: '&'
       scope: keyword.operator.objc++
     - match: \b0\b
-      scope: constant.numeric.objc++
+      scope: constant.numeric.integer.decimal.objc++
     - match: \b(default|delete)\b
       scope: storage.modifier.objc++
     - match: '(?=:)'

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -262,7 +262,6 @@ contexts:
     - include: preprocessor-expressions
     - include: comments
     - include: case-default
-    - include: access
     - include: typedef
     - include: keywords-parens
     - include: keywords
@@ -273,6 +272,7 @@ contexts:
     - include: block
     - include: variables
     - include: constants
+    - include: access
     - match: ','
       scope: punctuation.separator.objc
     - match: '\)|\}'
@@ -477,7 +477,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -503,7 +503,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -911,7 +911,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -937,7 +937,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -981,7 +981,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1008,7 +1008,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1113,7 +1113,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:
@@ -1139,7 +1139,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc
         2: keyword.control.import.objc
-        3: constant.numeric.preprocessor.objc
+        3: constant.numeric.integer.decimal.objc
       push:
         - match: ^\s*(#\s*endif)\b
           captures:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -432,7 +432,7 @@ class MyClass : public CrtpClass<MyClass>
 {
     using typename CrtpClass<MyClass>::PointerType;
 /*  ^ keyword.control */
-/*        ^ storage.modifier */ 
+/*        ^ storage.modifier */
     using CrtpClass<
 /*  ^ keyword.control */
         MyClass>::method;
@@ -678,7 +678,7 @@ int main() {
 
 // Example from section 14.2/4 of
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf
-struct X 
+struct X
 {
     template <std::size_t>
     X* alloc();
@@ -686,12 +686,12 @@ struct X
     template <std::size_t>
     static X* adjust();
 };
-template <class T> 
-void f(T* p) 
+template <class T>
+void f(T* p)
 {
     // Be optimistic: scope it as a template member function call anyway.
     T* p1 = p->alloc<200>(); // ill-formed: < means less than
-    
+
     T* p2 = p->template alloc<200>(); // OK: < starts template argument list
     /*        ^ punctuation.accessor           */
     /*         ^ storage.type - variable.other */
@@ -699,7 +699,7 @@ void f(T* p)
 
     // Be optimistic: scope it as a template member function call anyway.
     T::adjust<100>(); // ill-formed: < means less than
-    
+
     T::template adjust<100>(); // OK: < starts template argument list
     /* <- - variable.function                    */
     /*^ punctuation.accessor                     */
@@ -934,135 +934,266 @@ std::cout << __LINE__ << '\n';
 /////////////////////////////////////////////
 
 dec1 = 1234567890;
-/*     ^ constant.numeric */
-/*              ^ constant.numeric */
+/*     ^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^ punctuation.terminator - constant */
 
 dec2 = 1'924'013;
-/*     ^ constant.numeric */
-/*             ^ constant.numeric */
+/*     ^^^^^^^^^ constant.numeric.integer.decimal */
+/*              ^ punctuation.terminator - constant */
 
 dec3 = 124ul;
-/*     ^ constant.numeric */
-/*         ^ constant.numeric */
+/*     ^^^^^ constant.numeric.integer.decimal */
+/*        ^^ storage.type.numeric */
+/*          ^ punctuation.terminator - constant */
 
 dec4 = 9'204lu;
-/*     ^ constant.numeric */
-/*           ^ constant.numeric */
+/*     ^^^^^^^ constant.numeric.integer.decimal */
+/*          ^^ storage.type.numeric */
+/*            ^ punctuation.terminator - constant */
 
 dec5 = 2'354'202'076LL;
-/*     ^ constant.numeric */
-/*                   ^ constant.numeric */
+/*     ^^^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*                  ^^ storage.type.numeric */
+/*                    ^ punctuation.terminator - constant */
 
-int oct1 = 01234567;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+oct1 = 0123_567;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*         ^^^^ storage.type.numeric */
+/*             ^ punctuation.terminator - constant */
 
-int oct2 = 014'70;
-/*         ^ constant.numeric */
-/*              ^ constant.numeric */
+oct2 = 014'70;
+/*     ^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*           ^ punctuation.terminator - constant */
 
-int hex1 = 0x1234567890ABCDEF;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex1 = 0x1234567890ABCDEF;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex2 = 0X1234567890ABCDEF;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex2 = 0X1234567890ABCDEF;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex3 = 0x1234567890abcdef;
-/*         ^ constant.numeric */
-/*                          ^ constant.numeric */
+hex3 = 0x1234567890abcdef;
+/*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                       ^ punctuation.terminator - constant */
 
-int hex4 = 0xA7'45'8C'38;
-/*         ^ constant.numeric */
-/*                     ^ constant.numeric */
+hex4 = 0xA7'45'8C'38;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*                  ^ punctuation.terminator - constant */
 
-int bin1 = 0b010110;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+hex5 = 0x0+0xFL+0xaull+0xallu+0xfu+0xf'12_4_uz;
+/*     ^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^^^^ constant.numeric.integer.hexadecimal */
+/*         ^^ punctuation.definition.numeric.base */
+/*            ^ storage.type.numeric */
+/*              ^^^^^^ constant.numeric.integer.hexadecimal */
+/*              ^^ punctuation.definition.numeric.base */
+/*                 ^^^ storage.type.numeric */
+/*                     ^^^^^^ constant.numeric.integer.hexadecimal */
+/*                     ^^ punctuation.definition.numeric.base */
+/*                        ^^^ storage.type.numeric */
+/*                            ^^^^ constant.numeric.integer.hexadecimal */
+/*                            ^^ punctuation.definition.numeric.base */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^^^^^^^^ constant.numeric.integer.hexadecimal */
+/*                                 ^^ punctuation.definition.numeric.base */
+/*                                       ^^^^^ storage.type.numeric */
+/*                                            ^ punctuation.terminator - constant */
 
-int bin2 = 0B010010;
-/*         ^ constant.numeric */
-/*                ^ constant.numeric */
+hex2 = 0xc1.01AbFp-1;
+/*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^ punctuation.separator.decimal */
+/*                  ^ punctuation.terminator - constant */
 
-int bin3 = 0b1001'1101'0010'1100;
-/*         ^ constant.numeric */
-/*                             ^ constant.numeric */
+bin1 = 0b010110;
+/*     ^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*             ^ punctuation.terminator - constant */
 
-units1 = 134h;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+bin2 = 0B010010;
+/*     ^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*             ^ punctuation.terminator - constant */
 
-units2 = 147min;
-/*       ^ constant.numeric */
-/*            ^ constant.numeric */
+bin3 = 0b1001'1101'0010'1100;
+/*     ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary */
+/*     ^^ punctuation.definition.numeric.base */
+/*                          ^ punctuation.terminator - constant */
 
-units3 = 357s;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^^ constant.numeric.float.decimal */
+/*       ^ punctuation.separator.decimal */
+/*           ^ keyword.operator.arithmetic */
+/*            ^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.separator.decimal */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                      ^ storage.type.numeric */
+/*                       ^ keyword.operator.arithmetic */
+/*                        ^^^^^^ constant.numeric.float.decimal */
+/*                         ^ punctuation.separator.decimal */
+/*                             ^ storage.type.numeric */
+/*                              ^ keyword.operator.arithmetic */
+/*                               ^^^^^^^ constant.numeric.float.decimal */
+/*                                ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ keyword.operator.arithmetic */
+/*                                       ^^^^ constant.numeric.float.decimal */
+/*                                        ^ punctuation.separator.decimal */
+/*                                          ^ storage.type.numeric */
+/*                                           ^ keyword.operator.arithmetic */
+/*                                            ^^^^^^ constant.numeric.float.decimal */
+/*                                             ^ punctuation.separator.decimal */
+/*                                                 ^ storage.type.numeric */
+/*                                                  ^ keyword.operator.arithmetic */
+/*                                                   ^^^^^^^ constant.numeric.float.decimal */
+/*                                                    ^ punctuation.separator.decimal */
+/*                                                         ^ storage.type.numeric */
+/*                                                          ^ punctuation.terminator - constant */
 
-units4 = 234_custom;
-/*       ^ constant.numeric */
-/*                ^ constant.numeric */
+f = 1.e1+1.e-1+1.e1f+1.e-1f+1.e1L+1.e-1L;
+/*  ^^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*      ^ keyword.operator.arithmetic */
+/*       ^^^^^ constant.numeric.float.decimal */
+/*        ^ punctuation.separator.decimal */
+/*            ^ keyword.operator.arithmetic */
+/*             ^^^^^ constant.numeric.float.decimal */
+/*              ^ punctuation.separator.decimal */
+/*                 ^ storage.type.numeric */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^ constant.numeric.float.decimal */
+/*                           ^ punctuation.separator.decimal */
+/*                              ^ storage.type.numeric */
+/*                               ^ keyword.operator.arithmetic */
+/*                                ^^^^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ punctuation.terminator - constant */
 
-fixed1 = 123.456;
-/*       ^ constant.numeric */
-/*             ^ constant.numeric */
+f = 1.+1.f+1.L+1..;
+/*  ^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^ constant.numeric.float.decimal */
+/*      ^ punctuation.separator.decimal */
+/*       ^ storage.type.numeric */
+/*        ^ keyword.operator.arithmetic */
+/*         ^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*           ^ storage.type.numeric */
+/*            ^ keyword.operator.arithmetic */
+/*             ^ constant.numeric.integer.decimal */
+/*              ^^ invalid.illegal.syntax */
+/*                ^ punctuation.terminator - constant */
 
-fixed2 = 12.;
-/*       ^ constant.numeric */
-/*         ^ constant.numeric */
+f = 1e1+1e1f+1e1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^ constant.numeric.float.decimal */
+/*         ^ storage.type.numeric */
+/*          ^ keyword.operator.arithmetic */
+/*           ^^^^ constant.numeric.float.decimal */
+/*              ^ storage.type.numeric */
+/*               ^ punctuation.terminator - constant */
 
-fixed3 = .35;
-/*       ^ constant.numeric */
-/*         ^ constant.numeric */
+f = .1+.1e1+.1e-1+.1f+.1e1f+.1e-1f+.1L+.1e1L+.1e-1L;
+/*  ^^ constant.numeric.float.decimal */
+/*  ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^^ constant.numeric.float.decimal */
+/*     ^ punctuation.separator.decimal */
+/*         ^ keyword.operator.arithmetic */
+/*          ^^^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*               ^ keyword.operator.arithmetic */
+/*                ^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ keyword.operator.arithmetic */
+/*                    ^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^^ constant.numeric.float.decimal */
+/*                          ^ punctuation.separator.decimal */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                   ^ storage.type.numeric */
+/*                                    ^ keyword.operator.arithmetic */
+/*                                     ^^^^^ constant.numeric.float.decimal */
+/*                                     ^ punctuation.separator.decimal */
+/*                                         ^ storage.type.numeric */
+/*                                          ^ keyword.operator.arithmetic */
+/*                                           ^^^^^^ constant.numeric.float.decimal */
+/*                                           ^ punctuation.separator.decimal */
+/*                                                ^ storage.type.numeric */
+/*                                                 ^ punctuation.terminator - constant */
 
-fixed4 = 1'843'290.245'123;
-/*       ^ constant.numeric */
-/*                       ^ constant.numeric */
+f = 1'843'290.245'123;
+/*  ^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal */
+/*           ^ punctuation.separator.decimal */
+/*                   ^ punctuation.terminator - constant */
 
-fixed5 = 0.3f;
-/*       ^ constant.numeric */
-/*          ^ constant.numeric */
+f = 2'837e1'000;
+/*  ^^^^^^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.terminator - constant */
 
-fixed6 = 0.82L;
-/*       ^ constant.numeric */
-/*           ^ constant.numeric */
+f = 23e-1'000;
+/*  ^^^^^^^^^ constant.numeric.float.decimal */
+/*           ^ punctuation.terminator - constant */
 
-float sci1 = 1.23e10;
-/*           ^ constant.numeric */
-/*                 ^ constant.numeric */
+units1 = 134h + 123.45h;
+/*       ^^^^ constant.numeric.integer.decimal */
+/*          ^ storage.type.numeric */
+/*           ^^^ - constant */
+/*              ^^^^^^^ constant.numeric.float.decimal */
+/*                 ^ punctuation.separator.decimal */
+/*                    ^ storage.type.numeric */
+/*                     ^ punctuation.terminator - constant */
 
-float sci2 = 13e5;
-/*           ^ constant.numeric */
-/*              ^ constant.numeric */
+units2 = 147min + 147.min;
+/*       ^^^^^^ constant.numeric.integer.decimal */
+/*          ^^^ storage.type.numeric */
+/*             ^^^ - constant */
+/*                ^^^^^^^ constant.numeric.float.decimal */
+/*                   ^ punctuation.separator.decimal */
+/*                    ^^^ storage.type.numeric */
+/*                       ^ punctuation.terminator - constant */
 
-float sci3 = 14.23e+14;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
+units3 = 357s + 34.7s;
+/*       ^^^^ constant.numeric.integer.decimal */
+/*          ^ storage.type.numeric */
+/*           ^^^ - constant */
+/*              ^^^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ punctuation.terminator - constant */
 
-float sci4 = 14e+14;
-/*           ^ constant.numeric */
-/*                ^ constant.numeric */
-
-float sci5 = 18.84e-12;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
-
-float sci6 = 46e-14;
-/*           ^ constant.numeric */
-/*                ^ constant.numeric */
-
-float sci7 = 2'837e1'000;
-/*           ^ constant.numeric */
-/*                     ^ constant.numeric */
-
-float sci8 = 23e-1'000;
-/*           ^ constant.numeric */
-/*                   ^ constant.numeric */
-
-double sci_hex = 0xc1.01AbFp-1;
-/*               ^^^^^^^^^^^^^ constant.numeric */
+units4 = 234_custom + 10e-1_custom;
+/*       ^^^^^^^^^^ constant.numeric.integer.decimal */
+/*          ^^^^^^^ storage.type.numeric */
+/*                 ^^^ - constant */
+/*                    ^^^^^^^^^^^^ constant.numeric.float.decimal */
+/*                         ^^^^^^^ storage.type.numeric */
+/*                                ^ punctuation.terminator - constant */
 
 /////////////////////////////////////////////
 // Functions
@@ -1368,7 +1499,7 @@ using namespace NAME __attribute__((visibility ("hidden")));
 /*                   ^ storage.modifier */
 /*                                               ^ string */
 
-using namespace 
+using namespace
 /* <- keyword.control */
 /*    ^ keyword.control */
 
@@ -2067,7 +2198,7 @@ enum class Namespace::MyEnum
 };
 
 class Namespace::
-MyClass MACRO1 
+MyClass MACRO1
 /* <- entity.name.class */
 /*      ^ - entity.name */
 {
@@ -2409,7 +2540,7 @@ void sayHi()
 /*         ^ constant.numeric */
 /*          ^ punctuation.section.generic.end */
 /*           ^^ meta.group */
-    
+
     ::myns::foo<int>();
 /*  ^^ punctuation.accessor.double-colon */
 /*        ^^ punctuation.accessor.double-colon */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -680,6 +680,219 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
 
+/////////////////////////////////////////////
+// Numeric Constants
+/////////////////////////////////////////////
+
+dec0 = 0;
+/*     ^ constant.numeric.integer.decimal */
+
+dec1 = 1234567890;
+/*     ^^^^^^^^^^ constant.numeric.integer.decimal */
+
+dec2 = 1234567890f;
+/*     ^^^^^^^^^^^ constant.numeric.float.decimal */
+/*               ^ storage.type.numeric */
+
+dec3 = 1234567890L;
+/*     ^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^ storage.type.numeric */
+
+dec4 = 1234567890ul;
+/*     ^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^ storage.type.numeric */
+
+dec5 = 1234567890Lu;
+/*     ^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^ storage.type.numeric */
+
+dec6 = 1234567890LLU;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^^ storage.type.numeric */
+
+dec7 = 1234567890uLL;
+/*     ^^^^^^^^^^^^^ constant.numeric.integer.decimal */
+/*               ^^^ storage.type.numeric */
+
+dec8 = 1'234_567'890s0f;
+/*     ^ constant.numeric.integer.decimal */
+/*      ^^^^^^^^^ string.quoted.single */
+/*               ^^^^^^ constant.numeric.integer.decimal */
+/*                  ^^^ invalid.illegal.numeric.suffix */
+/*                     ^ punctuation.terminator - constant */
+
+oct1 = 01234567;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+
+oct2 = 01234567L;
+/*     ^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^ storage.type.numeric */
+
+oct3 = 01234567LL;
+/*     ^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^^ storage.type.numeric */
+
+oct4 = 01234567ulL;
+/*     ^^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*             ^^^ storage.type.numeric */
+
+oct2 = 01284967Z0L;
+/*     ^^^^^^^^^^^ constant.numeric.integer.octal */
+/*     ^ punctuation.definition.numeric.base */
+/*        ^ invalid.illegal.numeric.digit */
+/*          ^ invalid.illegal.numeric.digit */
+/*             ^^^ invalid.illegal.numeric.suffix */
+
+hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
+/*     ^^^ constant.numeric.integer.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^^^^ constant.numeric.integer.hexadecimal */
+/*         ^^ punctuation.definition.numeric.base */
+/*            ^ storage.type.numeric */
+/*              ^^^^^^ constant.numeric.integer.hexadecimal */
+/*              ^^ punctuation.definition.numeric.base */
+/*                 ^^^ storage.type.numeric */
+/*                     ^^^^^^ constant.numeric.integer.hexadecimal */
+/*                     ^^ punctuation.definition.numeric.base */
+/*                        ^^^ storage.type.numeric */
+/*                            ^^^^ constant.numeric.integer.hexadecimal */
+/*                            ^^ punctuation.definition.numeric.base */
+/*                               ^ storage.type.numeric */
+/*                                 ^^ constant.numeric.integer.hexadecimal */
+/*                                 ^^ punctuation.definition.numeric.base */
+/*                                   ^^^ string.quoted.single */
+/*                                      ^^^^^^ constant.numeric.integer.decimal */
+/*                                        ^^^^ invalid.illegal.numeric.suffix */
+/*                                            ^ punctuation.terminator - constant */
+
+hex2 = 0xc1.01AbFp-1;
+/*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
+/*     ^^ punctuation.definition.numeric.base */
+/*         ^ punctuation.separator.decimal */
+/*                  ^ punctuation.terminator - constant */
+
+f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^^ constant.numeric.float.decimal */
+/*       ^ punctuation.separator.decimal */
+/*           ^ keyword.operator.arithmetic */
+/*            ^^^^^^ constant.numeric.float.decimal */
+/*             ^ punctuation.separator.decimal */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                      ^ storage.type.numeric */
+/*                       ^ keyword.operator.arithmetic */
+/*                        ^^^^^^ constant.numeric.float.decimal */
+/*                         ^ punctuation.separator.decimal */
+/*                             ^ storage.type.numeric */
+/*                              ^ keyword.operator.arithmetic */
+/*                               ^^^^^^^ constant.numeric.float.decimal */
+/*                                ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ keyword.operator.arithmetic */
+/*                                       ^^^^ constant.numeric.float.decimal */
+/*                                        ^ punctuation.separator.decimal */
+/*                                          ^ storage.type.numeric */
+/*                                           ^ keyword.operator.arithmetic */
+/*                                            ^^^^^^ constant.numeric.float.decimal */
+/*                                             ^ punctuation.separator.decimal */
+/*                                                 ^ storage.type.numeric */
+/*                                                  ^ keyword.operator.arithmetic */
+/*                                                   ^^^^^^^ constant.numeric.float.decimal */
+/*                                                    ^ punctuation.separator.decimal */
+/*                                                         ^ storage.type.numeric */
+/*                                                          ^ punctuation.terminator.objc */
+
+f = 1.e1+1.e-1+1.e1f+1.e-1f+1.e1L+1.e-1L;
+/*  ^^^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*      ^ keyword.operator.arithmetic */
+/*       ^^^^^ constant.numeric.float.decimal */
+/*        ^ punctuation.separator.decimal */
+/*            ^ keyword.operator.arithmetic */
+/*             ^^^^^ constant.numeric.float.decimal */
+/*              ^ punctuation.separator.decimal */
+/*                 ^ storage.type.numeric */
+/*                  ^ keyword.operator.arithmetic */
+/*                   ^^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^ constant.numeric.float.decimal */
+/*                           ^ punctuation.separator.decimal */
+/*                              ^ storage.type.numeric */
+/*                               ^ keyword.operator.arithmetic */
+/*                                ^^^^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                     ^ storage.type.numeric */
+/*                                      ^ punctuation.terminator.objc */
+
+f = 1.+1.f+1.L+1..;
+/*  ^^ constant.numeric.float.decimal */
+/*   ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^ constant.numeric.float.decimal */
+/*      ^ punctuation.separator.decimal */
+/*       ^ storage.type.numeric */
+/*        ^ keyword.operator.arithmetic */
+/*         ^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*           ^ storage.type.numeric */
+/*            ^ keyword.operator.arithmetic */
+/*             ^ constant.numeric.integer.decimal */
+/*              ^^ invalid.illegal.syntax */
+/*                ^ punctuation.terminator.objc */
+
+f = 1e1+1e1f+1e1L;
+/*  ^^^ constant.numeric.float.decimal */
+/*     ^ keyword.operator.arithmetic */
+/*      ^^^^ constant.numeric.float.decimal */
+/*         ^ storage.type.numeric */
+/*          ^ keyword.operator.arithmetic */
+/*           ^^^^ constant.numeric.float.decimal */
+/*              ^ storage.type.numeric */
+/*               ^ punctuation.terminator.objc */
+
+f = .1+.1e1+.1e-1+.1f+.1e1f+.1e-1f+.1L+.1e1L+.1e-1L;
+/*  ^^ constant.numeric.float.decimal */
+/*  ^ punctuation.separator.decimal */
+/*    ^ keyword.operator.arithmetic */
+/*     ^^^^ constant.numeric.float.decimal */
+/*     ^ punctuation.separator.decimal */
+/*         ^ keyword.operator.arithmetic */
+/*          ^^^^^ constant.numeric.float.decimal */
+/*          ^ punctuation.separator.decimal */
+/*               ^ keyword.operator.arithmetic */
+/*                ^^^ constant.numeric.float.decimal */
+/*                ^ punctuation.separator.decimal */
+/*                  ^ storage.type.numeric */
+/*                   ^ keyword.operator.arithmetic */
+/*                    ^^^^^ constant.numeric.float.decimal */
+/*                    ^ punctuation.separator.decimal */
+/*                        ^ storage.type.numeric */
+/*                         ^ keyword.operator.arithmetic */
+/*                          ^^^^^^ constant.numeric.float.decimal */
+/*                          ^ punctuation.separator.decimal */
+/*                               ^ storage.type.numeric */
+/*                                 ^^^ constant.numeric.float.decimal */
+/*                                 ^ punctuation.separator.decimal */
+/*                                   ^ storage.type.numeric */
+/*                                    ^ keyword.operator.arithmetic */
+/*                                     ^^^^^ constant.numeric.float.decimal */
+/*                                     ^ punctuation.separator.decimal */
+/*                                         ^ storage.type.numeric */
+/*                                          ^ keyword.operator.arithmetic */
+/*                                           ^^^^^^ constant.numeric.float.decimal */
+/*                                           ^ punctuation.separator.decimal */
+/*                                                ^ storage.type.numeric */
+/*                                                 ^ punctuation.terminator.objc */
 
 /////////////////////////////////////////////
 // Objective-C specific format specifiers


### PR DESCRIPTION
This commit...

1. applies scope naming guidelines to all numeric literals
2. implements dedicated C style and C++ style contexts with the syntax specific behavior.

   a) C/ObjC supports only limited amount of predefined suffixes C++/ObjC++ supports all kind of suffixes which are either predefined (see C) or user defined via `operator ""` keyword.
   b) C++14 introduces `'` as digit to improve readability of large numbers, while C does not support it.
   c) both C and C++ support hexadecimal floats

   Dedicated means, C++ does no longer import C number contexts as the required patterns are simply differ too much.

3. adds illegal matching of octal or hexadecimal digits as well as unsupported suffixes (in C). The implementation is inspired by Bash.sublime-syntax and complies with the compiler error messages.

4. fixes an issue with decimal points being matched as accessor in some situations.

5. Depending on the mix of numbers the parsing performance is improved by 4 ... 40% especially in C++.