### PR TITLE
[CSS] Improve completions

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -1,13 +1,13 @@
 [
 	// Add a colon followed by space and semicolon after a property name,
-	// if the next none-whitespace character is no semicolon.
+	// if the next following token doesn't look like a value.
 	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
-			{ "key": "following_text", "operator": "not_regex_contains", "operand": "^\\s*;", "match_all": false }
+			{ "key": "following_text", "operator": "not_regex_contains", "operand": "^[^:}]*;", "match_all": false }
 		]
 	},
 	// Add a colon followed by space after a property name,

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -1,10 +1,18 @@
 [
-	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\}|$)", "match_all": true }
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	},
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t[^;]| [^;]|\\}|$)", "match_all": true }
 		]
 	},
 	{ "keys": [";"], "command": "move", "args": {"by": "characters", "forward": true}, "context":

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -7,7 +7,7 @@
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
-			{ "key": "following_text", "operator": "not_regex_contains", "operand": "^[^:}]*;", "match_all": false }
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
 		]
 	},
 	// Add a colon followed by space after a property name,

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -32,6 +32,14 @@
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
 		]
 	},
+	{ "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line.sublime-macro"} , "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^[\t ]*;", "match_all": true }
+		]
+	},
 
 	// Expand {|} to { | } when space is pressed
 	{ "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -1,43 +1,54 @@
 [
-	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0"}, "context":
-		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
-		]
-	},
+	// Add a colon followed by space and semicolon after a property name,
+	// if the next none-whitespace character is no semicolon.
 	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t[^;]| [^;]|\\}|$)", "match_all": true }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
+			{ "key": "following_text", "operator": "not_regex_contains", "operand": "^\\s*;", "match_all": false }
 		]
 	},
+	// Add a colon followed by space after a property name,
+	// if the next character is a semicolon or the following token looks like a value.
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
+		]
+	},
+	// Move the cursor to prevent adding a duplicated semicolon.
 	{ "keys": [";"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": false }
 		]
 	},
+	// Delete both the colon on the left and a semicolon on the right.
 	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": false },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": false }
 		]
 	},
+	// Move the caret to the next line and leave the terminating semicolon untouched.
+	// This is to not bother with semicolons even though completions end up with the caret directy in front of it.
 	{ "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line.sublime-macro"} , "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^[\t ]*;", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": ";\\s*$", "match_all": false },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*;", "match_all": false }
 		]
 	},
 

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -71,4 +71,30 @@
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\}", "match_all": true }
 		]
 	},
+
+	// Auto-pair double quotes (also if followed by comma or semicolon)
+	// Example: key: |; -> key: "|";
+	{ "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - string", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|,|;|$)", "match_all": true },
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
+			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+		]
+	},
+
+	// Auto-pair double quotes (also if followed by comma or semicolon)
+	// Example: key: |; -> key: '|';
+	{ "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'$0'"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - string", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|,|;|$)", "match_all": true },
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "['a-zA-Z0-9_]$", "match_all": true },
+			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+		]
+	},
 ]

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -59,7 +59,7 @@
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\{$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true }
 		]
 	},
 	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
@@ -96,5 +96,5 @@
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "['a-zA-Z0-9_]$", "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
 		]
-	},
+	}
 ]

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -487,7 +487,9 @@ class CSSCompletions(sublime_plugin.EventListener):
             self.re_name = re.compile(r"([a-zA-Z-]+)\s*:[^:;{}]*$")
             self.re_value = re.compile(r"^(?:\s*(:)|([ \t]*))([^:]*)[;}]")
 
-        if match_selector(view, pt, "meta.property-value.css"):
+        if match_selector(view, pt, "meta.property-value.css meta.function-call"):
+            items = self.complete_function_argument(view, prefix, pt)
+        elif match_selector(view, pt, "meta.property-value.css"):
             items = self.complete_property_value(view, prefix, pt)
         else:
             items = self.complete_property_name(view, prefix, pt)
@@ -540,3 +542,6 @@ class CSSCompletions(sublime_plugin.EventListener):
                 kind=KIND_CSS_FUNCTION if "(" in value else KIND_CSS_CONSTANT
             ) for value in values
         )
+
+    def complete_function_argument(self, view, prefix, pt):
+        return None

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -482,8 +482,7 @@ class CSSCompletions(sublime_plugin.EventListener):
             # - <style type="text/css">.foo { font-weight: b|</style>
             view.match_selector(pt - 1, prop_value_scope)):
 
-            alt_loc = pt - len(prefix)
-            line = view.substr(sublime.Region(view.line(alt_loc).begin(), alt_loc))
+            line = view.substr(sublime.Region(view.line(pt).begin(), pt - len(prefix)))
 
             match = re.search(self.regex, line)
             if match:

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -453,14 +453,11 @@ def match_selector(view, pt, scope):
     return any(view.match_selector(p, scope) for p in (pt, pt - 1))
 
 
