### PR TITLE
[Scala] Fix infinite loop

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1771,7 +1771,7 @@ contexts:
       pop: true
 
   single-type-expression-tail:
-    - match: (?=@{{plainid}})
+    - match: (?=@{{alphaplainid}})
       set:
         - include: annotation
         - match: '(?=\S)'

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -2202,3 +2202,6 @@ foo eq bar
 
 foo ne bar
 //  ^^ keyword.operator.comparison.scala
+
+:s@/
+//^^ meta.group.scala meta.group.scala support.type.scala


### PR DESCRIPTION
In `single-type-expression-tail`, `@/` would match the lookahead on line `1774` but not the annotation, thus causing an infinite loop.