### PR TITLE
[HTML] Consolidate tag/attribute name matching

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -22,8 +22,9 @@ variables:
   unquoted_attribute_break: (?=[{{ascii_space}}]|/?>)
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
-  tag_name_char: '[^{{ascii_space}}/<>]'
-  tag_name_break: (?=[^{{tag_name_char}}])
+  tag_name_break_char: '[{{ascii_space}}/<>]'
+  tag_name_break: (?={{tag_name_break_char}})
+  tag_name_char: '[^{{tag_name_break_char}}]'
   tag_name: '[A-Za-z]{{tag_name_char}}*'
 
   block_tag_name: |-
@@ -70,7 +71,8 @@ variables:
       | [\x{10000}-\x{EFFFF}]
     )
 
-  script_close_lookahead: (?i:(?=(?:-->\s*)?</script))
+  script_close_lookahead: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}})
+  style_close_lookahead: (?=(?:-->\s*)?</(?i:style){{tag_name_break_char}})
 
 contexts:
   immediately-pop:
@@ -308,7 +310,7 @@ contexts:
         - match: (?=\S)
           embed: scope:source.css
           embed_scope: source.css.embedded.html
-          escape: (?=(?:-->\s*)?</(?i:style){{tag_name_break}})
+          escape: '{{style_close_lookahead}}'
 
   style-other:
     - meta_content_scope: meta.tag.style.begin.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -259,7 +259,7 @@ contexts:
           scope: invalid.illegal.bad-comments-or-CDATA.html
 
   doctype:
-    - match: (<!)(DOCTYPE)
+    - match: (<!)((?i:doctype){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: keyword.declaration.doctype.html
@@ -282,7 +282,7 @@ contexts:
     - include: else-pop
 
   doctype-content-type:
-    - match: (?:PUBLIC|SYSTEM)\b
+    - match: (?i:public|system){{tag_name_break}}
       scope: keyword.content.external.html
       pop: true
     - include: else-pop

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -72,7 +72,7 @@ variables:
     )
 
   script_close_lookahead: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}})
-  style_close_lookahead: (?=(?:-->\s*)?</(?i:style){{tag_name_break_char}})
+  style_close_lookahead: (?=</(?i:style){{tag_name_break_char}})
 
 contexts:
   immediately-pop:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -103,7 +103,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push: style-css
-    - match: '(<)((?i:script)){{tag_name_break}}'
+    - match: (<)((?i:script)){{tag_name_break}}
       captures:
         0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
@@ -308,24 +308,24 @@ contexts:
         - match: (?=\S)
           embed: scope:source.css
           embed_scope: source.css.embedded.html
-          escape: (?i)(?=(?:-->\s*)?</style)
+          escape: (?=(?:-->\s*)?</(?i:style){{tag_name_break}})
 
   style-other:
     - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - include: style-close-tag
+      set: style-close-tag
 
   style-close-tag:
-    - match: (?i)(</)(style)(>)
-      scope: meta.tag.style.end.html
+    - match: (</)((?i:style){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
-        3: punctuation.definition.tag.end.html
-      pop: true
+      set:
+        - meta_scope: meta.tag.style.end.html
+        - include: tag-end
+        - include: tag-attributes
 
   style-common:
     - include: style-type-attribute
@@ -333,7 +333,7 @@ contexts:
     - include: tag-end-self-closing
 
   style-type-attribute:
-    - match: (?i)\btype\b
+    - match: (?i:type){{attribute_name_break}}
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
@@ -346,12 +346,12 @@ contexts:
           set: style-css
 
   style-type-decider:
-    - match: (?i)(?=text/css{{unquoted_attribute_break}}|'text/css'|"text/css")
+    - match: (?=(?i:text/css{{unquoted_attribute_break}}|'text/css'|"text/css"))
       set:
         - style-css
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=>|''|"")
+    - match: (?=>|''|"")
       set:
         - style-css
         - tag-generic-attribute-meta
@@ -390,8 +390,7 @@ contexts:
     - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - include: script-close-tag
+      set: script-close-tag
 
   script-close-tag:
     - match: <!--
@@ -400,7 +399,7 @@ contexts:
       set:
         - match: '-->'
           scope: comment.block.html punctuation.definition.comment.end.html
-        - match: (?i:(</)(script))
+        - match: (</)((?i:script){{tag_name_break}})
           captures:
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.script.html
@@ -415,7 +414,7 @@ contexts:
     - include: tag-end-self-closing
 
   script-type-attribute:
-    - match: (?i)\btype\b
+    - match: (?i:type){{attribute_name_break}}
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
@@ -428,22 +427,22 @@ contexts:
           set: script-javascript
 
   script-type-decider:
-    - match: (?i)(?={{javascript_mime_type}}{{unquoted_attribute_break}}|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
+    - match: (?={{javascript_mime_type}}{{unquoted_attribute_break}}|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
       set:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=module{{unquoted_attribute_break}}|'module'|"module")
+    - match: (?=(?i:module{{unquoted_attribute_break}}|'module'|"module"))
       set:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=>|''|"")
+    - match: (?=>|''|"")
       set:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=text/html{{unquoted_attribute_break}}|'text/html'|"text/html")
