### PR TITLE
[Ruby] Meta Numbers

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -206,97 +206,102 @@ contexts:
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
     # hexadecimal imaginary numbers: 0xAi, 0xAri
-    - match: '\b(0[xX]){{hex_digits}}(r?i)(r)?\b'
-      scope: constant.numeric.imaginary.hexadecimal.ruby
+    - match: '\b(0[xX])({{hex_digits}})(r?i(r)?)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
-        3: invalid.illegal.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
+        2: meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
+        3: meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
+        4: invalid.illegal.numeric.ruby
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
-    - match: '\b(0[oO]?){{oct_digits}}(r?i)(r)?\b'
-      scope: constant.numeric.imaginary.octal.ruby
+    - match: '\b(0[oO]?)({{oct_digits}})(r?i(r)?)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
-        3: invalid.illegal.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.imaginary.octal.ruby
+        2: meta.number.value.ruby constant.numeric.imaginary.octal.ruby
+        3: meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
+        4: invalid.illegal.numeric.ruby
     # binary imaginary numbers: 0b1i, 0b1ri
-    - match: '\b(0[bB]){{bin_digits}}(r?i)(r)?\b'
-      scope: constant.numeric.imaginary.binary.ruby
+    - match: '\b(0[bB])({{bin_digits}})(r?i(r)?)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
-        3: invalid.illegal.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.imaginary.binary.ruby
+        2: meta.number.value.ruby constant.numeric.imaginary.binary.ruby
+        3: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+        4: invalid.illegal.numeric.ruby
     # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
     - match: |-
         \b(?x:
           (?:
             # 0d1i, 0d1ri, 1i, 1ri | 1.1i, 1.1ri
-            (?: (0[dD])? {{dec_digits}} | {{dec_digits}} (\.) {{dec_digits}} ) (r?i)
+            (?: (0[dD])? ({{dec_digits}}) | ({{dec_digits}} (\.) {{dec_digits}}) ) (r?i)
             # 1e1i, 1.1e1i
-            | {{dec_digits}} (?: (\.) {{dec_digits}} )? {{dec_exponent}} (r)? (i)
+            | ({{dec_digits}} (?: (\.) {{dec_digits}} )? {{dec_exponent}}) (r)?(i)
           ) (r)?
         )\b
-      scope: constant.numeric.imaginary.decimal.ruby
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: punctuation.separator.decimal.ruby
-        3: storage.type.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
+        2: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+        3: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
         4: punctuation.separator.decimal.ruby
-        5: invalid.illegal.numeric.ruby
-        6: storage.type.numeric.ruby
-        7: invalid.illegal.numeric.ruby
+        5: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+        6: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+        7: punctuation.separator.decimal.ruby
+        8: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby invalid.illegal.numeric.ruby
+        9: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+        10: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby invalid.illegal.numeric.ruby
     # hexadecimal rational numbers: 0xAr
-    - match: '\b(0[xX]){{hex_digits}}(r)\b'
-      scope: constant.numeric.rational.hexadecimal.ruby
+    - match: '\b(0[xX])({{hex_digits}})(r)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.rational.hexadecimal.ruby
+        2: meta.number.value.ruby constant.numeric.rational.hexadecimal.ruby
+        3: meta.number.suffix.ruby constant.numeric.rational.hexadecimal.ruby
     # octal rational numbers: 0o1r, 01r
-    - match: '\b(0[oO]?){{oct_digits}}(r)\b'
-      scope: constant.numeric.rational.octal.ruby
+    - match: '\b(0[oO]?)({{oct_digits}})(r)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.rational.octal.ruby
+        2: meta.number.value.ruby constant.numeric.rational.octal.ruby
+        3: meta.number.suffix.ruby constant.numeric.rational.octal.ruby
     # binary rational numbers: 0b1r
-    - match: '\b(0[bB]){{bin_digits}}(r)\b'
-      scope: constant.numeric.rational.binary.ruby
+    - match: '\b(0[bB])({{bin_digits}})(r)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: storage.type.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.rational.binary.ruby
+        2: meta.number.value.ruby constant.numeric.rational.binary.ruby
+        3: meta.number.suffix.ruby constant.numeric.rational.binary.ruby
     # decimal rational numbers: 0d1r, 1r, 1.1r
