### PR TITLE
[Java] Rewrite Java Server Page Syntax

### DIFF
--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -43,34 +43,34 @@ contexts:
         - match: <%!
           scope: punctuation.section.embedded.begin.jsp
           push:
+            # NOTE: we push into the context to work around core issue #3002
             - meta_scope: meta.embedded.declaration.jsp
-            - meta_content_scope: source.java.embedded.html
             - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: (?=\S)
+            - match: ''
               embed: java
               escape: (?=%>)
         - match: <%=
           scope: punctuation.section.embedded.begin.jsp
           push:
+            # NOTE: we push into the context to work around core issue #3002
             - meta_scope: meta.embedded.expression.jsp
-            - meta_content_scope: source.java.embedded.html
             - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: (?=\S)
+            - match: ''
               embed: java
               escape: (?=%>)
         - match: <%
           scope: punctuation.section.embedded.begin.jsp
           push:
+            # NOTE: we push into the context to work around core issue #3002
             - meta_scope: meta.embedded.scriptlet.jsp
-            - meta_content_scope: source.java.embedded.html
             - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: (?=\S)
+            - match: ''
               embed: java
               escape: (?=%>)
 

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -33,42 +33,42 @@ contexts:
               scope: punctuation.definition.comment.end.jsp
               pop: true
         - match: <%@
-          scope: punctuation.section.directive.begin.jsp
+          scope: punctuation.section.embedded.begin.jsp
           push:
-            - meta_scope: meta.directive.jsp
+            - meta_scope: meta.embedded.directive.jsp
             - match: '%>'
-              scope: punctuation.section.directive.end.jsp
+              scope: punctuation.section.embedded.end.jsp
               pop: true
             - include: jsp-directive
         - match: <%!
-          scope: punctuation.section.declaration.begin.jsp
+          scope: punctuation.section.embedded.begin.jsp
           push:
-            - meta_scope: meta.declaration.jsp
+            - meta_scope: meta.embedded.declaration.jsp
             - meta_content_scope: source.java.embedded.html
             - match: '%>'
-              scope: punctuation.section.declaration.end.jsp
+              scope: punctuation.section.embedded.end.jsp
               pop: true
             - match: ''
               embed: java
               escape: (?=%>)
         - match: <%=
-          scope: punctuation.section.expression.begin.jsp
+          scope: punctuation.section.embedded.begin.jsp
           push:
-            - meta_scope: meta.expression.jsp
+            - meta_scope: meta.embedded.expression.jsp
             - meta_content_scope: source.java.embedded.html
             - match: '%>'
-              scope: punctuation.section.expression.end.jsp
+              scope: punctuation.section.embedded.end.jsp
               pop: true
             - match: ''
               embed: java
               escape: (?=%>)
         - match: <%
-          scope: punctuation.section.scriptlet.begin.jsp
+          scope: punctuation.section.embedded.begin.jsp
           push:
-            - meta_scope: meta.scriptlet.jsp
+            - meta_scope: meta.embedded.scriptlet.jsp
             - meta_content_scope: source.java.embedded.html
             - match: '%>'
-              scope: punctuation.section.scriptlet.end.jsp
+              scope: punctuation.section.embedded.end.jsp
               pop: true
             - match: ''
               embed: java

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -29,14 +29,14 @@ contexts:
           scope: punctuation.definition.comment.begin.jsp
           push:
             - meta_scope: comment.block.jsp
-            - match: '--%>'
+            - match: --%>
               scope: punctuation.definition.comment.end.jsp
               pop: true
         - match: <%@
           scope: punctuation.section.embedded.begin.jsp
           push:
             - meta_scope: meta.embedded.directive.jsp
-            - match: '%>'
+            - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
             - include: jsp-directive
@@ -45,10 +45,10 @@ contexts:
           push:
             - meta_scope: meta.embedded.declaration.jsp
             - meta_content_scope: source.java.embedded.html
-            - match: '%>'
+            - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: ''
+            - match: (?=\S)
               embed: java
               escape: (?=%>)
         - match: <%=
@@ -56,10 +56,10 @@ contexts:
           push:
             - meta_scope: meta.embedded.expression.jsp
             - meta_content_scope: source.java.embedded.html
-            - match: '%>'
+            - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: ''
+            - match: (?=\S)
               embed: java
               escape: (?=%>)
         - match: <%
@@ -67,10 +67,10 @@ contexts:
           push:
             - meta_scope: meta.embedded.scriptlet.jsp
             - meta_content_scope: source.java.embedded.html
-            - match: '%>'
+            - match: \%>
               scope: punctuation.section.embedded.end.jsp
               pop: true
-            - match: ''
+            - match: (?=\S)
               embed: java
               escape: (?=%>)
 
@@ -273,7 +273,7 @@ contexts:
 
   tag-jsp-text-attributes:
     - meta_scope: meta.tag.jsp.text.begin.html
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set: tag-jsp-text-body
     - include: tag-end-self-closing
@@ -308,7 +308,7 @@ contexts:
     - include: scope:text.html.basic#tag-end-self-closing
 
   tag-end-set-java:
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set: java
 

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -20,8 +20,7 @@ contexts:
     - include: tag-jsp-text
     - include: tag-jsp-other
     - match: (?=\S)
-      push:
-        - include: scope:text.html.basic
+      push: scope:text.html.basic
       with_prototype:
         - match: (?=</?(?i:jsp):)
           pop: true

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -112,28 +112,26 @@ contexts:
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push: [tag-jsp-declaration-body, tag-jsp-declaration-attributes]
-
-  tag-jsp-declaration-attributes:
-    - meta_scope: meta.tag.jsp.declaration.begin.html
-    - include: tag-end
-    - include: tag-attributes
-
-  tag-jsp-declaration-body:
+      embed: tag-jsp-declaration-attributes
+      escape: (?=(?i)</jsp:declaration{{break_char}})
     - match: (?i)(</)(jsp)(:)(declaration){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      set:
-        - meta_scope: meta.tag.jsp.declaration.end.html
-        - include: tag-end
-        - include: illegal-attributes
-    - match: ''
-      embed: java
-      embed_scope: source.java.embedded.html
-      escape: (?=(?i)</jsp:declaration{{break_char}})
+      push: tag-jsp-declaration-end
+
+  tag-jsp-declaration-attributes:
+    - meta_scope: meta.tag.jsp.declaration.begin.html
+    - include: tag-end-set-java
+    - include: tag-end-self-closing
+    - include: tag-attributes
+
+  tag-jsp-declaration-end:
+    - meta_scope: meta.tag.jsp.declaration.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ DIRECTIVE ]###############################################################
 
@@ -146,10 +144,26 @@ contexts:
         4: entity.name.tag.localname.html
         5: punctuation.accessor.dot.jsp
         6: keyword.control.directive.jsp
-      push:
-        - meta_scope: meta.tag.jsp.directive.html
-        - include: tag-end-self-closing
-        - include: tag-attributes
+      push: tag-jsp-directive-attributes
+    - match: (?i)(</)(jsp)(:)(directive){{break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+        5: punctuation.accessor.dot.jsp
+        6: keyword.control.directive.jsp
+      push: tag-jsp-directive-end
+
+  tag-jsp-directive-attributes:
+    - meta_scope: meta.tag.jsp.directive.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-jsp-directive-end:
+    - meta_scope: meta.tag.jsp.directive.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ EXPRESSION ]#############################################################
 
@@ -160,28 +174,26 @@ contexts:
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push: [tag-jsp-expression-body, tag-jsp-expression-attributes]
-
-  tag-jsp-expression-attributes:
-    - meta_scope: meta.tag.jsp.expression.begin.html
-    - include: tag-end
-    - include: tag-attributes
-
-  tag-jsp-expression-body:
+      embed: tag-jsp-expression-attributes
+      escape: (?=(?i)</jsp:expression{{break_char}})
     - match: (?i)(</)(jsp)(:)(expression){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      set:
-        - meta_scope: meta.tag.jsp.expression.end.html
-        - include: tag-end
-        - include: illegal-attributes
-    - match: ''
-      embed: java
-      embed_scope: source.java.embedded.html
-      escape: (?=(?i)</jsp:expression{{break_char}})
+      push: tag-jsp-expression-end
+
+  tag-jsp-expression-attributes:
+    - meta_scope: meta.tag.jsp.expression.begin.html
+    - include: tag-end-set-java
+    - include: tag-end-self-closing
+    - include: tag-attributes
+
+  tag-jsp-expression-end:
+    - meta_scope: meta.tag.jsp.expression.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ OTHER ]##################################################################
 
@@ -192,20 +204,24 @@ contexts:
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push:
-        - meta_scope: meta.tag.jsp.other.begin.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
+      push: tag-jsp-other-attributes
     - match: (?i)(</)(jsp)(:)([^{{break_char}}]+)
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push:
-        - meta_scope: meta.tag.jsp.other.end.html
-        - include: tag-end
-        - include: illegal-attributes
+      push: tag-jsp-other-end
+
+  tag-jsp-other-attributes:
+    - meta_scope: meta.tag.jsp.other.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-jsp-other-end:
+    - meta_scope: meta.tag.jsp.other.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ SCRIPTLETS ]#############################################################
 
@@ -216,28 +232,26 @@ contexts:
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push: [tag-jsp-scriptlet-body, tag-jsp-scriptlet-attributes]
-
-  tag-jsp-scriptlet-attributes:
-    - meta_scope: meta.tag.jsp.scriptlet.begin.html
-    - include: tag-end
-    - include: tag-attributes
-
-  tag-jsp-scriptlet-body:
+      embed: tag-jsp-scriptlet-attributes
+      escape: (?=(?i)</jsp:scriptlet{{break_char}})
     - match: (?i)(</)(jsp)(:)(scriptlet){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      set:
-        - meta_scope: meta.tag.jsp.expression.end.html
-        - include: tag-end
-        - include: illegal-attributes
-    - match: ''
-      embed: java
-      embed_scope: source.java.embedded.html
-      escape: (?=(?i)</jsp:scriptlet{{break_char}})
+      push: tag-jsp-scriptlet-end
+
+  tag-jsp-scriptlet-attributes:
+    - meta_scope: meta.tag.jsp.scriptlet.begin.html
+    - include: tag-end-set-java
+    - include: tag-end-self-closing
+    - include: tag-attributes
+
+  tag-jsp-scriptlet-end:
+    - meta_scope: meta.tag.jsp.scriptlet.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ TEXT ]###################################################################
 
@@ -248,24 +262,32 @@ contexts:
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      push: [tag-jsp-text-body, tag-jsp-text-attributes]
-
-  tag-jsp-text-attributes:
-    - meta_scope: meta.tag.jsp.text.begin.html
-    - include: tag-end
-    - include: illegal-attributes
-
-  tag-jsp-text-body:
+      push: tag-jsp-text-attributes
     - match: (?i)(</)(jsp)(:)(text){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
         3: entity.name.tag.html punctuation.separator.namespace.html
         4: entity.name.tag.localname.html
-      set:
-        - meta_scope: meta.tag.jsp.text.end.html
-        - include: tag-end
-        - include: illegal-attributes
+      push: tag-jsp-text-end
+
+  tag-jsp-text-attributes:
+    - meta_scope: meta.tag.jsp.text.begin.html
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set: tag-jsp-text-body
+    - include: tag-end-self-closing
+    - include: illegal-attributes
+
+  tag-jsp-text-body:
+    - meta_content_scope: text.plain.jsp
+    - match: (?=(?i)</jsp:text{{break_char}})
+      pop: true
+
+  tag-jsp-text-end:
+    - meta_scope: meta.tag.jsp.text.end.html
+    - include: tag-end
+    - include: illegal-attributes
 
 ###[ PROTOTYPES ]#############################################################
 
@@ -285,7 +307,13 @@ contexts:
     - match: '[^{{break_char}}]+'
       scope: invalid.illegal.attributes-unexpected.html
 
+  tag-end-set-java:
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set: java
+
   java:
+    - meta_content_scope: source.java.embedded.html
     # Prevent stray brace detection since brace matching won't work with
     # %> pop pattern
     - match: \}

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -318,4 +318,5 @@ contexts:
     # %> pop pattern
     - match: \}
       scope: punctuation.section.block.end.java
+    - include: scope:source.java#prototype
     - include: scope:source.java

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -291,21 +291,21 @@ contexts:
 
 ###[ PROTOTYPES ]#############################################################
 
-  tag-end:
-    - include: scope:text.html.basic#tag-end
-
-  tag-end-self-closing:
-    - include: scope:text.html.basic#tag-end-self-closing
-
-  tag-end-maybe-self-closing:
-    - include: scope:text.html.basic#tag-end-maybe-self-closing
+  illegal-attributes:
+    - match: '[^{{break_char}}]+'
+      scope: invalid.illegal.attributes-unexpected.html
 
   tag-attributes:
     - include: scope:text.html.basic#tag-attributes
 
-  illegal-attributes:
-    - match: '[^{{break_char}}]+'
-      scope: invalid.illegal.attributes-unexpected.html
+  tag-end:
+    - include: scope:text.html.basic#tag-end
+
+  tag-end-maybe-self-closing:
+    - include: scope:text.html.basic#tag-end-maybe-self-closing
+
+  tag-end-self-closing:
+    - include: scope:text.html.basic#tag-end-self-closing
 
   tag-end-set-java:
     - match: '>'

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -223,7 +223,7 @@ contexts:
     - include: tag-end
     - include: illegal-attributes
 
-###[ SCRIPTLETS ]#############################################################
+###[ SCRIPTLET ]##############################################################
 
   tag-jsp-scriptlet:
     - match: (?i)(<)(jsp)(:)(scriptlet){{break}}

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -1,87 +1,293 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# https://www.oracle.com/technetwork/java/syntaxref12-149806.pdf
+# https://www.sublimetext.com/docs/3/syntax.html
 name: Java Server Page (JSP)
 file_extensions:
   - jsp
 scope: text.html.jsp
+
+variables:
+  # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
+  break_char: '[\t\n\f /<>]'
+
 contexts:
   main:
-    - match: <%--
-      scope: punctuation.definition.comment.jsp
+    - include: tag-jsp-declaration
+    - include: tag-jsp-directive
+    - include: tag-jsp-expression
+    - include: tag-jsp-scriptlet
+    - include: tag-jsp-text
+    - include: tag-jsp-other
+    - match: (?=\S)
       push:
-        - meta_scope: comment.block.jsp
-        - match: "--%>"
-          scope: punctuation.definition.comment.jsp
+        - include: scope:text.html.basic
+      with_prototype:
+        - match: (?=</?(?i:jsp):)
           pop: true
-    - match: <%@
-      scope: punctuation.section.directive.jsp
+        - match: <%--
+          scope: punctuation.definition.comment.begin.jsp
+          push:
+            - meta_scope: comment.block.jsp
+            - match: '--%>'
+              scope: punctuation.definition.comment.end.jsp
+              pop: true
+        - match: <%@
+          scope: punctuation.section.directive.begin.jsp
+          push:
+            - meta_scope: meta.directive.jsp
+            - match: '%>'
+              scope: punctuation.section.directive.end.jsp
+              pop: true
+            - include: jsp-directive
+        - match: <%!
+          scope: punctuation.section.declaration.begin.jsp
+          push:
+            - meta_scope: meta.declaration.jsp
+            - meta_content_scope: source.java.embedded.html
+            - match: '%>'
+              scope: punctuation.section.declaration.end.jsp
+              pop: true
+            - match: ''
+              embed: java
+              escape: (?=%>)
+        - match: <%=
+          scope: punctuation.section.expression.begin.jsp
+          push:
+            - meta_scope: meta.expression.jsp
+            - meta_content_scope: source.java.embedded.html
+            - match: '%>'
+              scope: punctuation.section.expression.end.jsp
+              pop: true
+            - match: ''
+              embed: java
+              escape: (?=%>)
+        - match: <%
+          scope: punctuation.section.scriptlet.begin.jsp
+          push:
+            - meta_scope: meta.scriptlet.jsp
+            - meta_content_scope: source.java.embedded.html
+            - match: '%>'
+              scope: punctuation.section.scriptlet.end.jsp
+              pop: true
+            - match: ''
+              embed: java
+              escape: (?=%>)
+
+  jsp-directive:
+    - match: \w+
+      scope: keyword.control.directive.jsp
       push:
-        - meta_scope: meta.directive.jsp
-        - match: "%>"
-          scope: punctuation.section.directive.jsp
-          pop: true
         - match: \w+
-          scope: keyword.other.directive.jsp
+          scope: entity.other.attribute-name.jsp
+        - match: =
+          scope: punctuation.separator.key-value.jsp
+        - match: \"
+          scope: punctuation.definition.string.begin.jsp
           push:
-            - match: \w+
-              scope: constant.other.directive.attribute.jsp
-            - match: "="
-              scope: keyword.operator.assignment.jsp
-            - match: '"'
-              scope: punctuation.definition.string.begin.jsp
-              push:
-                - meta_scope: string.quoted.double.jsp
-                - match: '"'
-                  scope: punctuation.definition.string.end.jsp
-                  pop: true
-                - match: \\.
-                  scope: constant.character.escape.jsp
-            - match: "'"
-              scope: punctuation.definition.string.begin.jsp
-              push:
-                - meta_scope: string.quoted.single.jsp
-                - match: "'"
-                  scope: punctuation.definition.string.end.jsp
-                  pop: true
-                - match: \\.
-                  scope: constant.character.escape.jsp
-            - match: '(?=\S)'
+            - meta_scope: meta.string.jsp string.quoted.double.jsp
+            - match: \"
+              scope: punctuation.definition.string.end.jsp
               pop: true
-    - match: "(<%[!=]?)|(<jsp:scriptlet>|<jsp:expression>|<jsp:declaration>)"
-      captures:
-        1: punctuation.section.embedded.begin.jsp
-        2: meta.tag.block.jsp
-      push:
-        - match: (</jsp:scriptlet>|</jsp:expression>|</jsp:declaration>)|(%>)
-          captures:
-            1: meta.tag.block.jsp
-            2: punctuation.section.embedded.end.jsp
+            - match: \\.
+              scope: constant.character.escape.jsp
+        - match: \'
+          scope: punctuation.definition.string.begin.jsp
+          push:
+            - meta_scope: meta.string.jsp string.quoted.single.jsp
+            - match: \'
+              scope: punctuation.definition.string.end.jsp
+              pop: true
+            - match: \\.
+              scope: constant.character.escape.jsp
+        - match: (?=\S)
           pop: true
