### PR TITLE
[TypeScript] Fix bug at end of function types.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -628,6 +628,7 @@ contexts:
     - include: ts-type-basic
 
     - match: (?=\()
+      pop: true
       branch_point: ts-function-type
       branch:
         - ts-type-parenthesized

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -696,6 +696,10 @@ let x: ( foo ? : any ) => bar;
 //                     ^^ storage.type.function
 //                        ^^^ support.class
 
+let x: () => T
+    U
+//  ^ variable.other.constant - meta.type
+
 let x: ( foo );
 //     ^^^^^^^ meta.type meta.group
 //     ^ punctuation.section.group.begin


### PR DESCRIPTION
Reported in https://github.com/sublimehq/Packages/pull/2574#issuecomment-722975089, but can be merged independently (especially since that PR may need more work).

In a type expression, an opening paren may indicate either a type in parentheses or the beginning of a function type. The TypeScript syntax uses branching to distinguish them. However, because `branch` is like `push`, after parsing the type the syntax was still in the `expression-begin` state instead of `expression-end`. Adding a `pop` to the `branch` rule will fix this so that the stack is correct after parsing the function type.