### PR TITLE
[HTML] Consolidate quotes

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -269,7 +269,7 @@ contexts:
 
   doctype-meta:
     - meta_scope: meta.tag.sgml.doctype.html
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       pop: true
 
@@ -301,7 +301,7 @@ contexts:
   style-css:
     - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
@@ -313,7 +313,7 @@ contexts:
   style-other:
     - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
@@ -365,7 +365,7 @@ contexts:
   script-javascript:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
@@ -377,7 +377,7 @@ contexts:
   script-html:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - meta_content_scope: text.html.embedded.html
@@ -388,7 +388,7 @@ contexts:
   script-other:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
@@ -717,7 +717,7 @@ contexts:
         - include: else-pop
 
   tag-end:
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.tag.end.html
       pop: true
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -91,7 +91,7 @@ contexts:
         2: entity.name.tag.xml.html
       push:
         - meta_scope: meta.tag.preprocessor.xml.html
-        - match: '\?>'
+        - match: \?>
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-generic-attribute
@@ -248,12 +248,12 @@ contexts:
         2: invalid.illegal.bad-comments-or-CDATA.html
       push:
         - meta_scope: comment.block.html
-        - match: '(<!-)?(--\s*>)'
+        - match: (<!-)?(--\s*>)
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
             2: punctuation.definition.comment.end.html
           pop: true
-        - match: '<!--(?!-?>)|--!>'
+        - match: <!--(?!-?>)|--!>
           scope: invalid.illegal.bad-comments-or-CDATA.html
 
   doctype:
@@ -269,7 +269,7 @@ contexts:
 
   doctype-meta:
     - meta_scope: meta.tag.sgml.doctype.html
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       pop: true
 
@@ -301,7 +301,7 @@ contexts:
   style-css:
     - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
@@ -313,7 +313,7 @@ contexts:
   style-other:
     - meta_content_scope: meta.tag.style.begin.html
     - include: style-common
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
@@ -365,7 +365,7 @@ contexts:
   script-javascript:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
@@ -377,7 +377,7 @@ contexts:
   script-html:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set:
         - meta_content_scope: text.html.embedded.html
@@ -388,7 +388,7 @@ contexts:
   script-other:
     - meta_content_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
@@ -398,7 +398,7 @@ contexts:
       scope: comment.block.html punctuation.definition.comment.begin.html
     - match: '{{script_close_lookahead}}'
       set:
-        - match: '-->'
+        - match: -->
           scope: comment.block.html punctuation.definition.comment.end.html
         - match: (?i:(</)(script))
           captures:
@@ -455,20 +455,20 @@ contexts:
         - tag-generic-attribute-value
 
   string-double-quoted:
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.html
       push:
         - meta_scope: string.quoted.double.html
-        - match: '"'
+        - match: \"
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
   string-single-quoted:
-    - match: "'"
+    - match: \'
       scope: punctuation.definition.string.begin.html
       push:
         - meta_scope: string.quoted.single.html
-        - match: "'"
+        - match: \'
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
@@ -492,25 +492,25 @@ contexts:
     - include: immediately-pop
 
   tag-generic-attribute-equals:
-    - match: '='
+    - match: =
       scope: punctuation.separator.key-value.html
       set: tag-generic-attribute-value
     - include: else-pop
 
   tag-generic-attribute-value:
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.double.html
-        - match: '"'
+        - match: \"
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
-    - match: "'"
+    - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.single.html
-        - match: "'"
+        - match: \'
           scope: punctuation.definition.string.end.html
           pop: true
         - include: entities
@@ -536,28 +536,28 @@ contexts:
     - include: immediately-pop
 
   tag-class-attribute-equals:
-    - match: '='
+    - match: =
       scope: punctuation.separator.key-value.html
       set: tag-class-attribute-value
     - include: else-pop
 
   tag-class-attribute-value:
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.double.html
         - meta_content_scope: meta.class-name.html
-        - match: '"'
+        - match: \"
           scope: punctuation.definition.string.end.html
           pop: true
         - include: tag-attribute-value-separator
         - include: entities
-    - match: "'"
+    - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.single.html
         - meta_content_scope: meta.class-name.html
-        - match: "'"
+        - match: \'
           scope: punctuation.definition.string.end.html
           pop: true
         - include: tag-attribute-value-separator
@@ -584,28 +584,28 @@ contexts:
     - include: immediately-pop
 
   tag-id-attribute-equals:
-    - match: '='
+    - match: =
       scope: punctuation.separator.key-value.html
       set: tag-id-attribute-value
     - include: else-pop
 
   tag-id-attribute-value:
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.double.html
         - meta_content_scope: meta.toc-list.id.html
-        - match: '"'
+        - match: \"
           scope: punctuation.definition.string.end.html
           pop: true
         - include: tag-attribute-value-separator
         - include: entities
-    - match: "'"
+    - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: string.quoted.single.html
         - meta_content_scope: meta.toc-list.id.html
-        - match: "'"
+        - match: \'
           scope: punctuation.definition.string.end.html
           pop: true
         - include: tag-attribute-value-separator
@@ -632,24 +632,24 @@ contexts:
     - include: immediately-pop
 
   tag-style-attribute-equals:
-    - match: '='
+    - match: =
       scope: punctuation.separator.key-value.html
       set: tag-style-attribute-value
     - include: else-pop
 
   tag-style-attribute-value:
-    - match: '"'
+    - match: \"
       scope: string.quoted.double punctuation.definition.string.begin.html
       embed: scope:source.css#rule-list-body
       embed_scope: source.css
-      escape: '"'
+      escape: \"
       escape_captures:
         0: string.quoted.double punctuation.definition.string.end.html
-    - match: "'"
+    - match: \'
       scope: string.quoted.single punctuation.definition.string.begin.html
       embed: scope:source.css#rule-list-body
       embed_scope: source.css
-      escape: "'"
+      escape: \'
       escape_captures:
         0: string.quoted.single punctuation.definition.string.end.html
     - include: else-pop
@@ -677,24 +677,24 @@ contexts:
     - include: immediately-pop
 
   tag-event-attribute-equals:
-    - match: '='
+    - match: =
       scope: punctuation.separator.key-value.html
       set: tag-event-attribute-value
     - include: else-pop
 
   tag-event-attribute-value:
-    - match: '"'
+    - match: \"
       scope: string.quoted.double punctuation.definition.string.begin.html
       embed: scope:source.js
       embed_scope: meta.attribute-with-value.event.html
-      escape: '"'
+      escape: \"
       escape_captures:
         0: string.quoted.double punctuation.definition.string.end.html
-    - match: "'"
+    - match: \'
       scope: string.quoted.single punctuation.definition.string.begin.html meta.attribute-with-value.event.html
       embed: scope:source.js
       embed_scope: meta.attribute-with-value.event.html
-      escape: "'"
+      escape: \'
       escape_captures:
         0: string.quoted.single punctuation.definition.string.end.html
     - include: else-pop
@@ -717,16 +717,16 @@ contexts:
         - include: else-pop
 
   tag-end:
-    - match: '>'
+    - match: \>
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-self-closing:
-    - match: '/>'
+    - match: />
       scope: punctuation.definition.tag.end.html
       pop: true
 
   tag-end-maybe-self-closing:
-    - match: '/?>'
+    - match: /?>
       scope: punctuation.definition.tag.end.html
       pop: true


### PR DESCRIPTION
This PR proposes to consolidate the usage of escapes vs. quotes in all remaining matches. It prefers unquoted values, if the required escapes are shorter and still well readable.

It does not provide any functional changes.