### PR TITLE
[Graphviz] Change relationship scope

### DIFF
--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -26,7 +26,7 @@ contexts:
     - match: \b(bgcolor|center|clusterrank|color|comment|compound|concentrate|fillcolor|fontname|fontpath|fontsize|label|labeljust|labelloc|layers|margin|mclimit|nodesep|nslimit|nslimit1|ordering|orientation|page|pagedir|quantum|rank|rankdir|ranksep|ratio|remincross|rotate|samplepoints|searchsize|size|style|URL)\b
       scope: support.constant.attribute.graph.dot
     - match: '-[->]'
-      scope: punctuation.operator.relationship.dot
+      scope: keyword.operator.relationship.dot
     - match: '='
       scope: keyword.operator.assignment.dot
     - match: ';'
@@ -40,6 +40,9 @@ contexts:
           pop: true
         - match: \\.
           scope: constant.character.escape.dot
+        - match: (\\)$\n?
+          captures:
+            1: punctuation.separator.continuation.line.dot
         - match: '[{}|]'
           scope: punctuation.separator.memory-block.dot
     - include: braces

--- a/Graphviz/syntax_test_dot.dot
+++ b/Graphviz/syntax_test_dot.dot
@@ -50,7 +50,7 @@ graph cluster_n {
 //    ^^^^^^^^  meta.annotation.dot variable.annotation.cluster.dot
 //            ^ - meta.annotation.dot variable.annotation.cluster.dot
     t -> n;
-//    ^^        punctuation.operator.relationship.dot
+//    ^^        keyword.operator.relationship.dot
 }
 
 // Loosely taken from http://www.graphviz.org/content/node-shapes#html


### PR DESCRIPTION
Since relationships are the primary thing of interest in Graphviz files, they shouldn't be marked as `punctuation`.

I've had this locally for ages and forgot to push it.