### PR TITLE
[PHP] Fix "fn" function call

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -635,7 +635,18 @@ contexts:
 
   # https://wiki.php.net/rfc/arrow_functions_v2
   arrow-function:
-    - match: '(?i)\b(fn)\b\s*(&)?\s*(?=\()'
+    # "fn" can be a function name before PHP 7.4
+    # Since PHP 7.4, "fn" is a reserved word
+    - match: (?i)(?=\bfn\b\s*&?\s*\()
+      branch_point: arrow-function-branch
+      branch:
+        # Anonymous function definition: fn($a) => $a * 2;
+        - is-arrow-function
+        # Function call, where "fn" is the function name: fn($a);
+        - fn-function-call
+
+  is-arrow-function:
+    - match: (?i)\b(fn)\b\s*(&)?\s*(?=\()
       scope: meta.function.arrow-function.php
       captures:
         1: storage.type.function.php
@@ -643,19 +654,21 @@ contexts:
       push:
         - match: \(
           scope: meta.function.parameters.php meta.group.php punctuation.section.group.begin.php
-          push:
-            - include: function-parameters
-            - match: (?==>)
-              pop: true
-        - match: "=>"
+          push: function-parameters
+        - match: '=>'
           scope: punctuation.definition.arrow-function.php
-          push:
+          set:
             - match: '(?=;|,|\)|\s*\?>)'
-              pop: true
+              pop: 2
             - include: expressions
-        # Exit on unexpected content
+        - include: comments
         - match: (?=\S)
-          pop: true
+          fail: arrow-function-branch
+
+  fn-function-call:
+    - include: function-call
+    - match: ''
+      pop: true
 
   closure:
     - match: (?i)\b(function)\s*(&)?\s*(?=\()

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -202,6 +202,15 @@ $fn = fn($x) => fn($y) => $x * $y + $z;
 //                   ^ punctuation.section.group.end
 //                     ^^ punctuation.definition.arrow-function.php
 
+$var = fn($x)
+//     ^^ meta.function.arrow-function.php - meta.function-call
+   => $x * 2;
+// ^^ punctuation.definition.arrow-function
+
+$var = fn($x)
+//     ^^ meta.function-call - meta.function.arrow-function.php
+;
+
 $var = function(array $ar=array(), ClassName $cls) use ($var1, $var2) {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //     ^^^^^^^^ meta.function.closure


### PR DESCRIPTION
Congrats for ST 4 :beer: 

```php
$var = fn($x)
//     ^^ meta.function.arrow-function.php - meta.function-call
   => $x * 2;
// ^^ punctuation.definition.arrow-function

$var = fn($x)
//     ^^ meta.function-call - meta.function.arrow-function.php
;
```

- Before PHP 7.4, `fn` can be used as a function name.
- Since PHP 7.4, `fn` is a reserved word for arrow function.

[Previously](https://github.com/sublimehq/Packages/pull/1961/commits/c6210f7a1cfa62376f0aa9aed499e983b337e430), I assumed that `fn` is always a reserved word because of ST's parsing engine's limitation.

---

PHP 7.4.0 will just be released by the end of this month.