-    - match: '\b(?:(0[dD])?{{dec_digits}}|{{dec_digits}}(\.){{dec_digits}})(r)\b'
-      scope: constant.numeric.rational.decimal.ruby
+    - match: '\b(?:(0[dD])?({{dec_digits}})|({{dec_digits}}(\.){{dec_digits}}))(r)\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
-        2: punctuation.separator.decimal.ruby
-        3: storage.type.numeric.ruby
+        1: meta.number.base.ruby constant.numeric.rational.decimal.ruby
+        2: meta.number.value.ruby constant.numeric.rational.decimal.ruby
+        3: meta.number.value.ruby constant.numeric.rational.decimal.ruby
+        4: punctuation.separator.decimal.ruby
+        5: meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
-    - match: '\b{{dec_digits}}(?:(\.){{dec_digits}}|(?:(\.){{dec_digits}})?{{dec_exponent}}(r)?)\b'
-      scope: constant.numeric.float.decimal.ruby
+    - match: '\b({{dec_digits}})(?:((\.){{dec_digits}})|((?:(\.){{dec_digits}})?{{dec_exponent}})(r)?)\b'
       captures:
-        1: punctuation.separator.decimal.ruby
-        2: punctuation.separator.decimal.ruby
-        3: invalid.illegal.numeric.rational.ruby
+        1: meta.number.value.ruby constant.numeric.float.decimal.ruby
+        2: meta.number.value.ruby constant.numeric.float.decimal.ruby
+        3: punctuation.separator.decimal.ruby
+        4: meta.number.value.ruby constant.numeric.float.decimal.ruby
+        5: punctuation.separator.decimal.ruby
+        6: meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
     # hexadecimal integer numbers: 0xA
-    - match: '\b(0[xX]){{hex_digits}}\b'
-      scope: constant.numeric.integer.hexadecimal.ruby
+    - match: '\b(0[xX])({{hex_digits}})\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
+        2: meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
     # octal integer numbers: 0o1, 01
-    - match: '\b(0[oO]?){{oct_digits}}\b'
-      scope: constant.numeric.integer.octal.ruby
+    - match: '\b(0[oO]?)({{oct_digits}})\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: meta.number.base.ruby constant.numeric.integer.octal.ruby
+        2: meta.number.value.ruby constant.numeric.integer.octal.ruby
     # binary integer numbers: 0b1
-    - match: '\b(0[bB]){{bin_digits}}\b'
-      scope: constant.numeric.integer.binary.ruby
+    - match: '\b(0[bB])({{bin_digits}})\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: meta.number.base.ruby constant.numeric.integer.binary.ruby
+        2: meta.number.value.ruby constant.numeric.integer.binary.ruby
     # decimal integer numbers: 0d1, 1
-    - match: '\b(0[dD])?{{dec_digits}}\b'
-      scope: constant.numeric.integer.decimal.ruby
+    - match: '\b(0[dD])?({{dec_digits}})\b'
       captures:
-        1: punctuation.definition.numeric.base.ruby
+        1: meta.number.base.ruby constant.numeric.integer.decimal.ruby
+        2: meta.number.value.ruby constant.numeric.integer.decimal.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -66,11 +66,11 @@ first_line_match: |-
   )
 scope: source.ruby
 variables:
-  bdigits: (?:[01]+(?:_[01]+)*)
-  ddigits: (?:\d+(?:_\d+)*)
-  hdigits: (?:\h+(?:_\h+)*)
-  odigits: (?:[0-7]+(?:_[0-7]+)*)
-  exponent: (?:[Ee][-+]?{{ddigits}})
+  bin_digits: (?:[01]+(?:_[01]+)*)
+  dec_digits: (?:\d+(?:_\d+)*)
+  hex_digits: (?:\h+(?:_\h+)*)
+  oct_digits: (?:[0-7]+(?:_[0-7]+)*)
+  dec_exponent: (?:[Ee][-+]?{{dec_digits}})
   heredoc_type_css: (?:[[:upper:]_]_)?CSS\b
   heredoc_type_html: (?:[[:upper:]_]_)?HTML\b
   heredoc_type_js: (?:[[:upper:]_]_)?(?:JS|JAVASCRIPT)\b
@@ -206,21 +206,21 @@ contexts:
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
     # hexadecimal imaginary numbers: 0xAi, 0xAri
-    - match: '\b(0[xX]){{hdigits}}(r?i)(r)?\b'
+    - match: '\b(0[xX]){{hex_digits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
-    - match: '\b(0[oO]?){{odigits}}(r?i)(r)?\b'
+    - match: '\b(0[oO]?){{oct_digits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.octal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
         3: invalid.illegal.numeric.ruby
     # binary imaginary numbers: 0b1i, 0b1ri