-def is_next_none_whitespace(view, pt, what):
-    while True:
+def next_none_whitespace(view, pt):
+    for pt in range(pt, view.size()):
         ch = view.substr(pt)
-        if ch == what:
-            return True
-        elif ch not in (' ', '\t'):
-            return False
-        pt += 1
+        if ch not in (' ', '\t'):
+            return ch
 
 
 class CSSCompletions(sublime_plugin.EventListener):
@@ -501,7 +498,7 @@ class CSSCompletions(sublime_plugin.EventListener):
             if not values:
                 return None
 
-            add_semi_colon = not is_next_none_whitespace(view, pt, ";")
+            add_semi_colon = next_none_whitespace(view, pt) != ";"
 
             items = []
             for value in values:
@@ -517,9 +514,10 @@ class CSSCompletions(sublime_plugin.EventListener):
 
         # complete property names
         else:
-            if view.match_selector(pt, prop_name_scope):
+            ch = next_none_whitespace(view, pt)
+            if ch == ":" or view.match_selector(pt, prop_name_scope):
                 suffix = ""
-            elif is_next_none_whitespace(view, pt, ";"):
+            elif ch == ";":
                 suffix = ": "
             else:
                 suffix = ": $0;"

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -476,7 +476,6 @@ class CSSCompletions(sublime_plugin.EventListener):
             self.props = parse_css_data()
             self.regex = re.compile(r"([a-zA-Z-]+):\s*$")
 
