### PR TITLE
[Python] Non-deterministic format-spec matching

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1395,6 +1395,8 @@ contexts:
 
   formatting-syntax:
     # https://docs.python.org/3.6/library/string.html#formatstrings
+    # Technically allows almost every character for the key,
+    # but those are rarely used if ever.
     - match: |- # simple form
         (?x)
         (\{)
@@ -1410,14 +1412,27 @@ contexts:
         2: storage.modifier.conversion.python
         3: constant.other.format-spec.python
         4: punctuation.definition.placeholder.end.python
-    - match: \{(?=[^\}"']+\{[^"']*\}) # complex (nested) form
+    - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
+      branch_point: formatting-syntax-branch
+      branch:
+        - formatting-syntax-complex
+        - formatting-syntax-fallback
+
+  formatting-syntax-fallback:
+    - match: \{
+      scope: meta.debug.formatting-syntax-fallback.python
+      pop: true
+
+  formatting-syntax-complex:
+    - match: \{
       scope: punctuation.definition.placeholder.begin.python
       push:
         - meta_scope: constant.other.placeholder.python
         - match: \}
           scope: punctuation.definition.placeholder.end.python
-          pop: true
-        - match: '[\w.\[\]]+'
+          pop: 2
+        # TODO could match numeric indices or everything else as a key
+        # and also [] indexing
         - match: '![ars]'
           scope: storage.modifier.conversion.python
         - match: ':'
@@ -1425,7 +1440,10 @@ contexts:
             - meta_scope: meta.format-spec.python constant.other.format-spec.python
             - match: (?=\})
               pop: true
-            - include: formatting-syntax
+            - match: (?=\{)
+              push: formatting-syntax-complex  # need to push extra because of pop: 2
+        - match: '[{"''\n]'
+          fail: formatting-syntax-branch
 
   f-string-content:
     # https://www.python.org/dev/peps/pep-0498/

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1400,18 +1400,19 @@ contexts:
     - match: |- # simple form
         (?x)
         (\{)
-          (?: [\w.\[\]]+)?             # field_name
-          (   ! [ars])?                # conversion
-          (   : (?:{{format_spec}}|    # format_spec OR
-                   [^}%]*%.[^}]*)      # any format-like string
+          (?: [\w.\[\]]+)?           # field_name
+          (   ! [ars])?              # conversion
+          (?: (:) ({{format_spec}}|  # format_spec OR
+                   [^}%]*%.[^}]*)    # any format-like string
           )?
         (\})
       scope: constant.other.placeholder.python
       captures:
         1: punctuation.definition.placeholder.begin.python
         2: storage.modifier.conversion.python
-        3: constant.other.format-spec.python
-        4: punctuation.definition.placeholder.end.python
+        3: punctuation.separator.format-spec.python
+        4: meta.format-spec.python constant.other.format-spec.python
+        5: punctuation.definition.placeholder.end.python
     - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
       branch_point: formatting-syntax-branch
       branch:
@@ -1426,22 +1427,23 @@ contexts:
   formatting-syntax-complex:
     - match: \{
       scope: punctuation.definition.placeholder.begin.python
-      push:
+      set:
         - meta_scope: constant.other.placeholder.python
         - match: \}
           scope: punctuation.definition.placeholder.end.python
-          pop: 2
+          pop: true
         # TODO could match numeric indices or everything else as a key
         # and also [] indexing
         - match: '![ars]'
           scope: storage.modifier.conversion.python
         - match: ':'
+          scope: punctuation.separator.format-spec.python
           push:
-            - meta_scope: meta.format-spec.python constant.other.format-spec.python
+            - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
             - match: (?=\})
               pop: true
             - match: (?=\{)
-              push: formatting-syntax-complex  # need to push extra because of pop: 2
+              push: formatting-syntax-complex
         - match: '[{"''\n]'
           fail: formatting-syntax-branch
 

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -549,6 +549,45 @@ foo = "{text{" # Comment
 bar = "}}" # Comment
 #      ^^ constant.character.escape
 
+# The following section contains unusual and legal or illegal format placeholders.
+# We don't actually want to match the syntax 100% of the time,
+# since we never know for sure if the string is used as a format string,
+# so some of these matches are incorrect because of implementation details.
+
+# Not format specs
+"{:{ }"  # unclosed
+# ^ - constant.other.placeholder
+'{{foo!r:4.2}'  # escaped opening
+# ^ - constant.other.placeholder
+'{{foo!r:4.2}}'  # escaped opening and closing
+# ^ - constant.other.placeholder
+'{foo!a:ran{dom}'  # unclosed
+# ^ - constant.other.placeholder
+'{foo!a:ran{dom}'  # unclosed
+# ^ - constant.other.placeholder
+
+# Invalid field names
+'{foo{d}}'
+# ^ - constant.other.placeholder
+'{foo.!a:d}'
+# ^ constant.other.placeholder
+"{:{ {}}"  # issue 2232
+# ^ - constant.other.placeholder
+
+# Syntactically correct, but hardly come up in real code
+"{:{ ()}}".format(0, **{" ()": "d"}) == '0'
+# ^ constant.other.placeholder
+'{foo/bar}'.format(**{"foo/bar": 1}) == '1'
+# ^ - constant.other.placeholder
+
+# Legal but non-standard format spec
+'{foo:{{w}}.{{p}}}}'  # illegal double {{ in format spec
+# ^ - constant.other.placeholder
+'{foo!a:random}'
+# ^ - constant.other.placeholder
+'{foo!a:ran{d}om}'  # nested specification
+# ^ constant.other.placeholder
+
 f"string"
 # <- storage.type.string
 #^^^^^^^^ string.quoted.double

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -569,10 +569,10 @@ bar = "}}" # Comment
 # Invalid field names
 '{foo{d}}'
 # ^ - constant.other.placeholder
-'{foo.!a:d}'
-# ^ constant.other.placeholder
 "{:{ {}}"  # issue 2232
 # ^ - constant.other.placeholder
+'{foo.!a:d}'  # incomplete accessor (in simple form)
+# ^ constant.other.placeholder
 
 # Syntactically correct, but hardly come up in real code
 "{:{ ()}}".format(0, **{" ()": "d"}) == '0'
@@ -581,7 +581,9 @@ bar = "}}" # Comment
 # ^ - constant.other.placeholder
 
 # Legal but non-standard format spec
-'{foo:{{w}}.{{p}}}}'  # illegal double {{ in format spec
+'{foo:{{w}}.{{p}}}'
+# ^ - constant.other.placeholder
+'{foo:w}}}'
 # ^ - constant.other.placeholder
 '{foo!a:random}'
 # ^ - constant.other.placeholder

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -415,7 +415,8 @@ datetime.strftime(datetime.now(), '%Y%V%uT')
 '{0:%Y}-{0:%m}-{0:%d}'.format(datetime.date.today())
 # ^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
-#  ^^^ constant.other.format-spec.python
+#  ^ punctuation.separator.format-spec.python
+#   ^^ meta.format-spec.python constant.other.format-spec.python
 #      ^ - constant.other.placeholder.python
 #       ^^^^^^ constant.other.placeholder.python
 #          ^^ constant.other.format-spec.python
@@ -425,13 +426,11 @@ datetime.strftime(datetime.now(), '%Y%V%uT')
 '{0:%Y}-{0:%m
 # ^^^^^^^^^^^ string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
-#  ^^^ constant.other.format-spec.python
 #      ^^^^ - constant.other.placeholder.python
 #            ^ invalid.illegal.unclosed-string.python
 '{0:%Y}-{0:%
 # ^^^^^^^^^^^ string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
-#  ^^^ constant.other.format-spec.python
 #      ^^^^^ - constant.other.placeholder.python
 #           ^ invalid.illegal.unclosed-string.python
 
@@ -496,6 +495,8 @@ sql = b'just some \
 #     ^^^^ constant.other.placeholder.python
 "More {!a: <10s}"                 # Calls ascii() on the argument first, then formats
 #     ^^^^^^^^^^ constant.other.placeholder.python
+#        ^ punctuation.separator.format-spec.python - meta.format-spec.python
+#         ^^^^^ meta.format-spec.python constant.other.format-spec.python
 "Escaped {{0}}"                   # outputs: "Escaped {0}"
 #        ^^^^^ - constant.other.placeholder.python
 #        ^^ constant.character.escape.python
@@ -528,12 +529,13 @@ datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
 
 "Testing {:j^9,}".format(1000)
 #        ^^^^^^^ constant.other.placeholder
-#         ^^^^^ constant.other.format-spec
+#          ^^^^ meta.format-spec.python constant.other.format-spec
 
 "result: {value:{width}.{precision}}"
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.placeholder
-#              ^^^^^^^^^^^^^^^^^^^^ meta.format-spec.python
+#               ^^^^^^^^^^^^^^^^^^^ meta.format-spec.python
 #        ^ punctuation.definition.placeholder.begin
+#              ^ punctuation.separator.format-spec.python
 #               ^^^^^^^ constant.other.placeholder constant.other.placeholder
 #               ^ punctuation.definition.placeholder.begin
 #                       ^^^^^^^^^^^ constant.other.placeholder constant.other.placeholder


### PR DESCRIPTION
Correctly match some tricky format specifications using branches. Some
quite unusual ones are not correctly matched but tests have been added
to document the exact behavior.

My first experiement with non-determinism and quite a tricky case at that because we're not aiming for 100% accuracy but it still allows for more correct highlighting.

Closes #2232.
Closes #2241. 