### PR TITLE
[Lua] Don't trip on unexpected characters

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -28,11 +28,13 @@ variables:
   # __metatable and __mode don't use functions
   metaproperty: (?:__(?:metatable|mode){{identifier_break}})
 
-  identifier_start: (?:[A-Za-z_])
-  identifier_char: (?:[A-Za-z0-9_])
+  identifier_start: '[A-Za-z_]'
+  identifier_char: '[A-Za-z0-9_]'
   identifier_break: (?!{{identifier_char}})
   identifier_raw: (?:{{identifier_start}}{{identifier_char}}*)
   identifier: (?:(?!{{reserved_word}}){{identifier_raw}})
+
+  trailing_expression_char: '[,\]})]'
 
   function_args_begin: (?:\(|"|'|\[=*\[|\{)
   function_call_ahead: (?=\s*{{function_args_begin}})
@@ -272,6 +274,10 @@ contexts:
 
     - include: infix-operator
     - include: accessor
+
+    # Safety match for unexpected characters so we don't confuse the syntax by exiting contexts too early
+    - match: '[^{{trailing_expression_char}}{{identifier_char}}\s]'
+      scope: invalid.illegal.unexpected-character.lua
 
     - include: else-pop
 

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -526,6 +526,12 @@
 --  ^^^^^^^^^^^ - meta.block
 --          ^^^ invalid.illegal.unexpected-end
 
+
+    if a ! = b then end
+--       ^ invalid.illegal.unexpected-character.lua
+--             ^^^^ keyword.control.conditional
+--                  ^^^ keyword.control.end
+
     while true do
 --  ^^^^^ keyword.control.loop
 --             ^^ keyword.control


### PR DESCRIPTION
expression-end used to pop on any otherwise unrecognized character, but in the context of the expression context being pushed on the stack as part of a statement, this meant the expression was terminated unexpectedly early and the following keyword match, such as in `if … then` would fail to match and also exit early, resulting in an unfortunate context stack.

The introduced match just matches any unexpected characters and highlights them as invalid, while also not popping, so the match can resume after the character.

Closes #1939.
cc @Thom1729