### PR TITLE
[Perl] Fix ambiguous function arguments

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -31,30 +31,40 @@ variables:
   no_escape_behind: '(?<![^\\]\\)(?<![^\\][\\]{3})'
 
   # SEE: https://perldoc.perl.org/index-functions.html
-  builtin_functions: |-
+  builtin_functions:
+    (?:{{builtins_with_pattern_args}}|{{builtins_without_pattern_args}})
+
+  # functions which may be followed by `/<pattern>/<flags>`
+  builtins_with_pattern_args: |-
     \b(?x:
-      abs|accept|alarm|atan2|bind|binmode|bless|chdir|chmod|
-      chomp|chop|chown|chr|chroot|close|closedir|connect|cos|crypt|
+      accept|alarm|bind|binmode|bless|chdir|chmod|
+      chomp|chop|chown|chr|chroot|close|closedir|connect|crypt|
       dbmclose|dbmopen|defined|delete|each|endgrent|endhostent|
       endnetent|endprotoent|endpwent|endservent|eof|eval|evalbytes|exec|
-      exists|exp|fc|fcntl|fileno|flock|fork|formline|getc|
+      exists|fc|fcntl|fileno|flock|fork|formline|getc|
       getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent|
       getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp|
       getppid|getpriority|getprotobyname|getprotobynumber|getprotoent|
       getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent|
       getsockname|getsockopt|glob|gmtime|grep|hex|index|int|ioctl|join|
-      keys|kill|lc|lcfirst|length|link|listen|localtime|lock|log|
+      keys|kill|lc|lcfirst|length|link|listen|localtime|lock|
       lstat|map|mkdir|msgctl|msgget|msgrcv|msgsnd|oct|open|opendir|ord|
       pack|pipe|pop|pos|print|printf|prototype|push|quotemeta|
-      rand|read|readdir|readline|readlink|readpipe|recv|ref|rename|
+      read|readdir|readline|readlink|readpipe|recv|ref|rename|
       reset|reverse|rewinddir|rindex|rmdir|say|scalar|seek|seekdir|select|
       semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp|
-      setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl|
-      shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort|
-      splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall|
-      sysopen|sysread|sysseek|system|syswrite|tell|telldir|tie|tied|time|
-      times|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie|
-      utime|values|vec|wait|waitpid|wantarray|warn|write
+      setpriority|setprotoent|setpwent|setservent|setsockopt|shmctl|
+      shmget|shmread|shmwrite|shutdown|sleep|socket|socketpair|sort|
+      splice|split|sprintf|stat|study|substr|symlink|syscall|
+      sysopen|sysread|sysseek|system|syswrite|tell|telldir|tie|tied|
+      truncate|uc|ucfirst|umask|undef|unlink|unpack|untie|
+      values|vec|wait|waitpid|wantarray|warn|write
+    ){{break}}
+
+  # functions which may not be followed by `/<pattern>/<flags>`
+  builtins_without_pattern_args: |-
+    \b(?x:
+      abs|atan2|cos|exp|log|rand|shift|sin|sqrt|srand|time|times|unshift|utime
     ){{break}}
 
   builtin_variables: |-
@@ -1607,24 +1617,36 @@ contexts:
 
   function-identifier:
     # builtin function calls
-    - match: '{{builtin_functions}}'
+    - match: '{{builtins_with_pattern_args}}'
       scope: meta.function-call.perl support.function.perl
-      set: expressions-begin
+      set: maybe-regexp-match
+    - match: '{{builtins_without_pattern_args}}'
+      scope: meta.function-call.perl support.function.perl
+      set: function-call-arguments
     # user defined function calls
     - match: '{{identifier}}{{break}}'
       scope: meta.function-call.perl variable.function.perl
-      set: expressions-begin
+      set: function-call-arguments
     - include: immediately-pop
 
   unqualified-function-call:
     # builtin function calls
-    - match: '{{builtin_functions}}'
+    - match: '{{builtins_with_pattern_args}}'
       scope: meta.function-call.perl support.function.perl
-      push: expressions-begin
+      push: maybe-regexp-match
+    - match: '{{builtins_without_pattern_args}}'
+      scope: meta.function-call.perl support.function.perl
+      push: function-call-arguments
     # user defined function calls
     - match: '{{identifier}}(?=\s*(?:$|[;#/(''"`$@%]|<<|(?!(?:{{operator_keywords}}){{break}})\w))'
       scope: meta.function-call.perl variable.function.perl
-      push: expressions-begin
+      push: function-call-arguments
+
+  function-call-arguments:
+    - include: string-quoted-angle-pop
+    - include: variable-not-operator
+    - include: else-pop
+    - include: eol-pop
 
 ###[ VARIABLES INTERPOLATION ]################################################
 

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -4722,10 +4722,21 @@ state
   print /pattern/g;
 # ^^^^^ support.function.perl
 #       ^ punctuation.section.generic.begin.perl
