### PR TITLE
[JavaScript] Remove meta.function.declaration scope.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -559,7 +559,7 @@ contexts:
     - include: else-pop
 
   function-initializer:
-    - meta_scope: meta.function.declaration.js
+    - meta_scope: meta.function.js
     - match: (=){{nothing}}
       captures:
         1: keyword.operator.assignment.js
@@ -948,7 +948,6 @@ contexts:
       set:
         - function-meta
         - arrow-function-expect-body
-        - function-declaration-meta
         - arrow-function-expect-arrow-or-fail-async
         - arrow-function-expect-parameters
 
@@ -1283,7 +1282,6 @@ contexts:
       push:
         - function-meta
         - function-declaration-expect-body
-        - function-declaration-meta
         - function-declaration-expect-parameters
 
     - match: static{{identifier_break}}
@@ -1356,7 +1354,7 @@ contexts:
     - match: (?:get|set){{identifier_break}}
       scope: storage.type.accessor.js
       set:
-        - meta_scope: meta.function.declaration.js
+        - meta_scope: meta.function.js
         - match: (?={{class_element_name}})
           set: method-declaration
         - match: (?=\S)
@@ -1364,7 +1362,7 @@ contexts:
     - match: (?:async){{identifier_break}}
       scope: storage.type.js
       set:
-        - meta_scope: meta.function.declaration.js
+        - meta_scope: meta.function.js
         - match: (?=\*|{{class_element_name}})
           set: method-declaration
         - match: (?=\S)
@@ -1374,7 +1372,7 @@ contexts:
     - match: (?:get|set){{identifier_break}}
       scope: storage.type.accessor.js
       set:
-        - meta_scope: meta.function.declaration.js
+        - meta_scope: meta.function.js
         - match: (?={{class_element_name}})
           set: method-declaration
         - match: (?=\S)
@@ -1382,7 +1380,7 @@ contexts:
     - match: (?:async){{identifier_break}}
       scope: storage.type.js
       set:
-        - meta_scope: meta.function.declaration.js
+        - meta_scope: meta.function.js
         - match: (?=\*|{{class_element_name}})
           set: method-declaration
         - match: (?=\S)
@@ -1475,7 +1473,6 @@ contexts:
       set:
         - function-meta
         - function-declaration-expect-body
-        - function-declaration-meta
         - function-declaration-expect-parameters
         - function-declaration-expect-name
         - function-declaration-expect-generator-star
@@ -1489,17 +1486,6 @@ contexts:
   function-meta:
     - meta_include_prototype: false
     - meta_scope: meta.function.js
-    - include: immediately-pop
-
-  function-declaration-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.declaration.js
-    - clear_scopes: 1
-    - include: immediately-pop
-
-  function-declaration-meta-no-clear:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.declaration.js
     - include: immediately-pop
 
   function-declaration-expect-parameters:
@@ -1536,7 +1522,6 @@ contexts:
       set:
         - function-meta
         - arrow-function-expect-body
-        - function-declaration-meta
         - arrow-function-expect-arrow
         - arrow-function-expect-parameters
 
@@ -1608,7 +1593,7 @@ contexts:
         )
       push:
         - expression-no-comma
-        - function-declaration-meta-no-clear
+        - function-meta
         - object-literal-expect-colon
         - object-literal-meta-key
         - method-name
@@ -1787,7 +1772,6 @@ contexts:
       set:
         - function-meta
         - function-declaration-expect-body
-        - function-declaration-meta
         - function-declaration-expect-parameters
         - method-name
         - method-declaration-expect-prefix

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -563,15 +563,6 @@ contexts:
       set: expression-no-comma
     - include: else-pop
 
-  function-initializer:
-    - meta_scope: meta.function.js
-    - match: (=){{nothing}}
-      captures:
-        1: keyword.operator.assignment.js
-      set: expression-no-comma
-
-    - include: else-pop
-
   expression-statement:
     - match: (?=\S)
       set:
@@ -1317,7 +1308,7 @@ contexts:
           {{either_func_lookahead}}
         )
       push:
-        - function-initializer
+        - initializer
         - function-name-meta
         - literal-variable-base
 
@@ -1440,9 +1431,7 @@ contexts:
           \s* = \s*
           {{either_func_lookahead}}
         )
-      set:
-        - function-initializer
-        - function-declaration-identifiers
+      set: function-declaration-identifiers
 
   function-declaration-identifiers:
     - match: '(?={{identifier}}\s*{{dot_accessor}})'
@@ -1616,7 +1605,6 @@ contexts:
         )
       push:
         - expression-no-comma
