### PR TITLE
[Perl] Add shebang

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -95,18 +95,8 @@ variables:
 
 contexts:
   main:
-    - match: ^\#!
-      scope: punctuation.definition.comment.perl
-      set:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.shebang.perl
-        # Note: Keep sync with first_line_match!
-        - match: \bperl\b
-          scope: constant.language.shebang.perl
-        - match: \n
-          set: statements
-    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Perl is embedded.
-      set: statements
+    - match: ''
+      push: [statements, shebang]
 
   statements:
     - include: comment-pod
@@ -167,6 +157,20 @@ contexts:
       pop: true
 
 ###[ COMMENTS ]###############################################################
+
+  shebang:
+    - match: ^\#!
+      scope: punctuation.definition.comment.perl
+      set:
+        - meta_include_prototype: false
+        - meta_scope: comment.line.shebang.perl
+        # Note: Keep sync with first_line_match!
+        - match: \bperl\b
+          scope: constant.language.shebang.perl
+        - match: \n
+          pop: true
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Perl is embedded.
+      pop: true
 
   comment-line:
     - match: \#+

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -95,6 +95,20 @@ variables:
 
 contexts:
   main:
+    - match: ^\#!
+      scope: punctuation.definition.comment.perl
+      set:
+        - meta_include_prototype: false
+        - meta_scope: comment.line.shebang.perl
+        # Note: Keep sync with first_line_match!
+        - match: \bperl\b
+          scope: constant.language.shebang.perl
+        - match: \n
+          set: statements
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Perl is embedded.
+      set: statements
+
+  statements:
     - include: comment-pod
     - include: package
     - include: imports
@@ -575,7 +589,7 @@ contexts:
     - match: \}
       scope: punctuation.section.block.end.perl
       pop: true
-    - include: main
+    - include: statements
 
   brackets:
     # can't push into scope due to HEREDOCs!


### PR DESCRIPTION
This PR adds a support for specieal highlighting of the shebang line.

Some fonts provide ligatures for the `#!` sign, thus need to ensure it is tokenized correctly.

The statements context is set onto stack after shebang matches but not after the next start of line or non-whitespace character. This is to make sure, the shebang is highlighted within fenced code blocks of Markdown.

Related with Erlang. Others may follow.