### PR TITLE
[CSS] Number fixes revolving exponents

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -18,8 +18,14 @@ variables:
 
   # Types
   # https://www.w3.org/TR/css3-values/#numeric-types
+  # https://www.w3.org/TR/css-syntax-3/#number-token-diagram
   integer: '(?:[-+]?\d+)'
-  float:  '(?:[-+]?\d*(\.)\d+(?:[eE]{{integer}})*)'
+  exponent: '(?:[eE]{{integer}})'
+  float: |-
+    (?x:
+      [-+]? \d* (\.) \d+ {{exponent}}?
+    | [-+]? \d+          {{exponent}}
+    )
 
   # Units
   # https://www.w3.org/TR/css3-values/#lengths

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -340,6 +340,11 @@
     top: +.95e-20;
 /*       ^^^^^^^^ constant.numeric.float.decimal.css */
 /*        ^ punctuation.separator.decimal.css */
+    top: +1e1e1 .1e1e1;
+/*       ^^^^ constant.numeric.float.decimal.css */
+/*           ^ - constant.numeric */
+/*              ^^^^ constant.numeric.float.decimal.css */
+/*                  ^ - constant.numeric */
     top: -1.5e+93%;
 /*       ^^^^^^^^^ constant.numeric.float.decimal.css */
 /*         ^ punctuation.separator.decimal.css */


### PR DESCRIPTION
`1e1` wasn't recognized and the exponent pattern was repeated, allowing
`.1e1e1`.