### PR TITLE
[Markdown] Assign specific scopes to level 3~5 headings

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -585,7 +585,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(##)(?!#)\s*(?=\S)'
+    - match: '(#{2})(?!#)\s*(?=\S)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -593,11 +593,35 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{3,6})(?!#)\s*(?=\S)'
+    - match: '(#{3})(?!#)\s*(?=\S)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
-        - meta_scope: markup.heading.markdown
+        - meta_scope: markup.heading.3.markdown
+        - meta_content_scope: entity.name.section.markdown
+        - include: atx-heading-terminator
+        - include: inline-bold-italic
+    - match: '(#{4})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.begin.markdown
+      push:
+        - meta_scope: markup.heading.4.markdown
+        - meta_content_scope: entity.name.section.markdown
+        - include: atx-heading-terminator
+        - include: inline-bold-italic
+    - match: '(#{5})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.begin.markdown
+      push:
+        - meta_scope: markup.heading.5.markdown
+        - meta_content_scope: entity.name.section.markdown
+        - include: atx-heading-terminator
+        - include: inline-bold-italic
+    - match: '(#{6})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.begin.markdown
+      push:
+        - meta_scope: markup.heading.6.markdown
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic


### PR DESCRIPTION
This PR proposes to use

- `markup.heading.3.markdown` for level 3 heading (changed from `markup.heading.markdown`)
- `markup.heading.4.markdown` for level 4 heading (changed from `markup.heading.markdown`)
- `markup.heading.5.markdown` for level 5 heading (changed from `markup.heading.markdown`)
- `markup.heading.6.markdown` for level 6 heading (changed from `markup.heading.markdown`)

---

My original idea is to give headings different background colors via color scheme rules according to their levels.

![Snipaste_2020-08-11_19-26-09](https://user-images.githubusercontent.com/6594915/89892369-201fe900-dc09-11ea-9f69-95bf47e21ced.png)

But soon I found that there are only `markup.heading.1.markdown`, `markup.heading.2.markdown` and other levels are all `markup.heading.markdown`. It's weird that we highlight `punctuation.definition.heading.begin.markdown` up to 6 levels but only gives level 1 and level 2 specific `meta_scope`s.