-        - function-meta
         - object-literal-expect-colon
         - object-literal-meta-key
         - method-name
@@ -2415,7 +2403,6 @@ contexts:
           {{either_func_lookahead}}
         )
       set:
-        - function-initializer
         - function-name-meta
         - object-property-base
 

--- a/JavaScript/Symbol List.tmPreferences
+++ b/JavaScript/Symbol List.tmPreferences
@@ -3,7 +3,7 @@
 <dict>
 	<key>scope</key>
 	<string>
-		source.js meta.function.declaration entity.name.function,
+		source.js entity.name.function,
 		source.js meta.class entity.name.class
 	</string>
 	<key>settings</key>

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -311,7 +311,6 @@ contexts:
       set:
         - function-meta
         - function-declaration-expect-body
-        - function-declaration-meta
         - ts-type-annotation
         - function-declaration-expect-parameters
         - ts-type-parameter-list
@@ -401,7 +400,6 @@ contexts:
       set:
         - function-meta
         - function-declaration-expect-body
-        - function-declaration-meta
         - ts-type-annotation
         - function-declaration-expect-parameters
         - ts-type-parameter-list

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -52,7 +52,6 @@ contexts:
       set:
         - function-meta
         - arrow-function-expect-body
-        - function-declaration-meta
         - arrow-function-expect-arrow-or-fail-async
         - ts-type-annotation
         - arrow-function-expect-parameters
@@ -63,7 +62,6 @@ contexts:
       set:
         - function-meta
         - arrow-function-expect-body
