### PR TITLE
[Perl] Fix single-quoted escapes

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -791,7 +791,7 @@ contexts:
         - match: \'
           scope: punctuation.definition.string.end.perl
           pop: true
-        - match: \\\'
+        - match: \\[\\']
           scope: constant.character.escape.perl
         - include: literal-common
 
@@ -1444,7 +1444,7 @@ contexts:
         - include: literal-braces-common
 
   literal-braces-common:
-    - match: \\\}
+    - match: \\[\\\}]
       scope: constant.character.escape.perl
     - include: literal-braces-nested
     - include: literal-common
@@ -1468,7 +1468,7 @@ contexts:
         - include: literal-brackets-common
 
   literal-brackets-common:
-    - match: \\\]
+    - match: \\[\\\]]
       scope: constant.character.escape.perl
     - include: literal-brackets-nested
     - include: literal-common
@@ -1492,7 +1492,7 @@ contexts:
         - include: literal-angle-common
 
   literal-angle-common:
-    - match: \\\>
+    - match: \\[\\\>]
       scope: constant.character.escape.perl
     - include: literal-angle-nested
     - include: literal-common
@@ -1516,7 +1516,7 @@ contexts:
         - include: literal-parens-common
 
   literal-parens-common:
-    - match: \\\)
+    - match: \\[\\\)]
       scope: constant.character.escape.perl
     - include: literal-parens-nested
     - include: literal-common
@@ -1530,7 +1530,7 @@ contexts:
         # Need a lookbehind here to avoid popping on escaped end-of-string token
         # as a normal `\\\1` rule fails to run. As backrefs use oniguruma anyway
         # it shouldn't hurt performance much.
-        - match: (?<!\\)\1
+        - match: '{{no_escape_behind}}\1'
           scope: punctuation.section.generic.end.perl
           pop: true
         - include: literal-common

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -791,6 +791,8 @@ contexts:
         - match: \'
           scope: punctuation.definition.string.end.perl
           pop: true
+        - match: \\\'
+          scope: constant.character.escape.perl
         - include: literal-common
 
   string-format:
@@ -1418,6 +1420,8 @@ contexts:
         - include: interpolated-common
 
   interpolated-common:
+    - match: \\.
+      scope: constant.character.escape.perl
     - include: literal-common
     - include: variables-interpolation
 
@@ -1430,16 +1434,20 @@ contexts:
         - match: \}
           scope: punctuation.section.braces.end.perl
           pop: true
-        - include: literal-braces-nested
-        - include: literal-common
+        - include: literal-braces-common
 
   literal-braces-nested:
     - match: \{
       push:
         - match: \}
           pop: true
-        - include: literal-braces-nested
-        - include: literal-common
+        - include: literal-braces-common
+
+  literal-braces-common:
+    - match: \\\}
+      scope: constant.character.escape.perl
+    - include: literal-braces-nested
+    - include: literal-common
 
   literal-brackets-pop:
     - match: \[
@@ -1450,16 +1458,20 @@ contexts:
         - match: \]
           scope: punctuation.section.brackets.end.perl
           pop: true
-        - include: literal-brackets-nested
-        - include: literal-common
+        - include: literal-brackets-common
 
   literal-brackets-nested:
     - match: \[
       push:
         - match: \]
           pop: true
-        - include: literal-brackets-nested
-        - include: literal-common
+        - include: literal-brackets-common
+
+  literal-brackets-common:
+    - match: \\\]
+      scope: constant.character.escape.perl
+    - include: literal-brackets-nested
+    - include: literal-common
 
   literal-angle-pop:
     - match: \<
@@ -1470,16 +1482,20 @@ contexts:
         - match: \>
           scope: punctuation.section.generic.end.perl
           pop: true
-        - include: literal-angle-nested
-        - include: literal-common
+        - include: literal-angle-common
 
   literal-angle-nested:
     - match: \<
       push:
         - match: \>
           pop: true
-        - include: literal-angle-nested
-        - include: literal-common
+        - include: literal-angle-common
+
+  literal-angle-common:
+    - match: \\\>
+      scope: constant.character.escape.perl
+    - include: literal-angle-nested
+    - include: literal-common
 
   literal-parens-pop:
     - match: \(
@@ -1490,16 +1506,20 @@ contexts:
         - match: \)
           scope: punctuation.section.parens.end.perl
           pop: true
