### PR TITLE
[Ruby] Add lambda operator to the list of builtin functions

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -860,6 +860,10 @@ contexts:
         )
       scope: support.function.builtin.ruby
       push: function-call-arguments
+    # Lambda operator from the Kernel class not handled elsewhere
+    - match: ->
+      scope: support.function.builtin.ruby
+      push: function-call-arguments
     # Methods from the Module class not handled elsewhere
     - match: |-
         (?x:

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -861,8 +861,8 @@ contexts:
       scope: support.function.builtin.ruby
       push: function-call-arguments
     # Lambda operator from the Kernel class not handled elsewhere
-    - match: ->
-      scope: support.function.builtin.ruby
+    - match: '->'
+      scope: meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
       push: function-call-arguments
     # Methods from the Module class not handled elsewhere
     - match: |-

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1129,7 +1129,7 @@ exit! 2
 #^^^^ support.function.builtin
 
  ->
-#^^ support.function.builtin
+#^^ meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
 
 
 ##################

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1128,8 +1128,8 @@ abort "Ending"
 exit! 2
 #^^^^ support.function.builtin
 
- ->
-#^^ meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
+get :name, -> { "John" }
+#          ^^ meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
 
 
 ##################

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1128,6 +1128,8 @@ abort "Ending"
 exit! 2
 #^^^^ support.function.builtin
 
+ ->
+#^^ support.function.builtin
 
 
 ##################


### PR DESCRIPTION
This is mostly to fix the ligature issue, since `->` is currently tokenizing as arithmetic and comparision

Before:
![image](https://user-images.githubusercontent.com/1993929/87745100-aab02c80-c7b2-11ea-9348-31a20222895b.png)
![image](https://user-images.githubusercontent.com/1993929/87745091-a421b500-c7b2-11ea-94a8-7f3a843d9216.png)

After (ligature works):
![image](https://user-images.githubusercontent.com/1993929/87745145-c7e4fb00-c7b2-11ea-9dfd-12197832d227.png)