-        - match: '(?<!\n)(?!</jsp:scriptlet>|</jsp:expression>|</jsp:declaration>|%>|\{|\})'
-          push:
-            - meta_scope: source.java.embedded.html
-            - match: '(?=</jsp:scriptlet>|</jsp:expression>|</jsp:declaration>|%>|\{|\})|\n'
-              pop: true
-            - include: scope:source.java
-        - match: "{"
-          push:
-            - match: "}"
-              pop: true
-            - match: (</jsp:scriptlet>|</jsp:expression>|</jsp:declaration>)|(%>)
-              captures:
-                1: meta.tag.block.jsp
-                2: punctuation.section.embedded.end.jsp
-              push:
-                - match: "(<jsp:scriptlet>|<jsp:expression>|<jsp:declaration>)|(<%(?!--)[!=]?)"
-                  captures:
-                    1: meta.tag.block.jsp
-                    2: punctuation.section.embedded.begin.jsp
-                  pop: true
-                - include: scope:text.html.jsp
-            - include: scope:source.java
-        # Prevent stray brace detection since brace matching won't work with
-        # %> pop pattern
-        - match: "}"
-        - include: scope:source.java
-    - include: scope:text.html.basic
+
+###[ DECLARATION ]############################################################
+
+  tag-jsp-declaration:
+    - match: (?i)(<)(jsp)(:)(declaration)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push: [tag-jsp-declaration-body, tag-jsp-declaration-attributes]
+
+  tag-jsp-declaration-attributes:
+    - meta_scope: meta.tag.jsp.declaration.begin.html
+    - include: tag-end
+    - include: tag-attributes
+
+  tag-jsp-declaration-body:
+    - match: (?i)(</)(jsp)(:)(declaration)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      set:
+        - meta_scope: meta.tag.jsp.declaration.end.html
+        - include: tag-end
+        - include: illegal-attributes
+    - match: ''
+      embed: java
+      embed_scope: source.java.embedded.html
+      escape: (?=(?i)</jsp:declaration{{break_char}})
+
+###[ DIRECTIVE ]###############################################################
+
+  tag-jsp-directive:
+    - match: (?i)(<)(jsp)(:)(directive)(.)([^{{break_char}}]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+        5: punctuation.accessor.dot.jsp
+        6: keyword.control.directive.jsp
+      push:
+        - meta_scope: meta.tag.jsp.directive.html
+        - include: tag-end-self-closing
+        - include: tag-attributes
+
+###[ EXPRESSION ]#############################################################
+
+  tag-jsp-expression:
+    - match: (?i)(<)(jsp)(:)(expression)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push: [tag-jsp-expression-body, tag-jsp-expression-attributes]
+
+  tag-jsp-expression-attributes:
+    - meta_scope: meta.tag.jsp.expression.begin.html
+    - include: tag-end
+    - include: tag-attributes
+
+  tag-jsp-expression-body:
+    - match: (?i)(</)(jsp)(:)(expression)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      set:
+        - meta_scope: meta.tag.jsp.expression.end.html
+        - include: tag-end
+        - include: illegal-attributes
+    - match: ''
+      embed: java
+      embed_scope: source.java.embedded.html
+      escape: (?=(?i)</jsp:expression{{break_char}})
+
+###[ OTHER ]##################################################################
+
+  tag-jsp-other:
+    - match: (?i)(<)(jsp)(:)([^{{break_char}}]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push:
+        - meta_scope: meta.tag.jsp.other.begin.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (?i)(</)(jsp)(:)([^{{break_char}}]+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push:
+        - meta_scope: meta.tag.jsp.other.end.html
+        - include: tag-end
+        - include: illegal-attributes
+
+###[ SCRIPTLETS ]#############################################################
+
+  tag-jsp-scriptlet:
+    - match: (?i)(<)(jsp)(:)(scriptlet)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push: [tag-jsp-scriptlet-body, tag-jsp-scriptlet-attributes]
+
+  tag-jsp-scriptlet-attributes:
+    - meta_scope: meta.tag.jsp.scriptlet.begin.html
+    - include: tag-end
+    - include: tag-attributes
+
+  tag-jsp-scriptlet-body:
+    - match: (?i)(</)(jsp)(:)(scriptlet)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      set:
+        - meta_scope: meta.tag.jsp.expression.end.html
+        - include: tag-end
+        - include: illegal-attributes
+    - match: ''
+      embed: java
+      embed_scope: source.java.embedded.html
+      escape: (?=(?i)</jsp:scriptlet{{break_char}})
+
+###[ TEXT ]###################################################################
+
+  tag-jsp-text:
+    - match: (?i)(<)(jsp)(:)(text)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      push: [tag-jsp-text-body, tag-jsp-text-attributes]
+
+  tag-jsp-text-attributes:
+    - meta_scope: meta.tag.jsp.text.begin.html
+    - include: tag-end
+    - include: illegal-attributes
+
+  tag-jsp-text-body:
+    - match: (?i)(</)(jsp)(:)(text)(?={{break_char}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.namespace.html
+        3: entity.name.tag.html punctuation.separator.namespace.html
+        4: entity.name.tag.localname.html
+      set:
+        - meta_scope: meta.tag.jsp.text.end.html
+        - include: tag-end
+        - include: illegal-attributes
+
+###[ PROTOTYPES ]#############################################################
+
+  tag-end:
+    - include: scope:text.html.basic#tag-end
+
+  tag-end-self-closing:
+    - include: scope:text.html.basic#tag-end-self-closing
+
+  tag-end-maybe-self-closing:
+    - include: scope:text.html.basic#tag-end-maybe-self-closing
+
+  tag-attributes:
+    - include: scope:text.html.basic#tag-attributes
+
+  illegal-attributes:
+    - match: '[^{{break_char}}]+'
+      scope: invalid.illegal.attributes-unexpected.html
+
+  java:
+    # Prevent stray brace detection since brace matching won't work with
+    # %> pop pattern
+    - match: \}
+      scope: punctuation.section.block.end.java
+    - include: scope:source.java

--- a/Java/Java Server Pages (JSP).sublime-syntax
+++ b/Java/Java Server Pages (JSP).sublime-syntax
@@ -10,6 +10,7 @@ scope: text.html.jsp
 variables:
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
   break_char: '[\t\n\f /<>]'
+  break: (?={{break_char}})
 
 contexts:
   main:
@@ -105,7 +106,7 @@ contexts:
 ###[ DECLARATION ]############################################################
 
   tag-jsp-declaration:
-    - match: (?i)(<)(jsp)(:)(declaration)(?={{break_char}})
+    - match: (?i)(<)(jsp)(:)(declaration){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -119,7 +120,7 @@ contexts:
     - include: tag-attributes
 
   tag-jsp-declaration-body:
-    - match: (?i)(</)(jsp)(:)(declaration)(?={{break_char}})
+    - match: (?i)(</)(jsp)(:)(declaration){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -153,7 +154,7 @@ contexts:
 ###[ EXPRESSION ]#############################################################
 
   tag-jsp-expression:
-    - match: (?i)(<)(jsp)(:)(expression)(?={{break_char}})
+    - match: (?i)(<)(jsp)(:)(expression){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -167,7 +168,7 @@ contexts:
     - include: tag-attributes
 
   tag-jsp-expression-body:
-    - match: (?i)(</)(jsp)(:)(expression)(?={{break_char}})
+    - match: (?i)(</)(jsp)(:)(expression){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -209,7 +210,7 @@ contexts:
 ###[ SCRIPTLETS ]#############################################################
 
   tag-jsp-scriptlet:
-    - match: (?i)(<)(jsp)(:)(scriptlet)(?={{break_char}})
+    - match: (?i)(<)(jsp)(:)(scriptlet){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -223,7 +224,7 @@ contexts:
     - include: tag-attributes
 
   tag-jsp-scriptlet-body:
-    - match: (?i)(</)(jsp)(:)(scriptlet)(?={{break_char}})
+    - match: (?i)(</)(jsp)(:)(scriptlet){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -241,7 +242,7 @@ contexts:
 ###[ TEXT ]###################################################################
 
   tag-jsp-text:
-    - match: (?i)(<)(jsp)(:)(text)(?={{break_char}})
+    - match: (?i)(<)(jsp)(:)(text){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html
@@ -255,7 +256,7 @@ contexts:
     - include: illegal-attributes
 
   tag-jsp-text-body:
-    - match: (?i)(</)(jsp)(:)(text)(?={{break_char}})
+    - match: (?i)(</)(jsp)(:)(text){{break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.namespace.html

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -32,8 +32,6 @@ variables:
 
 contexts:
   prototype:
-    - match: (?=%>)
-      pop: true
     - include: comments
     - include: illegal-keywords
 

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -44,7 +44,6 @@ contexts:
       pop: true
 
   main:
-    - include: prototype
     - include: package-statement
     - include: import-statement
     - include: module

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -488,8 +488,6 @@ contexts:
         - meta_scope: comment.line.double-slash.java
         - match: \n
           pop: true
-        - match: (?=%>)
-          pop: true
 
   constants-and-special-vars:
     - match: \b(true|false|null)\b

--- a/Java/syntax_test_jsp.jsp
+++ b/Java/syntax_test_jsp.jsp
@@ -41,7 +41,7 @@
     <!-- DIRECTIVE TESTS -->
 
     <jsp:directive.include file="foo.bar" />
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.directive.html
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.directive.begin.html
 //  ^ punctuation.definition.tag.begin.html
 //   ^^^ entity.name.tag.namespace.html
 //      ^ entity.name.tag.html punctuation.separator.namespace.html
@@ -52,6 +52,25 @@
 //                             ^ meta.attribute-with-value.html punctuation.separator.key-value.html
 //                              ^^^^^^^^^ meta.attribute-with-value.html string.quoted.double.html
 //                                        ^^ punctuation.definition.tag.end.html
+
+    <jsp:directive.include file="foo.bar"></jsp:directive>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.directive.begin.html
+//                                        ^^^^^^^^^^^^^^^^ meta.tag.jsp.directive.end.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ entity.name.tag.html punctuation.separator.namespace.html
+//       ^^^^^^^^^ entity.name.tag.localname.html
+//                ^ punctuation.accessor.dot.jsp
+//                 ^^^^^^^ keyword.control.directive.jsp
+//                         ^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
+//                             ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                              ^^^^^^^^^ meta.attribute-with-value.html string.quoted.double.html
+//                                       ^ punctuation.definition.tag.end.html
+//                                        ^^ punctuation.definition.tag.begin.html
+//                                          ^^^ entity.name.tag.namespace.html
+//                                             ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                              ^^^^^^^^^ entity.name.tag.localname.html
+//                                                       ^ punctuation.definition.tag.end.html
 
     <%@ include file="foo.bar" %>
 // ^ - meta
@@ -65,6 +84,21 @@
 //                             ^^ punctuation.section.embedded.end.jsp
 
     <!-- DECLARATION TESTS -->
+
+    <jsp:declaration/>int i = 0;</jsp:declaration>
+//  ^^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ entity.name.tag.html punctuation.separator.namespace.html
+//       ^^^^^^^^^^^ entity.name.tag.localname.html
+//                  ^^ punctuation.definition.tag.end.html
+//                    ^^^^^^^^^^ - source.java.embedded
+//                              ^^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.end.html
+//                              ^^ punctuation.definition.tag.begin.html
+//                                ^^^ entity.name.tag.namespace.html
+//                                   ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                    ^^^^^^^^^^^ entity.name.tag.localname.html
+//                                               ^ punctuation.definition.tag.end.html
 
     <jsp:declaration>int i = 0;</jsp:declaration>
 //  ^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.begin.html
@@ -125,6 +159,24 @@
 //                                                                      ^^^^^^^^^^ entity.name.tag.localname.html
 //                                                                                ^ punctuation.definition.tag.end.html
 //                                                                                 ^^^^ meta.tag.inline.any.html
+
+    Good guess, but nope. Try<b><jsp:expression/>numguess.getHint()</jsp:expression></b>.
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta
+//                           ^^^ meta.tag.inline.any.html
+//                              ^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.begin.html
+//                              ^ punctuation.definition.tag.begin.html
+//                               ^^^ entity.name.tag.namespace.html
+//                                  ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                   ^^^^^^^^^^ entity.name.tag.localname.html
+//                                             ^^ punctuation.definition.tag.end.html
+//                                               ^^^^^^^^^^^^^^^^^^ - source.java.embedded
+//                                                                 ^^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.end.html
+//                                                                 ^^ punctuation.definition.tag.begin.html
+//                                                                   ^^^ entity.name.tag.namespace.html
+//                                                                      ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                                                       ^^^^^^^^^^ entity.name.tag.localname.html
+//                                                                                 ^ punctuation.definition.tag.end.html
+//                                                                                  ^^^^ meta.tag.inline.any.html
 
     <!-- FORWARD TESTS -->
 
@@ -222,6 +274,21 @@
     Plain text
 //  ^^^^^^^^^^ text.html.jsp - meta
 
+    <jsp:text/>Plain text</jsp:text>
+//  ^^^^^^^^^^^ meta.tag.jsp.text.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ punctuation.separator.namespace.html
+//       ^^^^ entity.name.tag.localname.html
+//           ^^ punctuation.definition.tag.end.html
+//             ^^^^^^^^^^ - text.plain.jsp
+//                       ^^^^^^^^^^^ meta.tag.jsp.text.end.html
+//                       ^^ punctuation.definition.tag.begin.html
+//                         ^^^ entity.name.tag.namespace.html
+//                            ^ punctuation.separator.namespace.html
+//                             ^^^^ entity.name.tag.localname.html
+//                                 ^ punctuation.definition.tag.end.html
+
     <jsp:text>Plain text</jsp:text>
 //  ^^^^^^^^^^ meta.tag.jsp.text.begin.html
 //  ^ punctuation.definition.tag.begin.html
@@ -229,6 +296,7 @@
 //      ^ punctuation.separator.namespace.html
 //       ^^^^ entity.name.tag.localname.html
 //           ^ punctuation.definition.tag.end.html
+//            ^^^^^^^^^^ text.plain.jsp
 //                      ^^^^^^^^^^^ meta.tag.jsp.text.end.html
 //                      ^^ punctuation.definition.tag.begin.html
 //                        ^^^ entity.name.tag.namespace.html

--- a/Java/syntax_test_jsp.jsp
+++ b/Java/syntax_test_jsp.jsp
@@ -7,53 +7,234 @@
 //  ^^^^^^^^^^^^^^^ meta.tag
 </head>
 <body>
-    <%@ include file="foo.bar" %>
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.directive
-//  ^^^ punctuation.section.directive
-//                             ^^ punctuation.section.directive
-
-    Plain text
-//  ^^^^^^^^^^ text.html.jsp - meta
 
     <%-- This is a comment --%>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.jsp
+
+    <!-- ROOT TESTS -->
+
+    <jsp:root
+//  ^^^^^^^^^^ meta.tag.jsp.other.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ entity.name.tag.html punctuation.separator.namespace.html
+//       ^^^^ entity.name.tag.localname.html
+        xmlns:jsp="http://java.sun.com/JSP/Page"
+        xmlns:public="http://www.jspcentral.com/tags"
+        version="1.2"
+// ^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.other.begin.html
+//      ^^^^^^^^^^^^^ meta.attribute-with-value.html
+//      ^^^^^^^ entity.other.attribute-name.html
+//             ^ punctuation.separator.key-value.html
+//              ^^^^^ string.quoted.double.html
+    >
+//  ^ meta.tag.jsp.other.begin.html punctuation.definition.tag.end.html
+
+    </jsp:root>
+//  ^^^^^^^^^^^ meta.tag.jsp.other.end.html
+//  ^^ punctuation.definition.tag.begin.html
+//    ^^^ entity.name.tag.namespace.html
+//       ^ punctuation.separator.namespace.html
+//        ^^^^ entity.name.tag.localname.html
+//            ^ punctuation.definition.tag.end.html
+
+    <!-- DIRECTIVE TESTS -->
+
+    <jsp:directive.include file="foo.bar" />
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.directive.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ entity.name.tag.html punctuation.separator.namespace.html
+//       ^^^^^^^^^ entity.name.tag.localname.html
+//                ^ punctuation.accessor.dot.jsp
+//                 ^^^^^^^ keyword.control.directive.jsp
+//                         ^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
+//                             ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                              ^^^^^^^^^ meta.attribute-with-value.html string.quoted.double.html
+//                                        ^^ punctuation.definition.tag.end.html
+
+    <%@ include file="foo.bar" %>
+// ^ - meta
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.directive.jsp
+//                               ^ - meta
+//  ^^^ punctuation.section.directive.begin.jsp
+//      ^^^^^^^ keyword.control.directive.jsp
+//              ^^^^ entity.other.attribute-name.jsp
+//                  ^ punctuation.separator.key-value.jsp
+//                   ^^^^^^^^^ string.quoted.double.jsp
+//                             ^^ punctuation.section.directive.end.jsp
+
+    <!-- DECLARATION TESTS -->
+
+    <jsp:declaration>int i = 0;</jsp:declaration>
+//  ^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ entity.name.tag.html punctuation.separator.namespace.html
+//       ^^^^^^^^^^^ entity.name.tag.localname.html
+//                  ^ punctuation.definition.tag.end.html
+//                   ^^^^^^^^^^ source.java.embedded.html
+//                   ^^^ storage.type.primitive.java
+//                             ^^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.end.html
+//                             ^^ punctuation.definition.tag.begin.html
+//                               ^^^ entity.name.tag.namespace.html
+//                                  ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                   ^^^^^^^^^^^ entity.name.tag.localname.html
+//                                              ^ punctuation.definition.tag.end.html
+
+    <%! int i = 0; %>
+// ^ - meta
+//  ^^^ meta.declaration.jsp - source.java.embedded.html
+//     ^^^^^^^^^^^^ meta.declaration.jsp source.java.embedded.html
+//                 ^^ meta.declaration.jsp - source.java.embedded.html
+//                   ^ - meta
+//  ^^^ punctuation.section.declaration.begin.jsp
+//      ^^^ storage.type.primitive.java
+//                 ^^ punctuation.section.declaration.end.jsp
+
+    <!-- EXPRESSIONS TESTS -->
+
+    The map file has <font color="<%=color.blue()%>"><%= map.size() %></font> entries.
+//  ^^^^^^^^^^^^^^^^^ - meta
+//                   ^^^^^^ meta.tag.inline.any.html - meta.attribute-with-value.html
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.html
+//                                ^^^ meta.expression.jsp punctuation.section.expression.begin.jsp - source.java
+//                                   ^^^^^^^^^^^^ meta.expression.jsp source.java.embedded.html
+//                                               ^^ meta.expression.jsp punctuation.section.expression.end.jsp - source.java
+//                                                  ^ meta.tag.inline.any.html - meta.attribute-with-value.html
+//                                                   ^^^ meta.expression.jsp punctuation.section.expression.begin.jsp - source.java
+//                                                      ^^^^^^^^^^^^ meta.expression.jsp source.java.embedded.html
+//                                                                  ^^ meta.expression.jsp punctuation.section.expression.end.jsp - source.java
+//                                                                    ^^^^^^^ meta.tag.inline.any.html
+//                                                                           ^^^^^^^^^ - meta
+
+    Good guess, but nope. Try<b><jsp:expression>numguess.getHint()</jsp:expression></b>.
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta
+//                           ^^^ meta.tag.inline.any.html
+//                              ^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.begin.html
+//                              ^ punctuation.definition.tag.begin.html
+//                               ^^^ entity.name.tag.namespace.html
+//                                  ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                   ^^^^^^^^^^ entity.name.tag.localname.html
+//                                             ^ punctuation.definition.tag.end.html
+//                                              ^^^^^^^^^^^^^^^^^^ source.java.embedded.html
+//                                                                ^^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.end.html
+//                                                                ^^ punctuation.definition.tag.begin.html
+//                                                                  ^^^ entity.name.tag.namespace.html
+//                                                                     ^ entity.name.tag.html punctuation.separator.namespace.html
+//                                                                      ^^^^^^^^^^ entity.name.tag.localname.html
+//                                                                                ^ punctuation.definition.tag.end.html
+//                                                                                 ^^^^ meta.tag.inline.any.html
+
+    <!-- FORWARD TESTS -->
+
+    <jsp:forward page="/servlet/login" />
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.other.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ punctuation.separator.namespace.html
+//       ^^^^^^^ entity.name.tag.localname.html
+//                                     ^^ punctuation.definition.tag.end.html
+
+    <jsp:forward page="/servlet/login">
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.other.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ punctuation.separator.namespace.html
+//       ^^^^^^^ entity.name.tag.localname.html
+//                                    ^ punctuation.definition.tag.end.html
+
+        <jsp:param name="username" value="jsmith" />
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.jsp.other.begin.html
+//      ^ punctuation.definition.tag.begin.html
+//       ^^^ entity.name.tag.namespace.html
+//          ^ punctuation.separator.namespace.html
+//           ^^^^^ entity.name.tag.localname.html
+//                                                ^^ punctuation.definition.tag.end.html
+
+    </jsp:forward>
+//  ^^^^^^^^^^^^^^ meta.tag.jsp.other.end.html
+//  ^^ punctuation.definition.tag.begin.html
+//    ^^^ entity.name.tag.namespace.html
+//       ^ punctuation.separator.namespace.html
+//        ^^^^^^^ entity.name.tag.localname.html
+//               ^ punctuation.definition.tag.end.html
+
+    <!-- SCRIPTLET TESTS -->
+
     <%
-//  ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
+//  ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
 //    ^ source.java.embedded.html
     if (!foo && !bar) {
 //  ^^ keyword.control.conditional.if.java
 //      ^ keyword.operator.logical.java
 //           ^^ keyword.operator.logical.java
-    %><div style="width: 90%"></div><%
-//  ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
-//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//                                  ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
+    %><div style="width: <%=with%>"></div><%
+//  ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
+//    ^^^^^ meta.tag.block.any.html - meta.attribute-with-value
+//         ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
+//                ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css - meta.expression
+//                       ^^^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css meta.expression.jsp
+//                                ^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
+//                                 ^^^^^^^ meta.tag.block.any.html - meta.attribute-with-value.style.html - source.css
+//    ^ punctuation.definition.tag.begin.html
+//     ^^^ entity.name.tag.block.any.html
+//         ^^^^^ entity.other.attribute-name.style.html
+//              ^ punctuation.separator.key-value.html
+//               ^ string.quoted.double punctuation.definition.string.begin.html
+//                ^^^^^ meta.property-name.css support.type.property-name.css
+//                     ^ punctuation.separator.key-value.css
+//                       ^^^ punctuation.section.expression.begin.jsp - source.java.embedded
+//                          ^^^^ source.java.embedded.html
+//                              ^^ punctuation.section.expression.end.jsp - source.java.embedded
+//                                ^ string.quoted.double punctuation.definition.string.end.html
+//                                 ^ punctuation.definition.tag.end.html
+//                                        ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
         if (foot.shouldBe()) {
 //      ^^ keyword.control.conditional.if.java
             boolean test = false;
 //          ^^^^^^^ storage.type
 //                         ^^^^^ constant
             %>
-//          ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
+//          ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
 //            ^ text.html.jsp - source.java.embedded.html
 
             <%-- This is a comment --%>
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.jsp
             <% int aNumber = 0; // this scriptlet should close %>
 //                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.java
-//                                                             ^^ punctuation.section.embedded.end.jsp
+//                                                             ^^ punctuation.section.scriptlet.end.jsp
 
 
             <div style="width: 90%"></div>
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
             <%
-//          ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
+//          ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
         }
 //      ^ - invalid.illegal.stray-brace-end
     }
 //  ^ - invalid.illegal.stray-brace-end
     %>
-//  ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
+//  ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
 //    ^ text.html.jsp - source.java.embedded.html
+
+
+    Plain text
+//  ^^^^^^^^^^ text.html.jsp - meta
+
+    <jsp:text>Plain text</jsp:text>
+//  ^^^^^^^^^^ meta.tag.jsp.text.begin.html
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.namespace.html
+//      ^ punctuation.separator.namespace.html
+//       ^^^^ entity.name.tag.localname.html
+//           ^ punctuation.definition.tag.end.html
+//                      ^^^^^^^^^^^ meta.tag.jsp.text.end.html
+//                      ^^ punctuation.definition.tag.begin.html
+//                        ^^^ entity.name.tag.namespace.html
+//                           ^ punctuation.separator.namespace.html
+//                            ^^^^ entity.name.tag.localname.html
+//                                ^ punctuation.definition.tag.end.html
+
 </body>
 </html>

--- a/Java/syntax_test_jsp.jsp
+++ b/Java/syntax_test_jsp.jsp
@@ -55,14 +55,14 @@
 
     <%@ include file="foo.bar" %>
 // ^ - meta
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.directive.jsp
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.directive.jsp
 //                               ^ - meta
-//  ^^^ punctuation.section.directive.begin.jsp
+//  ^^^ punctuation.section.embedded.begin.jsp
 //      ^^^^^^^ keyword.control.directive.jsp
 //              ^^^^ entity.other.attribute-name.jsp
 //                  ^ punctuation.separator.key-value.jsp
 //                   ^^^^^^^^^ string.quoted.double.jsp
-//                             ^^ punctuation.section.directive.end.jsp
+//                             ^^ punctuation.section.embedded.end.jsp
 
     <!-- DECLARATION TESTS -->
 
@@ -84,13 +84,13 @@
 
     <%! int i = 0; %>
 // ^ - meta
-//  ^^^ meta.declaration.jsp - source.java.embedded.html
-//     ^^^^^^^^^^^^ meta.declaration.jsp source.java.embedded.html
-//                 ^^ meta.declaration.jsp - source.java.embedded.html
+//  ^^^ meta.embedded.declaration.jsp - source.java.embedded.html
+//     ^^^^^^^^^^^^ meta.embedded.declaration.jsp source.java.embedded.html
+//                 ^^ meta.embedded.declaration.jsp - source.java.embedded.html
 //                   ^ - meta
-//  ^^^ punctuation.section.declaration.begin.jsp
+//  ^^^ punctuation.section.embedded.begin.jsp
 //      ^^^ storage.type.primitive.java
-//                 ^^ punctuation.section.declaration.end.jsp
+//                 ^^ punctuation.section.embedded.end.jsp
 
     <!-- EXPRESSIONS TESTS -->
 
@@ -98,13 +98,13 @@
 //  ^^^^^^^^^^^^^^^^^ - meta
 //                   ^^^^^^ meta.tag.inline.any.html - meta.attribute-with-value.html
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.html
-//                                ^^^ meta.expression.jsp punctuation.section.expression.begin.jsp - source.java
-//                                   ^^^^^^^^^^^^ meta.expression.jsp source.java.embedded.html
-//                                               ^^ meta.expression.jsp punctuation.section.expression.end.jsp - source.java
+//                                ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
+//                                   ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.html
+//                                               ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
 //                                                  ^ meta.tag.inline.any.html - meta.attribute-with-value.html
-//                                                   ^^^ meta.expression.jsp punctuation.section.expression.begin.jsp - source.java
-//                                                      ^^^^^^^^^^^^ meta.expression.jsp source.java.embedded.html
-//                                                                  ^^ meta.expression.jsp punctuation.section.expression.end.jsp - source.java
+//                                                   ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
+//                                                      ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.html
+//                                                                  ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
 //                                                                    ^^^^^^^ meta.tag.inline.any.html
 //                                                                           ^^^^^^^^^ - meta
 
@@ -163,18 +163,18 @@
     <!-- SCRIPTLET TESTS -->
 
     <%
-//  ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
+//  ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
 //    ^ source.java.embedded.html
     if (!foo && !bar) {
 //  ^^ keyword.control.conditional.if.java
 //      ^ keyword.operator.logical.java
 //           ^^ keyword.operator.logical.java
     %><div style="width: <%=with%>"></div><%
-//  ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
+//  ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
 //    ^^^^^ meta.tag.block.any.html - meta.attribute-with-value
 //         ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
 //                ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css - meta.expression
-//                       ^^^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css meta.expression.jsp
+//                       ^^^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css meta.embedded.expression.jsp
 //                                ^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
 //                                 ^^^^^^^ meta.tag.block.any.html - meta.attribute-with-value.style.html - source.css
 //    ^ punctuation.definition.tag.begin.html
@@ -184,38 +184,38 @@
 //               ^ string.quoted.double punctuation.definition.string.begin.html
 //                ^^^^^ meta.property-name.css support.type.property-name.css
 //                     ^ punctuation.separator.key-value.css
-//                       ^^^ punctuation.section.expression.begin.jsp - source.java.embedded
+//                       ^^^ punctuation.section.embedded.begin.jsp - source.java.embedded
 //                          ^^^^ source.java.embedded.html
-//                              ^^ punctuation.section.expression.end.jsp - source.java.embedded
+//                              ^^ punctuation.section.embedded.end.jsp - source.java.embedded
 //                                ^ string.quoted.double punctuation.definition.string.end.html
 //                                 ^ punctuation.definition.tag.end.html
-//                                        ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
+//                                        ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
         if (foot.shouldBe()) {
 //      ^^ keyword.control.conditional.if.java
             boolean test = false;
 //          ^^^^^^^ storage.type
 //                         ^^^^^ constant
             %>
-//          ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
+//          ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
 //            ^ text.html.jsp - source.java.embedded.html
 
             <%-- This is a comment --%>
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.jsp
             <% int aNumber = 0; // this scriptlet should close %>
 //                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.java
-//                                                             ^^ punctuation.section.scriptlet.end.jsp
+//                                                             ^^ punctuation.section.embedded.end.jsp
 
 
             <div style="width: 90%"></div>
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
             <%
-//          ^^ punctuation.section.scriptlet.begin.jsp - source.java.embedded.html
+//          ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
         }
 //      ^ - invalid.illegal.stray-brace-end
     }
 //  ^ - invalid.illegal.stray-brace-end
     %>
-//  ^^ punctuation.section.scriptlet.end.jsp - source.java.embedded.html
+//  ^^ punctuation.section.embedded.end.jsp - source.java.embedded.html
 //    ^ text.html.jsp - source.java.embedded.html
 
 

--- a/Java/syntax_test_jsp.jsp
+++ b/Java/syntax_test_jsp.jsp
@@ -107,7 +107,7 @@
 //      ^ entity.name.tag.html punctuation.separator.namespace.html
 //       ^^^^^^^^^^^ entity.name.tag.localname.html
 //                  ^ punctuation.definition.tag.end.html
-//                   ^^^^^^^^^^ source.java.embedded.html
+//                   ^^^^^^^^^^ source.java.embedded.html - source.java source.java
 //                   ^^^ storage.type.primitive.java
 //                             ^^^^^^^^^^^^^^^^^^ meta.tag.jsp.declaration.end.html
 //                             ^^ punctuation.definition.tag.begin.html
@@ -119,7 +119,7 @@
     <%! int i = 0; %>
 // ^ - meta
 //  ^^^ meta.embedded.declaration.jsp - source.java.embedded.html
-//     ^^^^^^^^^^^^ meta.embedded.declaration.jsp source.java.embedded.html
+//     ^^^^^^^^^^^^ meta.embedded.declaration.jsp source.java.embedded.html - source.java source.java
 //                 ^^ meta.embedded.declaration.jsp - source.java.embedded.html
 //                   ^ - meta
 //  ^^^ punctuation.section.embedded.begin.jsp
@@ -133,7 +133,7 @@
 //                   ^^^^^^ meta.tag.inline.any.html - meta.attribute-with-value.html
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.html
 //                                ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
-//                                   ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.html
+//                                   ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.html - source.java source.java
 //                                               ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
 //                                                  ^ meta.tag.inline.any.html - meta.attribute-with-value.html
 //                                                   ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
@@ -151,7 +151,7 @@
 //                                  ^ entity.name.tag.html punctuation.separator.namespace.html
 //                                   ^^^^^^^^^^ entity.name.tag.localname.html
 //                                             ^ punctuation.definition.tag.end.html
-//                                              ^^^^^^^^^^^^^^^^^^ source.java.embedded.html
+//                                              ^^^^^^^^^^^^^^^^^^ source.java.embedded.html - source.java source.java
 //                                                                ^^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.end.html
 //                                                                ^^ punctuation.definition.tag.begin.html
 //                                                                  ^^^ entity.name.tag.namespace.html
@@ -216,7 +216,7 @@
 
     <%
 //  ^^ punctuation.section.embedded.begin.jsp - source.java.embedded.html
-//    ^ source.java.embedded.html
+//    ^ source.java.embedded.html - source.java source.java
     if (!foo && !bar) {
 //  ^^ keyword.control.conditional.if.java
 //      ^ keyword.operator.logical.java


### PR DESCRIPTION
This PR addresses an issue reportet at:
https://forum.sublimetext.com/t/jsp-source-theme-change/48165/2

This PR proposes a rewritten JSP syntax definition in order to ...

1. make use of the `embed` technology to inject the `<%%>` tags into the HTML.sublime-syntax, which fixes an issue with `<%%>` not being highlighted within tag attributes
2. apply the HTML like tag scope names.