### PR TITLE
[Markdown] Alias jsonc -> json

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1122,7 +1122,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:json))
+          ((?i:jsonc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.json.markdown-gfm


### PR DESCRIPTION
In Sublime Text, JSON is really JSONC (JSON with comments and trailing commas), so enable `jsonc` as a marker for the same embed.