### PR TITLE
[D] Fix conditional statements

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1494,6 +1494,11 @@ contexts:
       pop: true
     - match: '(?=\S)'
       set: [value-list-after, value]
+  value-list-no-mapping-key:
+    - match: '(?=\)|}|]|;|:)'
+      pop: true
+    - match: '(?=\S)'
+      set: [value-list-after, value-no-mapping-key]
   value-list-after:
     - match: '(?=\)|}|]|;|:)'
       pop: true
@@ -2086,9 +2091,10 @@ contexts:
         - match: '\('
           scope: punctuation.section.parens.begin.d
           set: [switch-after, value]
+        - include: not-whitespace-illegal-pop
     - match: '\bcase\b'
       scope: keyword.control.flow.d
-      push: [case-after, value-list]
+      push: [case-after, value-list-no-mapping-key]
     - match: '\bdefault\b'
       scope: keyword.control.flow.d
       push:
@@ -2110,7 +2116,7 @@ contexts:
           set:
             - match: '\bcase\b'
               scope: keyword.control.flow.d
-              set: [case-after, value]
+              set: [case-after, value-no-mapping-key]
             - include: not-whitespace-illegal-pop
         - match: '(?=\S)'
           pop: true

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1109,6 +1109,13 @@ contexts:
     - include: first-value-parens-after
 
   value:
+    - match: '\b({{name}})\s*(:)'
+      captures:
+        1: variable.other.d
+        2: punctuation.separator.mapping.key-value.d
+      set: value
+    - include: value-no-mapping-key
+  value-no-mapping-key:
     - include: attribute-in
     - match: '!'
       scope: keyword.operator.logical.d
@@ -1236,11 +1243,6 @@ contexts:
     - match: \.
       scope: meta.path.d punctuation.accessor.dot.d
       set: [value-after, value-identifier]
-    - match: '\b({{name}})\s*(:)'
-      captures:
-        1: variable.other.d
-        2: punctuation.separator.mapping.key-value.d
-      set: value
     - match: '{{name_lookahead}}'
       set: [value-after, value-identifier]
     - include: not-whitespace-illegal-pop
@@ -1432,7 +1434,7 @@ contexts:
       set: value-maybe-pointer-after
     - match: '\?'
       scope: keyword.operator.ternary.d
-      set: [value-condition-after, value]
+      set: [value-condition-after, value-condition]
     - match: '(?=\b(function|delegate)\b)'
       set: [value-after, basic-type2]
     - match: '(?=\S)'
@@ -1464,6 +1466,10 @@ contexts:
       set: basic-type2
     - match: '(?=\S)'
       set: value
+  value-condition:
+    - match: (?=:)
+      pop: 1
+    - include: value-no-mapping-key
   value-condition-after:
     - match: ':'
       scope: keyword.operator.ternary.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2118,6 +2118,28 @@ extern(1)
 //                    ^^ meta.number.integer.decimal.d
 //                      ^ punctuation.terminator.d
 
+  int a = b ? c : d;
+//^^^ storage.type.d
+//    ^ variable.other.d
+//      ^ keyword.operator.assignment.d
+//        ^ meta.path.d variable.other.d
+//          ^ keyword.operator.ternary.d
+//            ^ meta.path.d variable.other.d
+//              ^ keyword.operator.ternary.d
+//                ^ meta.path.d variable.other.d
+//                 ^ punctuation.terminator.d
+
+  int a=b?c:d;
+//^^^ storage.type.d
+//    ^ variable.other.d
+//     ^ keyword.operator.assignment.d
+//      ^ meta.path.d variable.other.d
+//       ^ keyword.operator.ternary.d
+//        ^ meta.path.d variable.other.d
+//         ^ keyword.operator.ternary.d
+//          ^ meta.path.d variable.other.d
+//           ^ punctuation.terminator.d
+
   foreach (ref a; foo) {}
 //^^^^^^^ keyword.control.loop.d
 //        ^ punctuation.section.parens.begin.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2224,6 +2224,30 @@ extern(1)
   //           ^^^^ keyword.control.flow.d
   //                ^ meta.number.integer.decimal.d
   //                 ^ punctuation.separator.case-statement.d
+    case NO_KEY:
+  //^^^^ keyword.control.flow.d
+  //     ^^^^^^ meta.path.d variable.other.d
+  //           ^ punctuation.separator.case-statement.d
+      if (foo) {
+  //  ^^ keyword.control.conditional.d
+      }
+      break;
+  //  ^^^^^ keyword.control.flow.d
+  //       ^ punctuation.terminator.d
+    case no_key: .. case NO_KEY:
+  //^^^^ keyword.control.flow.d
+  //     ^^^^^^ meta.path.d variable.other.d
+  //           ^ punctuation.separator.case-statement.d
+  //             ^^ keyword.operator.d
+  //                ^^^^ keyword.control.flow.d
+  //                     ^^^^^^ meta.path.d variable.other.d
+  //                           ^ punctuation.separator.case-statement.d
+      if (foo) {
+  //  ^^ keyword.control.conditional.d
+      }
+      break;
+  //  ^^^^^ keyword.control.flow.d
+  //       ^ punctuation.terminator.d
     default:
   //^^^^^^^ keyword.control.flow.d
   //       ^ punctuation.separator.case-statement.d


### PR DESCRIPTION
Fixes #2558
Fixes #2567

Problem Description

D matches mapping keys globally in a general `value` context, which causes identifiers followed by colon such as `c :` to be matched as mapping key instead of variable followed by ternary operator or case label separator.

Thus ternary statements and switch case statements fail in such situations.

Solution

This commit creates intermediate contexts `value-condition` and `value-no-mapping-key` to avoid matching keys within ternary statements.

Case statements are fixed by `value-list-no-mapping-key`.