### PR TITLE
[C#] assorted fixes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -860,6 +860,10 @@ contexts:
         1: keyword.control.using.cs
         2: meta.group.cs punctuation.section.group.begin.cs
       set: [using_block, line_of_code]
+    - match: \b(using)\s*
+      captures:
+        1: keyword.control.using.cs
+      push: var_declaration
     - match: \b(fixed)\s*(\()
       captures:
         1: keyword.control.other.fixed.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -768,8 +768,10 @@ contexts:
                 - include: line_of_code_in
             - match: (?=\S)
               pop: true
-        - match: \b(get)\b
-          scope: storage.type.function.accessor.get.cs
+        - match: (?:\b(readonly)\b\s+)?\b(get)\b
+          captures:
+            1: storage.modifier.cs
+            2: storage.type.function.accessor.get.cs
           push: method_body
         - match: \b(set)\b
           scope: storage.type.function.accessor.set.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1137,7 +1137,7 @@ contexts:
     - meta_content_scope: meta.instance.cs
     - match: \{
       scope: punctuation.section.block.begin.cs
-      # Found an anounymous class
+      # Found an anonymous class
       set:
         - meta_scope: meta.instance.cs meta.class.body.anonymous.cs meta.block.cs
         - match: \}
@@ -1153,7 +1153,7 @@ contexts:
         - match: (?=\S)
           push: line_of_code_in
     - match: (?=[^{\s])
-      # This is not an anounymous class
+      # This is not an anonymous class
       set:
         - meta_content_scope: meta.instance.cs
         - match: '{{brackets_capture}}'
@@ -1272,6 +1272,12 @@ contexts:
       push: accessor_arguments
     - match: '({{base_type}})\b'
       scope: storage.type.cs
+    - match: stackalloc\b
+      scope: storage.modifier.cs
+      push:
+        - match: (?=\[)
+          pop: true
+        - include: type
     - match: '({{reserved}})\b'
       scope: keyword.other.cs
     - match: '(?:(global)|({{name}}))\s*(::)'
@@ -1480,10 +1486,10 @@ contexts:
       push: type_argument
     - match: '{{name}}'
       scope: support.type.cs
-    - match: '[{:]'
-      scope: invalid.illegal
-      pop: true
-    - match: (?=\}|\)|>|\]|,|;|>|=>)
+    # - match: '[{:]'
+    #   scope: invalid.illegal
+    #   pop: true
+    - match: (?=[]})>,;>:]|=>)
       pop: true
 
   type_arg_param_common:

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -525,6 +525,9 @@ contexts:
       scope: storage.modifier.cs
     - match: '{{visibility}}'
       scope: storage.modifier.access.cs
+    - match: '\b(operator)\b'
+      scope: storage.modifier.cs
+      push: method_name
     - match: '({{name}})\s*(<)'
       captures:
         1: support.type.cs
@@ -560,9 +563,6 @@ contexts:
             6: keyword.operator.pointer.cs
         - match: ''
           set: method_name
-    - match: '\b(operator)\b'
-      scope: storage.modifier.cs
-      push: method_name
     - match: (?=\()
       push: [method_name, type_tuple]
 

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -844,7 +844,7 @@ contexts:
       captures:
         1: keyword.control.loop.for.cs
         2: meta.group.cs punctuation.section.group.begin.cs
-      set: [for_block, line_of_code_in, line_of_code_in, line_of_code_in_no_semicolon]
+      set: [for_block, line_of_code_in, line_of_code_in, line_of_code_in]
     - match: \b(foreach)\s*(\()
       captures:
         1: keyword.control.loop.foreach.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -513,7 +513,7 @@ contexts:
       pop: true
 
   method_declaration:
-    - match: '\b(abstract|async|const|extern|new|override|readonly|ref|sealed|static|unsafe|virtual|volatile)\b'
+    - match: '\b(?:abstract|async|const|extern|new|override|readonly|ref|sealed|static|unsafe|virtual|volatile)\b'
       scope: storage.modifier.cs
     - match: \b(event)\b\s*
       captures:
@@ -521,11 +521,11 @@ contexts:
       push: [event_handler_declaration, type_no_space]
     - match: \bdelegate\b
       scope: storage.type.delegate.cs
-    - match: '\b(implicit|explicit)\b'
+    - match: '\b(?:implicit|explicit)\b'
       scope: storage.modifier.cs
     - match: '{{visibility}}'
       scope: storage.modifier.access.cs
-    - match: '\b(operator)\b'
+    - match: '\boperator\b'
       scope: storage.modifier.cs
       push: method_name
     - match: '({{name}})\s*(<)'
@@ -1490,9 +1490,6 @@ contexts:
       push: type_argument
     - match: '{{name}}'
       scope: support.type.cs
-    # - match: '[{:]'
-    #   scope: invalid.illegal
-    #   pop: true
     - match: (?=[]})>,;>:]|=>)
       pop: true
 

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -654,9 +654,16 @@ void Foo (in string s, in int x, in Point point)
 void TestFoo() => Foo ("hello", 123, new Point (2, 3));
 
 // https://msdn.microsoft.com/en-us/magazine/mt814808.aspx
