### PR TITLE
[YAML] Update numeric scopes to meta.number constant.numeric

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -110,29 +110,33 @@ variables:
 
   # patterns for plain scalars of implicit different types
   # (for the Core Schema: http://www.yaml.org/spec/1.2/spec.html#schema/core/)
-  _type_null: (?:null|Null|NULL|~) # http://yaml.org/type/null.html
-  _type_bool: |- # http://yaml.org/type/bool.html
+  
+  # http://yaml.org/type/null.html
+  _type_null: (?:null|Null|NULL|~)
+  
+  # http://yaml.org/type/bool.html
+  _type_bool: |-
     (?x:
        y|Y|yes|Yes|YES|n|N|no|No|NO
       |true|True|TRUE|false|False|FALSE
       |on|On|ON|off|Off|OFF
     )
-  _type_int: |- # http://yaml.org/type/int.html
-    (?x:
-        ([-+]? (0b) [0-1_]+) # (base 2)
-      | ([-+]? (0)  [0-7_]+) # (base 8)
-      | ([-+]? (?: 0|[1-9][0-9_]*)) # (base 10)
-      | ([-+]? (0x) [0-9a-fA-F_]+) # (base 16)
-      | ([-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+) # (base 60)
-    )
-  _type_float: |- # http://yaml.org/type/float.html
-    (?x:
-        ([-+]? (?: [0-9] [0-9_]*)? (\.) [0-9.]* (?: [eE] [-+] [0-9]+)?) # (base 10)
-      | ([-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ (\.) [0-9_]*) # (base 60)
-      | ([-+]? (\.) (?: inf|Inf|INF)) # (infinity)
-      | (      (\.) (?: nan|NaN|NAN)) # (not a number)
-    )
-  _type_timestamp: |- # http://yaml.org/type/timestamp.html
+
+  # http://yaml.org/type/int.html
+  _type_int_binary: ([-+]?)(0b)([0-1_]+) # (base 2)
+  _type_int_octal: ([-+]?)(0)([0-7_]+) # (base 8)
+  _type_int_decimal: ([-+]?)(0|[1-9][0-9_]*) # (base 10)
+  _type_int_hexadecimal: ([-+]?)(0x)([0-9a-fA-F_]+) # (base 16)
+  _type_int_other: ([-+]?)([1-9][0-9_]*(?::[0-5]?[0-9])+) # (base 60)
+
+  # http://yaml.org/type/float.html
+  _type_float_decimal: ([-+]?)((?:[0-9][0-9_]*)?(\.)[0-9.]*(?:[eE][-+][0-9]+)?)
+  _type_float_other: ([-+]?)([0-9][0-9_]*(?::[0-5]?[0-9])+(\.)[0-9_]*) # (base 60)
+  _type_float_infitity: ([-+]?)((\.)(?:inf|Inf|INF)) # (infinity)
+  _type_float_nan: (\.)(?:nan|NaN|NAN) # (not a number)
+
+  # http://yaml.org/type/timestamp.html
+  _type_timestamp: |-
     (?x:
         \d{4} (-) \d{2} (-) \d{2}       # (y-m-d)
       | \d{4}                           # (year)
@@ -148,19 +152,11 @@ variables:
         )?                              # (time zone)
     )
 
-  _type_value: '=' # http://yaml.org/type/value.html
-  _type_merge: '<<' # http://yaml.org/type/merge.html
+  # http://yaml.org/type/value.html
+  _type_value: '='
 
-  _type_all: |-
-    (?x:
-        ({{_type_null}})
-      | ({{_type_bool}})
-      | ({{_type_int}})
-      | ({{_type_float}})
-      | ({{_type_timestamp}})
-      | ({{_type_value}})
-      | ({{_type_merge}})
-     )
+  # http://yaml.org/type/merge.html
+  _type_merge: '<<'
 
 ##############################################################################
 
@@ -325,99 +321,154 @@ contexts:
           pop: true
 
   flow-scalar-plain-in-implicit-type:
-    - match: |
-        (?x)
-        {{_type_all}}
-        {{_flow_scalar_end_plain_in}}
-      captures: # &implicit_type_captures
-        1: constant.language.null.yaml
-        2: constant.language.boolean.yaml
-        # binary integer
-        4: constant.numeric.integer.binary.yaml
-        5: punctuation.definition.numeric.base.yaml
-        # octal integer
-        6: constant.numeric.integer.octal.yaml
-        7: punctuation.definition.numeric.base.yaml
-        # decimal integer
-        8: constant.numeric.integer.decimal.yaml
-        # hexadecimal integer
-        9: constant.numeric.integer.hexadecimal.yaml
-        10: punctuation.definition.numeric.base.yaml
-        # other integer
-        11: constant.numeric.integer.other.yaml
-        # decimal float
-        13: constant.numeric.float.decimal.yaml
-        14: punctuation.separator.decimal.yaml
-        # other float
-        15: constant.numeric.float.other.yaml
-        16: punctuation.separator.decimal.yaml
-        # infinity float
-        17: constant.numeric.float.other.yaml
-        18: punctuation.separator.decimal.yaml
-        # not a number
-        19: constant.numeric.float.other.yaml
-        20: punctuation.separator.decimal.yaml
-        # timestamp
-        21: constant.other.timestamp.yaml
-        22: punctuation.separator.date.yaml
-        23: punctuation.separator.date.yaml
-        24: punctuation.separator.date.yaml
-        25: punctuation.separator.date.yaml
-        26: punctuation.separator.time.yaml
-        27: punctuation.separator.time.yaml
-        28: punctuation.separator.time.yaml
-        29: punctuation.separator.time.yaml
-        # constants
-        30: constant.language.value.yaml
-        31: constant.language.merge.yaml
+    - match: '{{_type_null}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.null.yaml
+    - match: '{{_type_bool}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.boolean.yaml
+    - match: '{{_type_value}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.value.yaml
+    - match: '{{_type_merge}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.merge.yaml
+    # integers
+    - match: '{{_type_int_binary}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.integer.binary.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_octal}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.integer.octal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_decimal}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.integer.decimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_hexadecimal}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.integer.hexadecimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_other}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.integer.other.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+    # floats
+    - match: '{{_type_float_decimal}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.float.decimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_other}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.float.other.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_infitity}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.float.infinite.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_in}}'
+      scope: meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+      captures:
+        1: punctuation.separator.decimal.yaml
+    # timestamp
+    - match: '{{_type_timestamp}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.other.timestamp.yaml
+      captures:
+        1: punctuation.separator.date.yaml
+        2: punctuation.separator.date.yaml
+        3: punctuation.separator.date.yaml
+        4: punctuation.separator.date.yaml
+        5: punctuation.separator.time.yaml
+        6: punctuation.separator.time.yaml
+        7: punctuation.separator.time.yaml
+        8: punctuation.separator.time.yaml
 
   flow-scalar-plain-out-implicit-type:
-    - match: |
-        (?x)
-        {{_type_all}}
-        {{_flow_scalar_end_plain_out}}
-      captures: # *implicit_type_captures
-        # Alias does not work, see https://github.com/SublimeTextIssues/Core/issues/967
-        1: constant.language.null.yaml
-        2: constant.language.boolean.yaml
-        # binary integer
-        4: constant.numeric.integer.binary.yaml
-        5: punctuation.definition.numeric.base.yaml
-        # octal integer
-        6: constant.numeric.integer.octal.yaml
-        7: punctuation.definition.numeric.base.yaml
-        # decimal integer
-        8: constant.numeric.integer.decimal.yaml
-        # hexadecimal integer
-        9: constant.numeric.integer.hexadecimal.yaml
-        10: punctuation.definition.numeric.base.yaml
-        # other integer
-        11: constant.numeric.integer.other.yaml
-        # decimal float
-        13: constant.numeric.float.decimal.yaml
-        14: punctuation.separator.decimal.yaml
-        # other float
-        15: constant.numeric.float.other.yaml
-        16: punctuation.separator.decimal.yaml
-        # infinity float
-        17: constant.numeric.float.other.yaml
-        18: punctuation.separator.decimal.yaml
-        # not a number
-        19: constant.numeric.float.other.yaml
-        20: punctuation.separator.decimal.yaml
-        # timestamp
-        21: constant.other.timestamp.yaml
-        22: punctuation.separator.date.yaml
-        23: punctuation.separator.date.yaml
-        24: punctuation.separator.date.yaml
-        25: punctuation.separator.date.yaml
-        26: punctuation.separator.time.yaml
-        27: punctuation.separator.time.yaml
-        28: punctuation.separator.time.yaml
-        29: punctuation.separator.time.yaml
-        # constants
-        30: constant.language.value.yaml
-        31: constant.language.merge.yaml
+    - match: '{{_type_null}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.null.yaml
+    - match: '{{_type_bool}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.boolean.yaml
+    - match: '{{_type_value}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.value.yaml
+    - match: '{{_type_merge}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.merge.yaml
+    # integers
+    - match: '{{_type_int_binary}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.integer.binary.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_octal}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.integer.octal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_decimal}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.integer.decimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_hexadecimal}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.integer.hexadecimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.base.yaml
+        3: constant.numeric.value.yaml
+    - match: '{{_type_int_other}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.integer.other.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+    # floats
+    - match: '{{_type_float_decimal}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.float.decimal.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_other}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.float.other.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_infitity}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.float.infinite.yaml
+      captures:
+        1: constant.numeric.sign.yaml
+        2: constant.numeric.value.yaml
+        3: punctuation.separator.decimal.yaml
+    - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_out}}'
+      scope: meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+      captures:
+        1: punctuation.separator.decimal.yaml
+    # timestamp
+    - match: '{{_type_timestamp}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.other.timestamp.yaml
+      captures:
+        1: punctuation.separator.date.yaml
+        2: punctuation.separator.date.yaml
+        3: punctuation.separator.date.yaml
+        4: punctuation.separator.date.yaml
+        5: punctuation.separator.time.yaml
+        6: punctuation.separator.time.yaml
+        7: punctuation.separator.time.yaml
+        8: punctuation.separator.time.yaml
 
   flow-scalar-plain-out:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -379,7 +379,7 @@ contexts:
         2: constant.numeric.value.yaml
         3: punctuation.separator.decimal.yaml
     - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_in}}'
