### PR TITLE
[Markdown] Fix tmPreferences

### DIFF
--- a/Markdown/Indentation Rules.tmPreferences
+++ b/Markdown/Indentation Rules.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Indent: Raw Block</string>
 	<key>scope</key>
 	<string>text.html.markdown markup.raw</string>
 	<key>settings</key>

--- a/Markdown/Symbol List - Heading.tmPreferences
+++ b/Markdown/Symbol List - Heading.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Heading</string>
 	<key>scope</key>
 	<string>text.html.markdown markup.heading - meta.whitespace.newline.markdown</string>
 	<key>settings</key>

--- a/Markdown/Symbol List - Reference Link.tmPreferences
+++ b/Markdown/Symbol List - Reference Link.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: Reference Link</string>
 	<key>scope</key>
 	<string>text.html.markdown meta.link.reference.def</string>
 	<key>settings</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.