### PR TITLE
[Matlab] Meta Numbers

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -434,23 +434,26 @@ contexts:
       comment: Not equal is written ~= not !=.
       scope: invalid.illegal.invalid-inequality.matlab
   number:
-    - match: '\b(0[xX])\h+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
-      scope: constant.numeric.integer.hexadecimal.matlab
+    - match: '\b(0[xX])(\h+)(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
+      scope: meta.number.integer.hexadecimal.matlab
       captures:
-        1: punctuation.definition.numeric.base.matlab
-        2: storage.type.numeric.matlab
-    - match: '\b(0[bB])[01]+(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
-      scope: constant.numeric.integer.binary.matlab
+        1: constant.numeric.base.matlab
+        2: constant.numeric.value.matlab
+        3: constant.numeric.suffix.matlab
+    - match: '\b(0[bB])([01]+)(u8|u16|u32|u64|s8|s16|s32|s64)?\b'
+      scope: meta.number.integer.binary.matlab
       captures:
-        1: punctuation.definition.numeric.base.matlab
-        2: storage.type.numeric.matlab
-    - match: '(?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?(i|j)\b'
-      scope: constant.numeric.imaginary.decimal.matlab
+        1: constant.numeric.base.matlab
+        2: constant.numeric.value.matlab
+        3: constant.numeric.suffix.matlab
+    - match: '((?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?)(i|j)\b'
+      scope: meta.number.imaginary.decimal.matlab
       captures:
-        1: punctuation.separator.decimal.matlab
-        2: storage.type.numeric.matlab
+        1: constant.numeric.value.matlab
+        2: punctuation.separator.decimal.matlab
+        3: constant.numeric.suffix.matlab
     - match: '(?:\d*(\.))?\d+(?:[Ee][-+]?\d+)?\b'
-      scope: constant.numeric.float.decimal.matlab
+      scope: meta.number.float.decimal.matlab constant.numeric.value.matlab
       captures:
         1: punctuation.separator.decimal.matlab
   operators:

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -41,7 +41,7 @@ x = [ 1.76 ]
 % <- source.matlab meta.variable.other.valid.matlab
 % ^ source.matlab keyword.operator.symbols.matlab
 %   ^ source.matlab punctuation.section.brackets.begin.matlab
-%     ^^^^ source.matlab meta.brackets.matlab constant.numeric.float.decimal.matlab
+%     ^^^^ source.matlab meta.brackets.matlab meta.number.float.decimal.matlab constant.numeric.value.matlab
 %          ^ source.matlab punctuation.section.brackets.end.matlab
 
 
@@ -79,7 +79,7 @@ x = 5
 x = 5 %{ not block comment
 % ^ keyword.operator.symbols.matlab
 x = 5
-%   ^ constant.numeric.float.decimal.matlab
+%   ^ meta.number.float.decimal.matlab constant.numeric.value.matlab
 
 
 %---------------------------------------------
@@ -146,52 +146,62 @@ end
 % Numbers
 
  1
-%^ constant.numeric.float.decimal.matlab
+%^ meta.number.float.decimal.matlab constant.numeric.value.matlab
  .1
-%^^ constant.numeric.float.decimal.matlab
+%^^ meta.number.float.decimal.matlab constant.numeric.value.matlab
 %^ punctuation.separator.decimal.matlab
  1.1
-%^^^ constant.numeric.float.decimal.matlab
+%^^^ meta.number.float.decimal.matlab constant.numeric.value.matlab
 % ^ punctuation.separator.decimal.matlab
  .1e1
-%^^^^ constant.numeric.float.decimal.matlab
+%^^^^ meta.number.float.decimal.matlab constant.numeric.value.matlab
 %^ punctuation.separator.decimal.matlab
  1.1e1
-%^^^^^ constant.numeric.float.decimal.matlab
+%^^^^^ meta.number.float.decimal.matlab constant.numeric.value.matlab
 % ^ punctuation.separator.decimal.matlab
  1e1
-%^^^ constant.numeric.float.decimal.matlab
+%^^^ meta.number.float.decimal.matlab constant.numeric.value.matlab
  1i - (4i)
-%^^ constant.numeric.imaginary.decimal.matlab
-% ^ storage.type.numeric.matlab
-%      ^^ constant.numeric.imaginary.decimal.matlab
-%       ^ storage.type.numeric.matlab
+%^^ meta.number.imaginary.decimal.matlab constant.numeric
+%^ constant.numeric.value.matlab
+% ^ constant.numeric.suffix.matlab
+%      ^^ meta.number.imaginary.decimal.matlab constant.numeric
+%      ^ constant.numeric.value.matlab
+%       ^ constant.numeric.suffix.matlab
  1j
-%^^ constant.numeric.imaginary.decimal.matlab
-% ^ storage.type.numeric.matlab
+%^^ meta.number.imaginary.decimal.matlab constant.numeric
+%^ constant.numeric.value.matlab
+% ^ constant.numeric.suffix.matlab
  1e2j
-%^^^^ constant.numeric.imaginary.decimal.matlab
-%   ^ storage.type.numeric.matlab
+%^^^^ meta.number.imaginary.decimal.matlab constant.numeric
+%^^^ constant.numeric.value.matlab
+%   ^ constant.numeric.suffix.matlab
  0x2A
-%^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^^^ meta.number.integer.hexadecimal.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^ constant.numeric.value.matlab
  0X2A
-%^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^^^ meta.number.integer.hexadecimal.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^ constant.numeric.value.matlab
  0b101010
-%^^^^^^^^ constant.numeric.integer.binary.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^^^^^^^ meta.number.integer.binary.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^^^^^ constant.numeric.value.matlab
  0B101010
-%^^^^^^^^ constant.numeric.integer.binary.matlab
-%^^ punctuation.definition.numeric.base.matlab
+%^^^^^^^^ meta.number.integer.binary.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^^^^^ constant.numeric.value.matlab
  0x2Au8
-%^^^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
-%    ^^ storage.type.numeric.matlab
+%^^^^^^ meta.number.integer.hexadecimal.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^ constant.numeric.value.matlab
+%    ^^ constant.numeric.suffix.matlab
  0x2As32
-%^^^^^^^ constant.numeric.integer.hexadecimal.matlab
-%^^ punctuation.definition.numeric.base.matlab
-%    ^^^ storage.type.numeric.matlab
+%^^^^^^^ meta.number.integer.hexadecimal.matlab constant.numeric
+%^^ constant.numeric.base.matlab
+%  ^^ constant.numeric.value.matlab
+%    ^^^ constant.numeric.suffix.matlab
 
 
 %---------------------------------------------


### PR DESCRIPTION
This implements the approach for meta scopes suggested in https://github.com/sublimehq/Packages/pull/2460#issuecomment-680957362. It is a different approach from #2462 and #2463, because here the number kind and base (radix) are moved to the `meta.number` scope, while the notation to denote the different parts of a number (`base|value|suffix`) is appended to `constant.numeric`.