### PR TITLE
[Applescript]Fixed the multi-line comment characters that are used/reported.

### DIFF
--- a/AppleScript/Comments.tmPreferences
+++ b/AppleScript/Comments.tmPreferences
@@ -25,13 +25,13 @@
 				<key>name</key>
 				<string>TM_COMMENT_START_3</string>
 				<key>value</key>
-				<string>/*</string>
+				<string>(*</string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END_3</string>
 				<key>value</key>
-				<string>*/</string>
+				<string>*)</string>
 			</dict>
 			<dict>
 				<key>name</key>


### PR DESCRIPTION
The old file was causing the wrong multi-line comment characters to be reported to a package extension i have. This change fixes it