### PR TITLE
Rename scope punctuation.definition.numeric.base → constant.numeric.integer.base

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1544,11 +1544,11 @@ contexts:
     - match: (0[xX])[\h_]*\h
       scope: constant.numeric.integer.hexadecimal.cs
       captures:
-        1: punctuation.definition.numeric.base.cs
+        1: constant.numeric.integer.base.cs
     - match: (0[bB])[01_]*[01]
       scope: constant.numeric.integer.binary.cs
       captures:
-        1: punctuation.definition.numeric.base.cs
+        1: constant.numeric.integer.base.cs
     - match: '{{dec_digits}}(?:(?:(?:(\.){{dec_digits}}){{dec_exponent}}?|{{dec_exponent}})({{float_suffix}})?|({{float_suffix}}))'
       scope: constant.numeric.float.decimal.cs
       captures:

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -145,10 +145,10 @@ class Foo {
         // https://github.com/dotnet/roslyn/pull/2950
         int bin = 0b1001_1010_0001_0100;
 ///               ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-///               ^^ punctuation.definition.numeric.base
+///               ^^ constant.numeric.integer.base
         int hex = 0x1b_a0_44_fe;
 ///               ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-///               ^^ punctuation.definition.numeric.base
+///               ^^ constant.numeric.integer.base
         int dec = 33_554_432;
 ///               ^^^^^^^^^^ constant.numeric.integer.decimal
         int weird = 1_2__3___4____5_____6______7_______8________9;

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -183,7 +183,7 @@ contexts:
 
     # hexadecimal float (C99)
     - match: \b0[xX](?=[[:alnum:]_''.]+?[pP])
-      scope: punctuation.definition.numeric.base.c++
+      scope: constant.numeric.integer.base.c++
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.float.hexadecimal.c++
@@ -198,7 +198,7 @@ contexts:
 
     # binary integer
     - match: \b0[bB]
-      scope: punctuation.definition.numeric.base.c++
+      scope: constant.numeric.integer.base.c++
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.integer.binary.c++
@@ -207,14 +207,14 @@ contexts:
           scope: invalid.illegal.numeric.digit.c++
     # hexadecimal integer
     - match: \b0[xX]
-      scope: punctuation.definition.numeric.base.c++
+      scope: constant.numeric.integer.base.c++
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.integer.hexadecimal.c++
         - include: hexadecimal-suffix
     # octal integer
     - match: \b0(?=[\d''])
-      scope: punctuation.definition.numeric.base.c++
+      scope: constant.numeric.integer.base.c++
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.integer.octal.c++

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -201,7 +201,7 @@ contexts:
         7: invalid.illegal.numeric.suffix.c
     # hexadecimal float (C99)
     - match: \b0[xX](?=[[:alnum:].]+?[pP])
-      scope: punctuation.definition.numeric.base.c
+      scope: constant.numeric.integer.base.c
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.float.hexadecimal.c
@@ -216,14 +216,14 @@ contexts:
 
     # hexadecimal integer
     - match: \b0[xX]
-      scope: punctuation.definition.numeric.base.c
+      scope: constant.numeric.integer.base.c
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.integer.hexadecimal.c
         - include: hexadecimal-suffix
     # octal integer
     - match: \b0(?=\d)
-      scope: punctuation.definition.numeric.base.c
+      scope: constant.numeric.integer.base.c
       push:
         - meta_include_prototype: false
         - meta_scope: constant.numeric.integer.octal.c

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -685,30 +685,30 @@ dec8 = 1'234_567'890s0f;
 
 oct1 = 01234567;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^ punctuation.terminator - constant */
 
 oct2 = 01234567L;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^ storage.type.numeric */
 /*              ^ punctuation.terminator - constant */
 
 oct3 = 01234567LL;
 /*     ^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^^ storage.type.numeric */
 /*               ^ punctuation.terminator - constant */
 
 oct4 = 01234567ulL;
 /*     ^^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^^^ storage.type.numeric */
 /*                ^ punctuation.terminator - constant */
 
 oct2 = 01284967Z0L;
 /*     ^^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*        ^ invalid.illegal.numeric.digit */
 /*          ^ invalid.illegal.numeric.digit */
 /*             ^^^ invalid.illegal.numeric.suffix */
@@ -716,21 +716,21 @@ oct2 = 01284967Z0L;
 
 hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 /*     ^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^^^^ constant.numeric.integer.hexadecimal */
-/*         ^^ punctuation.definition.numeric.base */
+/*         ^^ constant.numeric.integer.base */
 /*            ^ storage.type.numeric */
 /*              ^^^^^^ constant.numeric.integer.hexadecimal */
-/*              ^^ punctuation.definition.numeric.base */
+/*              ^^ constant.numeric.integer.base */
 /*                 ^^^ storage.type.numeric */
 /*                     ^^^^^^ constant.numeric.integer.hexadecimal */
-/*                     ^^ punctuation.definition.numeric.base */
+/*                     ^^ constant.numeric.integer.base */
 /*                        ^^^ storage.type.numeric */
 /*                            ^^^^ constant.numeric.integer.hexadecimal */
-/*                            ^^ punctuation.definition.numeric.base */
+/*                            ^^ constant.numeric.integer.base */
 /*                               ^ storage.type.numeric */
 /*                                 ^^ constant.numeric.integer.hexadecimal */
-/*                                 ^^ punctuation.definition.numeric.base */
+/*                                 ^^ constant.numeric.integer.base */
 /*                                   ^^^ string.quoted.single */
 /*                                      ^^^^^^ constant.numeric.integer.decimal */
 /*                                        ^^^^ invalid.illegal.numeric.suffix */
@@ -738,7 +738,7 @@ hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 
 hex2 = 0xc1.01AbFp-1;
 /*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^ punctuation.separator.decimal */
 /*                  ^ punctuation.terminator - constant */
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1026,74 +1026,74 @@ dec5 = 2'354'202'076LL;
 
 oct1 = 0123_567;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*         ^^^^ storage.type.numeric */
 /*             ^ punctuation.terminator - constant */
 
 oct2 = 014'70;
 /*     ^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*           ^ punctuation.terminator - constant */
 
 hex1 = 0x1234567890ABCDEF;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex2 = 0X1234567890ABCDEF;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex3 = 0x1234567890abcdef;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex4 = 0xA7'45'8C'38;
 /*     ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                  ^ punctuation.terminator - constant */
 
 hex5 = 0x0+0xFL+0xaull+0xallu+0xfu+0xf'12_4_uz;
 /*     ^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^^^^ constant.numeric.integer.hexadecimal */
-/*         ^^ punctuation.definition.numeric.base */
+/*         ^^ constant.numeric.integer.base */
 /*            ^ storage.type.numeric */
 /*              ^^^^^^ constant.numeric.integer.hexadecimal */
-/*              ^^ punctuation.definition.numeric.base */
+/*              ^^ constant.numeric.integer.base */
 /*                 ^^^ storage.type.numeric */
 /*                     ^^^^^^ constant.numeric.integer.hexadecimal */
-/*                     ^^ punctuation.definition.numeric.base */
+/*                     ^^ constant.numeric.integer.base */
 /*                        ^^^ storage.type.numeric */
 /*                            ^^^^ constant.numeric.integer.hexadecimal */
-/*                            ^^ punctuation.definition.numeric.base */
+/*                            ^^ constant.numeric.integer.base */
 /*                               ^ storage.type.numeric */
 /*                                 ^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*                                 ^^ punctuation.definition.numeric.base */
+/*                                 ^^ constant.numeric.integer.base */
 /*                                       ^^^^^ storage.type.numeric */
 /*                                            ^ punctuation.terminator - constant */
 
 hex2 = 0xc1.01AbFp-1;
 /*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^ punctuation.separator.decimal */
 /*                  ^ punctuation.terminator - constant */
 
 bin1 = 0b010110;
 /*     ^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*             ^ punctuation.terminator - constant */
 
 bin2 = 0B010010;
 /*     ^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*             ^ punctuation.terminator - constant */
 
 bin3 = 0b1001'1101'0010'1100;
 /*     ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                          ^ punctuation.terminator - constant */
 
 f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;

--- a/Clojure/Clojure.sublime-syntax
+++ b/Clojure/Clojure.sublime-syntax
@@ -84,13 +84,13 @@ contexts:
       scope: constant.numeric.integer.hexadecimal.clojure
       captures:
         1: punctuation.definition.numeric.sign.clojure
-        2: punctuation.definition.numeric.base.clojure
+        2: constant.numeric.integer.base.clojure
         3: storage.type.numeric.clojure
     - match: '{{other_integer}}'
       scope: constant.numeric.integer.other.clojure
       captures:
         1: punctuation.definition.numeric.sign.clojure
-        2: punctuation.definition.numeric.base.clojure
+        2: constant.numeric.integer.base.clojure
     - match: '{{rational}}'
       scope: constant.numeric.rational.decimal.clojure
       captures:
@@ -160,14 +160,14 @@ contexts:
       scope: constant.numeric.integer.hexadecimal.clojure
       captures:
         1: punctuation.definition.numeric.sign.clojure
-        2: punctuation.definition.numeric.base.clojure
+        2: constant.numeric.integer.base.clojure
         3: storage.type.numeric.clojure
       pop: true
     - match: '{{other_integer}}'
       scope: constant.numeric.integer.other.clojure
       captures:
         1: punctuation.definition.numeric.sign.clojure
-        2: punctuation.definition.numeric.base.clojure
+        2: constant.numeric.integer.base.clojure
       pop: true
     - match: '{{rational}}'
       scope: constant.numeric.rational.decimal.clojure

--- a/Clojure/tests/syntax_test_clojure.clj
+++ b/Clojure/tests/syntax_test_clojure.clj
@@ -96,120 +96,120 @@
 ;                               ^^^^^^ constant.numeric.integer.decimal.clojure
 ;                                    ^ storage.type.numeric.clojure
   0x1234af 0x1234afN 0X1234AF 0X1234AFN
-; ^^ punctuation.definition.numeric.base.clojure
+; ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;         ^ - constant
-;          ^^ punctuation.definition.numeric.base.clojure
+;          ^^ constant.numeric.integer.base.clojure
 ;          ^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                  ^ storage.type.numeric.clojure
 ;                   ^ - constant
-;                    ^^ punctuation.definition.numeric.base.clojure
+;                    ^^ constant.numeric.integer.base.clojure
 ;                    ^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                            ^ - constant
-;                             ^^ punctuation.definition.numeric.base.clojure
+;                             ^^ constant.numeric.integer.base.clojure
 ;                             ^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                                     ^ storage.type.numeric.clojure
   +0x1234af +0x1234afN +0X1234AF +0X1234AFN
 ; ^ punctuation.definition.numeric.sign.clojure
-;  ^^ punctuation.definition.numeric.base.clojure
+;  ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;          ^ - constant
 ;           ^ punctuation.definition.numeric.sign.clojure
-;            ^^ punctuation.definition.numeric.base.clojure
+;            ^^ constant.numeric.integer.base.clojure
 ;           ^^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                    ^ storage.type.numeric.clojure
 ;                     ^ - constant
 ;                      ^ punctuation.definition.numeric.sign.clojure
-;                       ^^ punctuation.definition.numeric.base.clojure
+;                       ^^ constant.numeric.integer.base.clojure
 ;                       ^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                               ^ - constant
 ;                                ^ punctuation.definition.numeric.sign.clojure
-;                                 ^^ punctuation.definition.numeric.base.clojure
+;                                 ^^ constant.numeric.integer.base.clojure
 ;                                ^^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                                         ^ storage.type.numeric.clojure
   -0x1234af -0x1234afN -0X1234AF -0X1234AFN
 ; ^ punctuation.definition.numeric.sign.clojure
-;  ^^ punctuation.definition.numeric.base.clojure
+;  ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;          ^ - constant
 ;           ^ punctuation.definition.numeric.sign.clojure
-;            ^^ punctuation.definition.numeric.base.clojure
+;            ^^ constant.numeric.integer.base.clojure
 ;           ^^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                    ^ storage.type.numeric.clojure
 ;                     ^ - constant
 ;                      ^ punctuation.definition.numeric.sign.clojure
-;                       ^^ punctuation.definition.numeric.base.clojure
+;                       ^^ constant.numeric.integer.base.clojure
 ;                      ^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                               ^ - constant
 ;                                ^ punctuation.definition.numeric.sign.clojure
-;                                 ^^ punctuation.definition.numeric.base.clojure
+;                                 ^^ constant.numeric.integer.base.clojure
 ;                                ^^^^^^^^^^ constant.numeric.integer.hexadecimal.clojure
 ;                                         ^ storage.type.numeric.clojure
   2r1010 16r1234af 32r1234az 2R1010 16R1234AF 32R1234AZ
-; ^^ punctuation.definition.numeric.base.clojure
+; ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^ constant.numeric.integer.other.clojure
 ;       ^ - constant
-;        ^^^ punctuation.definition.numeric.base.clojure
+;        ^^^ constant.numeric.integer.base.clojure
 ;        ^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                 ^ - constant
-;                  ^^^ punctuation.definition.numeric.base.clojure
+;                  ^^^ constant.numeric.integer.base.clojure
 ;                  ^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                           ^ - constant
-;                            ^^ punctuation.definition.numeric.base.clojure
+;                            ^^ constant.numeric.integer.base.clojure
 ;                            ^^^^^^ constant.numeric.integer.other.clojure
 ;                                  ^ - constant
-;                                   ^^^ punctuation.definition.numeric.base.clojure
+;                                   ^^^ constant.numeric.integer.base.clojure
 ;                                   ^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                                            ^ - constant
-;                                             ^^^ punctuation.definition.numeric.base.clojure
+;                                             ^^^ constant.numeric.integer.base.clojure
 ;                                             ^^^^^^^^^ constant.numeric.integer.other.clojure
   +2r1010 +16r1234af +32r1234az +2R1010 +16R1234AF +32R1234AZ
 ; ^ punctuation.definition.numeric.sign.clojure
-;  ^^ punctuation.definition.numeric.base.clojure
+;  ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^^ constant.numeric.integer.other.clojure
 ;        ^ - constant
 ;         ^ punctuation.definition.numeric.sign.clojure
-;          ^^^ punctuation.definition.numeric.base.clojure
+;          ^^^ constant.numeric.integer.base.clojure
 ;         ^^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                   ^ - constant
 ;                    ^ punctuation.definition.numeric.sign.clojure
-;                     ^^^ punctuation.definition.numeric.base.clojure
+;                     ^^^ constant.numeric.integer.base.clojure
 ;                    ^^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                              ^ - constant
 ;                               ^ punctuation.definition.numeric.sign.clojure
-;                                ^^ punctuation.definition.numeric.base.clojure
+;                                ^^ constant.numeric.integer.base.clojure
 ;                               ^^^^^^^ constant.numeric.integer.other.clojure
 ;                                      ^ - constant
 ;                                       ^ punctuation.definition.numeric.sign.clojure
-;                                        ^^^ punctuation.definition.numeric.base.clojure
+;                                        ^^^ constant.numeric.integer.base.clojure
 ;                                        ^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                                                 ^ - constant
 ;                                                  ^ punctuation.definition.numeric.sign.clojure
-;                                                   ^^^ punctuation.definition.numeric.base.clojure
+;                                                   ^^^ constant.numeric.integer.base.clojure
 ;                                                  ^^^^^^^^^^ constant.numeric.integer.other.clojure
   -2r1010 -16r1234af -32r1234az -2R1010 -16R1234AF -32R1234AZ
 ; ^ punctuation.definition.numeric.sign.clojure
-;  ^^ punctuation.definition.numeric.base.clojure
+;  ^^ constant.numeric.integer.base.clojure
 ; ^^^^^^^ constant.numeric.integer.other.clojure
 ;        ^ - constant
 ;         ^ punctuation.definition.numeric.sign.clojure
-;          ^^^ punctuation.definition.numeric.base.clojure
+;          ^^^ constant.numeric.integer.base.clojure
 ;          ^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                   ^ - constant
 ;                    ^ punctuation.definition.numeric.sign.clojure
-;                     ^^^ punctuation.definition.numeric.base.clojure
+;                     ^^^ constant.numeric.integer.base.clojure
 ;                    ^^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                              ^ - constant
 ;                               ^ punctuation.definition.numeric.sign.clojure
-;                                ^^ punctuation.definition.numeric.base.clojure
+;                                ^^ constant.numeric.integer.base.clojure
 ;                               ^^^^^^^ constant.numeric.integer.other.clojure
 ;                                      ^ - constant
 ;                                       ^ punctuation.definition.numeric.sign.clojure
-;                                        ^^^ punctuation.definition.numeric.base.clojure
+;                                        ^^^ constant.numeric.integer.base.clojure
 ;                                       ^^^^^^^^^^ constant.numeric.integer.other.clojure
 ;                                                 ^ - constant
 ;                                                  ^ punctuation.definition.numeric.sign.clojure
-;                                                   ^^^ punctuation.definition.numeric.base.clojure
+;                                                   ^^^ constant.numeric.integer.base.clojure
 ;                                                  ^^^^^^^^^^ constant.numeric.integer.other.clojure
   0/10 10/20 30/0
 ; ^^^^ constant.numeric.rational.decimal.clojure

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -197,14 +197,14 @@ contexts:
     - match: '(0[bB])(_?){{bin_digits}}({{integer_suffix}})?'
       scope: constant.numeric.integer.binary.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: storage.type.numeric.d
       pop: true
     - match: '(0[xX])(_?){{hex_digits}}({{integer_suffix}})?'
       scope: constant.numeric.integer.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: storage.type.numeric.d
       pop: true
@@ -261,7 +261,7 @@ contexts:
     - match: (0[xX])(_?){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}?({{imaginary_suffix}})
       scope: constant.numeric.imaginary.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: punctuation.separator.decimal.d
         4: storage.type.numeric.d
@@ -270,7 +270,7 @@ contexts:
     - match: (0[xX])(_?){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}({{integer_float_suffix}})?
       scope: constant.numeric.float.hexadecimal.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: punctuation.separator.decimal.d
         4: storage.type.numeric.d
@@ -280,7 +280,7 @@ contexts:
     - match: (0[bB])(_?){{bin_digits}}({{imaginary_suffix}})
       scope: constant.numeric.imaginary.binary.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: storage.type.numeric.d
       pop: true
@@ -288,7 +288,7 @@ contexts:
     - match: (0[bB])(_?){{bin_digits}}({{float_suffix}})
       scope: constant.numeric.float.binary.d
       captures:
-        1: punctuation.definition.numeric.base.d
+        1: constant.numeric.integer.base.d
         2: invalid.illegal.numeric.d
         3: storage.type.numeric.d
       pop: true

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -196,22 +196,22 @@ dec = 1UL;
 //    ^^^ constant.numeric.integer.decimal.d
 //     ^^ storage.type.numeric.d
 auto bin = 0b1;
-//         ^^ punctuation.definition.numeric.base.d
+//         ^^ constant.numeric.integer.base.d
 //         ^^^ constant.numeric.integer.binary.d
 bin = 0b10__1;
-//    ^^ punctuation.definition.numeric.base.d
+//    ^^ constant.numeric.integer.base.d
 //    ^^^^^^^ constant.numeric.integer.binary.d
 bin = 0B1;
-//    ^^ punctuation.definition.numeric.base.d
+//    ^^ constant.numeric.integer.base.d
 //    ^^^ constant.numeric.integer.binary.d
 auto hex = 0xFf;
-//         ^^ punctuation.definition.numeric.base.d
+//         ^^ constant.numeric.integer.base.d
 //         ^^^^ constant.numeric.integer.hexadecimal.d
 hex = 0x012_3;
-//    ^^ punctuation.definition.numeric.base.d
+//    ^^ constant.numeric.integer.base.d
 //    ^^^^^^^ constant.numeric.integer.hexadecimal.d
 hex = 0X1;
-//    ^^ punctuation.definition.numeric.base.d
+//    ^^ constant.numeric.integer.base.d
 //    ^^^ constant.numeric.integer.hexadecimal.d
 
 imag = 123_45i + 0_.1_i + 12_.e1i;
@@ -229,24 +229,24 @@ imag = 23134723__742e1i;
 //                    ^ storage.type.numeric.d
 imag = 0x_3472389742f_i;
 //     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.d
-//     ^^ punctuation.definition.numeric.base.d
+//     ^^ constant.numeric.integer.base.d
 //       ^ invalid.illegal.numeric.d
 //                    ^ storage.type.numeric.d
 imag = 0x_34723897p-34i;
 //     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.d
-//     ^^ punctuation.definition.numeric.base.d
+//     ^^ constant.numeric.integer.base.d
 //       ^ invalid.illegal.numeric.d
 //                    ^ storage.type.numeric.d
 imag = 0x347._23897p-34i;
 //     ^^^^^ constant.numeric.integer.hexadecimal.d
-//     ^^ punctuation.definition.numeric.base.d
+//     ^^ constant.numeric.integer.base.d
 //          ^ punctuation.accessor.dot.d
 //           ^^^^^^^ variable.other.d
 //                  ^ keyword.operator.arithmetic.d
 //                   ^^^ constant.numeric.imaginary.decimal.d
 imag = 0b_0100_010_00_i;
 //     ^^^^^^^^^^^^^^^^ constant.numeric.imaginary.binary.d
-//     ^^ punctuation.definition.numeric.base.d
+//     ^^ constant.numeric.integer.base.d
 //       ^ invalid.illegal.numeric.d
 //                    ^ storage.type.numeric.d
 
@@ -280,19 +280,19 @@ f =  1f;
 //   ^^ constant.numeric.float.decimal.d
 //    ^ storage.type.numeric.d
 f = 0x123p2f;
-//  ^^ punctuation.definition.numeric.base.d
+//  ^^ constant.numeric.integer.base.d
 //  ^^^^^^^^ constant.numeric.float.hexadecimal.d
 //         ^ storage.type.numeric.d
 f = 0b10101101f;
-//  ^^ punctuation.definition.numeric.base.d
+//  ^^ constant.numeric.integer.base.d
 //  ^^^^^^^^^^^ constant.numeric.float.binary.d
 //            ^ storage.type.numeric.d
 f = 0x.1aFp2;
-//  ^^ punctuation.definition.numeric.base.d
+//  ^^ constant.numeric.integer.base.d
 //  ^^^^^^^^ constant.numeric.float.hexadecimal.d
 //    ^ punctuation.separator.decimal.d
 f = 0xF.AP-2f;
-//  ^^ punctuation.definition.numeric.base.d
+//  ^^ constant.numeric.integer.base.d
 //  ^^^^^^^^^ constant.numeric.float.hexadecimal.d
 //     ^ punctuation.separator.decimal.d
 //          ^ storage.type.numeric.d

--- a/D/tests/syntax_test_old.d
+++ b/D/tests/syntax_test_old.d
@@ -21,7 +21,7 @@ shared int b = 5000;
 //              ^ constant.numeric
 
 int c = 0x0;
-//      ^^ punctuation.definition.numeric.base
+//      ^^ constant.numeric.integer.base
 //        ^ constant.numeric
 int d = 0x0_00;
 //          ^ constant.numeric

--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1805,47 +1805,47 @@ contexts:
         )\b
       captures:
         1: constant.numeric.integer.binary.erlang
