### PR TITLE
[HTML] Prepare for inheritance

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -672,23 +672,28 @@ contexts:
         - match: '<%=?'
           scope: punctuation.section.embedded.begin.inside-block.asp
           pop: true
-        - match: '\s+$' # eat whitespace so that the lookahead on the next match pattern can match the next line if appropriate
+        # Eat whitespace so that the lookahead on the next match pattern
+        # can match the next line if appropriate.
+        - match: '\s*\n'
           push:
             - match: ^
               pop: true
-        - match: '(\s*")?(?=[^<>]*>|\s+\w+=\s*")' # if the next occurrence of a < or > is a >, we are inside a tag. If it looks like an attribute is being defined, we are probably in a tag
-          scope: string.quoted.double.html punctuation.definition.string.end.html
-          push: # use a push and an include so that the root scope (text.html.basic) isn't applied
-            - meta_scope: meta.tag.after-embedded-asp.any.html
-            - match: '>'
-              scope: punctuation.definition.tag.end.html
-              set: scope:text.html.asp#html
-            - include: scope:text.html.basic#tag-attributes
-          with_prototype:
-            - match: '(?=<%)'
-              pop: true
+        # If the next occurrence of a < or > is a >, we are inside a tag.
+        # If it looks like an attribute is being defined, we are probably in a tag
+        - match: '(?:\s*("))?(?=[^<>]*>|\s+\w+=\s*")'
+          scope: string.quoted.double.html
+          captures:
+             1: punctuation.definition.string.end.html
+          embed: inside_block_html_tag_attributes
+          escape: '(?=<%)'
+        # Continue with normal HTML otherwise
         - match: ''
-          push: scope:text.html.asp#html
-          with_prototype:
-            - match: '(?=<%)'
-              pop: true
+          embed: Packages/HTML/HTML.sublime-syntax
+          escape: '(?=<%)'
+
+  inside_block_html_tag_attributes:
+    - meta_scope: meta.tag.after-embedded-asp.any.html
+    - match: '/?>'
+      scope: punctuation.definition.tag.end.html
+      set: Packages/HTML/HTML.sublime-syntax
+    - include: Packages/HTML/HTML.sublime-syntax#tag-attributes

--- a/ASP/HTML-ASP.sublime-syntax
+++ b/ASP/HTML-ASP.sublime-syntax
@@ -1,60 +1,144 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# http://www.sublimetext.com/docs/syntax.html
 name: HTML (ASP)
+scope: text.html.asp
+version: 2
+
+extends: Packages/HTML/HTML.sublime-syntax
+
 file_extensions:
   - asp
-scope: text.html.asp
+
 contexts:
-  main:
-    - include: html
 
-  asp_punctuation_begin:
-    - match: '<%'
+###[ HTML TAGS ]##############################################################
+
+  prototype:
+    # must use prototype to also apply to CSS/JS
+    - meta_prepend: true
+    - include: asp-tags
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: asp-interpolations
+
+  tag-class-attribute-value-double-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-class-attribute-value-single-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-generic-attribute-value-double-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-generic-attribute-value-single-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-href-attribute-value-double-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-href-attribute-value-single-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-id-attribute-value-double-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  tag-id-attribute-value-single-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: asp-interpolations
+
+  strings-double-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  strings-single-quoted-content:
+    # must explicitly disable prototypes
+    # to apply asp-interpolation instead of asp-tags
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+###[ ASP TAGS ]###############################################################
+
+  asp-tags:
+    - match: <%
       scope: punctuation.section.embedded.begin.asp
-      push:
-        - match: '@' # https://msdn.microsoft.com/en-us/library/ms525579%28v=vs.90%29.aspx
-          set: asp_directive
-        - match: '='
-          scope: punctuation.section.embedded.begin.asp
-          set: [close_embedded_asp, begin_embedded_asp_expression]
-        - match: '(?=\S)'
-          set: [close_embedded_asp, begin_embedded_asp]
+      push: asp-tag-content
 
-  asp_directive:
-    - match: '@?\s*\b((?i:ENABLESESSIONSTATE|LANGUAGE|LCID|TRANSACTION))\b'
+  asp-interpolations:
+    - match: <%
+      scope: punctuation.section.embedded.begin.asp
+      push: [asp-tag-clear-scope, asp-tag-content]
+
+  asp-tag-clear-scope:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.html
+    - include: immediately-pop
+
+  asp-tag-content:
+    - match: \@ # https://msdn.microsoft.com/en-us/library/ms525579%28v=vs.90%29.aspx
+      set: asp-directive
+    - match: =
+      scope: punctuation.section.embedded.begin.asp
+      set: asp-expression
+    - match: (?=\S)
+      set: asp-statements
+
+  asp-directive:
+    - match: \@?\s*\b((?i:ENABLESESSIONSTATE|LANGUAGE|LCID|TRANSACTION))\b
       captures:
         1: constant.language.processing-directive.asp
       push:
-        - match: '\s*(=)\s*'
-          scope: punctuation.separator.key-value.asp
-          pop: true
-        - match: '(?=%>)'
-          pop: true
+        - match: \s*(=)\s*
+          captures:
+            1: punctuation.separator.key-value.asp
+          pop: 1
+        - match: (?=%>)
+          pop: 1
+    - include: asp-end
+
+  asp-expression:
+    - meta_content_scope: source.asp.embedded.html
+    - include: asp-end
+    - include: Packages/ASP/ASP.sublime-syntax#expression
+      apply_prototype: true
+
+  asp-statements:
+    - meta_content_scope: source.asp.embedded.html
+    - include: asp-end
+    - include: Packages/ASP/ASP.sublime-syntax
+      apply_prototype: true
+
+  asp-end:
     - match: '%>'
       scope: punctuation.section.embedded.end.asp
-      pop: true
-
-  html:
-    - match: ''
-      set:
-        - include: scope:text.html.basic
-      with_prototype:
-        - include: asp_punctuation_begin
-
-  begin_embedded_asp:
-    - meta_content_scope: source.asp.embedded.html
-    - match: '(?=%>)'
-      pop: true
-    - include: scope:source.asp
-
-  begin_embedded_asp_expression:
-    - meta_content_scope: source.asp.embedded.html
-    - match: '(?=%>)'
-      pop: true
-    - include: scope:source.asp#expression
-
-  close_embedded_asp:
-    - match: '%>'
-      scope: punctuation.section.embedded.end.asp
-      pop: true
+      pop: 1

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1000,8 +1000,10 @@ test = "hello%>
 '^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html
 '                                         ^^^^^^^^^ meta.tag.block.any.html
 '   ^^^^^ meta.attribute-with-value.class.html entity.other.attribute-name.class.html
-'         ^^^ meta.attribute-with-value.class.html string.quoted.double.html
-'                                   ^^^^^^^^^^ meta.attribute-with-value.class.html string.quoted.double.html
+'         ^ meta.attribute-with-value.class.html meta.string.html string.quoted.double.html - meta.interpolation
+'          ^^ meta.attribute-with-value.class.html  meta.string.html meta.interpolation.html - string
+'                                   ^^^^^^^^^ meta.attribute-with-value.class.html meta.string.html meta.interpolation.html - string
+'                                            ^ meta.attribute-with-value.class.html meta.string.html string.quoted.double.html - meta.interpolation
 '                                             ^ - string
 '          ^^^^^^^^^^^^^^^^ meta.class-name.html
 '                                  ^^^^^^^^^^ meta.class-name.html
@@ -1027,7 +1029,7 @@ test = "hello%>
 '       ^^^^^^^^^^^^^^^^ string.quoted.double.asp
 '                        ^^ punctuation.section.embedded.end.asp
 '                           ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-'                               ^^^^^ meta.attribute-with-value.id.html string.quoted.double.html meta.toc-list.id.html
+'                               ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                     ^ punctuation.definition.tag.end.html
 '                                          ^ - meta.tag.block.any.html
 <% If True Then
@@ -1042,7 +1044,7 @@ test = "hello%>
        '                           ^^ punctuation.section.embedded.end.inside-block.asp
        '                             ^^^^^^^^^^^^ meta.tag
        '                              ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-       '                                  ^^^^^ meta.attribute-with-value.id.html string.quoted.double.html meta.toc-list.id.html
