### PR TITLE
[Markdown] Add scope for EOL in setext headings

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -345,17 +345,19 @@ contexts:
   heading1:
     - meta_scope: markup.heading.1.markdown
     - include: inline-bold-italic-linebreak
-    - match: '^[ \t]{0,3}(={3,})(?=[ \t]*$)'
+    - match: '^[ \t]{0,3}(={3,})(?=[ \t]*$)(\n?)'
       captures:
         1: markup.heading.1.setext.markdown punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
       pop: true
 
   heading2:
     - meta_scope: markup.heading.2.markdown
     - include: inline-bold-italic-linebreak
-    - match: '^[ \t]{0,3}(-{3,})(?=[ \t]*$)'
+    - match: '^[ \t]{0,3}(-{3,})(?=[ \t]*$)(\n?)'
       captures:
         1: markup.heading.2.setext.markdown punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
       pop: true
 
   ampersand:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -24,6 +24,7 @@ Alternate Heading
 | <- markup.heading.1
 =================
 |^^^^^^^^^^^^^^^^ markup.heading.1 punctuation.definition
+|                ^ meta.whitespace.newline
 
 heading underlined with dashes
 | <- markup.heading.2


### PR DESCRIPTION
Continued from https://github.com/sublimehq/Packages/pull/2446 but for setext-style headings. This PR makes the user be able to style the EOL (\n) char (such as adding a background color) just like it can already be done in atx-style headings.

![image](https://user-images.githubusercontent.com/6594915/91784908-9d51e300-ec36-11ea-883c-b2555f3781eb.png)
