### PR TITLE
[CSS] Remove 'CSS: ' from symbol transformation

### DIFF
--- a/CSS/Symbol List - Selector.tmPreferences
+++ b/CSS/Symbol List - Selector.tmPreferences
@@ -9,7 +9,10 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
-			s/\s+/ /g;	# remove multiple whitespace
+			s/\/\*.*?\*\///g;		# remove comments
+			s/\s+([,)\]}])/$1/g;	# remove whitespace before punctuation
+			s/([(\[{])\s+/$1/g;		# remove whitespace after punctuation
+			s/\s+/ /g;				# remove multiple whitespace
 		</string>
 	</dict>
 </dict>

--- a/CSS/Symbol List - Selector.tmPreferences
+++ b/CSS/Symbol List - Selector.tmPreferences
@@ -8,7 +8,9 @@
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>s/^\s*/CSS: /; s/\s+/ /g</string>
+		<string>
+			s/\s+/ /g;	# remove multiple whitespace
+		</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR proposes to remove symbol transformation from _Symbol List - Selector_ as the symbol's source (CSS) is displayed as hint on the right.