### PR TITLE
[JavaScript] Don't affect source.json scope

### DIFF
--- a/JavaScript/Comments.tmPreferences
+++ b/JavaScript/Comments.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>source.js, source.json, source.jsx, source.ts</string>
+	<string>source.js, source.jsx, source.ts</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
JSON is in a separate package now and defines [its own comments file](https://github.com/sublimehq/Packages/blob/master/JSON/Comments.tmPreferences).

Reverts 483657a3db466716505255c6380f57698354508b.
