### PR TITLE
[Pascal] Fix tmPreferences

### DIFF
--- a/Pascal/Comments.tmPreferences
+++ b/Pascal/Comments.tmPreferences
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Miscellaneous</string>
 	<key>scope</key>
 	<string>source.pascal</string>
 	<key>settings</key>
 	<dict>
-		<key>increaseIndentPattern</key>
-		<string>\b(?i:(begin|declare|else|except|exception|finally|for|if|loop|package|procedure|task|try|type|when))\b</string>
 		<key>shellVariables</key>
 		<array>
 			<dict>

--- a/Pascal/Indentation Rules.tmPreferences
+++ b/Pascal/Indentation Rules.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.pascal</string>
+	<key>settings</key>
+	<dict>
+		<key>increaseIndentPattern</key>
+		<string>\b(?i:(begin|declare|else|except|exception|finally|for|if|loop|package|procedure|task|try|type|when))\b</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This commit ...

1. splits and renames the tmPreferences according to their function
2. removes the `name` key.