### PR TITLE
[CSS] Fix `grid` property-name highlighting

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -595,6 +595,8 @@ contexts:
     - include: literal-string
     - match: \!\s*important
       scope: keyword.other.important.css
+    - match: /
+      scope: keyword.operator.arithmetic.css
 
   rule-list-terminator:
     - match: '\s*(\})'
@@ -719,7 +721,7 @@ contexts:
               | nbsp-mode|color|image-resolution|grid-row-gap|grid-row|grid-column
               | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
               | text-height|system|negative|prefix|suffix|range|pad|fallback
-              | additive-symbols|symbols|speak-as|speak|grid-gap
+              | additive-symbols|symbols|speak-as|speak|grid-gap|grid
             )\b
           scope: support.type.property-name.css
     - match: (:)([ \t]*)

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1054,11 +1054,28 @@
 
 .test-grid-functions {
     grid: repeat(20) / auto-flow 1fr;
+/*  ^^^^ support.type.property-name.css */
+/*      ^ punctuation.separator.key-value.css */
 /*        ^^^^^^ support.function.grid.css */
 /*               ^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                   ^ keyword.operator.arithmetic.css */
 /*                     ^^^^^^^^^ support.constant.property-value.css */
 /*                               ^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*                                ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    grid: [linename1] "a" 100px [linename2];
+/*  ^^^^ meta.property-list.css meta.property-name.css */
+/*       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.property-value.css */
+/*  ^^^^ support.type.property-name.css */
+/*      ^ punctuation.separator.key-value.css */
+/*        ^ punctuation.section.begin.css */
+/*         ^^^^^^^^^ string.unquoted.line-name.css */
+/*                  ^ punctuation.section.end.css */
+/*                    ^^^ string.quoted.double.css */
+/*                        ^^^^^ meta.number.integer.decimal.css */
+/*                              ^ punctuation.section.begin.css */
+/*                               ^^^^^^^^^ string.unquoted.line-name.css */
+/*                                        ^ punctuation.section.end.css */
 
     top: repeat(auto-fit, 2fr minmax(auto) 5%);
 /*              ^^^^^^^^ support.keyword.repetitions.css */
@@ -1083,7 +1100,9 @@
 /*                           ^^^ support.function.var.css */
 /*                               ^^^^^^ support.type.custom-property.css */
 /*                                     ^^ punctuation.definition.group.end.css */
+/*                                        ^ keyword.operator.arithmetic.css */
 /*                                          ^^^^^^ support.function.grid.css */
+
     grid-template-columns:
       [a-line-name] auto
 /*    ^ punctuation.section.begin.css */


### PR DESCRIPTION
This commit adds `grid` keyword to the list of valid property names.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/grid

Also scopes `/` as keyword.operator.arithmetic in all property-values in order highlight it in grid related properties.

Note: If we want to limit `/` highlighting dedicated `grid` related contexts need to be created.