+       '                                  ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
        '                                        ^ punctuation.definition.tag.end.html
        '                                         ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
        '                                         ^^ punctuation.definition.tag.begin.html
@@ -1066,13 +1068,13 @@ test = "hello%>
 '                          ^^^^^ entity.other.attribute-name.class.html
 '                               ^ punctuation.separator.key-value.html
 '                                ^ string.quoted.double.html punctuation.definition.string.begin.html
-'                                 ^^^^ string.quoted.double.html meta.class-name.html
+'                                 ^^^^ meta.class-name.html string.quoted.double.html
 '                                     ^ string.quoted.double.html punctuation.definition.string.end.html
 '                                       ^^ punctuation.section.embedded.begin.inside-block.asp
 '                                          ^^^^^^ keyword.control.flow.asp
 '                                                 ^^ punctuation.section.embedded.end.asp
 '                                                    ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-'                                                        ^^^^^ meta.attribute-with-value.id.html string.quoted.double.html meta.toc-list.id.html
+'                                                        ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                                              ^ punctuation.definition.tag.end.html
  <span <% If True Then %>
   class="test"
@@ -1081,7 +1083,7 @@ test = "hello%>
 ' ^^^^^ entity.other.attribute-name.class.html
 '      ^ punctuation.separator.key-value.html
 '       ^ string.quoted.double.html punctuation.definition.string.begin.html
-'        ^^^^ string.quoted.double.html meta.class-name.html
+'        ^^^^ meta.class-name.html string.quoted.double.html
 '            ^ string.quoted.double.html punctuation.definition.string.end.html
  <% End If %>
 '^^ punctuation.section.embedded.begin.inside-block.asp
@@ -1090,7 +1092,7 @@ test = "hello%>
  id="test4"></span>
 '^^^^^^^^^^^ meta.tag
 '^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-'    ^^^^^ meta.attribute-with-value.id.html string.quoted.double.html meta.toc-list.id.html
+'    ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '          ^ punctuation.definition.tag.end.html
 '           ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
 '           ^^ punctuation.definition.tag.begin.html
@@ -1107,7 +1109,7 @@ test = "hello%>
 '                          ^^^^^^^^^^^^^ meta.tag
 '                          ^ string.quoted.double.html punctuation.definition.string.end.html
 '                            ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-'                                ^^^^^ meta.attribute-with-value.id.html string.quoted.double.html meta.toc-list.id.html
+'                                ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                      ^ punctuation.definition.tag.end.html
 '                                       ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
 '                                       ^^ punctuation.definition.tag.begin.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -486,6 +486,13 @@ contexts:
     - include: tag-href-attribute
     - include: tag-generic-attribute
 
+  tag-attribute-unquoted-value-content:
+    - meta_scope: meta.string.html string.unquoted.html
+    - match: '{{unquoted_attribute_break}}'
+      pop: 1
+    - include: strings-unquoted-content
+    - include: tag-attribute-value-invalid-char
+
   tag-attribute-value-separator:
     - match: (?=[{{ascii_space}}])
       push:
@@ -533,10 +540,7 @@ contexts:
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
-        - match: '{{unquoted_attribute_break}}'
-          pop: 1
-        - include: tag-attribute-value-invalid-char
-        - include: entities
+        - include: tag-attribute-unquoted-value-content
     - include: else-pop
 
 ###[ EVENT ATTRIBUTE ]########################################################
@@ -620,12 +624,7 @@ contexts:
       scope: punctuation.definition.string.begin.html
       set: strings-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
-      set:
-        - meta_scope: meta.string.html string.unquoted.html
-        - match: '{{unquoted_attribute_break}}'
-          pop: 1
-        - include: tag-attribute-value-invalid-char
-        - include: entities
+      set: tag-attribute-unquoted-value-content
     - include: else-pop
 
 ###[ HREF ATTRIBUTE ]#########################################################
@@ -671,9 +670,7 @@ contexts:
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.path.html
-        - match: '{{unquoted_attribute_break}}'
-          pop: 1
-        - include: tag-attribute-value-invalid-char
+        - include: tag-attribute-unquoted-value-content
         - include: tag-href-entities
     - include: else-pop
 
@@ -721,10 +718,7 @@ contexts:
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
-        - match: '{{unquoted_attribute_break}}'
-          pop: 1
-        - include: tag-attribute-value-invalid-char
-        - include: entities
+        - include: tag-attribute-unquoted-value-content
     - include: else-pop
 
 ###[ STYLE ATTRIBUTE ]########################################################
@@ -813,6 +807,11 @@ contexts:
   strings-quoted-content:
     # This context exists as common entry point for inherited syntaxes to add
     # custom highlighting to all quoted strings (only quoted attributes).
+    - include: strings-common-content
+
+  strings-unquoted-content:
+    # This context exists as common entry point for inherited syntaxes to add
+    # custom highlighting to all unquoted strings (only unquoted attributes).
     - include: strings-common-content
 
   strings-common-content:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -670,13 +670,13 @@ contexts:
       scope: entity.other.attribute-name.href.html
       push:
         - tag-href-attributes-meta
-        - tag-href-attributes-equals
+        - tag-href-attributes-assignment
 
   tag-href-attributes-meta:
     - meta_scope: meta.attribute-with-value.href.html
     - include: immediately-pop
 
-  tag-href-attributes-equals:
+  tag-href-attributes-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-href-attribute-value

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -660,30 +660,25 @@ contexts:
       set:
         - meta_scope: meta.string.html string.quoted.double.html
         - meta_content_scope: meta.path.html
-        - match: \"
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-double-quoted-content
         - include: tag-attribute-value-separator
-        - include: tag-href-entities
+        - include: tag-href-attribute-value-content
     - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: meta.string.html string.quoted.single.html
         - meta_content_scope: meta.path.html
-        - match: \'
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-single-quoted-content
         - include: tag-attribute-value-separator
-        - include: tag-href-entities
+        - include: tag-href-attribute-value-content
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.path.html
         - include: tag-attribute-unquoted-value-content
-        - include: tag-href-entities
+        - include: tag-href-attribute-value-content
     - include: else-pop
 
-  tag-href-entities:
-    - include: entities
+  tag-href-attribute-value-content:
     - match: (%)\h{2}
       scope: constant.character.escape.url.html
       captures:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -193,6 +193,11 @@ contexts:
 ###[ TAGS ]###################################################################
 
   tag:
