### PR TITLE
[Go] Remove unused variables

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -100,23 +100,6 @@ variables:
   # Binary counterpart to dec_digits.
   bin_digits: (?:_?[01]+(?:_[01]+)*)
 
-  # Matches a digit with any number of numeric separators, while
-  # not allowing a numeric separator as the last or first character.
-  ddigits: (?:\d+(?:_\d+)*)
-
-  # Hexadecimal counterpart to ddigits.
-  hdigits: _?(?:\h+(?:_\h+)*)
-
-  # Same as hdigits, except the leading hex character
-  # coefficient is optional in this case.
-  ohdigits: _?(?:\h*(?:_\h+)*)
-
-  # Octal counterpart to ddigits.
-  odigits: _?(?:[0-7]+(?:_[0-7]+)*)
-
-  # Binary counterpart to ddigits.
-  bdigits: _?(?:[01]+(?:_[01]+)*)
-
 contexts:
   main:
     - include: match-any


### PR DESCRIPTION
This commit removes some variables which were replaced by
10c4b5c6051091132083f69518f273acb510835c and therefore are no longer used.