### PR TITLE
[Bash] Use LF as the default line ending

### DIFF
--- a/ShellScript/Bash.sublime-settings
+++ b/ShellScript/Bash.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"default_line_ending": "unix",
+}


### PR DESCRIPTION
I guess it's reasonable to use `\n` as the default line ending for the `Bash` syntax because

- `.sh` files are mostly run/written under/for Unix env 
- Unix bash will emit `: No such file or directory` or `'\r': command not found` if using `\r\n` as the line ending

  - My Windows git-bash won't emit error with either line ending. But I personally prefer using `\n` for everything unless it must be `\r\n` (such as `Batch`).

## hello.sh
```bash
#!/usr/bin/env bash

# save this file as `\r\n` line ending to test under Unix env

echo hello
```

## Execution Results Under Unix Env

It looks like the shebang executable is recognized as `bash\r` or `\r`.
```text
[root ~]$ ./hello.sh 
: No such file or directory
```

```text
[root ~]$ bash hello.sh 
hello.sh: line 2: $'\r': command not found
hello.sh: line 4: $'\r': command not found
hello
```


## Related

- https://forum.sublimetext.com/t/unix-line-endings-for-sh-files/47653