+    - include: tag-html
+    - include: tag-custom
+    - include: tag-incomplete
+
+  tag-html:
     - match: (<)((?i:style)){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.html
@@ -267,16 +272,8 @@ contexts:
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
-      scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-custom-body
-        - tag-custom-name
-    - match: </?(?=[A-Za-z])
-      scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-other-body
-        - tag-other-name
+
+  tag-incomplete:
     - match: <>
       scope: invalid.illegal.incomplete.html
 
@@ -296,6 +293,18 @@ contexts:
       pop: 1
 
 ###[ CUSTOM TAG ]#############################################################
+
+  tag-custom:
+    - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-custom-body
+        - tag-custom-name
+    - match: </?(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-other-body
+        - tag-other-name
 
   tag-custom-name:
       - meta_content_scope: entity.name.tag.custom.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -180,13 +180,15 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.xml.html
-      push:
-        - meta_scope: meta.tag.preprocessor.xml.html
-        - match: \?>
-          scope: punctuation.definition.tag.end.html
-          pop: 1
-        - include: tag-generic-attribute
-        - include: strings
+      push: preprocessor-content
+
+  preprocessor-content:
+    - meta_scope: meta.tag.preprocessor.xml.html
+    - match: \?>
+      scope: punctuation.definition.tag.end.html
+      pop: 1
+    - include: tag-generic-attribute
+    - include: strings
 
 ###[ TAGS ]###################################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -494,6 +494,10 @@ contexts:
         - clear_scopes: 1 # clear `meta.class-name` or `meta.toc-list.id`
         - include: else-pop
 
+  tag-attribute-value-invalid-char:
+    - match: '["''`<]'
+      scope: invalid.illegal.attribute-value.html
+
 ###[ CLASS ATTRIBUTE ]########################################################
 
   tag-class-attribute:
@@ -539,8 +543,7 @@ contexts:
         - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
         - match: '{{unquoted_attribute_break}}'
           pop: 1
-        - match: '["''`<]'
-          scope: invalid.illegal.attribute-value.html
+        - include: tag-attribute-value-invalid-char
         - include: entities
     - include: else-pop
 
@@ -639,8 +642,7 @@ contexts:
         - meta_scope: meta.string.html string.unquoted.html
         - match: '{{unquoted_attribute_break}}'
           pop: 1
-        - match: '["''`<]'
-          scope: invalid.illegal.attribute-value.html
+        - include: tag-attribute-value-invalid-char
         - include: entities
     - include: else-pop
 
@@ -680,8 +682,7 @@ contexts:
         - meta_scope: meta.string.html string.unquoted.html
         - match: '{{unquoted_attribute_break}}'
           pop: 2
-        - match: '["''`<]'
-          scope: invalid.illegal.attribute-value.html
+        - include: tag-attribute-value-invalid-char
         - include: tag-href-entities
     - include: else-pop
 
@@ -737,8 +738,7 @@ contexts:
         - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
         - match: '{{unquoted_attribute_break}}'
           pop: 1
-        - match: '["''`<]'
-          scope: invalid.illegal.attribute-value.html
+        - include: tag-attribute-value-invalid-char
         - include: entities
     - include: else-pop
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -712,13 +712,11 @@ contexts:
 
   tag-href-attribute-value-double-quoted-content:
     - meta_scope: meta.string.html string.quoted.double.html
-    - meta_content_scope: meta.path.html
     - include: strings-double-quoted-end
     - include: tag-href-attribute-value-quoted-content
 
   tag-href-attribute-value-single-quoted-content:
     - meta_scope: meta.string.html string.quoted.single.html
-    - meta_content_scope: meta.path.html
     - include: strings-single-quoted-end
     - include: tag-href-attribute-value-quoted-content
 
@@ -726,7 +724,7 @@ contexts:
     - include: tag-href-attribute-value-content
 
   tag-href-attribute-value-unquoted-content:
-    - meta_scope: meta.string.html string.unquoted.html meta.path.html
+    - meta_scope: meta.string.html string.unquoted.html
     - include: tag-attribute-value-unquoted-end
     - include: tag-href-attribute-value-content
     - include: tag-attribute-value-unquoted-invalid-char

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -116,15 +116,17 @@ contexts:
       captures:
         1: punctuation.definition.comment.begin.html
         2: invalid.illegal.bad-comments-or-CDATA.html
-      push:
-        - meta_scope: comment.block.html
-        - match: (<!-)?(--\s*>)
-          captures:
-            1: invalid.illegal.bad-comments-or-CDATA.html
-            2: punctuation.definition.comment.end.html
-          pop: 1
-        - match: <!--(?!-?>)|--!>
-          scope: invalid.illegal.bad-comments-or-CDATA.html
+      push: comment-content
+
+  comment-content:
+    - meta_scope: comment.block.html
+    - match: (<!-)?(--\s*>)
+      captures:
+        1: invalid.illegal.bad-comments-or-CDATA.html
+        2: punctuation.definition.comment.end.html
+      pop: 1
+    - match: <!--(?!-?>)|--!>
+      scope: invalid.illegal.bad-comments-or-CDATA.html
 
 ###[ DOCTYPE DECLARATION ]####################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -505,8 +505,7 @@ contexts:
     - include: tag-href-attribute
     - include: tag-generic-attribute
 
-  tag-attribute-unquoted-value-content:
-    - meta_scope: meta.string.html string.unquoted.html
+  tag-attribute-value-unquoted-content:
     - match: '{{unquoted_attribute_break}}'
       pop: 1
     - include: strings-unquoted-content
@@ -544,23 +543,29 @@ contexts:
   tag-class-attribute-value:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.double.html
-        - meta_content_scope: meta.class-name.html
-        - include: strings-double-quoted-content
-        - include: tag-attribute-value-separator
+      set: tag-class-attribute-value-double-quoted-content
     - match: \'
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.single.html
-        - meta_content_scope: meta.class-name.html
-        - include: strings-single-quoted-content
-        - include: tag-attribute-value-separator
+      set: tag-class-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
-      set:
-        - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
-        - include: tag-attribute-unquoted-value-content
+      set: tag-class-attribute-value-unquoted-content
     - include: else-pop
+
+  tag-class-attribute-value-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.class-name.html
+    - include: strings-double-quoted-content
+    - include: tag-attribute-value-separator
+
+  tag-class-attribute-value-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.class-name.html
+    - include: strings-single-quoted-content
+    - include: tag-attribute-value-separator
+
+  tag-class-attribute-value-unquoted-content:
+    - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
+    - include: tag-attribute-value-unquoted-content
 
 ###[ EVENT ATTRIBUTE ]########################################################
 
@@ -638,13 +643,25 @@ contexts:
   tag-generic-attribute-value:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      set: strings-double-quoted-content
+      set: tag-generic-attribute-value-double-quoted-content
     - match: \'
       scope: punctuation.definition.string.begin.html
-      set: strings-single-quoted-content
+      set: tag-generic-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
-      set: tag-attribute-unquoted-value-content
+      set: tag-generic-attribute-value-unquoted-content
     - include: else-pop
+
+  tag-generic-attribute-value-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - include: strings-double-quoted-content
+
+  tag-generic-attribute-value-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - include: strings-single-quoted-content
+
+  tag-generic-attribute-value-unquoted-content:
+    - meta_scope: meta.string.html string.unquoted.html
+    - include: tag-attribute-value-unquoted-content
 
 ###[ HREF ATTRIBUTE ]#########################################################
 
@@ -668,24 +685,30 @@ contexts:
   tag-href-attribute-value:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.double.html
-        - meta_content_scope: meta.path.html
-        - include: strings-double-quoted-content
-        - include: tag-href-attribute-value-content
+      set: tag-href-attribute-value-double-quoted-content
     - match: \'
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.single.html
-        - meta_content_scope: meta.path.html
-        - include: strings-single-quoted-content
-        - include: tag-href-attribute-value-content
+      set: tag-href-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
-      set:
-        - meta_scope: meta.string.html string.unquoted.html meta.path.html
-        - include: tag-attribute-unquoted-value-content
-        - include: tag-href-attribute-value-content
+      set: tag-href-attribute-value-unquoted-content
     - include: else-pop
+
+  tag-href-attribute-value-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.path.html
+    - include: strings-double-quoted-content
+    - include: tag-href-attribute-value-content
+
+  tag-href-attribute-value-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.path.html
+    - include: strings-single-quoted-content
+    - include: tag-href-attribute-value-content
+
+  tag-href-attribute-value-unquoted-content:
+    - meta_scope: meta.string.html string.unquoted.html meta.path.html
+    - include: tag-attribute-value-unquoted-content
+    - include: tag-href-attribute-value-content
 
   tag-href-attribute-value-content:
     - match: (%)\h{2}
@@ -715,23 +738,29 @@ contexts:
   tag-id-attribute-value:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.double.html
-        - meta_content_scope: meta.toc-list.id.html
-        - include: strings-double-quoted-content
-        - include: tag-attribute-value-separator
+      set: tag-id-attribute-value-double-quoted-content
     - match: \'
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.single.html
-        - meta_content_scope: meta.toc-list.id.html
-        - include: strings-single-quoted-content
-        - include: tag-attribute-value-separator
+      set: tag-id-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
-      set:
-        - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
-        - include: tag-attribute-unquoted-value-content
+      set: tag-id-attribute-value-unquoted-content
     - include: else-pop
+
+  tag-id-attribute-value-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.toc-list.id.html
+    - include: strings-double-quoted-content
+    - include: tag-attribute-value-separator
+
+  tag-id-attribute-value-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.toc-list.id.html
+    - include: strings-single-quoted-content
+    - include: tag-attribute-value-separator
+
+  tag-id-attribute-value-unquoted-content:
+    - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
+    - include: tag-attribute-value-unquoted-content
 
 ###[ STYLE ATTRIBUTE ]########################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -370,13 +370,13 @@ contexts:
 
   script-type-attribute:
     - match: (?i:type){{attribute_name_break}}
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      scope: entity.other.attribute-name.html
       set:
-        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
             - include: script-type-decider
         - match: (?=\S)
           set: script-javascript
@@ -446,13 +446,13 @@ contexts:
 
   style-type-attribute:
     - match: (?i:type){{attribute_name_break}}
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      scope: entity.other.attribute-name.html
       set:
-        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
             - include: style-type-decider
         - match: (?=\S)
           set: style-css

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -672,7 +672,6 @@ contexts:
         - meta_scope: meta.string.html string.quoted.double.html
         - meta_content_scope: meta.path.html
         - include: strings-double-quoted-content
-        - include: tag-attribute-value-separator
         - include: tag-href-attribute-value-content
     - match: \'
       scope: punctuation.definition.string.begin.html
@@ -680,7 +679,6 @@ contexts:
         - meta_scope: meta.string.html string.quoted.single.html
         - meta_content_scope: meta.path.html
         - include: strings-single-quoted-content
-        - include: tag-attribute-value-separator
         - include: tag-href-attribute-value-content
     - match: '{{unquoted_attribute_start}}'
       set:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -164,8 +164,7 @@ contexts:
           scope: punctuation.section.brackets.end.html
           pop: 1
         - include: comment
-    - include: string-double-quoted
-    - include: string-single-quoted
+    - include: strings
     - include: else-pop
 
 ###[ PREPROCESSOR ]###########################################################
@@ -181,8 +180,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: 1
         - include: tag-generic-attribute
-        - include: string-double-quoted
-        - include: string-single-quoted
+        - include: strings
 
 ###[ TAGS ]###################################################################
 
@@ -523,21 +521,15 @@ contexts:
       set:
         - meta_scope: meta.string.html string.quoted.double.html
         - meta_content_scope: meta.class-name.html
-        - match: \"
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-double-quoted-content
         - include: tag-attribute-value-separator
-        - include: entities
     - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: meta.string.html string.quoted.single.html
         - meta_content_scope: meta.class-name.html
-        - match: \'
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-single-quoted-content
         - include: tag-attribute-value-separator
-        - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
@@ -623,20 +615,10 @@ contexts:
   tag-generic-attribute-value:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.double.html
-        - match: \"
-          scope: punctuation.definition.string.end.html
-          pop: 1
-        - include: entities
+      set: strings-double-quoted-content
     - match: \'
       scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: meta.string.html string.quoted.single.html
-        - match: \'
-          scope: punctuation.definition.string.end.html
-          pop: 1
-        - include: entities
+      set: strings-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html
@@ -727,21 +709,15 @@ contexts:
       set:
         - meta_scope: meta.string.html string.quoted.double.html
         - meta_content_scope: meta.toc-list.id.html
-        - match: \"
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-double-quoted-content
         - include: tag-attribute-value-separator
-        - include: entities
     - match: \'
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: meta.string.html string.quoted.single.html
         - meta_content_scope: meta.toc-list.id.html
-        - match: \'
-          scope: punctuation.definition.string.end.html
-          pop: 1
+        - include: strings-single-quoted-content
         - include: tag-attribute-value-separator
-        - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
@@ -806,25 +782,43 @@ contexts:
         1: punctuation.definition.entity.html
         2: punctuation.terminator.entity.html
 
-  string-double-quoted:
+  strings:
+    - include: strings-double-quoted
+    - include: strings-single-quoted
+
+  strings-double-quoted:
     - match: \"
       scope: punctuation.definition.string.begin.html
-      push:
-        - meta_scope: meta.string.html string.quoted.double.html
-        - match: \"
-          scope: punctuation.definition.string.end.html
-          pop: 1
-        - include: entities
+      push: strings-double-quoted-content
 
-  string-single-quoted:
+  strings-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - match: \"
+      scope: punctuation.definition.string.end.html
+      pop: 1
+    - include: strings-quoted-content
+
+  strings-single-quoted:
     - match: \'
       scope: punctuation.definition.string.begin.html
-      push:
-        - meta_scope: meta.string.html string.quoted.single.html
-        - match: \'
-          scope: punctuation.definition.string.end.html
-          pop: 1
-        - include: entities
+      push: strings-single-quoted-content
+
+  strings-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - match: \'
+      scope: punctuation.definition.string.end.html
+      pop: 1
+    - include: strings-quoted-content
+
+  strings-quoted-content:
+    # This context exists as common entry point for inherited syntaxes to add
+    # custom highlighting to all quoted strings (only quoted attributes).
+    - include: strings-common-content
+
+  strings-common-content:
+    # This context exists as common entry point for inherited syntaxes to add
+    # custom highlighting to all strings (quoted and unquoted attributes).
+    - include: entities
 
 ###[ PROTOTYPES ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -508,10 +508,20 @@ contexts:
   tag-attribute-value-content:
     - include: entities
 
-  tag-attribute-value-separator:
+  tag-attribute-value-separator-double-quoted:
     - match: (?=[{{ascii_space}}])
       push:
-        - clear_scopes: 1 # clear `meta.class-name` or `meta.toc-list.id`
+        - clear_scopes: 3 # clear `meta.class-name` or `meta.toc-list.id`
+        - meta_include_prototype: false
+        - meta_scope: meta.string.html string.quoted.double.html
+        - include: else-pop
+
+  tag-attribute-value-separator-single-quoted:
+    - match: (?=[{{ascii_space}}])
+      push:
+        - clear_scopes: 3 # clear `meta.class-name` or `meta.toc-list.id`
+        - meta_include_prototype: false
+        - meta_scope: meta.string.html string.quoted.single.html
         - include: else-pop
 
   tag-attribute-value-unquoted-end:
@@ -543,33 +553,36 @@ contexts:
 
   tag-class-attribute-value:
     - match: \"
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
       set: tag-class-attribute-value-double-quoted-content
     - match: \'
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
       set: tag-class-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
       set: tag-class-attribute-value-unquoted-content
     - include: else-pop
 
   tag-class-attribute-value-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
-    - meta_content_scope: meta.class-name.html
+    - meta_content_scope: meta.class-name.html meta.string.html string.quoted.double.html
     - include: strings-double-quoted-end
     - include: tag-class-attribute-value-quoted-content
+    - include: tag-attribute-value-separator-double-quoted
 
   tag-class-attribute-value-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
-    - meta_content_scope: meta.class-name.html
+    - meta_content_scope: meta.class-name.html meta.string.html string.quoted.single.html
     - include: strings-single-quoted-end
     - include: tag-class-attribute-value-quoted-content
+    - include: tag-attribute-value-separator-single-quoted
 
   tag-class-attribute-value-quoted-content:
-    - include: tag-attribute-value-separator
     - include: tag-class-attribute-value-content
 
   tag-class-attribute-value-unquoted-content:
-    - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
+    - meta_content_scope: meta.class-name.html meta.string.html string.unquoted.html
     - include: tag-attribute-value-unquoted-end
     - include: tag-class-attribute-value-content
     - include: tag-attribute-value-unquoted-invalid-char
@@ -652,22 +665,26 @@ contexts:
 
   tag-generic-attribute-value:
     - match: \"
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
       set: tag-generic-attribute-value-double-quoted-content
     - match: \'
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
       set: tag-generic-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
       set: tag-generic-attribute-value-unquoted-content
     - include: else-pop
 
   tag-generic-attribute-value-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.string.html string.quoted.double.html
     - include: strings-double-quoted-end
     - include: tag-generic-attribute-value-quoted-content
 
   tag-generic-attribute-value-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.string.html string.quoted.single.html
     - include: strings-single-quoted-end
     - include: tag-generic-attribute-value-quoted-content
 
@@ -675,7 +692,7 @@ contexts:
     - include: tag-generic-attribute-value-content
 
   tag-generic-attribute-value-unquoted-content:
-    - meta_scope: meta.string.html string.unquoted.html
+    - meta_content_scope: meta.string.html string.unquoted.html
     - include: tag-attribute-value-unquoted-end
     - include: tag-generic-attribute-value-content
     - include: tag-attribute-value-unquoted-invalid-char
@@ -704,22 +721,26 @@ contexts:
 
   tag-href-attribute-value:
     - match: \"
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
       set: tag-href-attribute-value-double-quoted-content
     - match: \'
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
       set: tag-href-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
       set: tag-href-attribute-value-unquoted-content
     - include: else-pop
 
   tag-href-attribute-value-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.path.url.html meta.string.html string.quoted.double.html
     - include: strings-double-quoted-end
     - include: tag-href-attribute-value-quoted-content
 
   tag-href-attribute-value-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.path.url.html meta.string.html string.quoted.single.html
     - include: strings-single-quoted-end
     - include: tag-href-attribute-value-quoted-content
 
@@ -727,7 +748,7 @@ contexts:
     - include: tag-href-attribute-value-content
 
   tag-href-attribute-value-unquoted-content:
-    - meta_scope: meta.string.html string.unquoted.html
+    - meta_content_scope: meta.path.url.html meta.string.html string.unquoted.html
     - include: tag-attribute-value-unquoted-end
     - include: tag-href-attribute-value-content
     - include: tag-attribute-value-unquoted-invalid-char
@@ -760,33 +781,36 @@ contexts:
 
   tag-id-attribute-value:
     - match: \"
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
       set: tag-id-attribute-value-double-quoted-content
     - match: \'
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
       set: tag-id-attribute-value-single-quoted-content
     - match: '{{unquoted_attribute_start}}'
       set: tag-id-attribute-value-unquoted-content
     - include: else-pop
 
   tag-id-attribute-value-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
-    - meta_content_scope: meta.toc-list.id.html
+    - meta_content_scope: meta.toc-list.id.html meta.string.html string.quoted.double.html
     - include: strings-double-quoted-end
     - include: tag-id-attribute-value-quoted-content
+    - include: tag-attribute-value-separator-double-quoted
 
   tag-id-attribute-value-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
-    - meta_content_scope: meta.toc-list.id.html
+    - meta_content_scope: meta.toc-list.id.html meta.string.html string.quoted.single.html
     - include: strings-single-quoted-end
     - include: tag-id-attribute-value-quoted-content
+    - include: tag-attribute-value-separator-single-quoted
 
   tag-id-attribute-value-quoted-content:
-    - include: tag-attribute-value-separator
     - include: tag-id-attribute-value-content
 
   tag-id-attribute-value-unquoted-content:
-    - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
+    - meta_content_scope: meta.toc-list.id.html meta.string.html string.unquoted.html
     - include: tag-attribute-value-unquoted-end
     - include: tag-id-attribute-value-content
     - include: tag-attribute-value-unquoted-invalid-char
@@ -855,31 +879,39 @@ contexts:
 
   strings-double-quoted:
     - match: \"
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
       push: strings-double-quoted-content
 
   strings-double-quoted-end:
     - match: \"
-      scope: punctuation.definition.string.end.html
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.end.html
       pop: 1
 
   strings-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
+    - meta_content_scope: meta.string.html string.quoted.double.html
     - include: strings-double-quoted-end
     - include: strings-quoted-content
 
   strings-single-quoted:
     - match: \'
-      scope: punctuation.definition.string.begin.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
       push: strings-single-quoted-content
 
   strings-single-quoted-end:
     - match: \'
-      scope: punctuation.definition.string.end.html
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.end.html
       pop: 1
 
   strings-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
+    - meta_content_scope: meta.string.html string.quoted.single.html
     - include: strings-single-quoted-end
     - include: strings-quoted-content
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -652,11 +652,18 @@ contexts:
     - match: (?i:href|src){{attribute_name_break}}
       scope: entity.other.attribute-name.href.html
       push:
-        - meta_scope: meta.attribute-with-value.href.html
-        - match: '='
-          scope: punctuation.separator.key-value.html
-          push: tag-href-attribute-value
-        - include: else-pop
+        - tag-href-attributes-meta
+        - tag-href-attributes-equals
+
+  tag-href-attributes-meta:
+    - meta_scope: meta.attribute-with-value.href.html
+    - include: immediately-pop
+
+  tag-href-attributes-equals:
+    - match: =
+      scope: punctuation.separator.key-value.html
+      set: tag-href-attribute-value
+    - include: else-pop
 
   tag-href-attribute-value:
     - match: \"
@@ -665,7 +672,7 @@ contexts:
         - meta_scope: meta.string.html string.quoted.double.html
         - match: \"
           scope: punctuation.definition.string.end.html
-          pop: 2
+          pop: 1
         - include: tag-attribute-value-separator
         - include: tag-href-entities
     - match: \'
@@ -674,14 +681,14 @@ contexts:
         - meta_scope: meta.string.html string.quoted.single.html
         - match: \'
           scope: punctuation.definition.string.end.html
-          pop: 2
+          pop: 1
         - include: tag-attribute-value-separator
         - include: tag-href-entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html
         - match: '{{unquoted_attribute_break}}'
-          pop: 2
+          pop: 1
         - include: tag-attribute-value-invalid-char
         - include: tag-href-entities
     - include: else-pop

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -162,14 +162,16 @@ contexts:
   doctype-content:
     - match: \[
       scope: punctuation.section.brackets.begin.html
-      set:
-        - meta_scope: meta.brackets.html meta.internal-subset.xml.html
-        - match: \]
-          scope: punctuation.section.brackets.end.html
-          pop: 1
-        - include: comment
+      set: doctype-internal-subset-content
     - include: strings
     - include: else-pop
+
+  doctype-internal-subset-content:
+    - meta_scope: meta.brackets.html meta.internal-subset.xml.html
+    - match: \]
+      scope: punctuation.section.brackets.end.html
+      pop: 1
+    - include: comment
 
 ###[ PREPROCESSOR ]###########################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -505,13 +505,13 @@ contexts:
       scope: entity.other.attribute-name.class.html
       push:
         - tag-class-attribute-meta
-        - tag-class-attribute-equals
+        - tag-class-attribute-assignment
 
   tag-class-attribute-meta:
     - meta_scope: meta.attribute-with-value.class.html
     - include: immediately-pop
 
-  tag-class-attribute-equals:
+  tag-class-attribute-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-class-attribute-value
@@ -565,13 +565,13 @@ contexts:
       scope: entity.other.attribute-name.event.html
       push:
         - tag-event-attribute-meta
-        - tag-event-attribute-equals
+        - tag-event-attribute-assignment
 
   tag-event-attribute-meta:
     - meta_scope: meta.attribute-with-value.event.html
     - include: immediately-pop
 
-  tag-event-attribute-equals:
+  tag-event-attribute-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-event-attribute-value
@@ -600,7 +600,7 @@ contexts:
     - match: '{{attribute_name_start}}'
       push:
         - tag-generic-attribute-meta
-        - tag-generic-attribute-equals
+        - tag-generic-attribute-assignment
         - tag-generic-attribute-name
 
   tag-generic-attribute-name:
@@ -614,7 +614,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.html
     - include: immediately-pop
 
-  tag-generic-attribute-equals:
+  tag-generic-attribute-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-generic-attribute-value
@@ -709,13 +709,13 @@ contexts:
       scope: entity.other.attribute-name.id.html
       push:
         - tag-id-attribute-meta
-        - tag-id-attribute-equals
+        - tag-id-attribute-assignment
 
   tag-id-attribute-meta:
     - meta_scope: meta.attribute-with-value.id.html
     - include: immediately-pop
 
-  tag-id-attribute-equals:
+  tag-id-attribute-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-id-attribute-value
@@ -758,13 +758,13 @@ contexts:
       scope: entity.other.attribute-name.style.html
       push:
         - tag-style-attribute-meta
-        - tag-style-attribute-equals
+        - tag-style-attribute-assignment
 
   tag-style-attribute-meta:
     - meta_scope: meta.attribute-with-value.style.html
     - include: immediately-pop
 
-  tag-style-attribute-equals:
+  tag-style-attribute-assignment:
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-style-attribute-value

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -105,7 +105,7 @@ contexts:
         - meta_content_scope: string.unquoted.cdata.html
         - match: ']]>'
           scope: punctuation.definition.tag.end.html
-          pop: true
+          pop: 1
 
 ###[ COMMENT ]################################################################
 
@@ -120,7 +120,7 @@ contexts:
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
             2: punctuation.definition.comment.end.html
-          pop: true
+          pop: 1
         - match: <!--(?!-?>)|--!>
           scope: invalid.illegal.bad-comments-or-CDATA.html
 
@@ -141,18 +141,18 @@ contexts:
     - meta_scope: meta.tag.sgml.doctype.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
 
   doctype-name:
     - match: '{{tag_name}}'
       scope: constant.language.doctype.html
-      pop: true
+      pop: 1
     - include: else-pop
 
   doctype-content-type:
     - match: (?i:public|system){{tag_name_break}}
       scope: keyword.content.external.html
-      pop: true
+      pop: 1
     - include: else-pop
 
   doctype-content:
@@ -162,7 +162,7 @@ contexts:
         - meta_scope: meta.brackets.html meta.internal-subset.xml.html
         - match: \]
           scope: punctuation.section.brackets.end.html
