### PR TITLE
[Lisp] Rescopes `parens` to be consistent with the guidelines and Clojure.

### DIFF
--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -69,6 +69,8 @@ contexts:
       scope: keyword.operator.bitwise.lisp
 
   parens:
+    - match: '\(\)'
+      scope: constant.language.lisp
     - match: '\('
       scope: punctuation.section.parens.begin.lisp
       push:

--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -70,11 +70,11 @@ contexts:
 
   parens:
     - match: '\('
-      scope: punctuation.definition.group.begin.lisp
+      scope: punctuation.section.parens.begin.lisp
       push:
-        - meta_scope: meta.group.lisp
+        - meta_scope: meta.parens.lisp
         - match: '\)'
-          scope: punctuation.definition.group.end.lisp
+          scope: punctuation.section.parens.end.lisp
           pop: true
         - include: expressions
         - include: parens

--- a/Lisp/syntax_test_lisp.lisp
+++ b/Lisp/syntax_test_lisp.lisp
@@ -87,6 +87,9 @@
 (nil)
 ;^^^ constant.language
 
+()
+;^^^ constant.language
+
 ;#######################
 ; ARITHMETIC OPERATORS #
 ;#######################

--- a/Lisp/syntax_test_lisp.lisp
+++ b/Lisp/syntax_test_lisp.lisp
@@ -37,11 +37,11 @@
 ;                    ^^^ invalid.illegal.stray-bracket-end
 
  (( #| nested |# ))
-;^ meta.group punctuation.definition.group.begin
-; ^ meta.group meta.group punctuation.definition.group.begin
+;^ meta.parens punctuation.section.parens.begin
+; ^ meta.parens meta.parens punctuation.section.parens.begin
 ;         ^ comment
-;                ^ meta.group meta.group punctuation.definition.group.end
-;                 ^ meta.group punctuation.definition.group.end
+;                ^ meta.parens meta.parens punctuation.section.parens.end
+;                 ^ meta.parens punctuation.section.parens.end
 
 ;##########
 ; STRINGS #

--- a/Lisp/syntax_test_lisp.lisp
+++ b/Lisp/syntax_test_lisp.lisp
@@ -87,8 +87,8 @@
 (nil)
 ;^^^ constant.language
 
-()
-;^^^ constant.language
+(())
+;^^ constant.language
 
 ;#######################
 ; ARITHMETIC OPERATORS #


### PR DESCRIPTION
## Changes

1. `parens` is changed from `punctuation.definition`... to `punctuation.section`.
2. `()` is included as a language constant.
3. Tests for both.
## Rationale
1. This is to more strictly [follow the scoping guidelines](https://www.sublimetext.com/docs/3/scope_naming.html#meta) which state that blocks of code delineated in brackets should be scoped in `meta.parens` with `punctuation.section.parens` for the brackets.
  The use of the `.definition` scope led to (perceived) incorrect colouring in Monokai Pro, and this change brings `Lisp.sublime-syntax` in line with `Clojure.sublime-syntax` which currently uses `punctuation.section.parens`.

2. Adding `()` as a `language.constant` because `()` ≡ `nil` for the sake of consistency.
3. By necessity.