### PR TITLE
[SQL] Add storage types bool, enum, longtext and tinytext

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -44,7 +44,7 @@ contexts:
         (?xi)
 
                 # normal stuff, capture 1
-                 \b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|datetime|double\sprecision|inet|int|integer|line|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text)\b
+                \b(bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\sprecision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
 
                 # numeric suffix, capture 2 + 3i
                 |\b(bit\svarying|character\s(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)


### PR DESCRIPTION
This PR adds some missing storage types (bool, enum, longtext, tinytext) to improve the compatibility with MySQL/MariaDB.