-    - match: '\b(0[bB]){{bdigits}}(r?i)(r)?\b'
+    - match: '\b(0[bB]){{bin_digits}}(r?i)(r)?\b'
       scope: constant.numeric.imaginary.binary.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
@@ -231,9 +231,9 @@ contexts:
         \b(?x:
           (?:
             # 0d1i, 0d1ri, 1i, 1ri | 1.1i, 1.1ri
-            (?: (0[dD])? {{ddigits}} | {{ddigits}} (\.) {{ddigits}} ) (r?i)
+            (?: (0[dD])? {{dec_digits}} | {{dec_digits}} (\.) {{dec_digits}} ) (r?i)
             # 1e1i, 1.1e1i
-            | {{ddigits}} (?: (\.) {{ddigits}} )? {{exponent}} (r)? (i)
+            | {{dec_digits}} (?: (\.) {{dec_digits}} )? {{dec_exponent}} (r)? (i)
           ) (r)?
         )\b
       scope: constant.numeric.imaginary.decimal.ruby
@@ -246,54 +246,54 @@ contexts:
         6: storage.type.numeric.ruby
         7: invalid.illegal.numeric.ruby
     # hexadecimal rational numbers: 0xAr
-    - match: '\b(0[xX]){{hdigits}}(r)\b'
+    - match: '\b(0[xX]){{hex_digits}}(r)\b'
       scope: constant.numeric.rational.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # octal rational numbers: 0o1r, 01r
-    - match: '\b(0[oO]?){{odigits}}(r)\b'
+    - match: '\b(0[oO]?){{oct_digits}}(r)\b'
       scope: constant.numeric.rational.octal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # binary rational numbers: 0b1r
-    - match: '\b(0[bB]){{bdigits}}(r)\b'
+    - match: '\b(0[bB]){{bin_digits}}(r)\b'
       scope: constant.numeric.rational.binary.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: storage.type.numeric.ruby
     # decimal rational numbers: 0d1r, 1r, 1.1r
-    - match: '\b(?:(0[dD])?{{ddigits}}|{{ddigits}}(\.){{ddigits}})(r)\b'
+    - match: '\b(?:(0[dD])?{{dec_digits}}|{{dec_digits}}(\.){{dec_digits}})(r)\b'
       scope: constant.numeric.rational.decimal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
         2: punctuation.separator.decimal.ruby
         3: storage.type.numeric.ruby
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
-    - match: '\b{{ddigits}}(?:(\.){{ddigits}}|(?:(\.){{ddigits}})?{{exponent}}(r)?)\b'
+    - match: '\b{{dec_digits}}(?:(\.){{dec_digits}}|(?:(\.){{dec_digits}})?{{dec_exponent}}(r)?)\b'
       scope: constant.numeric.float.decimal.ruby
       captures:
         1: punctuation.separator.decimal.ruby
         2: punctuation.separator.decimal.ruby
         3: invalid.illegal.numeric.rational.ruby
     # hexadecimal integer numbers: 0xA
-    - match: '\b(0[xX]){{hdigits}}\b'
+    - match: '\b(0[xX]){{hex_digits}}\b'
       scope: constant.numeric.integer.hexadecimal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
     # octal integer numbers: 0o1, 01
-    - match: '\b(0[oO]?){{odigits}}\b'
+    - match: '\b(0[oO]?){{oct_digits}}\b'
       scope: constant.numeric.integer.octal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
     # binary integer numbers: 0b1
-    - match: '\b(0[bB]){{bdigits}}\b'
+    - match: '\b(0[bB]){{bin_digits}}\b'
       scope: constant.numeric.integer.binary.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby
     # decimal integer numbers: 0d1, 1
-    - match: '\b(0[dD])?{{ddigits}}\b'
+    - match: '\b(0[dD])?{{dec_digits}}\b'
       scope: constant.numeric.integer.decimal.ruby
       captures:
         1: punctuation.definition.numeric.base.ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -207,24 +207,27 @@ contexts:
       scope: variable.language.ruby
     # hexadecimal imaginary numbers: 0xAi, 0xAri
     - match: '\b(0[xX])({{hex_digits}})(r?i(r)?)\b'
+      scope: meta.number.imaginary.hexadecimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
-        2: meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
-        3: meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
     - match: '\b(0[oO]?)({{oct_digits}})(r?i(r)?)\b'
+      scope: meta.number.imaginary.octal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.imaginary.octal.ruby
-        2: meta.number.value.ruby constant.numeric.imaginary.octal.ruby
-        3: meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
     # binary imaginary numbers: 0b1i, 0b1ri
     - match: '\b(0[bB])({{bin_digits}})(r?i(r)?)\b'
