### PR TITLE
[JavaScript] Add meta.number

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -13,7 +13,7 @@ variables:
   dec_digit: '[0-9_]'
   hex_digit: '[\h_]'
   dec_integer: (?:0|[1-9]{{dec_digit}}*)
-  dec_exponent: (?:[Ee](?:[-+]|(?![-+])){{dec_digit}}*)
+  dec_exponent: ([Ee](?:[-+]|(?![-+])){{dec_digit}}*)
 
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
@@ -1792,46 +1792,53 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          {{dec_integer}} (?: (\.) {{dec_digit}}* {{dec_exponent}}? | {{dec_exponent}} )
+          ({{dec_integer}}) (?: ((\.) {{dec_digit}}*) {{dec_exponent}}? | {{dec_exponent}} )
           # .1, .1e1, .1e-1
-          | (\.) {{dec_digit}}+ {{dec_exponent}}?
+          | ((\.) {{dec_digit}}+) {{dec_exponent}}?
         ){{identifier_break}}
-      scope: constant.numeric.float.decimal.js
       captures:
-        1: punctuation.separator.decimal.js
-        2: punctuation.separator.decimal.js
+        1: meta.number.mantissa.js constant.numeric.float.decimal.js
+        2: meta.number.mantissa.js constant.numeric.float.decimal.js
+        3: punctuation.separator.decimal.js
+        4: meta.number.exponent.js constant.numeric.float.decimal.js
+        5: meta.number.exponent.js constant.numeric.float.decimal.js
+        6: meta.number.mantissa.js constant.numeric.float.decimal.js
+        7: punctuation.separator.decimal.js
+        8: meta.number.exponent.js constant.numeric.float.decimal.js
       pop: true
 
     # integers
-    - match: 0{{dec_digit}}+{{identifier_break}}
-      scope: constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+    - match: (0)({{dec_digit}}+){{identifier_break}}
+      captures:
+        1: meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+        2: meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
-    - match: (0[Xx]){{hex_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.hexadecimal.js
+    - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.hexadecimal.js
+        2: meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+        3: meta.number.type.js constant.numeric.integer.hexadecimal.js
       pop: true
 
-    - match: (0[Oo]){{oct_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.octal.js
+    - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.octal.js
+        2: meta.number.mantissa.js constant.numeric.integer.octal.js
+        3: meta.number.type.js constant.numeric.integer.octal.js
       pop: true
 
-    - match: (0[Bb]){{bin_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.binary.js
+    - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.binary.js
+        2: meta.number.mantissa.js constant.numeric.integer.binary.js
+        3: meta.number.type.js constant.numeric.integer.binary.js
       pop: true
 
-    - match: '{{dec_integer}}(n|(?!\.)){{identifier_break}}'
-      scope: constant.numeric.integer.decimal.js
+    - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       captures:
-        1: storage.type.numeric.js
+        1: meta.number.mantissa.js constant.numeric.integer.decimal.js
+        2: meta.number.type.js constant.numeric.integer.decimal.js
       pop: true
 
     # illegal numbers

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1848,11 +1848,11 @@ function yy (a, b) {
 // Integers
 
     123_456_789_0n;
-//  ^^^^^^^^^^^^^^ constant.numeric.integer.decimal
-//               ^ storage.type.numeric
+//  ^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.decimal.js
+//               ^ meta.number.type.js constant.numeric.integer.decimal.js
 
     0;
-//  ^ constant.numeric.integer.decimal
+//  ^ meta.number.mantissa.js constant.numeric.integer.decimal.js
 
     123 .foo;
 //  ^^^ constant.numeric.integer.decimal
@@ -1874,54 +1874,60 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     0123456789;
-//  ^^^^^^^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 
     0123456789xyz;
 //  ^^^^^^^^^^^^^ invalid.illegal.numeric.octal
 
     0123456789.xyz;
-//  ^^^^^^^^^^ invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor
 //             ^^^ meta.property.object
 
     0123456789.123;
-//  ^^^^^^^^^^ invalid.deprecated.numeric.octal
-//            ^ punctuation.accessor
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//            ^ punctuation.accessor.js
 //             ^^^ invalid.illegal.illegal-identifier
 
     0b0110_1001_1001_0110n;
-//  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
-//                       ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//                       ^ meta.number.type.js constant.numeric.integer.binary.js
 
     0o0123_4567n;
-//  ^^^^^^^^^^^^ constant.numeric.integer.octal
-//  ^^ punctuation.definition.numeric.base
-//             ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.octal.js
+//    ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//             ^ meta.number.type.js constant.numeric.integer.octal.js
 
     0x01_23_45_67_89_ab_CD_efn;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-//  ^^ punctuation.definition.numeric.base
-//                           ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
+//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//                           ^ meta.number.type.js constant.numeric.integer.hexadecimal.js
 
     0B0; 0O0; 0X0;
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
-//       ^^^ constant.numeric.integer.octal
-//       ^^ punctuation.definition.numeric.base
-//            ^^^ constant.numeric.integer.hexadecimal
-//            ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//     ^ punctuation.terminator.statement.js
+//       ^^ meta.number.base.js constant.numeric.integer.octal.js
+//         ^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//          ^ punctuation.terminator.statement.js
+//            ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
+//              ^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//               ^ punctuation.terminator.statement.js
 
     0b1.foo;
 //  ^^^^^^^ - invalid
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 
@@ -1932,25 +1938,30 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//               ^ punctuation.separator.decimal.js
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//       ^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     123.456e+789;
-//  ^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //     ^ punctuation.separator.decimal
+//         ^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     .123E-7_8_9;
-//  ^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
+//      ^^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     0123.45;
-//  ^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //      ^ punctuation.accessor
 //       ^^ invalid.illegal - constant.numeric
 
@@ -1961,7 +1972,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ constant.numeric.float.decimal
+//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 


### PR DESCRIPTION
This PR replaces the `punctuation.definition.numeric` and `storage.type.numeric` by `meta.number.[base|type]` scope.