### PR TITLE
[JavaScript] Meta Numbers

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1835,44 +1835,49 @@ contexts:
           # .1, .1e1, .1e-1
           | (\.) {{dec_digit}}+ (?:{{dec_exponent}})?
         ){{identifier_break}}
+      scope: meta.number.float.decimal.js constant.numeric.value.js
       captures:
-        0: meta.number.float.decimal.js constant.numeric.value.js
         1: punctuation.separator.decimal.js
         2: punctuation.separator.decimal.js
       pop: true
 
     # integers
     - match: (0)({{dec_digit}}+){{identifier_break}}
+      scope: meta.number.integer.octal.js
       captures:
-        1: meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
-        2: meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
+        1: constant.numeric.base.js invalid.deprecated.numeric.octal.js
+        2: constant.numeric.value.js invalid.deprecated.numeric.octal.js
       pop: true
 
     - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
+      scope: meta.number.integer.hexadecimal.js
       captures:
-        1: meta.number.integer.hexadecimal.js constant.numeric.base.js
-        2: meta.number.integer.hexadecimal.js constant.numeric.value.js
-        3: meta.number.integer.hexadecimal.js constant.numeric.suffix.js
+        1: constant.numeric.base.js
+        2: constant.numeric.value.js
+        3: constant.numeric.suffix.js
       pop: true
 
     - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
+      scope: meta.number.integer.octal.js
       captures:
-        1: meta.number.integer.octal.js constant.numeric.base.js
-        2: meta.number.integer.octal.js constant.numeric.value.js
-        3: meta.number.integer.octal.js constant.numeric.suffix.js
+        1: constant.numeric.base.js
+        2: constant.numeric.value.js
+        3: constant.numeric.suffix.js
       pop: true
 
     - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
+      scope: meta.number.integer.binary.js
       captures:
-        1: meta.number.integer.binary.js constant.numeric.base.js
-        2: meta.number.integer.binary.js constant.numeric.value.js
-        3: meta.number.integer.binary.js constant.numeric.suffix.js
+        1: constant.numeric.base.js
+        2: constant.numeric.value.js
+        3: constant.numeric.suffix.js
       pop: true
 
     - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
+      scope: meta.number.integer.decimal.js
       captures:
-        1: meta.number.integer.decimal.js constant.numeric.value.js
-        2: meta.number.integer.decimal.js constant.numeric.suffix.js
+        1: constant.numeric.value.js
+        2: constant.numeric.suffix.js
       pop: true
 
     # illegal numbers

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -15,7 +15,7 @@ variables:
   dec_digit: '[0-9_]'
   hex_digit: '[\h_]'
   dec_integer: (?:0|[1-9]{{dec_digit}}*)
-  dec_exponent: (?:[Ee](?:[-+]|(?![-+])){{dec_digit}}*)
+  dec_exponent: ([Ee](?:[-+]|(?![-+])){{dec_digit}}*)
 
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
@@ -1831,46 +1831,53 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          {{dec_integer}} (?: (\.) {{dec_digit}}* {{dec_exponent}}? | {{dec_exponent}} )
+          ({{dec_integer}}) (?: ((\.) {{dec_digit}}*) {{dec_exponent}}? | {{dec_exponent}} )
           # .1, .1e1, .1e-1
-          | (\.) {{dec_digit}}+ {{dec_exponent}}?
+          | ((\.) {{dec_digit}}+) {{dec_exponent}}?
         ){{identifier_break}}
-      scope: constant.numeric.float.decimal.js
       captures:
-        1: punctuation.separator.decimal.js
-        2: punctuation.separator.decimal.js
+        1: meta.number.mantissa.js constant.numeric.float.decimal.js
+        2: meta.number.mantissa.js constant.numeric.float.decimal.js
+        3: punctuation.separator.decimal.js
+        4: meta.number.exponent.js constant.numeric.float.decimal.js
+        5: meta.number.exponent.js constant.numeric.float.decimal.js
+        6: meta.number.mantissa.js constant.numeric.float.decimal.js
+        7: punctuation.separator.decimal.js
+        8: meta.number.exponent.js constant.numeric.float.decimal.js
       pop: true
 
     # integers
