### PR TITLE
[Matlab] Improve numbers

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -434,9 +434,25 @@ contexts:
       comment: Not equal is written ~= not !=.
       scope: invalid.illegal.invalid-inequality.matlab
   number:
-    - match: '\d*\.?\d+([eE][+-]?\d)?([0-9&&[^\.]])*(i|j)?\b'
-      comment: "Valid numbers: 1, .1, 1.1, .1e1, 1.1e1, 1e1, 1i, 1j, 1e2j"
-      scope: constant.numeric.matlab
+    - match: '\b(0[xX])\h+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
+      scope: constant.numeric.integer.hexadecimal.matlab
+      captures:
+        1: punctuation.definition.numeric.base.matlab
+        2: storage.type.numeric.matlab
+    - match: '\b(0[bB])[01]+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
+      scope: constant.numeric.integer.binary.matlab
+      captures:
+        1: punctuation.definition.numeric.base.matlab
+        2: storage.type.numeric.matlab
+    - match: '(?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?(i|j)\b'
+      scope: constant.numeric.imaginary.decimal.matlab
+      captures:
+        1: punctuation.separator.decimal.matlab
+        2: storage.type.numeric.matlab
+    - match: '(?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?\b'
+      scope: constant.numeric.float.decimal.matlab
+      captures:
+        1: punctuation.separator.decimal.matlab
   operators:
     - match: \s*(==|~=|~|>|>=|<|<=|=|&|&&|:|\||\|\||\+|-|\*|\.\*|/|\./|\\|\.\\|\^|\.\^)\s*
       comment: Operator symbols

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -41,7 +41,7 @@ x = [ 1.76 ]
 % <- source.matlab meta.variable.other.valid.matlab
 % ^ source.matlab keyword.operator.symbols.matlab
 %   ^ source.matlab punctuation.section.brackets.begin.matlab
-%     ^^^^ source.matlab meta.brackets.matlab constant.numeric.matlab
+%     ^^^^ source.matlab meta.brackets.matlab constant.numeric.float.decimal.matlab
 %          ^ source.matlab punctuation.section.brackets.end.matlab
 
 
@@ -79,7 +79,7 @@ x = 5
 x = 5 %{ not block comment
 % ^ keyword.operator.symbols.matlab
 x = 5
-%   ^ constant.numeric.matlab
+%   ^ constant.numeric.float.decimal.matlab
 
 
 %---------------------------------------------
@@ -145,25 +145,53 @@ end
 %---------------------------------------------
 % Numbers
 
-1
-% <- constant.numeric.matlab
-.1
-% <- constant.numeric.matlab
-1.1
-% <- constant.numeric.matlab
-.1e1
-% <- constant.numeric.matlab
-1.1e1
-% <- constant.numeric.matlab
-1e1
-% <- constant.numeric.matlab
-1i - (4i)
-% <- constant.numeric.matlab
-%     ^^ constant.numeric.matlab
-1j
-% <- constant.numeric.matlab
-1e2j
-% <- constant.numeric.matlab
+ 1
+%^ constant.numeric.float.decimal.matlab
+ .1
+%^^ constant.numeric.float.decimal.matlab
+%^ punctuation.separator.decimal.matlab
+ 1.1
+%^^^ constant.numeric.float.decimal.matlab
+% ^ punctuation.separator.decimal.matlab
+ .1e1
+%^^^^ constant.numeric.float.decimal.matlab
+%^ punctuation.separator.decimal.matlab
+ 1.1e1
+%^^^^^ constant.numeric.float.decimal.matlab
+% ^ punctuation.separator.decimal.matlab
+ 1e1
+%^^^ constant.numeric.float.decimal.matlab
+ 1i - (4i)
+%^^ constant.numeric.imaginary.decimal.matlab
+% ^ storage.type.numeric.matlab
+%      ^^ constant.numeric.imaginary.decimal.matlab
+%       ^ storage.type.numeric.matlab
+ 1j
+%^^ constant.numeric.imaginary.decimal.matlab
+% ^ storage.type.numeric.matlab
+ 1e2j
+%^^^^ constant.numeric.imaginary.decimal.matlab
+%   ^ storage.type.numeric.matlab
+ 0x2A
+%^^^^ constant.numeric.integer.hexadecimal.matlab
+%^^ punctuation.definition.numeric.base.matlab
+ 0X2A
+%^^^^ constant.numeric.integer.hexadecimal.matlab
+%^^ punctuation.definition.numeric.base.matlab
+ 0b101010
+%^^^^^^^^ constant.numeric.integer.binary.matlab
+%^^ punctuation.definition.numeric.base.matlab
+ 0B101010
+%^^^^^^^^ constant.numeric.integer.binary.matlab
+%^^ punctuation.definition.numeric.base.matlab
+ 0x2Au8
+%^^^^^^ constant.numeric.integer.hexadecimal.matlab
+%^^ punctuation.definition.numeric.base.matlab
+%    ^^ storage.type.numeric.matlab
+ 0x2As32
+%^^^^^^^ constant.numeric.integer.hexadecimal.matlab
+%^^ punctuation.definition.numeric.base.matlab
+%    ^^^ storage.type.numeric.matlab
 
 
 %---------------------------------------------


### PR DESCRIPTION
* Add scope for base prefixes for [hexadecimal and binary number literals](https://www.mathworks.com/help/matlab/matlab_prog/specify-hexadecimal-and-binary-numbers.html), wich were introduced in R2019b
* Add scope for type suffixes for hexadecimal and binary number literals
* Add scope for decimal separator in floating point numbers
* Notice: all numbers without base prefix are stored as floating point by default in Matlab