### PR TITLE
[Lua] Fix goto function references

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -85,7 +85,7 @@ contexts:
       scope: punctuation.terminator.statement.lua
 
     - match: function{{identifier_break}}
-      scope: storage.type.function.lua
+      scope: storage.type.function.lua keyword.declaration.function.lua
       push:
         - function-meta
         - block-contents
@@ -344,7 +344,7 @@ contexts:
       scope: meta.property.lua entity.name.function.lua
       pop: true
     - match: '{{identifier}}{{function_call_ahead}}'
-      scope: meta.property.lua variable.function.lua
+      scope: meta.property.lua meta.function-call.lua variable.function.lua
       pop: true
     - match: '{{metaproperty}}'
       scope: meta.property.lua support.other.metaproperty.lua
@@ -423,8 +423,8 @@ contexts:
           |next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|select
           |setmetatable|tonumber|tostring|type|xpcall
           |require|getfenv|module|setfenv|unpack
-        ){{identifier_break}}
-      scope: support.function.builtin.lua
+        ){{function_call_ahead}}
+      scope: meta.function-call.lua support.function.builtin.lua
       pop: true
 
     - include: builtin-modules
@@ -435,7 +435,7 @@ contexts:
       pop: true
 
     - match: '{{identifier}}{{function_call_ahead}}'
-      scope: variable.function.lua
+      scope: meta.function-call.lua variable.function.lua
       pop: true
 
     - match: '{{identifier}}'
@@ -587,7 +587,7 @@ contexts:
 
   function-literal:
     - match: function{{identifier_break}}
-      scope: storage.type.function.lua
+      scope: storage.type.function.lua keyword.declaration.function.lua
       set:
         - function-meta
         - block-contents

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -348,23 +348,23 @@
 
     foo.baz();
 --     ^ punctuation.accessor
---      ^^^ meta.property variable.function
+--      ^^^ meta.property meta.function-call variable.function
 
     foo.baz "";
 --     ^ punctuation.accessor
---      ^^^ meta.property variable.function
+--      ^^^ meta.property meta.function-call variable.function
 
     foo.baz '';
 --     ^ punctuation.accessor
---      ^^^ meta.property variable.function
+--      ^^^ meta.property meta.function-call variable.function
 
     foo.baz [=[ a string ]=];
 --     ^ punctuation.accessor
---      ^^^ meta.property variable.function
+--      ^^^ meta.property meta.function-call variable.function
 
     foo.baz {};
 --     ^ punctuation.accessor
---      ^^^ meta.property variable.function
+--      ^^^ meta.property meta.function-call variable.function
 --          ^^ meta.function-call.arguments meta.mapping
 
     foo[bar + baz];
@@ -393,13 +393,13 @@
 --FUNCTION CALLS
 
     f(42);
---  ^ variable.function
+--  ^ meta.function-call variable.function
 --   ^ meta.function-call.arguments meta.group
 --   ^ punctuation.section.group.begin
 --      ^ punctuation.section.group.end
 
     f "argument";
---  ^ variable.function
+--  ^ meta.function-call variable.function
 --    ^^^^^^^^^^ meta.function-call.arguments string.quoted.double
 
     f
@@ -407,11 +407,11 @@
 --  ^^^^^^^^^^ meta.function-call.arguments string.quoted.single
 
     f [[ foo ]];
---  ^ variable.function
+--  ^ meta.function-call variable.function
 --    ^^^^^^^^^ meta.function-call.arguments string.quoted.multiline
 
     f {};
---  ^ variable.function
+--  ^ meta.function-call variable.function
 --    ^^ meta.function-call.arguments meta.mapping
 
     f( 'unclosed)
@@ -419,11 +419,14 @@
 --  ^^^^^^ meta.function-call.arguments.lua meta.group.lua invalid.unexpected-keyword.lua
 --         ^ - meta.function-call
 
+    print('argument')
+--  ^ meta.function-call.lua support.function.builtin.lua
+
 --FUNCTIONS
 
     function function_name( a, b, ... )
 --  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
---  ^^^^^^^^ storage.type.function
+--  ^^^^^^^^ storage.type.function keyword.declaration.function
 --           ^^^^^^^^^^^^^ entity.name.function
 --                        ^^^^^^^^^^^^^ meta.group
 --                        ^ punctuation.section.group.begin


### PR DESCRIPTION
This fixes missing references in "Goto Reference..." (Shift+F12) for Lua source files by using the appropriate scope `meta.function-call.lua` in functions calls.

Missing `keyword.declaration` scope names for **function** keyword were also added according to the documented syntax naming conventions to have a better Lua syntax highlighting in some newer color schemes.