-#        ^^^^^^^ meta.string.perl string.regexp.perl source.regexp
+#        ^^^^^^^ meta.string.perl string.regexp.perl source.regexp meta.literal.regexp
 #               ^ punctuation.section.generic.end.perl
 #                ^ constant.language.flags.regexp.perl
-#                 ^ punctuation.terminator.statement.perl
+  print(grep /^Client-/, $res->header_field_names)
+# ^^^^^ support.function.perl
+#      ^ punctuation.section.group.begin.perl
+#       ^^^^ support.function.perl
+#            ^ punctuation.section.generic.begin.perl
+#             ^^^^^^^^ meta.string.perl string.regexp.perl source.regexp
+#                     ^ punctuation.section.generic.end.perl
+#                      ^ punctuation.separator.sequence.perl
+#                        ^^^^ variable.other.readwrite.perl
+#                            ^^ punctuation.accessor.arrow.perl
+#                              ^^^^^^^^^^^^^^^^^^ variable.function.member.perl
+#                                                ^ punctuation.section.group.end.perl
   print "string";
 # ^^^^^ support.function.perl
 #       ^^^^^^^^ meta.string.perl string.quoted.double.perl
@@ -4771,13 +4782,30 @@ state
   func "string";
 # ^^^^ variable.function.perl
 #      ^^^^^^^^ meta.string.perl string.quoted.double.perl
+
+  # Patterns an ambigious argument and need parentheses
   func /pattern/g;
 # ^^^^ variable.function.perl
-#      ^ punctuation.section.generic.begin.perl
-#       ^^^^^^^ meta.string.perl string.regexp.perl source.regexp
-#              ^ punctuation.section.generic.end.perl
-#               ^ constant.language.flags.regexp.perl
+#      ^ - punctuation.section.generic.begin
+#       ^^^^^^^ - string.regexp
+#              ^ - punctuation.section.generic.end
+#               ^ - constant.language.flags.regexp
 #                ^ punctuation.terminator.statement.perl
+  func / 10
+# ^^^^ variable.function.perl
+#      ^ keyword.operator.arithmetic.perl
+#        ^^ constant.numeric.integer.decimal.perl
+
+  func / 10; $a = 10/2
+# ^^^^ variable.function.perl
+#      ^ keyword.operator.arithmetic.perl
+#        ^^ constant.numeric.integer.decimal.perl
+#          ^ punctuation.terminator.statement.perl
+#            ^^ variable.language.perl
+#               ^ keyword.operator.assignment.perl
+#                 ^^ constant.numeric.integer.decimal.perl
+#                   ^ keyword.operator.arithmetic.perl
+#                    ^ constant.numeric.integer.decimal.perl
   Func x::path
 # ^^^^ variable.function.perl
 #      ^^^^^^^ meta.path.perl
@@ -4840,6 +4868,18 @@ _EOD_
   no_func and 1
 # ^^^^^^^ - variable.function
 #         ^^^ keyword.operator.logical.perl
+
+  ## Some functions are known to not be followed by patterns.
+  ## Thus multiple slashes in the line don't denote /<pattern>/
+
+  time / 86400 << 16 / 50
+# ^^^^ meta.function-call.perl support.function.perl
+#      ^ keyword.operator.arithmetic.perl
+#        ^^^^^ constant.numeric.integer.decimal.perl
+#              ^^ keyword.operator.bitwise.perl
+#                 ^^ constant.numeric.integer.decimal.perl
+#                    ^ keyword.operator.arithmetic.perl
+#                      ^^ constant.numeric.integer.decimal.perl
 
   ## To ensure the interpreter identifies a function correctly,
   ## the arguments need to be encapsulated in parentheses.
@@ -4962,10 +5002,10 @@ _EOD_
 # ^^^^^^ meta.path.perl
 # ^^ punctuation.accessor.double-colon.perl
 #   ^^^^ variable.function.perl
-#        ^ punctuation.section.generic.begin.perl
-#         ^^^^^^^ meta.string.perl string.regexp.perl source.regexp
-#                ^ punctuation.section.generic.end.perl
-#                 ^ constant.language.flags.regexp.perl
+#        ^ - punctuation.section.generic.begin
+#         ^^^^^^^ - string.regexp
+#                ^ - punctuation.section.generic.end
+#                 ^ - constant.language.flags.regexp
 #                  ^ punctuation.terminator.statement.perl
   ::Func x::path
 # ^^^^^^ meta.path.perl


### PR DESCRIPTION
Fixes #2432

Using generic patterns or substitutions such as `/<pattern>/<flags>` as function arguments without enclosing them into parentheses may be an ambiguous expression as it can't be distinguished from arithmetic operations in many situations. Things become even more difficult if generic patterns span multiple lines or contain semi-colons.

This commit splits the list of builtin functions into those which are known to not support pattern like arguments and those which might do.

These lists might not be perfect. May be tweaked in future, when further issues about broken highlighting arrive - or maybe someone wants to investigate which ones do.

User defined functions require arguments to be enclosed in parentheses, if the first one is a pattern or substitution.