### PR TITLE
[XML] Fix tmPreferences

### DIFF
--- a/XML/Comments.tmPreferences
+++ b/XML/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>text.xml - meta.tag</string>
 	<key>settings</key>

--- a/XML/Indentation Rules.tmPreferences
+++ b/XML/Indentation Rules.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Miscellaneous</string>
 	<key>scope</key>
 	<string>text.xml</string>
 	<key>settings</key>


### PR DESCRIPTION
This commit ...

1. renames the tmPreferences according to their function
2. removes the `name` key

The goal is a common naming scheme to be applied to all packages, so files of a certain function have the same name in each package.