-        2: punctuation.definition.numeric.base.erlang
+        2: constant.numeric.integer.base.erlang
         3: constant.numeric.integer.octal.erlang
-        4: punctuation.definition.numeric.base.erlang
+        4: constant.numeric.integer.base.erlang
         5: constant.numeric.integer.decimal.erlang
-        6: punctuation.definition.numeric.base.erlang
+        6: constant.numeric.integer.base.erlang
         7: constant.numeric.integer.hexadecimal.erlang
-        8: punctuation.definition.numeric.base.erlang
+        8: constant.numeric.integer.base.erlang
         9: constant.numeric.integer.other.erlang
-        10: punctuation.definition.numeric.base.erlang
-        11: punctuation.definition.numeric.base.erlang
-        12: punctuation.definition.numeric.base.erlang
-        13: punctuation.definition.numeric.base.erlang
-        14: punctuation.definition.numeric.base.erlang
-        15: punctuation.definition.numeric.base.erlang
-        16: punctuation.definition.numeric.base.erlang
-        17: punctuation.definition.numeric.base.erlang
-        18: punctuation.definition.numeric.base.erlang
-        19: punctuation.definition.numeric.base.erlang
-        20: punctuation.definition.numeric.base.erlang
-        21: punctuation.definition.numeric.base.erlang
-        22: punctuation.definition.numeric.base.erlang
-        23: punctuation.definition.numeric.base.erlang
-        24: punctuation.definition.numeric.base.erlang
-        25: punctuation.definition.numeric.base.erlang
-        26: punctuation.definition.numeric.base.erlang
-        27: punctuation.definition.numeric.base.erlang
-        28: punctuation.definition.numeric.base.erlang
-        29: punctuation.definition.numeric.base.erlang
-        30: punctuation.definition.numeric.base.erlang
-        31: punctuation.definition.numeric.base.erlang
-        32: punctuation.definition.numeric.base.erlang
-        33: punctuation.definition.numeric.base.erlang
-        34: punctuation.definition.numeric.base.erlang
-        35: punctuation.definition.numeric.base.erlang
-        36: punctuation.definition.numeric.base.erlang
-        37: punctuation.definition.numeric.base.erlang
-        38: punctuation.definition.numeric.base.erlang
-        39: punctuation.definition.numeric.base.erlang
-        40: punctuation.definition.numeric.base.erlang
+        10: constant.numeric.integer.base.erlang
+        11: constant.numeric.integer.base.erlang
+        12: constant.numeric.integer.base.erlang
+        13: constant.numeric.integer.base.erlang
+        14: constant.numeric.integer.base.erlang
+        15: constant.numeric.integer.base.erlang
+        16: constant.numeric.integer.base.erlang
+        17: constant.numeric.integer.base.erlang
+        18: constant.numeric.integer.base.erlang
+        19: constant.numeric.integer.base.erlang
+        20: constant.numeric.integer.base.erlang
+        21: constant.numeric.integer.base.erlang
+        22: constant.numeric.integer.base.erlang
+        23: constant.numeric.integer.base.erlang
+        24: constant.numeric.integer.base.erlang
+        25: constant.numeric.integer.base.erlang
+        26: constant.numeric.integer.base.erlang
+        27: constant.numeric.integer.base.erlang
+        28: constant.numeric.integer.base.erlang
+        29: constant.numeric.integer.base.erlang
+        30: constant.numeric.integer.base.erlang
+        31: constant.numeric.integer.base.erlang
+        32: constant.numeric.integer.base.erlang
+        33: constant.numeric.integer.base.erlang
+        34: constant.numeric.integer.base.erlang
+        35: constant.numeric.integer.base.erlang
+        36: constant.numeric.integer.base.erlang
+        37: constant.numeric.integer.base.erlang
+        38: constant.numeric.integer.base.erlang
+        39: constant.numeric.integer.base.erlang
+        40: constant.numeric.integer.base.erlang
         41: invalid.illegal.integer.erlang
