### PR TITLE
[PHP] Fix catch multiple exceptions in a single catch

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -135,24 +135,27 @@ contexts:
           for | foreach | if | return | switch | use | while
         )\b
       scope: keyword.control.php
-    - match: \b(catch)\b\s*\(\s*
+    - match: \b(catch)\b\s*(\()
       captures:
         1: keyword.control.exception.catch.php
+        2: punctuation.section.group.begin.php
       push:
         - meta_scope: meta.catch.php
         - include: comments
         - include: identifier-parts-as-path
-        - match: '(\\)'
+        - match: \)
+          scope: punctuation.section.group.end.php
+          pop: true
+        - match: \|
+          scope: punctuation.separator.catch.php
+        - match: \\
           scope: meta.path.php punctuation.separator.namespace.php
-        - match: '({{identifier}})\s*(\|)?'
-          captures:
-            1: meta.path.php support.class.exception.php
-            2: punctuation.separator.catch.php
-        - match: '((\$+){{identifier}})\s*\)'
+        - match: '{{identifier}}'
+          scope: meta.path.php support.class.exception.php
+        - match: '((\$){{identifier}})'
           captures:
             1: variable.other.php
             2: punctuation.definition.variable.php
-          pop: true
     - match: \b(catch|try|throw|finally)\b
       scope: keyword.control.exception.php
     - include: arrow-function

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1009,6 +1009,10 @@ try {
 } catch (/* comment */ ExceptionExample $e) {
 //       ^^^^^^^^^^^^^ comment.block
     echo 'Caught exception: ', $e->getMessage(), "\n";
+} catch (Exception) {
+//^ keyword.control.exception
+//       ^^^^^^^^^ meta.path.php
+//       ^^^^^^^^^ support.class.exception.php
 } catch (Exception $e) {
 //^ keyword.control.exception
 //       ^^^^^^^^^ meta.path.php

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1046,6 +1046,23 @@ try {
 //                                    ^^^^^^^^^^ support.class.exception.php
 //                                               ^^ variable.other.php
     echo 'Caught exception: ', $e->getMessage(), "\n";
+} catch (
+//^ keyword.control.exception
+    \Custom\Exception1 |
+//  ^^^^^^^^^^^^^^^^^ meta.path.php
+//  ^ punctuation.separator.namespace.php
+//   ^^^^^^ support.other.namespace.php
+//         ^ punctuation.separator.namespace.php
+//          ^^^^^^^^^^ support.class.exception.php
+//                     ^ punctuation.separator.catch.php
+    \Custom\Exception2 $e
+//  ^ punctuation.separator.namespace.php
+//   ^^^^^^ support.other.namespace.php
+//         ^ punctuation.separator.namespace.php
+//          ^^^^^^^^^^ support.class.exception.php
+//                     ^^ variable.other.php
+) {
+    echo 'Caught exception: ', $e->getMessage(), "\n";
 } finally {
 //^ keyword.control.exception
     echo "First finally.\n";


### PR DESCRIPTION
The previous implementation is too strict so that it fails parsing exceptions scattered in multiple lines.

```php
try {
    // ...
} catch (
    // vvv failed
    \Custom\Exceptoin1 |
    \Custom\Exceptoin2 $e
    // ^^^ failed
) {
    // ...
}
```

If the `st3` branch is still maintained, I can make a PR to it.

---

Fixes https://github.com/sublimehq/Packages/issues/2358