### PR TITLE
[Bash] Change syntax name to "Bash"

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -3,7 +3,7 @@
 # [Bash]:    https://www.gnu.org/software/bash/manual/bash.html
 --- #---------------------------------------------------------------------------
 
-name: Bourne Again Shell (bash)
+name: Bash
 
 # The suffix is bash, but we still use .shell as a suffix anyway. This is to
 # promote reusability of foreign scopes.


### PR DESCRIPTION
So why do we use `Bourne Again Shell (bash)` while we don't use `Structured Query Language (SQL)`? Let's make it cleaner.

---

Resolves https://github.com/sublimehq/Packages/issues/2384