### PR TITLE
[Markdown] Add GitHub list checkboxes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -203,10 +203,12 @@ contexts:
         - include: table
         - match: ''
           pop: true
-    - match: '^([ ]{0,3})([*+-])(?=\s)'
+    - match: ^([ ]{0,3})([*+-])( (\[[ xX]\]))?(?=\s)
       captures:
         1: markup.list.unnumbered.markdown
         2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+        3: markup.list.unnumbered.markdown
+        4: constant.language.checkbox.markdown-gfm
       push:
         - meta_content_scope: markup.list.unnumbered.markdown
         - match: ^(?=\S)
@@ -987,10 +989,12 @@ contexts:
       push:
         - match: ^\s*$
           pop: true
-        - match: '([ ]*)([*+-])(?=\s)'
+        - match: ([ ]*)([*+-])( (\[[ xX]\]))?(?=\s)
           captures:
             1: markup.list.unnumbered.markdown
             2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+            3: markup.list.unnumbered.markdown
+            4: constant.language.checkbox.markdown-gfm
           push:
             - clear_scopes: 1
             - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -575,6 +575,24 @@ because it doesn't begin with the number one:
 * list continues
 | <- markup.list.unnumbered punctuation.definition.list_item - markup.raw.block
 * list continues
+* [ ] Unticked GitHub-flavored-markdown checkbox
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
+| ^^^ constant.language.checkbox
+* [x] Ticked GFM checkbox
+| ^^^ constant.language.checkbox
+* [X] Another ticked checkbox
+| ^^^ constant.language.checkbox
+    + [ ] Sub-item with checkbox
+|     ^^^ constant.language.checkbox
+* [] Not a checkbox
+| ^^^^^^^^^^^^^^^^^ - storage - constant
+* [/] Not a checkbox
+| ^^^^^^^^^^^^^^^^^^ - storage
+* Not [ ] a [x] checkbox [X]
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - storage - constant
+* [ ] [Checkbox][] with next word linked
+| ^^^ constant.language.checkbox
+|     ^^^^^^^^^^^^ meta.link
 
 - `code` - <a name="demo"></a>
 | ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw


### PR DESCRIPTION
Fixes #2248

Unsure on the scope to use, but I like the `.github` tag at the end. In a sense, `constant.language` is "right," considering that these represent Booleans, but I didn't think that would go over well.