-        - include: literal-parens-nested
-        - include: literal-common
+        - include: literal-parens-common
 
   literal-parens-nested:
     - match: \(
       push:
         - match: \)
           pop: true
-        - include: literal-parens-nested
-        - include: literal-common
+        - include: literal-parens-common
+
+  literal-parens-common:
+    - match: \\\)
+      scope: constant.character.escape.perl
+    - include: literal-parens-nested
+    - include: literal-common
 
   literal-generic-pop:
     - match: ({{regexp_delim}})
@@ -1507,14 +1527,17 @@ contexts:
       set:
         - meta_scope: meta.generic.perl
         - meta_content_scope: meta.string.perl string.unquoted.perl
-        - match: \1
+        # Need a lookbehind here to avoid popping on escaped end-of-string token
+        # as a normal `\\\1` rule fails to run. As backrefs use oniguruma anyway
+        # it shouldn't hurt performance much.
+        - match: (?<!\\)\1
           scope: punctuation.section.generic.end.perl
           pop: true
         - include: literal-common
 
   literal-common:
     # SEE: https://perldoc.perl.org/functions/sprintf.html
-    - match: '%%|\\.'
+    - match: '%%'
       scope: constant.character.escape.perl
     - match: |-
         (?x:

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1505,6 +1505,14 @@ EOT
 #                                     ^^^^ - variable
 #                                          ^ - variable
 #                                           ^ punctuation.definition.string.end.perl
+  'foo \' foo\\\' bar\\\\'
+# ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.single.perl
+# ^ punctuation.definition.string.begin.perl
+#      ^^ constant.character.escape.perl
+#            ^^^^ constant.character.escape.perl
+#                    ^^^^ constant.character.escape.perl
+#                        ^ punctuation.definition.string.end.perl
+#                         ^ - meta.string - string
   `quoted "interpolated" foo \`bar\` $baz $`
 # ^ punctuation.definition.string.begin.perl
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.backtick.perl - meta.interpolation
@@ -1553,6 +1561,11 @@ EOT
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.unquoted.perl - meta.interpolation
 #                                      ^^^^ - variable
 #                                          ^ punctuation.section.generic.end.perl - string
+  q/foo \/ foo\\\/ bar\\\\/
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl - string
+#                         ^ punctuation.section.generic.end.perl - meta.string - string
   q\quoted "interpolated" foo 'bar' \\ $baz\
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
@@ -1580,6 +1593,15 @@ EOT
 #                                     ^^ constant.character.escape.perl
 #                                        ^^^^ - variable
 #                                            ^ punctuation.section.brackets.end.perl - string
+  q[foo \] foo\\\] bar\\\\]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.brackets.begin.perl - string
+#       ^^ constant.character.escape.perl
+#             ^^^^ constant.character.escape.perl
+#                     ^^^^ constant.character.escape.perl
+#                         ^ punctuation.section.brackets.end.perl
+#                         ^ - meta.string - string
   q<quoted "interpolated" <foo> 'bar' \> $baz>
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
@@ -1589,6 +1611,15 @@ EOT
 #                                     ^^ constant.character.escape.perl
 #                                        ^^^^ - variable
 #                                            ^ punctuation.section.generic.end.perl - string
+  q<foo \> foo\\\> bar\\\\>
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.generic.begin.perl - string
+#       ^^ constant.character.escape.perl
+#             ^^^^ constant.character.escape.perl
+#                     ^^^^ constant.character.escape.perl
+#                         ^ punctuation.section.generic.end.perl
+#                         ^ - meta.string - string
   q(quoted "interpolated" [foo] 'bar' \) $baz)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
@@ -1598,6 +1629,15 @@ EOT
 #                                     ^^ constant.character.escape.perl
 #                                        ^^^^ - variable
 #                                            ^ punctuation.section.parens.end.perl - string