+      scope: meta.number.imaginary.binary.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.imaginary.binary.ruby
-        2: meta.number.value.ruby constant.numeric.imaginary.binary.ruby
-        3: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
     # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
     - match: |-
@@ -236,72 +239,81 @@ contexts:
             | ({{dec_digits}} (?: (\.) {{dec_digits}} )? {{dec_exponent}}) (r)?(i)
           ) (r)?
         )\b
+      scope: meta.number.imaginary.decimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
-        2: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-        3: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.value.ruby
         4: punctuation.separator.decimal.ruby
-        5: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
-        6: meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+        5: constant.numeric.suffix.ruby
+        6: constant.numeric.value.ruby
         7: punctuation.separator.decimal.ruby
-        8: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby invalid.illegal.numeric.ruby
-        9: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
-        10: meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby invalid.illegal.numeric.ruby
+        8: constant.numeric.suffix.ruby invalid.illegal.numeric.ruby
+        9: constant.numeric.suffix.ruby
+        10: constant.numeric.suffix.ruby invalid.illegal.numeric.ruby
     # hexadecimal rational numbers: 0xAr
     - match: '\b(0[xX])({{hex_digits}})(r)\b'
+      scope: meta.number.rational.hexadecimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.rational.hexadecimal.ruby
-        2: meta.number.value.ruby constant.numeric.rational.hexadecimal.ruby
-        3: meta.number.suffix.ruby constant.numeric.rational.hexadecimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
     # octal rational numbers: 0o1r, 01r
     - match: '\b(0[oO]?)({{oct_digits}})(r)\b'
+      scope: meta.number.rational.octal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.rational.octal.ruby
-        2: meta.number.value.ruby constant.numeric.rational.octal.ruby
-        3: meta.number.suffix.ruby constant.numeric.rational.octal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
     # binary rational numbers: 0b1r
     - match: '\b(0[bB])({{bin_digits}})(r)\b'
+      scope: meta.number.rational.binary.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.rational.binary.ruby
-        2: meta.number.value.ruby constant.numeric.rational.binary.ruby
-        3: meta.number.suffix.ruby constant.numeric.rational.binary.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: constant.numeric.suffix.ruby
     # decimal rational numbers: 0d1r, 1r, 1.1r
-    - match: '\b(?:(0[dD])?({{dec_digits}})|({{dec_digits}}(\.){{dec_digits}}))(r)\b'
+    - match: '\b(0[dD])?({{dec_digits}}|{{dec_digits}}(\.){{dec_digits}})(r)\b'
+      scope: meta.number.rational.decimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.rational.decimal.ruby
-        2: meta.number.value.ruby constant.numeric.rational.decimal.ruby
-        3: meta.number.value.ruby constant.numeric.rational.decimal.ruby
-        4: punctuation.separator.decimal.ruby
-        5: meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
+        3: punctuation.separator.decimal.ruby
+        4: constant.numeric.suffix.ruby
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
     - match: '\b({{dec_digits}})(?:((\.){{dec_digits}})|((?:(\.){{dec_digits}})?{{dec_exponent}})(r)?)\b'
+      scope: meta.number.float.decimal.ruby
       captures:
-        1: meta.number.value.ruby constant.numeric.float.decimal.ruby
-        2: meta.number.value.ruby constant.numeric.float.decimal.ruby
+        1: constant.numeric.value.ruby
+        2: constant.numeric.value.ruby
         3: punctuation.separator.decimal.ruby
-        4: meta.number.value.ruby constant.numeric.float.decimal.ruby
+        4: constant.numeric.value.ruby
         5: punctuation.separator.decimal.ruby
-        6: meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
+        6: constant.numeric.suffix.ruby invalid.illegal.numeric.rational.ruby
     # hexadecimal integer numbers: 0xA
     - match: '\b(0[xX])({{hex_digits}})\b'
+      scope: meta.number.integer.hexadecimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
-        2: meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
     # octal integer numbers: 0o1, 01
     - match: '\b(0[oO]?)({{oct_digits}})\b'
+      scope: meta.number.integer.octal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.integer.octal.ruby
-        2: meta.number.value.ruby constant.numeric.integer.octal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
     # binary integer numbers: 0b1
     - match: '\b(0[bB])({{bin_digits}})\b'
