### PR TITLE
[JavaScript] Use keyword.declaration.function instead of storage.type.function

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -947,7 +947,7 @@ contexts:
 
   async-arrow-function:
     - match: async{{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.async.js
       set:
         - function-meta
         - arrow-function-expect-body
@@ -1374,7 +1374,7 @@ contexts:
         - match: (?=\S)
           fail: prefixed-method
     - match: (?:async){{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.async.js
       set:
         - meta_scope: meta.function.js
         - match: (?=\*|{{class_element_name}})
@@ -1392,7 +1392,7 @@ contexts:
         - match: (?=\S)
           fail: prefixed-object-literal-method
     - match: (?:async){{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.async.js
       set:
         - meta_scope: meta.function.js
         - match: (?=\*|{{class_element_name}})
@@ -1524,7 +1524,7 @@ contexts:
 
   function-declaration-expect-async:
     - match: 'async{{identifier_break}}'
-      scope: storage.type.js
+      scope: keyword.declaration.async.js
       pop: true
     - include: else-pop
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1512,7 +1512,7 @@ contexts:
 
   function-declaration-expect-generator-star:
     - match: \*
-      scope: keyword.generator.asterisk.js
+      scope: keyword.declaration.generator.js
       pop: true
     - include: else-pop
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -956,7 +956,7 @@ contexts:
 
   arrow-function-expect-arrow-or-fail-async:
     - match: '=>'
-      scope: storage.type.function.arrow.js
+      scope: keyword.declaration.function.arrow.js
       pop: true
     - match: (?=\S)
       fail: async-arrow-function
@@ -1518,7 +1518,7 @@ contexts:
 
   function-declaration-expect-function-keyword:
     - match: function{{identifier_break}}
-      scope: storage.type.function.js
+      scope: keyword.declaration.function.js
       pop: true
     - include: else-pop
 
@@ -1546,7 +1546,7 @@ contexts:
 
   arrow-function-expect-arrow:
     - match: '=>'
-      scope: storage.type.function.arrow.js
+      scope: keyword.declaration.function.arrow.js
       pop: true
     - include: else-pop
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -783,7 +783,7 @@ contexts:
           scope: punctuation.section.group.end.js
           set:
             - match: =>
-              scope: storage.type.function.js
+              scope: keyword.declaration.function.js
               set:
                 - ts-type-expression-end
                 - ts-type-expression-end-no-line-terminator

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1159,17 +1159,17 @@ class MyClass extends TheirClass {
 //         ^^^^^^^^^^^^ meta.function
 
     async foo() {}
-//  ^^^^^ storage.type
+//  ^^^^^ keyword.declaration.async
 
     *foo() {}
 //  ^ keyword.generator.asterisk
 
     async *foo() {}
-//  ^^^^^ storage.type
+//  ^^^^^ keyword.declaration.async
 //        ^ keyword.generator.asterisk
 
     static async foo() {}
-//         ^^^^^ storage.type
+//         ^^^^^ keyword.declaration.async
 }
 // <- meta.block punctuation.section.block.end
 
@@ -1273,14 +1273,14 @@ class{}/**/
 
     async x => y;
 //  ^^^^^^^^^^^^ meta.function
-//  ^^^^^ storage.type
+//  ^^^^^ keyword.declaration.async
 //        ^ meta.function.parameters variable.parameter.function
 //          ^^ keyword.declaration.function.arrow
 //             ^ variable.other.readwrite
 
     async (x) => y;
 //  ^^^^^^^^^^^^^^ meta.function
-//  ^^^^^ storage.type
+//  ^^^^^ keyword.declaration.async
 //        ^^^ meta.function.parameters
 //         ^ variable.parameter.function
 //            ^^ keyword.declaration.function.arrow

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -110,7 +110,7 @@ export default function name1(b) { }
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^ keyword.control.import-export
 //     ^ keyword.control.import-export
-//             ^ storage.type
+//             ^^^^^^^^ keyword.declaration.function
 //                      ^ entity.name.function
 
 export default class Foo {};
@@ -248,7 +248,7 @@ someFunction({
 
     function foo() {
 //  ^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
-//  ^^^^^^^^ storage.type.function
+//  ^^^^^^^^ keyword.declaration.function
 //           ^^^ entity.name.function
     }
 //  ^ meta.function meta.block
@@ -257,13 +257,13 @@ someFunction({
 //  ^^^ storage.type
 //      ^^^ entity.name.function variable.other.readwrite
 //            ^^^^^^^^^^^^ meta.function - meta.function meta.function
-//            ^^^^^^^^ storage.type.function
+//            ^^^^^^^^ keyword.declaration.function
     }
 
     baz = function*()
 //  ^^^ entity.name.function variable.other.readwrite
 //        ^^^^^^^^^^^ meta.function - meta.function meta.function
-//        ^^^^^^^^ storage.type.function
+//        ^^^^^^^^ keyword.declaration.function
 //                ^ keyword.generator.asterisk
     {
 
@@ -275,7 +275,7 @@ someFunction({
 // Better highlighting when typing
 function
 function() {}
-// <- storage.type.function - entity.name.function
+// <- keyword.declaration.function - entity.name.function
 
 function foo(){}/**/
 //              ^ - meta.function
@@ -492,7 +492,7 @@ var obj = {
 //          ^^^^^ constant.language.boolean.false
 
     objKey: new function() {
-//              ^^^^^^^^ storage.type.function
+//              ^^^^^^^^ keyword.declaration.function
         this.foo = baz;
 //      ^^^^ variable.language.this
 //          ^ punctuation.accessor
@@ -500,7 +500,7 @@ var obj = {
     }(),
 
     objKey: new/**/function() {}(),
-//                 ^^^^^^^^ storage.type.function
+//                 ^^^^^^^^ keyword.declaration.function
 
     objKey: new class Foo {
 //              ^^^^^ storage.type.class
@@ -1225,7 +1225,7 @@ class{}/**/
 //  ^^^^^^^^ meta.function - meta.function meta.function
 //  ^ punctuation.section.group.begin
 //   ^ punctuation.section.group.end
-//     ^^ storage.type.function.arrow
+//     ^^ keyword.declaration.function.arrow
 //        ^^ meta.block
 //        ^ punctuation.section.block
 //         ^ punctuation.section.block
@@ -1262,32 +1262,32 @@ class{}/**/
 //        ^^^ meta.binding.name
     => 42;
 //  ^^^^^ meta.function
-//  ^^ storage.type.function.arrow
+//  ^^ keyword.declaration.function.arrow
 
     foo
 //  ^^^ meta.function variable.parameter.function
     => 42;
 //  ^^^^^ meta.function
-//  ^^ storage.type.function.arrow
+//  ^^ keyword.declaration.function.arrow
 
     async x => y;
 //  ^^^^^^^^^^^^ meta.function
 //  ^^^^^ storage.type
 //        ^ variable.parameter.function
-//          ^^ storage.type.function.arrow
+//          ^^ keyword.declaration.function.arrow
 //             ^ variable.other.readwrite
 
     async (x) => y;
 //  ^^^^^^^^^^^^^^ meta.function
 //  ^^^^^ storage.type
 //         ^ variable.parameter.function
-//            ^^ storage.type.function.arrow
+//            ^^ keyword.declaration.function.arrow
 //               ^ variable.other.readwrite
 
     async => {};
 //  ^^^^^^^^^^^ meta.function
 //  ^^^^^ variable.parameter.function
-//        ^^ storage.type.function.arrow
+//        ^^ keyword.declaration.function.arrow
 
     async;
 //  ^^^^^ variable.other.readwrite
@@ -1314,13 +1314,13 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 ([a,
   b]) => { return x; }
 //    ^^^^^^^^^^^^^^^^ meta.function
-//    ^^ storage.type.function.arrow
+//    ^^ keyword.declaration.function.arrow
 //         ^^^^^^ meta.block keyword.control.flow
 
 (
     ()
     => { return; }
-//  ^^ storage.type.function.arrow
+//  ^^ keyword.declaration.function.arrow
 //     ^^^^^^^^^^^ meta.block - meta.mapping
 //       ^^^^^^ keyword.control.flow
 );
@@ -1333,7 +1333,7 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
     b,
 //   ^ punctuation.separator.parameter - keyword.operator.comma
 }) => null;
-// ^^ storage.type.function.arrow
+// ^^ keyword.declaration.function.arrow
 
 MyClass.foo = function() {}
 // ^ support.class
@@ -1359,12 +1359,12 @@ var simpleArrow = foo => bar;
 //   ^ entity.name.function
 //                ^^^^^^^^^^ meta.function
 //                ^^^ variable.parameter.function
-//                    ^^ storage.type.function.arrow
+//                    ^^ keyword.declaration.function.arrow
 
 var Proto = () => {
 //   ^ entity.name.function
 //          ^^^^^^^ meta.function
-//             ^ storage.type.function.arrow
+//             ^ keyword.declaration.function.arrow
     this._var = 1;
 }
 
@@ -1376,7 +1376,7 @@ Proto.prototype.getVar = () => this._var;
 // ^ support.class
 //     ^ support.constant.prototype
 //                ^ entity.name.function
-//                           ^ storage.type.function.arrow
+//                           ^ keyword.declaration.function.arrow
 
 Class3.prototype = function() {
 // ^ support.class
@@ -1430,7 +1430,7 @@ var foo = ~{a:function(){}.a()}
 //            ^^^^^^^^^^^^ meta.function
 //          ^ entity.name.function
 //           ^ punctuation.separator.key-value
-//            ^^^^^^^^ storage.type.function
+//            ^^^^^^^^ keyword.declaration.function
 //                    ^ punctuation.section.group.begin
 //                     ^ punctuation.section.group.end
 //                      ^ meta.block punctuation.section.block.begin
@@ -1466,7 +1466,7 @@ var instance = new Constructor(param1, param2)
 //                                           ^ punctuation.section.group.end
 
 var obj = new function() {}();
-//            ^^^^^^^^ storage.type
+//            ^^^^^^^^ keyword.declaration.function
 
 var obj2 = new class Foo{}();
 //             ^^^^^ storage.type.class
@@ -1741,7 +1741,7 @@ var test =
 
 var arrowFuncBraceNextLine = () => /* comments! */
 //  ^ entity.name.function
-//                              ^^ storage.type.function
+//                              ^^ keyword.declaration.function
 //                                 ^^^^^^^^^^^^^^^ comment
 {
     foo.bar();

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -264,7 +264,7 @@ someFunction({
 //  ^^^ entity.name.function variable.other.readwrite
 //        ^^^^^^^^^^^ meta.function - meta.function meta.function
 //        ^^^^^^^^ keyword.declaration.function
-//                ^ keyword.generator.asterisk
+//                ^ keyword.declaration.generator
     {
 
     }

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -350,7 +350,7 @@ function f(this : any) {}
 //  ^^^^^^^^^^^^^^ meta.function
 //    ^ punctuation.separator.type
 //      ^^^ meta.type support.type.any
-//           ^^ storage.type.function.arrow
+//           ^^ keyword.declaration.function.arrow
 
     x ? (y) : z;
 //  ^ variable.other.readwrite
@@ -366,7 +366,7 @@ function f(this : any) {}
 //       ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.type
 //            ^ meta.type support.class
-//              ^^ storage.type.function.arrow
+//              ^^ keyword.declaration.function.arrow
 //                 ^meta.block variable.other.readwrite
 //                   ^ keyword.operator.ternary
 //                     ^ variable.other.readwrite
@@ -376,7 +376,7 @@ function f(this : any) {}
 //        ^ keyword.operator.ternary
 //          ^^^^^^ meta.function
 //          ^ variable.parameter.function
-//            ^^ storage.type.function.arrow
+//            ^^ keyword.declaration.function.arrow
 
     async (x): T => y;
 //  ^^^^^^^^^^^^^^^^^ meta.function
@@ -384,7 +384,7 @@ function f(this : any) {}
 //         ^ meta.binding.name variable.parameter.function
 //           ^ punctuation.separator.type
 //             ^ meta.type support.class
-//               ^^ storage.type.function.arrow
+//               ^^ keyword.declaration.function.arrow
 //                  ^ meta.block variable.other.readwrite
 
     x ? async (y) : T => r : z;
@@ -730,7 +730,7 @@ let x: ( foo ? : any ) => bar;
 //             ^ punctuation.separator.type
 //               ^^^ support.type.any
 //                   ^ punctuation.section.group.end
-//                     ^^ storage.type.function
+//                     ^^ keyword.declaration.function
 //                        ^^^ support.class
 
 let x: () => T


### PR DESCRIPTION
@deathaxe 

Currently, `async` is still `storage.type` and the asterisk in a generator function is `keyword.generator.asterisk`. Either or both of these could be re-scoped if anyone has a suggestion.