### PR TITLE
[Erlang] Tweak shebang

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -122,12 +122,13 @@ contexts:
       scope: punctuation.definition.comment.shell
       set:
         - meta_include_prototype: false
-        - meta_scope: comment.line.number-sign.shell
+        - meta_scope: comment.line.shebang.shell
+        # Note: Keep sync with first_line_match!
         - match: \b(erlang|escript)\b
           scope: constant.language.erlang
         - match: \n
           set: statements
-    - match: ''
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
       set: statements
 
   prototype:

--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -118,18 +118,8 @@ variables:
 contexts:
 
   main:
-    - match: ^\#!
-      scope: punctuation.definition.comment.shell
-      set:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.shebang.shell
-        # Note: Keep sync with first_line_match!
-        - match: \b(erlang|escript)\b
-          scope: constant.language.erlang
-        - match: \n
-          set: statements
-    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
-      set: statements
+    - match: ''
+      push: [statements, shebang]
 
   prototype:
     - include: comment
@@ -242,6 +232,20 @@ contexts:
         - meta_scope: comment.line.percentage.erlang
         - match: \n
           pop: true
+
+  shebang:
+    - match: ^\#!
+      scope: punctuation.definition.comment.shell
+      set:
+        - meta_include_prototype: false
+        - meta_scope: comment.line.shebang.shell
+        # Note: Keep sync with first_line_match!
+        - match: \b(erlang|escript)\b
+          scope: constant.language.erlang
+        - match: \n
+          pop: 1
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
+      pop: 1
 
 ###[ PREPROCESSOR CONTROL ]###################################################
 


### PR DESCRIPTION
This PR tweaks the shebang line highlighting.

1. The scope is changed to `comment.line.shebang` as JavaScript uses it.
   A dedicated scope further allows dedicated shebang highlighting.
2. The statements context is set onto stack after the shebang but not after the next start of line or non-whitespace character. This is to make sure, the shebang is highlighted within fenced code blocks of Markdown. It is to support _escript_.

   **Example**

   ```
   ```Erlang
   #!/usr/bin/erlang
   
   %% Erlang test module
   -module('my-test-module').
   -compile(export_all).
   
   -ifndef(HAVE_DEBUG).
   - define(HAVE_DEBUG, 1).
   -endif.

   ```

   **Screenshot**

   ![grafik](https://user-images.githubusercontent.com/16542113/89130074-65a22f00-d502-11ea-8ce1-f0ae3c30f0b1.png)