-          pop: true
+          pop: 1
         - include: comment
     - include: string-double-quoted
     - include: string-single-quoted
@@ -179,7 +179,7 @@ contexts:
         - meta_scope: meta.tag.preprocessor.xml.html
         - match: \?>
           scope: punctuation.definition.tag.end.html
-          pop: true
+          pop: 1
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
@@ -277,24 +277,24 @@ contexts:
   tag-end:
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
 
   tag-end-self-closing:
     - match: />
       scope: punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
 
   tag-end-maybe-self-closing:
     - match: /?>
       scope: punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
 
 ###[ CUSTOM TAG ]#############################################################
 
   tag-custom-name:
       - meta_content_scope: entity.name.tag.custom.html
       - match: '{{tag_name_break}}'
-        pop: true
+        pop: 1
       - match: '{{custom_element_char}}+'
         # no scope
       - match: '{{tag_name_char}}'
@@ -308,7 +308,7 @@ contexts:
   tag-other-name:
       - meta_content_scope: entity.name.tag.other.html
       - match: '{{tag_name_break}}'
-        pop: true
+        pop: 1
 
   tag-other-body:
       - meta_scope: meta.tag.other.html
@@ -521,7 +521,7 @@ contexts:
         - meta_content_scope: meta.class-name.html
         - match: \"
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: tag-attribute-value-separator
         - include: entities
     - match: \'