-        42: punctuation.definition.numeric.base.erlang
+        42: constant.numeric.integer.base.erlang
     - match: \d+\b
       scope: constant.numeric.integer.decimal.erlang
     - match: \d\w+

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -713,53 +713,53 @@ numbers_test() -> .
 
     1#0
 %   ^^^ invalid.illegal.integer.erlang
-%   ^^ punctuation.definition.numeric.base.erlang
+%   ^^ constant.numeric.integer.base.erlang
 
     2#01 2#012
 %   ^^^^ constant.numeric.integer.binary.erlang
-%   ^^ punctuation.definition.numeric.base.erlang
+%   ^^ constant.numeric.integer.base.erlang
 %        ^^^^^ invalid.illegal.integer.erlang
-%        ^^ punctuation.definition.numeric.base.erlang
+%        ^^ constant.numeric.integer.base.erlang
 
     3#012 3#123
 %   ^^^^^ constant.numeric.integer.other.erlang
-%   ^^ punctuation.definition.numeric.base.erlang
+%   ^^ constant.numeric.integer.base.erlang
 %         ^^^^^ invalid.illegal.integer.erlang
-%         ^^ punctuation.definition.numeric.base.erlang
+%         ^^ constant.numeric.integer.base.erlang
 
     4#0123 4#1234
 %   ^^^^^^ constant.numeric.integer.other.erlang
