### PR TITLE
[Ruby] Improve heredoc tag scoping

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1752,17 +1752,33 @@ contexts:
     - include: heredoc-plain
 
   heredoc-css:
-    - match: <<[-~]["`]?({{heredoc_type_css}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_css}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-css-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_css}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_css}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-css-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_css}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_css}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-css-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_css}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_css}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-css-unindented-literal, trailing-heredoc-start]
 
   heredoc-css-indented-interpolated:
@@ -1793,17 +1809,33 @@ contexts:
     - include: scope:source.css
 
   heredoc-js:
-    - match: <<[-~]["`]?({{heredoc_type_js}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_js}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-js-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_js}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_js}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-js-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_js}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_js}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-js-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_js}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_js}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-js-unindented-literal, trailing-heredoc-start]
 
   heredoc-js-indented-interpolated:
@@ -1834,17 +1866,33 @@ contexts:
     - include: scope:source.js
 
   heredoc-html:
-    - match: <<[-~]["`]?({{heredoc_type_html}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_html}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-html-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_html}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_html}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-html-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_html}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_html}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-html-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_html}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_html}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-html-unindented-literal, trailing-heredoc-start]
 
   heredoc-html-indented-interpolated:
@@ -1875,17 +1923,33 @@ contexts:
     - include: scope:text.html.basic
 
   heredoc-ruby:
-    - match: <<[-~]["`]?({{heredoc_type_ruby}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_ruby}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-ruby-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_ruby}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_ruby}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-ruby-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_ruby}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_ruby}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-ruby-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_ruby}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_ruby}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-ruby-unindented-literal, trailing-heredoc-start]
 
   heredoc-ruby-indented-interpolated:
@@ -1917,17 +1981,33 @@ contexts:
     - include: expressions
 
   heredoc-plain:
-    - match: <<[-~]["`]?(\w+)["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)(\w+)(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-plain-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'(\w+)'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')(\w+)(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-plain-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?(\w+)["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)(\w+)(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-plain-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'(\w+)'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')(\w+)(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-plain-unindented-literal, trailing-heredoc-start]
 
   heredoc-plain-indented-interpolated:
@@ -1955,17 +2035,33 @@ contexts:
     - include: unindented-heredoc-end
 
   heredoc-shell:
-    - match: <<[-~]["`]?({{heredoc_type_shell}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_shell}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-shell-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_shell}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_shell}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-shell-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_shell}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_shell}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-shell-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_shell}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_shell}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-shell-unindented-literal, trailing-heredoc-start]
 
   heredoc-shell-indented-interpolated:
@@ -1996,17 +2092,33 @@ contexts:
     - include: scope:source.shell
 
   heredoc-sql:
-    - match: <<[-~]["`]?({{heredoc_type_sql}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(["`]?)({{heredoc_type_sql}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-sql-indented-interpolated, trailing-heredoc-start]
-    - match: <<[-~]'({{heredoc_type_sql}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<[-~])(')({{heredoc_type_sql}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-sql-indented-literal, trailing-heredoc-start]
-    - match: <<["`]?({{heredoc_type_sql}})["`]?
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(["`]?)({{heredoc_type_sql}})(["`]?)
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-sql-unindented-interpolated, trailing-heredoc-start]
-    - match: <<'({{heredoc_type_sql}})'
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+    - match: (<<)(')({{heredoc_type_sql}})(')
+      captures:
+        1: punctuation.definition.heredoc.ruby
+        2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
+        3: meta.tag.heredoc.ruby entity.name.tag.ruby
+        4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
       push: [heredoc-sql-unindented-literal, trailing-heredoc-start]
 
   heredoc-sql-indented-interpolated:
@@ -2037,15 +2149,15 @@ contexts:
     - include: scope:source.sql
 
   indented-heredoc-end:
-    - match: ^\s*(\1)$ # HEREDOC delimiter
-      scope: string.unquoted.heredoc.ruby
+    - match: ^\s*(\3)$ # HEREDOC delimiter
+      scope: meta.tag.heredoc.ruby
       captures:
-        1: punctuation.definition.string.end.ruby
+        1: entity.name.tag.ruby
       pop: true
 
   unindented-heredoc-end:
-    - match: ^\1$ # HEREDOC delimiter
-      scope: string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+    - match: ^\3$ # HEREDOC delimiter
+      scope: meta.tag.heredoc.ruby entity.name.tag.ruby
       pop: true
 
   trailing-heredoc-start:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -34,7 +34,10 @@
 # HEREDOC with indented end tag containing an interpolated string
 puts <<~EOF; # comment
 #^^^^ - meta.string - string.unquoted
-#    ^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^^ meta.string.heredoc.ruby - meta.tag
+#       ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#    ^^^ punctuation.definition.heredoc.ruby
+#       ^^^ entity.name.tag.ruby
 #          ^ punctuation.terminator.statement.ruby - meta.string - string
 #            ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   Indented string!
@@ -51,13 +54,18 @@ puts <<~EOF; # comment
 #            ^^ punctuation.definition.variable.ruby
 #            ^^^^^ variable.other.readwrite.instance.ruby
   EOF
-# ^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+# ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #    ^ - meta.string - string.unquoted
 
 # HEREDOC with indented end tag containing a plain string
 puts <<~'EOF'; # comment
 #^^^^ - meta.string - string.unquoted
-#    ^^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^^ meta.string.heredoc.ruby - meta.tag
+#       ^^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#    ^^^ punctuation.definition.heredoc.ruby
+#       ^ punctuation.definition.tag.begin.ruby
+#        ^^^ entity.name.tag.ruby
+#           ^ punctuation.definition.tag.end.ruby
 #            ^ punctuation.terminator.statement.ruby - meta.string - string
 #              ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   Indented string!
@@ -65,13 +73,16 @@ puts <<~'EOF'; # comment
     #{ sym } #@var
 # ^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby - meta.interpolation
   EOF
-# ^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+# ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #    ^ - meta.string - string.unquoted
 
 # HEREDOC with unindented end tag containing an interpolated string
 puts <<EOF; # comment
 #^^^^ - meta.string - string.unquoted
-#    ^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^ meta.string.heredoc.ruby - meta.tag
+#      ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#    ^^ punctuation.definition.heredoc.ruby
+#      ^^^ entity.name.tag.ruby
 #         ^ punctuation.terminator.statement.ruby - meta.string - string
 #           ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   Indented string!
@@ -90,13 +101,18 @@ puts <<EOF; # comment
   EOF
 #^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby
 EOF
-#^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #  ^ - meta.string - string.unquoted
 
 # HEREDOC with unindented end tag containing a plain string
 puts <<'EOF'; # comment
 #^^^^ - meta.string - string.unquoted
-#    ^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^ meta.string.heredoc.ruby - meta.tag
+#      ^^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#    ^^ punctuation.definition.heredoc.ruby
+#      ^ punctuation.definition.tag.begin.ruby
+#       ^^^ entity.name.tag.ruby
+#          ^ punctuation.definition.tag.end.ruby
 #           ^ punctuation.terminator.statement.ruby - meta.string - string
 #             ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   Indented string!
@@ -106,12 +122,15 @@ puts <<'EOF'; # comment
   EOF
 #^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby
 EOF
-#^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #  ^ - meta.string - string.unquoted
 
 puts <<-HTML; # comment
 #^^^^ - meta.string - string.unquoted
-#    ^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^^ meta.string.heredoc.ruby - meta.tag
+#       ^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#    ^^^ punctuation.definition.heredoc.ruby
+#       ^^^^ entity.name.tag.ruby
 #           ^ punctuation.terminator.statement.ruby - meta.string
 #             ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   <body>
@@ -130,7 +149,7 @@ puts <<-HTML; # comment
   </body>
 # ^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag.structure.any.html
   HTML
-# ^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+# ^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #     ^ - meta.string - string.unquoted
 
 class_eval <<-RUBY, __FILE__, __LINE__ + 1
@@ -143,32 +162,37 @@ class_eval <<-RUBY, __FILE__, __LINE__ + 1
     custom(Mime[:#{sym}], *args, &block)
   end
 RUBY
-#^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #   ^ - meta.string - string.unquoted
 
 puts <<-SH; # comment
-#    ^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^^^^ meta.string.heredoc.ruby
+#    ^^^ punctuation.definition.heredoc.ruby
+#       ^^ entity.name.tag.ruby
 #         ^ punctuation.terminator.statement.ruby - meta.string - string
 #           ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   git log
 # ^^^^^^^ meta.string.heredoc.ruby source.shell.embedded.ruby
   SH
-# ^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+# ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #   ^ - meta.string - string.unquoted
 
 puts <<-SHELL; # comment
-#    ^^^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.begin.ruby
+#    ^^^ meta.string.heredoc.ruby punctuation.definition.heredoc.ruby
+#       ^^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #            ^ punctuation.terminator.statement.ruby - meta.string - string
 #              ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   git log
 # ^^^^^^^ meta.string.heredoc.ruby source.shell.embedded.ruby
   SHELL
-# ^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+# ^^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #      ^ - meta.string - string.unquoted
 
 DB.fetch(<<-SQL, conn).name
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ruby
-#        ^^^^^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby
+#        ^^^^^^ meta.string.heredoc.ruby
+#        ^^^ punctuation.definition.heredoc.ruby
+#           ^^^ entity.name.tag.ruby
 #              ^^^^^^^^^^^^ - meta.string - string
 #              ^ punctuation.separator
 #                    ^ punctuation.definition.group.end
@@ -177,17 +201,20 @@ SELECT * FROM #$users;
 #             ^^^^^^^ meta.string.heredoc.ruby source.sql.embedded.ruby meta.interpolation.ruby variable.other.readwrite.global
 #                    ^ meta.string.heredoc.ruby source.sql.embedded.ruby - meta.interpolation
 SQL
-#^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #  ^ - meta.string - string.unquoted
 
 foo, bar = <<BAR, 2
 #^^^^^^^^^^^^^^^^^^ source.ruby
-#          ^^^^^ string.unquoted
-#               ^^^ - string
+#          ^^ meta.string.heredoc.ruby - meta.tag
+#            ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby
+#               ^^^ - meta.string.heredoc
+#          ^^ punctuation.definition.heredoc.ruby
+#            ^^^ entity.name.tag.ruby
 #               ^ punctuation.separator
 #                 ^ constant.numeric
 BAR
-#^^ meta.string.heredoc.ruby string.unquoted.heredoc.ruby punctuation.definition.string.end.ruby
+#^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #  ^ - meta.string - string.unquoted
 
 ##################


### PR DESCRIPTION
This PR proposes to adapt HEREDOC scopes to those of _Perl_ and _Bash_.

It uses `meta.tag.heredoc entity.name.tag` to scope opening and closing HEREDOC tags.