+    - match: (?=(?i:text/html{{unquoted_attribute_break}}|'text/html'|"text/html"))
       set:
         - script-html
         - tag-generic-attribute-meta
@@ -525,7 +524,7 @@ contexts:
     - include: else-pop
 
   tag-class-attribute:
-    - match: '\bclass\b'
+    - match: (?i:class){{attribute_name_break}}
       scope: entity.other.attribute-name.class.html
       push:
         - tag-class-attribute-meta
@@ -573,7 +572,7 @@ contexts:
     - include: else-pop
 
   tag-id-attribute:
-    - match: '\bid\b'
+    - match: (?i:id){{attribute_name_break}}
       scope: entity.other.attribute-name.id.html
       push:
         - tag-id-attribute-meta
@@ -621,7 +620,7 @@ contexts:
     - include: else-pop
 
   tag-style-attribute:
-    - match: '\bstyle\b'
+    - match: (?i:style){{attribute_name_break}}
       scope: entity.other.attribute-name.style.html
       push:
         - tag-style-attribute-meta
@@ -656,7 +655,7 @@ contexts:
 
   tag-event-attribute:
     - match: |-
-        (?x)\bon(
+        (?ix:on(?:
           abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
           |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
           |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
@@ -666,7 +665,7 @@ contexts:
           |pause|play|playing|progress|ratechange|reset|resize|scroll|seeked
           |seeking|select|show|sort|stalled|submit|suspend|timeupdate|toggle
           |volumechange|waiting
-        )\b
+        )){{attribute_name_break}}
       scope: entity.other.attribute-name.event.html
       push:
         - tag-event-attribute-meta

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -13,13 +13,13 @@ variables:
   ascii_space: '\t\n\f '
 
   # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-  attribute_name_char: '[{{ascii_space}}=/>]'
-  attribute_name_start: (?=[^{{attribute_name_char}}])
-  attribute_name_break: (?={{attribute_name_char}})
+  attribute_name_break_char: '[{{ascii_space}}=/>]'
+  attribute_name_break: (?={{attribute_name_break_char}})
+  attribute_name_start: (?=[^{{attribute_name_break_char}}])
 
   # https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-value
-  unquoted_attribute_start: (?=[^{{ascii_space}}=>])
   unquoted_attribute_break: (?=[{{ascii_space}}]|/?>)
+  unquoted_attribute_start: (?=[^{{ascii_space}}=>])
 
   # https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
   tag_name_break_char: '[{{ascii_space}}/<>]'

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -115,6 +115,7 @@
                 ##             ^ string.quoted.double.css
             }
         </style>
+        ##^^^^^^^ - source.css.embedded
         ##^^^^^ entity.name.tag.style.html
         ##<- meta.tag.style.end.html - source.css.embedded.html
         ##^^^^^^ meta.tag.style.end.html - source.css.embedded.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -110,24 +110,24 @@
         >
         ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
 
