### PR TITLE
[Lua] Fix tmPreferences

### DIFF
--- a/Lua/Comments.tmPreferences
+++ b/Lua/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.lua</string>
 	<key>settings</key>

--- a/Lua/Symbol List.tmPreferences
+++ b/Lua/Symbol List.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List Function</string>
     <key>scope</key>
     <string>source.lua meta.name.function</string>
     <key>settings</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.