### PR TITLE
[Markdown] Make code spans end at new list item

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1399,6 +1399,8 @@ contexts:
           scope: punctuation.definition.raw.end.markdown
           pop: true
         - match: '`+'
+        - match: '^(?={{list_item}})'
+          pop: true
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -593,6 +593,10 @@ because it doesn't begin with the number one:
 * [ ] [Checkbox][] with next word linked
 | ^^^ constant.language.checkbox
 |     ^^^^^^^^^^^^ meta.link
+* list has `unclosed code
+* list continues
+| ^^^^^^^^^^^^^^^ - markup.raw
+
 
 - `code` - <a name="demo"></a>
 | ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw


### PR DESCRIPTION
Thoughts? GitHub's syntax highlighter clearly disagrees with this change.

I wrote it while I was editing a big Markdown file and adding code spans in list items that switched the highlighting for large swathes of the rest of the file. I found that to be disconcerting... but if someone forgot to close a code span in a README and pushed it, that could be worse, depending on their MD implementation. 🤷‍♂️ 