### PR TITLE
[SQL] Fix tmPreferences

### DIFF
--- a/SQL/Comments.tmPreferences
+++ b/SQL/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.sql</string>
 	<key>settings</key>

--- a/SQL/Indentation Rules.tmPreferences
+++ b/SQL/Indentation Rules.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Miscellaneous</string>
 	<key>scope</key>
 	<string>source.sql</string>
 	<key>settings</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.