### PR TITLE
[HTML] Fix dotted custom tag names

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -53,8 +53,7 @@ variables:
   custom_element_char: |-
     (?x:
       # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
-        [-_a-z0-9\x{00B7}]
-      | \\\.
+        [-._a-z0-9\x{00B7}]
       | [\x{00C0}-\x{00D6}]
       | [\x{00D8}-\x{00F6}]
       | [\x{00F8}-\x{02FF}]

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -526,12 +526,15 @@ class="foo"></div>
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
+        ##^^^^^^^^^^^^^^^^ meta.tag.custom.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
         ##                ^ - meta.tag.custom.html - punctuation.definition.tag.end.html
 
         <body-custom·tag₡name/>
-        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html - invalid
+
+        <body.tag-custom.name/>
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html - invalid
 
         <INVALID-custom-TAG></INVALID-CUSTOM-TAG>
         ## ^^^^^ invalid.illegal.custom-tag-name.html


### PR DESCRIPTION
Fixes #2403

According to the linked specification at (1) the `.` is part of the
allowed custom tag characters. The current implementation allows an escaped dot `\.` only, which is wrong.

```
PotentialCustomElementName ::=
    [a-z] (PCENChar)* '-' (PCENChar)*

PCENChar ::=
    "-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6]
    | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040]
    | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF]
    | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
```

(1) https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts