### PR TITLE
[Markdown] Fix more arrow like ligatures

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -211,8 +211,8 @@ contexts:
                         pattern will only match stuff matched by the sub-patterns.
       push:
         - meta_scope: meta.block-level.markdown
-        - include: ligatures
         - include: block-quote
+        - include: ligatures
         - include: indented-code-block
         - include: atx-heading
         - include: thematic-break
@@ -364,9 +364,16 @@ contexts:
         Markdown will convert this for us. We match it so that the
                         HTML grammar will not mark it up as invalid.
       scope: meta.other.valid-ampersand.markdown
+
   ligatures:
-    - match: '<=>'          # <=>
-    - match: '<[-=<]'       # <- <= <<
+    - match: '<?(-+|=+)<'     # -< --< ---< ----< <-< <--< <---< <----<
+                              # =< ==< ===< ====< <=< <==< <===< <====<
+    - match: '<(-+|=+)>?'     # <- <-- <--- <-> <--> <--->
+                              # <= <== <=== <=> <==> <===>
+    - match: '>(-+|=+)[<>]?'  # >- >-- >--- >-> >--> >---> >-< >--< >---<
+                              # >= >== >=== >=> >==> >===> >=< >==< >===<
+    - match: '<<+|<>|>>+'     # << <<< <<<< <> >>>> >>> >>
+
   block-quote:
     - match: '[ ]{,3}(>)[ ]?'
       comment: |

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -405,6 +405,9 @@ paragraph
     >=
 |   ^^ - punctuation.definition.blockquote.markdown
 
+>==
+| <- punctuation.definition.blockquote.markdown
+
 Code block below:
 
     this is code!
@@ -503,11 +506,40 @@ a.b-c_d@a.b.
 this is a raw ampersand & does not require HTML escaping
 |                       ^ meta.other.valid-ampersand
 
-this is a raw bracket < <= <- << does not require HTML escaping
+this is a raw bracket < > does not require HTML escaping
+|                     ^^^ - meta.tag 
 |                     ^ meta.other.valid-bracket
-|                       ^^ - meta.other-valid-bracket - meta.tag
-|                          ^^ - meta.other-valid-bracket - meta.tag
-|                             ^^ - meta.other-valid-bracket - meta.tag
+|                       ^ - meta.other.valid-bracket
+
+these are raw ligatures << <<< <<<< <<<<< >>>>> >>>> >>> >>
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures <- <-- <--- <---- <-< <--< <---< <----<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures -> --> ---> ----> >-> >--> >---> >---->
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >- >-- >--- >---- ----< ---< --< -<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >< >-< >--< >---< <---> <--> <-> <>
+|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures <= <== <=== <==== <=< <==< <===< <====<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures => ==> ===> ====> >=> >==> >===> >====>
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >= >== >=== >==== ====< ===< ==< =<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >< >=< >==< >===< <===> <==> <=> <>
+|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures - -- --- ---- ----- ===== ==== === == =
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
 
 [2]: https://github.com/sublimehq/Packages "Packages Repo"
 | <- meta.link.reference.def


### PR DESCRIPTION
Addresses https://github.com/MonoLisaFont/feedback/issues/36

This PR extends the existing ligatures tokenization fix to match more arrow like ligatures correctly, by just consuming everything, which looks like a ligature candidate.