### PR TITLE
[JavaScript] Simplify function assignmment lookahead.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -95,6 +95,12 @@ variables:
 
   function_call_lookahead: (?={{identifier}}\s*(?:{{dot_accessor}})?\()
 
+  function_assignment_lookahead: |-
+    (?x:(?=
+      \s* = \s*
+      {{either_func_lookahead}}
+    ))
+
 contexts:
   main:
     - include: comments-top-level
@@ -462,7 +468,11 @@ contexts:
     - include: else-pop
 
   variable-binding-top:
-    - include: function-assignment
+    - match: (?={{identifier}}{{function_assignment_lookahead}})
+      set:
+        - initializer
+        - function-name-meta
+        - variable-binding-pattern
     - match: (?={{binding_pattern_lookahead}})
       set:
         - initializer
@@ -910,7 +920,11 @@ contexts:
 
     - include: class
     - include: constants
-    - include: function-assignment
+
+    - match: (?={{identifier}}{{function_assignment_lookahead}})
+      set:
+        - function-name-meta
+        - literal-variable
 
     - include: regular-function
     - include: object-literal
@@ -1423,53 +1437,6 @@ contexts:
       scope: constant.language.null.js
       pop: true
 
-  function-assignment:
-    - match: |-
-        (?x)(?=
-          (?:{{identifier}} \s* \. \s*)*
-          {{identifier}}
-          \s* = \s*
-          {{either_func_lookahead}}
-        )
-      set: function-declaration-identifiers
-
-  function-declaration-identifiers:
-    - match: '(?={{identifier}}\s*{{dot_accessor}})'
-      push:
-        - expect-dot-accessor
-        - function-declaration-identifiers-expect-class
-    - match: 'prototype{{identifier_break}}'
-      scope: support.constant.prototype.js
-      pop: true
-    - match: (?=#?{{identifier}})
-      set:
-        - function-name-meta
-        - literal-variable-base
-
-  expect-dot-accessor:
-    - match: '{{dot_accessor}}'
-      scope: punctuation.accessor.js
-      pop: true
-    - include: else-pop
-
-  function-declaration-identifiers-expect-class:
-    - match: 'prototype{{identifier_break}}'
-      scope: support.constant.prototype.js
-      pop: true
-    - include: language-identifiers
-    - match: '{{dollar_only_identifier}}'
-      scope: support.class.dollar.only.js punctuation.dollar.js
-      pop: true
-    - match: '{{dollar_identifier}}'
-      scope: support.class.dollar.js
-      captures:
-        1: punctuation.dollar.js
-      pop: true
-    - match: '{{identifier}}'
-      scope: support.class.js
-      pop: true
-    - include: else-pop
-
   function-name-meta:
     - meta_include_prototype: false
     - meta_scope: entity.name.function.js
@@ -1610,8 +1577,6 @@ contexts:
           {{either_func_lookahead}}
         )
       push:
-        - expression-no-comma
-        - object-literal-expect-colon
         - object-literal-meta-key
         - method-name
 
@@ -1685,11 +1650,6 @@ contexts:
 
   object-literal-meta-key:
     - meta_scope: meta.mapping.key.js
-    - include: else-pop
-
-  object-literal-expect-colon:
-    - match: ':'
-      scope: punctuation.separator.key-value.js
     - include: else-pop
 
   method-name:
@@ -2402,17 +2362,12 @@ contexts:
     - include: object-property
 
   object-property:
-    - match: |-
-        (?x)(?=
-          \#?{{identifier}}
-          \s* = \s*
-          {{either_func_lookahead}}
-        )
+    - include: support-property
+
+    - match: (?=\#?{{identifier}}{{function_assignment_lookahead}})
       set:
         - function-name-meta
         - object-property-base
-
-    - include: support-property
 
     - match: '(?=#?{{identifier}}\s*(?:{{dot_accessor}})?\()'
       set: call-method-name

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1349,12 +1349,10 @@ MyClass.foo = () => {}
 //            ^^^^^^^^ meta.function
 
 xhr.onload = function() {}
-// <- support.class.js
 //  ^ entity.name.function
 //           ^^^^^^^^^^^^^ meta.function
 
 xhr.onload = () => {}
-// <- support.class.js
 //  ^ entity.name.function
 //           ^^^^^^^^ meta.function
 
@@ -1785,11 +1783,11 @@ $varname.method()
 // ^ variable.other.dollar
 
 $.fn.new_plugin = function() {}
-// <- support.class.dollar.only punctuation.dollar
+// <- variable.other.dollar.only punctuation.dollar
 
 $var.fn.name = () => {}
-// <- support.class.dollar punctuation.dollar - support.class.dollar.only
-// ^ support.class.dollar - punctuation.dollar
+// <- variable.other.dollar punctuation.dollar - variable.other.dollar.only
+// ^ variable.other.dollar - punctuation.dollar
 
 someFunction(() => [() => 'X']);
 //                           ^ punctuation.section.brackets.end


### PR DESCRIPTION
Example:

```js
foo.bar = () => {};
```

Previously, the JavaScript syntax would try to match the entire line with a complex lookahead, mark `foo` as `support.class` (instead of `variable.other`), and mark `bar` as `entity.name.function` (in addition to its usual scope). Marking `bar` makes sense, but marking `foo` probably doesn't, and lookahead was brittle.

This PR only tries to mark `bar`. This requires a simpler lookahead that's probably more reliable, and it allows for eliminating the special case code that would have marked `Foo`.

Function assignment detection should still probably be rewritten using branching (#2267), but this should make that simpler to implement.