### PR TITLE
[Scala] Removed fake jump markers and corrected class entity scoping

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -338,7 +338,7 @@ contexts:
         1: storage.type.function.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
-    - match: '\b(case\s+)?(class|trait|object)(\s+({{id}}))'
+    - match: '\b(case\s+)?(class|trait|object)\s+({{id}})'
       scope: meta.class.identifier.scala
       captures:
         1: storage.type.class.scala

--- a/Scala/Symbols-class.tmPreferences
+++ b/Scala/Symbols-class.tmPreferences
@@ -4,7 +4,7 @@
   <key>name</key>
   <string>Symbols (class)</string>
   <key>scope</key>
-  <string>source.scala meta.class.identifier</string>
+  <string>source.scala entity.name.class</string>
   <key>settings</key>
   <dict>
     <key>showInSymbolList</key>

--- a/Scala/Symbols-def.tmPreferences
+++ b/Scala/Symbols-def.tmPreferences
@@ -9,10 +9,6 @@
   <dict>
     <key>showInSymbolList</key>
     <integer>1</integer>
-    <key>symbolTransformation</key>
-    <string>
-      s/(.+)/  def $1\(...\)/
-    </string>
   </dict>
 </dict>
 </plist>

--- a/Scala/Symbols-namespace.tmPreferences
+++ b/Scala/Symbols-namespace.tmPreferences
@@ -9,10 +9,6 @@
   <dict>
     <key>showInSymbolList</key>
     <integer>1</integer>
-    <key>symbolTransformation</key>
-    <string>
-      s/(.+)/package $1 { ... }/
-    </string>
   </dict>
 </dict>
 </plist>

--- a/Scala/Symbols-type.tmPreferences
+++ b/Scala/Symbols-type.tmPreferences
@@ -9,10 +9,6 @@
   <dict>
     <key>showInSymbolList</key>
     <integer>1</integer>
-    <key>symbolTransformation</key>
-    <string>
-      s/(.+)/  type $1/
-    </string>
   </dict>
 </dict>
 </plist>

--- a/Scala/Symbols-val.tmPreferences
+++ b/Scala/Symbols-val.tmPreferences
@@ -9,10 +9,6 @@
   <dict>
     <key>showInSymbolList</key>
     <integer>1</integer>
-    <key>symbolTransformation</key>
-    <string>
-      s/(.+)/  val $1/
-    </string>
   </dict>
 </dict>
 </plist>

--- a/Scala/Symbols-var.tmPreferences
+++ b/Scala/Symbols-var.tmPreferences
@@ -9,10 +9,6 @@
   <dict>
     <key>showInSymbolList</key>
     <integer>1</integer>
-    <key>symbolTransformation</key>
-    <string>
-      s/(.+)/  var $1/
-    </string>
   </dict>
 </dict>
 </plist>

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -103,6 +103,7 @@ def foo(a: Int, b: Bar): Baz = 42
    class Foo[A](a: Bar) extends Baz with Bin
 // ^^^^^^^^^ meta.class.identifier.scala
 //    ^^ storage.type.class.scala
+//      ^ - entity
 //       ^^^ entity.name.class
 //           ^ support.class
 //              ^ variable.parameter


### PR DESCRIPTION
I couldn't think of a better name for these things. They're obsolete now, and removing them uncovered a bug (which I also fixed).