### PR TITLE
[ShellScript] Fix incomplete case patterns

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -191,30 +191,34 @@ contexts:
     - match: \besac{{keyword_break}}
       scope: keyword.control.conditional.end.shell
       pop: true
-    - match: (?=\()
-      push:
-        - clear_scopes: 1  # remove meta.conditional.case.shell
-        - match: \(
-          scope: keyword.control.conditional.patterns.begin.shell
-          set: case-clause-patterns
     - match: (?=\S)
-      push: case-clause-patterns
+      push:
+        - case-clause-commands
+        - case-clause-patterns
+        - case-clause-patterns-begin
+
+  case-clause-patterns-begin:
+    - match: \(
+      scope: keyword.control.conditional.patterns.begin.shell
+      pop: true
+    - match: ''
+      pop: true
 
   case-clause-patterns:
     - clear_scopes: 1  # remove meta.conditional.case.shell
     - meta_scope: meta.conditional.case.clause.patterns.shell
     - match: \)
       scope: keyword.control.conditional.patterns.end.shell
-      set: case-clause-commands
+      pop: true
     # emergency bail outs if ')' is missing
     - match: (?=;;&?|;&)
-      set: case-clause-commands
-    - include: case-end-ahead
+      pop: true
     - include: case-clause-patterns-body
 
   case-clause-patterns-body:
     # [Bash] 3.2.4.2: Each pattern undergoes tilde expansion, parameter
     # expansion, command substitution, and arithmetic expansion.
+    - include: case-end-ahead
     - include: expansion-pattern
     - include: expansion-tilde
     - include: expansion-parameter

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1163,6 +1163,15 @@ case
 esac
 #^ meta.conditional.case keyword.control.conditional.end
 
+case var in
+  ( patt ( esac
+#^ meta.conditional.case.shell
+# ^^^^^^^^^ meta.conditional.case.clause.patterns.shell
+# ^ keyword.control.conditional.patterns.begin.shell
+#        ^ punctuation.section.parens.begin.shell
+#          ^^^^ meta.conditional.case.shell keyword.control.conditional.end.shell
+#              ^ - meta.conditional
+
 case $_G_unquoted_arg in
 *[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")
 #^ keyword.control.regexp.set.begin


### PR DESCRIPTION
This commit adds the `case-end-ahead` context to all nested case pattern parentheses in order to ensure to limit invalid syntax highlighting to the `case ... esac` block if the closing parenthesis is missing.