### PR TITLE
[PHP] Minor snippet refinements

### DIFF
--- a/PHP/Snippets/class-{-}.sublime-snippet
+++ b/PHP/Snippets/class-{-}.sublime-snippet
@@ -7,7 +7,7 @@ class ${2:ClassName}${3: extends ${4:AnotherClass}}
 	$5
 	function ${6:__construct}(${7:argument})
 	{
-		${0:# code...}
+		${0:// code...}
 	}
 }
 ]]></content>

--- a/PHP/Snippets/declare-strict_types.sublime-snippet
+++ b/PHP/Snippets/declare-strict_types.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<!-- as of PHP 7.0 -->
+	<content><![CDATA[declare(strict_types=${1:1});$0]]></content>
+	<tabTrigger>decl</tabTrigger>
+	<scope>source.php - string - comment</scope>
+	<description>declare strict_types</description>
+</snippet>

--- a/PHP/Snippets/do-while(-).sublime-snippet
+++ b/PHP/Snippets/do-while(-).sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[do {
-	${0:# code...}
-} while (${1:$a <= 10});]]></content>
+	${0:// code...}
+} while (${1:condition});]]></content>
 	<tabTrigger>do</tabTrigger>
 	<scope>source.php - string - comment</scope>
 	<description>do … while …</description>

--- a/PHP/Snippets/elseif(-).sublime-snippet
+++ b/PHP/Snippets/elseif(-).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[elseif (${1:condition}) {
-	${0:# code...}
+	${0:// code...}
 }]]></content>
 	<tabTrigger>elseif</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/for(-).sublime-snippet
+++ b/PHP/Snippets/for(-).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[for (\$${1:i}=${2:0}; \$${1:i} < $3; \$${1:i}++) { 
-	${0:# code...}
+	${0:// code...}
 }]]></content>
 	<tabTrigger>for</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/foreach(-).sublime-snippet
+++ b/PHP/Snippets/foreach(-).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[foreach (\$${1:variable} as \$${2:key}${3: => \$${4:value}}) {
-	${0:# code...}
+	${0:// code...}
 }]]></content>
 	<tabTrigger>foreach</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/function-xx(-).sublime-snippet
+++ b/PHP/Snippets/function-xx(-).sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[${1:public }function ${2:FunctionName}(${3:\$${4:value}${5:=''}})
 {
-	${0:# code...}
+	${0:// code...}
 }]]></content>
 	<tabTrigger>fun</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/if(-)-else(-).sublime-snippet
+++ b/PHP/Snippets/if(-)-else(-).sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[if (${1:condition}) {
-	${2:# code...}
+	${2:// code...}
 } else {
-	${3:# code...}
+	${3:// code...}
 }
 $0]]></content>
 	<tabTrigger>ifelse</tabTrigger>

--- a/PHP/Snippets/if(-).sublime-snippet
+++ b/PHP/Snippets/if(-).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[if (${1:condition}) {
-	${0:# code...}
+	${0:// code...}
 }]]></content>
 	<tabTrigger>if</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/switch(-)-case.sublime-snippet
+++ b/PHP/Snippets/switch(-)-case.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[case '${1:variable}':
-	${0:# code...}
+	${0:// code...}
 	break;]]></content>
 	<tabTrigger>case</tabTrigger>
 	<scope>source.php - string - comment</scope>

--- a/PHP/Snippets/switch(-).sublime-snippet
+++ b/PHP/Snippets/switch(-).sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[switch (${1:variable}) {
 	case '${2:value}':
-		${3:# code...}
+		${3:// code...}
 		break;
 	$0
 	default:
-		${4:# code...}
+		${4:// code...}
 		break;
 }]]></content>
 	<tabTrigger>switch</tabTrigger>

--- a/PHP/Snippets/while(-).sublime-snippet
+++ b/PHP/Snippets/while(-).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[while (${1:$a <= 10}) {
-	${0:# code...}
+	<content><![CDATA[while (${1:condition}) {
+	${0:// code...}
 }]]></content>
 	<tabTrigger>while</tabTrigger>
 	<scope>source.php - string - comment</scope>


### PR DESCRIPTION
- use `//` to comment rather than `#` (`#` is valid but I have never seen people use it in PHP)
- use `condition` rather than `$a <= 10` (just like other snippets such as [if-else](https://github.com/sublimehq/Packages/blob/f36b8f807d5f30d2b8ef639232a9fc5960f550fa/PHP/Snippets/if(-)-else(-).sublime-snippet))

and

- add a snippet for adding `declare(strict_types=1);`, which is used basically at the beginning of every serious modern PHP files.
