### PR TITLE
[Java] Unicode and octal escapes in strings

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -1128,8 +1128,19 @@ contexts:
     - match: \n
       scope: invalid.illegal.newline.java
       pop: true
-    - match: \\.
+    - include: strings-escape
+
+  strings-escape:
+    - match: \\u+\h{4}
+      scope: constant.character.escape.unicode.java
+    - match: \\[0-3][0-7]{2}
+      scope: constant.character.escape.octal.java
+    - match: \\[0-7]{1,2}
+      scope: constant.character.escape.octal.java
+    - match: \\[btnfr"'\\]
       scope: constant.character.escape.java
+    - match: \\.
+      scope: invalid.illegal.escape.java
 
   module:
     - match: (?=\b(?:open\s+)?module\b)

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -1133,9 +1133,7 @@ contexts:
   strings-escape:
     - match: \\u+\h{4}
       scope: constant.character.escape.unicode.java
-    - match: \\[0-3][0-7]{2}
-      scope: constant.character.escape.octal.java
-    - match: \\[0-7]{1,2}
+    - match: \\[0-3]?[0-7]{1,2}
       scope: constant.character.escape.octal.java
     - match: \\[btnfr"'\\]
       scope: constant.character.escape.java

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -1128,9 +1128,9 @@ contexts:
     - match: \n
       scope: invalid.illegal.newline.java
       pop: true
-    - include: strings-escape
+    - include: string-escapes
 
-  strings-escape:
+  string-escapes:
     - match: \\u+\h{4}
       scope: constant.character.escape.unicode.java
     - match: \\[0-3]?[0-7]{1,2}

--- a/Java/syntax_test_java.java
+++ b/Java/syntax_test_java.java
@@ -1801,14 +1801,23 @@ public class Foo {
 //                      ^ punctuation.definition.string.begin
 //                        ^ punctuation.definition.string.end
 
-    String escapes = "Here \2 are \n some \t escaped \'\\' characters \"";
-//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
-//                         ^^ constant.character.escape
+    String escapes = "\b \t \n \f \r \" \' \\ \0 \12 \123 \u00e4 \uu00E4";
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+//                    ^^ constant.character.escape
+//                       ^^ constant.character.escape
+//                          ^^ constant.character.escape
+//                             ^^ constant.character.escape
 //                                ^^ constant.character.escape
-//                                                   ^^^^ constant.character.escape
-//                                                                    ^^ constant.character.escape
+//                                   ^^ constant.character.escape
+//                                      ^^ constant.character.escape
+//                                         ^^ constant.character.escape
+//                                            ^^ constant.character.escape.octal
+//                                               ^^^ constant.character.escape.octal
+//                                                   ^^^^ constant.character.escape.octal
+//                                                        ^^^^^^ constant.character.escape.unicode
+//                                                               ^^^^^^^ constant.character.escape.unicode
 
-    char escape = '\t' + '\1' + '\'' + '\\';
+    char escape = '\b' + '\t' + '\n' + '\f' + '\r' + '\"' + '\'' + '\\' + '\0' + '\12' + '\123' + '\u00e4' + '\uu00E4';
 //                ^^^^ string.quoted.single
 //                 ^^ constant.character.escape
 //                       ^^^^ string.quoted.single
@@ -1817,6 +1826,45 @@ public class Foo {
 //                               ^^ constant.character.escape
 //                                     ^^^^ string.quoted.single
 //                                      ^^ constant.character.escape
+//                                            ^^^^ string.quoted.single
+//                                             ^^ constant.character.escape
+//                                                   ^^^^ string.quoted.single
+//                                                    ^^ constant.character.escape
+//                                                          ^^^^ string.quoted.single
+//                                                           ^^ constant.character.escape
+//                                                                 ^^^^ string.quoted.single
+//                                                                  ^^ constant.character.escape
+//                                                                        ^^^^ string.quoted.single
+//                                                                         ^^ constant.character.escape.octal
+//                                                                               ^^^^^ string.quoted.single
+//                                                                                ^^^ constant.character.escape.octal
+//                                                                                       ^^^^^^ string.quoted.single
+//                                                                                        ^^^^ constant.character.escape.octal
+//                                                                                                ^^^^^^^^ string.quoted.single
+//                                                                                                 ^^^^^^ constant.character.escape.unicode
+//                                                                                                           ^^^^^^^^^ string.quoted.single
+//                                                                                                            ^^^^^^^ constant.character.escape.unicode
+
+    String octalEscapesLimits = "\078 \456"
+//                               ^^^ constant.character.escape.octal
+//                                  ^ -constant.character.escape.octal
+//                                    ^^^ constant.character.escape.octal
+//                                       ^ -constant.character.escape.octal
+
+    String illegalEscapes = "\x \+ \8 \9" + '\x' + '\+' + '\8' + '\9'
+//                          ^^^^^^^^^^^^^ string.quoted.double
+//                           ^^ invalid.illegal.escape
+//                              ^^ invalid.illegal.escape
+//                                 ^^ invalid.illegal.escape
+//                                    ^^ invalid.illegal.escape
+//                                          ^^^^ string.quoted.single
+//                                           ^^ invalid.illegal.escape
+//                                                 ^^^^ string.quoted.single
+//                                                  ^^ invalid.illegal.escape
+//                                                        ^^^^ string.quoted.single
+//                                                         ^^ invalid.illegal.escape
+//                                                               ^^^^ string.quoted.single
+//                                                                ^^ invalid.illegal.escape
 
     String text = "String without closing quote
 //                                             ^ invalid.illegal.newline


### PR DESCRIPTION
Extended rules for escapes to handle all types present in Java:

1. Unicode escape:
```
System.out.println("\u0078 \u0079 \u007A");
```

2. Octal escapes:
```
System.out.println("\170 \171 \172");
```

3. Simple escapes now limited to a set of allowed ones instead of matching `\\.`