### PR TITLE
[TypeScript] Remove vestigial match rule

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -417,7 +417,6 @@ contexts:
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin
-    - match: (?=\b\B)
 
   ts-type-assertion:
     - match: '!(?!\.)'


### PR DESCRIPTION
The rule in question is a no-op that's part of some conditional logic in the JS Custom TypeScript extension. Since the new TypeScript extension doesn't have that conditional logic, it doesn't need the no-op.