-%   ^^ punctuation.definition.numeric.base.erlang
+%   ^^ constant.numeric.integer.base.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
-%          ^^ punctuation.definition.numeric.base.erlang
+%          ^^ constant.numeric.integer.base.erlang
 
     8#0723 8#1834
 %   ^^^^^^ constant.numeric.integer.octal.erlang
-%   ^^ punctuation.definition.numeric.base.erlang
+%   ^^ constant.numeric.integer.base.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
-%          ^^ punctuation.definition.numeric.base.erlang
+%          ^^ constant.numeric.integer.base.erlang
 
     10#0943 10#183A
 %   ^^^^^^^ constant.numeric.integer.decimal.erlang
-%   ^^^ punctuation.definition.numeric.base.erlang
+%   ^^^ constant.numeric.integer.base.erlang
 %           ^^^^^^ invalid.illegal.integer.erlang
-%           ^^^ punctuation.definition.numeric.base.erlang
+%           ^^^ constant.numeric.integer.base.erlang
 
     16#0F2B 16#F8G4
 %   ^^^^^^^ constant.numeric.integer.hexadecimal.erlang
-%   ^^^ punctuation.definition.numeric.base.erlang
+%   ^^^ constant.numeric.integer.base.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
-%           ^^^ punctuation.definition.numeric.base.erlang
+%           ^^^ constant.numeric.integer.base.erlang
 
     35#0Y2B 35#F8Z4
 %   ^^^^^^^ constant.numeric.integer.other.erlang
-%   ^^^ punctuation.definition.numeric.base.erlang
+%   ^^^ constant.numeric.integer.base.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
-%           ^^^ punctuation.definition.numeric.base.erlang
+%           ^^^ constant.numeric.integer.base.erlang
 
     37#ABC
 %   ^^^^^^ invalid.illegal.integer.erlang
-%   ^^^ punctuation.definition.numeric.base.erlang
+%   ^^^ constant.numeric.integer.base.erlang
 
 % String tests
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -408,20 +408,20 @@ contexts:
     - match: (0[xX]){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}?(i)
       scope: constant.numeric.imaginary.hexadecimal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
         2: punctuation.separator.decimal.go
         3: storage.type.numeric.go
     # Octal imaginary numbers
     - match: (0[oO]){{oct_digits}}(i)
       scope: constant.numeric.imaginary.octal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
         2: storage.type.numeric.go
     # Binary imaginary numbers
     - match: (0[bB]){{bin_digits}}(i)
       scope: constant.numeric.imaginary.binary.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
         2: storage.type.numeric.go
 
   match-floats:
