### PR TITLE
[Lisp] Expand symbol character support

### DIFF
--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
       scope: keyword.control.lisp
 
   functions:
-    - match: \b(?i:(defun|defmethod|defmacro))\b\s+([\w\-!?<>]*)
+    - match: \b(?i:(defun|defmethod|defmacro|defvar|defconstant))\b\s+([\w\-!?<>%+*]*)
       scope: meta.function.lisp
       captures:
         1: storage.type.function-type.lisp

--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -18,6 +18,8 @@ file_extensions:
   - lsp
   - fasl # Scheme dialect of Lisp
 scope: source.lisp
+variables:
+  symbol: '[\w\-!?<>%+*]*'
 contexts:
   main:
     - include: comments
@@ -29,6 +31,7 @@ contexts:
     - include: constants
     - include: strings
     - include: variables
+    - include: globals
     - include: control
     - include: functions
     - include: operators
@@ -49,8 +52,15 @@ contexts:
     - match: \b(?i:with|while|when|unless|typecase|to|thereis|then|return-from name|return|repeat|prog*|prog|never|named|maplist|mapl|mapcon|mapcar|mapcan|mapc|loop|let|initially|if|from|for|finally|etypecase|else|dotimes|dolist|doing|do*|do|ctypecase|cond|case|block|as|always)\b
       scope: keyword.control.lisp
 
+  globals:
+    - match: \b(?i:(defvar|defconstant))\b\s+({{symbol}})
+      scope: meta.name.lisp
+      captures:
+        1: storage.type.name-type.lisp
+        2: entity.name.type.lisp
+
   functions:
-    - match: \b(?i:(defun|defmethod|defmacro|defvar|defconstant))\b\s+([\w\-!?<>%+*]*)
+    - match: \b(?i:(defun|defmethod|defmacro))\b\s+({{symbol}})
       scope: meta.function.lisp
       captures:
         1: storage.type.function-type.lisp

--- a/Lisp/syntax_test_lisp.lisp
+++ b/Lisp/syntax_test_lisp.lisp
@@ -226,3 +226,14 @@
 ;^ storage.type.function-type
 ;      ^^^^^ entity.name.function
 )
+
+
+(defmacro %inner-macro (n1 n2 n3 n4)
+;^ storage.type.function-type
+;         ^^^^^^^^^^^^ entity.name.function
+)
+
+(defvar *global*)
+;^ storage.type.function-type
+;       ^^^^^^^^ entity.name.function
+

--- a/Lisp/syntax_test_lisp.lisp
+++ b/Lisp/syntax_test_lisp.lisp
@@ -233,7 +233,13 @@
 ;         ^^^^^^^^^^^^ entity.name.function
 )
 
-(defvar *global*)
-;^ storage.type.function-type
-;       ^^^^^^^^ entity.name.function
+;############
+; GLOBALS #
+;############
 
+(defvar *global*)
+;^ storage.type.name-type
+;       ^^^^^^^^ entity.name.type
+(defconstant +constant+)
+;^ storage.type.name-type
+;            ^^^^^^^^^^ entity.name.type


### PR DESCRIPTION
Expand characters available to symbols.
Allow Goto Definition on constants and variables as well.