### PR TITLE
[JSON] Fix invalid highlighting

### DIFF
--- a/JavaScript/JSON.sublime-syntax
+++ b/JavaScript/JSON.sublime-syntax
@@ -109,9 +109,8 @@ contexts:
         - match: ":"
           scope: punctuation.separator.mapping.key-value.json
           push:
-            - match: '(,)|(?=\})'
-              captures:
-                1: invalid.illegal.expected-mapping-value.json
+            - match: ',|\s?(?=\})'
+              scope: invalid.illegal.expected-mapping-value.json
               pop: true
             - match: (?=\S)
               set:
@@ -120,11 +119,12 @@ contexts:
                 - include: value
                 - match: ''
                   set:
-                    - match: '(,)|(?=\s*\})'
-                      captures:
-                        1: punctuation.separator.mapping.pair.json
+                    - match: ','
+                      scope: punctuation.separator.mapping.pair.json
                       pop: true
-                    - match: '\s(?=[^\s,])|[^\s,]'
+                    - match: \s*(?=\})
+                      pop: true
+                    - match: \s(?!/[/*])(?=[^\s,])|[^\s,]
                       scope: invalid.illegal.expected-mapping-separator.json
                       pop: true
         - match: '[^\s\}]'

--- a/JavaScript/tests/syntax_test_json.json
+++ b/JavaScript/tests/syntax_test_json.json
@@ -30,6 +30,34 @@
 //           ^^^^ comment.block.json
 //                ^ punctuation.section.sequence.end.json
 
+  "dict": {"foo": },
+//               ^ invalid.illegal.expected-mapping-value.json
+//                ^ punctuation.section.mapping.end.json
+  "dict": {"foo":
+   },
+//^ invalid.illegal.expected-mapping-value.json
+// ^ punctuation.section.mapping.end.json
+
+  "dict": {"foo"/*comment*/:/*comment*/"bar"/*comment*/},
+//              ^^^^^^^^^^^ comment.block.json
+//                          ^^^^^^^^^^^ comment.block.json
+//                                          ^^^^^^^^^^^ comment.block.json
+
+  "dict": {
+    "foo": "bar"
+    // comment
+// ^ - invalid
+//  ^^^^^^^^^^ comment.line.double-slash.js
+    ,
+//  ^ punctuation.separator.mapping.pair.json
+    "foo": "bar"
+    /* comment */
+// ^ - invalid
+//  ^^^^^^^^^^^^^ comment.block.json
+  },
+//^ punctuation.section.mapping.end.json
+// ^ punctuation.separator.mapping.pair.json
+
   "string": "string",
 //          ^        punctuation.definition.string.begin.json
 //          ^^^^^^^^ meta.mapping.value.json string.quoted.double.json


### PR DESCRIPTION
Fixes #2193

This commit fixes some issues with invalid highlighting.

1. Don't highlight spaces in front of comments which are located between a value and the `,` as invalid (#2193)
2. Don't highlight a `,` after a comment (1.) as invalid.
3. Scope the last space between a colon and a closing brace as illegal as we expect a value there.