### PR TITLE
[Pascal] Rename storage.type.function scope

### DIFF
--- a/Pascal/Pascal.sublime-syntax
+++ b/Pascal/Pascal.sublime-syntax
@@ -14,12 +14,12 @@ contexts:
     - match: \b(?i:(function|procedure))\b\s+(\w+(\.\w+)?)(\(.*?\))?;\s*(?=(?i:attribute|forward|external))
       scope: meta.function.prototype.pascal
       captures:
-        1: storage.type.prototype.pascal
-        2: entity.name.function.prototype.pascal
+        1: keyword.declaration.function.pascal
+        2: entity.name.function.pascal
     - match: \b(?i:(function|procedure))\b\s+(\w+(\.\w+)?)
       scope: meta.function.pascal
       captures:
-        1: storage.type.function.pascal
+        1: keyword.declaration.function.pascal
         2: entity.name.function.pascal
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
       scope: constant.numeric.pascal

--- a/Pascal/syntax_test.pas
+++ b/Pascal/syntax_test.pas
@@ -12,7 +12,7 @@
 
 // comment
 procedure foo;
-// ^ meta.function.pascal
+// ^ meta.function.pascal keyword.declaration.function
 begin
 	// comment
 end;
@@ -20,7 +20,7 @@ end;
 
 -- comment
 procedure bar;
-// ^ meta.function.pascal
+// ^ meta.function.pascal keyword.declaration.function
 begin
 	-- comment
 end;


### PR DESCRIPTION
This commit replaces storage.type.function by keyword.declaration.function