### PR TITLE
[Python] Highlight trailing accessor

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -117,68 +117,38 @@ contexts:
     - match: \b(import)\b
       scope: keyword.control.import.python
       push:
-        - meta_scope: meta.statement.import.python
-        - include: line-continuation-or-pop
-        - match: ','
-          scope: punctuation.separator.import-list.python
-        - match: \.
-          scope: invalid.illegal.unexpected-relative-import.python
-        - include: import-alias
-        - include: qualified-name
-        - match: (?=\S)
-          pop: true
+        - imports-import-body
+        - expect-absolute-import
     - match: \b(from)\b
       scope: keyword.control.import.from.python
-      push:
-        - meta_scope: meta.statement.import.python
-        - meta_content_scope: meta.import-source.python
-        - include: line-continuation-or-pop
-        - match: \b(import)\b
-          scope: keyword.control.import.python
-          set:
-            - meta_scope: meta.statement.import.python
-            - include: line-continuation-or-pop
-            - match: ' *(\()'
-              captures:
-                1: punctuation.section.import-list.begin.python
-              set:
-                - meta_scope: meta.statement.import.python
-                - include: comments
-                - match: \)
-                  scope: punctuation.section.import-list.end.python
-                  pop: true
-                - include: import-name-list
-                - match: (?=\S)
-                  pop: true
-            - match: ''
-              set:
-                - meta_scope: meta.statement.import.python
-                - include: line-continuation-or-pop
-                - include: import-name-list
-                - match: (?=\S)
-                  pop: true
-            - match: (?=\S)
-              pop: true
-        - include: import-from-name
-        - match: (?=\S)
-          pop: true
+      push: imports-from-body
 
-  import-name-list:
+  imports-import-body:
+    - meta_scope: meta.statement.import.python
+    - include: line-continuation-or-pop
     - match: ','
       scope: punctuation.separator.import-list.python
-    - include: import-alias
-    - include: name
-    - match: \*
-      scope: constant.language.import-all.python
-    - match: \S+
-      scope: invalid.illegal.name.import.python
+      push: expect-absolute-import
+    - match: (?=\bas\b)
+      set:
+        - meta_scope: meta.statement.import.python
+        - include: line-continuation-or-pop
+        - include: import-name-list
+    - include: qualified-name
+    - match: (?=\S)
+      pop: true
 
-  import-alias:
-    - match: \b(as)\b
-      scope: keyword.control.import.as.python
-
-  import-from-name:
-    - match: \.+
+  imports-from-body:
+    - meta_scope: meta.statement.import.python
+    - meta_content_scope: meta.import-source.python
+    - include: line-continuation-or-pop
+    - match: (?=\bimport\b)
+      set:
+        - meta_include_prototype: false
+        - match: import
+          scope: keyword.control.import.python
+          set: imports-from-import-body
+    - match: \.*
       scope: meta.import-path.python keyword.control.import.relative.python
     - match: (?={{path}})
       push:
@@ -187,7 +157,7 @@ contexts:
           scope: invalid.illegal.name.python
         - match: '{{identifier}}'
           scope: meta.import-name.python
-        - match: \s*(\.) *(?:({{illegal_names}}\b)|({{identifier}}))
+        - match: \s*(\.) *(?:({{illegal_names}}\b)|({{identifier}})|$)
           captures:
             1: punctuation.accessor.dot.python
             2: invalid.illegal.name.python
@@ -198,6 +168,47 @@ contexts:
           pop: true
         - match: ''
           pop: true
+    - match: (?=\S)
+      pop: true
+
+  imports-from-import-body:
+    - meta_scope: meta.statement.import.python
+    - include: line-continuation-or-pop
+    - match: (?=\()
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.import-list.begin.python
+          set:
+            - meta_scope: meta.statement.import.python meta.import-list.python
+            - match: \)
+              scope: punctuation.section.import-list.end.python
+              pop: true
+            - include: comments
+            - include: import-name-list
+    - match: (?=\S)
+      set:
+        - meta_scope: meta.statement.import.python
+        - include: line-continuation-or-pop
+        - include: import-name-list
+
+  import-name-list:
+    - match: ','
+      scope: punctuation.separator.import-list.python
+    - match: \*
+      scope: constant.language.import-all.python
+    - match: \b(as)\b
+      scope: keyword.control.import.as.python
+    - include: name
+    - match: '[^\s,)]+'
+      scope: invalid.illegal.name.import.python
+
+  expect-absolute-import:
+    - include: line-continuation-or-pop
+    - match: \.+
+      scope: invalid.illegal.unexpected-relative-import.python
+    - match: (?=\S)
+      pop: true
 
   block-statements:
     # async for ... in ...:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1165,6 +1165,8 @@ contexts:
         - include: dotted-name
         - match: ''
           pop: true
