### PR TITLE
[ASP] Update meta.number constant.numeric

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -14,8 +14,8 @@ variables:
   math_operators: '(?:[+*^&/\\-]|\b(?i:Mod)\b)'
   logical_operators: '\b(?i:And|Not|Or|Xor|Is)\b'
   operators: '{{comparison_operators}}|{{math_operators}}|{{logical_operators}}'
-  literal_number_hex: '(&[hH])\h+(&)?(?={{whitespace_or_end_of_statement}}|{{operators}}|[,)_])'
-  literal_number_decimal: '(?:(?:\d+\.\d*|\.?\d+)(?i:e[+-]?\d+)?)(?={{whitespace_or_end_of_statement}}|{{operators}}|[,)_])'
+  literal_number_hex: '(&)([hH])(\h+)(&?)(?={{whitespace_or_end_of_statement}}|{{operators}}|[,)_])'
+  literal_number_decimal: '(?:(?:\d+(\.)\d*|(\.?)\d+)(?i:e[+-]?\d+)?)(?={{whitespace_or_end_of_statement}}|{{operators}}|[,)_])'
   reserved_words: '\b(?i:Class|Sub|Function|Const|Dim|ReDim|Public|Private|End|Preserve|Select|Case|If|Else|ElseIf|Then|For|Each|Next|ByRef|ByVal|Set|Call|New|Option|With|To|In|While|Wend|Until|Loop|On|GoTo|Resume|Let|Get|Exit|Do)\b' # Default|Step|Error|Property are not reserved words
   keywords: '\b(?i:Empty|False|Nothing|Null|True)\b'
   constants: '\b(?i:vbTrue|vbFalse|vbCr|vbCrLf|vbFormFeed|vbLf|vbNewLine|vbNullChar|vbNullString|vbTab|vbVerticalTab|vbBinaryCompare|vbTextCompare|vbSunday|vbMonday|vbTuesday|vbWednesday|vbThursday|vbFriday|vbSaturday|vbUseSystemDayOfWeek|vbFirstJan1|vbFirstFourDays|vbFirstFullWeek|vbGeneralDate|vbLongDate|vbShortDate|vbLongTime|vbShortTime|vbObjectError|vbEmpty|vbNull|vbInteger|vbLong|vbSingle|vbDouble|vbCurrency|vbDate|vbString|vbObject|vbError|vbBoolean|vbVariant|vbDataObject|vbDecimal|vbByte|vbArray|vbOkCancel|vbOkOnly|vbYesNo|vbYesNoCancel|vbAbortRetryIgnore|vbRetryCancel|vbYes|vbNo|vbAbort|vbCancel|vbIgnore|vbRetry|vbCritical|vbExclamation|vbInformation|vbQuestion|vbDefaultButton[123])\b'
@@ -258,13 +258,18 @@ contexts:
     - match: '{{whitespace_or_end_of_statement}}' # as the above include has been commented out, this match pattern has been added to pop at the end of the logical statement
       pop: true
     - match: '{{literal_number_hex}}'
-      scope: constant.numeric.integer.hexadecimal.asp
+      scope: meta.number.integer.hexadecimal.asp
       captures:
-        1: punctuation.definition.numeric.hexadecimal.asp
-        2: punctuation.definition.numeric.hexadecimal.asp
+        1: constant.numeric.asp punctuation.definition.numeric.asp
+        2: constant.numeric.base.asp
+        3: constant.numeric.value.asp
+        4: constant.numeric.asp punctuation.definition.numeric.asp
       pop: true
     - match: '{{literal_number_decimal}}'
-      scope: constant.numeric.float.decimal.asp
+      scope: meta.number.float.decimal.asp constant.numeric.value.asp
+      captures:
+        1: punctuation.separator.decimal.asp
+        2: punctuation.separator.decimal.asp
       pop: true
     - match: '{{constants}}'
       scope: constant.language.asp
@@ -444,12 +449,17 @@ contexts:
     - match: \)
       scope: invalid.illegal.stray-close-bracket.asp
     - match: '{{literal_number_hex}}'
-      scope: constant.numeric.integer.hexadecimal.asp
+      scope: meta.number.integer.hexadecimal.asp
       captures:
-        1: punctuation.definition.numeric.hexadecimal.asp
-        2: punctuation.definition.numeric.hexadecimal.asp
+        1: constant.numeric.asp punctuation.definition.numeric.asp
+        2: constant.numeric.base.asp
+        3: constant.numeric.value.asp
+        4: constant.numeric.asp punctuation.definition.numeric.asp
     - match: '{{literal_number_decimal}}'
-      scope: constant.numeric.float.decimal.asp
+      scope: meta.number.float.decimal.asp constant.numeric.value.asp
+      captures:
+        1: punctuation.separator.decimal.asp
+        2: punctuation.separator.decimal.asp
     - match: '{{constants}}'
       scope: support.type.vb.asp # maybe this should be constant.language.asp
     - match: '{{functions}}'

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -64,7 +64,7 @@
        '^^^^^^^^^^^^ storage.modifier.asp
        '             ^ entity.name.constant.asp
        '               ^ keyword.operator.assignment.asp
-       '                 ^^^^ constant.numeric.float.decimal.asp
+       '                 ^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
        '                     ^ punctuation.separator.variable-declaration.asp
        '                       ^^ entity.name.constant.asp
        '                         ^ keyword.operator.assignment.asp
@@ -75,8 +75,10 @@
 '<- - invalid.illegal.unexpected-token.asp
         Const d = &HAB
        '^^^^^ storage.modifier.asp
