### PR TITLE
[R] Rename storage.type.function scope

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -299,7 +299,7 @@ contexts:
     - match: \b(function)\s*(?=\()
       scope: meta.function.r
       captures:
-        1: storage.type.function.r
+        1: keyword.declaration.function.r
       push:
         - match: \(
           scope: punctuation.section.parameters.begin.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -427,7 +427,7 @@ f = function(x, y){ }
 # ^^^^^^^^^^ meta.function.r - meta.function.parameters.r
 # <- entity.name.function.r
 # ^ keyword.operator.assignment.r
-#   ^^^^^^^^ storage.type.function.r
+#   ^^^^^^^^ keyword.declaration.function.r
 #           ^ punctuation.section.parameters.begin.r
 #            ^^^^ meta.function.parameters.r - meta.function.r
 #            ^ variable.parameter.r
@@ -450,7 +450,7 @@ foo(200, x = function(x) {x + y})
 #   ^^^ meta.function-call.arguments.r meta.number.float.decimal.r constant.numeric.value.r
 #        ^ variable.parameter.r
 #          ^ keyword.operator.assignment.r
-#            ^^^^^^^^ meta.function.r storage.type.function.r - meta.function.parameters.r
+#            ^^^^^^^^ meta.function.r keyword.declaration.function.r - meta.function.parameters.r
 #                    ^^^ meta.function.parameters.r
 #                               ^ punctuation.section.arguments.end.r
 


### PR DESCRIPTION
This commit replaces storage.type.function by keyword.declaration.function