### PR TITLE
[Git Formats] Update meta.number constant.numeric

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -303,7 +303,7 @@ contexts:
           scope: meta.function-call.arguments.pretty-formats.git punctuation.section.parens.end.pretty-formats.git
           pop: true
         - match: \d+
-          scope: constant.numeric.integer.pretty-formats.git
+          scope: meta.number.integer.decimal.git constant.numeric.value.git
         - match: ',,'
           scope: invalid.illegal.pretty-formats.git
         - match: ','
@@ -325,7 +325,7 @@ contexts:
         1: meta.function-call.pretty-formats.git variable.function.pretty-formats.git
         2: meta.function-call.arguments.pretty-formats.git
         3: punctuation.section.parens.begin.pretty-formats.git
-        4: constant.numeric.integer.pretty-formats.git
+        4: meta.number.integer.decimal.git constant.numeric.value.git
         5: punctuation.separator.parameters.pretty-formats.git
         6: support.constant.truncation.pretty-formats.git
         7: punctuation.section.parens.end.pretty-formats.git

--- a/Git Formats/syntax_test_git_config
+++ b/Git Formats/syntax_test_git_config
@@ -320,14 +320,14 @@ stray-bracket]
 #                      ^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                        ^^^ meta.function-call.arguments.pretty-formats.git
 #                        ^   punctuation.section.parens.begin.pretty-formats.git
-#                         ^  constant.numeric.integer.pretty-formats.git
+#                         ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                          ^ punctuation.section.parens.end.pretty-formats.git
 #                           ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%<(5,ltrunc)%h
 #                      ^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                        ^^^^^^^^^^ meta.function-call.arguments.pretty-formats.git
 #                        ^   punctuation.section.parens.begin.pretty-formats.git
-#                         ^  constant.numeric.integer.pretty-formats.git
+#                         ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                          ^ punctuation.separator.parameters.pretty-formats.git
 #                           ^^^^^^ support.constant.truncation.pretty-formats.git
 #                                 ^ punctuation.section.parens.end.pretty-formats.git
@@ -336,7 +336,7 @@ stray-bracket]
 #                      ^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                         ^^^ meta.function-call.arguments.pretty-formats.git
 #                         ^   punctuation.section.parens.begin.pretty-formats.git
-#                          ^  constant.numeric.integer.pretty-formats.git
+#                          ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                           ^ punctuation.section.parens.end.pretty-formats.git
 #                            ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%<<(5)%h
@@ -347,42 +347,42 @@ stray-bracket]
 #                      ^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                        ^^^ meta.function-call.arguments.pretty-formats.git
 #                        ^   punctuation.section.parens.begin.pretty-formats.git
-#                         ^  constant.numeric.integer.pretty-formats.git
+#                         ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                          ^ punctuation.section.parens.end.pretty-formats.git
 #                           ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%>|(5)%h
 #                      ^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                         ^^^ meta.function-call.arguments.pretty-formats.git
 #                         ^   punctuation.section.parens.begin.pretty-formats.git
-#                          ^  constant.numeric.integer.pretty-formats.git
+#                          ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                           ^ punctuation.section.parens.end.pretty-formats.git
 #                            ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%>>(5)%h
 #                      ^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                         ^^^ meta.function-call.arguments.pretty-formats.git
 #                         ^   punctuation.section.parens.begin.pretty-formats.git
-#                          ^  constant.numeric.integer.pretty-formats.git
+#                          ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                           ^ punctuation.section.parens.end.pretty-formats.git
 #                            ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%>>|(5)%h
 #                      ^^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                          ^^^ meta.function-call.arguments.pretty-formats.git
 #                          ^   punctuation.section.parens.begin.pretty-formats.git
-#                           ^  constant.numeric.integer.pretty-formats.git
+#                           ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                            ^ punctuation.section.parens.end.pretty-formats.git
 #                             ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%><(5)%h
 #                      ^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                         ^^^ meta.function-call.arguments.pretty-formats.git
 #                         ^   punctuation.section.parens.begin.pretty-formats.git
-#                          ^  constant.numeric.integer.pretty-formats.git
+#                          ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                           ^ punctuation.section.parens.end.pretty-formats.git
 #                            ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=%><|(5)%h
 #                      ^^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                          ^^^ meta.function-call.arguments.pretty-formats.git
 #                          ^   punctuation.section.parens.begin.pretty-formats.git
-#                           ^  constant.numeric.integer.pretty-formats.git
+#                           ^  meta.number.integer.decimal.git constant.numeric.value.git
 #                            ^ punctuation.section.parens.end.pretty-formats.git
 #                             ^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty=format:%h
@@ -427,11 +427,11 @@ stray-bracket]
 #                                                   ^^ meta.function-call.pretty-formats.git variable.function.pretty-formats.git
 #                                                     ^^^^^^^ meta.function-call.arguments.pretty-formats.git
 #                                                     ^ punctuation.section.parens.begin.pretty-formats.git
-#                                                      ^ constant.numeric.integer.pretty-formats.git
+#                                                      ^ meta.number.integer.decimal.git constant.numeric.value.git
 #                                                       ^ punctuation.separator.parameters.pretty-formats.git
-#                                                        ^ constant.numeric.integer.pretty-formats.git
+#                                                        ^ meta.number.integer.decimal.git constant.numeric.value.git
 #                                                         ^ punctuation.separator.parameters.pretty-formats.git
-#                                                          ^ constant.numeric.integer.pretty-formats.git
+#                                                          ^ meta.number.integer.decimal.git constant.numeric.value.git
 #                                                           ^ punctuation.section.parens.end.pretty-formats.git
 #                                                                    ^^^ constant.other.placeholder.pretty-formats.git
     foo = log --pretty='%%f%x26f%H%h%T%t%P%p%d%D%e%s%S%f%b%B%N%m%n'


### PR DESCRIPTION
This commit applies updated meta.number scope naming guidelines.

Note: Do we really need all the `pretty-format` sub scopes everywhere?