-      scope: meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+      scope: constant.language.nan.yaml
       captures:
         1: punctuation.separator.decimal.yaml
     # timestamp
@@ -454,7 +454,7 @@ contexts:
         2: constant.numeric.value.yaml
         3: punctuation.separator.decimal.yaml
     - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_out}}'
-      scope: meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+      scope: constant.language.nan.yaml
       captures:
         1: punctuation.separator.decimal.yaml
     # timestamp

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -132,7 +132,7 @@ variables:
   # http://yaml.org/type/float.html
   _type_float_decimal: ([-+]?)((?:[0-9][0-9_]*)?(\.)[0-9.]*(?:[eE][-+][0-9]+)?)
   _type_float_other: ([-+]?)([0-9][0-9_]*(?::[0-5]?[0-9])+(\.)[0-9_]*) # (base 60)
-  _type_float_infitity: ([-+]?)((\.)(?:inf|Inf|INF)) # (infinity)
+  _type_float_infitity: '[-+]?(\.)(?:inf|Inf|INF)' # (infinity)
   _type_float_nan: (\.)(?:nan|NaN|NAN) # (not a number)
 
   # http://yaml.org/type/timestamp.html
@@ -373,11 +373,9 @@ contexts:
         2: constant.numeric.value.yaml
         3: punctuation.separator.decimal.yaml
     - match: '{{_type_float_infitity}}{{_flow_scalar_end_plain_in}}'
