### PR TITLE
[HTML] don't indent after DOCTYPE, add indentation tests

### DIFF
--- a/HTML/Indentation Rules.tmPreferences
+++ b/HTML/Indentation Rules.tmPreferences
@@ -26,8 +26,9 @@
 			^.* (
 				# a valid non-self-closing HTML tag that doesn't close itself on the same line
 				<(?!
-					  !--   # no comment
-					| [?%]  # no section
+					  !--      # no comment
+					| [?%]     # no preprocessor section like PHP/ASP
+					| !DOCTYPE # no document type
 					| (?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)[\t\n\f /<>]
 				)(?:
 					# tag name

--- a/HTML/syntax_test_html_indentation.html
+++ b/HTML/syntax_test_html_indentation.html
@@ -1,0 +1,24 @@
+## SYNTAX TEST reindent-unchanged "Packages/HTML/HTML.sublime-syntax"
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Page Title Here</title>
+    <!-- this comment's
+        indentation should
+        be unchanged
+    -->
+</head>
+<body>
+
+    <div class="main">
+        <span class="something">Blah</span>
+        <span class="something">
+            Foobar
+        </span>
+    </div>
+
+    <script type="text/javascript" src="/some_script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds some basic indentation tests for the HTML package, and prevents unexpected indentation from occurring after a `doctype` directive. This follows [the PHP one](https://github.com/sublimehq/Packages/pull/2328), whereby we are only using the test file to make assertions about indentation, not scopes, to keep things simple. (IMO, it would be a fairly invasive style change to rework the existing syntax tests to also assert indentation doesn't change, so a separate test file keeps it neat and tidy.)

EDIT: note that due to the presence of multi-line comments in the test file, we can only assert `reindent-unchanged` and not `reindent-unindented` due to the default `preserveIndent` behavior as mentioned at https://github.com/sublimehq/sublime_text/issues/1271#issuecomment-231296051