### PR TITLE
[PHP] Fix tmPreferences

### DIFF
--- a/PHP/Comments.tmPreferences
+++ b/PHP/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.php</string>
 	<key>settings</key>

--- a/PHP/Indentation Rules - Annex.tmPreferences
+++ b/PHP/Indentation Rules - Annex.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Indentation Rules Annex</string>
 	<key>scope</key>
 	<string>source.php</string>
 	<key>settings</key>

--- a/PHP/Indentation Rules - heredoc end.tmPreferences
+++ b/PHP/Indentation Rules - heredoc end.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Indentation Rules - HEREDOC end</string>
 	<key>scope</key>
 	<string>source.php meta.heredoc-end.php</string>
 	<key>settings</key>

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Indentation Rules</string>
 	<key>scope</key>
-	<string>source.php - comment - meta.embedded.html - string, meta.html-newline-after-php</string>
+	<string>
+		source.php - comment - meta.embedded.html - string,
+		meta.html-newline-after-php
+	</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/PHP/Symbol List.tmPreferences
+++ b/PHP/Symbol List.tmPreferences
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbols List: Indent Functions</string>
 	<key>scope</key>
-	<string>entity.name.function.php, support.function.magic.php, entity.name.class.php, entity.name.interface.php, entity.name.trait.php</string>
+	<string>
+		source.php entity.name.function,
+		source.php support.function.magic,
+		source.php entity.name.class,
+		source.php entity.name.interface,
+		source.php entity.name.trait
+	</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key
3. tweaks the formatting of some tmPreferences

The goal is a common naming scheme to be applied to all packages, so
files of a certain function have the same name in each package.