### PR TITLE
[ShellScript] Add anonymous functions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -99,6 +99,7 @@ contexts:
     - include: line-continuations
     - include: operators
     - include: redirections
+    - include: def-anonymous
     - include: cmd-alias
     - include: cmd-arithmetic
     - include: cmd-compound
@@ -191,6 +192,22 @@ contexts:
 
 ###[ FUNCTION DEFINITIONS ]####################################################
 
+  def-anonymous:
+    - match: (\()\s*(\))
+      scope: meta.function.parameters.shell
+      captures:
+        1: punctuation.section.parameters.begin.shell
+        2: punctuation.section.parameters.end.shell
+      push:
+        - def-functions-redirection
+        - def-anonymous-body
+
+  def-anonymous-body:
+    - include: def-function-body-braces
+    - include: line-continuations
+    - include: comments
+    - include: else-pop
+
   def-functions:
     # [Bash] 3.3 Shell Functions
     - match: (?={{cmd_literal}}\s*\(\s*\))
@@ -230,9 +247,18 @@ contexts:
         1: punctuation.section.parameters.begin.shell
         2: punctuation.section.parameters.end.shell
       pop: 1
+    - include: line-continuations
+    - include: comments
     - include: else-pop
 
   def-functions-body:
+    - include: def-function-body-braces
+    - include: def-function-body-parens
+    - include: line-continuations
+    - include: comments
+    - include: else-pop
+
+  def-function-body-braces:
     - match: \{  # Bash expects `{{cmd_break}}` but we don't care.
       scope: punctuation.section.compound.begin.shell
       set:
@@ -241,6 +267,8 @@ contexts:
           scope: punctuation.section.compound.end.shell
           pop: 1
         - include: statements
+
+  def-function-body-parens:
     - match: \(
       scope: punctuation.section.compound.begin.shell
       set:
@@ -249,8 +277,6 @@ contexts:
           scope: punctuation.section.compound.end.shell
           pop: 1
         - include: statements
-    - include: comments
-    - include: else-pop
 
   def-functions-redirection:
     - meta_content_scope: meta.function.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -865,6 +865,46 @@ coproc foobar {
 # 3.3 Shell Functions                                              #
 ####################################################################
 
+   ()
+#^^ - meta.function
+#  ^ meta.function.parameters.shell
+#   ^ meta.function.parameters.shell
+#    ^ meta.function.shell
+
+   ()
+   {}
+# ^ meta.function.shell - meta.compound
+#  ^^ meta.function.shell meta.compound.shell
+#    ^ - meta.function
+#  ^ punctuation.section.compound.begin.shell
+#   ^ punctuation.section.compound.end.shell
+
+   () \
+   {}
+# ^ meta.function.shell - meta.compound
+#  ^^ meta.function.shell meta.compound.shell
+#    ^ - meta.function
+#  ^ punctuation.section.compound.begin.shell
+#   ^ punctuation.section.compound.end.shell
+
+   () { [[ $# == 2 ]] && tput setaf $2 || tput setaf 3; echo -e "$1"; tput setaf 15; }
+#^^ - meta.function
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+#  ^ meta.function.parameters.shell
+#   ^ meta.function.parameters.shell
+#    ^ meta.function.shell - meta.function.identifier - meta.compound
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.shell meta.compound.shell
+#  ^ punctuation.section.parameters.begin.shell
+#   ^ punctuation.section.parameters.end.shell
+#    ^ - punctuation
+#     ^ punctuation.section.compound.begin.shell
+#       ^^ support.function.double-brace.begin
+#          ^ punctuation.definition.variable
+#           ^ variable.language
+#             ^^ keyword.operator.comparison
+#                  ^^ support.function.double-brace.end
+#                     ^^ keyword.operator.logical
+
    logC () { [[ $# == 2 ]] && tput setaf $2 || tput setaf 3; echo -e "$1"; tput setaf 15; }
 #^^ - meta.function
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function


### PR DESCRIPTION
Fixes #2608

This commit handles `() { ... }` as incomplete function definition in Bash, while it is valid anonymous function definition in ZSH.