+    - match: \.
+      scope: punctuation.accessor.dot.python
 
   qualified-name-until-leaf:
     # Push this together with another context to match a qualified name

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -121,7 +121,9 @@ contexts:
         - expect-absolute-import
     - match: \b(from)\b
       scope: keyword.control.import.from.python
-      push: imports-from-body
+      push:
+        - imports-from-body
+        - maybe-relative-import
 
   imports-import-body:
     - meta_scope: meta.statement.import.python
@@ -130,10 +132,7 @@ contexts:
       scope: punctuation.separator.import-list.python
       push: expect-absolute-import
     - match: (?=\bas\b)
-      set:
-        - meta_scope: meta.statement.import.python
-        - include: line-continuation-or-pop
-        - include: import-name-list
+      set: import-alias-list
     - include: qualified-name
     - match: (?=\S)
       pop: true
@@ -142,32 +141,26 @@ contexts:
     - meta_scope: meta.statement.import.python
     - meta_content_scope: meta.import-source.python
     - include: line-continuation-or-pop
+    - match: (?=\bas\b)
+      set: import-alias-list
     - match: (?=\bimport\b)
       set:
         - meta_include_prototype: false
         - match: import
           scope: keyword.control.import.python
           set: imports-from-import-body
-    - match: \.*
-      scope: meta.import-path.python keyword.control.import.relative.python
-    - match: (?={{path}})
-      push:
-        - meta_scope: meta.import-path.python
-        - match: '{{illegal_names}}\b'
-          scope: invalid.illegal.name.python
-        - match: '{{identifier}}'
-          scope: meta.import-name.python
-        - match: \s*(\.) *(?:({{illegal_names}}\b)|({{identifier}})|$)
-          captures:
-            1: punctuation.accessor.dot.python
-            2: invalid.illegal.name.python
-            3: meta.import-name.python
-        - match: \ *(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
-          captures:
-            1: invalid.illegal.name.python
-          pop: true
-        - match: ''
-          pop: true
+    - match: '{{illegal_names}}\b'
+      scope: meta.import-path.python invalid.illegal.name.python
+    - match: '{{identifier}}'
+      scope: meta.import-path.python meta.import-name.python
+    - match: \s*(\.) *(?={{identifier}}|$)
+      captures:
+        0: meta.import-path.python
+        1: punctuation.accessor.dot.python
+    - match: \s*(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
+      captures:
+        0: meta.import-path.python
+        1: invalid.illegal.name.python
     - match: (?=\S)
       pop: true
 
@@ -187,10 +180,12 @@ contexts:
             - include: comments
             - include: import-name-list
     - match: (?=\S)
-      set:
-        - meta_scope: meta.statement.import.python
-        - include: line-continuation-or-pop
-        - include: import-name-list
+      set: import-alias-list
+
+  import-alias-list:
+    - meta_content_scope: meta.statement.import.python
+    - include: line-continuation-or-pop
+    - include: import-name-list
 
   import-name-list:
     - match: ','
@@ -207,6 +202,13 @@ contexts:
     - include: line-continuation-or-pop
     - match: \.+
       scope: invalid.illegal.unexpected-relative-import.python
+    - match: (?=\S)
+      pop: true
+
+  maybe-relative-import:
+    - include: line-continuation-or-pop
+    - match: \.+
+      scope: meta.import-path.python keyword.control.import.relative.python
     - match: (?=\S)
       pop: true
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -33,39 +33,154 @@ This is a variable docstring, as supported by sphinx and epydoc
 import sys # comment
 #^^^^^ keyword.control.import
 #          ^ comment
+import sys. # comment
+#^^^^^ keyword.control.import
+#         ^ punctuation.accessor.dot.python
+#           ^ comment
+import sys.path # comment
+#^^^^^ keyword.control.import
+#         ^ punctuation.accessor.dot.python
+#               ^ comment
+import .
+#      ^ invalid.illegal.unexpected-relative-import.python
+import ..
+#      ^^ invalid.illegal.unexpected-relative-import.python
+import .. sys
+#      ^^ invalid.illegal.unexpected-relative-import.python
+
 from os import path, chdir # comment
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#      ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#       ^^^^^^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                         ^ - meta.statement
 #^^^ keyword.control.import.from
 #       ^^^^^^ keyword.control.import
 #                  ^ punctuation.separator.import-list
 #                          ^ comment
 from . import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#     ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#      ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                   ^ - meta.statement
 #    ^ keyword.control.import.relative.python
 #      ^^^^^^ keyword.control.import
 from .import module  # yes, this is actually legit
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#     ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                  ^ - meta.statement
 #    ^ keyword.control.import.relative.python
 #     ^^^^^^ keyword.control.import.python
 from collections.abc import Iterable
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^^^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#                   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#                    ^^^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                                   ^ - meta.statement
 #                    ^^^^^^ keyword.control.import
+from a.b.c.
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#          ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^ punctuation.accessor.dot.python
+from a.b.c..
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#           ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^^ invalid.illegal.name.python
+from a.b.c.. import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#           ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#            ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                         ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^^ invalid.illegal.name.python
+#            ^^^^^^ keyword.control.import
 from a.b.c.else import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#              ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#               ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                            ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^ punctuation.accessor.dot.python
 #          ^^^^ invalid.illegal.name.python
 #               ^^^^^^ keyword.control.import
 from .while import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#          ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#           ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                        ^ - meta.statement
+#    ^ keyword.control.import.relative.python
 #     ^^^^^ invalid.illegal.name.python
 #           ^^^^^^ keyword.control.import
 from .index import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#          ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#           ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                        ^ - meta.statement
+#    ^ keyword.control.import.relative.python
 #     ^^^^^ - invalid
+#           ^^^^^^ keyword.control.import.python
+from \
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^^^ meta.statement.import.python meta.import-source.python - meta.import-path
+from \
+    ..\
+#^^^ meta.statement.import.python meta.import-source.python - meta.import-path
+#   ^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#     ^^ meta.statement.import.python meta.import-source.python - meta.import-path
+#   ^^ keyword.control.import.relative.python
+#     ^ punctuation.separator.continuation.line.python
+from \
+    ..\
+    lib \
+#^^^ meta.statement.import.python meta.import-source.python - meta.import-path
+#   ^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#      ^^^ meta.statement.import.python meta.import-source.python - meta.import-path
+#       ^ punctuation.separator.continuation.line.python
+from \
+    ..\
+    lib \
+    import \
+#^^^ meta.statement.import.python meta.import-source.python - meta.import-path
+#   ^^^^^^^^^ meta.statement.import.python - meta.import-source meta.import-path.python
+#   ^^^^^^ keyword.control.import.python
+#          ^ punctuation.separator.continuation.line.python
 from \
     os \
     import \
     path
-#   ^^^^ meta.statement.import
+# ^^^^^^ meta.statement.import
+#       ^ - meta.statement
 from sys import (version, # comment
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.import
 #               ^ punctuation.section.import-list.begin
 #                         ^ comment
                  version_info, . ) # comment
 #                ^^^^^^^^^^^^^ meta.statement.import
-#                              ^ invalid.illegal.name.import
+#                              ^ invalid.illegal.name.import.python
 #                                ^ punctuation.section.import-list.end
 #                                  ^ comment
 import path from os
@@ -74,6 +189,10 @@ from .sub import *
 #                ^ constant.language.import-all.python
 import a as b
 #        ^^ keyword.control.import.as.python
+import a as .b, .b
+#        ^^ keyword.control.import.as.python
+#           ^^ invalid.illegal.name.import.python
+#               ^^ invalid.illegal.name.import.python
 from a import b as c, d as e
 #               ^^ keyword.control.import.as.python
 #                       ^^ keyword.control.import.as.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -131,8 +131,11 @@ TypeError module.TypeError
 #^^^^^^^^ support.type.exception
 #                ^^^^^^^^^ - support
 
-open.open.open
+open.open.open.
 #    ^^^^^^^^^ - support
+#   ^ punctuation.accessor.dot.python
+#        ^ punctuation.accessor.dot.python
+#             ^ punctuation.accessor.dot.python
 
 ... Ellipsis __debug__
 #^^ constant.language.python
@@ -172,6 +175,12 @@ identifier()
 
 IDENTIFIER()
 #^^^^^^^^^ meta.qualified-name variable.function - variable.other.constant
+
+dotted.
+#     ^ punctuation.accessor.dot
+
+dotted .
+#      ^ punctuation.accessor.dot
 
 dotted . identifier(12, True)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call - meta.function-call meta.function-call
@@ -234,8 +243,9 @@ def _():
 #   ^^^^^ keyword.control.flow.yield
 #         ^^^^ keyword.control.flow.yield-from
 
-    yield fromsomething
+    yield fromsomething.
 #         ^^^^ - keyword
+#                      ^ punctuation.accessor.dot.python
 
     a if b else c
 #     ^^ keyword.control.conditional.if
@@ -404,8 +414,12 @@ range(20)[10:2:-2]
 "string"[12]
 #       ^^^^ meta.item-access - meta.structure
 
+"string".
+#       ^ punctuation.accessor.dot.python
+
 "string".upper()
 #       ^^^^^^^^ meta.function-call
+#       ^ punctuation.accessor.dot.python
 
 (i for i in range(10))[5]
 #                     ^^^ meta.item-access - meta.structure
@@ -414,8 +428,24 @@ range(20)[10:2:-2]
 #^^^^^^^^ meta.sequence
 #        ^^^ meta.item-access - meta.structure
 
+[a.b., a., .][2]
+#^^^^^^^^^^^^ meta.sequence
+# ^ punctuation.accessor.dot.python
+#   ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#          ^ punctuation.accessor.dot.python
+#            ^^^ meta.item-access - meta.structure
+
+{foo.: bar.baz.}.
+#   ^ punctuation.accessor.dot.python
+#    ^ punctuation.separator.mapping.key-value.python
+#         ^ punctuation.accessor.dot.python
+#             ^ punctuation.accessor.dot.python
+#               ^ punctuation.accessor.dot.python
+
 {True: False}.get(True)
 #            ^^^^^^^^^^ meta.function-call
+#            ^ punctuation.accessor.dot.python
 
 1[12]
 #^^^^ - meta.item-access
@@ -428,8 +458,12 @@ range(20)[10:2:-2]
 def _():
     print (file=None)
 #   ^^^^^ support.function.builtin - keyword
+    print .
+#   ^^^^^ support.function.builtin - keyword
+#         ^ punctuation.accessor.dot.python
     print . __class__
 #   ^^^^^ support.function.builtin - keyword
+#         ^ punctuation.accessor.dot.python
     print "keyword"
 #   ^^^^^ keyword.other.print
     print __init__

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -92,6 +92,26 @@ from a.b.c.
 #     ^ punctuation.accessor.dot.python
 #       ^ punctuation.accessor.dot.python
 #         ^ punctuation.accessor.dot.python
+from a.b.c. import module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#           ^^^^^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                        ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^ punctuation.accessor.dot.python
+#           ^^^^^^ keyword.control.import
+from a.b.c. as module
+#^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#   ^ meta.statement.import.python meta.import-source.python - meta.import-path
+#    ^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
+#           ^^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
+#                    ^ - meta.statement
+#     ^ punctuation.accessor.dot.python
+#       ^ punctuation.accessor.dot.python
+#         ^ punctuation.accessor.dot.python
+#           ^^ keyword.control.import.as.python
 from a.b.c..
 #^^^ meta.statement.import.python - meta.import-source - meta.import-path
 #   ^ meta.statement.import.python meta.import-source.python - meta.import-path


### PR DESCRIPTION
Fixes #2580 

This PR 

1. adds a simple `\.` pattern to `qualified-name` context to match all remaining/trailing dots `punctuation.accessor`.
2. reworks import statement contexts to support trailing accessor dots, which have been highlighted invalid before as they were treated as relative import punctuation.
3. fixes an issue which causes import statements like `from foo. import` to break highlighting because `import` or `as` being marked illegal. It created a poor behavior while typing import library paths.
4. fixes several overlapping meta scope issues in import statements.