### PR TITLE
[Git] Add 'bright' versions of colors

### DIFF
--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -135,8 +135,10 @@ contexts:
     # example: bold, italic, underline
     - match: \b(?:no-?)?(?:ul|strike|reverse|italic|dim|bold|blink)\b
       scope: support.constant.color-attribute.git.config
+    - match: \b(?:normal|auto)\b
+      scope: support.constant.color.automatic.git.config
     # example: red, blue, green
-    - match: \b(?:yellow|white|red|normal|magenta|green|cyan|blue|black|auto)\b
+    - match: \b(?:bright)?(?:yellow|white|red|magenta|green|cyan|blue|black)\b
       scope: support.constant.color.git.config
     # example: 0-255
     - match: \b(?:{{zero_to_255}})\b

--- a/Git Formats/syntax_test_git_config
+++ b/Git Formats/syntax_test_git_config
@@ -150,6 +150,10 @@
 #                   ^^ -constant.other.color.rgb-value
     commit = yellow 999
 #                   ^^^ -constant.other.color.rgb-value
+    commit = brightyellow 0
+#            ^^^^^^^^^^^^ support.constant.color
+#                         ^ constant.other.color.rgb-value
+
 
 # ESCAPE TESTS
 [escapes]


### PR DESCRIPTION
https://github.com/git/git/commit/87f17d790d8e350e8df1101476882f7751581ee0

The release notes [say](https://github.com/git/git/blob/master/Documentation/RelNotes/2.26.0.txt#L38-L39) "the basic 7 colors" get "bright" modifiers, but there are 8. I think they forgot to count "0" in 0-7.