### PR TITLE
[Lua] Fix indention rules' scopes

### DIFF
--- a/Lua/Indentation Rules.tmPreferences
+++ b/Lua/Indentation Rules.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 	<dict>
-		<key>name</key>
-		<string>Indention Rules</string>
 		<key>scope</key>
 		<string>source.lua - comment - string</string>
 		<key>settings</key>

--- a/Lua/Indention Rules.tmPreferences
+++ b/Lua/Indention Rules.tmPreferences
@@ -2,9 +2,9 @@
 <plist version="1.0">
 	<dict>
 		<key>name</key>
-		<string>Indent</string>
+		<string>Indention Rules</string>
 		<key>scope</key>
-		<string>source.lua</string>
+		<string>source.lua - comment - string</string>
 		<key>settings</key>
 		<dict>
 			<key>decreaseIndentPattern</key>


### PR DESCRIPTION
Fixes #2260

This commit ...

1. excludes `comment` and `string` quotes from indention rules
2. renames the file to `Indention Rules.tmPreferences` as this is the most commonly used name in most packages in order to improve the common look of the packages.