@@ -531,14 +531,14 @@ contexts:
         - meta_content_scope: meta.class-name.html
         - match: \'
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: tag-attribute-value-separator
         - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
         - match: '{{unquoted_attribute_break}}'
-          pop: true
+          pop: 1
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
         - include: entities
@@ -603,7 +603,7 @@ contexts:
   tag-generic-attribute-name:
     - meta_scope: entity.other.attribute-name.html
     - match: '{{attribute_name_break}}'
-      pop: true
+      pop: 1
     - match: '["''`<]'
       scope: invalid.illegal.attribute-name.html
 
@@ -624,7 +624,7 @@ contexts:
         - meta_scope: meta.string.html string.quoted.double.html
         - match: \"
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: entities
     - match: \'
       scope: punctuation.definition.string.begin.html
@@ -632,13 +632,13 @@ contexts:
         - meta_scope: meta.string.html string.quoted.single.html
         - match: \'
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html
         - match: '{{unquoted_attribute_break}}'
-          pop: true
+          pop: 1
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
         - include: entities
@@ -719,7 +719,7 @@ contexts:
         - meta_content_scope: meta.toc-list.id.html
         - match: \"
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: tag-attribute-value-separator
         - include: entities
     - match: \'
@@ -729,14 +729,14 @@ contexts:
         - meta_content_scope: meta.toc-list.id.html
         - match: \'
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: tag-attribute-value-separator
         - include: entities
     - match: '{{unquoted_attribute_start}}'
       set:
         - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
         - match: '{{unquoted_attribute_break}}'
