### PR TITLE
[C#] Simplify pattern to avoid catastrophic backtracking

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1312,7 +1312,7 @@ contexts:
             2: punctuation.separator.cs
             3: punctuation.section.brackets.end.cs
             4: keyword.operator.pointer.cs
-    - match: \((?=(?:[^,)(]*|\([^\)]*\))*,)
+    - match: \((?=(?:[^,)(]|\([^\)]*\))*,)
       scope: punctuation.section.group.begin.cs
       push:
         - meta_scope: meta.group.tuple.cs


### PR DESCRIPTION
This PR simplifies a pattern in the C# syntax while leaving it functionally unchanged.

The old pattern is susceptible to catastrophic backtracking due to a combinatorial explosion caused by the inner and outer `*` modifier. Sublime text didn't really show any performance problems, but we did experience problems downstream in syntect/bat: https://github.com/sharkdp/bat/issues/677

The appearance of catastrophic backtracking for the old pattern can be seen here: https://regex101.com/r/O2AcN7/1

This change was originally proposed by @keith-hall [here](https://github.com/sharkdp/bat/issues/677#issuecomment-612502648).

Performance in Sublime text is not adversely affected.