### PR TITLE
[HTML] Remove ID symbol transformation

### DIFF
--- a/HTML/Symbol List - ID.tmPreferences
+++ b/HTML/Symbol List - ID.tmPreferences
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-	<key>name</key>
-	<string>Symbol List: ID</string>
 	<key>scope</key>
 	<string>text.html meta.toc-list.id.html</string>
 	<key>settings</key>
 	<dict>
-		<key>symbolTransformation</key>
-		<string>s/^/ID: /</string>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR proposes to remove symbol transformation from _Symbol List - ID_ as

1. the `ID:` is represented by the `i` symbol kind icon
2. the symbol's source (HTML) is displayed as hint on the right.