### PR TITLE
[XML] Fix comment trigger scopes

### DIFF
--- a/XML/Comments.tmPreferences
+++ b/XML/Comments.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>text.xml - meta.tag</string>
+	<string>text.xml - (meta.tag - punctuation.definition.tag)</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/XML/Comments.tmPreferences
+++ b/XML/Comments.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>text.xml - (meta.tag - punctuation.definition.tag)</string>
+	<string>text.xml</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
Fixes #2325

This commit includes the punctuation.definition.tag scope into the
comments trigger selector to enable commenting out a tag if

1. the caret is positioned directly before the tag
2. the caret is located at the end of a tag, which also is the end of file as this situation prevents the `meta.tag` scope from being popped off the stack correctly.

As a result the toggle_command does

1. still not work when toggled from within a tag (which is intended behavior) in order to
2. prevent a tag from being messed up by comments.