### PR TITLE
[TypeScript] Implement function call type arguments.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -94,6 +94,8 @@ variables:
       )
     ))
 
+  function_call_lookahead: (?={{identifier}}\s*(?:{{dot_accessor}})?\()
+
 contexts:
   main:
     - include: comments-top-level
@@ -1961,7 +1963,7 @@ contexts:
       scope: support.class.js
       pop: true
 
-    - match: (?={{identifier}}\s*(?:{{dot_accessor}})?\()
+    - match: '{{function_call_lookahead}}'
       set: call-function-name
 
     - include: literal-variable-base

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -10,6 +10,20 @@ extends: JavaScript.sublime-syntax
 variables:
   dot_accessor: (?:[?!]?\.)
 
+  function_call_lookahead: >-
+    (?x:(?=
+      {{identifier}}
+      \s*
+      (?:
+        <
+        .*
+        >
+        \s*
+      )?
+      (?:{{dot_accessor}})?
+      \(
+    ))
+
 contexts:
   ts-import-type:
     - match: type{{identifier_break}}
@@ -398,6 +412,37 @@ contexts:
   expression-end:
     - meta_prepend: true
     - include: ts-type-assertion
+
+    - match: (?=<)
+      branch_point: ts-function-type-arguments
+      branch:
+        - ts-function-type-arguments
+        - ts-less-than
+
+  ts-function-type-arguments:
+    - match: \<
+      scope: punctuation.definition.generic.begin.js
+      set:
+        - - meta_scope: meta.generic.js
+          - match: \>
+            scope: punctuation.definition.generic.end.js
+            pop: true
+          - match: ','
+            scope: punctuation.separator.comma.js
+            push:
+              - ts-type-expression-end
+              - ts-type-expression-end-no-line-terminator
+              - ts-type-expression-begin
+          - match: (?=\S)
+            fail: ts-function-type-arguments
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
+
+  ts-less-than:
+    - match: '<'
+      scope: keyword.operator.logical.js
+      set: expression-begin
 
   expression-begin:
     - meta_prepend: true

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -726,3 +726,17 @@ let x: import ( "foo" ) . Bar ;
 //                    ^ punctuation.section.group.end
 //                      ^ punctuation.separator.accessor
 //                        ^^^ support.class
+
+    foo < bar > ();
+//  ^^^ variable.function
+//      ^^^^^^^ meta.generic
+//      ^ punctuation.definition.generic.begin
+//        ^^^ support.class
+//            ^ punctuation.definition.generic.end
+//              ^^ meta.group
+
+    foo < bar
+//  ^^^ variable.other.readwrite
+//      ^ keyword.operator.logical
+//        ^^^ variable.other.readwrite
+    ;

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -740,3 +740,13 @@ let x: import ( "foo" ) . Bar ;
 //      ^ keyword.operator.logical
 //        ^^^ variable.other.readwrite
     ;
+
+    new Foo<bar>;
+//  ^^^ keyword.operator.word.new
+//      ^^^ variable.other.constant
+//         ^^^^^ meta.generic
+
+    foo<bar>``;
+//  ^^^ variable.other.readwrite
+//     ^^^^^ meta.generic
+//          ^^ meta.string string.quoted.other


### PR DESCRIPTION
Fix #2515.

I think this should reliably distinguish function type arguments from the less than sign, except for one corner case:

```ts
foo < bar // end of file
```

Since there's apparently [no way to detect the end of the file](https://forum.sublimetext.com/t/sublime-syntax-regex-to-detect-end-of-file-as-opposed-to-end-of-line/35879), this is probably not fixable. (Any non-whitespace non-comment character after `bar` will allow it to highlight correctly.)

This PR also updates the code that detects when an identifier is a function being invoked. The implementation is simplistic and could be fooled, but it should work in basically all real-world scenarios and the failure mode isn't problematic.