### PR TITLE
[YAML] Replace entity.name.tag with meta.mapping.key

### DIFF
--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1935,12 +1935,12 @@ echo <<< yml
 //       ^^^ entity.name.tag.heredoc
 one: two
 //^^^^^^ meta.embedded.yaml source.yaml
-//^ string.unquoted.plain.out entity.name.tag
+//^ meta.mapping.key string
 // ^       punctuation.separator.key-value.mapping
-//   ^^^ string.unquoted.plain.out
+//   ^^^ string
 three: "$four"
 //^^^^^^^^^^^^ meta.embedded.yaml source.yaml
-//^^^ string.unquoted.plain.out entity.name.tag
+//^^^ meta.mapping.key string
 //   ^       punctuation.separator.key-value.mapping
 //     ^^^^^^^ string.quoted.double
 //      ^^^^^ variable.other.php

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -37,6 +37,7 @@
 ---
 name: YAML
 scope: source.yaml
+version: 2
 
 file_extensions:
   - yaml
@@ -107,6 +108,34 @@ variables:
           \s* $
         | \s+ \#
         | \s* : (\s|$)
+      )
+    )
+
+  _flow_key_in_lookahead: |-
+    (?x:
+      (?=
+        {{ns_plain_first_plain_in}}
+        ( [^\s:{{c_flow_indicator}}]
+        | : [^\s{{c_flow_indicator}}]
+        | \s+ (?![#\s])
+        )*
+        \s*
+        :
+        (\s|$)
+      )
+    )
+
+  _flow_key_out_lookahead: |-
+    (?x:
+      (?=
+        {{ns_plain_first_plain_out}}
+        ( [^\s:]
+        | : \S
+        | \s+ (?![#\s])
+        )*
+        \s*
+        :
+        (\s|$)
       )
     )
 
@@ -512,15 +541,13 @@ contexts:
     - match: \[
       scope: punctuation.definition.sequence.begin.yaml
       push:
-        # Pushes an extra 'meta' on the scope stack that flow-pair can then clear,
-        # so we don't have to duplicate the context
-        - meta_scope: meta.sequence.flow.yaml meta.workaround.yaml
+        - meta_scope: meta.sequence.flow.yaml
         - match: \]
           scope: punctuation.definition.sequence.end.yaml
           pop: true
         - match: ','
           scope: punctuation.separator.sequence.yaml
-        - include: flow-pair
+        - include: flow-pair-no-clear
         - include: flow-node
 
   flow-mapping:
@@ -534,50 +561,83 @@ contexts:
         - match: ','
           scope: punctuation.separator.mapping.yaml
         - include: flow-pair
+        - include: flow-node  # for sets
 
   flow-pair:
     - match: \?
-      scope: meta.mapping.key.explicit.yaml punctuation.definition.key.begin.yaml
+      scope: meta.mapping.key.yaml punctuation.definition.key.begin.yaml
       push:
-        - - match: ''
-            set: flow-pair-value
-        - - clear_scopes: 1
-          - meta_content_scope: meta.mapping.key.explicit.yaml
-          - match: (?=[},\]])  # Empty mapping keys & values are allowed
-            pop: true
-          - match: :(?=\s|$|{{c_flow_indicator}})
-            scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-            pop: true
-          - include: flow-node
+        - flow-pair-value-set
+        - flow-pair-key
     # Attempt to match plain-in scalars followed by a colon
-    - match: |
-        (?x)
-        (?=
-          {{ns_plain_first_plain_in}}
-          ( [^\s:{{c_flow_indicator}}]
-          | : [^\s{{c_flow_indicator}}]
-          | \s+ (?![#\s])
-          )*
-          \s*
-          :
-          (\s|$)
-        )
+    - match: '{{_flow_key_in_lookahead}}'
       push:
-        - - clear_scopes: 1
-          - meta_scope: meta.mapping.key.yaml
-          - include: flow-scalar-plain-in-implicit-type-12
-          - match: ''
-            pop: true
-        - - match: (?=\S)
-            pop: true
+        - flow-pair-value-set
+        - flow-pair-key-12
     - match: :(?=\s|$|{{c_flow_indicator}}) # Empty mapping keys allowed
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
       push: flow-pair-value
-    # TODO match as meta.mapping.key
+
+  # Variant without clearing the parent scope for pairs in a sequence
+  flow-pair-no-clear:
+    - match: \?
+      scope: meta.mapping.key.yaml punctuation.definition.key.begin.yaml
+      push:
+        - flow-pair-value-set-no-clear
+        - flow-pair-key-no-clear
+    - match: '{{_flow_key_in_lookahead}}'
+      push:
+        - flow-pair-value-set-no-clear
+        - flow-pair-key-no-clear
+    - match: :(?=\s|$|{{c_flow_indicator}})
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      push: flow-pair-value-no-clear
+
+  flow-pair-key:
+    - clear_scopes: 1
+    - meta_content_scope: meta.mapping.key.yaml
+    - match: (?=[},\]])  # Empty mapping keys & values are allowed
+      pop: true
+    - match: :(?=\s|$|{{c_flow_indicator}})
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      pop: true
     - include: flow-node
+
+  flow-pair-key-12:
+    - clear_scopes: 1
+    - meta_content_scope: meta.mapping.key.yaml
+    - match: (?=[},\]])  # Empty mapping keys & values are allowed
+      pop: true
+    - match: :(?=\s|$|{{c_flow_indicator}})
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      pop: true
+    - include: flow-scalar-plain-in-implicit-type-12
+
+  flow-pair-key-no-clear:
+    - meta_content_scope: meta.mapping.key.yaml
+    - match: (?=[},\]])
+      pop: true
+    - match: :(?=\s|$|{{c_flow_indicator}})
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      pop: true
+    - include: flow-node
+
+  flow-pair-value-set:
+    - match: ''
+      set: flow-pair-value
 
   flow-pair-value:
     - clear_scopes: 1
