### PR TITLE
[Git Formats] Add support for subject length

### DIFF
--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -57,6 +57,7 @@ contexts:
     - match: $\n?
       set: commit-separator
     - include: Git Common.sublime-syntax#references
+    - include: commit-subject-length
 
   commit-separator:
     # empty line between subject and message
@@ -81,6 +82,12 @@ contexts:
       captures:
         1: keyword.other.signed-off-by.git.commit
         2: punctuation.separator.mapping.pair.git.commit
+
+  commit-subject-length:
+    - match: '^((.{1,50}\s*)|(.{51,72}\s*)|(.+\s*))$'
+      captures:
+        3: invalid.warning.line-too-long.git.commit
+        4: invalid.error.line-too-long.git.commit
 
 ##[ COMMENTS ]#########################################################
 


### PR DESCRIPTION
[As documented in blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), this adds support for two new ways to style subject, longer than 50/less than 72 characters is considered warning, everything over 72 is considered error.