-          pop: true
+          pop: 1
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.html
         - include: entities
@@ -804,7 +804,7 @@ contexts:
         - meta_scope: meta.string.html string.quoted.double.html
         - match: \"
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: entities
 
   string-single-quoted:
@@ -814,15 +814,15 @@ contexts:
         - meta_scope: meta.string.html string.quoted.single.html
         - match: \'
           scope: punctuation.definition.string.end.html
-          pop: true
+          pop: 1
         - include: entities
 
 ###[ PROTOTYPES ]#############################################################
 
   else-pop:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   immediately-pop:
     - match: ''
-      pop: true
+      pop: 1

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -197,6 +197,27 @@ contexts:
     - include: tag-custom
     - include: tag-incomplete
 
+  tag-incomplete:
+    - match: <>
+      scope: invalid.illegal.incomplete.html
+
+  tag-end:
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      pop: 1
+
+  tag-end-self-closing:
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: 1
+
+  tag-end-maybe-self-closing:
+    - match: /?>
+      scope: punctuation.definition.tag.end.html
+      pop: 1
+
+###[ HTML TAGS ]##############################################################
+
   tag-html:
     - match: (<)((?i:style)){{tag_name_break}}
       captures:
@@ -272,25 +293,6 @@ contexts:
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-
-  tag-incomplete:
-    - match: <>
-      scope: invalid.illegal.incomplete.html
-
-  tag-end:
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      pop: 1
-
-  tag-end-self-closing:
-    - match: />
-      scope: punctuation.definition.tag.end.html
-      pop: 1
-
-  tag-end-maybe-self-closing:
-    - match: /?>
-      scope: punctuation.definition.tag.end.html
-      pop: 1
 
 ###[ CUSTOM TAG ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -505,6 +505,9 @@ contexts:
     - include: tag-href-attribute
     - include: tag-generic-attribute
 
+  tag-attribute-value-content:
+    - include: entities
+
   tag-attribute-value-separator:
     - match: (?=[{{ascii_space}}])
       push:
@@ -572,7 +575,7 @@ contexts:
     - include: tag-attribute-value-unquoted-invalid-char
 
   tag-class-attribute-value-content:
-    - include: tag-generic-attribute-value-content
+    - include: tag-attribute-value-content
 
 ###[ EVENT ATTRIBUTE ]########################################################
 
@@ -678,7 +681,7 @@ contexts:
     - include: tag-attribute-value-unquoted-invalid-char
 
   tag-generic-attribute-value-content:
-    - include: entities
+    - include: tag-attribute-value-content
 
 ###[ HREF ATTRIBUTE ]#########################################################
 
@@ -734,7 +737,7 @@ contexts:
       scope: constant.character.escape.url.html
       captures:
         1: punctuation.definition.escape.html
-    - include: tag-generic-attribute-value-content
+    - include: tag-attribute-value-content
 
 ###[ ID ATTRIBUTE ]###########################################################
 
@@ -789,7 +792,7 @@ contexts:
     - include: tag-attribute-value-unquoted-invalid-char
 
   tag-id-attribute-value-content:
-    - include: tag-generic-attribute-value-content
+    - include: tag-attribute-value-content
 
 ###[ STYLE ATTRIBUTE ]########################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -670,6 +670,7 @@ contexts:
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: meta.string.html string.quoted.double.html
+        - meta_content_scope: meta.path.html
         - match: \"
           scope: punctuation.definition.string.end.html
           pop: 1
@@ -679,6 +680,7 @@ contexts:
       scope: punctuation.definition.string.begin.html
       set:
         - meta_scope: meta.string.html string.quoted.single.html
+        - meta_content_scope: meta.path.html
         - match: \'
           scope: punctuation.definition.string.end.html
           pop: 1
@@ -686,7 +688,7 @@ contexts:
         - include: tag-href-entities
     - match: '{{unquoted_attribute_start}}'
       set:
-        - meta_scope: meta.string.html string.unquoted.html
+        - meta_scope: meta.string.html string.unquoted.html meta.path.html
         - match: '{{unquoted_attribute_break}}'
           pop: 1
         - include: tag-attribute-value-invalid-char

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -505,19 +505,17 @@ contexts:
     - include: tag-href-attribute
     - include: tag-generic-attribute
 
-  tag-attribute-value-unquoted-content:
-    - match: '{{unquoted_attribute_break}}'
-      pop: 1
-    - include: strings-unquoted-content
-    - include: tag-attribute-value-invalid-char
-
   tag-attribute-value-separator:
     - match: (?=[{{ascii_space}}])
       push:
         - clear_scopes: 1 # clear `meta.class-name` or `meta.toc-list.id`
         - include: else-pop
 
