### PR TITLE
[Makefile] Embed extended ShellScript

### DIFF
--- a/Makefile/Makefile Shell.sublime-syntax
+++ b/Makefile/Makefile Shell.sublime-syntax
@@ -1,0 +1,24 @@
+%YAML 1.2
+---
+scope: source.shell.embedded.makefile
+version: 2
+hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
+
+contexts:
+  main:
+    # skip shebang
+    - include: statements
+
+  expansions-parameter:
+    - meta_prepend: true
+    - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions
+
+  string-ansi-c-body:
+    - meta_append: true
+    - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions
+
+  string-quoted-single-body:
+    - meta_append: true
+    - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions

--- a/Makefile/Makefile Shell.sublime-syntax
+++ b/Makefile/Makefile Shell.sublime-syntax
@@ -4,12 +4,9 @@ scope: source.shell.embedded.makefile
 version: 2
 hidden: true
 
-extends: Packages/ShellScript/Bash.sublime-syntax
+extends: Packages/ShellScript/Shell-Unix-Generic.sublime-syntax
 
 contexts:
-  main:
-    # skip shebang
-    - include: statements
 
   expansions-parameter:
     - meta_prepend: true

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -275,20 +275,19 @@ contexts:
       pop: true
 
   recipe-inline:
-    - meta_content_scope: meta.function.body.makefile
+    - meta_content_scope: meta.function.body.makefile source.shell.embedded.makefile
     - include: recipe-junction-between-spaces-or-tabs
     - include: control-flow
     - match: $
       set: recipe-junction-between-spaces-or-tabs
-    - match: ""
-      push: shell
+    - include: shell-content
 
   recipe-with-spaces:
     - meta_content_scope: meta.function.body.makefile
     - match: ^([ ]+)([-@]{1,2})?
       captures:
         2: constant.language.makefile
-      push: shell
+      push: shell-common
     - match: ^(\t)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.spaces.makefile
@@ -302,7 +301,7 @@ contexts:
     - match: ^\t([-@]{1,2})?
       captures:
         1: constant.language.makefile
-      push: shell
+      push: shell-common
     - match: ^([ ]+)([-@]{1,2})?
       captures:
         1: invalid.illegal.inconsistent.expected.tab.makefile
@@ -315,28 +314,14 @@ contexts:
     - include: control-flow
     - match: ^\n
 