+      scope: meta.number.integer.binary.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.integer.binary.ruby
-        2: meta.number.value.ruby constant.numeric.integer.binary.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
     # decimal integer numbers: 0d1, 1
     - match: '\b(0[dD])?({{dec_digits}})\b'
+      scope: meta.number.integer.decimal.ruby
       captures:
-        1: meta.number.base.ruby constant.numeric.integer.decimal.ruby
-        2: meta.number.value.ruby constant.numeric.integer.decimal.ruby
+        1: constant.numeric.base.ruby
+        2: constant.numeric.value.ruby
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby
@@ -355,7 +367,7 @@ contexts:
           scope: meta.braces.ruby punctuation.section.braces.end.ruby
           pop: true
         - match: \h{0,6}
-          scope: constant.numeric.integer.hexadecimal.ruby
+          scope: meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
         - match: \S
           scope: invalid.illegal.escape.ruby
     - match: |-

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -195,192 +195,192 @@ BAR
 ##################
 
  1234
-#^^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
  1_234
-#^^^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^^^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
  0d170
-#^^ meta.number.base.ruby constant.numeric.integer.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^ meta.number.integer.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
  0D170
-#^^ meta.number.base.ruby constant.numeric.integer.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^ meta.number.integer.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
  0xAa
-#^^ meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
+#^^ meta.number.integer.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
  0XAa
-#^^ meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
+#^^ meta.number.integer.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
  0252
-#^ meta.number.base.ruby constant.numeric.integer.octal.ruby
-# ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
+#^ meta.number.integer.octal.ruby constant.numeric.base.ruby
+# ^^^ meta.number.integer.octal.ruby constant.numeric.value.ruby
  0o252
-#^^ meta.number.base.ruby constant.numeric.integer.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
+#^^ meta.number.integer.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.integer.octal.ruby constant.numeric.value.ruby
  0O252
-#^^ meta.number.base.ruby constant.numeric.integer.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
+#^^ meta.number.integer.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.integer.octal.ruby constant.numeric.value.ruby
  0b10101010
-#^^ meta.number.base.ruby constant.numeric.integer.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.integer.binary.ruby
+#^^ meta.number.integer.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.integer.binary.ruby constant.numeric.value.ruby
  0B10101010
-#^^ meta.number.base.ruby constant.numeric.integer.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.integer.binary.ruby
+#^^ meta.number.integer.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.integer.binary.ruby constant.numeric.value.ruby
  12.
-#^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
  12.ir
-#^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
+#^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
 #   ^^ - constant.numeric - invalid.illegal - storage.type.numeric
 
  12.34
-#^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
+#^^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.separator.decimal
  1234e-2
-#^^^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
+#^^^^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
  1.234E1
-#^^^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
+#^^^^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
 # ^ punctuation.separator.decimal
  12e3r
-#^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
-#    ^ meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
+#^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
+#    ^ meta.number.float.decimal.ruby constant.numeric.suffix.ruby invalid.illegal.numeric.rational.ruby
  1.2e3r
-#^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
+#^^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
 # ^ punctuation.separator.decimal
-#     ^ meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
+#     ^ meta.number.float.decimal.ruby constant.numeric.suffix.ruby invalid.illegal.numeric.rational.ruby
 
  12r
-#^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
-#  ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
+#^^ meta.number.rational.decimal.ruby constant.numeric.value.ruby
+#  ^ meta.number.rational.decimal.ruby constant.numeric.suffix.ruby
  12.3r
-#^^^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
+#^^^^ meta.number.rational.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.separator.decimal
-#    ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
+#    ^ meta.number.rational.decimal.ruby constant.numeric.suffix.ruby
  0d170r
-#^^ meta.number.base.ruby constant.numeric.rational.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
-#     ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
+#^^ meta.number.rational.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.rational.decimal.ruby constant.numeric.value.ruby
+#     ^ meta.number.rational.decimal.ruby constant.numeric.suffix.ruby
  0xAar
-#^^ meta.number.base.ruby constant.numeric.rational.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.rational.hexadecimal.ruby
-#    ^ meta.number.suffix.ruby constant.numeric.rational.hexadecimal.ruby
+#^^ meta.number.rational.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.rational.hexadecimal.ruby constant.numeric.value.ruby
+#    ^ meta.number.rational.hexadecimal.ruby constant.numeric.suffix.ruby
  0o252r
-#^^ meta.number.base.ruby constant.numeric.rational.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.rational.octal.ruby
-#     ^ meta.number.suffix.ruby constant.numeric.rational.octal.ruby
+#^^ meta.number.rational.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.rational.octal.ruby constant.numeric.value.ruby
+#     ^ meta.number.rational.octal.ruby constant.numeric.suffix.ruby
  0b10101010r
