### PR TITLE
[Cabal] Add Cabal.sublime-syntax

### DIFF
--- a/Cabal/Cabal.sublime-syntax
+++ b/Cabal/Cabal.sublime-syntax
@@ -1,0 +1,91 @@
+%YAML 1.2
+---
+# Derived from https://github.com/JustusAdam/language-haskell/blob/2859b32113407977f0edcb6c19f0fe3eaae1294f/syntaxes/cabal.tmLanguage
+name: Cabal
+file_extensions:
+  - cabal
+scope: source.cabal
+contexts:
+  main:
+    - match: |-
+        (?ix)(\n|^)
+            ( name
+            | version
+            | cabal-version
+            | build-type
+            | license(-file)?
+            | copyright
+            | author
+            | maintainer
+            | stability
+            | homepage
+            | bug-reports
+            | package-url
+            | synopsis
+            | data-(files|dir)
+            | description
+            | category
+            | extra-(source|doc|tmp)-files
+            | tested-with
+            ):
+      scope: keyword.other.cabal
+    - match: |-
+        (?ix)^[ \t]+
+            ( build-depends
+            | other-modules
+            | hs-source-dirs
+            | ((other|default)-)?extensions
+            | build-tools
+            | buildable
+            | ghc(-(prof|shared))?-options
+            | (install-)?includes
+            | include-dirs
+            | (c|js)-sources
+            | extra(-ghci)?-libraries
+            | extra-lib-dirs
+            | (cc|cpp|ld)-options
+            | pkgconfig-depends
+            | default-language
+            | frameworks
+            | default
+            | manual
+            | location
+            | branch
+            | tag
+            | subdir
+            | exposed(-modules)?
+            | reexported-modules
+            | main-is
+            | type
+            | test-module
+            | description
+            | setup-depends
+            | mixins
+            ):
+      scope: keyword.other.cabal
+    - match: (==|>=|<=|<|>|\|\||&&|!)
+      scope: keyword.operator.cabal
+    - match: '(?<=[^\w])\d+(\.\d+)*(\.\*)?'
+      scope: constant.numeric.cabal
+    - match: '\w+:/(/[\w._\-\d%])+(\?[\w.+_\-\d%]+)(&[\w._+\-\d%]+)*'
+      scope: markup.underline.link.cabal
+    - match: |-
+        ^(?ix:
+        ( library
+        | custom-setup
+        ))$
+      scope: entity.name.section.cabal
+    - match: |-
+        ^(?ix:
+        ( executable
+        | flag
+        | test-suite
+        | source-repository
+        ))( |\t)+([\w\-_]+)$
+      captures:
+        1: entity.name.section.cabal
+        3: entity.name.function.cabal
+    - match: '^[ \t]*(if|else)'
+      scope: keyword.control.cabal
+    - match: ^\s*--.*$
+      scope: comment.line.double-dash


### PR DESCRIPTION
It would be great to have built-in support for Haskell [Cabal](https://www.haskell.org/cabal/) files :heart: This pull request makes it possible.

## Samples

![image](https://user-images.githubusercontent.com/287532/73788594-9399f700-479d-11ea-81c9-93d6378201a3.png)


```cabal
version: 0

name:
  hedgehog-dieharder
author:
  Nikos Baxevanis
maintainer:
  Nikos Baxevanis <nikos.baxevanis@gmail.com>
homepage:
  https://github.com/hedgehogqa/haskell-hedgehog
synopsis:
  Hedgehog dieharder project.
description:
  This is the hedgehog dieharder project. It contains diehard tests.
  The diehard tests are a battery of statistical tests for measuring
  the quality of our random number generator.
category:
  Testing
license:
  BSD3
license-file:
  LICENSE
cabal-version:
  >= 1.8
build-type:
  Simple
tested-with:
    GHC == 8.0.2
  , GHC == 8.2.2
  , GHC == 8.4.4
  , GHC == 8.6.5
  , GHC == 8.8.1

executable dieharder-input
  main-is:
    Dieharder.hs

  ghc-options:
    -Wall -threaded -O2

  hs-source-dirs:
    test

  build-depends:
      hedgehog
    , base                            >= 3          && < 5
    , bytestring                      >= 0.10.4.0   && < 0.11

```