### PR TITLE
[TypeScript] Implement arrow function return types.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -924,10 +924,18 @@ contexts:
     - include: either-function-declaration
     - include: object-literal
 
-    - match: (?=\(|{{identifier_start}})
-      branch_point: arrow-function
+    - include: literal-call
+
+    - match: (?={{identifier_start}})
+      branch_point: bare-arrow-function
       branch:
-        - branch-possible-arrow-function
+        - branch-possible-bare-arrow-function
+        - arrow-function-fallback
+
+    - match: (?=\()
+      branch_point: parenthesized-arrow-function
+      branch:
+        - branch-possible-parenthesized-arrow-function
         - arrow-function-fallback
 
     - include: array-literal
@@ -936,21 +944,29 @@ contexts:
 
     - include: else-pop
 
-  branch-possible-arrow-function:
+  branch-possible-bare-arrow-function:
     - meta_include_prototype: false
     - match: ''
       push:
-        - detect-arrow
-        - branch-not-arrow-function
+        - detect-bare-arrow
+        - literal-variable
 
-  branch-not-arrow-function:
-    - include: parenthesized-expression
-    - include: literal-call
-    - include: literal-variable
-
-  detect-arrow:
+  detect-bare-arrow:
     - match: (?==>)
-      fail: arrow-function
+      fail: bare-arrow-function
+    - match: (?=\S)
+      pop: 3
+
+  branch-possible-parenthesized-arrow-function:
+    - meta_include_prototype: false
+    - match: ''
+      push:
+        - detect-parenthesized-arrow
+        - parenthesized-expression
+
+  detect-parenthesized-arrow:
+    - match: (?==>)
+      fail: parenthesized-arrow-function
     - match: (?=\S)
       pop: 3
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -50,6 +50,7 @@ contexts:
       push:
         - ts-detect-arrow
         - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin
 
   ts-detect-arrow:
@@ -673,6 +674,7 @@ contexts:
     - include: ts-type-basic
 
     - match: (?=\()
+      pop: true
       branch_point: ts-function-type
       branch:
         - ts-type-parenthesized

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -48,11 +48,11 @@ contexts:
   ts-detect-arrow-function-return-type:
     - match: ':'
       push:
-        - ts-detect-arrow-foobar
+        - ts-detect-arrow
         - ts-type-expression-end
         - ts-type-expression-begin
 
-  ts-detect-arrow-foobar:
+  ts-detect-arrow:
     - match: (?==>)
       fail: arrow-function
     - match: (?=\S)

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -25,6 +25,51 @@ variables:
     ))
 
 contexts:
+  branch-possible-arrow-function:
+    - meta_include_prototype: false
+    - match: ''
+      push:
+        - ts-detect-arrow-function
+        - branch-not-arrow-function
+
+  ts-detect-arrow-function:
+    - match: (?=:)
+      branch_point: ts-arrow-function-return-type
+      branch:
+        - ts-detect-arrow-function-return-type
+        - ts-immediately-pop-3
+    - include: detect-arrow
+
+  ts-immediately-pop-3:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 3
+
+  ts-detect-arrow-function-return-type:
+    - match: ':'
+      push:
+        - ts-detect-arrow-foobar
+        - ts-type-expression-end
+        - ts-type-expression-begin
+
+  ts-detect-arrow-foobar:
+    - match: (?==>)
+      fail: arrow-function
+    - match: (?=\S)
+      fail: ts-arrow-function-return-type
+
+  arrow-function-declaration:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - function-meta
+        - arrow-function-expect-body
+        - function-declaration-meta
+        - arrow-function-expect-arrow
+        - ts-type-annotation
+        - arrow-function-expect-parameters
+        - function-declaration-expect-async
+
   ts-import-type:
     - match: type{{identifier_break}}
       scope: keyword.control.import-export.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -24,18 +24,6 @@ variables:
       \(
     ))
 
-  arrow_func_lookahead: |-
-    (?x:
-      \s*
-      (?:async\s*)?
-      (?:
-        {{identifier}}
-        | \( ( [^()] | \( [^()]* \) )* \)
-      )
-      \s*
-      (?:=>|:)
-    )
-
 contexts:
   branch-possible-arrow-function:
     - meta_include_prototype: false

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -24,6 +24,18 @@ variables:
       \(
     ))
 
+  arrow_func_lookahead: |-
+    (?x:
+      \s*
+      (?:async\s*)?
+      (?:
+        {{identifier}}
+        | \( ( [^()] | \( [^()]* \) )* \)
+      )
+      \s*
+      (?:=>|:)
+    )
+
 contexts:
   branch-possible-arrow-function:
     - meta_include_prototype: false

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -25,20 +25,23 @@ variables:
     ))
 
 contexts:
-  branch-possible-arrow-function:
+  branch-possible-parenthesized-arrow-function:
     - meta_include_prototype: false
     - match: ''
       push:
-        - ts-detect-arrow-function
-        - branch-not-arrow-function
+        - ts-detect-parenthesized-arrow-function
+        - parenthesized-expression
 
