### PR TITLE
[HTML] Improvements to attribute completions

### DIFF
--- a/HTML/Default.sublime-keymap
+++ b/HTML/Default.sublime-keymap
@@ -1,0 +1,9 @@
+[
+	{ "keys": [">"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+		[
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^>", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "punctuation.definition.tag.end.html", "match_all": true },
+		]
+	},
+]

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -582,6 +582,9 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
             # add a space if not there
             suffix = ' '
 
+        # ensure the user can always tab to the end of the completion
+        suffix += '$0'
+
         # got the tag, now find all attributes that match
         return sublime.CompletionList(
             [


### PR DESCRIPTION
This include two changes that make typing HTML a slightly less frustrating experience:

 - Allow over-typing the closing > of an HTML tag. This seems fairly straightforward, and shouldn't cause any trouble, at least from situations I could think of. If a user does with to have multiple >>, then can press the > key twice.
 - Augment attribute completions with extra fields. Now when a user completes an attribute, they will always have a field they can tab to "finish" the completion. If the completion closes the tag, they will have two fields, one after the attribute to allow for more attributes to be added, and a second one after the closing > of the tag.