-        items = []
         if (view.match_selector(loc, prop_value_scope) or
             # This will catch scenarios like:
             # - .foo {font-style: |}
@@ -494,6 +493,7 @@ class CSSCompletions(sublime_plugin.EventListener):
 
                     add_semi_colon = view.substr(sublime.Region(loc, loc + 1)) != ';'
 
+                    items = []
                     for value in values:
                         desc = value + "\t" + prop_name
                         snippet = value
@@ -512,6 +512,7 @@ class CSSCompletions(sublime_plugin.EventListener):
         else:
             add_colon = not view.match_selector(loc, prop_name_scope)
 
+            items = []
             for prop in self.props:
                 if add_colon:
                     items.append((prop + "\tproperty", prop + ": "))

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -490,7 +490,7 @@ class CSSCompletions(sublime_plugin.EventListener):
         if not self.props:
             self.props = parse_css_data()
             self.re_name = re.compile(r"([a-zA-Z-]+)\s*:[^:;{}]*$")
-            self.re_value = re.compile(r"^(?:\s*(:)|([ \t]*))([^:]*)[;}]")
+            self.re_value = re.compile(r"^(?:\s*(:)|([ \t]*))([^:]*)([;}])")
             self.re_trigger = re.compile(r"\$(?:\d+|\{\d+\:([^}]+)\})")
 
         if match_selector(view, pt, "meta.property-value.css meta.function-call"):
@@ -509,13 +509,16 @@ class CSSCompletions(sublime_plugin.EventListener):
         text = view.substr(sublime.Region(pt, view.line(pt).end()))
         matches = self.re_value.search(text)
         if matches:
-            colon, space, value = matches.groups()
+            colon, space, value, term = matches.groups()
             if colon:
                 # don't append anything if the next character is a colon
                 suffix = ""
             elif value:
                 # only append colon if value already exists
                 suffix = ":" if space else ": "
+            elif term == ";":
+                # ommit semicolon if rule is already terminated
+                suffix = ": $0"
 
         return (
             sublime.CompletionItem.snippet_completion(

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -510,7 +510,7 @@ class CSSCompletions(sublime_plugin.EventListener):
 
                 snippet = value
                 if add_semi_colon:
-                    snippet += ";"
+                    snippet += "$0;"
 
                 items.append((desc, snippet))
 

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -476,7 +476,7 @@ class CSSCompletions(sublime_plugin.EventListener):
             self.props = parse_css_data()
             self.regex = re.compile(r"([a-zA-Z-]+):\s*$")
 
-        l = []
+        items = []
         if (view.match_selector(loc, prop_value_scope) or
             # This will catch scenarios like:
             # - .foo {font-style: |}
@@ -504,9 +504,9 @@ class CSSCompletions(sublime_plugin.EventListener):
                         if "$1" in snippet:
                             desc = desc.replace("$1", "")
 
-                        l.append((desc, snippet))
+                        items.append((desc, snippet))
 
-                    return (l, sublime.INHIBIT_WORD_COMPLETIONS)
+                    return (items, sublime.INHIBIT_WORD_COMPLETIONS)
 
             return None
         else:
@@ -514,8 +514,8 @@ class CSSCompletions(sublime_plugin.EventListener):
 
             for prop in self.props:
                 if add_colon:
-                    l.append((prop + "\tproperty", prop + ": "))
+                    items.append((prop + "\tproperty", prop + ": "))
                 else:
-                    l.append((prop + "\tproperty", prop))
+                    items.append((prop + "\tproperty", prop))
 
-            return (l, sublime.INHIBIT_WORD_COMPLETIONS)
+            return (items, sublime.INHIBIT_WORD_COMPLETIONS)

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -444,17 +444,20 @@ def parse_css_data():
 
     return props
 
+
 class CSSCompletions(sublime_plugin.EventListener):
     props = None
     regex = None
 
     def on_query_completions(self, view, prefix, locations):
-        # match inside a CSS document and
-        # match inside the style attribute of HTML tags, incl. just before the quote that closes the attribute value
-        css_selector_scope = "source.css - meta.selector.css"
-        html_style_attr_selector_scope = "text.html meta.attribute-with-value.style.html " + \
-                                    "string.quoted - punctuation.definition.string.begin.html"
-        selector_scope = css_selector_scope + ', ' + html_style_attr_selector_scope
+        selector_scope = (
+            # match inside a CSS document and
+            "source.css - meta.selector.css, "
+            # match inside the style attribute of HTML tags, incl. just before
+            # the quote that closes the attribute value
+            "text.html meta.attribute-with-value.style.html "
+            "string.quoted - punctuation.definition.string.begin.html"
+        )
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
         pt = locations[0]

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -576,9 +576,10 @@ class CSSCompletions(sublime_plugin.EventListener):
                 suffix = ": $0"
 
         return (
-            sublime.CompletionItem.snippet_completion(
+            sublime.CompletionItem(
                 trigger=prop,
-                snippet=prop + suffix,
+                completion=prop + suffix,
+                completion_format=sublime.COMPLETION_FORMAT_SNIPPET,
                 kind=KIND_CSS_PROPERTY
             ) for prop in self.props
         )

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -457,17 +457,17 @@ class CSSCompletions(sublime_plugin.EventListener):
         selector_scope = css_selector_scope + ', ' + html_style_attr_selector_scope
         prop_name_scope = "meta.property-name.css"
         prop_value_scope = "meta.property-value.css"
-        loc = locations[0]
+        pt = locations[0]
 
         # When not inside CSS, don’t trigger
-        if not view.match_selector(loc, selector_scope):
+        if not view.match_selector(pt, selector_scope):
             # if the text immediately after the caret is a HTML style tag beginning, and the character before the
             # caret matches the CSS scope, then probably the user is typing here (where | represents the caret):
             # <style type="text/css">.test { f|</style>
             # i.e. after a "style" HTML open tag and immediately before the closing tag.
             # so we want to offer CSS completions here.
-            if view.match_selector(loc, 'text.html meta.tag.style.end punctuation.definition.tag.begin.html') and \
-               view.match_selector(loc - 1, selector_scope):
+            if view.match_selector(pt, 'text.html meta.tag.style.end punctuation.definition.tag.begin.html') and \
+               view.match_selector(pt - 1, selector_scope):
                 pass
             else:
                 return []
@@ -476,13 +476,13 @@ class CSSCompletions(sublime_plugin.EventListener):
             self.props = parse_css_data()
             self.regex = re.compile(r"([a-zA-Z-]+):\s*$")
 
-        if (view.match_selector(loc, prop_value_scope) or
+        if (view.match_selector(pt, prop_value_scope) or
             # This will catch scenarios like:
             # - .foo {font-style: |}
             # - <style type="text/css">.foo { font-weight: b|</style>
-            view.match_selector(loc - 1, prop_value_scope)):
+            view.match_selector(pt - 1, prop_value_scope)):
 
-            alt_loc = loc - len(prefix)
+            alt_loc = pt - len(prefix)
             line = view.substr(sublime.Region(view.line(alt_loc).begin(), alt_loc))
 
             match = re.search(self.regex, line)
@@ -491,7 +491,7 @@ class CSSCompletions(sublime_plugin.EventListener):
                 if prop_name in self.props:
                     values = self.props[prop_name]
 
-                    add_semi_colon = view.substr(sublime.Region(loc, loc + 1)) != ';'
+                    add_semi_colon = view.substr(sublime.Region(pt, pt + 1)) != ';'
 
                     items = []
                     for value in values:
@@ -510,7 +510,7 @@ class CSSCompletions(sublime_plugin.EventListener):
 
             return None
         else:
-            add_colon = not view.match_selector(loc, prop_name_scope)
+            add_colon = not view.match_selector(pt, prop_name_scope)
 
             items = []
             for prop in self.props:

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -1,5 +1,6 @@
-import sublime, sublime_plugin
 import re
+import sublime
+import sublime_plugin
 
 
 # Prepare some common property values for when there is more than one way to


### PR DESCRIPTION
Fixes #2076

This PR proposes several changes to the css_completions module. The main goal is to create a consistent behavior in manner of completing property names and adding colon and/or semi-colon after it. The current implementation of the css_completions and the related keymap entries result in different behavior in manner of handling the `: ;` after a property name.

Furthermore completions should always be triggered at the end of a CSS selector section no matter which syntax embedds the CSS. It was limited to HTML up to this commit.

Some more details can be found in the commit messages.