### PR TITLE
[Python] Remove storage.type scope

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -579,7 +579,7 @@ contexts:
   classes:
     - match: '^\s*(class)\b'
       captures:
-        1: storage.type.class.python keyword.declaration.class.python
+        1: keyword.declaration.class.python
       push:
         - meta_scope: meta.class.python
         - include: line-continuation-or-pop
@@ -628,8 +628,8 @@ contexts:
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\b'
       captures:
-        1: storage.modifier.async.python
-        2: storage.type.function.python keyword.declaration.function.python
+        1: keyword.declaration.async.python
+        2: keyword.declaration.function.python
       push:
         - meta_scope: meta.function.python
         - include: line-continuation-or-pop

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -248,9 +248,9 @@ identifier
 #^^^^^^^^^ meta.qualified-name meta.generic-name
 
 class
-#^^^^ storage.type.class keyword.declaration.class.python
+#^^^^ keyword.declaration.class.python
 def
-#^^ storage.type.function keyword.declaration.function.python
+#^^ keyword.declaration.function.python
 
 # async and await are still recognized as valid identifiers unless in an "async" block
 async
@@ -963,8 +963,8 @@ def type_annotations_line_continuation() \
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                  ^^^^^^^^ meta.function.parameters - meta.function meta.function
-# <- storage.modifier.async
-#     ^ storage.type
+# <- keyword.declaration.async
+#     ^^^ keyword.declaration.function.python
 #         ^ entity.name.function
    pass
 
@@ -1174,7 +1174,7 @@ class Class():
     @deco \
 
     def f(): pass
-#   ^^^ storage.type.function keyword.declaration.function.python - meta.decorator
+#   ^^^ keyword.declaration.function.python - meta.decorator
 
 
 class AClass:


### PR DESCRIPTION
This commit removes storage.type in patterns which already make use of keyword.declaration no avoid obsolete stacking of those scopes.