### PR TITLE
[Makefile] Fix embedded ShellScript prototypes

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -602,8 +602,8 @@ contexts:
       set: value-to-be-defined
 
   embedded-shell:
-    - include: scope:source.shell#prototype
     - include: scope:source.shell
+      apply_prototype: true
 
   value-to-be-defined:
     - meta_content_scope: meta.string.makefile string.unquoted.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -325,7 +325,7 @@ contexts:
       set:
         # I don't like putting the string "source.shell" here, as the delegation
         # seeps into this syntax now. But I don't see a cleaner way right now.
-        - meta_scope: source.shell comment.line.number-sign.shell
+        - meta_scope: source.shell.embedded comment.line.number-sign.shell
         - include: comments-pop-on-line-end
     # Otherwise, delegate to the shell syntax (with various extra prototypes).
     - match: ''

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -328,13 +328,15 @@ contexts:
         - meta_scope: source.shell comment.line.number-sign.shell
         - include: comments-pop-on-line-end
     # Otherwise, delegate to the shell syntax (with various extra prototypes).
-    - match: ""
-      set: scope:source.shell
+    - match: ''
+      set: shell-body
       with_prototype:
-        - include: pop-on-line-end
-        - include: scope:source.shell#prototype
-        - include: line-continuation
         - include: variable-substitutions
+
+  shell-body:
+    - meta_scope: source.shell.embedded
+    - include: embedded-shell
+    - include: pop-on-line-end
 
   line-continuation:
     - match: (\\)([ ]*)$\n?
@@ -523,7 +525,7 @@ contexts:
           scope: keyword.other.block.end.makefile
           pop: true
         - match: ''
-          push: scope:source.shell
+          push: shell-body
           with_prototype:
             - match: (?=\))
               pop: true
@@ -563,10 +565,9 @@ contexts:
           set:
             - match: '!='
               scope: keyword.operator.assignment.makefile
-              set: scope:source.shell
+              set: shell-body
               with_prototype:
                 - include: variable-substitutions
-                - include: pop-on-line-end
                 - include: textual-parenthesis-balancer
         - match: (?=\s*(!|\?|\+|::?)?=)
           set:
@@ -592,13 +593,17 @@ contexts:
       captures:
         1: meta.string.makefile string.unquoted.makefile
         2: meta.string.makefile meta.interpolation.makefile punctuation.section.interpolation.begin.makefile
-      embed: scope:source.shell
-      embed_scope: meta.string.makefile meta.interpolation.makefile
+      embed: embedded-shell
+      embed_scope: meta.string.makefile meta.interpolation.makefile source.shell.embedded
       escape: (?!<\\)\2
       escape_captures:
         0: meta.string.makefile meta.interpolation.makefile punctuation.section.interpolation.end.makefile
     - match: ''
       set: value-to-be-defined
+
+  embedded-shell:
+    - include: scope:source.shell#prototype
+    - include: scope:source.shell
 
   value-to-be-defined:
     - meta_content_scope: meta.string.makefile string.unquoted.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -289,6 +289,12 @@ sources := $($(a1)_objects:.o=.c)
 #                             ^^ string variable
 #                               ^ string variable keyword.other.block.end
 
+.build/vernum: ../meta/version
+    sed -i.bak 's/.*automatically updated.*/version = "$(VER)" # automatically updated/' setup.py
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded meta.function-call
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single - comment
+#                                                      ^^^^^^ variable.parameter.makefile
+
 CC=g++
 #<- variable.other
 # ^ keyword.operator.assignment

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -930,11 +930,11 @@ TESTTOOL = sh -c '\
 #                ^^^ meta.string.makefile meta.interpolation.makefile
 #          ^^^^^^ string.unquoted.makefile
 #                ^ punctuation.section.interpolation.begin.makefile
-#                 ^ source.shell punctuation.separator.continuation.line.shell
+#                 ^ source.shell.embedded punctuation.separator.continuation.line.shell - source.shell source.shell
   if something; then
     build_thisway $$1 $$2;
   fi' TESTTOOL
 # ^^^ meta.string.makefile meta.interpolation.makefile
 #    ^^^^^^^^^ meta.string.makefile string.unquoted.makefile - meta.interpolation
-# ^^ source.shell keyword.control.conditional.end.shell
+# ^^ source.shell.embedded keyword.control.conditional.end.shell - source.shell source.shell
 #   ^ punctuation.section.interpolation.end.makefile


### PR DESCRIPTION
Fixes #2318

### Problem Description

  The Makefile.sublime-syntax includes the Bash.sublime-syntax.

  The `scope:source.shell#prototype` is injected into the embedded Bash.sublime-syntax using `with_prototype` maybe as workaround for https://github.com/sublimehq/sublime_text/issues/1062

  The `with_prototype` command ignores `meta_include_prototype: false`, which is heavily used by Bash.sublime-syntax to prevent the `prototype` context from being included into a bunch of contexts such as strings.

### Fix Description

  As the prototype context is not included into source.shell's main context only, it is not necessary to inject it via `with_protoype`. Hence it is moved to the `shell-body` together with `source.shell`, which is suggested by the core issue as proper workaround.

### Notes:

  The `prototype` context of the Bash.sublime-syntax also includes proper rules to pop off all contexts at eol with respect of line continuation. Hence those don't need to be part of the `with_proptype`  statement as well. They are moved to just pop off the Bash's main context as soon as the eol is reached.

  The `source.shell.embedded` scope is applied to all embedded shell syntax regions.