@@ -439,7 +439,7 @@ contexts:
     - match: (0[xX]){{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}
       scope: constant.numeric.float.hexadecimal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
         2: punctuation.separator.decimal.go
 
   match-integers:
@@ -452,25 +452,25 @@ contexts:
     - match: (0){{oct_digits}}(?=\D)
       scope: constant.numeric.integer.octal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
     - match: 0[0-7]*[8-9]+
       scope: invalid.illegal.go
     - match: (0[oO]){{oct_digits}}
       scope: constant.numeric.integer.octal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
 
   match-hex-integer:
     - match: (0[xX]){{hex_digits}}
       scope: constant.numeric.integer.hexadecimal.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
 
   match-binary-integer:
     - match: (0[bB]){{bin_digits}}
       scope: constant.numeric.integer.binary.go
       captures:
-        1: punctuation.definition.numeric.base.go
+        1: constant.numeric.integer.base.go
 
   match-decimal-integer:
     - match: '{{dec_digits}}'

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1780,16 +1780,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ### Octal
 
     00; 01234567; -01234567; 0_0; 012_45;
-//  ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//  ^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //   ^ constant.numeric.integer.octal.go
-//      ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//      ^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //       ^^^^^^^ constant.numeric.integer.octal.go
 //                ^ keyword.operator.arithmetic.go
-//                 ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                 ^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                  ^^^^^^^ constant.numeric.integer.octal.go
-//                           ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                           ^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                            ^^ constant.numeric.integer.octal.go
-//                                ^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                                ^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                                 ^^^^^ constant.numeric.integer.octal.go
 
     08; 09;
@@ -1797,16 +1797,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^ invalid.illegal.go
 
     0o660; 0O061; -0o02; 0o_660; 0O0_6_1;
-//  ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //    ^^^ constant.numeric.integer.octal.go
-//         ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//         ^^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //           ^^^ constant.numeric.integer.octal.go
 //                ^ keyword.operator.arithmetic.go
-//                 ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                 ^^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                   ^^ constant.numeric.integer.octal.go
-//                       ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                       ^^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                         ^^^^ constant.numeric.integer.octal.go
-//                               ^^ constant.numeric.integer.octal.go punctuation.definition.numeric.base.go
+//                               ^^ constant.numeric.integer.octal.go constant.numeric.integer.base.go
 //                                 ^^^^^ constant.numeric.integer.octal.go
 
 // ### Hex
@@ -1818,24 +1818,24 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
 
     0x_0; 0x012_3456_7_8_9ABCDEFabcd_ef;
-//  ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.integer.hexadecimal.go constant.numeric.integer.base.go
 //    ^^ constant.numeric.integer.hexadecimal.go
-//        ^^ constant.numeric.integer.hexadecimal.go punctuation.definition.numeric.base.go
+//        ^^ constant.numeric.integer.hexadecimal.go constant.numeric.integer.base.go
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal.go
 
 // ### Binary
 
     0b1011; 0B00001; -0b1; 0b_1; 0B1_0;
-//  ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.integer.binary.go constant.numeric.integer.base.go
 //    ^^^^ constant.numeric.integer.binary.go
-//          ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//          ^^ constant.numeric.integer.binary.go constant.numeric.integer.base.go
 //            ^^^^^ constant.numeric.integer.binary.go
 //                   ^ keyword.operator.arithmetic.go
-//                    ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                    ^^ constant.numeric.integer.binary.go constant.numeric.integer.base.go
 //                      ^ constant.numeric.integer.binary.go
-//                         ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                         ^^ constant.numeric.integer.binary.go constant.numeric.integer.base.go
 //                           ^^ constant.numeric.integer.binary.go
-//                               ^^ constant.numeric.integer.binary.go punctuation.definition.numeric.base.go
+//                               ^^ constant.numeric.integer.binary.go constant.numeric.integer.base.go
 //                                 ^^^ constant.numeric.integer.binary.go
 
 // ## Floats
@@ -1924,47 +1924,47 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^ punctuation.separator.decimal.go
 
     0x1p-2; 0X1P+2; 0x1p2;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //    ^^^^ constant.numeric.float.hexadecimal.go
-//          ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//          ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //            ^^^^ constant.numeric.float.hexadecimal.go
-//                  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//                  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //                    ^^^ constant.numeric.float.hexadecimal.go
 
     0x_1p-2; 0X1_1P+2; 0x_1p2_1;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //    ^^^^^ constant.numeric.float.hexadecimal.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//           ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //             ^^^^^^ constant.numeric.float.hexadecimal.go
-//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//                     ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //                       ^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x1.0P-1021; 0X1.0p-1021;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //    ^ constant.numeric.float.hexadecimal.go
 //     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //      ^^^^^^^ constant.numeric.float.hexadecimal.go
-//               ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//               ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //                 ^ constant.numeric.float.hexadecimal.go
 //                  ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                   ^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x_1_1.0_7P-1_021;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //    ^^^^ constant.numeric.float.hexadecimal.go
 //        ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //         ^^^^^^^^^^ constant.numeric.float.hexadecimal.go
 
     0x2.p10; 0x1.Fp+0; 0X.8p-0;
-//  ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //    ^ constant.numeric.float.hexadecimal.go
 //     ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //      ^^^ constant.numeric.float.hexadecimal.go
-//           ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//           ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //             ^ constant.numeric.float.hexadecimal.go
 //              ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //               ^^^^ constant.numeric.float.hexadecimal.go
-//                     ^^ constant.numeric.float.hexadecimal.go punctuation.definition.numeric.base.go
+//                     ^^ constant.numeric.float.hexadecimal.go constant.numeric.integer.base.go
 //                       ^ constant.numeric.float.hexadecimal.go punctuation.separator.decimal.go
 //                        ^^^^ constant.numeric.float.hexadecimal.go
 
@@ -2031,60 +2031,60 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^ constant.numeric.imaginary.decimal.go storage.type.numeric.go
 
     0o6i; 0O35i; 0o_6i; 0O3_5i;
-//  ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.imaginary.octal.go constant.numeric.integer.base.go
 //    ^ constant.numeric.imaginary.octal.go
 //     ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
-//        ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//        ^^ constant.numeric.imaginary.octal.go constant.numeric.integer.base.go
 //          ^^ constant.numeric.imaginary.octal.go
 //            ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
-//               ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//               ^^ constant.numeric.imaginary.octal.go constant.numeric.integer.base.go
 //                 ^^ constant.numeric.imaginary.octal.go
 //                   ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
-//                      ^^ constant.numeric.imaginary.octal.go punctuation.definition.numeric.base.go
+//                      ^^ constant.numeric.imaginary.octal.go constant.numeric.integer.base.go
 //                        ^^^ constant.numeric.imaginary.octal.go
 //                           ^ constant.numeric.imaginary.octal.go storage.type.numeric.go
 
     0x0i; 0x0123456789ABCDEFabcdefi; 0x_012_CD_Efi;
-//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //    ^ constant.numeric.imaginary.hexadecimal.go
 //     ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
-//        ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//        ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //          ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
 //                                ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
-//                                   ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//                                   ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //                                     ^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
 //                                               ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 
     0b1011i; 0B00001i; 0b_1011i; 0B000_01i;
-//  ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.imaginary.binary.go constant.numeric.integer.base.go
 //    ^^^^ constant.numeric.imaginary.binary.go
 //        ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
-//           ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//           ^^ constant.numeric.imaginary.binary.go constant.numeric.integer.base.go
 //             ^^^^^ constant.numeric.imaginary.binary.go
 //                  ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
-//                     ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//                     ^^ constant.numeric.imaginary.binary.go constant.numeric.integer.base.go
 //                       ^^^^^ constant.numeric.imaginary.binary.go
 //                            ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
-//                               ^^ constant.numeric.imaginary.binary.go punctuation.definition.numeric.base.go
+//                               ^^ constant.numeric.imaginary.binary.go constant.numeric.integer.base.go
 //                                 ^^^^^^ constant.numeric.imaginary.binary.go
 //                                       ^ constant.numeric.imaginary.binary.go storage.type.numeric.go
 
     0x1p-2i; 0x1.0P-1021i; 0x1.Fp+0i;
-//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //    ^^^^ constant.numeric.imaginary.hexadecimal.go
 //        ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
-//           ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//           ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //             ^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
 //                      ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
-//                         ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//                         ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //                           ^^^^^^ constant.numeric.imaginary.hexadecimal.go
 //                                 ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 
     0x_1p-2i; 0x1_4.0_5P-102_1i;
-//  ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//  ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //    ^^^^^ constant.numeric.imaginary.hexadecimal.go
 //         ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
-//            ^^ constant.numeric.imaginary.hexadecimal.go punctuation.definition.numeric.base.go
+//            ^^ constant.numeric.imaginary.hexadecimal.go constant.numeric.integer.base.go
 //              ^^^^^^^^^^^^^^ constant.numeric.imaginary.hexadecimal.go
 //                            ^ constant.numeric.imaginary.hexadecimal.go storage.type.numeric.go
 

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -88,11 +88,11 @@ contexts:
     - match: \b(0[oO])[0-7]+\b
       scope: constant.numeric.integer.octal.haskell
       captures:
-        1: punctuation.definition.numeric.base.haskell
+        1: constant.numeric.integer.base.haskell
     - match: \b(0[xX])\h+\b
       scope: constant.numeric.integer.hexadecimal.haskell
       captures:
-        1: punctuation.definition.numeric.base.haskell
+        1: constant.numeric.integer.base.haskell
     - match: \b\d+\b
       scope: constant.numeric.integer.decimal.haskell
 

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -272,7 +272,7 @@ main = do
 
     0o1234567
 --  ^^^^^^^^^ constant.numeric.integer.octal
---  ^^ punctuation.definition.numeric.base.haskell
+--  ^^ constant.numeric.integer.base.haskell
 
     1.
 --  ^ constant.numeric.integer.decimal
@@ -298,11 +298,11 @@ main = do
 
     0x0
 --  ^^^ constant.numeric.integer.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 
     0XdeafBEEF42
 --  ^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 
 --STRINGS
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1849,21 +1849,21 @@ contexts:
     - match: (0[Xx]){{hex_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.hexadecimal.js
       captures:
-        1: punctuation.definition.numeric.base.js
+        1: constant.numeric.integer.base.js
         2: storage.type.numeric.js
       pop: true
 
     - match: (0[Oo]){{oct_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.octal.js
       captures:
-        1: punctuation.definition.numeric.base.js
+        1: constant.numeric.integer.base.js
         2: storage.type.numeric.js
       pop: true
 
     - match: (0[Bb]){{bin_digit}}*(n)?{{identifier_break}}
       scope: constant.numeric.integer.binary.js
       captures:
-        1: punctuation.definition.numeric.base.js
+        1: constant.numeric.integer.base.js
         2: storage.type.numeric.js
       pop: true
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1900,37 +1900,37 @@ function yy (a, b) {
 
     0b0110_1001_1001_0110n;
 //  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //                       ^ storage.type.numeric
 
     0o0123_4567n;
 //  ^^^^^^^^^^^^ constant.numeric.integer.octal
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //             ^ storage.type.numeric
 
     0x01_23_45_67_89_ab_CD_efn;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //                           ^ storage.type.numeric
 
     0B0; 0O0; 0X0;
 //  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //       ^^^ constant.numeric.integer.octal
-//       ^^ punctuation.definition.numeric.base
+//       ^^ constant.numeric.integer.base
 //            ^^^ constant.numeric.integer.hexadecimal
-//            ^^ punctuation.definition.numeric.base
+//            ^^ constant.numeric.integer.base
 
     0b1.foo;
 //  ^^^^^^^ - invalid
 //  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
 //  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ constant.numeric.integer.base
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -446,14 +446,14 @@ contexts:
     - match: (0[Xx])\h*(?:(\.)\h*{{hex_exponent}}?|{{hex_exponent}})
       scope: constant.numeric.float.hexadecimal.lua
       captures:
-        1: punctuation.definition.numeric.base.lua
+        1: constant.numeric.integer.base.lua
         2: punctuation.separator.decimal.lua
       pop: true
 
     - match: (0[Xx])\h+
       scope: constant.numeric.integer.hexadecimal.lua
       captures:
-        1: punctuation.definition.numeric.base.lua
+        1: constant.numeric.integer.base.lua
       pop: true
 
     - match: \d+(?:(\.)\d*{{dec_exponent}}?|{{dec_exponent}})|(\.)\d+{{dec_exponent}}?

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -95,31 +95,31 @@
 
     0x0;
 --  ^^^ constant.numeric.integer.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 
     0XdeafBEEF42;
 --  ^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 
     0xa.bc + 0xa. + 0x.b;
 --  ^^^^^^ constant.numeric.float.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 --     ^ punctuation.separator.decimal
 --           ^^^^ constant.numeric.float.hexadecimal
---           ^^ punctuation.definition.numeric.base
+--           ^^ constant.numeric.integer.base
 --              ^ punctuation.separator.decimal
 --                  ^^^^ constant.numeric.float.hexadecimal
---                  ^^ punctuation.definition.numeric.base
+--                  ^^ constant.numeric.integer.base
 --                    ^ punctuation.separator.decimal
 
     0x1p10 + 0x1.p10 + 0x.1p10;
 --  ^^^^^^ constant.numeric.float.hexadecimal
---  ^^ punctuation.definition.numeric.base
+--  ^^ constant.numeric.integer.base
 --           ^^^^^^^ constant.numeric.float.hexadecimal
---           ^^ punctuation.definition.numeric.base
+--           ^^ constant.numeric.integer.base
 --              ^ punctuation.separator.decimal
 --                     ^^^^^^^ constant.numeric.float.hexadecimal
---                     ^^ punctuation.definition.numeric.base
+--                     ^^ constant.numeric.integer.base
 --                       ^ punctuation.separator.decimal
 
     'foo';

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -437,12 +437,12 @@ contexts:
     - match: '\b(0[xX])\h+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
       scope: constant.numeric.integer.hexadecimal.matlab
       captures:
-        1: punctuation.definition.numeric.base.matlab
+        1: constant.numeric.integer.base.matlab
         2: storage.type.numeric.matlab
     - match: '\b(0[bB])[01]+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
       scope: constant.numeric.integer.binary.matlab
       captures:
-        1: punctuation.definition.numeric.base.matlab
+        1: constant.numeric.integer.base.matlab
         2: storage.type.numeric.matlab
     - match: '(?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?(i|j)\b'
       scope: constant.numeric.imaginary.decimal.matlab

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -174,23 +174,23 @@ end
 %   ^ storage.type.numeric.matlab
  0x2A
 %^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
  0X2A
 %^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
  0b101010
 %^^^^^^^^ constant.numeric.integer.binary.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
  0B101010
 %^^^^^^^^ constant.numeric.integer.binary.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
  0x2Au8
 %^^^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
 %    ^^ storage.type.numeric.matlab
  0x2As32
 %^^^^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^ constant.numeric.integer.base.matlab
 %    ^^^ storage.type.numeric.matlab
 
 

--- a/OCaml/OCaml.sublime-syntax
+++ b/OCaml/OCaml.sublime-syntax
@@ -418,7 +418,7 @@ contexts:
       scope: constant.numeric.float.hexadecimal.ocaml
       captures:
         1: punctuation.definition.numeric.sign.ocaml
-        2: punctuation.definition.numeric.base.ocaml
+        2: constant.numeric.integer.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: punctuation.separator.decimal.ocaml
         5: invalid.illegal.numeric.ocaml
@@ -436,7 +436,7 @@ contexts:
       scope: constant.numeric.integer.hexadecimal.ocaml
       captures:
         1: punctuation.definition.numeric.sign.ocaml
-        2: punctuation.definition.numeric.base.ocaml
+        2: constant.numeric.integer.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: storage.type.numeric.ocaml
     # octal integers
@@ -444,7 +444,7 @@ contexts:
       scope: constant.numeric.integer.octal.ocaml
       captures:
         1: punctuation.definition.numeric.sign.ocaml
-        2: punctuation.definition.numeric.base.ocaml
+        2: constant.numeric.integer.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: storage.type.numeric.ocaml
     # binary integers
@@ -452,7 +452,7 @@ contexts:
       scope: constant.numeric.integer.binary.ocaml
       captures:
         1: punctuation.definition.numeric.sign.ocaml
-        2: punctuation.definition.numeric.base.ocaml
+        2: constant.numeric.integer.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: storage.type.numeric.ocaml
     # decimal integers

--- a/OCaml/syntax_test_ml.ml
+++ b/OCaml/syntax_test_ml.ml
@@ -57,31 +57,31 @@
 
     0b0110_1001_1001_0110n 0b_10_01
 (*  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary *)
-(*  ^^ punctuation.definition.numeric.base *)
+(*  ^^ constant.numeric.integer.base *)
 (*                       ^ storage.type.numeric *)
 (*                         ^^^^^^^^ constant.numeric.integer.binary *)
-(*                         ^^ punctuation.definition.numeric.base *)
+(*                         ^^ constant.numeric.integer.base *)
 (*                           ^ invalid.illegal.numeric *)
 
     0o0123_4567n 0O_127
 (*  ^^^^^^^^^^^^ constant.numeric.integer.octal *)
-(*  ^^ punctuation.definition.numeric *)
+(*  ^^ constant.numeric.integer.base *)
 (*             ^ storage.type.numeric *)
 (*               ^^^^^^ constant.numeric.integer.octal *)
-(*               ^^ punctuation.definition.numeric *)
+(*               ^^ constant.numeric.integer.base *)
 (*                 ^ invalid.illegal.numeric *)
 
     0x01_23_45_67_89_ab_CD_efn 0X_01l
 (*  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal *)
-(*  ^^ punctuation.definition.numeric.base *)
+(*  ^^ constant.numeric.integer.base *)
 (*                           ^ storage.type.numeric *)
 (*                             ^^^^^^ constant.numeric.integer.hexadecimal *)
-(*                             ^^ punctuation.definition.numeric.base *)
+(*                             ^^ constant.numeric.integer.base *)
 (*                               ^ invalid.illegal.numeric *)
 (*                                  ^ storage.type.numeric *)
 
     0b
-(*  ^^ constant.numeric.integer.binary punctuation.definition.numeric.base *)
+(*  ^^ constant.numeric.integer.binary constant.numeric.integer.base *)
 
     0B0 0O0 0X0
 (*  ^^^ constant.numeric.integer.binary *)
@@ -90,16 +90,16 @@
 
     0xa. 0xa.b  0xa.ep1 0xa.ep-_1
 (*  ^^^^ constant.numeric.float.hexadecimal *)
-(*  ^^ punctuation.definition.numeric.base *)
+(*  ^^ constant.numeric.integer.base *)
 (*     ^ punctuation.separator.decimal *)
 (*       ^^^^^ constant.numeric.float.hexadecimal *)
-(*       ^^ punctuation.definition.numeric.base *)
+(*       ^^ constant.numeric.integer.base *)
 (*          ^ punctuation.separator.decimal *)
 (*              ^^^^^^^ constant.numeric.float.hexadecimal *)
-(*              ^^ punctuation.definition.numeric.base *)
+(*              ^^ constant.numeric.integer.base *)
 (*                 ^ punctuation.separator.decimal *)
 (*                      ^^^^^^^^^ constant.numeric.float.hexadecimal *)
-(*                      ^^ punctuation.definition.numeric.base *)
+(*                      ^^ constant.numeric.integer.base *)
 (*                         ^ punctuation.separator.decimal *)
 (*                             ^ invalid.illegal.numeric *)
 

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -990,74 +990,74 @@ dec5 = 2'354'202'076LL;
 
 oct1 = 0123_567;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*         ^^^^ storage.type.numeric */
 /*             ^ punctuation.terminator - constant */
 
 oct2 = 014'70;
 /*     ^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*           ^ punctuation.terminator - constant */
 
 hex1 = 0x1234567890ABCDEF;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex2 = 0X1234567890ABCDEF;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex3 = 0x1234567890abcdef;
 /*     ^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                       ^ punctuation.terminator - constant */
 
 hex4 = 0xA7'45'8C'38;
 /*     ^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                  ^ punctuation.terminator - constant */
 
 hex5 = 0x0+0xFL+0xaull+0xallu+0xfu+0xf'12_4_uz;
 /*     ^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^^^^ constant.numeric.integer.hexadecimal */
-/*         ^^ punctuation.definition.numeric.base */
+/*         ^^ constant.numeric.integer.base */
 /*            ^ storage.type.numeric */
 /*              ^^^^^^ constant.numeric.integer.hexadecimal */
-/*              ^^ punctuation.definition.numeric.base */
+/*              ^^ constant.numeric.integer.base */
 /*                 ^^^ storage.type.numeric */
 /*                     ^^^^^^ constant.numeric.integer.hexadecimal */
-/*                     ^^ punctuation.definition.numeric.base */
+/*                     ^^ constant.numeric.integer.base */
 /*                        ^^^ storage.type.numeric */
 /*                            ^^^^ constant.numeric.integer.hexadecimal */
-/*                            ^^ punctuation.definition.numeric.base */
+/*                            ^^ constant.numeric.integer.base */
 /*                               ^ storage.type.numeric */
 /*                                 ^^^^^^^^^^ constant.numeric.integer.hexadecimal */
-/*                                 ^^ punctuation.definition.numeric.base */
+/*                                 ^^ constant.numeric.integer.base */
 /*                                       ^^^^^ storage.type.numeric */
 /*                                            ^ punctuation.terminator - constant */
 
 hex2 = 0xc1.01AbFp-1;
 /*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^ punctuation.separator.decimal */
 /*                  ^ punctuation.terminator - constant */
 
 bin1 = 0b010110;
 /*     ^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*             ^ punctuation.terminator - constant */
 
 bin2 = 0B010010;
 /*     ^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*             ^ punctuation.terminator - constant */
 
 bin3 = 0b1001'1101'0010'1100;
 /*     ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*                          ^ punctuation.terminator - constant */
 
 f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -723,47 +723,47 @@ dec8 = 1'234_567'890s0f;
 
 oct1 = 01234567;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 
 oct2 = 01234567L;
 /*     ^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^ storage.type.numeric */
 
 oct3 = 01234567LL;
 /*     ^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^^ storage.type.numeric */
 
 oct4 = 01234567ulL;
 /*     ^^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*             ^^^ storage.type.numeric */
 
 oct2 = 01284967Z0L;
 /*     ^^^^^^^^^^^ constant.numeric.integer.octal */
-/*     ^ punctuation.definition.numeric.base */
+/*     ^ constant.numeric.integer.base */
 /*        ^ invalid.illegal.numeric.digit */
 /*          ^ invalid.illegal.numeric.digit */
 /*             ^^^ invalid.illegal.numeric.suffix */
 
 hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 /*     ^^^ constant.numeric.integer.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^^^^ constant.numeric.integer.hexadecimal */
-/*         ^^ punctuation.definition.numeric.base */
+/*         ^^ constant.numeric.integer.base */
 /*            ^ storage.type.numeric */
 /*              ^^^^^^ constant.numeric.integer.hexadecimal */
-/*              ^^ punctuation.definition.numeric.base */
+/*              ^^ constant.numeric.integer.base */
 /*                 ^^^ storage.type.numeric */
 /*                     ^^^^^^ constant.numeric.integer.hexadecimal */
-/*                     ^^ punctuation.definition.numeric.base */
+/*                     ^^ constant.numeric.integer.base */
 /*                        ^^^ storage.type.numeric */
 /*                            ^^^^ constant.numeric.integer.hexadecimal */
-/*                            ^^ punctuation.definition.numeric.base */
+/*                            ^^ constant.numeric.integer.base */
 /*                               ^ storage.type.numeric */
 /*                                 ^^ constant.numeric.integer.hexadecimal */
-/*                                 ^^ punctuation.definition.numeric.base */
+/*                                 ^^ constant.numeric.integer.base */
 /*                                   ^^^ string.quoted.single */
 /*                                      ^^^^^^ constant.numeric.integer.decimal */
 /*                                        ^^^^ invalid.illegal.numeric.suffix */
@@ -771,7 +771,7 @@ hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 
 hex2 = 0xc1.01AbFp-1;
 /*     ^^^^^^^^^^^^^ constant.numeric.float.hexadecimal */
-/*     ^^ punctuation.definition.numeric.base */
+/*     ^^ constant.numeric.integer.base */
 /*         ^ punctuation.separator.decimal */
 /*                  ^ punctuation.terminator - constant */
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -430,36 +430,36 @@ contexts:
     - match: \b(?i)(0x)\h*(L) # py2
       scope: constant.numeric.integer.hexadecimal.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
         2: storage.type.numeric.python
     - match: \b(?i)(0x)(_?\h)+
       scope: constant.numeric.integer.hexadecimal.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
     # octal
     - match: \b(?i)(0o?)(?=o|[0-7])[0-7]*(L) # py2
       scope: constant.numeric.integer.octal.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
         2: storage.type.numeric.python
     - match: \b(?i)(0)[0-7]+ # py2
       scope: constant.numeric.integer.octal.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
     - match: \b(?i)(0o)(_?[0-7])+
       scope: constant.numeric.integer.octal.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
     # binary
     - match: \b(?i)(0b)[01]*(L) # py2
       scope: constant.numeric.integer.binary.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
         2: storage.type.numeric.python
     - match: \b(?i)(0b)(_?[01])*
       scope: constant.numeric.integer.binary.python
       captures:
-        1: punctuation.definition.numeric.base.python
+        1: constant.numeric.integer.base.python
     # complex
     - match: |-
         (?x:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1338,39 +1338,39 @@ floating = 0.1 - .1 * 10e-20 - 0.0e2 % 2.
 
 binary = 0b1010011 | 0b0110110L
 #        ^^^^^^^^^ constant.numeric.integer.binary.python
-#        ^^ punctuation.definition.numeric.base.python
+#        ^^ constant.numeric.integer.base.python
 #                    ^^^^^^^^^^ constant.numeric.integer.binary.python
-#                    ^^ punctuation.definition.numeric.base.python
+#                    ^^ constant.numeric.integer.base.python
 #                             ^ storage.type.numeric.python
 
 octal = 0o755 ^ 0o644L
 #       ^^^^^ constant.numeric.integer.octal.python
-#       ^^ punctuation.definition.numeric.base.python
+#       ^^ constant.numeric.integer.base.python
 #                    ^ storage.type.numeric.python
 #               ^^^^^^ constant.numeric.integer.octal.python
-#               ^^ punctuation.definition.numeric.base.python
+#               ^^ constant.numeric.integer.base.python
 
 old_style_octal = 010 + 007 - 012345670L
 #                 ^^^ constant.numeric.integer.octal.python
-#                 ^ punctuation.definition.numeric.base.python
+#                 ^ constant.numeric.integer.base.python
 #                       ^^^ constant.numeric.integer.octal.python
-#                       ^ punctuation.definition.numeric.base.python
+#                       ^ constant.numeric.integer.base.python
 #                             ^^^^^^^^^^ constant.numeric.integer.octal.python
-#                             ^ punctuation.definition.numeric.base.python
+#                             ^ constant.numeric.integer.base.python
 #                                      ^ storage.type.numeric.python
 
 hexadecimal = 0x100af - 0XDEADF00L
 #             ^^^^^^^ constant.numeric.integer.hexadecimal.python
-#             ^^ punctuation.definition.numeric.base.python
+#             ^^ constant.numeric.integer.base.python
 #                       ^^^^^^^^^^ constant.numeric.integer.hexadecimal.python
-#                       ^^ punctuation.definition.numeric.base.python
+#                       ^^ constant.numeric.integer.base.python
 #                                ^ storage.type.numeric.python
 
 unintuitive = 0B101 + 0O101 + 10l
 #             ^^^^^ constant.numeric.integer.binary.python
-#             ^^ punctuation.definition.numeric.base.python
+#             ^^ constant.numeric.integer.base.python
 #                     ^^^^^ constant.numeric.integer.octal.python
-#                     ^^ punctuation.definition.numeric.base.python
+#                     ^^ constant.numeric.integer.base.python
 #                             ^^^ constant.numeric.integer.decimal.python
 #                               ^ storage.type.numeric.python
 
@@ -1395,11 +1395,11 @@ very_complex = 23_2.2e2_0J + 2_1j
 
 addr = 0xCAFE_F00D
 #      ^^^^^^^^^^^ constant.numeric
-#      ^^ punctuation.definition.numeric.base.python
+#      ^^ constant.numeric.integer.base.python
 
 flags = 0b_0011_1111_0100_1110 | 0b_1 & 0b_0_
 #       ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric
-#       ^^ punctuation.definition.numeric.base.python
+#       ^^ constant.numeric.integer.base.python
 #                                ^^^^ constant.numeric.integer.binary.python
 #                                           ^ - constant
 

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -209,21 +209,21 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
     - match: '\b(0[oO]?){{odigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.octal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # binary imaginary numbers: 0b1i, 0b1ri
     - match: '\b(0[bB]){{bdigits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.binary.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
@@ -238,7 +238,7 @@ contexts:
         )\b
       scope: constant.numeric.imaginary.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: punctuation.separator.decimal.ruby
         3: storage.type.numeric.ruby
         4: punctuation.separator.decimal.ruby
@@ -249,25 +249,25 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}(r)\b'
       scope: constant.numeric.rational.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
     # octal rational numbers: 0o1r, 01r
     - match: '\b(0[oO]?){{odigits}}(r)\b'
       scope: constant.numeric.rational.octal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
     # binary rational numbers: 0b1r
     - match: '\b(0[bB]){{bdigits}}(r)\b'
       scope: constant.numeric.rational.binary.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: storage.type.numeric.ruby
     # decimal rational numbers: 0d1r, 1r, 1.1r
     - match: '\b(?:(0[dD])?{{ddigits}}|{{ddigits}}(\.){{ddigits}})(r)\b'
       scope: constant.numeric.rational.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
         2: punctuation.separator.decimal.ruby
         3: storage.type.numeric.ruby
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
@@ -281,22 +281,22 @@ contexts:
     - match: '\b(0[xX]){{hdigits}}\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
     # octal integer numbers: 0o1, 01
     - match: '\b(0[oO]?){{odigits}}\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
     # binary integer numbers: 0b1
     - match: '\b(0[bB]){{bdigits}}\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
     # decimal integer numbers: 0d1, 1
     - match: '\b(0[dD])?{{ddigits}}\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: constant.numeric.integer.base.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -200,31 +200,31 @@ BAR
 #^^^^^ constant.numeric.integer.decimal
  0d170
 #^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0D170
 #^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0xAa
 #^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0XAa
 #^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0252
 #^^^^ constant.numeric.integer.octal
-#^ punctuation.definition.numeric.base
+#^ constant.numeric.integer.base
  0o252
 #^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0O252
 #^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0b10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  0B10101010
 #^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
  12.
 #^^ constant.numeric.integer.decimal
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
@@ -258,19 +258,19 @@ BAR
 #    ^ storage.type.numeric
  0d170r
 #^^^^^^ constant.numeric.rational.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
  0xAar
 #^^^^^ constant.numeric.rational.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #    ^ storage.type.numeric
  0o252r
 #^^^^^^ constant.numeric.rational.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
  0b10101010r
 #^^^^^^^^^^^ constant.numeric.rational.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #          ^ storage.type.numeric
 
  12i
@@ -303,35 +303,35 @@ BAR
 #    ^^ storage.type.numeric
  0d170i
 #^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
  0d170ri
 #^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^^ storage.type.numeric
  0xAai
 #^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #    ^ storage.type.numeric
  0xAari
 #^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #    ^^ storage.type.numeric
  0o252i
 #^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
  0o252ri
 #^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^^ storage.type.numeric
  0b10101010i
 #^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #          ^ storage.type.numeric
  0b10101010ri
 #^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #          ^^ storage.type.numeric
  12e3ri
 #^^^^^^ constant.numeric.imaginary.decimal
@@ -362,22 +362,22 @@ BAR
 #      ^ invalid.illegal.numeric
  0d170ir
 #^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
 #      ^ invalid.illegal.numeric
  0xAair
 #^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #    ^ storage.type.numeric
 #     ^ invalid.illegal.numeric
  0o252ir
 #^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #     ^ storage.type.numeric
 #      ^ invalid.illegal.numeric
  0b10101010ir
 #^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
+#^^ constant.numeric.integer.base
 #          ^ storage.type.numeric
 #           ^ invalid.illegal.numeric
 

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -289,7 +289,7 @@ contexts:
     - match: \b(0[xX])\h+([lL]?)\b
       scope: constant.numeric.integer.hexadecimal.scala
       captures:
-        1: punctuation.definition.numeric.base.scala
+        1: constant.numeric.integer.base.scala
         2: storage.type.numeric.scala
     - match: \b(?:0|[1-9][0-9]*)([lL]?)\b
       scope: constant.numeric.integer.decimal.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -283,14 +283,14 @@ type Foo = Bar[A] forSome { type A }
 
    0x0aF9123 0x42L 0x42l
 //^ - constant
-// ^^ punctuation.definition.numeric.base.scala
+// ^^ constant.numeric.integer.base.scala
 // ^^^^^^^^^ constant.numeric.integer.hexadecimal.scala
 //          ^ - constant
-//           ^^ punctuation.definition.numeric.base.scala
+//           ^^ constant.numeric.integer.base.scala
 //           ^^^^^ constant.numeric.integer.hexadecimal.scala
 //               ^ storage.type.numeric.scala
 //                ^ - constant
-//                 ^^ punctuation.definition.numeric.base.scala
+//                 ^^ constant.numeric.integer.base.scala
 //                 ^^^^^ constant.numeric.integer.hexadecimal.scala
 //                     ^ storage.type.numeric.scala
 //                      ^ - constant

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -334,15 +334,15 @@ contexts:
         2: constant.language.boolean.yaml
         # binary integer
         4: constant.numeric.integer.binary.yaml
-        5: punctuation.definition.numeric.base.yaml
+        5: constant.numeric.integer.base.yaml
         # octal integer
         6: constant.numeric.integer.octal.yaml
-        7: punctuation.definition.numeric.base.yaml
+        7: constant.numeric.integer.base.yaml
         # decimal integer
         8: constant.numeric.integer.decimal.yaml
         # hexadecimal integer
         9: constant.numeric.integer.hexadecimal.yaml
-        10: punctuation.definition.numeric.base.yaml
+        10: constant.numeric.integer.base.yaml
         # other integer
         11: constant.numeric.integer.other.yaml
         # decimal float
@@ -382,15 +382,15 @@ contexts:
         2: constant.language.boolean.yaml
         # binary integer
         4: constant.numeric.integer.binary.yaml
-        5: punctuation.definition.numeric.base.yaml
+        5: constant.numeric.integer.base.yaml
         # octal integer
         6: constant.numeric.integer.octal.yaml
-        7: punctuation.definition.numeric.base.yaml
+        7: constant.numeric.integer.base.yaml
         # decimal integer
         8: constant.numeric.integer.decimal.yaml
         # hexadecimal integer
         9: constant.numeric.integer.hexadecimal.yaml
-        10: punctuation.definition.numeric.base.yaml
+        10: constant.numeric.integer.base.yaml
         # other integer
         11: constant.numeric.integer.other.yaml
         # decimal float

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -39,20 +39,20 @@
 
 - [0b0, +0b1_0_1, -0b1, ~, 0b, 0b2, 0b1 abc
 #  ^^^                                      constant.numeric.integer.binary
-#  ^^                                       punctuation.definition.numeric.base
+#  ^^                                       constant.numeric.integer.base
 #       ^^^^^^^^                            constant.numeric.integer.binary
-#        ^^                                 punctuation.definition.numeric.base
+#        ^^                                 constant.numeric.integer.base
 #                 ^^^^                      constant.numeric.integer.binary
-#                  ^^                       punctuation.definition.numeric.base
+#                  ^^                       constant.numeric.integer.base
 #                          ^^^^^^^^^^^^^^^^ -constant
 
    01, +0_761, -07, ~, 09, 0123 f
 #  ^^                             constant.numeric.integer.octal
-#  ^                              punctuation.definition.numeric.base
+#  ^                              constant.numeric.integer.base
 #      ^^^^^^                     constant.numeric.integer.octal
-#       ^                         punctuation.definition.numeric.base
+#       ^                         constant.numeric.integer.base
 #              ^^^                constant.numeric.integer.octal
-#               ^                 punctuation.definition.numeric.base
+#               ^                 constant.numeric.integer.base
 #                      ^^^^^^^^^^ -constant
 
    0, +1, -12_345, ~, 3 not a number
@@ -63,11 +63,11 @@
 
    0x0, +0x12_34_56, -0xabcdef, ~, 0xyz, 0x,
 #  ^^^                                      constant.numeric.integer.hexadecimal
-#  ^^                                       punctuation.definition.numeric.base
+#  ^^                                       constant.numeric.integer.base
 #       ^^^^^^^^^^^                         constant.numeric.integer.hexadecimal
-#        ^^                                 punctuation.definition.numeric.base
+#        ^^                                 constant.numeric.integer.base
 #                    ^^^^^^^^^              constant.numeric.integer.hexadecimal
-#                     ^^                    punctuation.definition.numeric.base
+#                     ^^                    constant.numeric.integer.base
 #                                  ^^^^^^^^ -constant
 
 # Note: pyyaml does not handle hexagesimal literals correctly (for linting purposes)


### PR DESCRIPTION
`0b` and related should not be punctuation. There's currently a workaround in the default colorschemes for this but this is a proper fix.