### PR TITLE
[ShellScript] Fix tmPreferences

### DIFF
--- a/ShellScript/Comments.tmPreferences
+++ b/ShellScript/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.shell</string>
 	<key>settings</key>

--- a/ShellScript/Indentation Rules.tmPreferences
+++ b/ShellScript/Indentation Rules.tmPreferences
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Indentation</string>
 	<key>scope</key>
-	<string>source.shell</string>
+	<string>source.shell - comment - string</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/ShellScript/Symbol List - Aliases.tmPreferences
+++ b/ShellScript/Symbol List - Aliases.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List - Aliases</string>
     <key>scope</key>
     <string>entity.name.function.alias.shell</string>
     <key>settings</key>
@@ -11,8 +9,6 @@
         <integer>1</integer>
         <key>showInIndexedSymbolList</key>
         <integer>1</integer>
-        <key>symbolTransformation</key>
-        <string>s/.+/alias\: $0/</string>
     </dict>
 </dict>
 </plist>

--- a/ShellScript/Symbol List - Expansions.tmPreferences
+++ b/ShellScript/Symbol List - Expansions.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List - Variables</string>
     <key>scope</key>
     <string>meta.group.expansion</string>
     <key>settings</key>
@@ -11,8 +9,6 @@
         <integer>1</integer>
         <key>showInIndexedSymbolList</key>
         <integer>0</integer>
-        <key>symbolTransformation</key>
-        <string>s/.+/expansion\: $0/</string>
     </dict>
 </dict>
 </plist>

--- a/ShellScript/Symbol List - Functions.tmPreferences
+++ b/ShellScript/Symbol List - Functions.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List - Functions</string>
     <key>scope</key>
     <string>entity.name.function.shell</string>
     <key>settings</key>
@@ -11,8 +9,6 @@
         <integer>1</integer>
         <key>showInIndexedSymbolList</key>
         <integer>1</integer>
-        <key>symbolTransformation</key>
-        <string>s/.+/function\: $0/</string>
     </dict>
 </dict>
 </plist>

--- a/ShellScript/Symbol List - Variables.tmPreferences
+++ b/ShellScript/Symbol List - Variables.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List - Variables</string>
     <key>scope</key>
     <string>variable.other.readwrite.assignment.shell</string>
     <key>settings</key>
@@ -11,8 +9,6 @@
         <integer>1</integer>
         <key>showInIndexedSymbolList</key>
         <integer>0</integer>
-        <key>symbolTransformation</key>
-        <string>s/.+/variable\: $0/</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key
3. removes symbol transformations to display symbols as collected from the source code

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.