-        <style type="text/css">
+        <style type="text/css"> <!--
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
         ## ^ entity.name.tag.style.html
         ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
         ##                     ^ - meta.tag
+        ##                      ^^^^ - comment
             h2 {
             ## <- entity.name.tag.css
 ## <- source.css.embedded.html
                 font-family: "Arial";
                 ##             ^ string.quoted.double.css
             }
-        </style>
-        ##^^^^^^^ - source.css.embedded
-        ##^^^^^ entity.name.tag.style.html
-        ##<- meta.tag.style.end.html - source.css.embedded.html
-        ##^^^^^^ meta.tag.style.end.html - source.css.embedded.html
-        ##      ^ - meta.tag
+        --> </style>
+        ## <- - comment
+        ##  ^^^^^^^^ meta.tag.style.end.html - source.css.embedded.html
+        ##    ^^^^^ entity.name.tag.style.html
+        ##          ^ - meta.tag
 
         <style
         type

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -97,7 +97,10 @@
         >
             var foo = 100;
         ##  ^^^^^^^^^^^^^^^ - source.js
-        </script>
+        </script
+        ##^^^^^^ meta.tag.script.end.html entity.name.tag.script.html
+        >
+        ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
 
         <style type="text/css">
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
@@ -131,8 +134,10 @@
         text/csss>
             div {}
         ##  ^^^^^^ - source.css
-        </style>
-
+        </style
+        ##^^^^^ meta.tag.style.end.html entity.name.tag.style.html
+        >
+        ## <- meta.tag.style.end.html punctuation.definition.tag.end.html
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.style entity.name.tag.style
@@ -292,21 +297,33 @@ class="foo"></div>
         ##         ^ punctuation.definition.string.begin
         ##                     ^ punctuation.definition.string.end
 
+        <div id()=MyId></div>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^ entity.other.attribute-name.html
+        ##   ^^^^^^^^^ meta.attribute-with-value - meta.attribute-with-value.id
+        ##        ^^^^ string.unquoted - meta.toc-list.id
+
+        <DIV ID=MYID></DIV>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^ entity.other.attribute-name.id
+        ##   ^^^^^^^ meta.attribute-with-value.id
+        ##      ^^^^ string.unquoted meta.toc-list.id
+
         <div id=MyId></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^ meta.attribute-with-value.id
         ##      ^^^^ string.unquoted meta.toc-list.id
 
         <div id=My&#x49;d></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
         ##      ^^^^^^^^^ string.unquoted meta.toc-list.id
         ##        ^^^^^^ constant.character.entity.hexadecimal
 
         <div id='MyId2'></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^ meta.attribute-with-value.id
         ##   ^^ entity.other.attribute-name.id
         ##      ^^^^^^^ string.quoted.single
@@ -315,7 +332,7 @@ class="foo"></div>
         ##            ^ punctuation.definition.string.end - meta.toc-list.id
 
         <div id="ElementID"></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^ meta.attribute-with-value.id
         ##   ^^ entity.other.attribute-name.id
         ##      ^^^^^^^^^^^ string.quoted.double
@@ -324,7 +341,7 @@ class="foo"></div>
         ##                ^ punctuation.definition.string.end - meta.toc-list.id
 
         <div id=el-&foo;" bar&baz;></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
         ##      ^^^^^^^^^ string.unquoted meta.toc-list.id
@@ -334,7 +351,7 @@ class="foo"></div>
         ##                ^^^^^^^^ meta.attribute-with-value entity.other.attribute-name
 
         <div id='el-&foo;" bar&baz;'></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id
         ##   ^^ entity.other.attribute-name.id
         ##      ^^^^^^^^^^^^^^^^^^^^ string.quoted.single
@@ -347,7 +364,7 @@ class="foo"></div>
         ##                         ^ punctuation.definition.string.end - meta.toc-list.id
 
         <div id="el-&foo;' bar&baz;"></div>
-        ##  ^ - meta.attribute-with-value.id
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id
         ##   ^^ entity.other.attribute-name.id
         ##      ^^^^^^^^^^^^^^^^^^^^ string.quoted.double
