### PR TITLE
[Lua] Remove storage.type scope

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
       scope: punctuation.terminator.statement.lua
 
     - match: function{{identifier_break}}
-      scope: storage.type.function.lua keyword.declaration.function.lua
+      scope: keyword.declaration.function.lua
       push:
         - function-meta
         - block-contents
@@ -595,7 +595,7 @@ contexts:
 
   function-literal:
     - match: function{{identifier_break}}
-      scope: storage.type.function.lua keyword.declaration.function.lua
+      scope: keyword.declaration.function.lua
       set:
         - function-meta
         - block-contents

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -434,7 +434,7 @@
 
     function function_name( a, b, ... )
 --  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
---  ^^^^^^^^ storage.type.function keyword.declaration.function
+--  ^^^^^^^^ keyword.declaration.function
 --           ^^^^^^^^^^^^^ entity.name.function
 --                        ^^^^^^^^^^^^^ meta.group
 --                        ^ punctuation.section.group.begin
@@ -473,7 +473,7 @@
 
     ~function( a, b, ... ) end;
 --   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
---   ^^^^^^^^ storage.type
+--   ^^^^^^^^ keyword.declaration.function.lua
 --           ^^^^^^^^^^^^^ meta.group
 --                         ^^^ keyword.control.end
 


### PR DESCRIPTION
This commit removes storage.type in patterns which already make use of
keyword.declaration no avoid obsolete stacking of those scopes.