### PR TITLE
[PHP] Fix typed property not highlighted in trait

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -55,6 +55,7 @@ contexts:
       captures:
         1: storage.type.trait.php
         2: entity.name.trait.php
+    - include: typed-property
     - include: function
     - match: '^\s*((?!default|else){{identifier}})\s*(:)(?!:)'
       captures:
@@ -591,6 +592,9 @@ contexts:
               pop: true
         - match: ','
           scope: punctuation.separator.php
+    - include: statements
+
+  typed-property:
     # https://wiki.php.net/rfc/typed_properties_v2
     - match: (?=\b(?:var|public|private|protected|static)\b)
       push:
@@ -606,7 +610,6 @@ contexts:
         # Exit on unexpected content
         - match: (?=\S)
           pop: true
-    - include: statements
 
   function:
     - match: (?i)(?=(?:\b(?:final|abstract|var|public|private|protected|static)\s+)*\bfunction\b\s*(&\s*)?{{identifier_start}})

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -894,7 +894,14 @@ trait A
 // ^ storage.type.trait
 //    ^ entity.name.trait
 {
-
+    public static ?Foo $str = '';
+//  ^^^^^^ storage.modifier
+//         ^^^^^^ storage.modifier
+//                ^ storage.type.nullable
+//                 ^^^ support.class
+//                     ^ punctuation.definition.variable
+//                      ^^^ variable.other
+//                          ^ keyword.operator.assignment
 }
 
 class B


### PR DESCRIPTION
Previously it's only done in the `class-body`.

```php
trait {
    public static ?Foo $str = '';
//                ^ storage.type.nullable
//                 ^^^ support.class
}
```

If the `st3` branch is still maintained, I can make a PR to it.