-    - match: 0{{dec_digit}}+{{identifier_break}}
-      scope: constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+    - match: (0)({{dec_digit}}+){{identifier_break}}
+      captures:
+        1: meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+        2: meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
-    - match: (0[Xx]){{hex_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.hexadecimal.js
+    - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.hexadecimal.js
+        2: meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+        3: meta.number.type.js constant.numeric.integer.hexadecimal.js
       pop: true
 
-    - match: (0[Oo]){{oct_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.octal.js
+    - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.octal.js
+        2: meta.number.mantissa.js constant.numeric.integer.octal.js
+        3: meta.number.type.js constant.numeric.integer.octal.js
       pop: true
 
-    - match: (0[Bb]){{bin_digit}}*(n)?{{identifier_break}}
-      scope: constant.numeric.integer.binary.js
+    - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: punctuation.definition.numeric.base.js
-        2: storage.type.numeric.js
+        1: meta.number.base.js constant.numeric.integer.binary.js
+        2: meta.number.mantissa.js constant.numeric.integer.binary.js
+        3: meta.number.type.js constant.numeric.integer.binary.js
       pop: true
 
-    - match: '{{dec_integer}}(n|(?!\.)){{identifier_break}}'
-      scope: constant.numeric.integer.decimal.js
+    - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       captures:
-        1: storage.type.numeric.js
+        1: meta.number.mantissa.js constant.numeric.integer.decimal.js
+        2: meta.number.type.js constant.numeric.integer.decimal.js
       pop: true
 
     # illegal numbers

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1836,47 +1836,47 @@ contexts:
           | ((\.) {{dec_digit}}+) {{dec_exponent}}?
         ){{identifier_break}}
       captures:
-        1: meta.number.mantissa.js constant.numeric.float.decimal.js
-        2: meta.number.mantissa.js constant.numeric.float.decimal.js
+        1: meta.number.value.mantissa.js constant.numeric.float.decimal.js
+        2: meta.number.value.mantissa.js constant.numeric.float.decimal.js
         3: punctuation.separator.decimal.js
-        4: meta.number.exponent.js constant.numeric.float.decimal.js
-        5: meta.number.exponent.js constant.numeric.float.decimal.js
-        6: meta.number.mantissa.js constant.numeric.float.decimal.js
+        4: meta.number.value.exponent.js constant.numeric.float.decimal.js
+        5: meta.number.value.exponent.js constant.numeric.float.decimal.js
+        6: meta.number.value.mantissa.js constant.numeric.float.decimal.js
         7: punctuation.separator.decimal.js
-        8: meta.number.exponent.js constant.numeric.float.decimal.js
+        8: meta.number.value.exponent.js constant.numeric.float.decimal.js
       pop: true
 
     # integers
     - match: (0)({{dec_digit}}+){{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-        2: meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+        2: meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
       pop: true
 
     - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.hexadecimal.js
-        2: meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+        2: meta.number.value.js constant.numeric.integer.hexadecimal.js
         3: meta.number.type.js constant.numeric.integer.hexadecimal.js
       pop: true
 
     - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.octal.js
-        2: meta.number.mantissa.js constant.numeric.integer.octal.js
+        2: meta.number.value.js constant.numeric.integer.octal.js
         3: meta.number.type.js constant.numeric.integer.octal.js
       pop: true
 
     - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.binary.js
-        2: meta.number.mantissa.js constant.numeric.integer.binary.js
+        2: meta.number.value.js constant.numeric.integer.binary.js
         3: meta.number.type.js constant.numeric.integer.binary.js
       pop: true
 
     - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       captures:
-        1: meta.number.mantissa.js constant.numeric.integer.decimal.js
+        1: meta.number.value.js constant.numeric.integer.decimal.js
         2: meta.number.type.js constant.numeric.integer.decimal.js
       pop: true
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1836,7 +1836,7 @@ contexts:
           | (\.) {{dec_digit}}+ (?:{{dec_exponent}})?
         ){{identifier_break}}
       captures:
-        0: meta.number.value.js constant.numeric.float.decimal.js
+        0: meta.number.float.decimal.js constant.numeric.value.js
         1: punctuation.separator.decimal.js
         2: punctuation.separator.decimal.js
       pop: true
@@ -1844,35 +1844,35 @@ contexts:
     # integers
     - match: (0)({{dec_digit}}+){{identifier_break}}
       captures:
-        1: meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-        2: meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+        1: meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
+        2: meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
       pop: true
 
     - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: meta.number.base.js constant.numeric.integer.hexadecimal.js
-        2: meta.number.value.js constant.numeric.integer.hexadecimal.js
-        3: meta.number.suffix.js constant.numeric.integer.hexadecimal.js
+        1: meta.number.integer.hexadecimal.js constant.numeric.base.js
+        2: meta.number.integer.hexadecimal.js constant.numeric.value.js
+        3: meta.number.integer.hexadecimal.js constant.numeric.suffix.js
       pop: true
 
     - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: meta.number.base.js constant.numeric.integer.octal.js
-        2: meta.number.value.js constant.numeric.integer.octal.js
-        3: meta.number.suffix.js constant.numeric.integer.octal.js
+        1: meta.number.integer.octal.js constant.numeric.base.js
+        2: meta.number.integer.octal.js constant.numeric.value.js
+        3: meta.number.integer.octal.js constant.numeric.suffix.js
       pop: true
 
     - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       captures:
-        1: meta.number.base.js constant.numeric.integer.binary.js
-        2: meta.number.value.js constant.numeric.integer.binary.js
-        3: meta.number.suffix.js constant.numeric.integer.binary.js
+        1: meta.number.integer.binary.js constant.numeric.base.js
+        2: meta.number.integer.binary.js constant.numeric.value.js
+        3: meta.number.integer.binary.js constant.numeric.suffix.js
       pop: true
 
     - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       captures:
-        1: meta.number.value.js constant.numeric.integer.decimal.js
-        2: meta.number.suffix.js constant.numeric.integer.decimal.js
+        1: meta.number.integer.decimal.js constant.numeric.value.js
+        2: meta.number.integer.decimal.js constant.numeric.suffix.js
       pop: true
 
     # illegal numbers

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -15,7 +15,7 @@ variables:
   dec_digit: '[0-9_]'
   hex_digit: '[\h_]'
   dec_integer: (?:0|[1-9]{{dec_digit}}*)
-  dec_exponent: ([Ee](?:[-+]|(?![-+])){{dec_digit}}*)
+  dec_exponent: '[Ee](?:[-+]|(?![-+])){{dec_digit}}*'
 
   identifier_escape: (?:\\u(?:\h{4}|\{\h+\}))
   identifier_start: (?:[_$\p{L}\p{Nl}]|{{identifier_escape}})
@@ -1831,9 +1831,9 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          ({{dec_integer}}) (?: ((\.) {{dec_digit}}*) {{dec_exponent}}? | {{dec_exponent}} )
+          ({{dec_integer}}) (?: ((\.) {{dec_digit}}*) ({{dec_exponent}})? | ({{dec_exponent}}) )
           # .1, .1e1, .1e-1
-          | ((\.) {{dec_digit}}+) {{dec_exponent}}?
+          | ((\.) {{dec_digit}}+) ({{dec_exponent}})?
         ){{identifier_break}}
       captures:
         1: meta.number.value.mantissa.js constant.numeric.float.decimal.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1831,19 +1831,14 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          ({{dec_integer}}) (?: ((\.) {{dec_digit}}*) ({{dec_exponent}})? | ({{dec_exponent}}) )
+          {{dec_integer}} (?: (\.) {{dec_digit}}* (?:{{dec_exponent}})? | {{dec_exponent}} )
           # .1, .1e1, .1e-1
-          | ((\.) {{dec_digit}}+) ({{dec_exponent}})?
+          | (\.) {{dec_digit}}+ (?:{{dec_exponent}})?
         ){{identifier_break}}
       captures:
-        1: meta.number.value.mantissa.js constant.numeric.float.decimal.js
-        2: meta.number.value.mantissa.js constant.numeric.float.decimal.js
-        3: punctuation.separator.decimal.js
-        4: meta.number.value.exponent.js constant.numeric.float.decimal.js
-        5: meta.number.value.exponent.js constant.numeric.float.decimal.js
-        6: meta.number.value.mantissa.js constant.numeric.float.decimal.js
-        7: punctuation.separator.decimal.js
-        8: meta.number.value.exponent.js constant.numeric.float.decimal.js
+        0: meta.number.value.js constant.numeric.float.decimal.js
+        1: punctuation.separator.decimal.js
+        2: punctuation.separator.decimal.js
       pop: true
 
     # integers
@@ -1857,27 +1852,27 @@ contexts:
       captures:
         1: meta.number.base.js constant.numeric.integer.hexadecimal.js
         2: meta.number.value.js constant.numeric.integer.hexadecimal.js
-        3: meta.number.type.js constant.numeric.integer.hexadecimal.js
+        3: meta.number.suffix.js constant.numeric.integer.hexadecimal.js
       pop: true
 
     - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.octal.js
         2: meta.number.value.js constant.numeric.integer.octal.js
-        3: meta.number.type.js constant.numeric.integer.octal.js
+        3: meta.number.suffix.js constant.numeric.integer.octal.js
       pop: true
 
     - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       captures:
         1: meta.number.base.js constant.numeric.integer.binary.js
         2: meta.number.value.js constant.numeric.integer.binary.js
-        3: meta.number.type.js constant.numeric.integer.binary.js
+        3: meta.number.suffix.js constant.numeric.integer.binary.js
       pop: true
 
     - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       captures:
         1: meta.number.value.js constant.numeric.integer.decimal.js
-        2: meta.number.type.js constant.numeric.integer.decimal.js
+        2: meta.number.suffix.js constant.numeric.integer.decimal.js
       pop: true
 
     # illegal numbers

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1857,11 +1857,11 @@ function yy (a, b) {
 // Integers
 
     123_456_789_0n;
-//  ^^^^^^^^^^^^^^ constant.numeric.integer.decimal
-//               ^ storage.type.numeric
+//  ^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.decimal.js
+//               ^ meta.number.type.js constant.numeric.integer.decimal.js
 
     0;
-//  ^ constant.numeric.integer.decimal
+//  ^ meta.number.mantissa.js constant.numeric.integer.decimal.js
 
     123 .foo;
 //  ^^^ constant.numeric.integer.decimal
@@ -1883,54 +1883,60 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     0123456789;
-//  ^^^^^^^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 
     0123456789xyz;
 //  ^^^^^^^^^^^^^ invalid.illegal.numeric.octal
 
     0123456789.xyz;
-//  ^^^^^^^^^^ invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor
 //             ^^^ meta.property.object
 
     0123456789.123;
-//  ^^^^^^^^^^ invalid.deprecated.numeric.octal
-//            ^ punctuation.accessor
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//            ^ punctuation.accessor.js
 //             ^^^ invalid.illegal.illegal-identifier
 
     0b0110_1001_1001_0110n;
-//  ^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
-//                       ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//                       ^ meta.number.type.js constant.numeric.integer.binary.js
 
     0o0123_4567n;
-//  ^^^^^^^^^^^^ constant.numeric.integer.octal
-//  ^^ punctuation.definition.numeric.base
-//             ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.octal.js
+//    ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//             ^ meta.number.type.js constant.numeric.integer.octal.js
 
     0x01_23_45_67_89_ab_CD_efn;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
-//  ^^ punctuation.definition.numeric.base
-//                           ^ storage.type.numeric
+//  ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
+//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//                           ^ meta.number.type.js constant.numeric.integer.hexadecimal.js
 
     0B0; 0O0; 0X0;
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
-//       ^^^ constant.numeric.integer.octal
-//       ^^ punctuation.definition.numeric.base
-//            ^^^ constant.numeric.integer.hexadecimal
-//            ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//     ^ punctuation.terminator.statement.js
+//       ^^ meta.number.base.js constant.numeric.integer.octal.js
+//         ^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//          ^ punctuation.terminator.statement.js
+//            ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
+//              ^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//               ^ punctuation.terminator.statement.js
 
     0b1.foo;
 //  ^^^^^^^ - invalid
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
-//  ^^^ constant.numeric.integer.binary
-//  ^^ punctuation.definition.numeric.base
+//  ^^ meta.number.base.js constant.numeric.integer.binary.js
+//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 
@@ -1941,25 +1947,30 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//               ^ punctuation.separator.decimal.js
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//       ^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     123.456e+789;
-//  ^^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //     ^ punctuation.separator.decimal
+//         ^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     .123E-7_8_9;
-//  ^^^^^^^^^^^ constant.numeric.float.decimal
+//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
+//      ^^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
 
     0123.45;
-//  ^^^^ constant.numeric.integer.octal invalid.deprecated.numeric.octal
+//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //      ^ punctuation.accessor
 //       ^^ invalid.illegal - constant.numeric
 
@@ -1970,7 +1981,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ constant.numeric.float.decimal
+//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1858,7 +1858,7 @@ function yy (a, b) {
 
     123_456_789_0n;
 //  ^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.decimal.js
-//               ^ meta.number.type.js constant.numeric.integer.decimal.js
+//               ^ meta.number.suffix.js constant.numeric.integer.decimal.js
 
     0;
 //  ^ meta.number.value.js constant.numeric.integer.decimal.js
@@ -1904,17 +1904,17 @@ function yy (a, b) {
     0b0110_1001_1001_0110n;
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
 //    ^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.binary.js
-//                       ^ meta.number.type.js constant.numeric.integer.binary.js
+//                       ^ meta.number.suffix.js constant.numeric.integer.binary.js
 
     0o0123_4567n;
 //  ^^ meta.number.base.js constant.numeric.integer.octal.js
 //    ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js
-//             ^ meta.number.type.js constant.numeric.integer.octal.js
+//             ^ meta.number.suffix.js constant.numeric.integer.octal.js
 
     0x01_23_45_67_89_ab_CD_efn;
 //  ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
 //    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.hexadecimal.js
-//                           ^ meta.number.type.js constant.numeric.integer.hexadecimal.js
+//                           ^ meta.number.suffix.js constant.numeric.integer.hexadecimal.js
 
     0B0; 0O0; 0X0;
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
@@ -1947,26 +1947,23 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
 //               ^ punctuation.separator.decimal.js
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
-//       ^^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
 
     123.456e+789;
-//  ^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
 //     ^ punctuation.separator.decimal
-//         ^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
 
     .123E-7_8_9;
-//  ^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
-//      ^^^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
 
     0123.45;
 //  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
@@ -1981,7 +1978,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^ meta.number.value.js constant.numeric.float.decimal.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1857,11 +1857,11 @@ function yy (a, b) {
 // Integers
 
     123_456_789_0n;
-//  ^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.decimal.js
+//  ^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.decimal.js
 //               ^ meta.number.type.js constant.numeric.integer.decimal.js
 
     0;
-//  ^ meta.number.mantissa.js constant.numeric.integer.decimal.js
+//  ^ meta.number.value.js constant.numeric.integer.decimal.js
 
     123 .foo;
 //  ^^^ constant.numeric.integer.decimal
@@ -1884,59 +1884,59 @@ function yy (a, b) {
 
     0123456789;
 //  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 
     0123456789xyz;
 //  ^^^^^^^^^^^^^ invalid.illegal.numeric.octal
 
     0123456789.xyz;
 //  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor
 //             ^^^ meta.property.object
 
     0123456789.123;
 //  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor.js
 //             ^^^ invalid.illegal.illegal-identifier
 
     0b0110_1001_1001_0110n;
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//    ^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.binary.js
 //                       ^ meta.number.type.js constant.numeric.integer.binary.js
 
     0o0123_4567n;
 //  ^^ meta.number.base.js constant.numeric.integer.octal.js
-//    ^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//    ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js
 //             ^ meta.number.type.js constant.numeric.integer.octal.js
 
     0x01_23_45_67_89_ab_CD_efn;
 //  ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
-//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.hexadecimal.js
 //                           ^ meta.number.type.js constant.numeric.integer.hexadecimal.js
 
     0B0; 0O0; 0X0;
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//    ^ meta.number.value.js constant.numeric.integer.binary.js
 //     ^ punctuation.terminator.statement.js
 //       ^^ meta.number.base.js constant.numeric.integer.octal.js
-//         ^ meta.number.mantissa.js constant.numeric.integer.octal.js
+//         ^ meta.number.value.js constant.numeric.integer.octal.js
 //          ^ punctuation.terminator.statement.js
 //            ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
-//              ^ meta.number.mantissa.js constant.numeric.integer.hexadecimal.js
+//              ^ meta.number.value.js constant.numeric.integer.hexadecimal.js
 //               ^ punctuation.terminator.statement.js
 
     0b1.foo;
 //  ^^^^^^^ - invalid
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//    ^ meta.number.value.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
 //  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.mantissa.js constant.numeric.integer.binary.js
+//    ^ meta.number.value.js constant.numeric.integer.binary.js
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 
@@ -1947,30 +1947,30 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
 //               ^ punctuation.separator.decimal.js
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
-//       ^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
+//  ^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
+//       ^^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
 
     123.456e+789;
-//  ^^^^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
 //     ^ punctuation.separator.decimal
-//         ^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
+//         ^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
 
     .123E-7_8_9;
-//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
 //  ^ punctuation.separator.decimal
-//      ^^^^^^^ meta.number.exponent.js constant.numeric.float.decimal.js
+//      ^^^^^^^ meta.number.value.exponent.js constant.numeric.float.decimal.js
 
     0123.45;
 //  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^ meta.number.mantissa.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//   ^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
 //      ^ punctuation.accessor
 //       ^^ invalid.illegal - constant.numeric
 
@@ -1981,7 +1981,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ meta.number.mantissa.js constant.numeric.float.decimal.js
+//  ^^^^ meta.number.value.mantissa.js constant.numeric.float.decimal.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1857,86 +1857,88 @@ function yy (a, b) {
 // Integers
 
     123_456_789_0n;
-//  ^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.decimal.js
-//               ^ meta.number.suffix.js constant.numeric.integer.decimal.js
+//  ^^^^^^^^^^^^^ meta.number.integer.decimal.js constant.numeric.value.js
+//               ^ meta.number.integer.decimal.js constant.numeric.suffix.js
 
     0;
-//  ^ meta.number.value.js constant.numeric.integer.decimal.js
+//  ^ meta.number.integer.decimal.js constant.numeric.value.js
 
     123 .foo;
-//  ^^^ constant.numeric.integer.decimal
+//  ^^^ meta.number.integer.decimal.js constant.numeric.value.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 
     +123;
 //  ^ keyword.operator.arithmetic
-//   ^^^ constant.numeric.integer.decimal - keyword
+//   ^^^ meta.number.integer.decimal.js constant.numeric.value.js - keyword
 
     -123;
 //  ^ keyword.operator.arithmetic
-//   ^^^ constant.numeric.integer.decimal - keyword
+//   ^^^ meta.number.integer.decimal.js constant.numeric.value.js - keyword
 
     + 123;
 //  ^ keyword.operator.arithmetic
+//   ^ - keyword - constant
+//    ^^^ meta.number.integer.decimal.js constant.numeric.value.js - keyword
 
     123xyz;
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     0123456789;
-//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//  ^ meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
 
     0123456789xyz;
 //  ^^^^^^^^^^^^^ invalid.illegal.numeric.octal
 
     0123456789.xyz;
-//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//  ^ meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor
 //             ^^^ meta.property.object
 
     0123456789.123;
-//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//  ^ meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
+//   ^^^^^^^^^ meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
 //            ^ punctuation.accessor.js
 //             ^^^ invalid.illegal.illegal-identifier
 
     0b0110_1001_1001_0110n;
-//  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.binary.js
-//                       ^ meta.number.suffix.js constant.numeric.integer.binary.js
+//  ^^ meta.number.integer.binary.js constant.numeric.base.js
+//    ^^^^^^^^^^^^^^^^^^^ meta.number.integer.binary.js constant.numeric.value.js
+//                       ^ meta.number.integer.binary.js constant.numeric.suffix.js
 
     0o0123_4567n;
-//  ^^ meta.number.base.js constant.numeric.integer.octal.js
-//    ^^^^^^^^^ meta.number.value.js constant.numeric.integer.octal.js
-//             ^ meta.number.suffix.js constant.numeric.integer.octal.js
+//  ^^ meta.number.integer.octal.js constant.numeric.base.js
+//    ^^^^^^^^^ meta.number.integer.octal.js constant.numeric.value.js
+//             ^ meta.number.integer.octal.js constant.numeric.suffix.js
 
     0x01_23_45_67_89_ab_CD_efn;
-//  ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
-//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.integer.hexadecimal.js
-//                           ^ meta.number.suffix.js constant.numeric.integer.hexadecimal.js
+//  ^^ meta.number.integer.hexadecimal.js constant.numeric.base.js
+//    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal.js constant.numeric.value.js
+//                           ^ meta.number.integer.hexadecimal.js constant.numeric.suffix.js
 
     0B0; 0O0; 0X0;
-//  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.value.js constant.numeric.integer.binary.js
+//  ^^ meta.number.integer.binary.js constant.numeric.base.js
+//    ^ meta.number.integer.binary.js constant.numeric.value.js
 //     ^ punctuation.terminator.statement.js
-//       ^^ meta.number.base.js constant.numeric.integer.octal.js
-//         ^ meta.number.value.js constant.numeric.integer.octal.js
+//       ^^ meta.number.integer.octal.js constant.numeric.base.js
+//         ^ meta.number.integer.octal.js constant.numeric.value.js
 //          ^ punctuation.terminator.statement.js
-//            ^^ meta.number.base.js constant.numeric.integer.hexadecimal.js
-//              ^ meta.number.value.js constant.numeric.integer.hexadecimal.js
+//            ^^ meta.number.integer.hexadecimal.js constant.numeric.base.js
+//              ^ meta.number.integer.hexadecimal.js constant.numeric.value.js
 //               ^ punctuation.terminator.statement.js
 
     0b1.foo;
 //  ^^^^^^^ - invalid
-//  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.value.js constant.numeric.integer.binary.js
+//  ^^ meta.number.integer.binary.js constant.numeric.base.js
+//    ^ meta.number.integer.binary.js constant.numeric.value.js
 //     ^ punctuation.accessor
 //      ^^^ meta.property.object
 
     0b1.0;
-//  ^^ meta.number.base.js constant.numeric.integer.binary.js
-//    ^ meta.number.value.js constant.numeric.integer.binary.js
+//  ^^ meta.number.integer.binary.js constant.numeric.base.js
+//    ^ meta.number.integer.binary.js constant.numeric.value.js
 //     ^ punctuation.accessor
 //      ^ invalid.illegal.illegal-identifier
 
@@ -1947,27 +1949,27 @@ function yy (a, b) {
 // Floats
 
     1_234_567_890.123_456_789_0;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.float.decimal.js constant.numeric.value.js
 //               ^ punctuation.separator.decimal.js
 
     .123_456_789_0;
-//  ^^^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^^^ meta.number.float.decimal.js constant.numeric.value.js
 //  ^ punctuation.separator.decimal
 
     12345e6_7_8;
-//  ^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^ meta.number.float.decimal.js constant.numeric.value.js
 
     123.456e+789;
-//  ^^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^^ meta.number.float.decimal.js constant.numeric.value.js
 //     ^ punctuation.separator.decimal
 
     .123E-7_8_9;
-//  ^^^^^^^^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^^^^^^^^ meta.number.float.decimal.js constant.numeric.value.js
 //  ^ punctuation.separator.decimal
 
     0123.45;
-//  ^ meta.number.base.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
-//   ^^^ meta.number.value.js constant.numeric.integer.octal.js invalid.deprecated.numeric.octal.js
+//  ^ meta.number.integer.octal.js constant.numeric.base.js invalid.deprecated.numeric.octal.js
+//   ^^^ meta.number.integer.octal.js constant.numeric.value.js invalid.deprecated.numeric.octal.js
 //      ^ punctuation.accessor
 //       ^^ invalid.illegal - constant.numeric
 
@@ -1978,7 +1980,7 @@ function yy (a, b) {
 //  ^^^^^^ invalid.illegal.numeric.decimal
 
     123..foo;
-//  ^^^^ meta.number.value.js constant.numeric.float.decimal.js
+//  ^^^^ meta.number.float.decimal.js constant.numeric.value.js
 //      ^ punctuation.accessor
 //       ^^^ meta.property.object
 

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -26,7 +26,7 @@ const [ x, [a, b], z] = value;
 const [ x = 42, y = [a, b, c] ] = value;
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //        ^ keyword.operator.assignment
-//          ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
+//          ^^ meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
 //                ^ keyword.operator.assignment
 //                  ^^^^^^^^^ meta.sequence
 //                   ^ variable.other.readwrite - meta.binding.name
@@ -105,7 +105,7 @@ function f ([ x, [a, b], z]) {}
 function f ([ x = 42, y = [a, b, c] ]) {}
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //              ^ keyword.operator.assignment
-//                ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
+//                ^^ meta.function.declaration.js meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
 //                      ^ keyword.operator.assignment
 //                        ^^^^^^^^^ meta.sequence
 //                         ^ variable.other.readwrite - meta.binding.name
@@ -165,7 +165,7 @@ let f = ([ x = 42, y = [a, b, c] ]) => {};
 //  ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //           ^ keyword.operator.assignment
-//             ^^ meta.binding.destructuring.sequence.js constant.numeric.integer.decimal.js
+//             ^^ meta.function.declaration.js meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
 //                   ^ keyword.operator.assignment
 //                     ^^^^^^^^^ meta.sequence
 //                      ^ variable.other.readwrite - meta.binding.name

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -116,7 +116,7 @@
 //       ^^^^^^^^^^^^ source.js.embedded.jsx meta.mapping
 //         ^^^^^ meta.mapping.key
 //              ^ punctuation.separator.key-value
-//               ^^ constant.numeric.integer.decimal
+//               ^^ meta.number.integer.decimal.js constant.numeric.value.js
 //                   ^ punctuation.definition.interpolation.end
 
 
@@ -133,7 +133,7 @@
 //      ^^^^^^^^^^^^ meta.mapping
 //        ^^^^^ meta.mapping.key
 //             ^ punctuation.separator.key-value
-//              ^^ constant.numeric.integer.decimal
+//              ^^ meta.number.integer.decimal.js constant.numeric.value.js
 //                  ^ punctuation.definition.interpolation.end
 
     // baz
@@ -171,7 +171,7 @@
 //   ^^^^^^^^^^^^ meta.mapping
 //     ^^^^^ meta.mapping.key
 //          ^ punctuation.separator.key-value
-//           ^^ constant.numeric.integer.decimal
+//           ^^ meta.number.integer.decimal.js constant.numeric.value.js
 //               ^ punctuation.definition.interpolation.end
 
     {//}

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -77,7 +77,7 @@
         y = 2,
 //      ^ variable.other.readwrite
 //        ^ keyword.operator.assignment
-//          ^ constant.numeric.integer.decimal
+//          ^ meta.number.integer.decimal.js constant.numeric.value.js
 //           ^ punctuation.separator.comma
 
         'FOO'
@@ -412,7 +412,7 @@ let x: any [ "foo" | 'bar' ];
 let x: any [ 0 ];
 //         ^^^^^ meta.type meta.brackets
 //         ^ punctuation.section.brackets.begin
-//           ^ constant.numeric.integer.decimal
+//           ^ meta.number.integer.decimal.js constant.numeric.value.js
 //             ^ punctuation.section.brackets.end
 
 let x: any [
@@ -477,7 +477,7 @@ let x: 'a string';
 //     ^ meta.type meta.string string.quoted.single
 
 let x: 42;
-//     ^^ meta.type constant.numeric.integer.decimal
+//     ^^ meta.number.integer.decimal.js constant.numeric.value.js
 
 let x: typeof Foo;
 //     ^^^^^^^^^^ meta.type


### PR DESCRIPTION
This PR is a proposal created from the latest discussion at #2460

It is to illustrate what it means to add meta.number scopes. It means to add one or up to 1 (2) additional capture groups per match pattern to assign meta.numbers.[base|value|suffix]. The complexity is the same for applying meta.numbers on top of below constant.numeric.

Note: It also contains the older more complex solutions for comparison.