### PR TITLE
[Rails] Remove Rails snippets for YAML

### DIFF
--- a/Rails/Snippets/$LABEL.sublime-snippet
+++ b/Rails/Snippets/$LABEL.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[\$LABEL]]></content>
-	<tabTrigger>$L</tabTrigger>
-	<scope>source.yaml</scope>
-	<description>$LABEL</description>
-</snippet>

--- a/Rails/Snippets/%3C%=-Fixtures_identify(%3Asymbol)-%%3E.sublime-snippet
+++ b/Rails/Snippets/%3C%=-Fixtures_identify(%3Asymbol)-%%3E.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<content><![CDATA[${TM_RAILS_TEMPLATE_START_RUBY_EXPR}Fixtures.identify(:${1:name})${TM_RAILS_TEMPLATE_END_RUBY_EXPR}$0]]></content>
-	<tabTrigger>fi</tabTrigger>
-	<scope>source.yaml</scope>
-	<description>&lt;%= Fixtures.identify(:symbol) %&gt;</description>
-</snippet>


### PR DESCRIPTION
Rails shouldn't pollute all YAML files with these snippets.