### PR TITLE
[ShellScript] Recognise Herestrings with no space following the operator 

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -558,7 +558,7 @@ contexts:
         2: keyword.operator.assignment.redirection.shell
 
   redirection-here-string:
-    - match: (\d*)(<<<)\s
+    - match: (\d*)(<<<)
       captures:
         1: constant.numeric.integer.decimal.file-descriptor.shell
         2: keyword.operator.herestring.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2059,6 +2059,21 @@ cat <<< "A wild herestring appears" ; cat more stuff | bar | qux
 #                                                   ^
 #                                                    ^ keyword.operator.logical.pipe
 
+if opam upgrade --check; then
+    opam upgrade --dry-run <<<n
+#                          ^^^ keyword.operator.herestring
+#                             ^ - keyword.control.heredoc-token
+#                             ^ - string.unquoted.heredoc
+fi
+# <- - string.unquoted.heredoc
+# <- keyword.control.conditional.end
+
+wc -c <<<$(echo pipephobic)
+#  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
+#     ^^^ keyword.operator.herestring
+#        ^^^^^^^^^^^^^^^^^^ meta.group.expansion.command.parens
+#          ^^^^ support.function
+
 # Escaped and non-escaped backticks in heredocs...
 cat << backticks_are_deprecated
 #      ^ meta.function-call.arguments string.unquoted.heredoc keyword.control.heredoc-token


### PR DESCRIPTION
Notably, the popular code auto-formatter `shfmt` chooses not to use a space.