### PR TITLE
[Markdown] Optional preview to the side

### DIFF
--- a/Markdown/Context.sublime-menu
+++ b/Markdown/Context.sublime-menu
@@ -1,0 +1,8 @@
+[
+    { "caption": "-" },
+    {
+        "caption": "HTML Preview (read_only)",
+        "command": "preview_markdown_via_html_sheet"
+    },
+    { "caption": "-" }
+]

--- a/Markdown/dependencies.json
+++ b/Markdown/dependencies.json
@@ -1,0 +1,13 @@
+{
+    "*": {
+        ">=3124": [
+            "markupsafe",
+            "mdpopups",
+            "pygments",
+            "pymdownx",
+            "python-jinja2",
+            "python-markdown",
+            "pyyaml"
+        ]
+    }
+}

--- a/Markdown/main.py
+++ b/Markdown/main.py
@@ -11,6 +11,7 @@ class PreviewMarkdownViaHtmlSheet(sublime_plugin.TextCommand):
     def run(self, edit):
         try:
             v = self.view
+            w = v.window()
             if not v.settings().get('syntax').startswith('Packages/Markdown/'):
                 return
             import mdpopups
@@ -22,7 +23,7 @@ class PreviewMarkdownViaHtmlSheet(sublime_plugin.TextCommand):
                 nl2br=True,
                 allow_code_wrap=False
             )
-            preview_sheet = v.window().new_html_sheet(
+            preview_sheet = w.new_html_sheet(
                 name='HTML Preview (read_only)',
                 contents=md_preview,
                 cmd='open_url',
@@ -30,14 +31,19 @@ class PreviewMarkdownViaHtmlSheet(sublime_plugin.TextCommand):
                 flags=0,
                 group=-1
             )
-            preview_sheet.window().run_command('new_pane')
+            w.run_command('new_pane')
         except Exception as e:
             pass
 
     # def is_enabled(self): return bool
 
     def is_visible(self):
-        return self.view.settings().get('syntax').startswith('Packages/Markdown/')
+        # only show for markdown when mdpopups can be imported
+        try:
+            import mdpopups
+            return self.view.settings().get('syntax').startswith('Packages/Markdown/')
+        except Exception as e:
+            return False
 
     # def description(self): return str
     # def want_event(): return bool

--- a/Markdown/main.py
+++ b/Markdown/main.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+
+import sublime
+import sublime_plugin
+
+
+class PreviewMarkdownViaHtmlSheet(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        try:
+            v = self.view
+            if not v.settings().get('syntax').startswith('Packages/Markdown/'):
+                return
+            import mdpopups
+            md_preview = mdpopups.md2html(
+                view=v,
+                markup=v.substr(sublime.Region(0, v.size())),
+                template_vars=None,
+                template_env_options=None,
+                nl2br=True,
+                allow_code_wrap=False
+            )
+            preview_sheet = v.window().new_html_sheet(
+                name='HTML Preview (read_only)',
+                contents=md_preview,
+                cmd='open_url',
+                args=None,
+                flags=0,
+                group=-1
+            )
+            preview_sheet.window().run_command('new_pane')
+        except Exception as e:
+            pass
+
+    # def is_enabled(self): return bool
+
+    def is_visible(self):
+        return self.view.settings().get('syntax').startswith('Packages/Markdown/')
+
+    # def description(self): return str
+    # def want_event(): return bool
+    # def input(self, args): return CommandInputHandler or None


### PR DESCRIPTION
Requires:

- `ST4065+` for new HTML sheets
- `Package Control` for dependencies

Usage:

- right-click for context menu in Markdown file
- context menu item grayed out (`is_visible` is `False`) unless `mdpopups` (dependency) can be imported and cursor is within `Markdown` view

---

![ScreenFlow](https://user-images.githubusercontent.com/8577450/73900359-ca503a00-488f-11ea-8761-e893118187b2.gif)