### PR TITLE
[Python] Fix overlapping meta scope in lambdas

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -870,11 +870,13 @@ contexts:
 
   lambda:
     - match: \b(lambda)(?=\s|:|$)
-      scope: storage.type.function.inline.python keyword.declaration.function.inline.python
+      scope: 
+        meta.function.inline.python
+        storage.type.function.inline.python
+        keyword.declaration.function.inline.python
       push: [lambda-parameters, allow-unpack-operators]
 
   lambda-parameters:
-    - meta_scope: meta.function.inline.python
     - meta_content_scope: meta.function.inline.parameters.python
     - include: line-continuation-or-pop
     - match: '\:'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -264,6 +264,10 @@ def _():
 #              ^^ invalid.illegal.name
 
     lambda *a, **kwa, ab*, * *: (a, kwa)
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function.inline meta.function.inline
+#   ^^^^^^ meta.function.inline.python
+#         ^^^^^^^^^^^^^^^^^^^^^ meta.function.inline.parameters.python
+#                              ^^^^^^^^^ meta.function.inline.body.python
 #          ^ keyword.operator.unpacking.sequence.python
 #           ^ variable.parameter.python
 #                ^^^ variable.parameter.python
@@ -275,10 +279,11 @@ def _():
 #   ^^^^^^ storage.type.function.inline keyword.declaration.function.inline.python
 
     lambda (x, y): 0
-#   ^^^^^^^^^^^^^^^^ meta.function.inline
+#   ^^^^^^^^^^^^^^^^ - meta.function.inline meta.function.inline
+#   ^^^^^^ meta.function.inline.python
 #         ^^^^^^^^ meta.function.inline.parameters.python
-#                 ^^ meta.function.inline.body.python
 #          ^^^^^^ meta.group.python
+#                 ^^ meta.function.inline.body.python
 #          ^ punctuation.section.group.begin.python
 #           ^ variable.parameter.python
 #            ^ punctuation.separator.parameters.python
@@ -286,7 +291,8 @@ def _():
 #               ^ punctuation.section.group.end.python
 #                ^ punctuation.section.function.begin.python
     lambda (
-#   ^^^^^^^^^ meta.function.inline.python
+#   ^^^^^^^^^ - meta.function.inline meta.function.inline
+#   ^^^^^^ meta.function.inline.python
 #         ^^^ meta.function.inline.parameters.python
 #          ^^ meta.group.python
 #          ^ punctuation.section.group.begin.python
@@ -298,6 +304,7 @@ def _():
 #      ^^^^ meta.function.inline.parameters.python meta.group.python
 #       ^ variable.parameter.python
     ):
+#^^^^^^ - meta.function.inline meta.function.inline
 #^^^^ meta.function.inline.parameters.python meta.group.python
 #   ^ punctuation.section.group.end.python
 #    ^ punctuation.section.function.begin.python


### PR DESCRIPTION
This commit removes overlapping of
`meta.function.inline.python meta.function.inline.parameters.python`