### PR TITLE
[ShellScript] Fix alias command

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -340,7 +340,29 @@ contexts:
         variable.parameter.option.shell
       captures:
         1: punctuation.definition.parameter.shell
-    - include: cmd-args-end-of-options-then-functions
+    - include: cmd-alias-args-end-of-options
+
+  cmd-alias-args-end-of-options:
+    - include: cmd-args-illegal-options
+    - match: --{{cmd_break}}|(?=\S)
+      scope: keyword.operator.end-of-options.shell
+      set: cmd-alias-args-name
+    - include: eoc-pop
+
+  cmd-alias-args-name:
+    - include: cmd-args-boilerplate
+    - match: =
+      scope: keyword.operator.assignment.shell
+      push: string-unquoted
+    - match: (?=\S)
+      push: cmd-alias-args-name-chars
+
+  cmd-alias-args-name-chars:
+    - meta_scope: meta.variable.shell
+    - match: '{{opt_literal_char}}+'
+      scope: entity.name.function.shell
+    - include: entity-function-expansions
+    - include: immediately-pop
 
 ###[ ARITHMETIC BUILTINS ]#####################################################
 
@@ -707,7 +729,7 @@ contexts:
         variable.parameter.option.shell
       captures:
         1: punctuation.definition.parameter.shell
-    - include: cmd-args-end-of-options-then-functions
+    - include: cmd-alias-args-end-of-options
 
 ###[ UNSET BUILTINS ]##########################################################
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1317,6 +1317,41 @@ alias -a -p -- foo=bar baz=qux
 #                         ^ keyword.operator.assignment.shell
 #                          ^^^ meta.string.shell string.unquoted.shell
 
+alias $foo=bar
+# <- meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#^^^^ meta.declaration.alias.shell
+#    ^^^^^^^^^ meta.declaration.alias.arguments.shell
+#             ^ - meta.declaration.alias
+#     ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#         ^ keyword.operator.assignment.shell
+#          ^^^ meta.string.shell string.unquoted.shell
+
+alias ..='cd ..'
+# <- meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#^^^^ meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#    ^^^^^^^^^^^ meta.declaration.alias.arguments.shell
+#     ^^ meta.variable.shell entity.name.function.shell
+#       ^ keyword.operator.assignment.shell
+#        ^^^^^^^ meta.string.shell string.quoted.single.shell
+
+alias -p ..='cd ..'
+# <- meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#^^^^ meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#    ^^^^^^^^^^^^^^ meta.declaration.alias.arguments.shell
+#     ^^ meta.parameter.option.shell variable.parameter.option.shell
+#        ^^ meta.variable.shell entity.name.function.shell
+#          ^ keyword.operator.assignment.shell
+#           ^^^^^^^ meta.string.shell string.quoted.single.shell
+
+alias -- -='cd -'
+# <- meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#^^^^ meta.declaration.alias.shell storage.type.alias.shell keyword.declaration.alias.shell
+#    ^^^^^^^^^^^^ meta.declaration.alias.arguments.shell
+#     ^^ keyword.operator.end-of-options.shell
+#        ^ meta.variable.shell entity.name.function.shell
+#         ^ keyword.operator.assignment.shell
+#          ^^^^^^ meta.string.shell string.quoted.single.shell
+
 
 ####################################################################
 # declare builtin                                                  #


### PR DESCRIPTION
Fixes #2482

Alias identifiers may consist of any arbitrary character but meta chars.

Only `=` is accepted as assignment operator.