### PR TITLE
[CSS] Fix tmPreferences

### DIFF
--- a/CSS/Comments.tmPreferences
+++ b/CSS/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.css</string>
 	<key>settings</key>

--- a/CSS/Symbol Index.tmPreferences
+++ b/CSS/Symbol Index.tmPreferences
@@ -2,7 +2,10 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>source.css entity.other.attribute-name.class, source.css entity.other.attribute-name.id</string>
+	<string>
+		source.css entity.other.attribute-name.class,
+		source.css entity.other.attribute-name.id
+	</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>

--- a/CSS/Symbol List - Group.tmPreferences
+++ b/CSS/Symbol List - Group.tmPreferences
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Selector</string>
 	<key>scope</key>
-	<string>source.css meta.selector</string>
+	<string>source.css comment.block.css - source.css.embedded</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>s/^\s*/CSS: /; s/\s+/ /g</string>
+		<string>
+			s/\/\*\*\s*(.*?)\s*\*\//** $1 **/;
+			s/\/\*.*?\*\*\//./;
+			s/\/\*[^\*].*?[^\*]\*\///
+		</string>
 	</dict>
 </dict>
 </plist>

--- a/CSS/Symbol List - Selector.tmPreferences
+++ b/CSS/Symbol List - Selector.tmPreferences
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Group</string>
 	<key>scope</key>
-	<string>source.css comment.block.css -source.css.embedded</string>
+	<string>source.css meta.selector</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>s/\/\*\*\s*(.*?)\s*\*\//** $1 **/; s/\/\*.*?\*\*\//./; s/\/\*[^\*].*?[^\*]\*\///</string>
+		<string>s/^\s*/CSS: /; s/\s+/ /g</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key
3. reformats some content

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.