-#^^ meta.number.base.ruby constant.numeric.rational.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.rational.binary.ruby
-#          ^ meta.number.suffix.ruby constant.numeric.rational.binary.ruby
+#^^ meta.number.rational.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.rational.binary.ruby constant.numeric.value.ruby
+#          ^ meta.number.rational.binary.ruby constant.numeric.suffix.ruby
 
  12i
-#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#  ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#  ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12.3i
-#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.separator.decimal
-#   ^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#    ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12e3i
-#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#    ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#    ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12e-3i
-#^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#     ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  1.2e3i
-#^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 # ^ punctuation.separator.decimal
-#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#     ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  1.2e-3i
-#^^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 # ^ punctuation.separator.decimal
-#      ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#      ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12ri
-#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#  ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12.3ri
-#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.separator.decimal
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#    ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  0d170i
-#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#     ^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  0d170ri
-#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#     ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  0xAai
-#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
-#    ^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
+#^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.value.ruby
+#    ^ meta.number.imaginary.hexadecimal.ruby constant.numeric.suffix.ruby
  0xAari
-#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
+#^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.value.ruby
+#    ^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.suffix.ruby
  0o252i
-#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
-#     ^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
+#^^ meta.number.imaginary.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.octal.ruby constant.numeric.value.ruby
+#     ^ meta.number.imaginary.octal.ruby constant.numeric.suffix.ruby
  0o252ri
-#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
+#^^ meta.number.imaginary.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.octal.ruby constant.numeric.value.ruby
+#     ^^ meta.number.imaginary.octal.ruby constant.numeric.suffix.ruby
  0b10101010i
-#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
-#          ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.imaginary.binary.ruby constant.numeric.value.ruby
+#          ^ meta.number.imaginary.binary.ruby constant.numeric.suffix.ruby
  0b10101010ri
-#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
-#          ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.imaginary.binary.ruby constant.numeric.value.ruby
+#          ^^ meta.number.imaginary.binary.ruby constant.numeric.suffix.ruby
  12e3ri
-#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#    ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #    ^ invalid.illegal.numeric
  1.2e3ri
-#^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#   ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#   ^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 #     ^ invalid.illegal.numeric.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#     ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
  12ir
-#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#  ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #   ^ invalid.illegal.numeric
  12.3ir
-#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.separator.decimal
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#    ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #     ^ invalid.illegal.numeric
  12e3ir
-#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#  ^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#    ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #     ^ invalid.illegal.numeric
  1.2e3ir
-#^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
 # ^ punctuation.separator.decimal
-#   ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#   ^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#     ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #      ^ invalid.illegal.numeric
  0d170ir
-#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.decimal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.decimal.ruby constant.numeric.value.ruby
+#     ^^ meta.number.imaginary.decimal.ruby constant.numeric.suffix.ruby
 #      ^ invalid.illegal.numeric
  0xAair
-#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
-#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
-#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
+#^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.base.ruby
+#  ^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.value.ruby
+#    ^^ meta.number.imaginary.hexadecimal.ruby constant.numeric.suffix.ruby
 #     ^ invalid.illegal.numeric
  0o252ir
-#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
-#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
-#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
+#^^ meta.number.imaginary.octal.ruby constant.numeric.base.ruby
+#  ^^^ meta.number.imaginary.octal.ruby constant.numeric.value.ruby
+#     ^^ meta.number.imaginary.octal.ruby constant.numeric.suffix.ruby
 #      ^ invalid.illegal.numeric
  0b10101010ir
-#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
-#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
-#          ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
+#^^ meta.number.imaginary.binary.ruby constant.numeric.base.ruby
+#  ^^^^^^^^ meta.number.imaginary.binary.ruby constant.numeric.value.ruby
+#          ^^ meta.number.imaginary.binary.ruby constant.numeric.suffix.ruby
 #           ^ invalid.illegal.numeric
 
 ##################
@@ -695,15 +695,15 @@ Symbol === :foo
 #    ^^^^ meta.constant.ruby meta.braces.ruby - constant.character.ruby
 # ^ punctuation.definition.constant.ruby
 #    ^ punctuation.section.braces.begin.ruby
-#     ^^ constant.numeric.integer.hexadecimal.ruby
+#     ^^ meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
 #       ^ punctuation.section.braces.end.ruby
   ?\u{012ACF 0gxs}
 # ^^^ meta.constant.ruby - meta.braces.ruby constant.character.ruby
 #    ^^^^^^^^^^^^^ meta.constant.ruby meta.braces.ruby - constant.character.ruby
 # ^ punctuation.definition.constant.ruby
 #    ^ punctuation.section.braces.begin.ruby