-Span<byte> bytes = length <= 128 ? stackalloc byte[length] : new byte[length];
-///                                ^^^^^^^^^^ keyword.other
-///                                           ^^^^ variable.other
+Span<byte> bytes = length > 128 ? new byte[length] : stackalloc byte[length];
+///                             ^ keyword.operator.ternary
+///                               ^^^ keyword.operator.new
+///                               ^^^^^^^^^^^^^^^^ meta.instance
+///                                                ^ keyword.operator.ternary - meta.instance
+///                                                  ^^^^^^^^^^ storage.modifier
+///                                                             ^^^^ storage.type
+///                                                                 ^ punctuation.section.brackets.begin
+///                                                                  ^^^^^^ variable.other
+///                                                                        ^ punctuation.section.brackets.end
 bytes[0] = 42;
 bytes[1] = 43;
 Assert.Equal(42, bytes[0]);

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -712,6 +712,18 @@ void Test ()
 ///                     ^^^^ variable.function
     place = 9; // replaces 7 with 9 in the array
     Console.WriteLine (array [4]); // prints 9
+
+    // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement#example
+    using var socket = new ClientWebSocket();
+/// ^^^^^ keyword.control.using
+///       ^^^ storage.type.variable
+///           ^^^^^^ variable.other
+///                  ^ keyword.operator.assignment
+///                    ^^^ keyword.operator.new
+///                        ^^^^^^^^^^^^^^^ support.type
+///                                       ^ punctuation.section.group.begin
+///                                        ^ punctuation.section.group.end
+///                                         ^ punctuation.terminator.statement
 }
 
 public ref int Find (int number, int[] numbers)

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1354,3 +1354,16 @@ public class AfterTopLevelMethod {
 ///                                                    ^ punctuation.section.block.begin
 ///                                                      ^ punctuation.section.block.end
 }
+
+struct Example
+{
+    // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct#readonly-instance-members
+    private int counter;
+    public int Counter
+    {
+        readonly get => counter;
+///     ^^^^^^^^ storage.modifier
+///              ^^^ storage.type.function.accessor.get
+        set => counter = value;
+    }
+}

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1183,6 +1183,12 @@ namespace TestNamespace.Test
 ///                                   ^ - constant
 ///                                    ^^^^^^^^ constant.other.placeholder
 
+        for (; ctr < names.Length; ctr++)
+///          ^ punctuation.terminator.statement
+///                              ^ punctuation.terminator.statement
+            continue;
+///         ^^^^^^^^ keyword.control.flow.break
+
         int MyInt = 100;
         Console.WriteLine("{0:C}", MyInt);
 ///                        ^^^^^ constant.other.placeholder - invalid

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1325,6 +1325,16 @@ public class AfterTopLevelMethod {
 ///                                 ^^^^^^^^^^^ variable.other.member
 ///                                            ^ punctuation.terminator.statement
 
+    public static implicit operator AfterTopLevelMethod(int[] some_ints)
+///        ^^^^^^ storage.modifier
+///               ^^^^^^^^ storage.modifier
+///                        ^^^^^^^^ storage.modifier
+///                                                     ^^^ meta.method.parameters storage.type
+///                                                           ^^^^^^^^^ meta.method.parameters variable.parameter
+    {
+        return new AfterTopLevelMethod(some_ints);
+    }
+    
     Action<float> actionDelegate = delegate { };
 ///                              ^ keyword.operator.assignment.variable
 ///                                ^^^^^^^^ keyword.other


### PR DESCRIPTION
Some fixes for bugs in the C# syntax definition which I noticed during day-to-day work; there are no open issues relating to these:

- fix `implicit operator` methods
- fix `for` loops without `var` etc.
- add support for `readonly get` accessors
- fix `stackalloc` and ternary operators 