-  tag-attribute-value-invalid-char:
+  tag-attribute-value-unquoted-end:
+    - match: '{{unquoted_attribute_break}}'
+      pop: 1
+
+  tag-attribute-value-unquoted-invalid-char:
     - match: '["''`<]'
       scope: invalid.illegal.attribute-value.html
 
@@ -554,18 +552,27 @@ contexts:
   tag-class-attribute-value-double-quoted-content:
     - meta_scope: meta.string.html string.quoted.double.html
     - meta_content_scope: meta.class-name.html
-    - include: strings-double-quoted-content
-    - include: tag-attribute-value-separator
+    - include: strings-double-quoted-end
+    - include: tag-class-attribute-value-quoted-content
 
   tag-class-attribute-value-single-quoted-content:
     - meta_scope: meta.string.html string.quoted.single.html
     - meta_content_scope: meta.class-name.html
-    - include: strings-single-quoted-content
+    - include: strings-single-quoted-end
+    - include: tag-class-attribute-value-quoted-content
+
+  tag-class-attribute-value-quoted-content:
     - include: tag-attribute-value-separator
+    - include: tag-class-attribute-value-content
 
   tag-class-attribute-value-unquoted-content:
     - meta_scope: meta.string.html string.unquoted.html meta.class-name.html
-    - include: tag-attribute-value-unquoted-content
+    - include: tag-attribute-value-unquoted-end
+    - include: tag-class-attribute-value-content
+    - include: tag-attribute-value-unquoted-invalid-char
+
+  tag-class-attribute-value-content:
+    - include: tag-generic-attribute-value-content
 
 ###[ EVENT ATTRIBUTE ]########################################################
 
@@ -653,15 +660,25 @@ contexts:
 
   tag-generic-attribute-value-double-quoted-content:
     - meta_scope: meta.string.html string.quoted.double.html
-    - include: strings-double-quoted-content
+    - include: strings-double-quoted-end
+    - include: tag-generic-attribute-value-quoted-content
 
   tag-generic-attribute-value-single-quoted-content:
     - meta_scope: meta.string.html string.quoted.single.html
-    - include: strings-single-quoted-content
+    - include: strings-single-quoted-end
+    - include: tag-generic-attribute-value-quoted-content
+
+  tag-generic-attribute-value-quoted-content:
+    - include: tag-generic-attribute-value-content
 
   tag-generic-attribute-value-unquoted-content:
     - meta_scope: meta.string.html string.unquoted.html
-    - include: tag-attribute-value-unquoted-content
+    - include: tag-attribute-value-unquoted-end
+    - include: tag-generic-attribute-value-content
+    - include: tag-attribute-value-unquoted-invalid-char
+
+  tag-generic-attribute-value-content:
+    - include: entities
 
 ###[ HREF ATTRIBUTE ]#########################################################
 
@@ -696,25 +713,30 @@ contexts:
   tag-href-attribute-value-double-quoted-content:
     - meta_scope: meta.string.html string.quoted.double.html
     - meta_content_scope: meta.path.html
-    - include: strings-double-quoted-content
-    - include: tag-href-attribute-value-content
+    - include: strings-double-quoted-end
+    - include: tag-href-attribute-value-quoted-content
 
   tag-href-attribute-value-single-quoted-content:
     - meta_scope: meta.string.html string.quoted.single.html
     - meta_content_scope: meta.path.html
-    - include: strings-single-quoted-content
+    - include: strings-single-quoted-end
+    - include: tag-href-attribute-value-quoted-content
+
+  tag-href-attribute-value-quoted-content:
     - include: tag-href-attribute-value-content
 
   tag-href-attribute-value-unquoted-content:
     - meta_scope: meta.string.html string.unquoted.html meta.path.html
-    - include: tag-attribute-value-unquoted-content
+    - include: tag-attribute-value-unquoted-end
     - include: tag-href-attribute-value-content
+    - include: tag-attribute-value-unquoted-invalid-char
 
   tag-href-attribute-value-content:
     - match: (%)\h{2}
       scope: constant.character.escape.url.html
       captures:
         1: punctuation.definition.escape.html
+    - include: tag-generic-attribute-value-content
 
 ###[ ID ATTRIBUTE ]###########################################################
 
@@ -749,18 +771,27 @@ contexts:
   tag-id-attribute-value-double-quoted-content:
     - meta_scope: meta.string.html string.quoted.double.html
     - meta_content_scope: meta.toc-list.id.html
-    - include: strings-double-quoted-content
-    - include: tag-attribute-value-separator
+    - include: strings-double-quoted-end
+    - include: tag-id-attribute-value-quoted-content
 
   tag-id-attribute-value-single-quoted-content:
     - meta_scope: meta.string.html string.quoted.single.html
     - meta_content_scope: meta.toc-list.id.html
-    - include: strings-single-quoted-content
+    - include: strings-single-quoted-end
+    - include: tag-id-attribute-value-quoted-content
+
+  tag-id-attribute-value-quoted-content:
     - include: tag-attribute-value-separator
+    - include: tag-id-attribute-value-content
 
   tag-id-attribute-value-unquoted-content:
     - meta_scope: meta.string.html string.unquoted.html meta.toc-list.id.html
-    - include: tag-attribute-value-unquoted-content
+    - include: tag-attribute-value-unquoted-end
+    - include: tag-id-attribute-value-content
+    - include: tag-attribute-value-unquoted-invalid-char
+
+  tag-id-attribute-value-content:
+    - include: tag-generic-attribute-value-content
 
 ###[ STYLE ATTRIBUTE ]########################################################
 
@@ -826,11 +857,14 @@ contexts:
       scope: punctuation.definition.string.begin.html
       push: strings-double-quoted-content
 
-  strings-double-quoted-content:
-    - meta_scope: meta.string.html string.quoted.double.html
+  strings-double-quoted-end:
     - match: \"
       scope: punctuation.definition.string.end.html
       pop: 1
+
+  strings-double-quoted-content:
+    - meta_scope: meta.string.html string.quoted.double.html
+    - include: strings-double-quoted-end
     - include: strings-quoted-content
 
   strings-single-quoted:
@@ -838,26 +872,29 @@ contexts:
       scope: punctuation.definition.string.begin.html
       push: strings-single-quoted-content
 
-  strings-single-quoted-content:
-    - meta_scope: meta.string.html string.quoted.single.html
+  strings-single-quoted-end:
     - match: \'
       scope: punctuation.definition.string.end.html
       pop: 1
+
+  strings-single-quoted-content:
+    - meta_scope: meta.string.html string.quoted.single.html
+    - include: strings-single-quoted-end
     - include: strings-quoted-content
 
   strings-quoted-content:
     # This context exists as common entry point for inherited syntaxes to add
-    # custom highlighting to all quoted strings (only quoted attributes).
+    # custom highlighting to all quoted strings.
     - include: strings-common-content
 
   strings-unquoted-content:
     # This context exists as common entry point for inherited syntaxes to add
-    # custom highlighting to all unquoted strings (only unquoted attributes).
+    # custom highlighting to all unquoted strings.
     - include: strings-common-content
 
   strings-common-content:
     # This context exists as common entry point for inherited syntaxes to add
-    # custom highlighting to all strings (quoted and unquoted attributes).
+    # custom highlighting to all strings.
     - include: entities
 
 ###[ PROTOTYPES ]#############################################################

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -100,12 +100,14 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: keyword.declaration.cdata.html
         3: punctuation.definition.tag.begin.html
-      push:
-        - meta_scope: meta.tag.sgml.cdata.html
-        - meta_content_scope: string.unquoted.cdata.html
-        - match: ']]>'
-          scope: punctuation.definition.tag.end.html
-          pop: 1
+      push: cdata-content
+
+  cdata-content:
+    - meta_scope: meta.tag.sgml.cdata.html
+    - meta_content_scope: string.unquoted.cdata.html
+    - match: ']]>'
+      scope: punctuation.definition.tag.end.html
+      pop: 1
 
 ###[ COMMENT ]################################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -298,12 +298,12 @@ contexts:
     - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-custom-body
