### PR TITLE
[Python] Fix tmPreferences

### DIFF
--- a/Python/Comments.tmPreferences
+++ b/Python/Comments.tmPreferences
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.python</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_LINE_TERMINATOR</string>
+				<key>value</key>
+				<string>:</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Python/Indentation Rules.tmPreferences
+++ b/Python/Indentation Rules.tmPreferences
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Miscellaneous</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>settings</key>
@@ -13,21 +11,6 @@
 		<string>^\s*(class|(\basync\s+)?(def|for|with)|elif|else|except|finally|if|try|while)\b.*:\s*$</string>
 		<key>disableIndentNextLinePattern</key>
 		<string></string>
-		<key>shellVariables</key>
-		<array>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_START</string>
-				<key>value</key>
-				<string># </string>
-			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_LINE_TERMINATOR</string>
-				<key>value</key>
-				<string>:</string>
-			</dict>
-		</array>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This commit ...

1. splits and renames the tmPreferences according to their function
2. removes the `name` key.

Note: Symbol List and Symbol Index are already part of a former PR.