### PR TITLE
[PHP] Add scope for null coalescing operator

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -268,6 +268,8 @@ contexts:
     - match: (?i)(!)|\b(and|or|xor|as)\b
       scope: keyword.operator.logical.php
     - include: function-call
+    - match: \?\?
+      scope: keyword.operator.null-coalescing.php
     - match: \.\.\.
       scope: keyword.operator.spread.php
     - match: \.

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1436,6 +1436,9 @@ $a .= 1;
 $a ??= 1;
 // ^^^ keyword.operator.assignment.augmented.php
 
+$a = $b ?? 1;
+//      ^^ keyword.operator.null-coalescing.php
+
 if ($a && $b || !$c);
 //     ^^ keyword.operator.logical
 //           ^^ keyword.operator.logical


### PR DESCRIPTION
```php
$a = $b ?? 1;
//      ^^ keyword.operator.null-coalescing.php
```

It's weird that I didn't notice this one.