### PR TITLE
[CSS] Fix <0x01> in completion labels

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -639,7 +639,7 @@ class CSSCompletions(sublime_plugin.EventListener):
 
                 for value in values:
                     if isinstance(value, str):
-                        desc = self.re_trigger.sub("\1", value)
+                        desc = self.re_trigger.sub(r"\1", value)
                         snippet = value
                     else:
                         desc, snippet = value


### PR DESCRIPTION
Looks like python 3.8? requires a raw string to perform proper regexp replacement. The intention here is to replace `${1:param}` by `param` so the completion list displays named function arguments.


![grafik](https://user-images.githubusercontent.com/16542113/90558491-73abad00-e19c-11ea-993d-6846206df133.png)
