### PR TITLE
[C/C++/Objective-C/Objective-C++] Keyword declaration

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -133,7 +133,7 @@ contexts:
     - match: \b(char16_t|char32_t|wchar_t|nullptr_t)\b
       scope: storage.type.c++
     - match: \bclass\b
-      scope: storage.type.c++
+      scope: keyword.declaration.class.c++
 
   unique-strings:
     - match: '((?:L|u8|u|U)?R)("([^\(\)\\ ]{0,16})\()'
@@ -523,7 +523,7 @@ contexts:
   types-parens:
     - match: '\b(decltype)\b\s*(\()'
       captures:
-        1: storage.type.c++
+        1: keyword.declaration.type.c++
         2: meta.group.c++ punctuation.section.group.begin.c++
       push:
         - meta_content_scope: meta.group.c++
@@ -607,7 +607,7 @@ contexts:
 
   template:
     - match: \btemplate\b
-      scope: storage.type.template.c++
+      scope: keyword.declaration.template.c++
       push:
         - meta_scope: meta.template.c++
         # Explicitly include comments here at the top, in order to NOT match the
@@ -623,14 +623,14 @@ contexts:
             - match: \.{3}
               scope: keyword.operator.variadic.c++
             - match: \b(typename|{{before_tag}})\b
-              scope: storage.type.c++
+              scope: keyword.declaration.c++
             - include: template # include template here for nested templates
             - include: template-common
         - match: (?=\S)
           set:
             - meta_content_scope: meta.template.c++
             - match: \b({{before_tag}})\b
-              scope: storage.type.c++
+              scope: keyword.declaration.c++
             - include: template-common
 
   generic-type:
@@ -638,7 +638,7 @@ contexts:
       push:
         - meta_scope: meta.function-call.c++
         - match: \btemplate\b
-          scope: storage.type.template.c++
+          scope: keyword.declaration.template.c++
         - match: (?:(::)\s*)?({{identifier}})\s*(<)
           captures:
             1: punctuation.accessor.double-colon.c++
@@ -767,7 +767,7 @@ contexts:
     # kind of entity we're accessing.
     - include: comments
     - match: \btemplate\b
-      scope: meta.method-call.c++ storage.type.template.c++
+      scope: meta.method-call.c++ keyword.declaration.template.c++
       # Guaranteed to be a template member function call after we match this
       set:
         - meta_content_scope: meta.method-call.c++
@@ -860,7 +860,7 @@ contexts:
 
   typedef:
     - match: \btypedef\b
-      scope: storage.type.c++
+      scope: keyword.declaration.type.c++
       push:
         - match: ({{identifier}})?\s*(?=;)
           captures:
@@ -868,7 +868,7 @@ contexts:
           pop: true
         - match: \b(struct)\s+({{identifier}})\b
           captures:
-            1: storage.type.c++
+            1: keyword.declaration.struct.c++
         - include: expressions-minus-generic-type
 
   parens:
@@ -984,7 +984,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.c++
+        1: keyword.declaration.c++
       set:
         - include: identifiers
         - match: ''
@@ -1164,19 +1164,19 @@ contexts:
 
   data-structures:
     - match: '\bclass\b'
-      scope: storage.type.c++
+      scope: keyword.declaration.class.c++
       set: data-structures-class-definition
     # Detect variable type definitions using struct/enum/union followed by a tag
     - match: '\b({{before_tag}})(?=\s+{{path_lookahead}}\s+{{path_lookahead}}\s*[=;\[])'
-      scope: storage.type.c++
+      scope: keyword.declaration.c++
     - match: '\bstruct\b'
-      scope: storage.type.c++
+      scope: keyword.declaration.struct.type.c++
       set: data-structures-struct-definition
     - match: '\benum(\s+(class|struct))?\b'
-      scope: storage.type.c++
+      scope: keyword.declaration.union.type.c++
       set: data-structures-enum-definition
     - match: '\bunion\b'
-      scope: storage.type.c++
+      scope: keyword.declaration.union.type.c++
       set: data-structures-union-definition
     - match: '(?=\S)'
       pop: true
@@ -1400,7 +1400,7 @@ contexts:
       push:
         - include: comments
         - match: '\b({{before_tag}})\b'
-          scope: storage.type.c++
+          scope: keyword.declaration.c++
           set: data-structures-modifier-friend
         - match: '(?=\S)(?=[^;]+;)'
           set: data-structures-modifier-friend