-#     ^^^^^^ constant.numeric.integer.hexadecimal.ruby
-#            ^ constant.numeric.integer.hexadecimal.ruby
+#     ^^^^^^ meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
+#            ^ meta.number.integer.hexadecimal.ruby constant.numeric.value.ruby
 #             ^^^ invalid.illegal.escape.ruby
 #                ^ punctuation.section.braces.end.ruby
 
@@ -721,7 +721,7 @@ Symbol === :foo
 #       ^^ constant.character.ruby
 #         ^ - constant
 #          ^ keyword.operator.conditional.ruby
-#           ^^ constant.numeric.integer.decimal.ruby
+#           ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
   ?a ?A ?あ ?abc ?a0
 #^ - constant
 # ^ punctuation.definition.constant.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -195,190 +195,192 @@ BAR
 ##################
 
  1234
-#^^^^ constant.numeric.integer.decimal
+#^^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
  1_234
-#^^^^^ constant.numeric.integer.decimal
+#^^^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
  0d170
-#^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
  0D170
-#^^^^^ constant.numeric.integer.decimal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
  0xAa
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
  0XAa
-#^^^^ constant.numeric.integer.hexadecimal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.integer.hexadecimal.ruby
  0252
-#^^^^ constant.numeric.integer.octal
-#^ punctuation.definition.numeric.base
+#^ meta.number.base.ruby constant.numeric.integer.octal.ruby
+# ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
  0o252
-#^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
  0O252
-#^^^^^ constant.numeric.integer.octal
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.integer.octal.ruby
  0b10101010
-#^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.integer.binary.ruby
  0B10101010
-#^^^^^^^^^^ constant.numeric.integer.binary
-#^^ punctuation.definition.numeric.base
+#^^ meta.number.base.ruby constant.numeric.integer.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.integer.binary.ruby
  12.
-#^^ constant.numeric.integer.decimal
+#^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
  12.ir
-#^^ constant.numeric.integer.decimal
+#^^ meta.number.value.ruby constant.numeric.integer.decimal.ruby
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
 #   ^^ - constant.numeric - invalid.illegal - storage.type.numeric
 
  12.34
-#^^^^^ constant.numeric.float.decimal
+#^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
 #  ^ punctuation.separator.decimal
  1234e-2
-#^^^^^^^ constant.numeric.float.decimal
+#^^^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
  1.234E1
-#^^^^^^^ constant.numeric.float.decimal
+#^^^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
 # ^ punctuation.separator.decimal
  12e3r
-#^^^^^ constant.numeric.float.decimal
-#    ^ invalid.illegal.numeric
+#^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
+#    ^ meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
  1.2e3r
-#^^^^^^ constant.numeric.float.decimal
+#^^^^^ meta.number.value.ruby constant.numeric.float.decimal.ruby
 # ^ punctuation.separator.decimal
-#     ^ invalid.illegal.numeric
+#     ^ meta.number.suffix.ruby constant.numeric.float.decimal.ruby invalid.illegal.numeric.rational.ruby
 
  12r
-#^^^ constant.numeric.rational.decimal
-#  ^ storage.type.numeric
+#^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
+#  ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
  12.3r
-#^^^^^ constant.numeric.rational.decimal
+#^^^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
 #  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric
+#    ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
  0d170r
-#^^^^^^ constant.numeric.rational.decimal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.rational.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.rational.decimal.ruby
+#     ^ meta.number.suffix.ruby constant.numeric.rational.decimal.ruby
  0xAar
-#^^^^^ constant.numeric.rational.hexadecimal
-#^^ punctuation.definition.numeric.base
-#    ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.rational.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.rational.hexadecimal.ruby
+#    ^ meta.number.suffix.ruby constant.numeric.rational.hexadecimal.ruby
  0o252r
-#^^^^^^ constant.numeric.rational.octal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.rational.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.rational.octal.ruby
+#     ^ meta.number.suffix.ruby constant.numeric.rational.octal.ruby
  0b10101010r
-#^^^^^^^^^^^ constant.numeric.rational.binary
-#^^ punctuation.definition.numeric.base
-#          ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.rational.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.rational.binary.ruby
+#          ^ meta.number.suffix.ruby constant.numeric.rational.binary.ruby
 
  12i