-      scope: meta.number.float.infinite.yaml
+      scope: constant.language.infinity.yaml
       captures:
-        1: constant.numeric.sign.yaml
-        2: constant.numeric.value.yaml
-        3: punctuation.separator.decimal.yaml
+        1: punctuation.separator.decimal.yaml
     - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_in}}'
       scope: constant.language.nan.yaml
       captures:
@@ -448,11 +446,9 @@ contexts:
         2: constant.numeric.value.yaml
         3: punctuation.separator.decimal.yaml
     - match: '{{_type_float_infitity}}{{_flow_scalar_end_plain_out}}'
-      scope: meta.number.float.infinite.yaml
+      scope: constant.language.infinity.yaml
       captures:
-        1: constant.numeric.sign.yaml
-        2: constant.numeric.value.yaml
-        3: punctuation.separator.decimal.yaml
+        1: punctuation.separator.decimal.yaml
     - match: '{{_type_float_nan}}{{_flow_scalar_end_plain_out}}'
       scope: constant.language.nan.yaml
       captures:

--- a/YAML/tests/syntax_test_flow-plain.yaml
+++ b/YAML/tests/syntax_test_flow-plain.yaml
@@ -77,9 +77,9 @@ p[l]a,in:[]
 
 
 { bar: 1}
-#      ^ constant.numeric.integer
+#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
 { bar: 1 }
