### PR TITLE
[YAML] Fix constant.numeric of decimal numbers

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -346,8 +346,7 @@ contexts:
       scope: meta.number.integer.decimal.yaml
       captures:
         1: keyword.operator.arithmetic.yaml
-        2: constant.numeric.base.yaml
-        3: constant.numeric.value.yaml
+        2: constant.numeric.value.yaml
     - match: '{{_type_int_hexadecimal}}{{_flow_scalar_end_plain_in}}'
       scope: meta.number.integer.hexadecimal.yaml
       captures:
@@ -418,8 +417,7 @@ contexts:
       scope: meta.number.integer.decimal.yaml
       captures:
         1: keyword.operator.arithmetic.yaml
-        2: constant.numeric.base.yaml
-        3: constant.numeric.value.yaml
+        2: constant.numeric.value.yaml
     - match: '{{_type_int_hexadecimal}}{{_flow_scalar_end_plain_out}}'
       scope: meta.number.integer.hexadecimal.yaml
       captures:

--- a/YAML/tests/syntax_test_flow-plain.yaml
+++ b/YAML/tests/syntax_test_flow-plain.yaml
@@ -77,9 +77,9 @@ p[l]a,in:[]
 
 
 { bar: 1}
-#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#      ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
 { bar: 1 }
-#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#      ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
 #       ^ - string
 { key: string }
 #      ^^^^^^ string.unquoted.plain.in

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -68,13 +68,13 @@
 #                      ^^^^^^^^^^ - constant
 
    0, +1, -12_345, ~, 3 not a number
-#  ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#  ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
 #     ^^ meta.number.integer.decimal.yaml
 #     ^ keyword.operator.arithmetic.yaml
-#      ^ constant.numeric.base.yaml
+#      ^ constant.numeric.value.yaml
 #         ^^^^^^^ meta.number.integer.decimal.yaml
 #         ^ keyword.operator.arithmetic.yaml
-#          ^^^^^^ constant.numeric.base.yaml
+#          ^^^^^^ constant.numeric.value.yaml
 #                     ^^^^^^^^^^^^^^ - constant
 
    0x0, +0x12_34_56, -0xabcdef, ~, 0xyz, 0x,
@@ -193,9 +193,9 @@ true: false
 {.NaN: 2, 2: 2015-08-15}
 #^^^^ constant.language.nan.yaml
 #    ^ punctuation.separator.key-value.mapping.yaml
-#      ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#      ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
 #       ^ punctuation.separator.mapping.yaml
-#         ^ meta.number.integer.decimal.yaml constant.numeric.base.yaml
+#         ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
 #          ^ punctuation.separator.key-value.mapping.yaml
 #            ^^^^^^^^^^ constant.other.timestamp.yaml
 #                ^ punctuation.separator.date.yaml


### PR DESCRIPTION
This commit fixes decimal number values being scoped as `constant.numeric.base` by accident.