### PR TITLE
[Ruby] Remove storage.type scope

### DIFF
--- a/Rails/syntax_test_rails.rb
+++ b/Rails/syntax_test_rails.rb
@@ -1,7 +1,7 @@
 # SYNTAX TEST "Packages/Rails/Ruby on Rails.sublime-syntax"
 
 class ApplicationController < ApplicationController
-# <- storage.type.class
+# <- keyword.declaration.class
 #     ^ entity.name.class
 #                           ^ punctuation.separator
 #                             ^ entity.other.inherited-class

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -123,9 +123,9 @@ contexts:
   class:
     # Defining a class method
     - match: \bclass\b(?=\s*<)
-      scope: storage.type.class.ruby keyword.declaration.class.ruby
+      scope: keyword.declaration.class.ruby
     - match: \bclass\b
-      scope: storage.type.class.ruby keyword.declaration.class.ruby
+      scope: keyword.declaration.class.ruby
       push: class-declaration
 
   class-declaration:
@@ -163,7 +163,7 @@ contexts:
 
   module:
     - match: \bmodule\b
-      scope: storage.type.namespace.ruby keyword.declaration.namespace.ruby
+      scope: keyword.declaration.namespace.ruby
       push: module-declaration
 
   module-declaration:
@@ -879,7 +879,7 @@ contexts:
       push: function-call-arguments
     # Lambda operator from the Kernel class not handled elsewhere
     - match: '->'
-      scope: meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
+      scope: meta.function.ruby keyword.declaration.function.anonymous.ruby
       push: function-call-arguments
     # Methods from the Module class not handled elsewhere
     - match: |-
@@ -936,7 +936,7 @@ contexts:
 
   method:
     - match: \bdef\b
-      scope: meta.function.ruby storage.type.function.ruby keyword.declaration.function.ruby
+      scope: meta.function.ruby keyword.declaration.function.ruby
       push:
         - meta_content_scope: meta.function.ruby
         - match: '(self)(\.)({{identifier}}{{method_punctuation}}|===?|>[>=]?|<=>|<[<=]?|[%&`/\|]|\*\*?|=?~|[-+]@?|\[\]=?)'

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -965,17 +965,17 @@ do |&bl| end
 
 module MyModule
 #^^^^^^^^^^^^^^ meta.namespace
-# <- meta.namespace storage.type.namespace keyword.declaration.namespace
-#^^^^^ storage.type.namespace keyword.declaration.namespace
+# <- meta.namespace keyword.declaration.namespace
+#^^^^^ keyword.declaration.namespace
 #     ^ - entity - keyword - storage
 #      ^^^^^^^^ entity.name.namespace
 end
 
 module MyModule::OtherModule
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.namespace
-# <- meta.namespace storage.type.namespace keyword.declaration.namespace
+# <- meta.namespace keyword.declaration.namespace
 #      ^^^^^^^^^^^^^^^^^^^^^ entity.name.namespace
-#^^^^^ storage.type.namespace keyword.declaration.namespace
+#^^^^^ keyword.declaration.namespace
 #     ^ - entity - keyword - storage
 #      ^^^^^^^^ support.other.namespace
 #              ^^ punctuation.accessor.double-colon
@@ -984,8 +984,8 @@ end
 
 class ::MyModule::MyClass < MyModule::InheritedClass
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class
-# <- meta.class storage.type.class keyword.declaration.class
-#^^^^ storage.type.class keyword.declaration.class
+# <- meta.class keyword.declaration.class
+#^^^^ keyword.declaration.class
 #    ^ - entity - keyword - storage - punctuation
 #     ^^ punctuation.accessor.double-colon
 #       ^^^^^^^^ support.other.namespace
@@ -997,7 +997,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 
   def my_method(param1, param2)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-# ^^^ storage.type.function keyword.declaration.function
+# ^^^ keyword.declaration.function
 #     ^^^^^^^^^ entity.name.function
 #              ^^^^^^^^^^^^^^^^ meta.function.parameters
 #              ^ punctuation.definition.group.begin
@@ -1007,7 +1007,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 
   def self.my_second_method *arg_without_parens # comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-# ^^^ storage.type.function keyword.declaration.function
+# ^^^ keyword.declaration.function
 #     ^^^^ variable.language
 #         ^ punctuation.accessor.dot
 #          ^^^^^^^^^^^^^^^^ entity.name.function
@@ -1019,7 +1019,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 
   def self.my_third_method(a, b="foo", c=[], d=foo(), *args)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-# ^^^ storage.type.function keyword.declaration.function
+# ^^^ keyword.declaration.function
 #     ^^^^ variable.language
 #         ^ punctuation.accessor.dot
 #          ^^^^^^^^^^^^^^^ entity.name.function
@@ -1047,7 +1047,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 
   def nested((a, b), c, (d, *e))
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-# ^^^ storage.type.function keyword.declaration.function
+# ^^^ keyword.declaration.function
 #     ^^^^^^ entity.name.function
 #           ^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #           ^ punctuation.definition.group.begin
@@ -1068,7 +1068,7 @@ class ::MyModule::MyClass < MyModule::InheritedClass
   end
 
   def block_param(&block)
-# ^^^ storage.type.function keyword.declaration.function
+# ^^^ keyword.declaration.function
 #                ^^^^^^^^ meta.function.parameters
 #                 ^ keyword.operator
 #                  ^^^^^ variable.parameter
@@ -1121,7 +1121,7 @@ def f.my_instance_method
 end
 
 class MyClass
-# ^ meta.class.ruby storage.type.class.ruby
+# ^ meta.class.ruby keyword.declaration.class.ruby
 #     ^ meta.class.ruby entity.name.class.ruby
 
   prepend Module.new
@@ -1153,7 +1153,7 @@ exit! 2
 #^^^^ support.function.builtin
 
 get :name, -> { "John" }
-#          ^^ meta.function.ruby storage.type.function.ruby keyword.declaration.function.lambda.ruby
+#          ^^ meta.function.ruby keyword.declaration.function.anonymous.ruby
 
 ##################
 # Symbol literals
@@ -1349,7 +1349,7 @@ def huh?(a, b=def huh?(a); "h?"; end)
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #             ^^^^^^^^^^^ meta.function meta.function
 #                     ^^^ meta.function.parameters meta.function.parameters
-#^^ storage.type.function keyword.declaration.function
+#^^ keyword.declaration.function
 #                      ^ variable.parameter
   a
 end


### PR DESCRIPTION
This commit removes storage.type in patterns which already make use of keyword.declaration no avoid obsolete stacking of those scopes.