-#      ^ constant.numeric.integer
+#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
 #       ^ - string
 { key: string }
 #      ^^^^^^ string.unquoted.plain.in

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -15,7 +15,7 @@
 #        ^^^^                         constant.language.null
 #              ^^^^                   constant.language.null
 #                    ^                constant.language.null
-#                       ^^^^^^^^^^^^^ -constant
+#                       ^^^^^^^^^^^^^ - constant
 
 
 ##############################################################################
@@ -31,51 +31,63 @@
 #                               ^^                                   constant.language.boolean
 #                                   ^^^                              constant.language.boolean
 #                                        ^^^                         constant.language.boolean
-#                                                ^^^^^^^^^^^^^^^^^^^ -constant
+#                                                ^^^^^^^^^^^^^^^^^^^ - constant
 
 
 ##############################################################################
 ## http://yaml.org/type/int.html
 
 - [0b0, +0b1_0_1, -0b1, ~, 0b, 0b2, 0b1 abc
-#  ^^^                                      constant.numeric.integer.binary
-#  ^^                                       punctuation.definition.numeric.base
-#       ^^^^^^^^                            constant.numeric.integer.binary
-#        ^^                                 punctuation.definition.numeric.base
-#                 ^^^^                      constant.numeric.integer.binary
-#                  ^^                       punctuation.definition.numeric.base
-#                          ^^^^^^^^^^^^^^^^ -constant
+#  ^^ meta.number.integer.binary.yaml constant.numeric.base.yaml
+#    ^ meta.number.integer.binary.yaml constant.numeric.value.yaml
+#       ^ meta.number.integer.binary.yaml constant.numeric.sign.yaml
+#        ^^ meta.number.integer.binary.yaml constant.numeric.base.yaml
+#          ^^^^^ meta.number.integer.binary.yaml constant.numeric.value.yaml
+#                 ^ meta.number.integer.binary.yaml constant.numeric.sign.yaml
+#                  ^^ meta.number.integer.binary.yaml constant.numeric.base.yaml
+#                    ^ meta.number.integer.binary.yaml constant.numeric.value.yaml
+#                       ^ constant.language.null.yaml
+#                          ^^^^^^^^^^^^^^^^ - constant
 
    01, +0_761, -07, ~, 09, 0123 f
-#  ^^                             constant.numeric.integer.octal
-#  ^                              punctuation.definition.numeric.base
-#      ^^^^^^                     constant.numeric.integer.octal
-#       ^                         punctuation.definition.numeric.base
-#              ^^^                constant.numeric.integer.octal
-#               ^                 punctuation.definition.numeric.base
-#                      ^^^^^^^^^^ -constant
+#  ^ meta.number.integer.octal.yaml constant.numeric.base.yaml
+#   ^ meta.number.integer.octal.yaml constant.numeric.value.yaml
+#      ^ meta.number.integer.octal.yaml constant.numeric.sign.yaml
+#       ^ meta.number.integer.octal.yaml constant.numeric.base.yaml
+#        ^^^^ meta.number.integer.octal.yaml constant.numeric.value.yaml
+#              ^ meta.number.integer.octal.yaml constant.numeric.sign.yaml
+#               ^ meta.number.integer.octal.yaml constant.numeric.base.yaml
+#                ^ meta.number.integer.octal.yaml constant.numeric.value.yaml
+#                   ^ constant.language.null.yaml
+#                      ^^^^^^^^^^ - constant
 
    0, +1, -12_345, ~, 3 not a number
-#  ^                                 constant.numeric.integer.decimal
-#     ^^                             constant.numeric.integer.decimal
-#         ^^^^^^^                    constant.numeric.integer.decimal
-#                     ^^^^^^^^^^^^^^ -constant
+#  ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#     ^ meta.number.integer.decimal.yaml constant.numeric.sign.yaml
+#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#         ^ meta.number.integer.decimal.yaml constant.numeric.sign.yaml
+#          ^^^^^^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#                     ^^^^^^^^^^^^^^ - constant
 
    0x0, +0x12_34_56, -0xabcdef, ~, 0xyz, 0x,
-#  ^^^                                      constant.numeric.integer.hexadecimal
-#  ^^                                       punctuation.definition.numeric.base
-#       ^^^^^^^^^^^                         constant.numeric.integer.hexadecimal
-#        ^^                                 punctuation.definition.numeric.base
-#                    ^^^^^^^^^              constant.numeric.integer.hexadecimal
-#                     ^^                    punctuation.definition.numeric.base
-#                                  ^^^^^^^^ -constant
+#  ^^ meta.number.integer.hexadecimal.yaml constant.numeric.base.yaml
+#    ^ meta.number.integer.hexadecimal.yaml constant.numeric.value.yaml
+#       ^ meta.number.integer.hexadecimal.yaml constant.numeric.sign.yaml
+#        ^^ meta.number.integer.hexadecimal.yaml constant.numeric.base.yaml
+#          ^^^^^^^^ meta.number.integer.hexadecimal.yaml constant.numeric.value.yaml
+#                    ^ meta.number.integer.hexadecimal.yaml constant.numeric.sign.yaml
+#                     ^^ meta.number.integer.hexadecimal.yaml constant.numeric.base.yaml
+#                       ^^^^^^ meta.number.integer.hexadecimal.yaml constant.numeric.value.yaml
+#                                  ^^^^^^^^^ - constant
 
 # Note: pyyaml does not handle hexagesimal literals correctly (for linting purposes)
    1:20, +1:9, -1_234:59:00, ~, 1:60, :60, 1:2 s
-#  ^^^^                                          constant.numeric.integer.other
-#        ^^^^                                    constant.numeric.integer.other
-#              ^^^^^^^^^^^^                      constant.numeric.integer.other
-#                               ^^^^^^^^^^^^^^^^ -constant
+#  ^^^^ meta.number.integer.other.yaml constant.numeric.value.yaml
+#        ^ meta.number.integer.other.yaml constant.numeric.sign.yaml
+#         ^^^ meta.number.integer.other.yaml constant.numeric.value.yaml
+#              ^ meta.number.integer.other.yaml constant.numeric.sign.yaml
+#               ^^^^^^^^^^^ meta.number.integer.other.yaml constant.numeric.value.yaml
+#                               ^^^^^^^^^^^^^^^^ - constant
   ]
 
 
