### PR TITLE
[Go] add scope for package name

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -726,7 +726,13 @@ contexts:
 
   match-keyword-package:
     - match: \bpackage\b
-      scope: keyword.other.package.go
+      scope: storage.type.namespace.go keyword.declaration.namespace.go
+      push:
+        - meta_scope: meta.namespace.go
+        - match: '{{ident}}'
+          scope: entity.name.namespace.go
+          pop: true
+        - include: pop-before-nonblank
 
   match-keyword-range:
     - match: \brange\b

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -74,8 +74,9 @@ You may have to disable Go-specific linters when working on this file.
 // # Imports
 
     package main
-//  ^^^^^^^ keyword.other.package.go
-//         ^^^^^ -keyword
+//  ^^^^^^^ storage.type.namespace.go keyword.declaration.namespace.go
+//         ^ - keyword - storage
+//          ^^^^ entity.name.namespace.go
 
     import "module"
 //  ^^^^^^ keyword.other.import.go


### PR DESCRIPTION
This commit scopes the `name` in `package name` statements as entity the same way as Perl.