### PR TITLE
[JavaScript] Fix key bindings in template strings.

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -26,7 +26,7 @@
     },
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.template.js" },
+            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
@@ -38,7 +38,7 @@
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.template.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
@@ -46,7 +46,7 @@
     },
     { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.template.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
         ]


### PR DESCRIPTION
When the interpolated string scopes were changed, the key bindings broke. This PR updates the keymap to use the new scopes.