### PR TITLE
[CSS] Add var() to global completions

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -562,7 +562,7 @@ def get_properties():
 
     for names, values in properties_dict.items():
         # Values that are allowed for all properties
-        allowed_values = ['all', 'inherit', 'initial', 'unset']
+        allowed_values = ['all', 'inherit', 'initial', 'unset', ['var()', 'var($1)']]
 
         # Determine which values are available for the current property name
         for value in values:


### PR DESCRIPTION
As `var()` is supported everywhere, we also might want to have a global completion for it.

This commit adds `var()` to all property-value completions.

Note: It might be useful to also add it to function-argument completions in a future commit.