### PR TITLE
[Python] Use Windows launcher for build system

### DIFF
--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -1,9 +1,13 @@
 {
-	"shell_cmd": "python -u \"$file\"",
+	"cmd": ["python", "-u", "$file"],
 	"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
 	"selector": "source.python",
 
 	"env": {"PYTHONIOENCODING": "utf-8"},
+
+	"windows": {
+		"cmd": ["py", "-u", "$file"],
+	},
 
 	"variants":
 	[


### PR DESCRIPTION
Since Python 3.3, a `py` launcher is installed on Windows, which is by
far the best choice to execute python scripts on Python. It can
interpret shebang lines, read the default Python version configuration
and even handle virtualenvs (although the latter is unlikely to occur
within ST's environment). It will also be available in the PATH with the
default installer configuration, unlike the `python` executable.

Also change the main command to use `cmd` instead of `shell_cmd`.

https://docs.python.org/3/using/windows.html#launcher

Closes #381.