### PR TITLE
[Markdown] Separate bibliography reference links

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -275,7 +275,7 @@ contexts:
         6: markup.underline.link.markdown
         7: punctuation.definition.link.end.markdown
         8: markup.underline.link.markdown
-      push: [link-ref-def, after-link-title, link-title]
+      push: [link-ref-def-expect-end, link-title]
     - match: '^(?=\S)(?![=-]{3,}\s*$)'
       branch_point: heading2-branch
       branch:
@@ -340,10 +340,6 @@ contexts:
         1: markup.heading.2.setext.markdown punctuation.definition.heading.setext.markdown
       pop: true
 
-  link-ref-def:
-    - meta_scope: meta.link.reference.def.markdown
-    - match: ''
-      pop: true
   ampersand:
     - match: (?!{{html_entity}})&
       comment: |
@@ -1426,45 +1422,40 @@ contexts:
     - include: image-inline
     - include: image-ref
   link-title:
-    - match: \s*(')
-      captures:
-        1: punctuation.definition.string.begin.markdown
+    - match: \'
+      scope: punctuation.definition.string.begin.markdown
       set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \'
           scope: punctuation.definition.string.end.markdown
           pop: true
-        - match: ^\s*$\n?
-          scope: invalid.illegal.non-terminated.link-title.markdown
-          pop: true
-    - match: \s*(")
-      captures:
-        1: punctuation.definition.string.begin.markdown
+        - include: non-terminated-link-title
+    - match: \"
+      scope: punctuation.definition.string.begin.markdown
       set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \"
           scope: punctuation.definition.string.end.markdown
           pop: true
-        - match: ^\s*$\n?
-          scope: invalid.illegal.non-terminated.link-title.markdown
-          pop: true
-    - match: \s*(\()
-      captures:
-        1: punctuation.definition.string.begin.markdown
+        - include: non-terminated-link-title
+    - match: \(
+      scope: punctuation.definition.string.begin.markdown
       set:
         - meta_scope: string.other.link.description.title.markdown
         - match: \)
           scope: punctuation.definition.string.end.markdown
           pop: true
-        - match: ^\s*$\n?
-          scope: invalid.illegal.non-terminated.link-title.markdown
-          pop: true
-    - match: \s*
+        - include: non-terminated-link-title
+    - match: $|(?=\S)
       pop: true
-  after-link-title:
-    - match: '(.*)$\n?'
-      captures:
-        1: invalid.illegal.expected-eol.markdown
+  non-terminated-link-title:
+    - match: ^\s*$\n?
+      scope: invalid.illegal.non-terminated.link-title.markdown
+      pop: true
+  link-ref-def-expect-end:
+    - meta_scope: meta.link.reference.def.markdown
+    - match: .*$
+      scope: invalid.illegal.expected-eol.markdown
       pop: true
 
 ###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1454,9 +1454,10 @@ contexts:
       pop: true
   link-ref-def-expect-end:
     - meta_scope: meta.link.reference.def.markdown
-    - match: .*$
-      scope: invalid.illegal.expected-eol.markdown
+    - match: $
       pop: true
+    - match: \s*\S+
+      scope: invalid.illegal.expected-eol.markdown
 
 ###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################
 

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1514,11 +1514,12 @@ blah
 text
 | <- meta.paragraph - meta.link.reference.def
 
-[foo]: <bar> "test"
+[foo]: <bar> "test" 
 |      ^ punctuation.definition.link.begin
 |       ^^^ markup.underline.link
 |          ^ punctuation.definition.link.end
 |            ^^^^^^ string.other.link.description.title
+|                  ^ - invalid.illegal.expected-eol
 
 [foo]: <bar>> "test"
 |      ^ punctuation.definition.link.begin

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1489,22 +1489,26 @@ _foo [**bar**](/url)_
 |^^^^^^^^^^^ meta.link.reference.def entity.name.reference.link
 |            ^ punctuation.separator.key-value
 |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                                                ^ - meta.link - markup
 
 [//]: # (This is a comment without a line-break.)
 |     ^ meta.link.reference.def markup.underline.link
 |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.description.title
+|                                                ^ - meta.link
 
 [//]: # (This is a comment with a
 |     ^ meta.link.reference.def markup.underline.link
 |       ^ punctuation.definition.string.begin
         line-break.)
 |                  ^ punctuation.definition.string.end
+|                   ^ - meta.link
 
 [//]: # (testing)blah
+|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
 |       ^ punctuation.definition.string.begin
-|^^^^^^^^^^^^^^^^ meta.link.reference.def
 |               ^ punctuation.definition.string.end
 |                ^^^^ invalid.illegal.expected-eol
+|                    ^ - meta.link - invalid
 
 [//]: # (testing
 blah
@@ -1515,17 +1519,22 @@ text
 | <- meta.paragraph - meta.link.reference.def
 
 [foo]: <bar> "test" 
+|^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|                   ^ - meta.link
 |      ^ punctuation.definition.link.begin
 |       ^^^ markup.underline.link
 |          ^ punctuation.definition.link.end
 |            ^^^^^^ string.other.link.description.title
 |                  ^ - invalid.illegal.expected-eol
 
-[foo]: <bar>> "test"
+[foo]: <bar>> "test" 
+|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|                    ^ - meta.link
 |      ^ punctuation.definition.link.begin
 |       ^^^ markup.underline.link
 |          ^ punctuation.definition.link.end
 |           ^^^^^^^^ invalid.illegal.expected-eol
+|                   ^ - invalid.illegal.expected-eol
 
 https://michelf.ca/projects/php-markdown/extra/#footnotes
 That's some text with a footnote.[^1]


### PR DESCRIPTION
Fixes #2360

Reference definitions need to be separated by line to correctly display them in the Goto Symbol Overlay. The newline `\n` is no longer included into the `meta.link.reference` scope in order to separate the lines from each other.

**Before**

![grafik](https://user-images.githubusercontent.com/16542113/82117733-9039e280-9772-11ea-8fe6-d44c5d19a19a.png)

**After**

![grafik](https://user-images.githubusercontent.com/16542113/82117725-6d0f3300-9772-11ea-9f32-af5b312d058d.png)

**Notes**

1. As `\s*` includes the `\n` the `link-title` context is modified accordingly.
2. The former `after-link-title` and `link-ref-def` contexts are merged into a `link-ref-def-expect-end`