### PR TITLE
[TCL] Support regex not in curly braces

### DIFF
--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -173,6 +173,9 @@ contexts:
         # The next non-space element will be a regex string
         - match: '(?=\{|\s+--\s+)'
           set:
+            - match: \s+(--)\s+
+              captures:
+                1: punctuation.separator.tcl
             - match: \{
               set:
                 - meta_content_scope: string.regexp.tcl
@@ -182,6 +185,12 @@ contexts:
             - match: '(?=")'
               set:
                 - include: strings
+                # One of these characters indicates the string is complete
+                - match: '(?={{inline_end_chars}})'
+                  pop: true
+            - match: '(?=\S)'
+              set:
+                - meta_content_scope: string.regexp.tcl
                 # One of these characters indicates the string is complete
                 - match: '(?={{inline_end_chars}})'
                   pop: true

--- a/TCL/syntax_test_tcl.tcl
+++ b/TCL/syntax_test_tcl.tcl
@@ -85,6 +85,11 @@ set res "[join [lrange [split $res ","] 0 end-1] ","] ..."
 regexp {instance="?([^" \t]+)"?} $counter matchedstring instance; # comment
 #       ^^^^^^^^^^^^^^^^^^^^^^^ string.regexp
 
+regexp -- tralla(lla) $text allMatched var1
+#      ^^ punctuation.separator
+#         ^^^^^^^^^^^ string.regexp
+#                     ^ variable.other punctuation.definition.variable
+
 set check1 [regexp {^'(.){0,32}'$} $param]
 #                   ^^^^^^^^^^^^^ string.regexp
 
@@ -275,8 +280,8 @@ proc test {} {
             set ifoid $paroid
             set eaoid [elm_oid_by_iface $ifoid]
             set earole [objectGetField -oid $eaoid -fieldname role]
-		}
-	}
+        }
+    }
 }
 
 # https://github.com/sublimehq/Packages/issues/1145


### PR DESCRIPTION
Fixes issue #2201 :
 - Add scope to the regexp flag separator
 - Allow regexp not in curly brace following the separator
 - Add relevant test
 - Remove tab indentation from the test (warning message from ST)