+        - tag-custom-content
         - tag-custom-name
     - match: </?(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-other-body
+        - tag-other-content
         - tag-other-name
 
   tag-custom-name:
@@ -315,7 +315,7 @@ contexts:
       - match: '{{tag_name_char}}'
         scope: invalid.illegal.custom-tag-name.html
 
-  tag-custom-body:
+  tag-custom-content:
       - meta_scope: meta.tag.custom.html
       - include: tag-end-maybe-self-closing
       - include: tag-attributes
@@ -325,7 +325,7 @@ contexts:
       - match: '{{tag_name_break}}'
         pop: 1
 
-  tag-other-body:
+  tag-other-content:
       - meta_scope: meta.tag.other.html
       - include: tag-end-maybe-self-closing
       - include: tag-attributes

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -227,14 +227,14 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^ meta.attribute-with-value
-        ##       ^ meta.string.html string.unquoted.html meta.path.html
+        ##       ^ meta.string.html string.unquoted.html
         ##        ^^ punctuation.definition.tag.end.html
 
         <img src=/f̱oo⏡/bar/baz//>
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.path.html
+        ##       ^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html
         ##                      ^^ punctuation.definition.tag.end.html
 
         <!-- Match utf-8 escapes (%2F) in src tags -->
@@ -242,7 +242,7 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.path.html
+        ##       ^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html
         ##                ^ - constant.character.escape
         ##                 ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##                  ^^ constant.character.escape.url.html - punctuation.definition
@@ -256,7 +256,7 @@
         ##   ^^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
         ##        ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - meta.path
-        ##         ^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html meta.path.html
+        ##         ^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html
         ##             ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##              ^^ constant.character.escape.url.html - punctuation.definition
         ##                       ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html - meta.path

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -227,14 +227,14 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^ meta.attribute-with-value
-        ##       ^ meta.string.html string.unquoted.html
+        ##       ^ meta.path.url.html meta.string.html string.unquoted.html
         ##        ^^ punctuation.definition.tag.end.html
 
         <img src=/f̱oo⏡/bar/baz//>
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html
+        ##       ^^^^^^^^^^^^^^^ meta.path.url.html meta.string.html string.unquoted.html
         ##                      ^^ punctuation.definition.tag.end.html
 
         <!-- Match utf-8 escapes (%2F) in src tags -->
@@ -242,7 +242,7 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html
+        ##       ^^^^^^^^^^^^^^^^^ meta.path.url.html meta.string.html string.unquoted.html
         ##                ^ - constant.character.escape
         ##                 ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##                  ^^ constant.character.escape.url.html - punctuation.definition
@@ -256,7 +256,7 @@
         ##   ^^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
         ##        ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - meta.path
-        ##         ^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html
+        ##         ^^^^^^^^^^^^^^ meta.path.url.html meta.string.html string.quoted.double.html
         ##             ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##              ^^ constant.character.escape.url.html - punctuation.definition
         ##                       ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html - meta.path
@@ -344,19 +344,19 @@ class="foo"></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^ meta.attribute-with-value.id
-        ##      ^^^^ string.unquoted meta.toc-list.id
+        ##      ^^^^ meta.toc-list.id string.unquoted
 
         <div id=MyId></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^ meta.attribute-with-value.id
-        ##      ^^^^ meta.string.html string.unquoted.html meta.toc-list.id
+        ##      ^^^^ meta.toc-list.id meta.string.html string.unquoted
 
         <div id=My&#x49;d></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
-        ##      ^^^^^^^^^ meta.string.html string.unquoted.html meta.toc-list.id
+        ##      ^^^^^^^^^ meta.toc-list.id meta.string.html string.unquoted
         ##        ^^^^^^ constant.character.entity.hexadecimal
 
         <div id='MyId2'></div>
@@ -381,7 +381,7 @@ class="foo"></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^ entity.other.attribute-name.id
         ##   ^^^^^^^^^^^^ meta.attribute-with-value.id
-        ##      ^^^^^^^^^ meta.string.html string.unquoted.html meta.toc-list.id
+        ##      ^^^^^^^^^ meta.toc-list.id meta.string.html string.unquoted
         ##         ^^^^^ constant.character.entity.named
         ##              ^ invalid.illegal.attribute-value.html
         ##               ^ - meta.attribute-with-value - entity - constant - string - punctuation
@@ -423,19 +423,19 @@ class="foo"></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
-        ##         ^^^^^^^^^^^^^ string.unquoted meta.class-name
+        ##         ^^^^^^^^^^^^^ meta.class-name string.unquoted
 
         <div class=element-class></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
-        ##         ^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.class-name
+        ##         ^^^^^^^^^^^^^ meta.class-name meta.string.html string.unquoted.html
 
         <div class=element&#xAD;class></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class
-        ##         ^^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.class-name
+        ##         ^^^^^^^^^^^^^^^^^^ meta.class-name meta.string.html string.unquoted.html
         ##                ^^^^^^ constant.character.entity.hexadecimal
 
         <div class='element-class'></div>
@@ -460,7 +460,7 @@ class="foo"></div>
         ##  ^ - meta.attribute-with-value
         ##   ^^^^^ entity.other.attribute-name.class
         ##   ^^^^^^^^^^^^^^^ meta.attribute-with-value.class
-        ##         ^^^^^^^^^ meta.string.html string.unquoted.html meta.class-name
+        ##         ^^^^^^^^^ meta.class-name meta.string.html string.unquoted.html
         ##            ^^^^^ constant.character.entity.named
         ##                 ^ invalid.illegal.attribute-value.html
         ##                  ^ - meta.attribute-with-value - entity - constant - string - punctuation

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -227,14 +227,14 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^ meta.attribute-with-value
-        ##       ^ string.unquoted.html
+        ##       ^ meta.string.html string.unquoted.html meta.path.html
         ##        ^^ punctuation.definition.tag.end.html
 
         <img src=/f̱oo⏡/bar/baz//>
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^ string.unquoted
+        ##       ^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.path.html
         ##                      ^^ punctuation.definition.tag.end.html
 
         <!-- Match utf-8 escapes (%2F) in src tags -->
@@ -242,7 +242,7 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##       ^^^^^^^^^^^^^^^^^ string.unquoted
+        ##       ^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.html meta.path.html
         ##                ^ - constant.character.escape
         ##                 ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##                  ^^ constant.character.escape.url.html - punctuation.definition
@@ -255,9 +255,11 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##        ^^^^^^^^^^^^^^^^ string.quoted.double
+        ##        ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - meta.path
+        ##         ^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html meta.path.html
         ##             ^ constant.character.escape.url.html punctuation.definition.escape.html
         ##              ^^ constant.character.escape.url.html - punctuation.definition
+        ##                       ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html - meta.path
         ##                        ^ - meta.attribute-with-value
         ##                         ^^ punctuation.definition.tag.end.html
 
@@ -266,7 +268,7 @@
         ##  ^ - meta.attribute-with-value
         ##   ^^^ entity.other.attribute-name
         ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value
-        ##         ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double - constant.character.escape
+        ##         ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double - constant.character.escape - meta.path
         ##                               ^ - meta.attribute-with-value
         ##                                ^^ punctuation.definition.tag.end.html
 


### PR DESCRIPTION
This PR...

1. proposes to use `pop: 1` instead of `pop: true` in sublime-syntax version 2 only.
2. renames the `attribute-...-equals` context to `attribute-...-assignment` which looks more appropriate.
3. adds a lot of named contexts in order to introduce entry points for inherited syntax definitions to add custom highlighting.
4. tweaks the recently added `src/href` attribute contexts 
   a) to ensure maximum re-usablility in inerhited syntax definitions by avoiding  `pop: 2`
   b) by adding `meta.path.url` to the url values.
5. tweaks the usage of `meta_scope` and `meta_content_scope` in the script/style attriubtes to avoid assigning meta scopes via normal `scope` directives.
6. moves `meta.class-name`, `meta.toc-list.id` and `meta.path` so that an inherited syntax can easily clear string scopes while maintaining symbol list related meta scopes within interpolations.
7. adapts ASP test cases to the new meta scope order
8. improves ASP<->HTML interaction by using `embed` and `extends`, which results in much smaller syntax cache files.