### PR TITLE
[Erlang] Rename scope meta...name->meta...identifier

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -344,7 +344,7 @@ contexts:
           - include: preproc-stray-arguments-end
 
   preproc-define-arguments-parameters:
-    - meta_content_scope: meta.macro.name.erlang
+    - meta_content_scope: meta.macro.identifier.erlang
     - match: (?=\()
       set:
         - match: \(
@@ -576,7 +576,7 @@ contexts:
         - match: ',?'
           scope: punctuation.separator.expressions.erlang
           push:
-            - - meta_content_scope: meta.field.name.erlang
+            - - meta_content_scope: meta.field.identifier.erlang
               - include: immediatelly-pop
             - - include: variable-anonymous-pop
               - match: '{{atom_unquoted}}'
@@ -874,7 +874,7 @@ contexts:
               - include: function-parameter
           - include: else-pop
         # 1. function name
-        - - meta_scope: meta.fun.name.erlang
+        - - meta_scope: meta.fun.identifier.erlang
           - include: else-pop
         - - include: variable-other-pop
           - include: macro-pop
@@ -895,7 +895,7 @@ contexts:
 
   function-parameters:
     - clear_scopes: 1
-    - meta_scope: meta.function.name.erlang
+    - meta_scope: meta.function.identifier.erlang
     - match: (?=\()
       set:
         - clear_scopes: 1
@@ -933,11 +933,11 @@ contexts:
       set: [function-call-arguments, function-call-path, variable-function]
 
   function-call-name:
-    - meta_scope: meta.function-call.name.erlang
+    - meta_scope: meta.function-call.identifier.erlang
     - include: else-pop
 
   function-call-path:
-    - meta_scope: meta.path.erlang meta.function-call.name.erlang
+    - meta_scope: meta.path.erlang meta.function-call.identifier.erlang
     - include: else-pop
 
   function-call-arguments:
@@ -973,11 +973,11 @@ contexts:
       set: [type-call-other-arguments, type-call-path, storage-type]
 
   type-call-name:
-    - meta_scope: meta.type-call.name.erlang
+    - meta_scope: meta.type-call.identifier.erlang
     - include: else-pop
 
   type-call-path:
-    - meta_scope: meta.path.erlang meta.type-call.name.erlang
+    - meta_scope: meta.path.erlang meta.type-call.identifier.erlang
     - include: else-pop
 
   type-call-fun-arguments:
@@ -1179,11 +1179,11 @@ contexts:
       push: [record-fields, record-name, variable-other-record]
     # records may look like normal variables in macro definitions
     - match: '{{variable}}(?=\.{{ident}})'
-      scope: meta.record.name.erlang variable.other.erlang
+      scope: meta.record.identifier.erlang variable.other.erlang
       push: record-fields
 
   record-name:
-    - meta_scope: meta.record.name.erlang
+    - meta_scope: meta.record.identifier.erlang
     - include: else-pop
 
   variable-other-record:
@@ -1215,7 +1215,7 @@ contexts:
         - match: ',?'
           scope: punctuation.separator.expressions.erlang
           push:
-            - - meta_content_scope: meta.field.name.erlang
+            - - meta_content_scope: meta.field.identifier.erlang
               - include: immediatelly-pop
             - - include: variable-anonymous-pop
               - include: variable-other-field

--- a/Erlang/Indexed Reference List.tmPreferences
+++ b/Erlang/Indexed Reference List.tmPreferences
@@ -3,11 +3,11 @@
 <dict>
 	<key>scope</key>
 	<string>
-		source.erlang meta.record.name variable.other.record,
-		source.erlang meta.function-call.name constant.language.macro,
-		source.erlang meta.function-call.name constant.other.macro,
-		source.erlang meta.type-call.name storage.type,
-		source.erlang meta.type-call.name support.type
+		source.erlang meta.record.identifier variable.other.record,
+		source.erlang meta.function-call.identifier constant.language.macro,
+		source.erlang meta.function-call.identifier constant.other.macro,
+		source.erlang meta.type-call.identifier storage.type,
+		source.erlang meta.type-call.identifier support.type
 	</string>
 	<key>settings</key>
 	<dict>

--- a/Erlang/Symbol List - Function Definition.tmPreferences
+++ b/Erlang/Symbol List - Function Definition.tmPreferences
@@ -3,8 +3,8 @@
 <dict>
 	<key>scope</key>
 	<string>
-		source.erlang meta.function.name constant.other.macro,
-		source.erlang meta.function.name entity.name.function
+		source.erlang meta.function.identifier constant.other.macro,
+		source.erlang meta.function.identifier entity.name.function
 	</string>
 	<key>settings</key>
 	<dict>

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -475,8 +475,8 @@ list_tests() -> .
     [2 || is_integer(2)]
 %  ^ - meta.sequence
 %   ^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
-%         ^^^^^^^^^^ meta.function-call.name.erlang - meta.function-call.arguments.erlang
-%                   ^^^ meta.function-call.arguments.erlang - meta.function-call.name.erlang
+%         ^^^^^^^^^^ meta.function-call.identifier.erlang - meta.function-call.arguments.erlang
+%                   ^^^ meta.function-call.arguments.erlang - meta.function-call.identifier.erlang
 %                       ^ - meta.sequence
 %   ^ punctuation.section.sequence.begin.erlang
 %    ^ constant.numeric.integer.decimal.erlang
@@ -520,7 +520,7 @@ map_tests() -> .
 %                     ^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                      ^^^^^^^^ meta.mapping.key.erlang - meta.mapping.value.erlang - meta.mapping.erlang meta.sequence.tuple.erlang
 %                              ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
-%                                ^^^^^ meta.mapping.value.erlang - meta.mapping.key.erlang - meta.mapping.erlang meta.function-call.name.erlang
+%                                ^^^^^ meta.mapping.value.erlang - meta.mapping.key.erlang - meta.mapping.erlang meta.function-call.identifier.erlang
 %                                     ^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                                      ^^^ meta.mapping.key.erlang - meta.mapping.value.erlang - meta.mapping.erlang
 %                                         ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
@@ -570,7 +570,7 @@ map_tests() -> .
 %                     ^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                      ^^^^^^^^^^^^^^ meta.mapping.key.erlang - meta.mapping.value.erlang - meta.mapping.erlang meta.sequence.tuple.erlang
 %                                    ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
-%                                      ^^^^^^^^ meta.mapping.value.erlang - meta.mapping.key.erlang - meta.mapping.erlang meta.function-call.name.erlang
+%                                      ^^^^^^^^ meta.mapping.value.erlang - meta.mapping.key.erlang - meta.mapping.erlang meta.function-call.identifier.erlang
 %                                              ^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                                               ^^^^^ meta.mapping.key.erlang - meta.mapping.value.erlang - meta.mapping.erlang
 %                                                    ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
@@ -1549,7 +1549,7 @@ preprocessor_define_tests() -> .
 %   ^^^^^^^ meta.preprocessor.define.erlang - meta.preprocessor.define.arguments.erlang
 %          ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.define.arguments.erlang
 %          ^ - meta.macro
-%           ^^^^ meta.macro.name.erlang - meta.macro.parameters
+%           ^^^^ meta.macro.identifier.erlang - meta.macro.parameters
 %               ^^^^^^ meta.macro.parameters.erlang
 %                     ^ - meta.macro
 %                       ^^^^^^^^^^^^ meta.sequence.tuple.erlang
@@ -1575,10 +1575,10 @@ preprocessor_define_tests() -> .
 %   ^^^^^^^ meta.preprocessor.define.erlang - meta.preprocessor.define.arguments.erlang
 %          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.define.arguments.erlang
 %          ^ - meta.macro
-%           ^^^^^^ meta.macro.name.erlang - meta.macro.parameters
+%           ^^^^^^ meta.macro.identifier.erlang - meta.macro.parameters
 %                 ^^^ meta.macro.parameters.erlang
 %                    ^ - meta.macro
-%                      ^^^^^^^ meta.function-call.name.erlang
+%                      ^^^^^^^ meta.function-call.identifier.erlang
 %                             ^^^ meta.function-call.arguments.erlang
 %                                         ^ meta.preprocessor.define.erlang - meta.preprocessor.define.arguments.erlang
 %   ^ punctuation.definition.keyword.erlang - keyword
@@ -1610,7 +1610,7 @@ preprocessor_define_tests() -> .
 %                                               ^^^^^^^^^^^^^^^ meta.sequence.list.erlang 
 %           ^^^^^^ meta.path.erlang support.namespace.erlang
 %                 ^ meta.path.erlang punctuation.accessor.double-colon.erlang
-%                  ^^^^^ meta.path.erlang meta.function-call.name.erlang support.function.erlang
+%                  ^^^^^ meta.path.erlang meta.function-call.identifier.erlang support.function.erlang
 %                       ^ punctuation.section.arguments.begin.erlang
 %                        ^^^ variable.other.erlang
 %                           ^ punctuation.accessor.dot.erlang
@@ -1633,7 +1633,7 @@ preprocessor_define_tests() -> .
 %       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.exception.try.erlang
 %                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.exception.catch.erlang
 %                                                                                         ^^^ meta.exception.try.erlang
-%           ^^^^ meta.function-call.name.erlang
+%           ^^^^ meta.function-call.identifier.erlang
 %               ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang
 %       ^^^ keyword.control.exception.try.erlang
 %           ^^^^ support.function.erlang
@@ -1725,19 +1725,19 @@ preprocessor_export_tests() -> .
 %                                                                 ^ meta.preprocessor.export.erlang - meta.preprocessor.export.arguments.erlang
 %           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
 %            ^^^^^^^^^^ meta.reference.function.name.erlang
-%                      ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                      ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                       ^ meta.reference.function.arity.erlang
 %                          ^^^^^^^ meta.reference.function.name.erlang
-%                                 ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                 ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                  ^^ meta.reference.function.arity.erlang
 %                                      ^^^^ meta.reference.function.name.erlang
-%                                          ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                          ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                           ^ meta.reference.function.arity.erlang
 %                                              ^^^^^^ meta.reference.function.name.erlang
-%                                                    ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                    ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                     ^ meta.reference.function.arity.erlang
 %                                                        ^^^^^^ meta.reference.function.name.erlang
-%                                                              ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity%   ^ punctuation.definition.keyword.erlang - keyword
+%                                                              ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity%   ^ punctuation.definition.keyword.erlang - keyword
 %    ^^^^^^ keyword.control.directive.export.erlang
 %          ^ punctuation.section.arguments.begin.erlang
 %           ^ punctuation.section.sequence.begin.erlang
@@ -1820,19 +1820,19 @@ preprocessor_export_tests() -> .
 %                                                                      ^ meta.preprocessor.export.erlang - meta.preprocessor.export.arguments.erlang
 %                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
 %                 ^^^^^^^^^^ meta.reference.function.name.erlang
-%                           ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                           ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                            ^ meta.reference.function.arity.erlang
 %                               ^^^^^^^ meta.reference.function.name.erlang
-%                                      ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                      ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                       ^^ meta.reference.function.arity.erlang
 %                                           ^^^^ meta.reference.function.name.erlang
-%                                               ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                               ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                ^ meta.reference.function.arity.erlang
 %                                                   ^^^^^^ meta.reference.function.name.erlang
-%                                                         ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                         ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                          ^ meta.reference.function.arity.erlang
 %                                                             ^^^^^^ meta.reference.function.name.erlang
-%                                                                   ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                                   ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %   ^ punctuation.definition.keyword.erlang - keyword
 %    ^^^^^^^^^^^ keyword.control.directive.export.erlang
 %               ^ punctuation.section.arguments.begin.erlang
@@ -1991,19 +1991,19 @@ preprocessor_import_tests() -> .
 %                                                                  ^ meta.preprocessor.import.erlang - meta.preprocessor.import.arguments.erlang
 %            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
 %             ^^^^^^^^^^ meta.reference.function.name.erlang
-%                       ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                       ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                        ^ meta.reference.function.arity.erlang
 %                           ^^^^^^^ meta.reference.function.name.erlang
-%                                  ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                  ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                   ^^ meta.reference.function.arity.erlang
 %                                       ^^^^ meta.reference.function.name.erlang
-%                                           ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                           ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                            ^ meta.reference.function.arity.erlang
 %                                               ^^^^^^ meta.reference.function.name.erlang
-%                                                     ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                     ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                      ^ meta.reference.function.arity.erlang
 %                                                         ^^^^^^ meta.reference.function.name.erlang
-%                                                               ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                               ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %   ^ punctuation.definition.keyword.erlang - keyword
 %    ^^^^^^ keyword.control.directive.import.erlang
 %          ^ punctuation.section.arguments.begin.erlang
@@ -2036,19 +2036,19 @@ preprocessor_import_tests() -> .
 %                                                                         ^ meta.preprocessor.import.erlang - meta.preprocessor.import.arguments.erlang
 %                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
 %                    ^^^^^^^^^^ meta.reference.function.name.erlang
-%                              ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                              ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                               ^ meta.reference.function.arity.erlang
 %                                  ^^^^^^^ meta.reference.function.name.erlang
-%                                         ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                         ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                          ^^ meta.reference.function.arity.erlang
 %                                              ^^^^ meta.reference.function.name.erlang
-%                                                  ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                  ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                   ^ meta.reference.function.arity.erlang
 %                                                      ^^^^^^ meta.reference.function.name.erlang
-%                                                            ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                            ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                                                             ^ meta.reference.function.arity.erlang
 %                                                                ^^^^^^ meta.reference.function.name.erlang
-%                                                                      ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                                                                      ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %   ^ punctuation.definition.keyword.erlang - keyword
 %    ^^^^^^ keyword.control.directive.import.erlang
 %          ^ punctuation.section.arguments.begin.erlang
@@ -2364,7 +2364,7 @@ preprocessor_onload_tests() -> .
 %   ^^^^^^^^ meta.preprocessor.attribute.erlang - meta.preprocessor.attribute.arguments.erlang
 %           ^^^^^^^^^^^^ meta.preprocessor.attribute.arguments.erlang
 %            ^^^^^^^^ meta.reference.function.name.erlang
-%                    ^ meta.reference.function.erlang - meta.reference.name - mete.reference.arity
+%                    ^ meta.reference.function.erlang - meta.reference.identifier - mete.reference.arity
 %                     ^ meta.reference.function.arity.erlang
 %                       ^ meta.preprocessor.attribute.erlang - meta.preprocessor.attribute.arguments.erlang
 %   ^ punctuation.definition.keyword.erlang - keyword
@@ -2771,7 +2771,7 @@ preprocessor_spec_tests() -> .
 %                   ^ source.erlang meta.preprocessor.spec.parameters.erlang punctuation.section.parameters.begin.erlang
                       Tag :: trace_tag() | seq_trace,
 %                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.preprocessor.spec.parameters.erlang
-%                            ^^^^^^^^^ meta.type-call.name.erlang
+%                            ^^^^^^^^^ meta.type-call.identifier.erlang
 %                                     ^^ meta.type-call.arguments.erlang
 %                                                   ^^ source.erlang meta.preprocessor.spec.parameters.erlang
 %                     ^^^ variable.parameter.erlang
@@ -2798,7 +2798,7 @@ preprocessor_spec_tests() -> .
 %                               ^^^^ keyword.control.conditional.when.erlang
                       Tag :: string(),
 %                    ^^^^^^^^^^^^^^^^^^ source.erlang meta.preprocessor.spec.guards.erlang
-%                            ^^^^^^ meta.type-call.name.erlang - meta.type-call.arguments.erlang
+%                            ^^^^^^ meta.type-call.identifier.erlang - meta.type-call.arguments.erlang
 %                                  ^^ meta.type-call.arguments.erlang
 %                     ^^^ variable.other.erlang
 %                         ^^ punctuation.separator.variable-type.erlang
@@ -3055,8 +3055,8 @@ preprocessor_type_tests() -> .
 %          ^^^^^^^^^^^^^^^^^^^^ source.erlang meta.preprocessor.type.erlang
 %              ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                ^^^^^^ meta.mapping.key.erlang - meta.mapping.erlang - meta.mapping.value.erlang
-%                ^^^ meta.type-call.name.erlang - meta.type-call.arguments.erlang
-%                   ^^ meta.type-call.arguments.erlang - meta.type-call.name.erlang
+%                ^^^ meta.type-call.identifier.erlang - meta.type-call.arguments.erlang
+%                   ^^ meta.type-call.arguments.erlang - meta.type-call.identifier.erlang
 %                      ^^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
 %                        ^^^^ meta.mapping.value.erlang - meta.mapping.erlang - meta.mapping.key.erlang
 %                            ^ meta.mapping.erlang - meta.mapping.key.erlang - meta.mapping.value.erlang
@@ -3158,8 +3158,8 @@ preprocessor_type_tests() -> .
 %       ^ - meta.sequence
 %        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang - meta.sequence.tuple.erlang
 %                     ^^^^^^^ source.erlang meta.preprocessor.type.erlang meta.path.erlang - meta.type-call
-%                            ^^^^^^^ source.erlang meta.preprocessor.type.erlang meta.path.erlang meta.type-call.name.erlang - meta.type-call.arguments.erlang
-%                                   ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang
+%                            ^^^^^^^ source.erlang meta.preprocessor.type.erlang meta.path.erlang meta.type-call.identifier.erlang - meta.type-call.arguments.erlang
+%                                   ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang
 %                                        ^^^^^^^^^^^^^^^^^^^ meta.sequence.list.erlang meta.sequence.tuple.erlang
 %                                                           ^^ meta.sequence.list.erlang - meta.sequence.tuple.erlang
 %                                                             ^ - meta.type - meta.sequence
@@ -3189,8 +3189,8 @@ preprocessor_fun_type_tests() -> .
 -type fun() :: fun().
 %     ^^^ entity.name.type.erlang
 %             ^ - meta.type-call
-%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.name.erlang - meta.type-call.arguments - meta.fun
-%                 ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun
+%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.identifier.erlang - meta.type-call.arguments - meta.fun
+%                 ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun
 %                   ^ - meta.type-call
 %              ^^^ support.type.erlang
 %                 ^ punctuation.section.arguments.begin.erlang
@@ -3199,10 +3199,10 @@ preprocessor_fun_type_tests() -> .
 
 -type fun() :: fun(()).
 %             ^ - meta.type-call
-%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.name.erlang - meta.type-call.arguments - meta.fun
-%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun
+%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.identifier.erlang - meta.type-call.arguments - meta.fun
+%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun
 %                  ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.parameters.erlang
-%                    ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun
+%                    ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun
 %                     ^ - meta.type-call
 %              ^^^ support.type.erlang
 %                 ^ punctuation.section.arguments.begin.erlang
@@ -3224,11 +3224,11 @@ preprocessor_fun_type_tests() -> .
 %                         ^ punctuation.section.arguments.end.erlang
 
 -type fun() :: fun(() -> int()).
-%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.name.erlang - meta.type-call.arguments.erlang
-%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun.parameters.erlang
+%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.identifier.erlang - meta.type-call.arguments.erlang
+%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun.parameters.erlang
 %                  ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.parameters.erlang
 %                    ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
-%                       ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang - meta.type-call.name.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
+%                       ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang - meta.type-call.identifier.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
 %                        ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
 %                           ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.arguments.erlang
 %                             ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
@@ -3244,12 +3244,12 @@ preprocessor_fun_type_tests() -> .
 %                              ^ punctuation.terminator.clause.erlang
 
 -type fun() :: fun((...) -> int()).
-%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.name.erlang - meta.type-call.arguments.erlang
-%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun.parameters.erlang
+%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.identifier.erlang - meta.type-call.arguments.erlang
+%                 ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun.parameters.erlang
 %                  ^^^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.parameters.erlang
 %                       ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
-%                          ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang - meta.type-call.name.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
-%                           ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.name.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
+%                          ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang - meta.type-call.identifier.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
+%                           ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.identifier.erlang - meta.type-call.arguments.erlang meta.type-call.arguments.erlang
 %                              ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.arguments.erlang
 %                                ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
 %              ^^^ support.type.erlang
@@ -3265,12 +3265,12 @@ preprocessor_fun_type_tests() -> .
 %                                 ^ punctuation.terminator.clause.erlang
 
 -type fun() :: fun( ( Key , int () , AccIn :: bool () ) -> AccOut :: void() ) .
-%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.name.erlang
-%                 ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.name.erlang - meta.fun.parameters.erlang
+%              ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.identifier.erlang
+%                 ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.type-call.identifier.erlang - meta.fun.parameters.erlang
 %                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.parameters.erlang
 %                                                      ^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
 %                                                         ^^^^^^^^^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang
-%                                                                    ^^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.name.erlang
+%                                                                    ^^^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.identifier.erlang
 %                                                                        ^^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang meta.type-call.arguments.erlang
 %                                                                          ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang meta.fun.return-type.erlang
 %                                                                           ^ source.erlang meta.preprocessor.type.erlang meta.type-call.arguments.erlang - meta.fun.parameters.erlang - meta.fun.return-type.erlang
@@ -3486,28 +3486,28 @@ preprocessor_record_tests() -> .
     -record(name, {field1="val1", Field2=3::integer()|Atom, field3, 'Field-4'={}, field5::tuple(), _=atom} illegal).
 %   ^^^^^^^ meta.preprocessor.record.erlang - meta.preprocessor.record.arguments.erlang
 %          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.record.arguments.erlang
-%                  ^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                        ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                         ^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.type.erlang
+%                  ^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                        ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                         ^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.type.erlang
 %                               ^ - meta.field
-%                                ^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                       ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                        ^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.type.erlang
+%                                ^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                       ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                        ^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.type.erlang
 %                                         ^^ meta.field.erlang - meta.field.value - meta.field.type
-%                                           ^^^^^^^^^^^^^^ meta.field.type.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
+%                                           ^^^^^^^^^^^^^^ meta.field.type.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
 %                                                         ^ - meta.field
-%                                                          ^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                                          ^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
 %                                                                 ^ - meta.field
-%                                                                  ^^^^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                                                            ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                                                             ^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.type.erlang
+%                                                                  ^^^^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                                                            ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                                                             ^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.type.erlang
 %                                                                               ^ - meta.field
-%                                                                                ^^^^^^^ meta.field.name.erlang
-%                                                                                       ^^ meta.field.erlang - meta.field.name - meta.field.type
-%                                                                                         ^^^^^^^ meta.field.type.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                                                                                  ^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                                                                                   ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang - meta.field.type.erlang
-%                                                                                                    ^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang - meta.field.type.erlang
+%                                                                                ^^^^^^^ meta.field.identifier.erlang
+%                                                                                       ^^ meta.field.erlang - meta.field.identifier - meta.field.type
+%                                                                                         ^^^^^^^ meta.field.type.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                                                                                  ^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                                                                                   ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang - meta.field.type.erlang
+%                                                                                                    ^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang - meta.field.type.erlang
 %                                                                                                        ^ - meta.field
 %                                                                                                                  ^ meta.preprocessor.record.erlang - meta.preprocessor.record.arguments.erlang
 %   ^ punctuation.definition.keyword.erlang - keyword
@@ -3624,11 +3624,11 @@ preprocessor_record_tests() -> .
     #record
 %  ^ - meta.record - variable
 %   ^ punctuation.definition.record.erlang
-%    ^^^^^^ meta.record.name.erlang variable.other.record.erlang
+%    ^^^^^^ meta.record.identifier.erlang variable.other.record.erlang
 
     #record.
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
 %           ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
@@ -3636,9 +3636,9 @@ preprocessor_record_tests() -> .
 
     #record.field
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
-%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
@@ -3647,9 +3647,9 @@ preprocessor_record_tests() -> .
 
     #record.Field
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
-%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
@@ -3658,9 +3658,9 @@ preprocessor_record_tests() -> .
 
     #record.'field-name'
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
-%           ^^^^^^^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%           ^^^^^^^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                       ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
@@ -3671,9 +3671,9 @@ preprocessor_record_tests() -> .
 
     #'atomic-record'.'field-name'
 %  ^ - meta.record
-%   ^^^^^^^^^^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%                   ^ meta.record.erlang - meta.record.name - meta.record.field
-%                    ^^^^^^^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^^^^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%                   ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%                    ^^^^^^^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                                ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^ punctuation.definition.atom.begin.erlang
@@ -3687,9 +3687,9 @@ preprocessor_record_tests() -> .
 
     #?MACRO.field
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
-%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%           ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^ punctuation.definition.macro.erlang
@@ -3699,9 +3699,9 @@ preprocessor_record_tests() -> .
 
     #?MACRO . field
 %  ^ - meta.record
-%   ^^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%           ^ meta.record.erlang - meta.record.name - meta.record.field
-%            ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%           ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%            ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                  ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^ punctuation.definition.macro.erlang
@@ -3713,9 +3713,9 @@ preprocessor_record_tests() -> .
 
     #?'MACRO'.field
 %  ^ - meta.record
-%   ^^^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%            ^ meta.record.erlang - meta.record.name - meta.record.field
-%             ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%            ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%             ^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                  ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^ punctuation.definition.macro.erlang
@@ -3725,9 +3725,9 @@ preprocessor_record_tests() -> .
 
     #?'MACRO' . field
 %  ^ - meta.record
-%   ^^^^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%             ^ meta.record.erlang - meta.record.name - meta.record.field
-%              ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%             ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%              ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                    ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^ punctuation.definition.macro.erlang
@@ -3738,9 +3738,9 @@ preprocessor_record_tests() -> .
 
     #record.?field
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.erlang - meta.record.field
-%          ^ meta.record.erlang - meta.record.name - meta.record.field
-%           ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.erlang - meta.record.field
+%          ^ meta.record.erlang - meta.record.identifier - meta.record.field
+%           ^^^^^^ meta.record.field.erlang - meta.record.erlang - meta.record.identifier
 %                 ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %          ^ punctuation.accessor.dot.erlang
@@ -3752,15 +3752,15 @@ local_record_definition_tests() -> .
     #'atomic-record'
 %  ^ - meta.record - variable
 %   ^ punctuation.definition.record.erlang
-%   ^^^^^^^^^^^^^^^^ meta.record.name.erlang - meta.record.fields
+%   ^^^^^^^^^^^^^^^^ meta.record.identifier.erlang - meta.record.fields
 %    ^ punctuation.definition.atom.begin.erlang
 %    ^^^^^^^^^^^^^^^ variable.other.record.erlang
 %           ^ - keyword - punctuation
 %                  ^ punctuation.definition.atom.end.erlang
 
     #record{}
-%   ^^^^^^^ meta.record.name.erlang - meta.record.fields.erlang
-%          ^^ meta.record.fields.erlang - meta.record.name
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.fields.erlang
+%          ^^ meta.record.fields.erlang - meta.record.identifier
 %            ^ - meta.record
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
@@ -3769,29 +3769,29 @@ local_record_definition_tests() -> .
 
     #record{field1="val1", Field2=3, field3, 'Field-4'={}, _=atom, ?FIELD=undefined}
 %  ^ - meta.record
-%   ^^^^^^^ meta.record.name.erlang - meta.record.fields.erlang
-%          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.record.fields.erlang - meta.record.name
-%           ^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                 ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                  ^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%   ^^^^^^^ meta.record.identifier.erlang - meta.record.fields.erlang
+%          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.record.fields.erlang - meta.record.identifier
+%           ^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                 ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                  ^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                        ^ - meta.field
-%                         ^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                                ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                 ^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%                         ^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                                ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                 ^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                                  ^ - meta.field
-%                                   ^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
+%                                   ^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
 %                                          ^ - meta.field
-%                                           ^^^^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                                                     ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                                      ^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%                                           ^^^^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                                                     ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                                      ^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                                                        ^ - meta.field
-%                                                         ^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                                                           ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                                            ^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%                                                         ^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                                                           ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                                            ^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                                                                ^ - meta.field
-%                                                                 ^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                                                                        ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                                                         ^^^^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%                                                                 ^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                                                                        ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                                                         ^^^^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                                                                                  ^ - meta.field
 %                                                                                    ^ - meta.record
 %   ^ punctuation.definition.record.erlang
@@ -3825,8 +3825,8 @@ local_record_definition_tests() -> .
 
     #record {
 %  ^ - meta.record
-%   ^^^^^^^^ meta.record.name.erlang - meta.record.fields.erlang
-%           ^^ meta.record.fields.erlang - meta.record.name
+%   ^^^^^^^^ meta.record.identifier.erlang - meta.record.fields.erlang
+%           ^^ meta.record.fields.erlang - meta.record.identifier
 %   ^ punctuation.definition.record.erlang
 %    ^^^^^^ variable.other.record.erlang
 %           ^ punctuation.section.fields.begin.erlang
@@ -3858,11 +3858,11 @@ local_record_definition_tests() -> .
 
     Expr#'record-name'{'field-name'='value-name','Field-name'="string"}
 %   ^^^^ variable.other.erlang
-%       ^^^^^^^^^^^^^^ meta.record.name.erlang - meta.record.fields
-%                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.record.fields.erlang - meta.record.name
-%                      ^^^^^^^^^^^^ meta.field.name.erlang - meta.field.erlang - meta.field.value.erlang
-%                                  ^ meta.field.erlang - meta.field.name.erlang - meta.field.value.erlang
-%                                   ^^^^^^^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.name.erlang
+%       ^^^^^^^^^^^^^^ meta.record.identifier.erlang - meta.record.fields
+%                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.record.fields.erlang - meta.record.identifier
+%                      ^^^^^^^^^^^^ meta.field.identifier.erlang - meta.field.erlang - meta.field.value.erlang
+%                                  ^ meta.field.erlang - meta.field.identifier.erlang - meta.field.value.erlang
+%                                   ^^^^^^^^^^^^ meta.field.value.erlang - meta.field.erlang - meta.field.identifier.erlang
 %                                                                      ^ - meta.record
 %       ^ punctuation.definition.record.erlang
 %        ^ punctuation.definition.atom.begin.erlang
@@ -3889,8 +3889,8 @@ local_record_definition_tests() -> .
 
     Expr#'record-name'{
 %   ^^^^ variable.other.erlang
-%       ^^^^^^^^^^^^^^ meta.record.name.erlang - meta.record.fields
-%                     ^^ meta.record.fields.erlang - meta.record.name
+%       ^^^^^^^^^^^^^^ meta.record.identifier.erlang - meta.record.fields
+%                     ^^ meta.record.fields.erlang - meta.record.identifier
 %       ^ punctuation.definition.record.erlang
 %        ^ punctuation.definition.atom.begin.erlang
 %        ^^^^^^^^^^^^^ variable.other.record.erlang
@@ -3898,13 +3898,13 @@ local_record_definition_tests() -> .
 %                    ^ punctuation.definition.atom.end.erlang
 %                     ^ punctuation.section.fields.begin.erlang
         'field-name'
-%      ^^^^^^^^^^^^^^ meta.record.fields.erlang meta.field.name.erlang
+%      ^^^^^^^^^^^^^^ meta.record.fields.erlang meta.field.identifier.erlang
 %       ^ punctuation.definition.atom.begin.erlang
 %       ^^^^^^^^^^^^ variable.other.field.erlang
 %                  ^ punctuation.definition.atom.end.erlang
         =
 %      ^^^ meta.record.fields.erlang
-%      ^ meta.field.name.erlang
+%      ^ meta.field.identifier.erlang
 %       ^ meta.field.erlang
 %        ^ meta.field.value.erlang
 %       ^ keyword.operator.assignment.erlang
@@ -3918,13 +3918,13 @@ local_record_definition_tests() -> .
 %       ^ meta.record.fields.erlang - meta.field
 %       ^ punctuation.separator.expressions.erlang
         'Field-name'
-%      ^^^^^^^^^^^^^^ meta.record.fields.erlang meta.field.name.erlang
+%      ^^^^^^^^^^^^^^ meta.record.fields.erlang meta.field.identifier.erlang
 %       ^ punctuation.definition.atom.begin.erlang
 %       ^^^^^^^^^^^ variable.other.field.erlang
 %                  ^ punctuation.definition.atom.end.erlang
         =
 %      ^^^ meta.record.fields.erlang
-%      ^ meta.field.name.erlang
+%      ^ meta.field.identifier.erlang
 %       ^ meta.field.erlang
 %        ^ meta.field.value.erlang
 %       ^ keyword.operator.assignment.erlang
@@ -3943,13 +3943,13 @@ local_record_definition_tests() -> .
 
     "nested0" = N2#nrec2.nrec1#nrec1.nrec0#nrec0.name,
 %                ^ - meta.record
-%                 ^^^^^^ meta.record.name.erlang
+%                 ^^^^^^ meta.record.identifier.erlang
 %                       ^ meta.record.erlang
 %                        ^^^^^ meta.record.field.erlang
-%                             ^^^^^^ meta.record.name.erlang
+%                             ^^^^^^ meta.record.identifier.erlang
 %                                   ^ meta.record.erlang
 %                                    ^^^^^ meta.record.field.erlang
-%                                         ^^^^^^ meta.record.name.erlang
+%                                         ^^^^^^ meta.record.identifier.erlang
 %                                               ^ meta.record.erlang
 %                                                ^^^^ meta.record.field.erlang
 %               ^^ variable.other.erlang
@@ -3969,13 +3969,13 @@ local_record_definition_tests() -> .
 
     N0n = N2#nrec2.nrec1#nrec1.nrec0#nrec0{name = "nested0a"},
 %          ^ - meta.record
-%           ^^^^^^ meta.record.name.erlang
+%           ^^^^^^ meta.record.identifier.erlang
 %                 ^ meta.record.erlang
 %                  ^^^^^ meta.record.field.erlang
-%                       ^^^^^^ meta.record.name.erlang
+%                       ^^^^^^ meta.record.identifier.erlang
 %                             ^ meta.record.erlang
 %                              ^^^^^ meta.record.field.erlang
-%                                   ^^^^^^ meta.record.name.erlang
+%                                   ^^^^^^ meta.record.identifier.erlang
 %                                         ^^^^^^^^^^^^^^^^^^^ meta.record.fields.erlang
 %                                                            ^ - meta.record
 %         ^^ variable.other.erlang
@@ -3996,22 +3996,22 @@ local_record_definition_tests() -> .
 % Function tests
 
 func_name(.)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ meta.function.parameters.erlang punctuation.section.parameters.begin.erlang
 %         ^ meta.function.erlang punctuation.terminator.clause.erlang
 %          ^ invalid.illegal.stray.erlang
 
 func_name(;)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ meta.function.parameters.erlang punctuation.section.parameters.begin.erlang
 %         ^ meta.function.erlang punctuation.separator.clauses.erlang
 %          ^ invalid.illegal.stray.erlang
 
 func_name( -> ;)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ punctuation.section.parameters.begin.erlang
 %        ^^ meta.function.parameters.erlang
 %          ^^ meta.function.erlang punctuation.separator.clause-head-body.erlang
@@ -4019,8 +4019,8 @@ func_name( -> ;)
 %              ^ invalid.illegal.stray.erlang
 
 func_name( when .)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ punctuation.section.parameters.begin.erlang
 %        ^^ meta.function.parameters.erlang
 %          ^^^^ meta.function.erlang keyword.control.conditional.when.erlang
@@ -4029,8 +4029,8 @@ func_name( when .)
 %                ^ invalid.illegal.stray.erlang
 
 func_name({[( -> ;)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ punctuation.section.parameters.begin.erlang
 %        ^^^^^ meta.function.parameters.erlang
 %             ^^ meta.function.erlang punctuation.separator.clause-head-body.erlang
@@ -4038,8 +4038,8 @@ func_name({[( -> ;)
 %                 ^ invalid.illegal.stray.erlang
 
 func_name({[( when .)
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %        ^ punctuation.section.parameters.begin.erlang
 %        ^^^^^ meta.function.parameters.erlang
 %             ^^^^ meta.function.erlang keyword.control.conditional.when.erlang
@@ -4048,8 +4048,8 @@ func_name({[( when .)
 %                   ^ invalid.illegal.stray.erlang
 
 func_name ( )
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^ punctuation.section.parameters.begin.erlang
 %         ^^^ meta.function.parameters.erlang
 %           ^ punctuation.section.parameters.end.erlang
@@ -4059,8 +4059,8 @@ func_name ( )
 %    ^ - meta.function.erlang
 
 func_name ( )
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^ punctuation.section.parameters.begin.erlang
 %         ^^^ meta.function.parameters.erlang
 %           ^ punctuation.section.parameters.end.erlang
@@ -4071,8 +4071,8 @@ func_name ( )
 
 
 func_name ( ) ->
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^ punctuation.section.parameters.begin.erlang
 %         ^^^ meta.function.parameters.erlang
 %           ^ punctuation.section.parameters.end.erlang
@@ -4083,8 +4083,8 @@ func_name ( ) ->
 %    ^ - meta.function.erlang
 
 func_name ( ) when true ->
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^^^ meta.function.parameters.erlang
 %            ^^^^^^^^^^^^^^ meta.function.erlang - meta.function.parameters.erlang.erlang
 %         ^ punctuation.section.parameters.begin.erlang
@@ -4097,8 +4097,8 @@ func_name ( ) when true ->
 %    ^ - meta.function.erlang
 
 func_name ( ) when is_list(), is_tuple(); is_atom() ->
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^^^ meta.function.parameters.erlang
 %            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang - meta.function.parameters
 %         ^ punctuation.section.parameters.begin.erlang
@@ -4119,8 +4119,8 @@ func_name ( ) when is_list(), is_tuple(); is_atom() ->
 %    ^ - meta.function.erlang
 
 func_name ( )
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 %         ^^^ meta.function.parameters.erlang
 %            ^ meta.function.erlang - meta.function.parameters.erlang.erlang
 %         ^ punctuation.section.parameters.begin.erlang
@@ -4139,8 +4139,8 @@ func_name ( )
 %    ^ - meta.function.erlang
 
 '2\'Bin'() -> .
-% <-  meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^ meta.function.name.erlang entity.name.function.erlang
+% <-  meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^ meta.function.identifier.erlang entity.name.function.erlang
 % <- punctuation.definition.atom.begin.erlang
 %      ^ punctuation.definition.atom.end.erlang
 %       ^ meta.function.parameters.erlang punctuation.section.parameters.begin.erlang
@@ -4149,24 +4149,24 @@ func_name ( )
 %             ^ meta.function.erlang punctuation.terminator.clause.erlang
 
 ?FUNC() -> .
-% <- meta.function.name.erlang constant.other.macro.erlang
-%^^^^ meta.function.name.erlang constant.other.macro.erlang
+% <- meta.function.identifier.erlang constant.other.macro.erlang
+%^^^^ meta.function.identifier.erlang constant.other.macro.erlang
 %    ^ meta.function.parameters.erlang punctuation.section.parameters.begin.erlang
 %     ^ meta.function.parameters.erlang punctuation.section.parameters.end.erlang
 %       ^^ meta.function.erlang punctuation.separator.clause-head-body.erlang
 %          ^ meta.function.erlang punctuation.terminator.clause.erlang
 
 ?'2\'Bin'() -> .
-%<- meta.function.name.erlang constant.other.macro.erlang
-%^^^^^^^^ meta.function.name.erlang constant.other.macro.erlang
+%<- meta.function.identifier.erlang constant.other.macro.erlang
+%^^^^^^^^ meta.function.identifier.erlang constant.other.macro.erlang
 %        ^ meta.function.parameters.erlang punctuation.section.parameters.begin.erlang
 %         ^ meta.function.parameters.erlang punctuation.section.parameters.end.erlang
 %           ^^ meta.function.erlang punctuation.separator.clause-head-body.erlang
 %              ^ meta.function.erlang punctuation.terminator.clause.erlang
 
 func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
-% <- meta.function.name.erlang entity.name.function.erlang
-%^^^^^^^^ meta.function.name.erlang
+% <- meta.function.identifier.erlang entity.name.function.erlang
+%^^^^^^^^ meta.function.identifier.erlang
 %        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.erlang
 %                       ^^^^^^^^^^^ meta.sequence.tuple.erlang
 %                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.binary.erlang
@@ -4197,12 +4197,12 @@ func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
 %                                                               ^ punctuation.section.parameters.end.erlang
 %                                                                 ^^ punctuation.separator.clause-head-body.erlang
     Identifier = lists:flatten(io_lib:format("~s:~s()", [Mod, Name])),
-%                      ^^^^^^^ meta.function-call.name.erlang - meta.function-call.arguments.erlang
-%                             ^ meta.function-call.arguments.erlang - meta.function-call.name.erlang
-%                              ^^^^^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.name.erlang meta.function-call.name.erlang
-%                                           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang meta.function-call.arguments.erlang - meta.function-call.name.erlang meta.function-call.arguments.erlang
+%                      ^^^^^^^ meta.function-call.identifier.erlang - meta.function-call.arguments.erlang
+%                             ^ meta.function-call.arguments.erlang - meta.function-call.identifier.erlang
+%                              ^^^^^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.identifier.erlang meta.function-call.identifier.erlang
+%                                           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang meta.function-call.arguments.erlang - meta.function-call.identifier.erlang meta.function-call.arguments.erlang
 %                                                       ^^^^^^^^^^^ meta.sequence.list
-%                                                                   ^ meta.function-call.arguments.erlang - meta.function-call.name.erlang - meta.function-call.arguments.erlang meta.function-call.arguments.erlang
+%                                                                   ^ meta.function-call.arguments.erlang - meta.function-call.identifier.erlang - meta.function-call.arguments.erlang meta.function-call.arguments.erlang
 %                                                                    ^ - meta.function-call
 %   ^^^^^^^^^^ variable.other.erlang
 %              ^ keyword.operator.assignment.erlang
@@ -4224,8 +4224,8 @@ func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
     io:format("~-*s", [Len, Identifier]).
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang
 %   ^^^ meta.path.erlang - meta.function-call
-%      ^^^^^^ meta.path.erlang meta.function-call.name.erlang - meta.function-call.arguments.erlang
-%            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.name - meta.path
+%      ^^^^^^ meta.path.erlang meta.function-call.identifier.erlang - meta.function-call.arguments.erlang
+%            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.identifier - meta.path
 %                      ^^^^^^^^^^^^^^^^ meta.sequence.list.erlang
 %                                       ^ - meta.function-call
 %   ^^ variable.namespace.erlang
@@ -4247,7 +4247,7 @@ func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
 %                                       ^ punctuation.terminator.clause.erlang
 
     foo(F,G) -> fun(E) -> F() end.
-%   ^^^ meta.function.name.erlang - meta.function.parameters.erlang
+%   ^^^ meta.function.identifier.erlang - meta.function.parameters.erlang
 %      ^^^^^ meta.function.parameters.erlang
 %           ^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang
 %   ^^^ entity.name.function.erlang
@@ -4261,7 +4261,7 @@ func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
 %                                ^ punctuation.terminator.clause.erlang
 
     fact(N) when N>0 ->  % first clause head
-%   ^^^^ meta.function.name.erlang - meta.function.parameters.erlang
+%   ^^^^ meta.function.identifier.erlang - meta.function.parameters.erlang
 %       ^^^ meta.function.parameters.erlang
 %           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang - meta.function.parameters.erlang
 %   ^^^^ entity.name.function.erlang
@@ -4280,7 +4280,7 @@ func_name(Mod, Name, _, {Enc,Depth}, <<Code:32/little-unsigned>>) ->
 %                    ^ punctuation.separator.clauses.erlang
 
     fact(0) ->           % second clause head
-%   ^^^^ meta.function.name.erlang - meta.function.parameters.erlang
+%   ^^^^ meta.function.identifier.erlang - meta.function.parameters.erlang
 %       ^^^ meta.function.parameters.erlang
 %          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang
 %   ^^^^ entity.name.function.erlang
@@ -4332,7 +4332,7 @@ case_tests() ->
 %      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.case.erlang
 %       ^^^^^^^^^^ meta.sequence.tuple.erlang
 %                 ^ - meta.sequence
-%                       ^^^^^^^^ meta.function-call.name.erlang
+%                       ^^^^^^^^ meta.function-call.identifier.erlang
 %                               ^^ meta.function-call.arguments.erlang
 %                  ^^^^ keyword.control.conditional.when.erlang
 %                       ^^^^^^^^ support.function.erlang
@@ -4389,7 +4389,7 @@ if_tests() ->
 %      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.if.erlang
 %       ^^^^^^^^^^ meta.sequence.tuple.erlang
 %                 ^ - meta.sequence
-%                       ^^^^^^^^ meta.function-call.name.erlang
+%                       ^^^^^^^^ meta.function-call.identifier.erlang
 %                               ^^ meta.function-call.arguments.erlang
 %                  ^^^^ keyword.control.conditional.when.erlang
 %                       ^^^^^^^^ support.function.erlang
@@ -4433,7 +4433,7 @@ function_call_tests() ->
     erlang:foo(X),
 %  ^ - meta.path
 %   ^^^^^^^ meta.path.erlang - meta.function-call
-%          ^^^ meta.path.erlang meta.function-call.name.erlang
+%          ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %             ^^^ meta.function-call.arguments.erlang - meta.path
 %                ^ - meta.path - meta.function-call
 %   ^^^^^^ support.namespace.erlang
@@ -4448,7 +4448,7 @@ function_call_tests() ->
 
     erlang:abs(X),
 %   ^^^^^^^ meta.path.erlang - meta.function-call
-%          ^^^ meta.path.erlang meta.function-call.name.erlang
+%          ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %             ^^^ meta.function-call.arguments.erlang - meta.path
 %                ^ - meta.path - meta.function-call
 %   ^^^^^^ support.namespace.erlang
@@ -4461,7 +4461,7 @@ function_call_tests() ->
 
     erlang : abs ( X ) ,
 %   ^^^^^^^^^ meta.path.erlang - meta.function-call
-%            ^^^^ meta.path.erlang meta.function-call.name.erlang
+%            ^^^^ meta.path.erlang meta.function-call.identifier.erlang
 %                ^^^^^ meta.function-call.arguments.erlang - meta.path
 %                     ^^ - meta.path - meta.function-call
 %   ^^^^^^ support.namespace.erlang
@@ -4476,7 +4476,7 @@ function_call_tests() ->
 
     module:abs(X),
 %   ^^^^^^^ meta.path.erlang - meta.function-call
-%          ^^^ meta.path.erlang meta.function-call.name.erlang
+%          ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %             ^^^ meta.function-call.arguments.erlang - meta.path
 %                ^ - meta.path - meta.function-call
 %   ^^^^^^ variable.namespace.erlang
@@ -4489,7 +4489,7 @@ function_call_tests() ->
 
     '\'od%le':abs(X),
 %   ^^^^^^^^^^ meta.path.erlang - meta.function-call
-%             ^^^ meta.path.erlang meta.function-call.name.erlang
+%             ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %                ^^^ meta.function-call.arguments.erlang - meta.path
 %                   ^ - meta.path - meta.function-call
 %   ^^^^^^^^^ variable.namespace.erlang
@@ -4502,7 +4502,7 @@ function_call_tests() ->
 
     'M\'od%le ' : abs ( X ),
 %   ^^^^^^^^^^^^^^ meta.path.erlang - meta.function-call
-%                 ^^^^ meta.path.erlang meta.function-call.name.erlang
+%                 ^^^^ meta.path.erlang meta.function-call.identifier.erlang
 %                     ^^^^^ meta.function-call.arguments.erlang - meta.path
 %                          ^ - meta.path - meta.function-call
 %   ^^^^^^^^^^^ variable.namespace.erlang
@@ -4517,7 +4517,7 @@ function_call_tests() ->
 
     Module:abs(X),
 %   ^^^^^^^ meta.path.erlang - meta.function-call
-%          ^^^ meta.path.erlang meta.function-call.name.erlang
+%          ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %             ^^^ meta.function-call.arguments.erlang - meta.path
 %                ^ - meta.path - meta.function-call
 %   ^^^^^^ variable.other.erlang
@@ -4530,7 +4530,7 @@ function_call_tests() ->
 
     ?MODULE:abs(X),
 %   ^^^^^^^^ meta.path.erlang - meta.function-call
-%           ^^^ meta.path.erlang meta.function-call.name.erlang
+%           ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %              ^^^ meta.function-call.arguments.erlang - meta.path
 %                 ^ - meta.path - meta.function-call
 %   ^ punctuation.definition.macro.erlang
@@ -4544,7 +4544,7 @@ function_call_tests() ->
 
     ?foo:abs(X),
 %   ^^^^^ meta.path.erlang - meta.function-call
-%        ^^^ meta.path.erlang meta.function-call.name.erlang
+%        ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %           ^^^ meta.function-call.arguments.erlang - meta.path
 %              ^ - meta.path - meta.function-call
 %   ^ punctuation.definition.macro.erlang
@@ -4558,7 +4558,7 @@ function_call_tests() ->
 
     ?'foo\'-%b':abs(X),
 %   ^^^^^^^^^^^^ meta.path.erlang - meta.function-call
-%               ^^^ meta.path.erlang meta.function-call.name.erlang
+%               ^^^ meta.path.erlang meta.function-call.identifier.erlang
 %                  ^^^ meta.function-call.arguments.erlang - meta.path
 %                     ^ - meta.path - meta.function-call
 %   ^ punctuation.definition.macro.erlang
@@ -4577,7 +4577,7 @@ function_call_tests() ->
 
     abs(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^ meta.function-call.name.erlang - meta.path
+%   ^^^ meta.function-call.identifier.erlang - meta.path
 %      ^^^ meta.function-call.arguments.erlang - meta.path
 %         ^ - meta.function-call - meta.path
 %   ^^^ support.function.erlang
@@ -4588,7 +4588,7 @@ function_call_tests() ->
 
     abs ( X ) ,
 %  ^ - meta.function-call - meta.path
-%   ^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^ meta.function-call.identifier.erlang - meta.path
 %       ^^^^^ meta.function-call.arguments.erlang - meta.path
 %            ^^^ - meta.function-call - meta.path
 %   ^^^ support.function.erlang
@@ -4600,7 +4600,7 @@ function_call_tests() ->
 
     abs@(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^ meta.function-call.identifier.erlang - meta.path
 %       ^^^ meta.function-call.arguments.erlang - meta.path
 %          ^ - meta.function-call - meta.path
 %   ^^^^ variable.function.erlang
@@ -4611,7 +4611,7 @@ function_call_tests() ->
 
     not@abs(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %          ^^^ meta.function-call.arguments.erlang - meta.path
 %             ^ - meta.function-call - meta.path
 %   ^^^^^^^ variable.function.erlang
@@ -4622,7 +4622,7 @@ function_call_tests() ->
 
     not_abs(X),
 %  ^ - meta.function-call
-%   ^^^^^^^ meta.function-call.name.erlang
+%   ^^^^^^^ meta.function-call.identifier.erlang
 %          ^^^ meta.function-call.arguments.erlang
 %             ^ - meta.function-call
 %   ^^^^^^^ variable.function.erlang
@@ -4635,7 +4635,7 @@ function_call_tests() ->
 
     'abs\''(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %          ^^^ meta.function-call.arguments.erlang - meta.path
 %             ^ - meta.function-call - meta.path
 %   ^^^^^^^ variable.function.erlang
@@ -4646,7 +4646,7 @@ function_call_tests() ->
 
     ' abs\' ' ( X ),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %             ^^^^^ meta.function-call.arguments.erlang - meta.path
 %                  ^ - meta.function-call - meta.path
 %   ^^^^^^^^^ variable.function.erlang
@@ -4660,7 +4660,7 @@ function_call_tests() ->
 
     '\'abs%\''(X),
 %  ^ - meta.function-call
-%   ^^^^^^^^^^ meta.function-call.name.erlang
+%   ^^^^^^^^^^ meta.function-call.identifier.erlang
 %             ^^^ meta.function-call.arguments.erlang
 %                ^ - meta.function-call
 %   ^^^^^^^^^^ variable.function.erlang
@@ -4671,7 +4671,7 @@ function_call_tests() ->
 
     ' \'abs%\' ' ( X ),
 %  ^ - meta.function-call
-%   ^^^^^^^^^^^^^ meta.function-call.name.erlang
+%   ^^^^^^^^^^^^^ meta.function-call.identifier.erlang
 %                ^^^^^ meta.function-call.arguments.erlang
 %                     ^ - meta.function-call
 %   ^^^^^^^^^^^^ variable.function.erlang
@@ -4685,7 +4685,7 @@ function_call_tests() ->
 
     ?FUNC(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^ meta.function-call.identifier.erlang - meta.path
 %        ^^^ meta.function-call.arguments.erlang - meta.path
 %           ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4697,7 +4697,7 @@ function_call_tests() ->
 
     ?ABS ( X ) ,
 %  ^ - meta.function-call - meta.path
-%   ^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^ meta.function-call.identifier.erlang - meta.path
 %        ^^^^^ meta.function-call.arguments.erlang - meta.path
 %             ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4710,7 +4710,7 @@ function_call_tests() ->
 
     ?'abs'(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^ meta.function-call.identifier.erlang - meta.path
 %         ^^^ meta.function-call.arguments.erlang - meta.path
 %            ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4724,7 +4724,7 @@ function_call_tests() ->
 
     ?'abs' ( X ) ,
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %          ^^^^^ meta.function-call.arguments.erlang - meta.path
 %               ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4739,7 +4739,7 @@ function_call_tests() ->
 
     ?'abs\''(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %           ^^^ meta.function-call.arguments.erlang - meta.path
 %              ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4753,7 +4753,7 @@ function_call_tests() ->
 
     ?' abs\' ' ( X ),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %              ^^^^^ meta.function-call.arguments.erlang - meta.path
 %                   ^ - meta.function-call - meta.path
 %   ^^^^^^^^^^ constant.other.macro.erlang - support.function
@@ -4765,7 +4765,7 @@ function_call_tests() ->
 
     ?'\'abs%\''(X),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %              ^^^ meta.function-call.arguments.erlang - meta.path
 %                 ^ - meta.function-call - meta.path
 %   ^^^^^^^^^^^ constant.other.macro.erlang - support.function
@@ -4776,7 +4776,7 @@ function_call_tests() ->
 
     ?' \'abs%\' ' ( X ),
 %  ^ - meta.function-call - meta.path
-%   ^^^^^^^^^^^^^^ meta.function-call.name.erlang - meta.path
+%   ^^^^^^^^^^^^^^ meta.function-call.identifier.erlang - meta.path
 %                 ^^^^^ meta.function-call.arguments.erlang - meta.path
 %                      ^ - meta.function-call - meta.path
 %   ^^^^^^^^^^^^^ constant.other.macro.erlang - support.function
@@ -4790,7 +4790,7 @@ function_call_tests() ->
 
     ?'2Bin'?abs(X),
 %         ^ - meta.function-call - meta.path
-%          ^^^^ meta.function-call.name.erlang - meta.path
+%          ^^^^ meta.function-call.identifier.erlang - meta.path
 %              ^^^ meta.function-call.arguments.erlang - meta.path
 %                 ^ - meta.function-call - meta.path
 %   ^ punctuation.definition.macro.erlang
@@ -4808,8 +4808,8 @@ function_call_tests() ->
 
     ?MODULE : ?FUNCTION_NAME ( X , Y ).
 %   ^^^^^^^^^^ meta.path.erlang - meta.function-call
-%             ^^^^^^^^^^^^^^^ meta.path.erlang meta.function-call.name.erlang - meta.function-call.arguments.erlang
-%                            ^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.name.erlang - meta.path
+%             ^^^^^^^^^^^^^^^ meta.path.erlang meta.function-call.identifier.erlang - meta.function-call.arguments.erlang
+%                            ^^^^^^^^^ meta.function-call.arguments.erlang - meta.function-call.identifier.erlang - meta.path
 %                                     ^ - meta.path - meta.function-call
 %   ^ punctuation.definition.macro.erlang
 %   ^^^^^^^ constant.language.macro.erlang
@@ -4890,7 +4890,7 @@ fun_expression_tests() ->
 
     Fun1 = fun name/10,
 %         ^ - meta.fun
-%          ^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.path
+%          ^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.path
 %                     ^ - meta.fun
 %   ^^^^ variable.other.erlang
 %        ^ keyword.operator.assignment.erlang
@@ -5007,7 +5007,7 @@ fun_expression_tests() ->
     Fun1 = fun abs(X) -> F = fun(Y) -> X+1 end, F(abs(X)) end,
 %         ^ - meta.fun
 %          ^^^^ meta.function.erlang meta.fun.erlang
-%              ^^^ meta.function.erlang meta.fun.name.erlang
+%              ^^^ meta.function.erlang meta.fun.identifier.erlang
 %                 ^^^ meta.function.erlang meta.fun.parameters.erlang
 %                    ^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun meta.fun
 %                            ^^^ meta.function.erlang meta.fun.erlang meta.fun.erlang
@@ -5045,11 +5045,11 @@ fun_expression_tests() ->
 
     Fun2 = fun (X) when X>=5 -> gt; (X) -> lt end,
 %         ^ - meta.fun
-%          ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
-%              ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.name
-%                 ^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters - meta.fun.name
-%                                   ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.name
-%                                      ^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
+%          ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
+%              ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.identifier
+%                 ^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters - meta.fun.identifier
+%                                   ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.identifier
+%                                      ^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
 %                                                ^ - meta.fun
 %   ^^^^ variable.other.erlang
 %        ^ keyword.operator.assignment.erlang
@@ -5075,13 +5075,13 @@ fun_expression_tests() ->
 
     Fun3 = fun Fact(1) -> 1; Fact(X) when X > 1 -> X * Fact(X - 1) end,
 %         ^ - meta.fun
-%          ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
-%              ^^^^ meta.function.erlang meta.fun.name.erlang - meta.fun.erlang - meta.fun.parameters
-%                  ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.name
-%                     ^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
-%                            ^^^^ meta.function.erlang meta.fun.name.erlang - meta.fun.erlang - meta.fun.parameters
-%                                ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.name
-%                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
+%          ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
+%              ^^^^ meta.function.erlang meta.fun.identifier.erlang - meta.fun.erlang - meta.fun.parameters
+%                  ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.identifier
+%                     ^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
+%                            ^^^^ meta.function.erlang meta.fun.identifier.erlang - meta.fun.erlang - meta.fun.parameters
+%                                ^^^ meta.function.erlang meta.fun.parameters.erlang - meta.fun.erlang - meta.fun.identifier
+%                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
 %                                                      ^^^^^^^^^^^ meta.function-call
 %                                                                     ^ - meta.fun
 %   ^^^^ variable.other.erlang
@@ -5122,7 +5122,7 @@ fun_expression_tests() ->
 %          ^^^ keyword.declaration.function.erlang
         (A, B) when A == true; is_tuple(B) ->
 %       ^^^^^^ meta.function.erlang meta.fun.parameters.erlang
-%             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
+%             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
 %                              ^^^^^^^^^^^ meta.function-call
 %       ^ punctuation.section.parameters.begin.erlang
 %        ^ variable.parameter.erlang
@@ -5149,7 +5149,7 @@ fun_expression_tests() ->
 
         (A, B) when C = #{A => B}, is_map(C); is_list(A++B) ->
 %       ^^^^^^ meta.function.erlang meta.fun.parameters.erlang
-%             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
+%             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
 %                       ^^^^^^^^^ meta.mapping
 %                                  ^^^^^^^^^ meta.function-call
 %                                             ^^^^^^^^^^^^^ meta.function-call
@@ -5171,7 +5171,7 @@ fun_expression_tests() ->
 
         (A, B) ->
 %       ^^^^^^ meta.function.erlang meta.fun.parameters.erlang
-%             ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.name - meta.fun.parameters
+%             ^^^^ meta.function.erlang meta.fun.erlang - meta.fun.identifier - meta.fun.parameters
 %       ^ punctuation.section.parameters.begin.erlang
 %        ^ variable.parameter.erlang
 %         ^ punctuation.separator.parameters.erlang


### PR DESCRIPTION
This commit renames all `meta.[function|macro|...].name` scopes to
`meta.[function|macro|...].identifier` because

1. the scope naming guideline uses `meta.annotation.identifier`
2. the identifier may consist of a qualifier and the name
3. this scope name is already used in syntaxes like Java.