### PR TITLE
[YAML] Fix tmPreferences

### DIFF
--- a/YAML/Comments.tmPreferences
+++ b/YAML/Comments.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Comments</string>
 	<key>scope</key>
 	<string>source.yaml</string>
 	<key>settings</key>

--- a/YAML/Symbol List.tmPreferences
+++ b/YAML/Symbol List.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>scope</key>


### PR DESCRIPTION
This commit just removes the `name` keys and the DOCTYPE.