### PR TITLE
[Erlang] Fix comment punctuation scope

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -235,7 +235,7 @@ contexts:
 ###[ COMMENTS ]###############################################################
 
   comment:
-    - match: \%
+    - match: \%+
       scope: punctuation.definition.comment.percentage.erlang
       push:
         - meta_scope: comment.line.percentage.erlang

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -3,6 +3,10 @@
 % ^ comment.line.percentage.erlang
 %                                                   ^^ comment.line.percentage.erlang
 
+%%%%%%%%%%%%%--%%
+%^^^^^^^^^^^^ comment.line.percentage.erlang punctuation.definition.comment.percentage.erlang
+%            ^^^^^ comment.line.percentage.erlang - punctuation
+
 % Atom tests
 
 atom_tests() -> .


### PR DESCRIPTION
This commit modifies the syntax definition in order to highlight all leading `%` as punctuation.definition.comment as it looks a bit odd to have only the first one colored differently in documentation comments like.

```Erlang
%%----------
%% Section
%%----------
```