### PR TITLE
[Groovy] Adding first_line_match to help identification

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -7,6 +7,7 @@ file_extensions:
   - gvy
   - gradle
   - Jenkinsfile
+first_line_match: #!groovy
 variables:
   unicode_letter: |-
     (?:(?xi)


### PR DESCRIPTION
This will help when editing files with no extension, such as those groovy config files commonly used for Jenkins.