### PR TITLE
[R] Comment Documentation

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -346,7 +346,7 @@ contexts:
         - include: main
 
   roxygen-content:
-    - meta_scope: comment.line.roxygen.r
+    - meta_scope: comment.line.documentation.r
     - match: $\n?
       pop: true
 

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -477,19 +477,19 @@ print.foo()
 # ^^^^ support.function.r
 
 #' @param xyz abcde
-#^^^^^^^^^^^^^^^^^^ comment.line.roxygen.r
+#^^^^^^^^^^^^^^^^^^ comment.line.documentation.r
 #  ^^^^^^ keyword.other.r
 #         ^^^ variable.parameter.r
 
 
     #' @param xyz abcde
-#   ^^^^^^^^^^^^^^^^^^^ comment.line.roxygen.r
+#   ^^^^^^^^^^^^^^^^^^^ comment.line.documentation.r
 #      ^^^^^^ keyword.other.r
 #             ^^^ variable.parameter.r
 
 
 #' "@param xyz abcde"
-#  ^^^^^^^^^ comment.line.roxygen.r
+#  ^^^^^^^^^ comment.line.documentation.r
 #   ^^^^^^ -keyword.other.r
 
 


### PR DESCRIPTION
Not sure if a documentation comment should use `comment.line` or `comment.block`, but a more general scope like `documentation` is propably usefull in both cases.