### PR TITLE
[ShellScript] Fix let statement termination

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -825,8 +825,9 @@ contexts:
       scope: support.function.let.bash
       push:
         - meta_scope: meta.function-call.shell
-        - match: $
+        - match: (?=;)
           pop: true
+        - include: line-continuation-or-pop-at-end
         - include: expression
     - match: (\[\[)(?=\s)
       captures:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1414,6 +1414,35 @@ unset -f -n -v foo
 #           ^ punctuation
 #            ^ variable
 
+
+let "two=5+5"; if [[ "$X" == "1" ]]; then X="one"; fi
+#^^^^^^^^^^^^ meta.function-call.shell
+#^^ support.function.let.bash
+#   ^^^^^^^^^ string.quoted.double.shell
+#            ^ keyword.operator.logical.continue.shell
+#              ^^ keyword.control.conditional.if.shell
+#                 ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                                  ^ keyword.operator.logical.continue.shell
+#                                    ^^^^ keyword.control.conditional.then.shell
+#                                         ^ variable.other.readwrite.assignment.shell
+#                                          ^ keyword.operator.assignment.shell
+#                                           ^^^^^ string.quoted.double.shell
+#                                                ^ keyword.operator.logical.continue.shell
+#                                                  ^^ keyword.control.conditional.end.shell
+
+let 5 \
+    + 5
+#^^^^^^ meta.function-call.shell
+#   ^ keyword.operator.arithmetic.shell
+#     ^ constant.numeric.integer.decimal.shell
+
+let 5+5 # comment
+#^^^^^^ meta.function-call.shell
+#^^ support.function.let.bash
+#   ^ constant.numeric.integer.decimal.shell
+#    ^ keyword.operator.arithmetic.shell
+#     ^ constant.numeric.integer.decimal.shell
+
 foo=`let 5+5`
 #   ^ punctuation.section.group.begin
 #          ^ constant.numeric.integer


### PR DESCRIPTION
This commit pops the `let` statement if a `;` is detected and adds support for line continuation operator `\`.

See: https://forum.sublimetext.com/t/color-bug-in-shell/51820