### PR TITLE
[ShellScript] Fix while/until condition highlighting

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -165,13 +165,16 @@ contexts:
       set: [cmd-post, cmd-args]
     - match: \bwhile{{keyword_break}}
       scope: keyword.control.loop.while.shell
+      pop: true
     - match: \buntil{{keyword_break}}
-      scope:  keyword.control.loop.until.shell
+      scope: keyword.control.loop.until.shell
+      pop: true
     - match: \bcase{{keyword_break}}
       scope: keyword.control.conditional.case.shell
       set: [case-body, case-word]
     - match: \bcontinue{{keyword_break}}
       scope: keyword.control.flow.continue.shell
+      pop: true
     - match: \bbreak{{keyword_break}}
       scope: keyword.control.flow.break.shell
       set: [cmd-post, cmd-args]

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1566,6 +1566,30 @@ while ! ( [[ true ]] ); do echo bar; done
 #                       ^^ keyword.control.loop.do
 #                                    ^^^^ keyword.control.loop.end
 
+while read -r -d '' f; do
+# <- keyword.control.loop.while
+#     ^^^^ support.function.read
+#          ^^ variable.parameter.option
+#             ^^ variable.parameter.option
+#                ^^ string.quoted.single.shell
+#                    ^ keyword.operator.logical.continue
+#                      ^^ keyword.control.loop.do
+done
+# <- keyword.control.loop.end
+
+while IFS= read -r -d '' f; do
+# <- keyword.control.loop.while
+#     ^^^ variable.other.readwrite.assignment
+#        ^ keyword.operator.assignment
+#          ^^^^ support.function.read
+#               ^^ variable.parameter.option
+#                  ^^ variable.parameter.option
+#                     ^^ string.quoted.single.shell
+#                         ^ keyword.operator.logical.continue
+#                           ^^ keyword.control.loop.do
+done
+# <- keyword.control.loop.end
+
 do echo bar; until ! { [[ true ]]; }
 # <- keyword.control.loop.do
 #            ^^^^^ keyword.control.loop.until.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -485,6 +485,39 @@ if [[ ! -z "$PLATFORM" ]] && ! cmd || ! cmd2; then PLATFORM=docker; fi
 #                                                         ^ variable.other.readwrite.assignment
 #                                                          ^ keyword.operator.assignment
 #                                                           ^ string.unquoted
+if { [[ ! -z "$PLATFORM" ]] && ! cmd || ! cmd2; }; then PLATFORM=docker; fi
+#^ keyword.control.conditional.if
+#  ^ punctuation.definition.compound.braces.begin
+#       ^ keyword.operator.logical
+#                           ^^ keyword.operator.logical.and
+#                              ^ keyword.operator.logical.shell
+#                                ^^^ meta.function-call.shell variable.function
+#                                    ^^ keyword.operator.logical.or.shell
+#                                       ^ keyword.operator.logical.shell
+#                                         ^^^^ meta.function-call.shell variable.function.shell
+#                                               ^ punctuation.definition.compound.braces.end
+#                                                ^ keyword.operator.logical.continue
+#                                                  ^^^^ keyword.control.conditional.then
+#                                                              ^ variable.other.readwrite.assignment
+#                                                               ^ keyword.operator.assignment
+#                                                                ^ string.unquoted
+if ( [[ ! -z "$PLATFORM" ]] && ! cmd || ! cmd2 ); then PLATFORM=docker; fi
+#^ keyword.control.conditional.if
+#  ^ punctuation.definition.compound.begin
+#       ^ keyword.operator.logical
+#                           ^^ keyword.operator.logical.and
+#                              ^ keyword.operator.logical.shell
+#                                ^^^ meta.function-call.shell variable.function
+#                                    ^^ keyword.operator.logical.or.shell
+#                                       ^ keyword.operator.logical.shell
+#                                         ^^^^ meta.function-call.shell variable.function.shell
+#                                              ^ punctuation.definition.compound.end
+#                                               ^ keyword.operator.logical.continue
+#                                                 ^^^^ keyword.control.conditional.then
+#                                                             ^ variable.other.readwrite.assignment
+#                                                              ^ keyword.operator.assignment
+#                                                               ^ string.unquoted
+
 if cmd && \
     ! cmd
 #   ^ keyword.operator.logical.shell
@@ -1479,7 +1512,7 @@ commits=($(git rev-list --reverse --abbrev-commit "$latest".. -- "$prefix"))
 ################
 
 while true; do
-# <- keyword.control
+# <- keyword.control.loop.while
 #        ^ meta.function-call variable.function
 #         ^ keyword.operator
 #            ^ keyword.control
@@ -1490,7 +1523,58 @@ while true; do
     # <- keyword.control.flow.continue.shell
 
 done
-# <- keyword.control
+# <- keyword.control.loop.end
+
+while ! true; do echo bar; done
+# <- keyword.control.loop.while
+#     ^ keyword.operator.logical
+#           ^ keyword.operator.logical.continue
+#             ^^ keyword.control.loop.do
+#                          ^^^^ keyword.control.loop.end
+
+while ! { true; }; do echo bar; done
+# <- keyword.control.loop.while
+#     ^ keyword.operator.logical
+#       ^ punctuation.definition.compound.braces.begin
+#         ^^^^ variable.function
+#             ^ keyword.operator.logical.continue
+#               ^ punctuation.definition.compound.braces.end
+#                ^ keyword.operator.logical.continue
+#                  ^^ keyword.control.loop.do
+#                               ^^^^ keyword.control.loop.end
+
+while ! { [[ true ]]; }; do echo bar; done
+# <- keyword.control.loop.while
+#     ^ keyword.operator.logical
+#       ^ punctuation.definition.compound.braces.begin
+#         ^^ support.function.double-brace.begin
+#                 ^^ support.function.double-brace.end
+#                   ^ keyword.operator.logical.continue
+#                     ^ punctuation.definition.compound.braces.end
+#                      ^ keyword.operator.logical.continue
+#                        ^^ keyword.control.loop.do
+#                                     ^^^^ keyword.control.loop.end
+
+while ! ( [[ true ]] ); do echo bar; done
+# <- keyword.control.loop.while
+#     ^ keyword.operator.logical
+#       ^ punctuation.definition.compound.begin
+#         ^^ support.function.double-brace.begin
+#                 ^^ support.function.double-brace.end
+#                    ^ punctuation.definition.compound.end
+#                     ^ keyword.operator.logical.continue
+#                       ^^ keyword.control.loop.do
+#                                    ^^^^ keyword.control.loop.end
+
+do echo bar; until ! { [[ true ]]; }
+# <- keyword.control.loop.do
+#            ^^^^^ keyword.control.loop.until.shell
+#                  ^ keyword.operator.logical
+#                    ^ punctuation.definition.compound.braces.begin
+#                      ^^ support.function.double-brace.begin
+#                              ^^ support.function.double-brace.end
+#                                ^ keyword.operator.logical.continue
+#                                  ^ punctuation.definition.compound.braces.end
 
 declare -a array
 array[500]=value


### PR DESCRIPTION
Fixes #2307
Closes #2315

This commit makes sure to pop off the context after matching while/until keywords to properly scope grouped conditions. The missing `pop` caused them to be scoped as expansions instead.