+  q(foo \) foo\\\) bar\\\\)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+# ^ support.function.perl
+#  ^ punctuation.section.parens.begin.perl - string
+#       ^^ constant.character.escape.perl
+#             ^^^^ constant.character.escape.perl
+#                     ^^^^ constant.character.escape.perl
+#                         ^ punctuation.section.parens.end.perl
+#                         ^ - meta.string - string
   q['
 # ^ support.function.perl
 #  ^ punctuation.section.brackets.begin.perl - string

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1485,24 +1485,26 @@ EOT
 #                                ^ meta.string.perl string.quoted.angle.perl
 #                                 ^ meta.string.perl string.quoted.angle.perl punctuation.definition.string.end.perl
 #                                  ^ - meta.string - string
-  "quoted \"interpolated\" foo 'bar' $baz $"
+  "quoted \"interpolated\" \foo 'bar' $baz $"
 # ^ punctuation.definition.string.begin.perl
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.double.perl - meta.interpolation
-#                                    ^^^^ meta.string.perl meta.interpolation.perl - string
-#                                        ^^^ meta.string.perl string.quoted.double.perl - meta.interpolation
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.double.perl - meta.interpolation
+#                                     ^^^^ meta.string.perl meta.interpolation.perl - string
+#                                         ^^^ meta.string.perl string.quoted.double.perl - meta.interpolation
 #         ^^ constant.character.escape.perl
 #                       ^^ constant.character.escape.perl
-#                                    ^^^^ variable.other.readwrite.perl
-#                                         ^ - variable
-#                                          ^ punctuation.definition.string.end.perl
-  'quoted "interpolated" foo \'bar\' $baz $'
+#                          ^^ constant.character.escape.perl
+#                                     ^^^^ variable.other.readwrite.perl
+#                                          ^ - variable
+#                                           ^ punctuation.definition.string.end.perl
+  'quoted "interpolated" \foo \'bar\' $baz $'
 # ^ punctuation.definition.string.begin.perl
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.single.perl
-#                            ^^ constant.character.escape.perl
-#                                 ^^ constant.character.escape.perl
-#                                    ^^^^ - variable
-#                                         ^ - variable
-#                                          ^ punctuation.definition.string.end.perl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.single.perl
+#                        ^^ - constant.character.escape
+#                             ^^ constant.character.escape.perl
+#                                  ^^ constant.character.escape.perl
+#                                     ^^^^ - variable
+#                                          ^ - variable
+#                                           ^ punctuation.definition.string.end.perl
   `quoted "interpolated" foo \`bar\` $baz $`
 # ^ punctuation.definition.string.begin.perl
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.quoted.backtick.perl - meta.interpolation
@@ -1543,22 +1545,24 @@ EOT
 #                                                  ^ - variable
 #                                                   ^ punctuation.definition.string.end.perl
 #                                                     ^ keyword.operator.comparison.perl
+  # Note: The \/ can't be highlighted as escaped due to ST backref limitations.
   q/quoted "interpolated" foo 'bar' \/ $baz/
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
 #  ^ punctuation.section.generic.begin.perl - string
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.unquoted.perl - meta.interpolation
-#                                   ^^ constant.character.escape.perl
 #                                      ^^^^ - variable
 #                                          ^ punctuation.section.generic.end.perl - string
-  q\quoted "interpolated" foo 'bar' / $baz\
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
+  q\quoted "interpolated" foo 'bar' \\ $baz\
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
 #  ^ punctuation.section.generic.begin.perl - string
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
-#                                     ^^^^ - variable
-#                                         ^ punctuation.section.generic.end.perl - string
-  q{quoted "interpolated" {foo} 'bar' \/ $baz}
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.perl
+#                                   ^ punctuation.section.generic.end.perl - string
+#                                    ^ keyword.operator.reference.perl
+#                                      ^^^^ variable.other.readwrite.perl
+#                                          ^ keyword.operator.reference.perl
+  q{quoted "interpolated" {foo} 'bar' \} $baz}
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
 #  ^ punctuation.section.braces.begin.perl - string
@@ -1585,7 +1589,7 @@ EOT
 #                                     ^^ constant.character.escape.perl
 #                                        ^^^^ - variable
 #                                            ^ punctuation.section.generic.end.perl - string
-  q(quoted "interpolated" [foo] 'bar' \] $baz)
+  q(quoted "interpolated" [foo] 'bar' \) $baz)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.perl
 # ^ support.function.perl
 #  ^ punctuation.section.parens.begin.perl - string


### PR DESCRIPTION
Fixes #2398

Only the closing characters of a single quoted string and the corresponding q// functions may be escaped. All other characters are
interpreted as is.