### PR TITLE
[Go] Help ST with proper bracket matching

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -499,12 +499,15 @@ contexts:
 
   # https://golang.org/ref/spec#Rune_literals
   match-runes:
-    - match: \'({{char_escape}})'
-      scope: constant.character.go
+    # Note: Scope constants as `string` to prevent ST' bracket matching from
+    #       failing in case the character contains '{', '}', '[', ']', etc.
+    - match: (\')(?:({{char_escape}})|([^']*))(\')
+      scope: meta.string.go string.quoted.single.go
       captures:
-        1: constant.character.escape.go
-    - match: \'[^']*'
-      scope: constant.character.go
+        1: punctuation.definition.string.begin.go
+        2: constant.character.escape.go
+        3: constant.character.literal.go
+        4: punctuation.definition.string.end.go
 
   match-strings:
     - include: match-raw-string

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2184,32 +2184,48 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## Runes
 
     ' '
-//  ^^^ constant.character.go
+//  ^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^ constant.character.literal.go
+//    ^ punctuation.definition.string.end.go - constant
 
     '0'
-//  ^^^ constant.character.go
+//  ^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^ constant.character.literal.go
+//    ^ punctuation.definition.string.end.go - constant
 
 // Escapes:
 
     '\n'
-//  ^^^^ constant.character.go
-//   ^^ constant.character.go constant.character.escape.go
+//  ^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^^ constant.character.escape.go
+//     ^ punctuation.definition.string.end.go - constant
 
     '\x00'
-//  ^^^^^^ constant.character.go
-//   ^^^^ constant.character.go constant.character.escape.go
+//  ^^^^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^^^^ constant.character.escape.go
+//       ^ punctuation.definition.string.end.go - constant
 
     '\u0000'
-//  ^^^^^^^^ constant.character.go
-//   ^^^^^^ constant.character.go constant.character.escape.go
+//  ^^^^^^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^^^^^^ constant.character.escape.go
+//         ^ punctuation.definition.string.end.go - constant
 
     '\U00000000'
-//  ^^^^^^^^^^^^ constant.character.go
-//   ^^^^^^^^^^ constant.character.go constant.character.escape.go
+//  ^^^^^^^^^^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^^^^^^^^^^ constant.character.escape.go
+//             ^ punctuation.definition.string.end.go - constant
 
     '\000'
-//  ^^^^^^ constant.character.go
-//   ^^^^ constant.character.go constant.character.escape.go
+//  ^^^^^^ meta.string.go string.quoted.single.go
+//  ^ punctuation.definition.string.begin.go - constant
+//   ^^^^ constant.character.escape.go
+//       ^ punctuation.definition.string.end.go - constant
 
 // ## Strings
 


### PR DESCRIPTION
ST needs all brackets scoped `string` or `comment`, which are to be ignored by bracket matching or goto matching bracket command.

Before this commit if the code contains `'}'` it was included into bracket matching causing false positives.

This commit therefore scopes "runes" as `string.quoted.single` with only the containing character assigned `constant.character.[literal|escape]`.