@@ -1479,7 +1479,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.c++
+        1: keyword.declaration.c++
       set:
         - include: identifiers
         - match: ''

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -162,7 +162,9 @@ contexts:
       scope: support.function.C99.c
 
   types:
-    - match: \b({{basic_types}}|{{before_tag}})\b
+    - match: \b({{before_tag}})\b
+      scope: keyword.declaration.c
+    - match: \b({{basic_types}})\b
       scope: storage.type.c
     - match: \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t|ptrdiff_t)\b
       scope: support.type.sys-types.c
@@ -451,7 +453,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.c
+        1: keyword.declaration.c
       set: global-maybe-function
     # The previous match handles return types of struct/enum/etc from a func,
     # there this one exits the context to allow matching an actual struct/union
@@ -553,15 +555,15 @@ contexts:
   data-structures:
     # Detect variable type definitions using struct/enum/union followed by a tag
     - match: '\b({{before_tag}})(?=\s+{{identifier}}\s+{{identifier}}\s*[=;\[])'
-      scope: storage.type.c
+      scope: keyword.declaration.c
     - match: '\bstruct\b'
-      scope: storage.type.c
+      scope: keyword.declaration.struct.c
       set: data-structures-struct-definition
     - match: '\benum\b'
-      scope: storage.type.c
+      scope: keyword.declaration.enum.c
       set: data-structures-enum-definition
     - match: '\bunion\b'
-      scope: storage.type.c
+      scope: keyword.declaration.union.c
       set: data-structures-union-definition
     - match: '(?=\S)'
       pop: true
@@ -775,7 +777,7 @@ contexts:
 
   typedef:
     - match: \btypedef\b
-      scope: storage.type.c
+      scope: keyword.declaration.type.c
       push:
         - match: ({{identifier}})?\s*(?=;)
           captures:
@@ -783,7 +785,7 @@ contexts:
           pop: true
         - match: \b(struct)\s+({{identifier}})
           captures:
-            1: storage.type.c
+            1: keyword.declaration.struct.c
         - include: expressions
 
   function-call:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -32,9 +32,9 @@ struct __declspec(dllimport) baz X {};
 struct foo {
 /*     ^ entity.name.struct */
     union {
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
         struct {
-/*      ^ storage.type */
+/*      ^ keyword.declaration */
             int a;
 /*          ^ storage.type */
             int b;
@@ -51,7 +51,7 @@ struct foo {
 /*      ^ entity.name.constant.preprocessor */
 /*                                        ^ comment.block */
 /*                                                              ^ keyword.operator.word */
-/*                                                                     ^ storage.type */
+/*                                                                     ^ keyword.declaration */
 /*                                                                                              ^ comment.line */
 
 #pragma foo(bar, \
@@ -284,11 +284,11 @@ if (4) {
 /////////////////////////////////////////////
 
 typedef int myint;
-/* <- storage.type */
+/* <- keyword.declaration */
 /*          ^ entity.name.type */
 
 typedef struct mystruct {
-/* <- storage.type */
+/* <- keyword.declaration */
 /*             ^ - entity */
 } mystruct;
 /* ^ entity.name.type */
@@ -298,7 +298,7 @@ typedef struct mystruct {
 /////////////////////////////////////////////
 
 struct point
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ entity.name.struct */
 {
     int x;
@@ -306,7 +306,7 @@ struct point
 }
 
 struct point2 {
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ entity.name.struct */
     int x;
     int y;
@@ -323,12 +323,12 @@ struct point get_point() {}
 /*                       ^^ meta.block */
 /*                       ^ punctuation.section.block.begin
 /*                        ^ punctuation.section.block.end
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*           ^ entity.name.function */
 
 struct point **alloc_points();
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*           ^^ keyword.operator */
 /*             ^ entity.name.function */
@@ -356,7 +356,7 @@ struct foo
 /*     ^ entity.name */
 
 struct UI_MenuBoxData
-/* <- storage.type */
+/* <- keyword.declaration */
 /*     ^ entity.name.struct */
 {
     struct UI_BoundingBox position;
@@ -511,14 +511,14 @@ MACRO1 void * MACRO2 myfuncname () {
     }
 
     struct Args {
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ entity.name.struct */
         void* hello;
         void* foobar;
     };
 
     struct Args args;
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ - entity */
 
 }

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -40,7 +40,7 @@ int main(){
 #define IGUARD_
  /* <- keyword.control.import.define */
 struct foo* alloc_foo();
-/* <- storage.type */
+/* <- keyword.declaration */
        /* <- - entity.name.type */
             /* <- entity.name.function */
 #endif
@@ -390,7 +390,7 @@ auto a = 2;
 /* <- storage.type */
 
 decltype(s) dt;
-/* <- storage.type */
+/* <- keyword.declaration.type */
 /*      ^ punctuation.section.group.begin */
 /*        ^ punctuation.section.group.end */
 
@@ -401,11 +401,11 @@ double d;
 /* <- storage.type */
 
 typedef int my_int;
-/* <- storage.type */
+/* <- keyword.declaration.type */
 /*          ^ entity.name.type */
 
 typedef struct Books {
-/*      ^ storage.type */
+/*      ^^^^^^ keyword.declaration.struct */
 /*             ^ - entity.name.type */
    char title[50];
    int book_id;
@@ -462,24 +462,24 @@ typedef struct Books Book;
 /*                   ^ entity.name.type.typedef */
 
 template class MyStack<int, 6>;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*                    ^ punctuation.section.generic */
 /*                     ^ storage.type */
 /*                          ^ meta.number */
 /*                           ^ punctuation.section.generic */
 
 template<class typeId, int N> class tupleTmpl;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.template */
 /*      ^ punctuation.section.generic.begin */
-/*       ^ storage.type */
+/*       ^^^^^ keyword.declaration.c++ */
 /*                      ^ storage.type */
 /*                          ^ punctuation.section.generic.end */
 
 template<typename First = U<V>, typename... Rest> class tupleVariadic;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*      ^ punctuation.section.generic.begin */
-/*       ^ storage.type */
+/*       ^^^^^^^^ keyword.declaration */
 /*                         ^ punctuation.section.generic.begin */
 /*                           ^ punctuation.section.generic.end */
 /*                            ^ punctuation.separator */
@@ -518,7 +518,7 @@ bool A::operator<(const A& a) { return false; }
 /*      ^^^^^^^^^ entity.name.function */
 /*               ^ meta.function.parameters punctuation.section.group.begin */
 template <class T> bool A<T>::operator<(const A& a) { return false; }
-/*     ^ storage.type.template */
+/*     ^ keyword.declaration.template */
 /*       ^ punctuation.section.generic.begin */
 /*               ^ punctuation.section.generic.end */
 /*                      ^^^^^^^^^^^^^^^ meta.function meta.toc-list.full-identifier */
@@ -611,9 +611,9 @@ template <class ...Types> class C { /* ... */ };
 template<template<class> class P> class X { /* ... */ };
 /*      ^ meta.template punctuation                              */
 /*               ^ meta.template meta.template punctuation       */
-/*                ^^^^^ meta.template meta.template storage.type */
+/*                ^^^^^ meta.template meta.template keyword.declaration */
 /*                     ^ meta.template meta.template punctuation */
-/*                       ^^^^^ meta.template storage.type        */
+/*                       ^^^^^ meta.template keyword.declaration */
 /*                              ^ meta.template punctuation      */
 
 X<A> xa; // OK
@@ -623,7 +623,7 @@ X<C> xc; // OK in C++14 after CWG 150
 
 // template declarations spanning multiple lines
 template
-/* <- meta.template storage.type */
+/* <- meta.template keyword.declaration.template */
 <
 /* <- meta.template punctuation.section.generic.begin */
     class T,
@@ -655,7 +655,7 @@ static bool decode(const Node& node, T& sequence) {
   for (const auto& item : node) {
     sequence.push_back(item.template as<typename T::value_type>());
     /*                     ^ punctuation.accessor                           */
-    /*                      ^ storage.type - variable.other                 */
+    /*                      ^ keyword.declaration.template - variable.other */
     /*                               ^ variable.function                    */
     /*                                 ^ punctuation                        */
     /*                                            ^^ punctuation.accessor   */
@@ -723,7 +723,7 @@ void f(T* p)
 
     T* p2 = p->template alloc<200>(); // OK: < starts template argument list
     /*        ^ punctuation.accessor           */
-    /*         ^ storage.type - variable.other */
+    /*         ^ keyword.declaration.template - variable.other */
     /*                  ^ variable.function    */
 
     // Be optimistic: scope it as a template member function call anyway.
@@ -732,7 +732,7 @@ void f(T* p)
     T::template adjust<100>(); // OK: < starts template argument list
     /* <- - variable.function                    */
     /*^ punctuation.accessor                     */
-    /* ^ storage.type - variable.other           */
+    /* ^ keyword.declaration.template - variable.other */
     /* ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call */
     /*          ^ variable.function              */
 }
@@ -1380,7 +1380,7 @@ struct foo **alloc_foo();
 /*                    ^^ meta.function.parameters meta.group */
 /*                    ^ punctuation.section.group.begin */
 /*                     ^ punctuation.section.group.end */
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*         ^^ keyword.operator */
 /*           ^ entity.name.function */
@@ -1432,7 +1432,7 @@ MACRO1 void * MACRO2 myfuncname () {
 /*                   ^ entity.name.function */
 
     struct Args {
-/*  ^ storage.type */
+/*  ^^^^^^ keyword.declaration.struct.type */
 /*         ^ entity.name.struct */
         void* hello;
         void* foobar;
@@ -1446,11 +1446,11 @@ MACRO1 void * MACRO2 myfuncname () {
     };
 
     struct Args args2;
-/*  ^ storage.type */
+/*  ^^^^^^ keyword.declaration */
 /*         ^ - entity */
 
     class LocalFoo MYMACRO
-/*  ^ storage.type */
+/*  ^^^^^ keyword.declaration.class */
 /*        ^ entity.name.class */
 /*                 ^ - entity */
     {
@@ -1459,7 +1459,7 @@ MACRO1 void * MACRO2 myfuncname () {
     }
 
     class LocalFoo test;
-/*  ^ storage.type */
+/*  ^^^^^ keyword.declaration.class */
 /*        ^ - entity */
 
 }
@@ -1594,7 +1594,7 @@ void test_in_extern_c_block()
 /*            <- meta.preprocessor */
 /*      <- keyword.control.import */
    typedef bool _Bool;   /* semi-hackish: C++ has no _Bool; bool is builtin */
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*              ^ entity.name.type.typedef */
 # endif
 /*     <- meta.preprocessor */
@@ -1749,7 +1749,7 @@ class BaseClass;
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
 class BaseClass // comment
-/* <- storage.type */
+/* <- keyword.declaration */
 /*    ^ entity.name.class */
 {
 public :
@@ -1997,7 +1997,7 @@ private:
 /*  ^ entity.name.function */
 
     enum
-/*  ^^^^ meta.enum storage.type */
+/*  ^^^^ meta.enum keyword.declaration */
     {
 /*  ^ meta.enum punctuation.section.block.begin */
         A = 1,
@@ -2025,7 +2025,7 @@ private:
 
     friend class ::FooBar;
 /*  ^ storage.modifier */
-/*         ^ storage.type
+/*         ^ keyword.declaration
 /*               ^^ punctuation.accessor */
 /*                 ^ - entity */
 
@@ -2180,7 +2180,7 @@ struct A {
 
 struct bar {
 /*^^^^^^^^^^ meta.struct */
-/*^^^^ storage.type */
+/*^^^^ keyword.declaration */
 /*     ^^^ entity.name.struct */
 /*         ^ meta.block punctuation.section.block.begin */
     bar()
@@ -2193,7 +2193,7 @@ struct bar {
 
 enum baz {
 /*^^^^^^^^ meta.enum */
-/* <- meta.enum storage.type */
+/* <- meta.enum keyword.declaration */
 /*   ^^^ entity.name.enum */
 /*       ^ meta.block punctuation.section.block.begin */
     FOO = 1,
@@ -2227,7 +2227,7 @@ struct foo
 /*     ^ entity.name */
 
 struct UI_MenuBoxData
-/* <- storage.type */
+/* <- keyword.declaration */
 /*     ^ entity.name.struct */
 {
     struct UI_BoundingBox position;
@@ -2245,7 +2245,7 @@ struct UI_MenuBoxData
 
 enum class qux : std::uint8_t
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum */
-/*^^^^^^^^ storage.type */
+/*^^^^^^^^ keyword.declaration */
 /*         ^^^ entity.name.enum */
 /*             ^ punctuation.separator */
 /*               ^^^^^^^^^^^^ entity.other.inherited-class */
@@ -2268,7 +2268,7 @@ enum LineEnding : uint32_t;
 /*                        ^ - meta.enum */
 
 union foobaz {
-/* <- meta.union storage.type */
+/* <- meta.union keyword.declaration */
 /*    ^^^^^^ entity.name.union */
 /*           ^ meta.block punctuation.section.block.begin */
 }
@@ -2280,7 +2280,7 @@ class SP {}
 /*    ^^ entity.name.class */
 
 class MyClass MACRO MACRO2
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*    ^ entity.name.class */
 /*            ^ - entity */
 /*                  ^ - entity */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -497,7 +497,7 @@ contexts:
   types-parens:
     - match: '\b(decltype)\b\s*(\()'
       captures:
-        1: storage.type.objc++
+        1: keyword.declaration.type.objc++
         2: meta.group.objc++ punctuation.section.group.begin.objc++
       push:
         - meta_content_scope: meta.group.objc++
@@ -581,7 +581,7 @@ contexts:
 
   template:
     - match: \btemplate\b
-      scope: storage.type.template.objc++
+      scope: keyword.declaration.template.objc++
       push:
         - meta_scope: meta.template.objc++
         # Explicitly include comments here at the top, in order to NOT match the
@@ -597,14 +597,14 @@ contexts:
             - match: \.{3}
               scope: keyword.operator.variadic.objc++
             - match: \b(typename|{{before_tag}})\b
-              scope: storage.type.objc++
+              scope: keyword.declaration.objc++
             - include: template # include template here for nested templates
             - include: template-common
         - match: (?=\S)
           set:
             - meta_content_scope: meta.template.objc++
             - match: \b({{before_tag}})\b
-              scope: storage.type.objc++
+              scope: keyword.declaration.objc++
             - include: template-common
 
   generic-type:
@@ -612,7 +612,7 @@ contexts:
       push:
         - meta_scope: meta.function-call.objc++
         - match: \btemplate\b
-          scope: storage.type.template.objc++
+          scope: keyword.declaration.template.objc++
         - match: (?:(::)\s*)?({{identifier}})\s*(<)
           captures:
             1: punctuation.accessor.double-colon.objc++
@@ -742,7 +742,7 @@ contexts:
     # kind of entity we're accessing.
     - include: comments
     - match: \btemplate\b
-      scope: meta.method-call.objc++ storage.type.template.objc++
+      scope: meta.method-call.objc++ keyword.declaration.template.objc++
       # Guaranteed to be a template member function call after we match this
       set:
         - meta_content_scope: meta.method-call.objc++
@@ -828,7 +828,7 @@ contexts:
 
   typedef:
     - match: \btypedef\b
-      scope: storage.type.objc++
+      scope: keyword.declaration.type.objc++
       push:
         - match: ({{identifier}})?\s*(?=;)
           captures:
@@ -836,7 +836,7 @@ contexts:
           pop: true
         - match: \b(struct)\s+({{identifier}})\b
           captures:
-            1: storage.type.objc++
+            1: keyword.declaration.struct.objc++
         - include: expressions-minus-generic-type
 
   parens:
@@ -952,7 +952,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.objc++
+        1: keyword.declaration.objc++
       set:
         - include: scope:source.c++#identifiers
         - match: ''
@@ -1132,19 +1132,19 @@ contexts:
 
   data-structures:
     - match: '\bclass\b'
-      scope: storage.type.objc++
+      scope: keyword.declaration.class.objc++
       set: data-structures-class-definition
     # Detect variable type definitions using struct/enum/union followed by a tag
     - match: '\b({{before_tag}})(?=\s+{{path_lookahead}}\s+{{path_lookahead}}\s*[=;\[])'
-      scope: storage.type.objc++
+      scope: keyword.declaration.objc++
     - match: '\bstruct\b'
-      scope: storage.type.objc++
+      scope: keyword.declaration.struct.objc++
       set: data-structures-struct-definition
     - match: '\benum(\s+(class|struct))?\b'
-      scope: storage.type.objc++
+      scope: keyword.declaration.enum.objc++
       set: data-structures-enum-definition
     - match: '\bunion\b'
-      scope: storage.type.objc++
+      scope: keyword.declaration.union.objc++
       set: data-structures-union-definition
     - match: '(?=\S)'
       pop: true
@@ -1371,7 +1371,7 @@ contexts:
       push:
         - include: comments
         - match: '\b({{before_tag}})\b'
-          scope: storage.type.objc++
+          scope: keyword.declaration.objc++
           set: data-structures-modifier-friend
         - match: '(?=\S)(?=[^;]+;)'
           set: data-structures-modifier-friend
@@ -1450,7 +1450,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.objc++
+        1: keyword.declaration.objc++
       set:
         - include: scope:source.c++#identifiers
         - match: ''

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -549,7 +549,7 @@ contexts:
           )
         )
       captures:
-        1: storage.type.objc
+        1: keyword.declaration.objc
       set: global-maybe-function
     # The previous match handles return types of struct/enum/etc from a func,
     # there this one exits the context to allow matching an actual struct/union
@@ -651,15 +651,15 @@ contexts:
   data-structures:
     # Detect variable type definitions using struct/enum/union followed by a tag
     - match: '\b({{before_tag}})(?=\s+{{identifier}}\s+{{identifier}}\s*[=;\[])'
-      scope: storage.type.objc
+      scope: keyword.declaration.objc
     - match: '\bstruct\b'
-      scope: storage.type.objc
+      scope: keyword.declaration.struct.objc
       set: data-structures-struct-definition
     - match: '\benum\b'
-      scope: storage.type.objc
+      scope: keyword.declaration.enum.objc
       set: data-structures-enum-definition
     - match: '\bunion\b'
-      scope: storage.type.objc
+      scope: keyword.declaration.union.objc
       set: data-structures-union-definition
     - match: '(?=\S)'
       pop: true
@@ -873,7 +873,7 @@ contexts:
 
   typedef:
     - match: \btypedef\b
-      scope: storage.type.objc
+      scope: keyword.declaration.type.objc
       push:
         - match: ({{identifier}})?\s*(?=;)
           captures:
@@ -881,7 +881,7 @@ contexts:
           pop: true
         - match: \b(struct)\s+({{identifier}})
           captures:
-            1: storage.type.objc
+            1: keyword.declaration.struct.objc
         - include: expressions
 
   function-call:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -40,7 +40,7 @@ int main(){
 #define IGUARD_
  /* <- keyword.control.import.define */
 struct foo* alloc_foo();
-/* <- storage.type */
+/* <- keyword.declaration */
        /* <- - entity.name.type */
             /* <- entity.name.function */
 #endif
@@ -389,7 +389,7 @@ auto a = 2;
 /* <- storage.type */
 
 decltype(s) dt;
-/* <- storage.type */
+/* <- keyword.declaration */
 /*      ^ punctuation.section.group.begin */
 /*        ^ punctuation.section.group.end */
 
@@ -400,11 +400,11 @@ double d;
 /* <- storage.type */
 
 typedef int my_int;
-/* <- storage.type */
+/* <- keyword.declaration */
 /*          ^ entity.name.type */
 
 typedef struct Books {
-/*      ^ storage.type */
+/*      ^ keyword.declaration */
 /*             ^ - entity.name.type */
    char title[50];
    int book_id;
@@ -461,24 +461,24 @@ class MyClass : public CrtpClass<MyClass>
 };
 
 template class MyStack<int, 6>;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*                    ^ punctuation.section.generic */
 /*                     ^ storage.type */
 /*                          ^ meta.number */
 /*                           ^ punctuation.section.generic */
 
 template<class typeId, int N> class tupleTmpl;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.template */
 /*      ^ punctuation.section.generic.begin */
-/*       ^ storage.type */
+/*       ^ keyword.declaration */
 /*                      ^ storage.type */
 /*                          ^ punctuation.section.generic.end */
 
 template<typename First = U<V>, typename... Rest> class tupleVariadic;
-/* <- storage.type.template */
+/* <- keyword.declaration.template */
 /*      ^ punctuation.section.generic.begin */
-/*       ^ storage.type */
+/*       ^ keyword.declaration */
 /*                         ^ punctuation.section.generic.begin */
 /*                           ^ punctuation.section.generic.end */
 /*                            ^ punctuation.separator */
@@ -517,7 +517,7 @@ bool A::operator<(const A& a) { return false; }
 /*      ^^^^^^^^^ entity.name.function */
 /*               ^ meta.function.parameters punctuation.section.group.begin */
 template <class T> bool A<T>::operator<(const A& a) { return false; }
-/*     ^ storage.type.template */
+/*     ^ keyword.declaration.template */
 /*       ^ punctuation.section.generic.begin */
 /*               ^ punctuation.section.generic.end */
 /*                      ^^^^^^^^^^^^^^^ meta.function meta.toc-list.full-identifier */
@@ -607,9 +607,9 @@ template <class ...Types> class C { /* ... */ };
 template<template<class> class P> class X { /* ... */ };
 /*      ^ meta.template punctuation                              */
 /*               ^ meta.template meta.template punctuation       */
-/*                ^^^^^ meta.template meta.template storage.type */
+/*                ^^^^^ meta.template meta.template keyword.declaration */
 /*                     ^ meta.template meta.template punctuation */
-/*                       ^^^^^ meta.template storage.type        */
+/*                       ^^^^^ meta.template keyword.declaration        */
 /*                              ^ meta.template punctuation      */
 
 X<A> xa; // OK
@@ -619,7 +619,7 @@ X<C> xc; // OK in C++14 after CWG 150
 
 // template declarations spanning multiple lines
 template
-/* <- meta.template storage.type */
+/* <- meta.template keyword.declaration */
 <
 /* <- meta.template punctuation.section.generic.begin */
     class T,
@@ -651,7 +651,7 @@ static bool decode(const Node& node, T& sequence) {
   for (const auto& item : node) {
     sequence.push_back(item.template as<typename T::value_type>());
     /*                     ^ punctuation.accessor                           */
-    /*                      ^ storage.type - variable.other                 */
+    /*                      ^ keyword.declaration - variable.other          */
     /*                               ^ variable.function                    */
     /*                                 ^ punctuation                        */
     /*                                            ^^ punctuation.accessor   */
@@ -719,7 +719,7 @@ void f(T* p)
 
     T* p2 = p->template alloc<200>(); // OK: < starts template argument list
     /*        ^ punctuation.accessor           */
-    /*         ^ storage.type - variable.other */
+    /*         ^ keyword.declaration - variable.other */
     /*                  ^ variable.function    */
 
     // Be optimistic: scope it as a template member function call anyway.
@@ -728,7 +728,7 @@ void f(T* p)
     T::template adjust<100>(); // OK: < starts template argument list
     /* <- - variable.function                    */
     /*^ punctuation.accessor                     */
-    /* ^ storage.type - variable.other           */
+    /* ^ keyword.declaration - variable.other    */
     /* ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call */
     /*          ^ variable.function              */
 }
@@ -1344,7 +1344,7 @@ struct foo **alloc_foo();
 /*                    ^^ meta.function.parameters meta.group */
 /*                    ^ punctuation.section.group.begin */
 /*                     ^ punctuation.section.group.end */
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*         ^^ keyword.operator */
 /*           ^ entity.name.function */
@@ -1397,7 +1397,7 @@ MACRO1 void * MACRO2 myfuncname () {
 /*                   ^ entity.name.function */
 
     struct Args {
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ entity.name.struct */
         void* hello;
         void* foobar;
@@ -1411,11 +1411,11 @@ MACRO1 void * MACRO2 myfuncname () {
     };
 
     struct Args args2;
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ - entity */
 
     class LocalFoo MYMACRO
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*        ^ entity.name.class */
 /*                 ^ - entity */
     {
@@ -1424,7 +1424,7 @@ MACRO1 void * MACRO2 myfuncname () {
     }
 
     class LocalFoo test;
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*        ^ - entity */
 
 }
@@ -1558,7 +1558,7 @@ void test_in_extern_c_block()
 /*            <- meta.preprocessor */
 /*      <- keyword.control.import */
    typedef bool _Bool;   /* semi-hackish: C++ has no _Bool; bool is builtin */
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*              ^ entity.name.type.typedef */
 # endif
 /*     <- meta.preprocessor */
@@ -1713,7 +1713,7 @@ class BaseClass;
 /*    ^^^^^^^^^ entity.name.class.forward-decl */
 
 class BaseClass // comment
-/* <- storage.type */
+/* <- keyword.declaration */
 /*    ^ entity.name.class */
 {
 public :
@@ -1961,7 +1961,7 @@ private:
 /*  ^ entity.name.function */
 
     enum
-/*  ^^^^ meta.enum storage.type */
+/*  ^^^^ meta.enum keyword.declaration */
     {
 /*  ^ meta.enum punctuation.section.block.begin */
         A = 1,
@@ -1989,7 +1989,7 @@ private:
 
     friend class ::FooBar;
 /*  ^ storage.modifier */
-/*         ^ storage.type
+/*         ^ keyword.declaration
 /*               ^^ punctuation.accessor */
 /*                 ^ - entity */
 
@@ -2144,7 +2144,7 @@ struct A {
 
 struct bar {
 /*^^^^^^^^^^ meta.struct */
-/*^^^^ storage.type */
+/*^^^^ keyword.declaration */
 /*     ^^^ entity.name.struct */
 /*         ^ meta.block punctuation.section.block.begin */
     bar()
@@ -2157,7 +2157,7 @@ struct bar {
 
 enum baz {
 /*^^^^^^^^ meta.enum */
-/* <- meta.enum storage.type */
+/* <- meta.enum keyword.declaration */
 /*   ^^^ entity.name.enum */
 /*       ^ meta.block punctuation.section.block.begin */
     FOO = 1,
@@ -2191,7 +2191,7 @@ struct foo
 /*     ^ entity.name */
 
 struct UI_MenuBoxData
-/* <- storage.type */
+/* <- keyword.declaration */
 /*     ^ entity.name.struct */
 {
     struct UI_BoundingBox position;
@@ -2209,7 +2209,7 @@ struct UI_MenuBoxData
 
 enum class qux : std::uint8_t
 /*^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum */
-/*^^^^^^^^ storage.type */
+/*^^^^^^^^ keyword.declaration */
 /*         ^^^ entity.name.enum */
 /*             ^ punctuation.separator */
 /*               ^^^^^^^^^^^^ entity.other.inherited-class */
@@ -2232,7 +2232,7 @@ enum LineEnding : uint32_t;
 /*                        ^ - meta.enum */
 
 union foobaz {
-/* <- meta.union storage.type */
+/* <- meta.union keyword.declaration */
 /*    ^^^^^^ entity.name.union */
 /*           ^ meta.block punctuation.section.block.begin */
 }
@@ -2244,7 +2244,7 @@ class SP {}
 /*    ^^ entity.name.class */
 
 class MyClass MACRO MACRO2
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*    ^ entity.name.class */
 /*            ^ - entity */
 /*                  ^ - entity */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -32,9 +32,9 @@ struct __declspec(dllimport) baz X {};
 struct foo {
 /*     ^ entity.name.struct */
     union {
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
         struct {
-/*      ^ storage.type */
+/*      ^ keyword.declaration */
             int a;
 /*          ^ storage.type */
             int b;
@@ -51,7 +51,7 @@ struct foo {
 /*      ^ entity.name.constant.preprocessor */
 /*                                        ^ comment.block */
 /*                                                              ^ keyword.operator.word */
-/*                                                                     ^ storage.type */
+/*                                                                     ^ keyword.declaration */
 /*                                                                                              ^ comment.line */
 
 #pragma foo(bar, \
@@ -281,11 +281,11 @@ if (4) {
 /////////////////////////////////////////////
 
 typedef int myint;
-/* <- storage.type */
+/* <- keyword.declaration */
 /*          ^ entity.name.type */
 
 typedef struct mystruct {
-/* <- storage.type */
+/* <- keyword.declaration */
 /*             ^ - entity */
 } mystruct;
 /* ^ entity.name.type */
@@ -295,7 +295,7 @@ typedef struct mystruct {
 /////////////////////////////////////////////
 
 struct point
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ entity.name.struct */
 {
     int x;
@@ -303,7 +303,7 @@ struct point
 }
 
 struct point2 {
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ entity.name.struct */
     int x;
     int y;
@@ -320,12 +320,12 @@ struct point get_point() {}
 /*                       ^^ meta.block */
 /*                       ^ punctuation.section.block.begin
 /*                        ^ punctuation.section.block.end
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*           ^ entity.name.function */
 
 struct point **alloc_points();
-/* ^ storage.type */
+/* ^ keyword.declaration */
 /*     ^ - entity.name.struct */
 /*           ^^ keyword.operator */
 /*             ^ entity.name.function */
@@ -354,7 +354,7 @@ struct foo
 /*     ^ entity.name */
 
 struct UI_MenuBoxData
-/* <- storage.type */
+/* <- keyword.declaration */
 /*     ^ entity.name.struct */
 {
     struct UI_BoundingBox position;
@@ -509,14 +509,14 @@ MACRO1 void * MACRO2 myfuncname () {
     }
 
     struct Args {
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ entity.name.struct */
         void* hello;
         void* foobar;
     };
 
     struct Args args;
-/*  ^ storage.type */
+/*  ^ keyword.declaration */
 /*         ^ - entity */
 
 }


### PR DESCRIPTION
This commit renames some `storage.type` scopes into `keyword.declaration` to highlight keywords like `class`, `union`,
`template`, `typename`, `struct`, ... as declaration keywords rather than primitive/ordinary data types.

Note:
It is an as good as possible with least effort approach, which means some `class`, ... keywords to be scoped `keyword.declaration.[c|c++|...]` only due to existing patterns. Don't want to rework the syntax at this point by splitting those.