### PR TITLE
[Groovy] Fix tmPreferences

### DIFF
--- a/Groovy/Comments.tmPreferences
+++ b/Groovy/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.groovy</string>
 	<key>settings</key>

--- a/Groovy/Symbol List - Class Variables.tmPreferences
+++ b/Groovy/Symbol List - Class Variables.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Class Variables</string>
 	<key>scope</key>
 	<string>source.groovy meta.definition.class meta.definition.class-variable.name</string>
 	<key>settings</key>

--- a/Groovy/Symbol List - Classes.tmPreferences
+++ b/Groovy/Symbol List - Classes.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Classes</string>
 	<key>scope</key>
 	<string>source.groovy entity.name.type.class</string>
 	<key>settings</key>

--- a/Groovy/Symbol List - Methods.tmPreferences
+++ b/Groovy/Symbol List - Methods.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Methods</string>
 	<key>scope</key>
 	<string>source.groovy meta.definition.method.signature</string>
 	<key>settings</key>

--- a/Groovy/Symbol List - Variables.tmPreferences
+++ b/Groovy/Symbol List - Variables.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Variables</string>
 	<key>scope</key>
 	<string>source.groovy meta.definition.class-variable.name</string>
 	<key>settings</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key

The goal is a common naming scheme to be applied to all packages, so
files of a certain function have the same name in each package.