@@ -83,27 +95,33 @@
 ## http://yaml.org/type/float.html
 
 - [0.1, +.293, -1_123.e-3, 2.234.567, ~, 0.1 f
-#  ^^^                                         constant.numeric.float.decimal
-#   ^                                          punctuation.separator.decimal
-#       ^^^^^                                  constant.numeric.float.decimal
-#        ^                                     punctuation.separator.decimal
-#              ^^^^^^^^^^                      constant.numeric.float.decimal
-#                    ^                         punctuation.separator.decimal
-#                          ^^^^^^^^^           constant.numeric.float.decimal
-#                           ^                  punctuation.separator.decimal
-#                                        ^^^^^ -constant
+#  ^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
+#   ^ punctuation.separator.decimal.yaml
+#       ^ meta.number.float.decimal.yaml constant.numeric.sign.yaml
+#        ^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
+#        ^ punctuation.separator.decimal.yaml
+#              ^ meta.number.float.decimal.yaml constant.numeric.sign.yaml
+#               ^^^^^^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
+#                    ^ punctuation.separator.decimal.yaml
+#                          ^^^^^^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
+#                           ^ punctuation.separator.decimal.yaml
+#                               ^ - punctuation
+#                                     ^ constant.language.null.yaml
+#                                        ^^^^^ - constant
    .inf, +.INF, -.Inf, ~, .inF, .inf .inf
-#  ^^^^                                   constant.numeric.float.other
-#  ^                                      punctuation.separator.decimal
-#        ^^^^^                            constant.numeric.float.other
-#         ^                               punctuation.separator.decimal
-#               ^^^^^                     constant.numeric.float.other
-#                ^                        punctuation.separator.decimal
-#                         ^^^^^^^^^^^^^^^ -constant
+#  ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#  ^ punctuation.separator.decimal.yaml
+#        ^ meta.number.float.infinite.yaml constant.numeric.sign.yaml
+#         ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#         ^ punctuation.separator.decimal.yaml
+#               ^ meta.number.float.infinite.yaml constant.numeric.sign.yaml
+#                ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#                ^ punctuation.separator.decimal.yaml
+#                         ^^^^^^^^^^^^^^^ - constant
    .NaN, ~, .Nan,
-#  ^^^^          constant.numeric.float.other
-#  ^                                      punctuation.separator.decimal
-#           ^^^^ -constant
+#  ^^^^ meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+#  ^ punctuation.separator.decimal.yaml
+#           ^^^^ - constant
 ]
 
 
