### PR TITLE
[YAML] Update numeric indentation indicator

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -571,7 +571,7 @@ contexts:
       captures:
         1: keyword.control.flow.block-scalar.literal.yaml
         2: keyword.control.flow.block-scalar.folded.yaml
-        3: constant.numeric.integer.decimal.indentation-indicator.yaml
+        3: constant.numeric.indentation-indicator.yaml
         4: storage.modifier.chomping-indicator.yaml
       push:
         - meta_include_prototype: false

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -18,11 +18,11 @@
 
 - >1
 # ^ keyword.control.flow.block-scalar
-#  ^ constant.numeric.integer.decimal.indentation-indicator
+#  ^ constant.numeric.indentation-indicator
 
 - |1-
 # ^ keyword.control.flow.block-scalar
-#  ^ constant.numeric.integer.decimal.indentation-indicator
+#  ^ constant.numeric.indentation-indicator
 #   ^ storage.modifier.chomping-indicator
 
 # Headers and content ################


### PR DESCRIPTION
This commit removes `integer.decimal` from indentation indicator literals as those sub scopes are no longer used.

As yaml version is scoped `constant.numeric.yaml-version`, `constant.numeric.decimal-indicator` should be sufficient here.