### PR TITLE
[Erlang] Add underscore support in numbers

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1839,63 +1839,63 @@ contexts:
 
   number:
     # http://erlang.org/doc/reference_manual/data_types.html#number
-    - match: \d+(\.)\d+([eE][-+]?\d+)?\b
+    - match: \d[\d_]*(\.)[\d_]+([eE][-+]?[\d_]+)?\b
       scope: meta.number.float.decimal.erlang constant.numeric.value.erlang
       captures:
         1: punctuation.separator.decimal.erlang
-    - match: (2\#)([0-1]+)\b
+    - match: (2\#)([0-1_]+)\b
       scope: meta.number.integer.binary.erlang
       captures:
         1: constant.numeric.base.erlang
         2: constant.numeric.value.erlang
-    - match: (8\#)([0-7]+)\b
+    - match: (8\#)([0-7_]+)\b
       scope: meta.number.integer.octal.erlang
       captures:
         1: constant.numeric.base.erlang
         2: constant.numeric.value.erlang
-    - match: (10\#)([0-9]+)\b
+    - match: (10\#)([0-9_]+)\b
       scope: meta.number.integer.decimal.erlang
       captures:
         1: constant.numeric.base.erlang
         2: constant.numeric.value.erlang
-    - match: (16\#)([\da-fA-F]+)\b
+    - match: (16\#)([\da-fA-F_]+)\b
       scope: meta.number.integer.hexadecimal.erlang
       captures:
         1: constant.numeric.base.erlang
         2: constant.numeric.value.erlang
     - match: |-
         (?x:
-            (3\#)([0-2]+)
-          | (4\#)([0-3]+)
-          | (5\#)([0-4]+)
-          | (6\#)([0-5]+)
-          | (7\#)([0-6]+)
-          | (9\#)([0-8]+)
-          | (11\#)([\daA]+)
-          | (12\#)([\da-bA-B]+)
-          | (13\#)([\da-cA-C]+)
-          | (14\#)([\da-dA-D]+)
-          | (15\#)([\da-eA-E]+)
-          | (17\#)([\da-gA-G]+)
-          | (18\#)([\da-hA-H]+)
-          | (19\#)([\da-iA-I]+)
-          | (20\#)([\da-jA-J]+)
-          | (21\#)([\da-kA-K]+)
-          | (22\#)([\da-lA-L]+)
-          | (23\#)([\da-mA-M]+)
-          | (24\#)([\da-nA-N]+)
-          | (25\#)([\da-oA-O]+)
-          | (26\#)([\da-pA-P]+)
-          | (27\#)([\da-qA-Q]+)
-          | (28\#)([\da-rA-R]+)
-          | (29\#)([\da-sA-S]+)
-          | (30\#)([\da-tA-T]+)
-          | (31\#)([\da-uA-U]+)
-          | (32\#)([\da-vA-V]+)
-          | (33\#)([\da-wA-W]+)
-          | (34\#)([\da-xA-X]+)
-          | (35\#)([\da-yA-Y]+)
-          | (36\#)([\da-zA-Z]+)
+            (3\#)([0-2_]+)
+          | (4\#)([0-3_]+)
+          | (5\#)([0-4_]+)
+          | (6\#)([0-5_]+)
+          | (7\#)([0-6_]+)
+          | (9\#)([0-8_]+)
+          | (11\#)([\daA_]+)
+          | (12\#)([\da-bA-B_]+)
+          | (13\#)([\da-cA-C_]+)
+          | (14\#)([\da-dA-D_]+)
+          | (15\#)([\da-eA-E_]+)
+          | (17\#)([\da-gA-G_]+)
+          | (18\#)([\da-hA-H_]+)
+          | (19\#)([\da-iA-I_]+)
+          | (20\#)([\da-jA-J_]+)
+          | (21\#)([\da-kA-K_]+)
+          | (22\#)([\da-lA-L_]+)
+          | (23\#)([\da-mA-M_]+)
+          | (24\#)([\da-nA-N_]+)
+          | (25\#)([\da-oA-O_]+)
+          | (26\#)([\da-pA-P_]+)
+          | (27\#)([\da-qA-Q_]+)
+          | (28\#)([\da-rA-R_]+)
+          | (29\#)([\da-sA-S_]+)
+          | (30\#)([\da-tA-T_]+)
+          | (31\#)([\da-uA-U_]+)
+          | (32\#)([\da-vA-V_]+)
+          | (33\#)([\da-wA-W_]+)
+          | (34\#)([\da-xA-X_]+)
+          | (35\#)([\da-yA-Y_]+)
+          | (36\#)([\da-zA-Z_]+)
         )\b
       scope: meta.number.integer.other.erlang
       captures:
@@ -1963,7 +1963,7 @@ contexts:
         62: constant.numeric.value.erlang
     - match: \d+\#\S+
       scope: invalid.illegal.integer.erlang
-    - match: \d+\b
+    - match: \d[\d_]*\b
       scope: meta.number.integer.decimal.erlang constant.numeric.value.erlang
     - match: \d\w+
       scope: invalid.illegal.integer.erlang

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -689,65 +689,100 @@ map_tests() -> .
 
 numbers_test() -> .
 
-    2
+    2 2_2 0__9
+%  ^ - meta.number - constant
 %   ^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
+%    ^ - meta.number - constant
+%     ^^^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
+%        ^ - meta.number - constant
+%         ^^^^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
+%             ^ - meta.number - constant
 
     45a
 %   ^^^ invalid.illegal.integer.erlang
 
-    2.3
+    2.3 2_._3_ 2_4.5_0 _2_._3_
+%  ^ - meta.number - constant
 %   ^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
 %    ^ punctuation.separator.decimal.erlang
+%      ^ - meta.number - constant
+%       ^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
+%             ^ - meta.number - constant
+%              ^^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
+%                     ^^^^^^^^ - meta.number - constant
 
-    2.3e3
+    2.3e3 2_2._3_3_e_2_3_
 %   ^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
 %    ^ punctuation.separator.decimal.erlang
+%        ^ - meta.number - constant
+%         ^^^^^^^^^^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
+%                        ^ - meta.number - constant
 
-    2.3e+3
+    2.3e+3 2_2._3_3_e+_2_3_
 %   ^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
 %    ^ punctuation.separator.decimal.erlang
+%         ^ - meta.number - constant
+%          ^^^^^^^^^^^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
+%                          ^ - meta.number - constant
 
-    2.3e-3
+    2.3e-3 2_2._3_3_e-_2_3_
 %   ^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
 %    ^ punctuation.separator.decimal.erlang
+%         ^ - meta.number - constant
+%          ^^^^^^^^^^^^^^^^ meta.number.float.decimal.erlang constant.numeric.value.erlang
+%                          ^ - meta.number - constant
 
     1#0
 %   ^^^ invalid.illegal.integer.erlang
 
-    2#01 2#012
+    2#01 2#012 2#_0_1_
 %   ^^ meta.number.integer.binary.erlang constant.numeric.base.erlang
 %     ^^ meta.number.integer.binary.erlang constant.numeric.value.erlang
 %        ^^^^^ invalid.illegal.integer.erlang
+%              ^^ meta.number.integer.binary.erlang constant.numeric.base.erlang
+%                ^^^^^ meta.number.integer.binary.erlang constant.numeric.value.erlang
 
-    3#012 3#123
+    3#012 3#123 3#_0_1_2_
 %   ^^ meta.number.integer.other.erlang constant.numeric.base.erlang
 %     ^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 %         ^^^^^ invalid.illegal.integer.erlang
+%               ^^ meta.number.integer.other.erlang constant.numeric.base.erlang
+%                 ^^^^^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 
-    4#0123 4#1234
+    4#0123 4#1234 4#_0_1_2_3_
 %   ^^ meta.number.integer.other.erlang constant.numeric.base.erlang
 %     ^^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
+%                 ^^ meta.number.integer.other.erlang constant.numeric.base.erlang
+%                   ^^^^^^^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 
-    8#0723 8#1834
+    8#0723 8#1834 8#_0_7_2_3_
 %   ^^ meta.number.integer.octal.erlang constant.numeric.base.erlang
 %     ^^^^ meta.number.integer.octal.erlang constant.numeric.value.erlang
 %          ^^^^^^ invalid.illegal.integer.erlang
+%                 ^^ meta.number.integer.octal.erlang constant.numeric.base.erlang
+%                   ^^^^^^^^^ meta.number.integer.octal.erlang constant.numeric.value.erlang
 
-    10#0943 10#183A
+    10#0943 10#183A 10#_0_9_4_3_
 %   ^^^ meta.number.integer.decimal.erlang constant.numeric.base.erlang
 %      ^^^^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
 %           ^^^^^^ invalid.illegal.integer.erlang
+%                   ^^^ meta.number.integer.decimal.erlang constant.numeric.base.erlang
+%                      ^^^^^^^^^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
 
-    16#0F2B 16#F8G4
+    16#0F2B 16#F8G4 16#_0_F_2_B_
 %   ^^^ meta.number.integer.hexadecimal.erlang constant.numeric.base.erlang
 %      ^^^^ meta.number.integer.hexadecimal.erlang constant.numeric.value.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
+%                   ^^^ meta.number.integer.hexadecimal.erlang constant.numeric.base.erlang
+%                      ^^^^^^^^^ meta.number.integer.hexadecimal.erlang constant.numeric.value.erlang
 
-    35#0Y2B 35#F8Z4
+    35#0Y2B 35#F8Z4 35#_0_Y_2_B_
 %   ^^^ meta.number.integer.other.erlang constant.numeric.base.erlang
 %      ^^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 %           ^^^^^^^ invalid.illegal.integer.erlang
+%                   ^^^ meta.number.integer.other.erlang constant.numeric.base.erlang
+%                      ^^^^^^^^^ meta.number.integer.other.erlang constant.numeric.value.erlang
 
     37#ABC
 %   ^^^^^^ invalid.illegal.integer.erlang


### PR DESCRIPTION
Closes #2502

This commit adds underscore support in numeric literals according to http://erlang.org/doc/reference_manual/data_types.html#number

This language feature was added in ErlangOTP 23.0
see: https://www.erlang.org/news/140

