### PR TITLE
[Rust] Fix scope for assignment operator

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -247,9 +247,11 @@ contexts:
   operators:
     - match: \.{2,3}
       scope: keyword.operator.range.rust
+    - match: '(?:[-+%/*^&|]|<<|>>)='
+      scope: keyword.operator.assignment.rust
     - match: '[!<>=]=|[<>]'
       scope: keyword.operator.comparison.rust
-    - match: '(?:[-+%/*^&|]|<<|>>)?='
+    - match: '='
       scope: keyword.operator.assignment.rust
       push: after-operator
     - match: '&&|\|\||!'

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -624,7 +624,8 @@ impl Point
     //  ^^^^ variable.language
     //      ^ punctuation.accessor.dot
     //         ^^ keyword.operator.assignment
-        self.y *= 2;
+        self.y >>= 2;
+    //         ^^^ keyword.operator.assignment.rust
     }
 
     fn sum((x, y): (i32, i32)) -> i32 {


### PR DESCRIPTION
Simply swap comparison and assignement operator to be sure assignment get tested first.
Add relevant test.

Fixes issue #2147