### PR TITLE
[Python] Fix snippet selectors

### DIFF
--- a/Python/Snippets/New-Class.sublime-snippet
+++ b/Python/Snippets/New-Class.sublime-snippet
@@ -4,6 +4,6 @@
 		${5:super($1, self).__init__()}
 ${4/(\A\s*,\s*\Z)|,?\s*([A-Za-z_][a-zA-Z0-9_]*)\s*(=[^,]*)?(,\s*|$)/(?2:\t\tself.$2 = $2\n)/g}		$0]]></content>
 	<tabTrigger>class</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>New Class</description>
 </snippet>

--- a/Python/Snippets/Try-Except-Else-Finally.sublime-snippet
+++ b/Python/Snippets/Try-Except-Else-Finally.sublime-snippet
@@ -8,6 +8,6 @@ else:
 finally:
 	${7:pass}]]></content>
 	<tabTrigger>try</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Try/Except/Else/Finally</description>
 </snippet>

--- a/Python/Snippets/Try-Except-Else.sublime-snippet
+++ b/Python/Snippets/Try-Except-Else.sublime-snippet
@@ -6,6 +6,6 @@ except ${2:Exception} as ${3:e}:
 else:
 	${5:pass}]]></content>
 	<tabTrigger>try</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Try/Except/Else</description>
 </snippet>

--- a/Python/Snippets/Try-Except-Finally.sublime-snippet
+++ b/Python/Snippets/Try-Except-Finally.sublime-snippet
@@ -6,6 +6,6 @@ except ${2:Exception} as ${3:e}:
 finally:
 	${5:pass}]]></content>
 	<tabTrigger>try</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Try/Except/Finally</description>
 </snippet>

--- a/Python/Snippets/Try-Except.sublime-snippet
+++ b/Python/Snippets/Try-Except.sublime-snippet
@@ -4,6 +4,6 @@
 except ${2:Exception} as ${3:e}:
 	${4:raise $3}]]></content>
 	<tabTrigger>try</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Try/Except</description>
 </snippet>

--- a/Python/Snippets/__magic__.sublime-snippet
+++ b/Python/Snippets/__magic__.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[__${1:init}__]]></content>
 	<tabTrigger>__</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - comments - string</scope>
 	<description>__magic__</description>
 </snippet>

--- a/Python/Snippets/for.sublime-snippet
+++ b/Python/Snippets/for.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
-	<tabTrigger>for</tabTrigger>
-	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
-	<description>For Loop</description>
 	<content><![CDATA[
 for ${1:x} in ${2:range(10)}:
 	${0:pass}
 ]]></content>
+	<tabTrigger>for</tabTrigger>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
+	<description>For Loop</description>
 </snippet>

--- a/Python/Snippets/for.sublime-snippet
+++ b/Python/Snippets/for.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>For Loop</description>
 	<content><![CDATA[
 for ${1:x} in ${2:range(10)}:

--- a/Python/Snippets/function.sublime-snippet
+++ b/Python/Snippets/function.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<tabTrigger>def</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Function</description>
 	<content><![CDATA[def ${1:function}($2):
 	${0:pass}]]></content>

--- a/Python/Snippets/function.sublime-snippet
+++ b/Python/Snippets/function.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
+	<content><![CDATA[def ${1:function}($2):
+	${0:pass}]]></content>
 	<tabTrigger>def</tabTrigger>
 	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Function</description>
-	<content><![CDATA[def ${1:function}($2):
-	${0:pass}]]></content>
 </snippet>

--- a/Python/Snippets/if-__name__-==-'__main__'.sublime-snippet
+++ b/Python/Snippets/if-__name__-==-'__main__'.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[if __name__ == '__main__':
 	${1:main()}$0]]></content>
 	<tabTrigger>ifmain</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>if __name__ == '__main__'</description>
 </snippet>

--- a/Python/Snippets/if.sublime-snippet
+++ b/Python/Snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>If Condition</description>
 	<content><![CDATA[
 if ${1:$SELECTION}:

--- a/Python/Snippets/if.sublime-snippet
+++ b/Python/Snippets/if.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
-	<tabTrigger>if</tabTrigger>
-	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
-	<description>If Condition</description>
 	<content><![CDATA[
 if ${1:$SELECTION}:
 	${0:pass}
 ]]></content>
+	<tabTrigger>if</tabTrigger>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
+	<description>If Condition</description>
 </snippet>

--- a/Python/Snippets/method.sublime-snippet
+++ b/Python/Snippets/method.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<tabTrigger>defs</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Method</description>
 	<content><![CDATA[def ${1:function}(self${2}):
 	${0:pass}]]></content>

--- a/Python/Snippets/method.sublime-snippet
+++ b/Python/Snippets/method.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
+	<content><![CDATA[def ${1:function}(self${2}):
+	${0:pass}]]></content>
 	<tabTrigger>defs</tabTrigger>
 	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>Method</description>
-	<content><![CDATA[def ${1:function}(self${2}):
-	${0:pass}]]></content>
 </snippet>

--- a/Python/Snippets/while.sublime-snippet
+++ b/Python/Snippets/while.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<tabTrigger>while</tabTrigger>
-	<scope>source.python</scope>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
 	<description>While Loop</description>
 	<content><![CDATA[
 while ${1:$SELECTION}:

--- a/Python/Snippets/while.sublime-snippet
+++ b/Python/Snippets/while.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
-	<tabTrigger>while</tabTrigger>
-	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
-	<description>While Loop</description>
 	<content><![CDATA[
 while ${1:$SELECTION}:
 	${0:pass}
 ]]></content>
+	<tabTrigger>while</tabTrigger>
+	<scope>source.python - meta.function.parameters - meta.function-call - meta.statement - meta.mapping - meta.sequence - meta.set - comment - string</scope>
+	<description>While Loop</description>
 </snippet>


### PR DESCRIPTION
This PR suggests to prevent statement like snippets from being suggested in

- comments
- function parameter lists
- function call argument lists
- lists
- mappings
- sets
- statements (imports, if, while, ...)
- strings

They are not valid in those situations anyway.