### PR TITLE
[Go] Identify entity.name.namespace.go

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -727,6 +727,14 @@ contexts:
   match-keyword-package:
     - match: \bpackage\b
       scope: keyword.other.package.go
+      push:
+        - match: \b_\b
+          scope: variable.language.blank.go
+
+        - match: '{{ident}}'
+          scope: entity.name.package.go
+
+        - include: pop-before-nonblank
 
   match-keyword-range:
     - match: \brange\b

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -733,6 +733,7 @@ contexts:
 
         - match: '{{ident}}'
           scope: entity.name.namespace.go
+          pop: true
 
         - include: pop-before-nonblank
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -732,7 +732,7 @@ contexts:
           scope: variable.language.blank.go
 
         - match: '{{ident}}'
-          scope: entity.name.package.go
+          scope: entity.name.namespace.go
 
         - include: pop-before-nonblank
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -75,7 +75,7 @@ You may have to disable Go-specific linters when working on this file.
 
     package main
 //  ^^^^^^^ keyword.other.package.go
-//          ^^^^ entity.name.package.go
+//          ^^^^ entity.name.namespace.go
 
     import "module"
 //  ^^^^^^ keyword.other.import.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -75,7 +75,7 @@ You may have to disable Go-specific linters when working on this file.
 
     package main
 //  ^^^^^^^ keyword.other.package.go
-//         ^^^^^ -keyword
+//          ^^^^ entity.name.package.go
 
     import "module"
 //  ^^^^^^ keyword.other.import.go


### PR DESCRIPTION
Add rule to interpret the `package {{ident}}` as a `entity.name.namespace.go`. Squash-able.