-  ts-detect-arrow-function:
+  ts-detect-parenthesized-arrow-function:
     - match: (?=:)
       branch_point: ts-arrow-function-return-type
       branch:
         - ts-detect-arrow-function-return-type
         - ts-immediately-pop-3
-    - include: detect-arrow
+    - match: (?==>)
+      fail: parenthesized-arrow-function
+    - match: (?=\S)
+      pop: 3
 
   ts-immediately-pop-3:
     - meta_include_prototype: false
@@ -48,14 +51,14 @@ contexts:
   ts-detect-arrow-function-return-type:
     - match: ':'
       push:
-        - ts-detect-arrow
+        - ts-detect-arrow-after-return-type
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin
 
-  ts-detect-arrow:
+  ts-detect-arrow-after-return-type:
     - match: (?==>)
-      fail: arrow-function
+      fail: parenthesized-arrow-function
     - match: (?=\S)
       fail: ts-arrow-function-return-type
 

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -359,6 +359,26 @@ function f(this : any) {}
 //      ^^^ meta.type support.type.any
 //           ^^ storage.type.function.arrow
 
+    x ? (y) : z;
+//  ^ variable.other.readwrite
+//    ^ keyword.operator.ternary
+//      ^^^ meta.group
+//       ^ variable.other.readwrite
+//          ^ keyword.operator.ternary
+
+    x ? (y) : T => r : z;
+//  ^ variable.other.readwrite
+//    ^ keyword.operator.ternary
+//      ^^^^^^^^^^^^^ meta.function
+//      ^ meta.function.declaration
+//       ^ meta.binding.name variable.parameter.function
+//          ^ punctuation.separator.type
+//            ^ meta.type support.class
+//              ^^ storage.type.function.arrow
+//                 ^meta.block variable.other.readwrite
+//                   ^ keyword.operator.ternary
+//                     ^ variable.other.readwrite
+
 /* Assertions */
 
 x as boolean;

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -379,6 +379,9 @@ function f(this : any) {}
 //                   ^ keyword.operator.ternary
 //                     ^ variable.other.readwrite
 
+    const f = (): T => 42;
+//        ^ meta.function.declaration entity.name.function variable.other.readwrite
+
 /* Assertions */
 
 x as boolean;

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -379,9 +379,6 @@ function f(this : any) {}
 //                   ^ keyword.operator.ternary
 //                     ^ variable.other.readwrite
 
-    const f = (): T => 42;
-//        ^ meta.function.declaration entity.name.function variable.other.readwrite
-
 /* Assertions */
 
 x as boolean;

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -379,6 +379,13 @@ function f(this : any) {}
 //                   ^ keyword.operator.ternary
 //                     ^ variable.other.readwrite
 
+    x ? y : T => z;
+//      ^ variable.other.readwrite - variable.parameter
+//        ^ keyword.operator.ternary
+//          ^^^^^^ meta.function
+//          ^ variable.parameter.function
+//            ^^ storage.type.function.arrow
+
 /* Assertions */
 
 x as boolean;


### PR DESCRIPTION
For #2468.

In regular JavaScript, when we see an identifier or open paren, we branch and first try to parse them as an identifier or open paren. Then, if the next token is `=>`, we fail the branch and parse it as an arrow function.

In TypeScript, we have another case. If the possible identifier or parenthesized expression is followed by a colon, then we have an arrow function if and only if the colon is followed by a syntactically valid type followed by `=>`. In this implementation we branch again and try to parse a type followed by an arrow. If we succeed, then we fail the original `arrow-function` branch. Otherwise, we fail the inner branch and pop out of the `arrow-function` branch. This is admittedly convoluted, but in principle it should do the right thing.

This PR should mostly work, but there are a few known issues:

- ~~Only arrow functions with parenthesized arguments lists should be able to have type arguments, and now arrow function with a single bare argument, but this PR does not yet make that distinction because both cases are handled the same in the base JavaScript syntax. They should probably be split, though this will involve some code duplication due to https://github.com/sublimehq/sublime_text/issues/3494.~~ Fixed
- In some cases, invalid type expressions will be accepted, e.g. `T||U`. The type expression contexts have some special handling to make this work for function type arguments, but because of https://github.com/sublimehq/sublime_text/issues/3494 this can't be re-used.
- There are a lot of magic multi-pop expressions, which bothers me personally. This may be fixable.
- If an arrow function has a return type, then the type will actually be parsed twice, which is not ideal. I'm not sure there's a good way around this.
- In statements like `const closeDialog = (): any => setDialogOpen(false);`, `closeDialog` will not be highlighted as a function name. This can probably be fixed by tinkering with the lookahead, though it won't be perfect. ~~Fixed, although it won't be exact in corner cases.~~ Never mind; the fix broke other things. I will probably punt this to #2267.

Comments welcome. I don't have a lot of TypeScript code laying around, so I'd appreciate anyone else giving it a whirl.