-#^^^ constant.numeric.imaginary.decimal
-#  ^ storage.type.numeric
+#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#  ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12.3i
-#^^^^^ constant.numeric.imaginary.decimal
+#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 #  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric
+#   ^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
  12e3i
-#^^^^^ constant.numeric.imaginary.decimal
-#    ^ storage.type.numeric
+#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#    ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12e-3i
-#^^^^^^ constant.numeric.imaginary.decimal
-#     ^ storage.type.numeric
+#^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  1.2e3i
-#^^^^^^ constant.numeric.imaginary.decimal
+#^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 # ^ punctuation.separator.decimal
-#     ^ storage.type.numeric
+#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  1.2e-3i
-#^^^^^^^ constant.numeric.imaginary.decimal
+#^^^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 # ^ punctuation.separator.decimal
-#      ^ storage.type.numeric
+#      ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12ri
-#^^^^ constant.numeric.imaginary.decimal
-#  ^^ storage.type.numeric
+#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12.3ri
-#^^^^^^ constant.numeric.imaginary.decimal
+#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 #  ^ punctuation.separator.decimal
-#    ^^ storage.type.numeric
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  0d170i
-#^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  0d170ri
-#^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
-#     ^^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  0xAai
-#^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
-#    ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
+#    ^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
  0xAari
-#^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
-#    ^^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
  0o252i
-#^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
+#     ^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
  0o252ri
-#^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
-#     ^^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
  0b10101010i
-#^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
-#          ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
+#          ^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  0b10101010ri
-#^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
-#          ^^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
+#          ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12e3ri
-#^^^^^^ constant.numeric.imaginary.decimal
+#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #    ^ invalid.illegal.numeric
-#     ^ storage.type.numeric
  1.2e3ri
-#^^^^^^^ constant.numeric.imaginary.decimal
-# ^ punctuation.separator.decimal
-#     ^ invalid.illegal.numeric
-#      ^ storage.type.numeric
+#^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#   ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^ invalid.illegal.numeric.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
  12ir
-#^^^^ constant.numeric.imaginary.decimal
-#  ^ storage.type.numeric
+#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #   ^ invalid.illegal.numeric
  12.3ir
-#^^^^^^ constant.numeric.imaginary.decimal
+#^^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 #  ^ punctuation.separator.decimal
-#    ^ storage.type.numeric
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #     ^ invalid.illegal.numeric
  12e3ir
-#^^^^^^ constant.numeric.imaginary.decimal
-#    ^ storage.type.numeric
+#^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #     ^ invalid.illegal.numeric
  1.2e3ir
-#^^^^^^^ constant.numeric.imaginary.decimal
+#^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
 # ^ punctuation.separator.decimal
-#     ^ storage.type.numeric
+#   ^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #      ^ invalid.illegal.numeric
  0d170ir
-#^^^^^^^ constant.numeric.imaginary.decimal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.decimal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.decimal.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #      ^ invalid.illegal.numeric
  0xAair
-#^^^^^^ constant.numeric.imaginary.hexadecimal
-#^^ punctuation.definition.numeric.base
-#    ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.hexadecimal.ruby
+#  ^^ meta.number.value.ruby constant.numeric.imaginary.hexadecimal.ruby
+#    ^^ meta.number.suffix.ruby constant.numeric.imaginary.hexadecimal.ruby
 #     ^ invalid.illegal.numeric
  0o252ir
-#^^^^^^^ constant.numeric.imaginary.octal
-#^^ punctuation.definition.numeric.base
-#     ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.octal.ruby
+#  ^^^ meta.number.value.ruby constant.numeric.imaginary.octal.ruby
+#     ^^ meta.number.suffix.ruby constant.numeric.imaginary.octal.ruby
 #      ^ invalid.illegal.numeric
  0b10101010ir
-#^^^^^^^^^^^^ constant.numeric.imaginary.binary
-#^^ punctuation.definition.numeric.base
-#          ^ storage.type.numeric
+#^^ meta.number.base.ruby constant.numeric.imaginary.binary.ruby
+#  ^^^^^^^^ meta.number.value.ruby constant.numeric.imaginary.binary.ruby
+#          ^^ meta.number.suffix.ruby constant.numeric.imaginary.binary.ruby
 #           ^ invalid.illegal.numeric
 
 ##################


### PR DESCRIPTION
This PR is a proposal created from the latest discussion at #2460 

It is to illustrate what it means to add `meta.number` scopes. It means to add one or up to 3 additional capture groups per match pattern to assign `meta.numbers.[base|value|suffix]`. The complexity is the same for applying `meta.numbers` on top of below `constant.numeric`.