### PR TITLE
[HTML] Add dedicated CSS/JS content contexts

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -199,10 +199,13 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
-        - match: (?=\S)
-          embed: scope:source.js
-          embed_scope: source.js.embedded.html
-          escape: '{{script_close_lookahead}}'
+        - include: script-javascript-content
+
+  script-javascript-content:
+    - match: (?=\S)
+      embed: scope:source.js
+      embed_scope: source.js.embedded.html
+      escape: '{{script_close_lookahead}}'
 
   script-html:
     - meta_scope: meta.tag.script.begin.html
@@ -292,10 +295,13 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
-        - match: ''
-          embed: scope:source.css
-          embed_scope: source.css.embedded.html
-          escape: '{{style_close_lookahead}}'
+        - include: style-css-content
+
+  style-css-content:
+    - match: ''
+      embed: scope:source.css
+      embed_scope: source.css.embedded.html
+      escape: '{{style_close_lookahead}}'
 
   style-other:
     - meta_scope: meta.tag.style.begin.html


### PR DESCRIPTION
This commit intends to make it easier for an inherit HTML syntax to replace the plain `source.js` and `source.css` by inherit definitions.

A syntax such as ASP or JSP needs to inherit CSS and JS in order to extend them by ASP/JSP tag support. Those extended CSS/JS variants need to be embedded in HTML-ASP or HTML-JSP then.

The strategy may be compared to what Makefile does with Bash via Makefile Shell.sublime-syntax.

Unfortunately the `embed:` command doesn't accept variables which could be used to replace the scope name more easily/consistently. So the dedicated context is the only way to minimize required code duplication.