-       '          ^^^^ constant.numeric.integer.hexadecimal.asp
-       '          ^^ punctuation.definition.numeric.hexadecimal.asp
+       '          ^^^^ meta.number.integer.hexadecimal.asp
+       '          ^ constant.numeric.asp punctuation.definition.numeric.asp
+       '           ^ constant.numeric.base.asp - punctuation
+       '            ^^ constant.numeric.value.asp
         Const e = "I am an unclosed string
         '         ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.asp
         '                                 ^ invalid.illegal.unclosed-string.asp
@@ -424,7 +426,7 @@
     value = 1/2
     '        ^ keyword.operator.asp
     value = &HFF mod 3
-    '       ^^^^ constant.numeric.integer.hexadecimal.asp
+    '       ^^^^ meta.number.integer.hexadecimal.asp
     '            ^^^ keyword.operator.asp
     Select Case call value:Case 1
    '^^^^^^^^^^^ keyword.control.flow.asp
@@ -505,9 +507,11 @@
         '    ^ punctuation.section.array.begin.asp
         '     ^ constant.numeric
         '      ^ punctuation.separator.array.asp
-        '       ^^^^ constant.numeric.integer.hexadecimal.asp
-        '       ^^ punctuation.definition.numeric.hexadecimal.asp
-        '          ^ punctuation.definition.numeric.hexadecimal.asp
+        '       ^^^^ meta.number.integer.hexadecimal.asp
+        '       ^ constant.numeric.asp punctuation.definition.numeric.asp
+        '        ^ constant.numeric.base.asp - punctuation
+        '         ^ constant.numeric.value.asp - punctuation
+        '          ^ constant.numeric.asp punctuation.definition.numeric.asp
         '           ^ punctuation.section.array.end.asp
         b = a Is Empty : Dim loop,nope : Dim foobar
        '^^^^^^^^^^^^^^^^^^^^^ - invalid.illegal.unexpected-token.asp - invalid.illegal.name.asp
@@ -526,7 +530,10 @@
        '               ^^^ variable.other.asp
        '                   ^^^^^^^^ meta.array.definition.asp
        '                   ^ punctuation.section.array.begin.asp
-       '                     ^^^ constant.numeric.integer.hexadecimal.asp
+       '                     ^^^ meta.number.integer.hexadecimal.asp
+       '                     ^ constant.numeric.asp punctuation.definition.numeric.asp
+       '                      ^ constant.numeric.base.asp - punctuation
+       '                       ^ constant.numeric.value.asp - punctuation
        '                        ^ punctuation.separator.array.asp
        '                          ^ punctuation.section.array.end.asp
         For x = LBound(a) to UBound(a) Step 2 'test
@@ -800,26 +807,34 @@
     ' ^^^ storage.type.function.end.asp - meta.method.identifier.asp
     
     a=3.4*.5*6.*0.25
-    ' ^^^ constant.numeric.float.decimal.asp
-    '     ^^ constant.numeric.float.decimal.asp
-    '        ^^ constant.numeric.float.decimal.asp
-    '           ^^^^ constant.numeric.float.decimal.asp
+    ' ^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '  ^ punctuation.separator.decimal.asp
+    '     ^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '     ^ punctuation.separator.decimal.asp
+    '        ^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '         ^ punctuation.separator.decimal.asp
+    '           ^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '            ^ punctuation.separator.decimal.asp
     a=a+0.8
-    '   ^^^ constant.numeric.float.decimal.asp
+    '   ^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '    ^ punctuation.separator.decimal.asp
     ExampleSub 3.4,.5,6.,&HA,&H2,7*2.1e2,9,-3.402823E+38, 3.402823E38 ,1.401298E-45,Round(4.94065645841247E-324),a2,2a,123.456.789.321.654.321
-    '          ^^^ constant.numeric.float.decimal.asp
-    '              ^^ constant.numeric.float.decimal.asp
-    '                 ^^ constant.numeric.float.decimal.asp
-    '                    ^^^ constant.numeric.integer.hexadecimal.asp
-    '                        ^^^ constant.numeric.integer.hexadecimal.asp
+    '          ^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '           ^ punctuation.separator.decimal.asp
+    '              ^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '              ^ punctuation.separator.decimal.asp
+    '                 ^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '                  ^ punctuation.separator.decimal.asp
+    '                    ^^^ meta.number.integer.hexadecimal.asp
+    '                        ^^^ meta.number.integer.hexadecimal.asp
     '                            ^ constant.numeric
-    '                              ^^^^^ constant.numeric.float.decimal.asp
+    '                              ^^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
     '                                    ^ constant.numeric
-    '                                       ^^^^^^^^^^^^ constant.numeric.float.decimal.asp
-    '                                                     ^^^^^^^^^^^ constant.numeric.float.decimal.asp
-    '                                                                  ^^^^^^^^^^^^ constant.numeric.float.decimal.asp
+    '                                       ^^^^^^^^^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '                                                     ^^^^^^^^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
+    '                                                                  ^^^^^^^^^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
     '                                                                               ^^^^^ support.function.vb.asp
-    '                                                                                     ^^^^^^^^^^^^^^^^^^^^^ constant.numeric.float.decimal.asp
+    '                                                                                     ^^^^^^^^^^^^^^^^^^^^^ meta.number.float.decimal.asp constant.numeric.value.asp
     '                                                                                                            ^^ - constant.numeric
     '                                                                                                                ^ - constant.numeric
     '                                                                                                                         ^^^^^^^^ - constant.numeric


### PR DESCRIPTION
This commit applies updated meta.number scope naming guidelines.

Note: Hexadecimal literals may be enclosed into `&` which are scoped `punctuation.definition.numeric`.