### PR TITLE
[CSS] Fix indexed symbol list

### DIFF
--- a/CSS/Symbol Index.tmPreferences
+++ b/CSS/Symbol Index.tmPreferences
@@ -11,7 +11,9 @@
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
 		<key>symbolIndexTransformation</key>
-		<string>/[#.]([A-Za-z0-9_~]+)/$1/;</string>
+		<string>
+			s/[#.]([\w_-]+)/$1/;
+		</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
According to https://www.w3.org/TR/css-syntax-3/#name-code-point a `class` or `id` identifier may consist of any unicode letter or digit including underscore `_` and hyphons `-`.

The current implementation of the indexed symbol list instead accepts only ASCII letters, underscores and `~`. The latter one is considered a typo. Thus symbol transformation (removing leading `#` or `.`) is not performed and matching against html classes and ids is not possible.

This PR therefore applies a simplified pattern that matches the public naming specification. Simplified means, we'd accept `--` or `-0` here which is not valid, but sufficient for the use case of symbol transformation.