### PR TITLE
[CSS] Replace remaining `keyword.other.unit`

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1465,7 +1465,7 @@ contexts:
                   | {{frequency_units}}
                   | {{resolution_units}}
                 )\b
-              scope: keyword.other.unit.css
+              scope: constant.numeric.suffix.css
             - match: '(?=\))'
               pop: true
             - include: comma-delimiter

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -942,7 +942,7 @@
 
     top: attr(size px, auto);
 /*            ^^^^ entity.other.attribute-name.css */
-/*                 ^^ keyword.other.unit.css */
+/*                 ^^ constant.numeric.suffix.css */
 /*                   ^ punctuation.separator.sequence.css */
 /*                     ^^^^ support.constant.property-value.css */
 


### PR DESCRIPTION
This commit replaces the last remaining `keyword.other.unit` as it was decided to use `constant.numeric.suffix` for all kinds of units and storage type denoting suffixes in numeric literals.

This commit handles the only situation units appear as standalone token without a numeric literal in front of them.