### PR TITLE
[SQL] Add various syntax tests to prevent regressions

### DIFF
--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -44,6 +44,78 @@ create table `dbo`."testing123" (id integer);
 --                  ^^^^^^^^^^ entity.name.function
 --                            ^^^^^^^^^^^^^^^^ - entity.name.function
 
+create table IF NOT EXISTS `testing123` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `lastchanged` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+--                ^^^^^^^^^ storage.type.sql
+--                                           ^^^^^^^^^^^^^^^^^ support.function.scalar.sql
+    `col` bool DEFAULT FALSE,
+--        ^^^^ storage.type.sql
+--             ^^^^^^^ storage.modifier.sql
+    `fkey` INT UNSIGNED NULL REFERENCES test2(id),
+--                           ^^^^^^^^^^ storage.modifier.sql
+    `version` tinytext DEFAULT NULL COMMENT 'important clarification',
+--            ^^^^^^^^ storage.type.sql
+    `percentage` float DEFAULT '0',
+    UNIQUE KEY `testing123_search` (`col`, `version`),
+--  ^^^^^^^^^^ storage.modifier.sql
+    KEY `testing123_col` (`col`),
+--  ^^^ storage.modifier.sql
+    FULLTEXT KEY `testing123_version` (`version`)
+) ENGINE=MyISAM AUTO_INCREMENT=42 DEFAULT CHARSET=utf8;
+
+create table fancy_table (
+    id SERIAL,
+--     ^^^^^^ storage.type.sql
+    foreign_id integer,
+--             ^^^^^^^ storage.type.sql
+    myflag boolean DEFAULT false,
+--         ^^^^^^^ storage.type.sql
+    mycount double precision DEFAULT 1,
+--          ^^^^^^^^^^^^^^^^ storage.type.sql
+    fancy_column character varying(42) DEFAULT 'nice'::character varying,
+--               ^^^^^^^^^^^^^^^^^ storage.type.sql
+    mytime timestamp(3) without time zone DEFAULT now(),
+--                      ^^^^^^^^^^^^^^^^^ storage.type.sql
+    mytime2 timestamp(3) without  time  zone DEFAULT '2008-01-18 00:00:00'::timestamp(3) without time zone,
+    primary key (id),
+--  ^^^^^^^^^^^ storage.modifier.sql
+    UNIQUE (foreign_id),
+    CONSTRAINT fancy_table_valid1 CHECK (id <> foreign_id)
+--  ^^^^^^^^^^ storage.modifier.sql
+--                                ^^^^^ storage.modifier.sql
+);
+
+CREATE INDEX ON fancy_table(mytime);
+--     ^^^^^ keyword.other.sql
+--           ^^ - entity.name.function.sql
+--              ^^^^^^^^^^^ entity.name.function.sql
+
+CREATE INDEX ON fancy_table USING gin (fancy_column gin_trgm_ops);
+--     ^^^^^ keyword.other.sql
+--           ^^ - entity.name.function.sql
+
+CREATE UNIQUE INDEX ON fancy_table(fancy_column,mycount) WHERE myflag IS NULL;
+--     ^^^^^^^^^^^^ keyword.other.sql
+--                  ^^ - entity.name.function.sql
+--                     ^^^^^^^^^^^ entity.name.function.sql
+--                                                       ^^^^^ keyword.other.DML.sql
+--                                                                    ^^ keyword.operator.logical.sql
+--                                                                       ^^^^ constant.language.sql
+
+create fulltext index if not exists `myindex` ON mytable;
+--     ^^^^^^^^^^^^^^ keyword.other.sql
+
+ALTER TABLE dbo.testing123 ADD COLUMN mycolumn longtext;
+--                                             ^^^^^^^^ storage.type.sql
+
+ALTER TABLE testing123 CHANGE COLUMN mycolumn mycolumn ENUM('foo', 'bar');
+--                                                     ^^^^ storage.type.sql
+
+DROP TABLE IF EXISTS testing123;
+-- <- meta.drop.sql keyword.other.create.sql
+--            ^^^^^^ keyword.operator.logical.sql
+
 select *
 from some_table
 where exists(select * from other_table where id = some_table.id)


### PR DESCRIPTION
Due to few syntax tests for the SQL language it is more likely to add regressions on modifications to the syntax file. This PR tries to address this issue. It adds syntax tests to preserve the status quo but also has SQL code which is not covered by the syntax definition file yet. To avoid failing tests that code parts have no scope annotations. Its like a collection of missing improvements for the syntax definition file. Some of them I will try to improve in the future.