@@ -146,7 +164,7 @@
 - [=, <<, ~, << abc]
 #  ^                constant.language.value
 #     ^^            constant.language.merge
-#            ^^^^^^ -constant
+#            ^^^^^^ - constant
 
 
 ##############################################################################
@@ -157,17 +175,17 @@ true: false
 #   ^       punctuation.separator.key-value.mapping
 #     ^^^^^ constant.language.boolean
 3.e-3: 3.e+3
-#^^^^        constant.numeric.float.decimal
-#^           punctuation.separator.decimal
-#    ^       punctuation.separator.key-value.mapping
-#      ^^^^^ constant.numeric.float.decimal
+#^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
+#^ punctuation.separator.decimal.yaml
+#    ^ punctuation.separator.key-value.mapping.yaml
+#      ^^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
 {.NaN: 2, 2: 2015-08-15}
-#^^^^                   constant.numeric.float.other
-#    ^                  punctuation.separator.key-value.mapping
-#      ^                constant.numeric.integer.decimal
-#       ^               punctuation.separator.mapping
-#         ^             constant.numeric.integer.decimal
-#          ^            punctuation.separator.key-value.mapping
-#            ^^^^^^^^^^ constant.other.timestamp
-#                ^      punctuation.separator.date
-#                   ^   punctuation.separator.date
+#^^^^ meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+#    ^ punctuation.separator.key-value.mapping.yaml
+#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#       ^ punctuation.separator.mapping.yaml
+#         ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#          ^ punctuation.separator.key-value.mapping.yaml
+#            ^^^^^^^^^^ constant.other.timestamp.yaml
+#                ^ punctuation.separator.date.yaml
+#                   ^ punctuation.separator.date.yaml

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -119,7 +119,7 @@
 #                ^ punctuation.separator.decimal.yaml
 #                         ^^^^^^^^^^^^^^^ - constant
    .NaN, ~, .Nan,
-#  ^^^^ meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+#  ^^^^ constant.language.nan.yaml
 #  ^ punctuation.separator.decimal.yaml
 #           ^^^^ - constant
 ]
@@ -180,7 +180,7 @@ true: false
 #    ^ punctuation.separator.key-value.mapping.yaml
 #      ^^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
 {.NaN: 2, 2: 2015-08-15}
-#^^^^ meta.number.float.not-a-number.yaml constant.numeric.value.yaml
+#^^^^ constant.language.nan.yaml
 #    ^ punctuation.separator.key-value.mapping.yaml
 #      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
 #       ^ punctuation.separator.mapping.yaml

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -109,13 +109,11 @@
 #                                     ^ constant.language.null.yaml
 #                                        ^^^^^ - constant
    .inf, +.INF, -.Inf, ~, .inF, .inf .inf
-#  ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#  ^^^^ constant.language.infinity.yaml
 #  ^ punctuation.separator.decimal.yaml
-#        ^ meta.number.float.infinite.yaml constant.numeric.sign.yaml
-#         ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#        ^^^^^ constant.language.infinity.yaml
 #         ^ punctuation.separator.decimal.yaml
-#               ^ meta.number.float.infinite.yaml constant.numeric.sign.yaml
-#                ^^^^ meta.number.float.infinite.yaml constant.numeric.value.yaml
+#               ^^^^^ constant.language.infinity.yaml
 #                ^ punctuation.separator.decimal.yaml
 #                         ^^^^^^^^^^^^^^^ - constant
    .NaN, ~, .Nan,


### PR DESCRIPTION
This PR applies `meta.number.<type> constant.numeric.[base|value|suffix]` to all numeric literals.

Each number type is matched by a dedicated pattern to improve readability. It is even slightly (but negligible) faster than a monolitic pattern with dozens of capture groups.

Note: We may want to discuss how to scope special number tokens like `NaN` and `inf`.