### PR TITLE
[Regex] Sublime internal file patterns

### DIFF
--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+# https://www.sublimetext.com/docs/file_patterns.html
+name: Sublime File Pattern
+file_extensions:
+  - sublime-file-patterns
+hidden: true
+scope: source.file-pattern
+
+contexts:
+  main:
+    - include: multiple
+
+  multiple:
+    - match: (,)\s*(?:(-)|(//))?
+      captures:
+        1: punctuation.separator.file-pattern
+        2: keyword.operator.logical.file-pattern
+        3: constant.language.file-pattern
+    - include: single
+
+  single:
+    - match: \*{2,}
+      scope: invalid.illegal.file-pattern
+    - match: \[|\]
+      scope: invalid.illegal.file-pattern
+    - match: ^\s*(?:(-)|(//))
+      captures:
+        1: keyword.operator.logical.file-pattern
+        2: constant.language.file-pattern
+    - match: (\*)/|/(\*)(?!\*)
+      captures:
+        1: variable.language.wildcard.file-pattern
+        2: variable.language.wildcard.file-pattern
+    - match: \*
+      scope: keyword.operator.wildcard.file-pattern
+    - match: \?
+      scope: keyword.operator.wildcard.file-pattern

--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -35,3 +35,5 @@ contexts:
         2: variable.language.wildcard.file-pattern
     - match: '[*?]'
       scope: keyword.operator.wildcard.file-pattern
+    - match: <(?:current file|open files|open folders|project filters)>
+      scope: support.constant.file-pattern

--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -2,8 +2,6 @@
 ---
 # https://www.sublimetext.com/docs/file_patterns.html
 name: Sublime File Pattern
-file_extensions:
-  - sublime-file-patterns
 hidden: true
 scope: source.file-pattern
 
@@ -12,27 +10,28 @@ contexts:
     - include: multiple
 
   multiple:
-    - match: (,)\s*(?:(-)|(//))?
-      captures:
-        1: punctuation.separator.file-pattern
-        2: keyword.operator.logical.file-pattern
-        3: constant.language.file-pattern
+    - match: ','
+      scope: punctuation.separator.file-pattern
     - include: single
 
   single:
+    - match: \s*(-)?(//)?(?=.)
+      captures:
+        1: keyword.operator.logical.file-pattern
+        2: meta.path.file-pattern constant.language.file-pattern
+      push: pattern
+
+  pattern:
+    - meta_content_scope: meta.path.file-pattern
+    - match: (?=\s*(?:,|$))
+      pop: true
     - match: \*{2,}
       scope: invalid.illegal.file-pattern
     - match: \[|\]
       scope: invalid.illegal.file-pattern
-    - match: ^\s*(?:(-)|(//))
-      captures:
-        1: keyword.operator.logical.file-pattern
-        2: constant.language.file-pattern
     - match: (\*)/|/(\*)(?!\*)
       captures:
         1: variable.language.wildcard.file-pattern
         2: variable.language.wildcard.file-pattern
-    - match: \*
-      scope: keyword.operator.wildcard.file-pattern
-    - match: \?
+    - match: '[*?]'
       scope: keyword.operator.wildcard.file-pattern

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -2,11 +2,25 @@
 
 *.py
 # <- keyword.operator.wildcard
+#^^^ meta.path
+#   ^ - meta.path
 */bar.py
 # <- variable.language
 src/**/foo.java
 #   ^^ invalid.illegal
 *.cs, *.py
 #   ^ punctuation.separator
+*.cs, -.aspx.cs
+#   ^^ - meta.path
+#   ^ punctuation.separator
+#     ^ keyword.operator.logical
+*.cs,-*.aspx.cs
+#   ^ punctuation.separator - meta.path
+#    ^ keyword.operator.logical
+#     ^ keyword.operator.wildcard
 -node_modules/
 # <- keyword.operator.logical
+ssh-agent
+#  ^ - keyword
+node_modules,-//ngx/node_modules
+#             ^^ constant.language

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -1,0 +1,12 @@
+# SYNTAX TEST "Packages/Regular Expressions/File Pattern.sublime-syntax"
+
+*.py
+# <- keyword.operator.wildcard
+*/bar.py
+# <- variable.language
+src/**/foo.java
+#   ^^ invalid.illegal
+*.cs, *.py
+#   ^ punctuation.separator
+-node_modules/
+# <- keyword.operator.logical

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -24,3 +24,11 @@ ssh-agent
 #  ^ - keyword
 node_modules,-//ngx/node_modules
 #             ^^ constant.language
+<current file>
+#^^^^^^^^^^^^^ support.constant.file-pattern
+<open files>
+#^^^^^^^^^^^ support.constant.file-pattern
+<open folders>
+#^^^^^^^^^^^^^ support.constant.file-pattern
+<project filters>
+#^^^^^^^^^^^^^^^^ support.constant.file-pattern


### PR DESCRIPTION
Minimal syntax for ST [file patterns](https://www.sublimetext.com/docs/file_patterns.html). Like #2214 does with Regex Replace, this is for internal use if/when the "Where" (which files) portion of "Find in Files" can be scoped.

Also provides an entry point for things like PackageDev's [Project.sublime-syntax](https://github.com/SublimeText/PackageDev/blob/master/Package/Sublime%20Text%20Project/Sublime%20Text%20Project.sublime-syntax) that might not want the `,` included. ~(Although the bits anchored with `^` probably won't work either as JSON values.)~ _[Fixed?]_

I tried to distinguish the `/*` and `*/` behavior from the normal `*` behavior so that people might notice it works differently.