@@ -359,21 +376,33 @@ class="foo"></div>
         ##                    ^^^^^ constant.character.entity
         ##                         ^ punctuation.definition.string.end - meta.toc-list.id
 
+        <div class*=element-class></div>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^^^ entity.other.attribute-name.html
+        ##   ^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value - meta.attribute-with-value.class
+        ##          ^^^^^^^^^^^^^ string.unquoted - meta.class-name
+
+        <DIV CLASS=ELEMENT-CLASS></DIV>
+        ##  ^ - meta.attribute-with-value
+        ##   ^^^^^ entity.other.attribute-name.class
+        ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
+        ##         ^^^^^^^^^^^^^ string.unquoted meta.class-name
+
         <div class=element-class></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##         ^^^^^^^^^^^^^ string.unquoted meta.class-name
 
         <div class=element&#xAD;class></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##         ^^^^^^^^^^^^^^^^^^ string.unquoted meta.class-name
         ##                ^^^^^^ constant.character.entity.hexadecimal
 
         <div class='element-class'></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##   ^^^^^ entity.other.attribute-name.class
         ##         ^^^^^^^^^^^^^^^ string.quoted.single
@@ -382,7 +411,7 @@ class="foo"></div>
         ##                       ^ punctuation.definition.string.end - meta.class-name
 
         <div class="element-class"></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##   ^^^^^ entity.other.attribute-name.class
         ##         ^^^^^^^^^^^^^^^ string.quoted.double
@@ -391,7 +420,7 @@ class="foo"></div>
         ##                       ^ punctuation.definition.string.end - meta.class-name
 
         <div class=el-&foo;" bar&baz;></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##         ^^^^^^^^^ string.unquoted meta.class-name
@@ -401,7 +430,7 @@ class="foo"></div>
         ##                   ^^^^^^^^ meta.attribute-with-value entity.other.attribute-name
 
         <div class='el-&foo;" bar&baz;'></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##   ^^^^^ entity.other.attribute-name.class
         ##         ^^^^^^^^^^^^^^^^^^^^ string.quoted.single
@@ -414,7 +443,7 @@ class="foo"></div>
         ##                            ^ punctuation.definition.string.end - meta.class-name
 
         <div class="el-&foo;' bar&baz;"></div>
-        ##  ^ - meta.attribute-with-value.class
+        ##  ^ - meta.attribute-with-value
         ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
         ##   ^^^^^ entity.other.attribute-name.class
         ##         ^^^^^^^^^^^^^^^^^^^^ string.quoted.double

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -18,6 +18,14 @@
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype meta.brackets meta.internal-subset
 ]>
 ## <- meta.tag.sgml.doctype meta.brackets meta.internal-subset punctuation.section.brackets.end
+<!doctype html system "html5.dtd">
+## <- meta.tag.sgml.doctype punctuation.definition.tag.begin
+##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype
+##^^^^^^^ keyword.declaration.doctype
+##        ^^^^ constant.language.doctype
+##             ^^^^^^ keyword.content.external
+##                    ^^^^^^^^^^^ string.quoted.double
+##                               ^ punctuation.definition.tag.end
 <html>
     <head>
         <title>Test HTML</title>


### PR DESCRIPTION
This PR ...

1. consolidates the way the case-insensitive flag `(?i)` is applied to match rules. All remaining rules are modified to apply it as local flag for strings only.

   Notes:
   a) The `{{javascript_mime_type}}` is case-insensitive already.
   b) It is removed from lookaheads with non-word characters only.
   c) All tag attributes are matched case-insensitive now.

2. removes the leading `\b` in some remaining tag and attribute names as the way the syntax works already ensures any match to start at an appropriate position (not in the middle of a word).

3. replaces the trailing `\b` in some remaining tag and attribute names by `{{tag_name_break}}` or `{{attribute_name_break}}` to make sure to properly match the name boundaries according to the whatwg specs under all circumstances.

4. consolidates the `</script>` and `</style>` closing tag match rules to behave like any other recently updated tags. The `>` can be at the next line now.