### PR TITLE
[Python] Update for snippet to Python 3

### DIFF
--- a/Python/Snippets/for.sublime-snippet
+++ b/Python/Snippets/for.sublime-snippet
@@ -3,7 +3,7 @@
 	<scope>source.python</scope>
 	<description>For Loop</description>
 	<content><![CDATA[
-for ${1:x} in ${2:xrange(1,10)}:
+for ${1:x} in ${2:range(10)}:
 	${0:pass}
 ]]></content>
 </snippet>


### PR DESCRIPTION
I also tried to be smart and replaced a couple `${1:pass}` with `${1:${SELECTION:pass}}`, but it seems the SELECTION variable is always defined, even if the selection is empty, so the default is never used.