### PR TITLE
[C#] Use comment.line scope for single-line doc comments

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -56,7 +56,7 @@ contexts:
   comments:
     - match: '^\s*(///)'
       captures:
-        1: comment.block.documentation.cs punctuation.definition.comment.documentation.cs
+        1: comment.line.documentation.cs punctuation.definition.comment.documentation.cs
       push: documentation
     - match: '//'
       scope: punctuation.definition.comment.cs
@@ -2182,7 +2182,7 @@ contexts:
 
   documentation:
     - meta_include_prototype: false
-    - meta_content_scope: comment.block.documentation.cs
+    - meta_content_scope: comment.line.documentation.cs
     - match: '(<)({{name}})'
       captures:
         1: punctuation.definition.tag.begin.cs

--- a/C#/tests/syntax_test_Comments.cs
+++ b/C#/tests/syntax_test_Comments.cs
@@ -8,7 +8,7 @@ namespace HelloWorld
 {
     /// <summary>
 //* ^^^ punctuation.definition.comment.documentation.cs
-//* ^^^^^^^^^^^^^^ comment.block.documentation
+//* ^^^^^^^^^^^^^^ comment.line.documentation
 //*     ^ punctuation.definition.tag.begin
 //*      ^^^^^^^ entity.name.tag.begin
 //*             ^ punctuation.definition.tag.end
@@ -16,7 +16,7 @@ namespace HelloWorld
 //*     ^^^^^^^^^ - text.documentation
 //*              ^ text.documentation
     /// This class is testing comments
-//* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
+//* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation
 //*    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.documentation
     /// </summary>
 //*     ^^ punctuation.definition.tag.begin


### PR DESCRIPTION
This PR changes the scope for single-line documentation comments (denoted by `///`) from `comment.block.documentation` to `comment.line.documentation`, because:

* They *are* line comments and not block comments
* The Microsoft C# documentation at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments explicitely distinguishes between *single-line-doc-comment* (starting with `///`) and *delimited-doc-comment* (starting with `/**`)
* There are several examples of such doc comments in the linked C# docs which indeed use only a single line, so they don't necessarily appear in blocks
* This is consistent with R, which also uses `comment.line` for line doc comments
* This complies with the scope naming guidelines, which recommends `comment.block.documentation` only for "*Multi-line* comments used as documentation"