-  shell:
-    # Due to how the shell syntax handles comments, we must account for the case
-    # where a recipe-line is a single comment in combination with an "@" or "-"
-    # from Make.
-    - match: \s*(#)
-      captures:
-        1: punctuation.definition.comment.begin.shell
-      set:
-        # I don't like putting the string "source.shell" here, as the delegation
-        # seeps into this syntax now. But I don't see a cleaner way right now.
-        - meta_scope: source.shell.embedded comment.line.number-sign.shell
-        - include: comments-pop-on-line-end
-    # Otherwise, delegate to the shell syntax (with various extra prototypes).
-    - match: ''
-      set: shell-body
-      with_prototype:
-        - include: variable-substitutions
-
-  shell-body:
-    - meta_scope: source.shell.embedded
-    - include: embedded-shell
+  shell-common:
+    - meta_content_scope: source.shell.embedded.makefile
     - include: pop-on-line-end
+    - include: shell-content
+
+  shell-content:
+    - include: Packages/Makefile/Makefile Shell.sublime-syntax
+      apply_prototype: true
 
   line-continuation:
     - match: (\\)([ ]*)$\n?
@@ -359,6 +344,7 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.begin.makefile
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.makefile string.quoted.single.makefile
         - match: "'"
           scope: punctuation.definition.string.end.makefile
@@ -369,6 +355,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.makefile
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.makefile string.quoted.double.makefile
         - match: '"'
           scope: punctuation.definition.string.end.makefile
@@ -521,18 +508,11 @@ contexts:
         1: keyword.other.block.begin.makefile
         2: support.function.builtin.makefile
       push:
+        - meta_content_scope: source.shell.embedded.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
           pop: true
-        - match: ''
-          push: shell-body
-          with_prototype:
-            - match: (?=\))
-              pop: true
-            - include: variable-substitutions
-            - include: quoted-string
-            - match: \(
-              push: textual-parenthesis-balancer
+        - include: shell-content
 
   variable-definitions:
     - match: \s*(override)\b
@@ -565,10 +545,7 @@ contexts:
           set:
             - match: '!='
               scope: keyword.operator.assignment.makefile
-              set: shell-body
-              with_prototype:
-                - include: variable-substitutions
-                - include: textual-parenthesis-balancer
+              set: shell-common
         - match: (?=\s*(!|\?|\+|::?)?=)
           set:
             - match: (!|\?|\+|::?)?=
@@ -593,17 +570,13 @@ contexts:
       captures:
         1: meta.string.makefile string.unquoted.makefile
         2: meta.string.makefile meta.interpolation.makefile punctuation.section.interpolation.begin.makefile
-      embed: embedded-shell
-      embed_scope: meta.string.makefile meta.interpolation.makefile source.shell.embedded
+      embed: shell-content
+      embed_scope: meta.string.makefile meta.interpolation.makefile source.shell.embedded.makefile
       escape: (?!<\\)\2
       escape_captures:
         0: meta.string.makefile meta.interpolation.makefile punctuation.section.interpolation.end.makefile
     - match: ''
       set: value-to-be-defined
-
-  embedded-shell:
-    - include: scope:source.shell
-      apply_prototype: true
 
   value-to-be-defined:
     - meta_content_scope: meta.string.makefile string.unquoted.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -710,8 +710,8 @@ else ifeq ($(shell svn info >/dev/null && echo USING_SVN),USING_SVN)
   # context in the with_prototype override so that we can account for this.
   # This does mean that the shell syntax looks a tiny bit different.
   VCSTURD := $(addsuffix /.svn/entries, $(shell svn info | grep 'Root Path' | sed -e 's/\(.*\:\)\(.*\) /\2/'))
-  #                                                                                  ^ string.quoted.single.makefile punctuation.definition.string.begin.makefile
-  #                                                                                                        ^ string.quoted.single.makefile punctuation.definition.string.end.makefile
+  #                                                                                  ^ string.quoted.single.shell punctuation.definition.string.begin.shell
+  #                                                                                                        ^ string.quoted.single.shell punctuation.definition.string.end.shell
 endif
 # <- keyword.control
 
@@ -868,8 +868,8 @@ $(call show_config_variable,CC_VERSION,[COMPUTED],($(CC_NAME)))
 
 LIBRARIES := $(filter $(notdir $(wildcard $(HOME)/energia_sketchbook/libraries/*)), \
     $(shell sed -ne "s/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p" $(SOURCES)))
-    #               ^ string.quoted.double.makefile punctuation.definition.string.begin.makefile
-    #                                                          ^ string.quoted.double.makefile punctuation.definition.string.end.makefile
+    #               ^ string.quoted.double.shell punctuation.definition.string.begin.shell
+    #                                                          ^ string.quoted.double.shell punctuation.definition.string.end.shell
 
 # FIX: https://github.com/sublimehq/Packages/issues/1941
 escape_shellstring = $(subst `,\`,$(subst ",\",$(subst $$,\$$,$(subst \,\\,$1))))
@@ -938,3 +938,17 @@ TESTTOOL = sh -c '\
 #    ^^^^^^^^^ meta.string.makefile string.unquoted.makefile - meta.interpolation
 # ^^ source.shell.embedded keyword.control.conditional.end.shell - source.shell source.shell
 #   ^ punctuation.section.interpolation.end.makefile
+
+
+# Fix https://github.com/sublimehq/Packages/issues/2388
+html:
+    $(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile - source.shell source.shell
+#   ^^^^^^^^^^ meta.function-call.identifier.shell
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#              ^^^^^^^^^^^ variable.parameter.makefile
+#                          ^^ variable.parameter.option.shell
+#                             ^^^^^^^^^^^ variable.parameter.makefile
+#                                          ^^ variable.parameter.option.shell
+#                                             ^^^^^^^^^^^ variable.parameter.makefile
+#                                                         ^^^^^^^^^^^^^^ variable.parameter.makefile

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -91,9 +91,8 @@ variables:
 
 contexts:
   main:
-    # - match: ''
-    #   push: [statements, shebang]
-    - include: statements
+    - match: ''
+      push: [statements, shebang]
 
   statements:
     - include: comments

--- a/ShellScript/Shell-Unix-Generic.sublime-syntax
+++ b/ShellScript/Shell-Unix-Generic.sublime-syntax
@@ -6,3 +6,8 @@ version: 2
 hidden: true
 
 extends: Packages/ShellScript/Bash.sublime-syntax
+
+contexts:
+  main:
+    # skip shebang
+    - include: statements


### PR DESCRIPTION
Fixes #2388

This commit creates an intermediate `Makefile Shell.sublime-syntax` as extended `Bash.sublime-syntax` with `variable-substitutions` from `Makefile.sublime-syntax` being added to proper contexts so that they are applied in a sane way, which respects the syntax structure of Bash.

The Makefile Shell.sublime-syntax is included into Makefile.sublime-syntax normally without `with_prototype`.