### PR TITLE
[TCL] Update meta.number constant.numeric

### DIFF
--- a/TCL/Tcl.sublime-syntax
+++ b/TCL/Tcl.sublime-syntax
@@ -84,16 +84,25 @@ contexts:
     - match: '{{unquoted_string}}'
 
   numbers:
-    - match: \b0x\h*\b(?={{inline_end_chars}})
-      scope: constant.numeric.integer.tcl
-    - match: \b0b[01]*\b(?={{inline_end_chars}})
-      scope: constant.numeric.integer.tcl
-    - match: \b0o[0-7]*\b(?={{inline_end_chars}})
-      scope: constant.numeric.integer.tcl
+    - match: \b(0x)(\h*)\b(?={{inline_end_chars}})
+      scope: meta.number.integer.hexadecimal.tcl
+      captures:
+        1: constant.numeric.base.tcl
+        2: constant.numeric.value.tcl
+    - match: \b(0b)([01]*)\b(?={{inline_end_chars}})
+      scope: meta.number.integer.binary.tcl
+      captures:
+        1: constant.numeric.base.tcl
+        2: constant.numeric.value.tcl
+    - match: \b(0o)([0-7]*)\b(?={{inline_end_chars}})
+      scope: meta.number.integer.octal.tcl
+      captures:
+        1: constant.numeric.base.tcl
+        2: constant.numeric.value.tcl
     - match: \b[0-9]+\.[0-9]+\b(?={{inline_end_chars}})
-      scope: constant.numeric.float.tcl
+      scope: meta.number.float.decimal.tcl constant.numeric.value.tcl
     - match: \b[0-9]+\b(?={{inline_end_chars}})
-      scope: constant.numeric.integer.tcl
+      scope: meta.number.float.decimal.tcl constant.numeric.value.tcl
 
   comments:
     - match: '#'

--- a/TCL/syntax_test_tcl.tcl
+++ b/TCL/syntax_test_tcl.tcl
@@ -387,14 +387,14 @@ if { $mpv(radar) eq "VHF" } {
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.substitution
 #                                   ^ meta.block meta.block punctuation.section.block.begin
         set imf -1
-#               ^ keyword.operator
-#                ^ constant.numeric
+#               ^ keyword.operator.tcl
+#                ^ meta.number.float.decimal.tcl constant.numeric.value.tcl
 
         if { $mpv(ifmon_errcount) < 5 } {
 #       ^ keyword.control
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block meta.block meta.block
 #                                 ^ keyword.operator
-#                                   ^ constant.numeric
+#                                   ^ meta.number.float.decimal.tcl constant.numeric.value.tcl
             EngineMsg [list $msg] [Utime]
 #           ^ variable.function
             incr mpv(ifmon,errcount)


### PR DESCRIPTION
This commit applies updated meta.number scope naming guidelines.