### PR TITLE
[Erlang] Distinguish operators that are words from those that are symbols

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1928,13 +1928,13 @@ contexts:
   operator:
     # http://erlang.org/doc/reference_manual/expressions.html#arithmetic-expressions
     - match: (div|rem){{ident_break}}
-      scope: keyword.operator.arithmetic.erlang
+      scope: keyword.operator.word.arithmetic.erlang
     - match: (band|bor|bxor|bnot|bsl|bsr){{ident_break}}
-      scope: keyword.operator.bitwise.erlang
+      scope: keyword.operator.word.bitwise.erlang
     # http://erlang.org/doc/reference_manual/expressions.html#boolean-expressions
     # http://erlang.org/doc/reference_manual/expressions.html#short-circuit-expressions
     - match: (and|or|xor|not|andalso|orelse){{ident_break}}
-      scope: keyword.operator.logical.erlang
+      scope: keyword.operator.word.logical.erlang
 
 ###[ SEPARATORS ]#############################################################
 

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -1128,6 +1128,22 @@ operator_tests() -> .
 %     ^^ punctuation.separator.mapping.key-value.erlang
 %        ^ meta.atom.erlang constant.other.symbol.erlang
 
+    10 div 3
+%   ^^ constant.numeric.integer.decimal.erlang
+%      ^^^ keyword.operator.word.arithmetic.erlang
+%          ^ constant.numeric.integer.decimal.erlang
+
+    2#10 bor 2#01
+%   ^^^^ constant.numeric.integer.binary.erlang
+%        ^^^ keyword.operator.word.bitwise.erlang
+%            ^^^^ constant.numeric.integer.binary.erlang
+
+    true and false
+%   ^^^^ constant.language.boolean.erlang
+%        ^^^ keyword.operator.word.logical.erlang
+%            ^^^^^ constant.language.boolean.erlang
+
+
 % directive-control-flow tests
 
 preprocessor_control_tests() -> .


### PR DESCRIPTION
Colour scheme authors can want to target these differently. For example, personally I don't colour operators like `= + *` but do colour operators like `and`.

Use of the scope `keyword.operator.word` is officially endorsed: https://www.sublimetext.com/docs/3/scope_naming.html#keyword