-        - function-declaration-meta
         - arrow-function-expect-arrow
         - ts-type-annotation
         - arrow-function-expect-parameters

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -255,14 +255,14 @@ someFunction({
 
     var bar = function() {
 //  ^^^ storage.type
-//      ^^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
 //      ^^^ entity.name.function variable.other.readwrite
+//            ^^^^^^^^^^^^ meta.function - meta.function meta.function
 //            ^^^^^^^^ storage.type.function
     }
 
     baz = function*()
-//  ^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
 //  ^^^ entity.name.function variable.other.readwrite
+//        ^^^^^^^^^^^ meta.function - meta.function meta.function
 //        ^^^^^^^^ storage.type.function
 //                ^ keyword.generator.asterisk
     {
@@ -464,9 +464,10 @@ var obj = {
     //     ^^^^^^^^^^^^^^ meta.string string.quoted.double
 
     $keyFunc: function() {
-//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
-    // <- meta.mapping.key.dollar entity.name.function punctuation.dollar
-     // <- meta.mapping.key.dollar entity.name.function - punctuation.dollar
+//  ^^^^^^^^ meta.mapping.key.dollar entity.name.function
+//  ^ punctuation.dollar
+//   ^^^^^^^ - punctuation.dollar
+//            ^^^^^^^^^^^^ meta.function
     },
 
     [true==false ? 'one' : 'two']: false,
@@ -509,40 +510,40 @@ var obj = {
     }(),
 
     funcKey: function() {
-//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^ meta.mapping.key entity.name.function
+//           ^^^^^^^^^^^^ meta.function
     },
 
     func2Key: function func2Key() {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //  ^^^^^^^^ meta.mapping.key entity.name.function
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.function
     },
 
     funcKeyArrow: () => {
-//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^ meta.mapping.key entity.name.function
+//                ^^^^^^^ meta.function
     },
 
     "funcStringKey": function funcStringKey()
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.double
 //   ^^^^^^^^^^^^^ entity.name.function
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
     { },
 
     'funcStringKey': function() {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.single
 //   ^^^^^^^^^^^^^ entity.name.function
+//                   ^^^^^^^^^^^^ meta.function
     },
 
     'funcStringKeyArrow': () => {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.single
 //   ^^^^^^^^^^^^^^^^^^ entity.name.function
+//                        ^^^^^^^ meta.function
     },
 
     "func\\String2KeyArrow": (foo) => {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//                           ^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.double
 //   ^^^^^^^^^^^^^^^^^^^^^ entity.name.function
 //       ^^ constant.character.escape
@@ -648,8 +649,8 @@ function x() {}
 // <- meta.brackets.js
 
 var $ = function(baz) {
-//  ^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.dollar.only punctuation.dollar
+//      ^^^^^^^^^^^^^ meta.function
 }
 
 $()
@@ -990,18 +991,18 @@ class MyClass extends TheirClass {
 //       ^^ constant.numeric
 
     f = a => b;
-//  ^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^ meta.function
 //      ^ variable.parameter.function
 
     g = function() {};
-//  ^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^^^^^^^^ meta.function
 
     #h = function() {};
-//  ^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ punctuation.definition.variable
 //   ^ entity.name.function variable.other.readwrite
+//       ^^^^^^^^^^^^^ meta.function
 
     static x = 42;
 //  ^^^^^^ storage.modifier.js
@@ -1038,13 +1039,13 @@ class MyClass extends TheirClass {
 //              ^^ constant.numeric
 
     static f = a => b;
-//         ^^^^^^^^^^ meta.function
 //         ^ entity.name.function variable.other.readwrite
+//             ^^^^^^ meta.function
 //             ^ variable.parameter.function
 
     static g = function() {};
-//         ^^^^^^^^^^^^^^^^^ meta.function
 //         ^ entity.name.function variable.other.readwrite
+//             ^^^^^^^^^^^^^ meta.function
 
     foo // You thought I was a field...
     () { return '...but was a method all along!'; }
@@ -1335,34 +1336,34 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 // ^^ storage.type.function.arrow
 
 MyClass.foo = function() {}
-// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ entity.name.function
+//            ^^^^^^^^^^^^^ meta.function
 
 MyClass.foo = () => {}
-// ^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ entity.name.function
+//            ^^^^^^^^ meta.function
 
 xhr.onload = function() {}
-// ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // <- support.class.js
 //  ^ entity.name.function
+//           ^^^^^^^^^^^^^ meta.function
 
 xhr.onload = () => {}
-// ^^^^^^^^^^^^^^^^^^ meta.function
 // <- support.class.js
 //  ^ entity.name.function
+//           ^^^^^^^^ meta.function
 
 var simpleArrow = foo => bar;
-//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //   ^ entity.name.function
-//                 ^ variable.parameter.function
-//                    ^ storage.type.function.arrow
+//                ^^^^^^^^^^ meta.function
+//                ^^^ variable.parameter.function
+//                    ^^ storage.type.function.arrow
 
 var Proto = () => {
-//  ^^^^^^^^^^^^^^^ meta.function
 //   ^ entity.name.function
+//          ^^^^^^^ meta.function
 //             ^ storage.type.function.arrow
     this._var = 1;
 }
@@ -1371,16 +1372,16 @@ var notAFunc = function$;
 //  ^^^^^^^^ - entity.name.function
 
 Proto.prototype.getVar = () => this._var;
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//                       ^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //     ^ support.constant.prototype
 //                ^ entity.name.function
 //                           ^ storage.type.function.arrow
 
 Class3.prototype = function() {
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ support.constant.prototype
+//                 ^^^^^^^^^^^^ meta.function
 }
 
 Proto.prototype.attr
@@ -1390,9 +1391,9 @@ Proto.prototype.attr
 
 Proto.prototype = {
     funcName: function() {
-//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^ entity.name.function
 //          ^ punctuation.separator.key-value
+//            ^^^^^^^^^^^^ meta.function
     }
 }
 
@@ -1426,7 +1427,7 @@ var foo = ~{a:function(){}.a()}
 //        ^ keyword.operator.bitwise
 //         ^ punctuation.section.block.begin
 //         ^^^^^^^^^^^^^^^^^^^^ meta.mapping
-//          ^^^^^^^^^^^^^^ meta.function
+//            ^^^^^^^^^^^^ meta.function
 //          ^ entity.name.function
 //           ^ punctuation.separator.key-value
 //            ^^^^^^^^ storage.type.function

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -66,19 +66,19 @@ export function bar() {}
 export function foo() {};
 //^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
-//     ^^^^^^^^^^^^^^  meta.function.declaration
+//     ^^^^^^^^^^^^^^^^^ meta.function
 //                      ^ punctuation.terminator.statement.empty
 
 export function* foo() {};
 //^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
-//     ^^^^^^^^^^^^^^^  meta.function.declaration
+//     ^^^^^^^^^^^^^^^^^^  meta.function
 //                       ^ punctuation.terminator.statement.empty
 
 export async function foo() {};
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
-//     ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //                            ^ punctuation.terminator.statement.empty
 
 export class Foo {};
@@ -96,14 +96,14 @@ export default function (a) { };
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
 //     ^^^^^^^ keyword.control.import-export
-//             ^^^^^^^^^^^^ meta.function.declaration.js
+//             ^^^^^^^^^^^^^^^^ meta.function
 //                             ^ punctuation.terminator.statement.empty - meta.export
 
 export default function* (a) { };
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
 //     ^^^^^^^ keyword.control.import-export
-//             ^^^^^^^^^^^^^ meta.function.declaration.js
+//             ^^^^^^^^^^^^^^^^^ meta.function
 //                              ^ punctuation.terminator.statement.empty - meta.export
 
 export default function name1(b) { }
@@ -124,7 +124,7 @@ export default +function (a) { };
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^^^^ keyword.control.import-export
 //     ^^^^^^^ keyword.control.import-export
-//              ^^^^^^^^^^^^ meta.function.declaration.js
+//              ^^^^^^^^^^^^^^^^ meta.function
 
 export { name1 as default };
 //^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
@@ -248,23 +248,20 @@ someFunction({
 
     function foo() {
 //  ^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
-//  ^^^^^^^^^^^^^^ meta.function.declaration
 //  ^^^^^^^^ storage.type.function
 //           ^^^ entity.name.function
-//                ^^ - meta.function.declaration
     }
 //  ^ meta.function meta.block
 
     var bar = function() {
 //  ^^^ storage.type
 //      ^^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
-//      ^^^^^^^^^^^^^^^^ meta.function.declaration
 //      ^^^ entity.name.function variable.other.readwrite
 //            ^^^^^^^^ storage.type.function
     }
 
     baz = function*()
-//  ^^^^^^^^^^^^^^^^^ meta.function.declaration - meta.function meta.function
+//  ^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
 //  ^^^ entity.name.function variable.other.readwrite
 //        ^^^^^^^^ storage.type.function
 //                ^ keyword.generator.asterisk
@@ -353,7 +350,6 @@ not_a_comment;
 
     "// /* not a comment"() {},
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ -comment() {}
-//                       ^ - meta.function.declaration meta.function.declaration
 });
 
 1
@@ -468,7 +464,7 @@ var obj = {
     //     ^^^^^^^^^^^^^^ meta.string string.quoted.double
 
     $keyFunc: function() {
-//  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
     // <- meta.mapping.key.dollar entity.name.function punctuation.dollar
      // <- meta.mapping.key.dollar entity.name.function - punctuation.dollar
     },
@@ -513,40 +509,40 @@ var obj = {
     }(),
 
     funcKey: function() {
-//  ^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^ meta.mapping.key entity.name.function
     },
 
     func2Key: function func2Key() {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //  ^^^^^^^^ meta.mapping.key entity.name.function
     },
 
     funcKeyArrow: () => {
-//  ^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^ meta.mapping.key entity.name.function
     },
 
     "funcStringKey": function funcStringKey()
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.double
 //   ^^^^^^^^^^^^^ entity.name.function
     { },
 
     'funcStringKey': function() {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.single
 //   ^^^^^^^^^^^^^ entity.name.function
     },
 
     'funcStringKeyArrow': () => {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.single
 //   ^^^^^^^^^^^^^^^^^^ entity.name.function
     },
 
     "func\\String2KeyArrow": (foo) => {
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key meta.string string.quoted.double
 //   ^^^^^^^^^^^^^^^^^^^^^ entity.name.function
 //       ^^ constant.character.escape
@@ -559,17 +555,17 @@ var obj = {
 //                ^^^^ constant.language.boolean.true
 
     qux()
-//  ^^^^^ meta.function.declaration
+//  ^^^^^ meta.function
 //  ^^^ entity.name.function
     {},
 
     'funcStringMethod'() {
-//  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^ meta.function
 //   ^^^^^^^^^^^^^^^^ entity.name.function
     },
 
     'funcStringMethodWithSameLineColon'() { var foo = { name: 'jeff' }; },
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.function
 
     "key (": true,
@@ -585,7 +581,7 @@ var obj = {
 //  ^^^^^^ variable.other.readwrite
 
     *baz(){
-//  ^^^^^^ meta.function.declaration
+//  ^^^^^^ meta.function
 //  ^ keyword.generator.asterisk
 //   ^^^ entity.name.function
     }
@@ -652,7 +648,7 @@ function x() {}
 // <- meta.brackets.js
 
 var $ = function(baz) {
-//  ^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.dollar.only punctuation.dollar
 }
 
@@ -994,7 +990,7 @@ class MyClass extends TheirClass {
 //       ^^ constant.numeric
 
     f = a => b;
-//  ^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
 //      ^ variable.parameter.function
 
@@ -1042,7 +1038,7 @@ class MyClass extends TheirClass {
 //              ^^ constant.numeric
 
     static f = a => b;
-//         ^^^^^^^^ meta.function.declaration
+//         ^^^^^^^^^^ meta.function
 //         ^ entity.name.function variable.other.readwrite
 //             ^ variable.parameter.function
 
@@ -1052,7 +1048,7 @@ class MyClass extends TheirClass {
 
     foo // You thought I was a field...
     () { return '...but was a method all along!'; }
-//  ^^ meta.class.js meta.block.js meta.function.declaration.js
+//  ^^ meta.class meta.block meta.function
 
     someMethod() {
         return #e * 2;
@@ -1071,7 +1067,7 @@ class MyClass extends TheirClass {
 //  ^ punctuation.definition.js
 
     constructor(el)
-//  ^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^ meta.function
     // ^ entity.name.function.constructor
     {
 //  ^ meta.class meta.block meta.function meta.block punctuation.section.block
@@ -1081,7 +1077,7 @@ class MyClass extends TheirClass {
 //  ^ meta.class meta.block meta.function meta.block punctuation.section.block
 
     get foo()
-//  ^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^ meta.function
     // <- storage.type.accessor
     //   ^ entity.name.function
     {
@@ -1090,18 +1086,18 @@ class MyClass extends TheirClass {
 
     static foo(baz) {
 //  ^^^^^^ storage.modifier
-//         ^^^^^^^^ meta.function.declaration
+//         ^^^^^^^^^^ meta.function
     //     ^^^ entity.name.function
 
     }
 
     qux()
-//  ^^^^^ meta.function.declaration
+//  ^^^^^ meta.function
     { }
 //  ^ meta.class meta.block meta.block punctuation.section.block.begin
 
     get bar () {
-//  ^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^ meta.function
 //             ^ meta.class meta.block meta.block punctuation.section.block.begin
     // <- storage.type.accessor
     //   ^ entity.name.function
@@ -1109,20 +1105,20 @@ class MyClass extends TheirClass {
     }
 
     baz() { return null }
-//  ^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
     // <- entity.name.function
 
     get() { return "foobar"; }
-//  ^^^^^ meta.function.declaration.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^ entity.name.function.js - storage.type.accessor
 
     set (value) { return value; }
-//  ^^^^^^^^^^^ meta.function.declaration.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^ variable.parameter.function.js
 //  ^^^ entity.name.function.js - storage.type.accessor
 
     set  abc(value1, value2) { return value1 + value2; }
-//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^ storage.type.accessor - entity.name.function.js
 //       ^^^ entity.name.function.js
 //           ^^^^^^ variable.parameter.function.js
@@ -1156,10 +1152,10 @@ class MyClass extends TheirClass {
 //              ^^^ entity.name.function
 
     ['foo']() {}
-//  ^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^ meta.function
 
     static ['foo']() {}
-//         ^^^^^^^^^ meta.function.declaration
+//         ^^^^^^^^^^^^ meta.function
 
     async foo() {}
 //  ^^^^^ storage.type
@@ -1226,7 +1222,6 @@ class{}/**/
 
     () => {}
 //  ^^^^^^^^ meta.function - meta.function meta.function
-//  ^^^^^ meta.function.declaration
 //  ^ punctuation.section.group.begin
 //   ^ punctuation.section.group.end
 //     ^^ storage.type.function.arrow
@@ -1253,30 +1248,29 @@ class{}/**/
 //   ^^^^^^^^^^ meta.group
 //              ^^^^^ storage.type.class
 
-() => {};
-// <- meta.function.declaration punctuation.section.group.begin
- // <- meta.function.declaration punctuation.section.group.end
-//^^^ meta.function.declaration
-//    ^ meta.block punctuation.section.block.begin
-//     ^ meta.block punctuation.section.block.end
+    () => {};
+//  ^^^^^ meta.function
+//  ^ punctuation.section.group.begin
+//   ^ punctuation.section.group.end
+//        ^ meta.block punctuation.section.block.begin
+//         ^ meta.block punctuation.section.block.end
 
     (foo, bar = 42)
-//  ^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^ meta.function
 //   ^^^ meta.binding.name
 //        ^^^ meta.binding.name
     => 42;
 //  ^^^^^ meta.function
-//  ^^ meta.function.declaration storage.type.function.arrow
+//  ^^ storage.type.function.arrow
 
     foo
-//  ^^^ meta.function.declaration variable.parameter.function
+//  ^^^ meta.function variable.parameter.function
     => 42;
 //  ^^^^^ meta.function
-//  ^^ meta.function.declaration storage.type.function.arrow
+//  ^^ storage.type.function.arrow
 
     async x => y;
 //  ^^^^^^^^^^^^ meta.function
-//  ^^^^^^^^^^ meta.function.declaration
 //  ^^^^^ storage.type
 //        ^ variable.parameter.function
 //          ^^ storage.type.function.arrow
@@ -1284,7 +1278,6 @@ class{}/**/
 
     async (x) => y;
 //  ^^^^^^^^^^^^^^ meta.function
-//  ^^^^^^^^^^^^ meta.function.declaration
 //  ^^^^^ storage.type
 //         ^ variable.parameter.function
 //            ^^ storage.type.function.arrow
@@ -1292,7 +1285,6 @@ class{}/**/
 
     async => {};
 //  ^^^^^^^^^^^ meta.function
-//  ^^^^^^^^ meta.function.declaration
 //  ^^^^^ variable.parameter.function
 //        ^^ storage.type.function.arrow
 
@@ -1305,13 +1297,12 @@ class{}/**/
 const test = ({a, b, c=()=>({active:false}) }) => {};
 //    ^ entity.name.function
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring
 //            ^ punctuation.section.block.begin
 //             ^ variable.parameter
 //                ^ variable.parameter
 //                   ^ variable.parameter
-//                     ^^^^ meta.function.declaration meta.function.declaration
+//                     ^^^^ meta.function meta.function
 //                     ^ punctuation.section.group.begin
 //                      ^ punctuation.section.group.end
 //                         ^^^^^^^^^^^^^^^^ meta.group
@@ -1344,33 +1335,33 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 // ^^ storage.type.function.arrow
 
 MyClass.foo = function() {}
-// ^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ entity.name.function
 
 MyClass.foo = () => {}
-// ^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ entity.name.function
 
 xhr.onload = function() {}
-// ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // <- support.class.js
 //  ^ entity.name.function
 
 xhr.onload = () => {}
-// ^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^ meta.function
 // <- support.class.js
 //  ^ entity.name.function
 
 var simpleArrow = foo => bar;
-//  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //   ^ entity.name.function
 //                 ^ variable.parameter.function
 //                    ^ storage.type.function.arrow
 
 var Proto = () => {
-//  ^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^ meta.function
 //   ^ entity.name.function
 //             ^ storage.type.function.arrow
     this._var = 1;
@@ -1380,14 +1371,14 @@ var notAFunc = function$;
 //  ^^^^^^^^ - entity.name.function
 
 Proto.prototype.getVar = () => this._var;
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //     ^ support.constant.prototype
 //                ^ entity.name.function
 //                           ^ storage.type.function.arrow
 
 Class3.prototype = function() {
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 // ^ support.class
 //       ^ support.constant.prototype
 }
@@ -1399,7 +1390,7 @@ Proto.prototype.attr
 
 Proto.prototype = {
     funcName: function() {
-//  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^^^^^^^^ entity.name.function
 //          ^ punctuation.separator.key-value
     }
@@ -1421,10 +1412,10 @@ return new Promise(resolve => preferenceObject.set({value}, resolve));
 //                                                                  ^ meta.function-call.constructor punctuation.section.group.end
 
 var anotherSingle = function(){a = param => param; return param2 => param2 * a}
-//                                 ^ meta.function.declaration variable.parameter.function
+//                                 ^ meta.function variable.parameter.function
 //                                          ^ meta.block meta.block variable.other.readwrite
 //                                               ^ meta.block punctuation.terminator.statement
-//                                                        ^ meta.function.declaration variable.parameter.function
+//                                                        ^ meta.function variable.parameter.function
 //                                                                           ^ meta.block meta.block variable.other.readwrite
 //                                                                            ^ meta.block punctuation.section.block.end
 
@@ -1435,7 +1426,7 @@ var foo = ~{a:function(){}.a()}
 //        ^ keyword.operator.bitwise
 //         ^ punctuation.section.block.begin
 //         ^^^^^^^^^^^^^^^^^^^^ meta.mapping
-//          ^^^^^^^^^^^^ meta.function.declaration
+//          ^^^^^^^^^^^^^^ meta.function
 //          ^ entity.name.function
 //           ^ punctuation.separator.key-value
 //            ^^^^^^^^ storage.type.function
@@ -1444,7 +1435,7 @@ var foo = ~{a:function(){}.a()}
 //                      ^ meta.block punctuation.section.block.begin
 //                       ^ meta.block punctuation.section.block.end
 //                        ^ meta.mapping
-//                         ^^^ - meta.function.declaration
+//                         ^^^ - meta.function
 //                         ^ variable.function - entity.name.function
 //                          ^ punctuation.section.group.begin
 //                           ^ punctuation.section.group.end
@@ -1709,16 +1700,16 @@ var re = /^\/[^/]+/;
 //    ^ meta.brackets keyword.operator.comma - meta.sequence - punctuation
 
 define(['common'], function(common) {
-//                 ^ meta.function.declaration
+//                 ^^^^^^^^^^^^^^^^^^ meta.function
     var namedFunc = function() {
-//        ^ meta.function.declaration
+//        ^ meta.function
     }
 });
 
 new FooBar(function(){
-//          ^ meta.function.declaration
+//          ^ meta.function
     var namedFunc2 = function() {
-//        ^ meta.function.declaration
+//        ^ meta.function
     }
 })
 
@@ -1888,7 +1879,6 @@ var str = `Hello, ${name}!`;
 
 function yy (a, b) {
 // ^^^^^^^^^^^^^^^^^ meta.function
-// ^^^^^^^^^^^^^^^ meta.function.declaration
 //       ^^ entity.name.function
 //          ^ punctuation.section.group.begin
 //           ^ variable.parameter.function

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -105,7 +105,7 @@ function f ([ x, [a, b], z]) {}
 function f ([ x = 42, y = [a, b, c] ]) {}
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //              ^ keyword.operator.assignment
-//                ^^ meta.function.declaration.js meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
+//                ^^ meta.function meta.binding.destructuring.sequence meta.number.integer.decimal constant.numeric.value
 //                      ^ keyword.operator.assignment
 //                        ^^^^^^^^^ meta.sequence
 //                         ^ variable.other.readwrite - meta.binding.name
@@ -142,7 +142,7 @@ function f (new) {}
 //          ^^^ invalid.illegal.identifier meta.binding.name variable.parameter.function
 
 let f = ([ x, y, ...z, ]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //         ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.parameter
@@ -153,7 +153,7 @@ let f = ([ x, y, ...z, ]) => {};
 //                   ^ punctuation.separator.parameter
 
 let f = ([ x, [a, b], z]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //            ^^^^^^ meta.binding.destructuring.sequence meta.binding.destructuring.sequence
@@ -161,17 +161,17 @@ let f = ([ x, [a, b], z]) => {};
 //                ^ meta.binding.name variable.parameter.function
 
 let f = ([ x = 42, y = [a, b, c] ]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //           ^ keyword.operator.assignment
-//             ^^ meta.function.declaration.js meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
+//             ^^ meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
 //                   ^ keyword.operator.assignment
 //                     ^^^^^^^^^ meta.sequence
 //                      ^ variable.other.readwrite - meta.binding.name
 
 let f = ({ a, b: c, ...d }) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^^^^^ meta.binding.destructuring.mapping
 //         ^ meta.mapping.key meta.binding.name variable.parameter.function
@@ -195,7 +195,7 @@ let f = ({ 'a': x, "b": y, [c]: z }) => {};
 //                              ^ meta.binding.name variable.parameter.function
 
 let f = (a, ...rest) => {};
-//  ^^^^^^^^^^^^^^^^ meta.function.declaration
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
 //       ^ meta.binding.name variable.parameter.function
 //          ^^^ keyword.operator.spread

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -142,7 +142,7 @@ function f (new) {}
 //          ^^^ invalid.illegal.identifier meta.binding.name variable.parameter.function
 
 let f = ([ x, y, ...z, ]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//      ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //         ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.parameter
@@ -153,16 +153,16 @@ let f = ([ x, y, ...z, ]) => {};
 //                   ^ punctuation.separator.parameter
 
 let f = ([ x, [a, b], z]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //            ^^^^^^ meta.binding.destructuring.sequence meta.binding.destructuring.sequence
 //             ^ meta.binding.name variable.parameter.function
 //                ^ meta.binding.name variable.parameter.function
 
 let f = ([ x = 42, y = [a, b, c] ]) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //           ^ keyword.operator.assignment
 //             ^^ meta.binding.destructuring.sequence.js meta.number.integer.decimal.js constant.numeric.value.js
@@ -171,8 +171,8 @@ let f = ([ x = 42, y = [a, b, c] ]) => {};
 //                      ^ variable.other.readwrite - meta.binding.name
 
 let f = ({ a, b: c, ...d }) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //       ^^^^^^^^^^^^^^^^^ meta.binding.destructuring.mapping
 //         ^ meta.mapping.key meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.parameter
@@ -195,12 +195,12 @@ let f = ({ 'a': x, "b": y, [c]: z }) => {};
 //                              ^ meta.binding.name variable.parameter.function
 
 let f = (a, ...rest) => {};
-//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //  ^ entity.name.function variable.other.readwrite
+//      ^^^^^^^^^^^^^^^^^^ meta.function
 //       ^ meta.binding.name variable.parameter.function
 //          ^^^ keyword.operator.spread
 //             ^^^^ meta.binding.name variable.parameter.function
 
 let f = (new) => {};
-//  ^^^^^^^^^^^^^^^ meta.function
+//      ^^^^^^^^^^^ meta.function
 //       ^^^ invalid.illegal.identifier meta.binding.name variable.parameter.function

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -180,14 +180,14 @@
 //                     ^^^ variable.other.readwrite
 
         foo(): any {}
-//      ^^^^^^^^^^^ meta.function.declaration
+//      ^^^^^^^^^^^^^ meta.function
 //      ^^^ entity.name.function
 //           ^ punctuation.separator.type
 //             ^^^ meta.type support.type.any
 //                 ^^ meta.function meta.block
 
         foo<T>(): any {}
-//      ^^^^^^^^^^^^^ meta.function.declaration
+//      ^^^^^^^^^^^^^^^^ meta.function
 //      ^^^ entity.name.function
 //         ^^^ meta.generic
 //              ^ punctuation.separator.type
@@ -293,15 +293,12 @@ function f(x?: any) {}
 
 function f(): any {}
 //^^^^^^^^^^^^^^^^^^ meta.function
-//^^^^^^ meta.function.declaration
 //          ^ punctuation.separator.type
 //            ^^^meta.type support.type.any
 //                ^^ meta.block
 
 function f ( x : any , ... y : any ) {}
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //           ^ meta.binding.name variable.parameter.function
 //             ^ punctuation.separator.type
 //               ^^^ meta.type support.type.any
@@ -324,7 +321,6 @@ function f ( @foo x , @bar() y ) {}
 
 function f<T, U>() {}
 //^^^^^^^^^^^^^^^^^^^ meta.function
-//^^^^^^^^^^^^^^^^^ meta.function.declaration
 //        ^^^^^^ meta.generic
 //         ^ variable.parameter.generic
 //          ^ punctuation.separator.comma
@@ -332,7 +328,6 @@ function f<T, U>() {}
 
 function f(x): x is any {};
 //^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //           ^ punctuation.separator.type
 //             ^^^^^^^^^ meta.type
 //               ^^ keyword.operator.word
@@ -340,7 +335,6 @@ function f(x): x is any {};
 
 function f(x): asserts x is any {};
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
 //           ^ punctuation.separator.type
 //            ^^^^^^^^^^^^^^^^^ meta.type
 //             ^^^^^^^ storage.modifier.asserts
@@ -354,7 +348,6 @@ function f(this : any) {}
 
     (x: any) => 42;
 //  ^^^^^^^^^^^^^^ meta.function
-//  ^^^^^^^^^^^ meta.function.declaration
 //    ^ punctuation.separator.type
 //      ^^^ meta.type support.type.any
 //           ^^ storage.type.function.arrow
@@ -370,7 +363,6 @@ function f(this : any) {}
 //  ^ variable.other.readwrite
 //    ^ keyword.operator.ternary
 //      ^^^^^^^^^^^^^ meta.function
-//      ^ meta.function.declaration
 //       ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.type
 //            ^ meta.type support.class
@@ -388,7 +380,6 @@ function f(this : any) {}
 
     async (x): T => y;
 //  ^^^^^^^^^^^^^^^^^ meta.function
-//  ^^^^^^^^^^^^^^^ meta.function.declaration
 //  ^^^^^ storage.type
 //         ^ meta.binding.name variable.parameter.function
 //           ^ punctuation.separator.type
@@ -516,7 +507,7 @@ let x: Foo<any, any>;
 
 
 function f<T extends Foo>() {}
-//        ^^^^^^^^^^^^^^^ meta.function.declaration meta.generic
+//        ^^^^^^^^^^^^^^^ meta.function meta.generic
 //         ^ variable.parameter.generic
 //           ^^^^^^^ storage.modifier.extends
 //                   ^^^ support.class


### PR DESCRIPTION
Historically, the JavaScript syntax scoped the parts of a function before the body as `meta.function.declaration`. This is not a standard scope. In the past, it was used to populate the symbol list so that a function might appear in the list as `function foo (bar)`. However, with the new symbol list functionality, only the function name itself is shown in the symbol list, so the `meta.function.declaration` scope serves no purpose.

~~I've marked this WIP because I think it might conflict with #2590. If so, it would be a trivial fix, but it's better to apply that fix here rather than in the more complicated PR.~~