+    - meta_content_scope: meta.mapping.value.yaml
+    - include: flow-node
+    - match: (?=[},\]])
+      pop: true
+
+  flow-pair-value-set-no-clear:
+    - match: ''
+      set: flow-pair-value-no-clear
+
+  flow-pair-value-no-clear:
     - meta_content_scope: meta.mapping.value.yaml
     - include: flow-node
     - match: (?=[},\]])
@@ -637,32 +697,18 @@ contexts:
     # Attempt to match plain-out scalars and highlight as "meta.mapping.key",
     # if followed by a colon
     # TODO rewrite with branching
-    - match: |
-        (?x)
-        (?=
-          {{ns_plain_first_plain_out}}
-          (
-              [^\s:]
-            | : \S
-            | \s+ (?![#\s])
-          )*
-          \s*
-          :
-          (\s|$)
-        )
+    - match: '{{_flow_key_out_lookahead}}'
       push:
-        - - meta_scope: meta.mapping.key.yaml
-          - match: ''
-            pop: true
-        - - include: flow-scalar-plain-out-implicit-type-12
-          - match: '{{_flow_scalar_end_plain_out}}'
-            pop: true
-          - match: (?={{ns_plain_first_plain_out}})
-            set:
-              - meta_scope: string.unquoted.plain.out.yaml
-              - meta_include_prototype: false
-              - match: '{{_flow_scalar_end_plain_out}}'
-                pop: true
+        - meta_scope: meta.mapping.key.yaml
+        - include: flow-scalar-plain-out-implicit-type-12
+        - match: '{{_flow_scalar_end_plain_out}}'
+          pop: true
+        - match: (?={{ns_plain_first_plain_out}})
+          set:
+            - meta_scope: meta.mapping.key.yaml string.unquoted.plain.out.yaml
+            - meta_include_prototype: false
+            - match: '{{_flow_scalar_end_plain_out}}'
+              pop: true
     - match: :(?=\s|$)
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
 

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -433,6 +433,28 @@ contexts:
         7: punctuation.separator.time.yaml
         8: punctuation.separator.time.yaml
 
+  flow-scalar-plain-in-11:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
+    # ns-plain(n,c) (c=flow-in, c=flow-key)
+    - include: flow-scalar-plain-in-implicit-type-11
+    - include: flow-scalar-plain-in-common
+
+  flow-scalar-plain-in-12:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
+    # ns-plain(n,c) (c=flow-in, c=flow-key)
+    - include: flow-scalar-plain-in-implicit-type-12
+    - include: flow-scalar-plain-in-common
+
+  flow-scalar-plain-in-common:
+    - match: (?={{ns_plain_first_plain_in}})
+      push: flow-scalar-plain-in-content
+
+  flow-scalar-plain-in-content:
+    - meta_scope: string.unquoted.plain.in.yaml
+    - meta_include_prototype: false
+    - match: '{{_flow_scalar_end_plain_in}}'
+      pop: true
+
   flow-scalar-plain-out-implicit-type-11:
     - match: '{{_type_bool_11}}{{_flow_scalar_end_plain_out}}'
       scope: constant.language.boolean.yaml
@@ -524,28 +546,6 @@ contexts:
     - meta_scope: string.unquoted.plain.out.yaml
     - meta_include_prototype: false
     - match: '{{_flow_scalar_end_plain_out}}'
-      pop: true
-
-  flow-scalar-plain-in-11:
-    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
-    # ns-plain(n,c) (c=flow-in, c=flow-key)
-    - include: flow-scalar-plain-in-implicit-type-11
-    - include: flow-scalar-plain-in-common
-
-  flow-scalar-plain-in-12:
-    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
-    # ns-plain(n,c) (c=flow-in, c=flow-key)
-    - include: flow-scalar-plain-in-implicit-type-12
-    - include: flow-scalar-plain-in-common
-
-  flow-scalar-plain-in-common:
-    - match: (?={{ns_plain_first_plain_in}})
-      push: flow-scalar-plain-in-content
-
-  flow-scalar-plain-in-content:
-    - meta_scope: string.unquoted.plain.in.yaml
-    - meta_include_prototype: false
-    - match: '{{_flow_scalar_end_plain_in}}'
       pop: true
 
   flow-sequence:

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -634,8 +634,9 @@ contexts:
           scope: meta.mapping.yaml invalid.illegal.expected-newline.yaml
           pop: true
         - include: block-node
-    # Attempt to match plain-out scalars and highlight as "entity.name.tag",
+    # Attempt to match plain-out scalars and highlight as "meta.mapping.key",
     # if followed by a colon
+    # TODO rewrite with branching
     - match: |
         (?x)
         (?=
@@ -650,17 +651,20 @@ contexts:
           (\s|$)
         )
       push:
-        - include: flow-scalar-plain-out-implicit-type-12
-        - match: '{{_flow_scalar_end_plain_out}}'
-          pop: true
-        - match: (?={{ns_plain_first_plain_out}})
-          set:
-            - meta_scope: string.unquoted.plain.out.yaml entity.name.tag.yaml
-            - meta_include_prototype: false
-            - match: '{{_flow_scalar_end_plain_out}}'
-              pop: true
+        - - meta_scope: meta.mapping.key.yaml
+          - match: ''
+            pop: true
+        - - include: flow-scalar-plain-out-implicit-type-12
+          - match: '{{_flow_scalar_end_plain_out}}'
+            pop: true
+          - match: (?={{ns_plain_first_plain_out}})
+            set:
+              - meta_scope: string.unquoted.plain.out.yaml
+              - meta_include_prototype: false
+              - match: '{{_flow_scalar_end_plain_out}}'
+                pop: true
     - match: :(?=\s|$)
-      scope: punctuation.separator.key-value.mapping.yaml
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
 
   comment:
     # http://www.yaml.org/spec/1.2/spec.html#comment//

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -223,7 +223,7 @@ contexts:
     # http://yaml.org/spec/1.2/spec.html#style/flow/scalar
     - include: flow-scalar-double-quoted
     - include: flow-scalar-single-quoted
-    - include: flow-scalar-plain-in
+    - include: flow-scalar-plain-in-11
 
   flow-collection:
     # http://yaml.org/spec/1.2/spec.html#style/flow/collection
@@ -518,33 +518,35 @@ contexts:
     # ns-plain(n,c) (c=flow-out, c=block-key)
     - include: flow-scalar-plain-out-implicit-type-11
     - match: (?={{ns_plain_first_plain_out}})
-      push:
-        - meta_scope: string.unquoted.plain.out.yaml
-        - meta_include_prototype: false
-        - match: '{{_flow_scalar_end_plain_out}}'
-          pop: true
+      push: flow-scalar-plain-out-content
 
-  flow-scalar-plain-in:
+  flow-scalar-plain-out-content:
+    - meta_scope: string.unquoted.plain.out.yaml
+    - meta_include_prototype: false
+    - match: '{{_flow_scalar_end_plain_out}}'
+      pop: true
+
+  flow-scalar-plain-in-11:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain
     # ns-plain(n,c) (c=flow-in, c=flow-key)
     - include: flow-scalar-plain-in-implicit-type-11
-    - match: (?={{ns_plain_first_plain_in}})
-      push:
-        - meta_scope: string.unquoted.plain.in.yaml
-        - meta_include_prototype: false
-        - match: '{{_flow_scalar_end_plain_in}}'
-          pop: true
+    - include: flow-scalar-plain-in-common
 
   flow-scalar-plain-in-12:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain
     # ns-plain(n,c) (c=flow-in, c=flow-key)
     - include: flow-scalar-plain-in-implicit-type-12
+    - include: flow-scalar-plain-in-common
+
+  flow-scalar-plain-in-common:
     - match: (?={{ns_plain_first_plain_in}})
-      push:
-        - meta_scope: string.unquoted.plain.in.yaml
-        - meta_include_prototype: false
-        - match: '{{_flow_scalar_end_plain_in}}'
-          pop: true
+      push: flow-scalar-plain-in-content
+
+  flow-scalar-plain-in-content:
+    - meta_scope: string.unquoted.plain.in.yaml
+    - meta_include_prototype: false
+    - match: '{{_flow_scalar_end_plain_in}}'
+      pop: true
 
   flow-sequence:
     # http://yaml.org/spec/1.2/spec.html#style/flow/sequence

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -114,11 +114,15 @@ variables:
   _flow_key_in_lookahead: |-
     (?x:
       (?=
-        {{ns_plain_first_plain_in}}
-        ( [^\s:{{c_flow_indicator}}]
-        | : [^\s{{c_flow_indicator}}]
-        | \s+ (?![#\s])
-        )*
+        (
+          {{ns_plain_first_plain_in}}
+          ( [^\s:{{c_flow_indicator}}]
+          | : [^\s{{c_flow_indicator}}]
+          | \s+ (?![#\s])
+          )*
+          | \".*\"
+          | \'.*\'
+        )
         \s*
         :
         (\s|$)
@@ -217,13 +221,26 @@ contexts:
     # ns-flow-yaml-node(n,c)
     - include: flow-alias
     - include: flow-collection
-    - include: flow-scalar
+    - include: flow-scalar-11
 
-  flow-scalar:
+  flow-node-12:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/
+    # ns-flow-yaml-node(n,c)
+    - include: flow-alias
+    - include: flow-collection
+    - include: flow-scalar-12
+
+  flow-scalar-11:
     # http://yaml.org/spec/1.2/spec.html#style/flow/scalar
     - include: flow-scalar-double-quoted
     - include: flow-scalar-single-quoted
     - include: flow-scalar-plain-in-11
+
+  flow-scalar-12:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/scalar
+    - include: flow-scalar-double-quoted
+    - include: flow-scalar-single-quoted
+    - include: flow-scalar-plain-in-12
 
   flow-collection:
     # http://yaml.org/spec/1.2/spec.html#style/flow/collection
@@ -580,79 +597,50 @@ contexts:
     - match: \?
       scope: meta.mapping.key.yaml punctuation.definition.key.begin.yaml
       push:
-        - flow-pair-value-set
+        - flow-pair-clear-1
         - flow-pair-key
     # Attempt to match plain-in scalars followed by a colon
     - match: '{{_flow_key_in_lookahead}}'
       push:
-        - flow-pair-value-set
-        - flow-pair-key-12
+        - flow-pair-clear-1
+        - flow-pair-key
     - match: :(?=\s|$|{{c_flow_indicator}}) # Empty mapping keys allowed
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      push: flow-pair-value
+      push:
+        - flow-pair-clear-1
+        - flow-pair-value
 
   # Variant without clearing the parent scope for pairs in a sequence
   flow-pair-no-clear:
     - match: \?
       scope: meta.mapping.key.yaml punctuation.definition.key.begin.yaml
-      push:
-        - flow-pair-value-set-no-clear
-        - flow-pair-key-no-clear
+      push: flow-pair-key
     - match: '{{_flow_key_in_lookahead}}'
-      push:
-        - flow-pair-value-set-no-clear
-        - flow-pair-key-no-clear
+      push: flow-pair-key
     - match: :(?=\s|$|{{c_flow_indicator}})
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      push: flow-pair-value-no-clear
+      push: flow-pair-value
 
   flow-pair-key:
-    - clear_scopes: 1
     - meta_content_scope: meta.mapping.key.yaml
-    - match: (?=[},\]])  # Empty mapping keys & values are allowed
-      pop: true
     - match: :(?=\s|$|{{c_flow_indicator}})
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      pop: true
-    - include: flow-node
-
-  flow-pair-key-12:
-    - clear_scopes: 1
-    - meta_content_scope: meta.mapping.key.yaml
-    - match: (?=[},\]])  # Empty mapping keys & values are allowed
-      pop: true
-    - match: :(?=\s|$|{{c_flow_indicator}})
-      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      pop: true
-    - include: flow-scalar-plain-in-12
-
-  flow-pair-key-no-clear:
-    - meta_content_scope: meta.mapping.key.yaml
-    - match: (?=[},\]])
-      pop: true
-    - match: :(?=\s|$|{{c_flow_indicator}})
-      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      pop: true
-    - include: flow-node
-
-  flow-pair-value-set:
-    - match: ''
       set: flow-pair-value
+    - include: flow-pair-end  # Empty mapping keys & values are allowed
+    - include: flow-node-12
 
   flow-pair-value:
-    - clear_scopes: 1
     - meta_content_scope: meta.mapping.value.yaml
+    - include: flow-pair-end
     - include: flow-node
-    - match: (?=[},\]])
+
+  flow-pair-clear-1:
+    - meta_include_prototype: false
+    - clear_scopes: 1
+    - match: ''
       pop: true
 
