### PR TITLE
[TypeScript] Arrow function return types, take two.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -929,12 +929,19 @@ contexts:
 
     - include: literal-call
 
-    - match: (?=\(|{{identifier_start}})
+    - match: (?={{identifier_start}})
       pop: true
-      branch_point: arrow-function
+      branch_point: bare-arrow-function
       branch:
-        - branch-possible-arrow-function
-        - arrow-function-fallback
+        - branch-possible-bare-arrow-function
+        - bare-arrow-function-fallback
+
+    - match: (?=\()
+      pop: true
+      branch_point: parenthesized-arrow-function
+      branch:
+        - branch-possible-parenthesized-arrow-function
+        - parenthesized-arrow-function-fallback
 
     - include: array-literal
 
@@ -959,31 +966,52 @@ contexts:
     - match: (?=\S)
       fail: async-arrow-function
 
-  branch-possible-arrow-function:
+  branch-possible-bare-arrow-function:
     - meta_include_prototype: false
     - match: ''
       push:
-        - detect-arrow
-        - branch-not-arrow-function
+        - detect-bare-arrow
+        - literal-variable
 
-  branch-not-arrow-function:
-    - include: parenthesized-expression
-    - include: literal-variable
-
-  detect-arrow:
+  detect-bare-arrow:
     - match: (?==>)
-      fail: arrow-function
+      fail: bare-arrow-function
     - match: (?=\S)
       pop: 2
 
-  arrow-function-fallback:
+  bare-arrow-function-fallback:
     - meta_include_prototype: false
     - match: ''
       push:
-        - branch-arrow-function-end
+        - branch-bare-arrow-function-end
         - arrow-function-declaration
 
-  branch-arrow-function-end:
+  branch-bare-arrow-function-end:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2
+
+  branch-possible-parenthesized-arrow-function:
+    - meta_include_prototype: false
+    - match: ''
+      push:
+        - detect-parenthesized-arrow
+        - parenthesized-expression
+
+  detect-parenthesized-arrow:
+    - match: (?==>)
+      fail: parenthesized-arrow-function
+    - match: (?=\S)
+      pop: 2
+
+  parenthesized-arrow-function-fallback:
+    - meta_include_prototype: false
+    - match: ''
+      push:
+        - branch-parenthesized-arrow-function-end
+        - arrow-function-declaration
+
+  branch-parenthesized-arrow-function-end:
     - meta_include_prototype: false
     - match: ''
       pop: 2

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -150,6 +150,11 @@ contexts:
     - match: ''
       pop: true
 
+  immediately-pop-2:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2
+
   comma-separator:
     - match: ','
       scope: punctuation.separator.comma.js
@@ -983,13 +988,8 @@ contexts:
     - meta_include_prototype: false
     - match: ''
       push:
-        - branch-bare-arrow-function-end
+        - immediately-pop-2
         - arrow-function-declaration
-
-  branch-bare-arrow-function-end:
-    - meta_include_prototype: false
-    - match: ''
-      pop: 2
 
   branch-possible-parenthesized-arrow-function:
     - meta_include_prototype: false
@@ -1008,13 +1008,8 @@ contexts:
     - meta_include_prototype: false
     - match: ''
       push:
-        - branch-parenthesized-arrow-function-end
+        - immediately-pop-2
         - arrow-function-declaration
-
-  branch-parenthesized-arrow-function-end:
-    - meta_include_prototype: false
-    - match: ''
-      pop: 2
 
   literal-string:
     - match: "'"

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -25,6 +25,50 @@ variables:
     ))
 
 contexts:
+  detect-parenthesized-arrow:
+    - meta_prepend: true
+    - match: (?=:)
+      pop: true
+      branch_point: ts-arrow-function-return-type
+      branch:
+        - ts-detect-arrow-function-return-type
+        - immediately-pop-2
+
+  ts-detect-arrow-function-return-type:
+    - match: ''
+      push:
+        - ts-detect-arrow-after-return-type
+        - ts-type-annotation
+
+  ts-detect-arrow-after-return-type:
+    - match: (?==>)
+      fail: parenthesized-arrow-function
+    - match: (?=\S)
+      fail: ts-arrow-function-return-type
+
+  async-arrow-function:
+    - match: async{{identifier_break}}
+      scope: storage.type.js
+      set:
+        - function-meta
+        - arrow-function-expect-body
+        - function-declaration-meta
+        - arrow-function-expect-arrow-or-fail-async
+        - ts-type-annotation
+        - arrow-function-expect-parameters
+
+  arrow-function-declaration:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - function-meta
+        - arrow-function-expect-body
+        - function-declaration-meta
+        - arrow-function-expect-arrow
+        - ts-type-annotation
+        - arrow-function-expect-parameters
+        - function-declaration-expect-async
+
   ts-import-type:
     - match: type{{identifier_break}}
       scope: keyword.control.import-export.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -359,6 +359,52 @@ function f(this : any) {}
 //      ^^^ meta.type support.type.any
 //           ^^ storage.type.function.arrow
 
+    x ? (y) : z;
+//  ^ variable.other.readwrite
+//    ^ keyword.operator.ternary
+//      ^^^ meta.group
+//       ^ variable.other.readwrite
+//          ^ keyword.operator.ternary
+
+    x ? (y) : T => r : z;
+//  ^ variable.other.readwrite
+//    ^ keyword.operator.ternary
+//      ^^^^^^^^^^^^^ meta.function
+//      ^ meta.function.declaration
+//       ^ meta.binding.name variable.parameter.function
+//          ^ punctuation.separator.type
+//            ^ meta.type support.class
+//              ^^ storage.type.function.arrow
+//                 ^meta.block variable.other.readwrite
+//                   ^ keyword.operator.ternary
+//                     ^ variable.other.readwrite
+
+    x ? y : T => z;
+//      ^ variable.other.readwrite - variable.parameter
+//        ^ keyword.operator.ternary
+//          ^^^^^^ meta.function
+//          ^ variable.parameter.function
+//            ^^ storage.type.function.arrow
+
+    async (x): T => y;
+//  ^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^ storage.type
+//         ^ meta.binding.name variable.parameter.function
+//           ^ punctuation.separator.type
+//             ^ meta.type support.class
+//               ^^ storage.type.function.arrow
+//                  ^ meta.block variable.other.readwrite
+
+    x ? async (y) : T => r : z;
+//      ^^^^^^^^^^^^^^^^^^ meta.function
+//                ^ punctuation.separator.type
+//                         ^ keyword.operator.ternary
+
+    x ? async (y) : T;
+//      ^^^^^ variable.function
+//                ^ keyword.operator.ternary
+
 /* Assertions */
 
 x as boolean;


### PR DESCRIPTION
Supersedes #2574. Built on top of the fixes and improvements in #2577.

Known issues:

- Invalid type expressions will not always be detected, which could lead to incorrect highlighting. I think this probably should be rare in practice. A perfect implementation is possible, but without something like https://github.com/sublimehq/sublime_text/issues/3494 it would require massive duplication of code.
- There are a lot of magical multi-pops in the arrow function branching code, though slightly fewer as a result of #2577. It should be possible to eliminate some more, but I've run into some infinite loops in the process. I have a hunch that https://github.com/sublimehq/sublime_text/issues/3732 might help here.
- If an arrow function (other than an async arrow function) has a return type, then the type will actually be parsed twice, which is not ideal. I'm not sure there's a good way around this.
- Statements like `const closeDialog = (): any => setDialogOpen(false);` will not be marked as function definitions, so `closeDialog` will not be in the symbol list. That entire feature is due for a rewrite anyway; see #2267. I could tweak the lookahead to make it work in the meantime, but at this point I'd rather not complicate it further.