### PR TITLE
[PHP] Add highlight for multiline regex string

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1465,43 +1465,63 @@ contexts:
       scope: meta.tag.inline.phpdoc.php
       captures:
         1: keyword.other.phpdoc.php
-  regex-double-quoted:
-    - match: (?="/(\\.|[^"/])+/[eimsuxADJSUX]*")
+  regex-double-quoted-branch:
+    - match: (")(/)
+      captures:
+        1: punctuation.definition.string.begin.php
+        2: punctuation.definition.string.regex-delimiter.begin.php
       push:
         - meta_scope: meta.string.php string.quoted.double.php
-        - match: (")(/)
-          captures:
-            1: punctuation.definition.string.begin.php
-            2: punctuation.definition.string.regex-delimiter.begin.php
         - match: (/)([eimsuxADJSUX]*)(")
           captures:
             1: punctuation.definition.string.regex-delimiter.end.php
             2: meta.regex.modifier.php
             3: punctuation.definition.string.end.php
+          pop: 2 # branch successful matched
+        - match: (?=")
           pop: true
         - match: ''
           push: scope:source.regexp.php
           with_prototype:
-            - match: (?=(/)([eimsuxADJSUX]*)("))
+            - match: (?=(/)([eimsuxADJSUX]*)(")|")
               pop: true
             - include: interpolation
-  regex-single-quoted:
-    - match: (?='/(\\.|[^'/])+/[eimsuxADJSUX]*')
+            - match: \\"
+              scope: constant.character.escape
+    - match: ''
+      fail: branch-point-double-quoted
+  regex-single-quoted-branch:
+    - match: (')(/)
+      captures:
+        1: punctuation.definition.string.begin.php
+        2: punctuation.definition.string.regex-delimiter.begin.php
       push:
         - meta_scope: meta.string.php string.quoted.single.php
-        - match: (')(/)
-          captures:
-            1: punctuation.definition.string.begin.php
-            2: punctuation.definition.string.regex-delimiter.begin.php
         - match: (/)([eimsuxADJSUX]*)(')
           captures:
             1: punctuation.definition.string.regex-delimiter.end.php
             2: meta.regex.modifier.php
             3: punctuation.definition.string.end.php
+          pop: 2 # branch successful matched
+        - match: (?=')
           pop: true
         - match: ''
-          embed: scope:source.regexp.php
-          escape: (?=(/)([eimsuxADJSUX]*)('))
+          push: scope:source.regexp.php
+          with_prototype:
+            - match: (?=(/)([eimsuxADJSUX]*)(')|')
+              pop: true
+            - match: \\'
+              scope: constant.character.escape
+    - match: ''
+      fail: branch-point-single-quoted
+  string-double-quoted-branch:
+    - include: string-double-quoted
+    - match: ''
+      pop: true
+  string-single-quoted-branch:
+    - include: string-single-quoted
+    - match: ''
+      pop: true
   string-backtick:
     - match: "`"
       scope: punctuation.definition.string.begin.php
@@ -1571,10 +1591,16 @@ contexts:
               scope: constant.character.escape.php
 
   strings:
-    - include: regex-double-quoted
-    - include: string-double-quoted
-    - include: regex-single-quoted
-    - include: string-single-quoted
+    - match: (?=")
+      branch_point: branch-point-double-quoted
+      branch:
+        - regex-double-quoted-branch
+        - string-double-quoted-branch
+    - match: (?=')
+      branch_point: branch-point-single-quoted
+      branch:
+        - regex-single-quoted-branch
+        - string-single-quoted-branch
   support:
     - match: |-
         \b(?xi:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -7,6 +7,7 @@ variables:
   identifier_start: '[[:alpha:]_]'
   identifier: '\b{{identifier_start}}[[:alnum:]_]*\b'
   path: '\\?({{identifier}}\\)*{{identifier}}'
+  regex_modifier: '[eimsuxADJSUX]*'
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b
 
 contexts:
@@ -1472,7 +1473,7 @@ contexts:
         2: punctuation.definition.string.regex-delimiter.begin.php
       push:
         - meta_scope: meta.string.php string.quoted.double.php
-        - match: (/)([eimsuxADJSUX]*)(")
+        - match: (/)({{regex_modifier}})(")
           captures:
             1: punctuation.definition.string.regex-delimiter.end.php
             2: meta.regex.modifier.php
@@ -1483,7 +1484,7 @@ contexts:
         - match: ''
           push: scope:source.regexp.php
           with_prototype:
-            - match: (?=(/)([eimsuxADJSUX]*)(")|")
+            - match: (?=(/)({{regex_modifier}})(")|")
               pop: true
             - include: interpolation
             - match: \\"
@@ -1497,7 +1498,7 @@ contexts:
         2: punctuation.definition.string.regex-delimiter.begin.php
       push:
         - meta_scope: meta.string.php string.quoted.single.php
-        - match: (/)([eimsuxADJSUX]*)(')
+        - match: (/)({{regex_modifier}})(')
           captures:
             1: punctuation.definition.string.regex-delimiter.end.php
             2: meta.regex.modifier.php
@@ -1508,7 +1509,7 @@ contexts:
         - match: ''
           push: scope:source.regexp.php
           with_prototype:
-            - match: (?=(/)([eimsuxADJSUX]*)(')|')
+            - match: (?=(/)({{regex_modifier}})(')|')
               pop: true
             - match: \\'
               scope: constant.character.escape

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1489,6 +1489,10 @@ contexts:
             - include: interpolation
             - match: \\"
               scope: constant.character.escape
+            - match: \s(#)([^"]*)$
+              captures:
+                1: comment.regexp.php punctuation.definition.comment.regexp.php
+                2: comment.regexp.php
     - match: ''
       fail: branch-point-double-quoted
   regex-single-quoted-branch:
@@ -1513,6 +1517,10 @@ contexts:
               pop: true
             - match: \\'
               scope: constant.character.escape
+            - match: \s(#)([^']*)$
+              captures:
+                1: comment.regexp.php punctuation.definition.comment.regexp.php
+                2: comment.regexp.php
     - match: ''
       fail: branch-point-single-quoted
   string-double-quoted-branch:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1335,8 +1335,9 @@ preg_replace("/a{,6}b{3,}c{3,6}/");
 $regex = '/
     a{,6}
 //   ^^^^ keyword.operator.quantifier.regexp
-    b{3,}
+    b{3,} # this is comment
 //   ^^^^ keyword.operator.quantifier.regexp
+//        ^^^^^^^^^^^^^^^^^ comment.regexp
     c{3,6}
 //   ^^^^^ keyword.operator.quantifier.regexp
 /ux';

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1332,6 +1332,28 @@ preg_replace("/a{,6}b{3,}c{3,6}/");
 //                   ^^^^ keyword.operator.quantifier.regexp
 //                        ^^^^^ keyword.operator.quantifier.regexp
 
+$regex = '/
+    a{,6}
+//   ^^^^ keyword.operator.quantifier.regexp
+    b{3,}
+//   ^^^^ keyword.operator.quantifier.regexp
+    c{3,6}
+//   ^^^^^ keyword.operator.quantifier.regexp
+/ux';
+
+$regex = '/foo?/ux';
+//            ^ keyword.operator.quantifier.regexp
+
+$not_regex = 'foo?';
+//               ^ string - source.regexp
+
+$not_regex = '/foo?';
+//                ^ string - source.regexp
+
+// there is no "T" regex modifier
+$not_regex = '/foo?/uTx';
+//                ^ string - source.regexp
+
 echo <<<EOT
 //   ^^^^^^ punctuation.definition.string
 //      ^^^ keyword.operator.heredoc


### PR DESCRIPTION
Our PHP syntax has already detected single/double-quoted regex strings which are written in a single line. Thanks to `branch_point` in ST 4, this PR makes it also detect those which are written in multiple lines.

```php
$regex = '/
    a{0,6}
//   ^^^^^ keyword.operator.quantifier.regexp
/ux';

$regex = '/foo?/ux';
//            ^ keyword.operator.quantifier.regexp

$not_regex = 'foo?';
//               ^ string - source.regexp

$not_regex = '/foo?';
//                ^ string - source.regexp

// there is no "T" regex modifier
$not_regex = '/foo?/uTx';
//                ^ string - source.regexp
```
