### PR TITLE
[GitHub Actions] Use build 4090 for CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Download syntax_tests
-        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4086_x64.tar.xz
+        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4090_x64.tar.xz
       - name: Extract syntax_tests
         run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.xz)"
       - name: Move syntax_tests


### PR DESCRIPTION
Should resolve the CI failure in #2577.