-  flow-pair-value-set-no-clear:
-    - match: ''
-      set: flow-pair-value-no-clear
-
-  flow-pair-value-no-clear:
-    - meta_content_scope: meta.mapping.value.yaml
-    - include: flow-node
+  flow-pair-end:
     - match: (?=[},\]])
       pop: true
 

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -112,10 +112,10 @@ variables:
 
   # patterns for plain scalars of implicit different types
   # (for the Core Schema: http://www.yaml.org/spec/1.2/spec.html#schema/core/)
-  
+
   # http://yaml.org/type/null.html
   _type_null: (?:null|Null|NULL|~)
-  
+
   # http://yaml.org/type/bool.html
   _type_bool_11: |-
     (?x:
@@ -266,23 +266,23 @@ contexts:
     # http://yaml.org/spec/1.2/spec.html#node/property/
     - match: (?=!|&)
       push:
-      - meta_scope: meta.property.yaml
-      # &Anchor
-      # http://yaml.org/spec/1.2/spec.html#&%20anchor//
-      - match: (&)({{ns_anchor_name}})(\S+)?
-        captures:
-          1: keyword.control.property.anchor.yaml punctuation.definition.anchor.yaml
-          2: entity.name.other.anchor.yaml
-          3: invalid.illegal.character.anchor.yaml
-        pop: true
-      # !Tag Handle
-      # http://yaml.org/spec/1.2/spec.html#tag/property/
-      - match: '{{c_ns_tag_property}}(?=\ |\t|$)'
-        scope: storage.type.tag-handle.yaml
-        pop: true
-      - match: \S+
-        scope: invalid.illegal.tag-handle.yaml
-        pop: true
+        - meta_scope: meta.property.yaml
+        # &Anchor
+        # http://yaml.org/spec/1.2/spec.html#&%20anchor//
+        - match: (&)({{ns_anchor_name}})(\S+)?
+          captures:
+            1: keyword.control.property.anchor.yaml punctuation.definition.anchor.yaml
+            2: entity.name.other.anchor.yaml
+            3: invalid.illegal.character.anchor.yaml
+          pop: true
+        # !Tag Handle
+        # http://yaml.org/spec/1.2/spec.html#tag/property/
+        - match: '{{c_ns_tag_property}}(?=\ |\t|$)'
+          scope: storage.type.tag-handle.yaml
+          pop: true
+        - match: \S+
+          scope: invalid.illegal.tag-handle.yaml
+          pop: true
 
   flow-alias:
     # http://yaml.org/spec/1.2/spec.html#alias//
@@ -672,7 +672,7 @@ contexts:
         - match: '#'
           scope: punctuation.definition.comment.line.number-sign.yaml
           set:
-          - meta_scope: comment.line.number-sign.yaml
-          - match: \n|\z
-            pop: true
+            - meta_scope: comment.line.number-sign.yaml
+            - match: \n|\z
+              pop: true
 ...

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -115,12 +115,12 @@ variables:
     (?x:
       (?=
         (
-          {{ns_plain_first_plain_in}}
-          ( [^\s:{{c_flow_indicator}}]
-          | : [^\s{{c_flow_indicator}}]
-          | \s+ (?![#\s])
-          )*
-          | \".*\"
+            {{ns_plain_first_plain_in}}
+            ( [^\s:{{c_flow_indicator}}]
+            | : [^\s{{c_flow_indicator}}]
+            | \s+ (?![#\s])
+            )*
+          | \".*\" # simplified
           | \'.*\'
         )
         \s*
@@ -132,11 +132,15 @@ variables:
   _flow_key_out_lookahead: |-
     (?x:
       (?=
-        {{ns_plain_first_plain_out}}
-        ( [^\s:]
-        | : \S
-        | \s+ (?![#\s])
-        )*
+        (
+            {{ns_plain_first_plain_out}}
+            ( [^\s:]
+            | : \S
+            | \s+ (?![#\s])
+            )*
+          | \".*\" # simplified
+          | \'.*\'
+        )
         \s*
         :
         (\s|$)
@@ -242,6 +246,12 @@ contexts:
     - include: flow-scalar-single-quoted
     - include: flow-scalar-plain-in-12
 
+  flow-scalar-out-12:
+    # for block keys
+    - include: flow-scalar-double-quoted
+    - include: flow-scalar-single-quoted
+    - include: flow-scalar-plain-out-12
+
   flow-collection:
     # http://yaml.org/spec/1.2/spec.html#style/flow/collection
     - include: flow-sequence
@@ -253,6 +263,13 @@ contexts:
     - include: block-collection
     - include: flow-scalar-plain-out  # needs higher priority than flow-node, which includes flow-scalar-plain-in
     - include: flow-node
+
+  block-node-12:
+    # http://yaml.org/spec/1.2/spec.html#style/block/
+    - include: block-scalar
+    - include: block-collection
+    - include: flow-scalar-plain-out-12
+    - include: flow-node-12  # the -12 variant should not make a difference
 
   block-collection:
     # http://yaml.org/spec/1.2/spec.html#style/block/collection
@@ -559,6 +576,13 @@ contexts:
     - match: (?={{ns_plain_first_plain_out}})
       push: flow-scalar-plain-out-content
 
+  flow-scalar-plain-out-12:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
+    # ns-plain(n,c) (c=flow-out, c=block-key)
+    - include: flow-scalar-plain-out-implicit-type-12
+    - match: (?={{ns_plain_first_plain_out}})
+      push: flow-scalar-plain-out-content
+
   flow-scalar-plain-out-content:
     - meta_scope: string.unquoted.plain.out.yaml
     - meta_include_prototype: false
@@ -680,38 +704,36 @@ contexts:
     - include: block-pair
 
   block-pair:
-    - match: \?
+    - match: \?(?=\s|$)
       scope: meta.mapping.yaml punctuation.definition.key-value.begin.yaml
       push:
-        - meta_content_scope: meta.mapping.key.yaml
-        - match: (?=\?) # Empty mapping keys & values are allowed
-          pop: true
-        - match: ^ *(:)
-          scope: meta.mapping.yaml
-          captures:
-            1: punctuation.separator.key-value.mapping.yaml
-          pop: true
-        - match: ':'
-          scope: meta.mapping.yaml invalid.illegal.expected-newline.yaml
-          pop: true
-        - include: block-node
+        - block-key-explicit
     # Attempt to match plain-out scalars and highlight as "meta.mapping.key",
     # if followed by a colon
-    # TODO rewrite with branching
     - match: '{{_flow_key_out_lookahead}}'
       push:
-        - meta_scope: meta.mapping.key.yaml
-        - include: flow-scalar-plain-out-implicit-type-12
-        - match: '{{_flow_scalar_end_plain_out}}'
-          pop: true
-        - match: (?={{ns_plain_first_plain_out}})
-          set:
-            - meta_scope: meta.mapping.key.yaml string.unquoted.plain.out.yaml
-            - meta_include_prototype: false
-            - match: '{{_flow_scalar_end_plain_out}}'
-              pop: true
+        - block-key-implicit
     - match: :(?=\s|$)
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+
+  block-key-implicit:
+    - meta_content_scope: meta.mapping.key.yaml
+    - match: :(?=\s|$)
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      pop: true
+    - include: flow-scalar-out-12
+
+  block-key-explicit:
+    - meta_content_scope: meta.mapping.key.yaml
+    # the colon *must* be on a new line
+    - match: ^ *(:)
+      scope: meta.mapping.yaml
+      captures:
+        1: punctuation.separator.key-value.mapping.yaml
+      pop: true
+    - match: (?=\?(?=\s|$))  # Empty mapping keys & values are allowed
+      pop: true
+    - include: block-node-12
 
   comment:
     # http://www.yaml.org/spec/1.2/spec.html#comment//

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -512,8 +512,9 @@ contexts:
     - match: \[
       scope: punctuation.definition.sequence.begin.yaml
       push:
-        # TODO use meta.sequence and adjust to flow-pair's clear_scopes
-        - meta_scope: meta.sequence.flow.yaml
+        # Pushes an extra 'meta' on the scope stack that flow-pair can then clear,
+        # so we don't have to duplicate the context
+        - meta_scope: meta.sequence.flow.yaml meta.workaround.yaml
         - match: \]
           scope: punctuation.definition.sequence.end.yaml
           pop: true

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -706,13 +706,11 @@ contexts:
   block-pair:
     - match: \?(?=\s|$)
       scope: meta.mapping.yaml punctuation.definition.key-value.begin.yaml
-      push:
-        - block-key-explicit
+      push: block-key-explicit
     # Attempt to match plain-out scalars and highlight as "meta.mapping.key",
     # if followed by a colon
     - match: '{{_flow_key_out_lookahead}}'
-      push:
-        - block-key-implicit
+      push: block-key-implicit
     - match: :(?=\s|$)
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
 

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -535,6 +535,17 @@ contexts:
         - match: '{{_flow_scalar_end_plain_in}}'
           pop: true
 
+  flow-scalar-plain-in-12:
+    # http://yaml.org/spec/1.2/spec.html#style/flow/plain
+    # ns-plain(n,c) (c=flow-in, c=flow-key)
+    - include: flow-scalar-plain-in-implicit-type-12
+    - match: (?={{ns_plain_first_plain_in}})
+      push:
+        - meta_scope: string.unquoted.plain.in.yaml
+        - meta_include_prototype: false
+        - match: '{{_flow_scalar_end_plain_in}}'
+          pop: true
+
   flow-sequence:
     # http://yaml.org/spec/1.2/spec.html#style/flow/sequence
     # c-flow-sequence(n,c)
@@ -611,7 +622,7 @@ contexts:
     - match: :(?=\s|$|{{c_flow_indicator}})
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
       pop: true
-    - include: flow-scalar-plain-in-implicit-type-12
+    - include: flow-scalar-plain-in-12
 
   flow-pair-key-no-clear:
     - meta_content_scope: meta.mapping.key.yaml

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -620,17 +620,18 @@ contexts:
 
   block-pair:
     - match: \?
-      scope: punctuation.definition.key-value.begin.yaml
+      scope: meta.mapping.yaml punctuation.definition.key-value.begin.yaml
       push:
-        - meta_scope: meta.block-mapping.yaml
+        - meta_content_scope: meta.mapping.key.yaml
         - match: (?=\?) # Empty mapping keys & values are allowed
           pop: true
         - match: ^ *(:)
+          scope: meta.mapping.yaml
           captures:
             1: punctuation.separator.key-value.mapping.yaml
           pop: true
         - match: ':'
-          scope: invalid.illegal.expected-newline.yaml
+          scope: meta.mapping.yaml invalid.illegal.expected-newline.yaml
           pop: true
         - include: block-node
     # Attempt to match plain-out scalars and highlight as "entity.name.tag",

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -513,7 +513,7 @@ contexts:
       scope: punctuation.definition.sequence.begin.yaml
       push:
         # TODO use meta.sequence and adjust to flow-pair's clear_scopes
-        - meta_scope: meta.flow-sequence.yaml
+        - meta_scope: meta.sequence.flow.yaml
         - match: \]
           scope: punctuation.definition.sequence.end.yaml
           pop: true

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -512,6 +512,7 @@ contexts:
     - match: \[
       scope: punctuation.definition.sequence.begin.yaml
       push:
+        # TODO use meta.sequence and adjust to flow-pair's clear_scopes
         - meta_scope: meta.flow-sequence.yaml
         - match: \]
           scope: punctuation.definition.sequence.end.yaml
@@ -525,7 +526,7 @@ contexts:
     - match: \{
       scope: punctuation.definition.mapping.begin.yaml
       push:
-        - meta_scope: meta.flow-mapping.yaml
+        - meta_scope: meta.mapping.yaml
         - match: \}
           scope: punctuation.definition.mapping.end.yaml
           pop: true
@@ -535,51 +536,48 @@ contexts:
 
   flow-pair:
     - match: \?
-      scope: punctuation.definition.key-value.begin.yaml
+      scope: meta.mapping.key.explicit.yaml punctuation.definition.key.begin.yaml
       push:
-        - meta_scope: meta.flow-pair.explicit.yaml
-        - match: (?=[},\]]) # Empty mapping keys & values are allowed
-          pop: true
-        - include: flow-pair
-        - include: flow-node
-        - match: :(?=\s|$|{{c_flow_indicator}})
-          scope: punctuation.separator.key-value.mapping.yaml
-          set: flow-pair-value
-    # Attempt to match plain-in scalars and highlight as "entity.name.tag",
-    # if followed by a colon
+        - - match: ''
+            set: flow-pair-value
+        - - clear_scopes: 1
+          - meta_content_scope: meta.mapping.key.explicit.yaml
+          - match: (?=[},\]])  # Empty mapping keys & values are allowed
+            pop: true
+          - match: :(?=\s|$|{{c_flow_indicator}})
+            scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+            pop: true
+          - include: flow-node
+    # Attempt to match plain-in scalars followed by a colon
     - match: |
         (?x)
         (?=
           {{ns_plain_first_plain_in}}
-          (
-              [^\s:{{c_flow_indicator}}]
-            | : [^\s{{c_flow_indicator}}]
-            | \s+ (?![#\s])
+          ( [^\s:{{c_flow_indicator}}]
+          | : [^\s{{c_flow_indicator}}]
+          | \s+ (?![#\s])
           )*
           \s*
           :
           (\s|$)
         )
       push:
-        # TODO Use a merge type here and add "pop: true" and "scope: entity.name.tag.yaml";
-        # https://github.com/SublimeTextIssues/Core/issues/966
-        - meta_scope: meta.flow-pair.key.yaml
-        - include: flow-scalar-plain-in-implicit-type-12
-        - match: '{{_flow_scalar_end_plain_in}}'
-          pop: true
-        - match: (?={{ns_plain_first_plain_in}})
-          set:
-            - meta_scope: meta.flow-pair.key.yaml string.unquoted.plain.in.yaml entity.name.tag.yaml
-            - meta_include_prototype: false
-            - match: '{{_flow_scalar_end_plain_in}}'
-              pop: true
-    - include: flow-node
+        - - clear_scopes: 1
+          - meta_scope: meta.mapping.key.yaml
+          - include: flow-scalar-plain-in-implicit-type-12
+          - match: ''
+            pop: true
+        - - match: (?=\S)
+            pop: true
     - match: :(?=\s|$|{{c_flow_indicator}}) # Empty mapping keys allowed
-      scope: meta.flow-pair.yaml punctuation.separator.key-value.mapping.yaml
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
       push: flow-pair-value
+    # TODO match as meta.mapping.key
+    - include: flow-node
 
   flow-pair-value:
-    - meta_content_scope: meta.flow-pair.value.yaml
+    - clear_scopes: 1
+    - meta_content_scope: meta.mapping.value.yaml
     - include: flow-node
     - match: (?=[},\]])
       pop: true

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -83,11 +83,11 @@ plain
 # http://yaml.org/spec/1.2/spec.html#style/block/mapping
 
 key: value
-#^^        string.unquoted.plain.out entity.name.tag
+#^^        meta.mapping.key string.unquoted.plain.out
 #  ^       punctuation.separator.key-value.mapping, -entity
 #    ^^^^^ string.unquoted.plain.out
 key#  :  value
-#^^^           string.unquoted.plain.out entity.name.tag
+#^^^           meta.mapping.key string.unquoted.plain.out
 #   ^          -string
 #     ^        punctuation.separator.key-value.mapping
 #        ^^^^^ string.unquoted.plain.out
@@ -95,12 +95,12 @@ key#  :  value
 # <- punctuation.separator.key-value.mapping
 
 _type_null: (?:null|Null|NULL|~) # http://yaml.org/type/null.html
-#^^^^^^^^^                         entity.name.tag
-#           ^^^^^^^^^^^^^^^^^^^^   -entity.name.tag
+#^^^^^^^^^                         meta.mapping.key
+#           ^^^^^^^^^^^^^^^^^^^^   -meta.mapping.key
 #                                ^ comment
 
 key on line one:
-#^^^^^^^^^^^^^^ entity.name.tag
+#^^^^^^^^^^^^^^ meta.mapping.key
   value on line two
 
 ? explicit key # Empty value
@@ -117,7 +117,7 @@ key on line one:
 # <- meta.mapping punctuation.separator.key-value.mapping
   - two: :three # block value
 # ^ punctuation.definition.block.sequence
-#   ^^^ string.unquoted.plain.out entity.name.tag
+#   ^^^ meta.mapping.key string.unquoted.plain.out
 #      ^ punctuation.separator.key-value.mapping
 #        ^^^^^^ string.unquoted.plain.out
 

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -104,17 +104,17 @@ key on line one:
   value on line two
 
 ? explicit key # Empty value
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block-mapping
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key
 # ^^^^^^^^^^^^               string.unquoted.plain.out
 #              ^^^^^^^^^^^^^ comment
-# <- meta.block-mapping punctuation.definition.key-value.begin
+# <- meta.mapping punctuation.definition.key-value.begin
 
 ? |
   block key
-# ^^^^^^^^^ meta.block-mapping string.unquoted.block
-# ^^^^^^^^^ -meta.block-mapping meta.block-mapping
+# ^^^^^^^^^ meta.mapping string.unquoted.block
+# ^^^^^^^^^ -meta.mapping meta.mapping
 : - one # Explicit compact
-# <- meta.block-mapping punctuation.separator.key-value.mapping
+# <- meta.mapping punctuation.separator.key-value.mapping
   - two: :three # block value
 # ^ punctuation.definition.block.sequence
 #   ^^^ string.unquoted.plain.out entity.name.tag
@@ -122,10 +122,10 @@ key on line one:
 #        ^^^^^^ string.unquoted.plain.out
 
 ? a key : not a value
-#       ^ meta.block-mapping invalid.illegal.expected-newline
+#       ^ meta.mapping invalid.illegal.expected-newline
 
 scalar
-# <- -meta.block-mapping
+# <- -meta.mapping
 
 x:
   - #1

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -100,8 +100,14 @@ _type_null: (?:null|Null|NULL|~) # http://yaml.org/type/null.html
 #                                ^ comment
 
 key on line one:
-#^^^^^^^^^^^^^^ meta.mapping.key
+#^^^^^^^^^^^^^^ meta.mapping.key string.unquoted.plain
   value on line two
+# ^^^^^^^^^^^^^^^^^ string.unquoted.plain.out - meta.mapping.key
+
+
+"quoted key": value
+#^^^^^^^^^^^ meta.mapping.key string.quoted.double
+#          ^ punctuation.definition.string.end
 
 ? explicit key # Empty value
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key
@@ -121,11 +127,19 @@ key on line one:
 #      ^ punctuation.separator.key-value.mapping
 #        ^^^^^^ string.unquoted.plain.out
 
+# the entire first line is the key (as a mapping with one entry)
 ? a key : not a value
-#       ^ meta.mapping invalid.illegal.expected-newline
+# ^^^^^^^^^^^^^^^^^^^ meta.mapping.key
+#       ^ meta.mapping.key meta.mapping punctuation.separator.key-value.mapping
+:
+# <- meta.mapping punctuation.separator.key-value.mapping - meta.mapping meta.mapping
 
 scalar
 # <- -meta.mapping
+
+ ?not a key
+#^^^^^^^^^^ - meta.mapping
+
 
 x:
   - #1

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -95,13 +95,13 @@ continuation"
 #     ^ meta.flow-sequence punctuation.definition.sequence.end
 
 [a: b, c,'d', e: f, g:h]
-#^                      meta.flow-pair.key string.unquoted.plain.in entity.name.tag
-# ^                     meta.flow-pair punctuation.separator.key-value.mapping -meta.flow-pair.value
-#   ^                   meta.flow-pair.value string.unquoted.plain.in -entity.name.tag
+#^                      meta.mapping.key string.unquoted.plain.in
+# ^                     meta.mapping punctuation.separator.key-value.mapping -meta.mapping.value
+#   ^                   meta.mapping.value string.unquoted.plain.in
 #      ^                string.unquoted.plain.in
 #       ^               punctuation.separator.sequence
 #        ^^^            string.quoted.single
-#             ^         string.unquoted.plain.in entity.name.tag
+#             ^         meta.mapping.key string.unquoted.plain.in
 #              ^        punctuation.separator.key-value.mapping
 #                 ^     punctuation.separator.sequence
 #                   ^^^ string.unquoted.plain.in - entity.name.tag
@@ -112,47 +112,53 @@ continuation"
 # http://yaml.org/spec/1.2/spec.html#style/flow/sequence
 
 {a: b, :c: :d,
-#^             meta.flow-pair.key string.unquoted.plain.in entity.name.tag
-# ^            meta.flow-pair punctuation.separator.key-value.mapping
-#   ^          meta.flow-pair.value string.unquoted.plain.in -entity.name.tag
-#    ^         punctuation.separator.mapping
-#      ^^      string.unquoted.plain.in entity.name.tag
-#        ^     punctuation.separator.key-value.mapping
-#          ^^  string.unquoted.plain.in, -entity.name.tag
+#^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
+#^ meta.mapping.key.yaml string.unquoted.plain.in.yaml
+# ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#   ^ meta.mapping.value string.unquoted.plain.in -entity.name.tag
+#    ^ meta.mapping.yaml punctuation.separator.mapping
+#      ^^ meta.mapping.key.yaml string.unquoted.plain.in
+#        ^ meta.mapping.yaml punctuation.separator.key-value.mapping
+#          ^^ meta.mapping.value.yaml string.unquoted.plain.in
 #            ^ punctuation.separator.mapping
-# <- meta.flow-mapping punctuation.definition.mapping.begin
-*alias, e : f }
-#^^^^^          variable.other.alias
-#     ^         punctuation.separator.mapping
-#       ^       string.unquoted.plain.in entity.name.tag
-#        ^      -string
-#         ^     punctuation.separator.key-value.mapping
-#           ^   string.unquoted.plain.in, -entity.name.tag
-#             ^ meta.flow-mapping punctuation.definition.mapping.end
+# <- meta.mapping.yaml punctuation.definition.mapping.begin
+*alias, true : false }
+#^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
+#^^^^^ variable.other.alias
+#     ^ punctuation.separator.mapping
+#       ^^^^ meta.mapping.key.yaml constant.language.boolean.yaml - string
+#            ^     punctuation.separator.key-value.mapping
+#              ^^^^^ meta.mapping.value.yaml constant.language.boolean.yaml
+#                    ^ meta.mapping.yaml punctuation.definition.mapping.end
+
+{ 1: 2 }
 
 {? !!str 'key' : !!str value,
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.flow-pair.explicit
-#               ^^^^^^^^^^^^  meta.flow-pair.value
-#                           ^ punctuation.separator.mapping -meta.flow-pair
-#^                            punctuation.definition.key-value.begin
-#  ^^^^^                      storage
-#        ^^^^^                string
-#        ^                    punctuation
-#            ^                punctuation
-#              ^              punctuation.separator.key-value.mapping
-#                ^^^^^        storage
-#                      ^^^^^  string
- ? !!str foo : :bar
-#^ punctuation.definition.key-value.begin
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
+#               ^^^^^^^^^^^^ meta.mapping.value
+#                           ^ punctuation.separator.mapping - meta.mapping.value
+#^ punctuation.definition.key.begin.yaml
+#^^^^^^^^^^^^^^ meta.mapping.key.explicit.yaml
 #  ^^^^^ storage
-#        ^^^ string entity.name.tag
-#            ^ punctuation.separator.key-value.mapping -string
-#              ^ string.unquoted.plain.in
+#        ^^^^^ string
+#        ^ punctuation
+#            ^ punctuation
+#              ^ meta.mapping.yaml punctuation.separator.key-value.mapping
+#                ^^^^^ storage
+#                      ^^^^^ string
+ ? !!str foo : :bar
+#^^^^^^^^^^^^ meta.mapping.key.explicit.yaml
+#^ punctuation.definition.key.begin.yaml
+#  ^^^^^ storage
+#        ^^^ string.unquoted.plain.in.yaml
+#            ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#              ^^^^ meta.mapping.value.yaml string.unquoted.plain.in.yaml
 }
 
+# TODO catch `!!set` and set meta.set scope
 !!set {this, is, a, set}
 #  ^ storage
-#      ^ string -entity
-#            ^ string -entity
-#                ^ string -entity
-#                   ^ string -entity
+#      ^ string - meta.mapping.key
+#            ^ string - meta.mapping.key
+#                ^ string - meta.mapping.key
+#                   ^ string - meta.mapping.key

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -139,7 +139,7 @@ continuation"
 #               ^^^^^^^^^^^^ meta.mapping.value
 #                           ^ punctuation.separator.mapping - meta.mapping.value
 #^ punctuation.definition.key.begin.yaml
-#^^^^^^^^^^^^^^ meta.mapping.key.explicit.yaml
+#^^^^^^^^^^^^^^ meta.mapping.key.yaml
 #  ^^^^^ storage
 #        ^^^^^ string
 #        ^ punctuation
@@ -148,7 +148,7 @@ continuation"
 #                ^^^^^ storage
 #                      ^^^^^ string
  ? !!str foo : :bar
-#^^^^^^^^^^^^ meta.mapping.key.explicit.yaml
+#^^^^^^^^^^^^ meta.mapping.key.yaml
 #^ punctuation.definition.key.begin.yaml
 #  ^^^^^ storage
 #        ^^^ string.unquoted.plain.in.yaml

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -86,13 +86,13 @@ continuation"
 # http://yaml.org/spec/1.2/spec.html#style/flow/sequence
 
 [a, b, c,
-# <- meta.flow-sequence punctuation.definition.sequence.begin
+# <- meta.sequence.flow punctuation.definition.sequence.begin
 #^        string.unquoted.plain.in
 # ^       punctuation.separator.sequence
 #    ^    punctuation.separator.sequence
 *alias]
 #^^^^^ variable.other.alias
-#     ^ meta.flow-sequence punctuation.definition.sequence.end
+#     ^ meta.sequence.flow punctuation.definition.sequence.end
 
 [a: b, c,'d', e: f, g:h]
 #^                      meta.mapping.key string.unquoted.plain.in

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -95,6 +95,7 @@ continuation"
 #     ^ meta.sequence.flow punctuation.definition.sequence.end
 
 [a: b, c,'d', e: f, g:h]
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.flow.yaml
 #^                      meta.mapping.key string.unquoted.plain.in
 # ^                     meta.mapping punctuation.separator.key-value.mapping -meta.mapping.value
 #   ^                   meta.mapping.value string.unquoted.plain.in

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -132,7 +132,12 @@ continuation"
 #              ^^^^^ meta.mapping.value.yaml constant.language.boolean.yaml
 #                    ^ meta.mapping.yaml punctuation.definition.mapping.end
 
-{ 1: 2 }
+ { 1: 2 }
+#^^^^^^^^ meta.mapping - meta.mapping meta.mapping - string
+#  ^ meta.mapping.key.yaml constant.numeric
+#   ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#    ^^^ meta.mapping.value.yaml
+#     ^ constant.numeric
 
 {? !!str 'key' : !!str value,
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -139,6 +139,22 @@ continuation"
 #    ^^^ meta.mapping.value.yaml
 #     ^ constant.numeric
 
+{ "key": "value", 'key': 0 }
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.yaml
+# <- source.yaml meta.mapping.yaml punctuation.definition.mapping.begin.yaml
+#^ meta.mapping.yaml
+# ^^^^^ meta.mapping.key string.quoted.double.yaml
+#      ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#       ^^^^^^^^ meta.mapping.value.yaml
+#        ^^^^^^^ string.quoted.double.yaml
+#               ^^ meta.mapping.yaml
+#               ^ punctuation.separator.mapping.yaml
+#                 ^^^^^ meta.mapping.key.yaml string.quoted.single.yaml
+#                      ^ punctuation.separator.key-value.mapping.yaml
+#                       ^^^ meta.mapping.value.yaml
+#                        ^ meta.number.integer.decimal.yaml constant.numeric.value.yaml
+#                          ^ meta.mapping.yaml punctuation.definition.mapping.end.yaml
+
 {? !!str 'key' : !!str value,
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #               ^^^^^^^^^^^^ meta.mapping.value


### PR DESCRIPTION
I've been wanting to do this for a while, as `entity.name.tag` was really just a hack for a lack of an appropriate scope name when I made this syntax. Now that JSON, JavaScript and Python (and probably other syntaxes) successfully use `meta.mapping.key`, YAML should not be exempted.

---

*(via https://github.com/sublimehq/Packages/pull/2564#pullrequestreview-894390337)*

Without addressing https://github.com/sublimehq/sublime_text/issues/3590, the UX of default color schemes with regards to highlighting keys differently from values will be *worse* but in line with JSON and the other languages using `meta.mapping.key` as the primary differntiator between keys and values.

The only thing needed for Mariana is something like:

```json
{
	"name": "Mapping Key Names",
	"scope": "meta.mapping.key string",
	"foreground": "var(red2)"
}
```

Monokai should be fixed as well to maintain the highlighting users are used to.