### PR TITLE
[Python] Fix function return type annotation

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -704,22 +704,26 @@ contexts:
 
   function-after-parameters:
     - meta_content_scope: meta.function.python
-    - match: '(?=->)'
-      set:
-        - meta_content_scope: meta.function.annotation.return.python
-        - match: ->
-          scope: punctuation.separator.annotation.return.python
-        - include: illegal-assignment-expression
-        - match: '(?=:)'
-          set: function-after-parameters
-        - include: line-continuation-or-pop
-        - include: expression-in-a-statement
+    - match: (?=->)
+      set: [function-return-type, function-return-type-separator]
+    - include: function-terminator
+
+  function-return-type:
+    - meta_content_scope: meta.function.annotation.return.python
+    - include: illegal-assignment-expression
+    - include: function-terminator
+    - include: expression-in-a-statement
+
+  function-return-type-separator:
+    - match: ->
+      scope: punctuation.separator.annotation.return.python
+      pop: true
+
+  function-terminator:
     - match: ':'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: true
-    - include: comments
-    - match: (?=\S)
-      pop: true
+    - include: line-continuation-or-pop
 
   decorators:
     - match: ^\s*(?=@)

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -618,6 +618,32 @@ def abc():
 #                ^^^ invalid.illegal.name
 #                               ^ invalid.illegal.name.storage
 
+def my_func # comment
+#^^^^^^^^^^ meta.function.python
+#          ^^^^^^^^^^^ - meta.function
+#   ^^^^^^^ entity.name.function.python
+#           ^^^^^^^^^ comment.line.number-sign.python
+
+def my_func() # comment
+#^^^^^^^^^^^^^ - meta.function meta.function
+#^^^^^^^^^^ meta.function.python
+#          ^^ meta.function.parameters.python
+#            ^^^^^^^^^^^ - meta.function
+#   ^^^^^^^ entity.name.function.python
+#          ^ punctuation.section.parameters.begin.python
+#           ^ punctuation.section.parameters.end.python
+#             ^^^^^^^^^ comment.line.number-sign.python
+
+def my_func(): # comment
+#^^^^^^^^^^ meta.function.python
+#          ^^ meta.function.parameters.python
+#            ^ meta.function.python
+#             ^^^^^^^^^^^ - meta.function
+#   ^^^^^^^ entity.name.function.python
+#          ^ punctuation.section.parameters.begin.python
+#           ^ punctuation.section.parameters.end.python
+#            ^ punctuation.section.function.begin.python
+#              ^^^^^^^^^ comment.line.number-sign.python
 
 def my_func(param1, # Multi-line function definition
 #                 ^ punctuation.separator.parameters
@@ -666,8 +692,54 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 #                                                                                                  ^^ punctuation.separator.annotation
 #                                                                                                     ^^^ support.type
 #                                                                                                        ^ punctuation.section.function.begin
+
+def type_annotations_line_continuation_without_terminator() \
+      -> int
+#^^^^^^^^^^^ - meta.function meta.function
+#           ^ - meta.function
+#^^^^^ meta.function.python
+#     ^^^^^^ meta.function.annotation.return
+#     ^^ punctuation.separator.annotation
+#        ^^^ support.type
     pass
 
+def type_annotations_line_continuation_without_terminator_but_comment() \
+      -> int # comment
+#^^^^^^^^^^^ - meta.function meta.function
+#           ^^^^^^^^^^ - meta.function
+#^^^^^ meta.function.python
+#     ^^^^^^ meta.function.annotation.return
+#     ^^ punctuation.separator.annotation
+#        ^^^ support.type
+    pass
+
+def type_annotations_line_continuation() \
+      -> int:
+#^^^^^^^^^^^^ - meta.function meta.function
+#^^^^^ meta.function.python
+#     ^^^^^^ meta.function.annotation.return
+#           ^ meta.function.python
+#     ^^ punctuation.separator.annotation
+#        ^^^ support.type
+#           ^ punctuation.section.function.begin
+    pass
+
+def type_annotations_line_continuation() \
+      -> \
+      int:
+#^^^^^^^^ meta.function.annotation.return
+#        ^ meta.function.python
+#     ^^^ support.type
+#        ^ punctuation.section.function.begin
+    pass
+
+def type_annotations_line_continuation() \
+      -> \
+      int \
+      :
+#^^^^^ meta.function.annotation.return
+#     ^ meta.function.python punctuation.section.function.begin.python
+    pass
 
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function


### PR DESCRIPTION
This commit fixes the return type annotation after line continuation.

It also removes the `comments` from the `function-after-parameters` as it seems not to be used at all.

The `:` is moved into a dedicated `function-terminator` context to avoid the `(?=:)` lookahead used to pop the return type annotation context.