### PR TITLE
[Groovy] Adding Groovy detection using shebang line

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -7,6 +7,9 @@ file_extensions:
   - gvy
   - gradle
   - Jenkinsfile
+
+first_line_match: ^#!.*\bgroovy\b
+
 variables:
   unicode_letter: |-
     (?:(?xi)


### PR DESCRIPTION
This will allow Sublime Text to detect syntax for files without extension but with specified shebang line, such as Jenkinsfiles with non-standard names (e.g. `Jenkinsfile-build`, `Jenkinsfile-deploy`, etc).

Tested locally (`~/.config/sublime-text-3/Packages/User/Groovy.sublime-syntax`) with different types of shebang lines:
* `#!/usr/bin/env groovy`
* `#!/usr/bin/groovy`
* `#! groovy`
* `#!groovy`
* etc