### PR TITLE
[Ruby] Fix SHELL heredoc tag boundaries

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -71,12 +71,12 @@ variables:
   hdigits: (?:\h+(?:_\h+)*)
   odigits: (?:[0-7]+(?:_[0-7]+)*)
   exponent: (?:[Ee][-+]?{{ddigits}})
-  heredoc_type_css: (?:[[:upper:]_]_)?CSS
-  heredoc_type_html: (?:[[:upper:]_]_)?HTML
-  heredoc_type_js: (?:[[:upper:]_]_)?(?:JS|JAVASCRIPT)
-  heredoc_type_ruby: (?:[[:upper:]_]_)?RUBY
-  heredoc_type_shell: (?:[[:upper:]_]_)?(?:SH|SHELL)
-  heredoc_type_sql: (?:[[:upper:]_]_)?SQL
+  heredoc_type_css: (?:[[:upper:]_]_)?CSS\b
+  heredoc_type_html: (?:[[:upper:]_]_)?HTML\b
+  heredoc_type_js: (?:[[:upper:]_]_)?(?:JS|JAVASCRIPT)\b
+  heredoc_type_ruby: (?:[[:upper:]_]_)?RUBY\b
+  heredoc_type_shell: (?:[[:upper:]_]_)?(?:SH|SHELL)\b
+  heredoc_type_sql: (?:[[:upper:]_]_)?SQL\b
   identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
   method_punctuation: '(?:[?!]|=(?![>=]))?'
   method_name: '{{identifier}}{{method_punctuation}}'

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -156,6 +156,16 @@ puts <<-SH; # comment
 # ^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
 #   ^ - meta.string - string.unquoted
 
+puts <<-SHELL; # comment
+#    ^^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#            ^ punctuation.terminator.statement.ruby - meta.string - string
+#              ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
+  git log
+# ^^^^^^^ meta.string.heredoc.ruby source.shell.embedded.ruby
+  SHELL
+# ^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#      ^ - meta.string - string.unquoted
+
 DB.fetch(<<-SQL, conn).name
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ruby
 #        ^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby


### PR DESCRIPTION
Add word boundary checks to the heredoc type names to ensure correct scoping of short and long tag names like SH vs. SHELL.

Without those only SH is scoped in SHELL.

A tag name like SHOUT was scoped as SH heredoc as well.