### PR TITLE
[HTML] Default Completions Selector

### DIFF
--- a/HTML/HTML.sublime-settings
+++ b/HTML/HTML.sublime-settings
@@ -1,0 +1,7 @@
+{
+    // Set to true to disable default completions.
+    "disable_default_completions": false,
+
+    // Controls what scopes default completions will be provided in.
+    "default_completions_selector": "text.html - string - source - text.html.markdown, text.html.markdown text.html, source text.html"
+}

--- a/HTML/HTML.sublime-settings
+++ b/HTML/HTML.sublime-settings
@@ -3,5 +3,13 @@
     "disable_default_completions": false,
 
     // Controls what scopes default completions will be provided in.
-    "default_completions_selector": "text.html - string - source - text.html.markdown, text.html.markdown text.html, source text.html"
+    // Can be a list of strings which are joined before matching.
+    "default_completions_selector": [
+        // Plain HTML
+        "text.html - source - string - text.html.markdown, ",
+        // Embedded HTML blocks
+        "text.html.embedded - text.html.embedded source, ",
+        // Markdown fenced code blocks
+        "markup.raw.code-fence text.html - markup.raw.code-fence text.html source"
+    ]
 }

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -442,20 +442,15 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
     @timing
     def on_query_completions(self, view, prefix, locations):
 
-        if sublime.load_settings('HTML.sublime-settings').get('disable_default_completions'):
+        settings = sublime.load_settings('HTML.sublime-settings')
+        if settings.get('disable_default_completions'):
             return None
 
         def match_selector(selector):
             return view.match_selector(locations[0], selector)
 
         # Only trigger within HTML
-        if not match_selector(
-            "text.html"
-            # disable in embedded script/css code
-            " - (source - source text.html) - meta.string"
-            # disable in markdown but not fenced code blocks
-            " - (text.html.markdown - text.html text.html)"
-        ):
+        if not match_selector(settings.get('default_completions_selector', '')):
             return None
 
         pt = locations[0] - len(prefix) - 1

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -446,11 +446,14 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
         if settings.get('disable_default_completions'):
             return None
 
+        selector = settings.get('default_completions_selector', '')
+        if isinstance(selector, list):
+            selector = ''.join(selector)
+
         def match_selector(selector):
             return view.match_selector(locations[0], selector)
 
-        # Only trigger within HTML
-        if not match_selector(settings.get('default_completions_selector', '')):
+        if not match_selector(selector):
             return None
 
         pt = locations[0] - len(prefix) - 1


### PR DESCRIPTION
This commit suggests to...

1. move main completion selector to a syntax specific `default_completions_selector` setting to make it easier for end users to customize it.

2. fix HTML completions not being provided within string interpolation by replacing `- meta.string` by `- string`. This issue was revealed when trying to auto complete html tags within Perl heredocs.

   ```Perl
   $var <<HTML

   <

   HTML
   ```

3. simplify and increase readability of selectors by avoiding nested subtraction.

_Note: The same selector might be used within `auto_complete_triggers`_

```json
"auto_complete_triggers":
[
	{
		"characters": "<&",
		"selector": "text.html - source - string - text.html.markdown, text.html.embedded - text.html.embedded source, markup.raw.code-fence text.html - markup.raw.code-fence text.html source, text.xml - source - string, source text.xml"
	},
	{
		"rhs_empty": true,
		"selector": "punctuation.accessor",
	}
],
```
