### PR TITLE
[Matlab] Merge percentage comment patterns

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -40,7 +40,11 @@ contexts:
           captures:
             1: punctuation.definition.comment.matlab
           pop: true
-    - match: (%+).*$\n?
+    - match: (%%(?!%)).*\n?
+      scope: comment.line.double-percentage.matlab
+      captures:
+        1: punctuation.definition.comment.matlab
+    - match: (%+).*\n?
       scope: comment.line.percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -31,20 +31,16 @@ contexts:
         2: punctuation.accessor.dot.matlab
       push: transpose_post_parens
   all_matlab_comments:
-    - match: (%%).*$\n?
-      scope: comment.double.percentage.matlab
-      captures:
-        1: punctuation.definition.comment.matlab
-    - match: '^\s*(%\{)\s*\n'
+    - match: ^\s*(%\{)\s*\n
       captures:
         1: punctuation.definition.comment.matlab
       push:
         - meta_scope: comment.block.percentage.matlab
-        - match: '^\s*(%\})\s*$\n?'
+        - match: ^\s*(%\})\s*$\n?
           captures:
             1: punctuation.definition.comment.matlab
           pop: true
-    - match: (%).*$\n?
+    - match: (%+).*$\n?
       scope: comment.line.percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -57,14 +57,28 @@ xAprox = fMetodoDeNewton( xi )
 %---------------------------------------------
 % Line comment test
 
+%
+%<- comment.line.percentage.matlab punctuation.definition.comment.matlab
+%^ comment.line.percentage.matlab - punctuation
+
 % comment % comment
 %<- comment.line.percentage.matlab punctuation.definition.comment.matlab
 %^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab - punctuation
 
+%%
+%<- comment.line.double-percentage.matlab punctuation.definition.comment.matlab
+%^ comment.line.double-percentage.matlab punctuation.definition.comment.matlab
+% ^ comment.line.double-percentage.matlab - punctuation
+
 %% comment % comment
+%<- comment.line.double-percentage.matlab punctuation.definition.comment.matlab
+%^ comment.line.double-percentage.matlab punctuation.definition.comment.matlab
+% ^^^^^^^^^^^^^^^^^^^ comment.line.double-percentage.matlab - punctuation
+
+%%%
 %<- comment.line.percentage.matlab punctuation.definition.comment.matlab
-%^ comment.line.percentage.matlab punctuation.definition.comment.matlab
-% ^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab - punctuation
+%^^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+%  ^ comment.line.percentage.matlab - punctuation
 
 %%%%% comment % comment %%%%
 %<- comment.line.percentage.matlab punctuation.definition.comment.matlab
@@ -76,8 +90,8 @@ a = b % doc
 %      ^^^^^ comment.line.percentage.matlab - punctuation
 
 a = b %% doc
-%     ^^ comment.line.percentage.matlab punctuation.definition.comment.matlab
-%       ^^^^^ comment.line.percentage.matlab - punctuation
+%     ^^ comment.line.double-percentage.matlab punctuation.definition.comment.matlab
+%       ^^^^^ comment.line.double-percentage.matlab - punctuation
 
 
 %---------------------------------------------

--- a/Matlab/syntax_test_matlab.m
+++ b/Matlab/syntax_test_matlab.m
@@ -55,6 +55,32 @@ xAprox = fMetodoDeNewton( xi )
 
 
 %---------------------------------------------
+% Line comment test
+
+% comment % comment
+%<- comment.line.percentage.matlab punctuation.definition.comment.matlab
+%^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab - punctuation
+
+%% comment % comment
+%<- comment.line.percentage.matlab punctuation.definition.comment.matlab
+%^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+% ^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab - punctuation
+
+%%%%% comment % comment %%%%
+%<- comment.line.percentage.matlab punctuation.definition.comment.matlab
+%^^^^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+%    ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab - punctuation
+
+a = b % doc
+%     ^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+%      ^^^^^ comment.line.percentage.matlab - punctuation
+
+a = b %% doc
+%     ^^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+%       ^^^^^ comment.line.percentage.matlab - punctuation
+
+
+%---------------------------------------------
 % Block comment test
 
 % Success case


### PR DESCRIPTION
This commit merges double-percentage and single-percentage comments.

The result is all types of comments beginning with an arbitrary number of percentage sign are accepted with highlighting all percentages as `punctuation.definition`.