### PR TITLE
[C#] Remove storage.type scope

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -729,7 +729,7 @@ contexts:
       scope: storage.modifier.other.cs
       push: type_constraint
     - match: (=>)
-      scope: storage.type.function.cs
+      scope: keyword.declaration.function.anonymous.cs
       set:
         - meta_content_scope: meta.method.cs
         - include: line_of_code_in
@@ -780,7 +780,7 @@ contexts:
           scope: storage.modifier.access.cs
         - include: attribute
     - match: '=>'
-      scope: storage.type.function.cs
+      scope: keyword.declaration.function.anonymous.cs
       set:
         - meta_content_scope: meta.method.cs
         - include: line_of_code_in

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -758,7 +758,7 @@ public class MyClass {
     public MyClass () => obj = null;
 ///        ^^^^^^^ meta.method.constructor entity.name.function.constructor
 ///               ^^^^^^^^^^^^^^^^^ meta.class.body meta.block meta.method
-///                   ^^ storage.type.function
+///                   ^^ keyword.declaration.function.anonymous.cs
 ///                      ^^^ variable.other
 ///                          ^ keyword.operator.assignment
 ///                            ^^^^ constant.language
@@ -783,7 +783,7 @@ public class Person // https://stackoverflow.com/a/41974829/4473405
 ///                                ^^^ variable.parameter
 ///                                   ^ punctuation.section.parameters.end
 ///                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method
-///                                     ^^ storage.type.function
+///                                     ^^ keyword.declaration.function.anonymous.cs
 ///                                        ^ meta.group punctuation.section.group.begin
 ///                                         ^^^^ meta.group variable.other
 ///                                             ^ meta.group punctuation.separator.tuple

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -71,7 +71,7 @@ namespace YourNamespace
 ///                         ^^^^ support.type
 ///                              ^^^^^ variable.parameter
 ///                                   ^ punctuation.section.parameters.end
-///                                     ^^ storage.type.function
+///                                     ^^ keyword.declaration.function.anonymous.cs
 ///                                        ^^^^ variable.language
 ///                                             ^^ keyword.operator.reflection
 ///                                                ^^^^^ support.type
@@ -120,7 +120,7 @@ namespace YourNamespace
 ///                     ^^^^^^^^^^^^^^^^^^^^ meta.method
 ///                     ^^^^^^^^^ entity.name.function
 ///                              ^^ meta.method.parameters
-///                                 ^^ storage.type.function
+///                                 ^^ keyword.declaration.function.anonymous.cs
 ///                                    ^^^^^ constant.language
     }
 


### PR DESCRIPTION
This commit removes storage.type in patterns which already make use of
keyword.declaration no avoid obsolete stacking of those scopes.

Note: `storage.type.variable` is interpreted as variant data type, so it
      is not renamed to keyword.declaration.