### PR TITLE
[JavaScript] Improve handling of identifiers.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -449,7 +449,7 @@ contexts:
           scope: punctuation.section.block.end.js
           pop: true
         - include: variable-binding-spread
-        - match: (?={{identifier_name}}|\[|'|")
+        - match: (?={{identifier_start}}|\[|'|")
           push:
             - initializer
             - variable-binding-object-alias
@@ -548,7 +548,7 @@ contexts:
           scope: punctuation.section.block.end.js
           pop: true
         - include: function-parameter-binding-spread
-        - match: (?={{identifier_name}}|\[|'|")
+        - match: (?={{identifier_start}}|\[|'|")
           push:
             - initializer
             - function-parameter-binding-object-alias

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -938,12 +938,16 @@ contexts:
     - include: class
     - include: constants
 
+    - include: regular-function
+
+    - match: (?={{reserved_word}})
+      pop: true
+
     - match: (?={{identifier}}{{function_assignment_lookahead}})
       set:
         - function-name-meta
         - literal-variable
 
-    - include: regular-function
     - include: object-literal
 
     # Newline not allowed between `async` and parameters.
@@ -1452,6 +1456,12 @@ contexts:
       pop: true
     - match: null{{identifier_break}}
       scope: constant.language.null.js
+      pop: true
+    - match: super{{identifier_break}}
+      scope: variable.language.super.js
+      pop: true
+    - match: this{{identifier_break}}
+      scope: variable.language.this.js
       pop: true
 
   function-name-meta:
@@ -1997,12 +2007,6 @@ contexts:
   language-identifiers:
     - match: arguments{{identifier_break}}
       scope: variable.language.arguments.js
-      pop: true
-    - match: super{{identifier_break}}
-      scope: variable.language.super.js
-      pop: true
-    - match: this{{identifier_break}}
-      scope: variable.language.this.js
       pop: true
     - match: globalThis{{identifier_break}}
       scope: variable.language.global.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -936,7 +936,7 @@ contexts:
     - include: import-meta-expression
 
     - include: class
-    - include: constants
+    - include: special-name
 
     - include: regular-function
 
@@ -1447,7 +1447,7 @@ contexts:
       fail: class-field
     - include: else-pop
 
-  constants:
+  special-name:
     - match: true{{identifier_break}}
       scope: constant.language.boolean.true.js
       pop: true
@@ -1968,7 +1968,7 @@ contexts:
     - include: else-pop
 
   literal-variable:
-    - include: language-identifiers
+    - include: special-identifier
     - include: support
 
     - match: '{{constant_identifier}}(?=\s*(?:{{dot_accessor}}|\[))'
@@ -2004,15 +2004,14 @@ contexts:
         2: variable.other.readwrite.js
       pop: true
 
-  language-identifiers:
+  special-identifier:
+    # These are ordinary identifiers, not reserved words
     - match: arguments{{identifier_break}}
       scope: variable.language.arguments.js
       pop: true
     - match: globalThis{{identifier_break}}
       scope: variable.language.global.js
       pop: true
-
-    # These three are ordinary variables, not literals!
     - match: undefined{{identifier_break}}
       scope: constant.language.undefined.js
       pop: true

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -22,7 +22,7 @@ variables:
   identifier_part: (?:[_$\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]|{{identifier_escape}})
   identifier_break: (?!{{identifier_part}})
 
-  identifier: (?:{{identifier_start}}{{identifier_part}}*{{identifier_break}})
+  identifier_name: (?:{{identifier_start}}{{identifier_part}}*{{identifier_break}})
   constant_identifier: (?:[[:upper:]]{{identifier_part}}*{{identifier_break}})
   dollar_only_identifier: (?:\${{identifier_break}})
   dollar_identifier: '(?:(\$){{identifier_part}}*{{identifier_break}})'
@@ -42,17 +42,17 @@ variables:
       null|true|false
     ){{identifier_break}}
 
-  non_reserved_identifier: (?:(?!{{reserved_word}}){{identifier}})
+  non_reserved_identifier: (?:(?!{{reserved_word}}){{identifier_name}})
 
   either_func_lookahead: (?:{{func_lookahead}}|{{arrow_func_lookahead}})
-  binding_pattern_lookahead: (?:{{identifier}}|\[|\{)
+  binding_pattern_lookahead: (?:{{identifier_name}}|\[|\{)
   left_expression_end_lookahead: (?!\s*[.\[\(])
 
   dot_accessor: (?:\??\.)
 
   property_name: >-
     (?x:
-      {{identifier}}
+      {{identifier_name}}
       | [0-9]+
       | '(?:[^\\']|\\.)*'
       | "(?:[^\\"]|\\.)*"
@@ -62,7 +62,7 @@ variables:
   class_element_name: |-
     (?x:
       {{property_name}}
-      | \#{{identifier}}
+      | \#{{identifier_name}}
     )
 
   # Newline not permitted between `async` and `function`.
@@ -76,7 +76,7 @@ variables:
     (?x:
       (?:async\s*)?
       (?:
-        {{identifier}}
+        {{identifier_name}}
         | \( ( [^()] | \( [^()]* \) )* \)
       )
       \s*
@@ -93,7 +93,7 @@ variables:
       )
     ))
 
-  function_call_lookahead: (?={{identifier}}\s*(?:{{dot_accessor}})?\()
+  function_call_lookahead: (?={{identifier_name}}\s*(?:{{dot_accessor}})?\()
 
   function_assignment_lookahead: |-
     (?x:(?=
@@ -222,7 +222,7 @@ contexts:
         - match: default{{identifier_break}}
           scope: keyword.control.import-export.js
           pop: true
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.other.readwrite.js
           pop: true
         - include: else-pop
@@ -269,7 +269,7 @@ contexts:
     - match: '\}'
       scope: punctuation.section.block.end.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       push: import-export-alias
     - match: '\*'
@@ -329,7 +329,7 @@ contexts:
     - match: '\}'
       scope: punctuation.section.block.end.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       push: import-export-alias
     - match: '\*'
@@ -396,12 +396,12 @@ contexts:
 
   expect-label:
     - meta_include_prototype: false
-    - match: '(?={{nothing}}{{identifier}})'
+    - match: '(?={{nothing}}{{identifier_name}})'
       set:
         - match: '{{non_reserved_identifier}}'
           scope: variable.label.js
           pop: true
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: invalid.illegal.identifier.js variable.label.js
           pop: true
         - include: else-pop
@@ -449,7 +449,7 @@ contexts:
           scope: punctuation.section.block.end.js
           pop: true
         - include: variable-binding-spread
-        - match: (?={{identifier}}|\[|'|")
+        - match: (?={{identifier_name}}|\[|'|")
           push:
             - initializer
             - variable-binding-object-alias
@@ -464,7 +464,7 @@ contexts:
     - include: else-pop
 
   variable-binding-object-key:
-    - match: '{{identifier}}(?=\s*:)'
+    - match: '{{identifier_name}}(?=\s*:)'
       pop: true
     - include: literal-string
     - include: computed-property-name
@@ -485,7 +485,7 @@ contexts:
     - include: else-pop
 
   variable-binding-top:
-    - match: (?={{identifier}}{{function_assignment_lookahead}})
+    - match: (?={{identifier_name}}{{function_assignment_lookahead}})
       set:
         - initializer
         - function-name-meta
@@ -524,7 +524,7 @@ contexts:
   function-parameter-binding-name:
     - match: '{{non_reserved_identifier}}'
       scope: meta.binding.name.js variable.parameter.function.js
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: invalid.illegal.identifier.js meta.binding.name.js variable.parameter.function.js
 
   function-parameter-binding-array-destructuring:
@@ -548,7 +548,7 @@ contexts:
           scope: punctuation.section.block.end.js
           pop: true
         - include: function-parameter-binding-spread
-        - match: (?={{identifier}}|\[|'|")
+        - match: (?={{identifier_name}}|\[|'|")
           push:
             - initializer
             - function-parameter-binding-object-alias
@@ -562,7 +562,7 @@ contexts:
     - include: else-pop
 
   function-parameter-binding-object-key:
-    - match: '{{identifier}}(?=\s*:)'
+    - match: '{{identifier_name}}(?=\s*:)'
       pop: true
     - include: literal-string
     - include: computed-property-name
@@ -853,7 +853,7 @@ contexts:
     - include: immediately-pop
 
   decorator-name:
-    - match: '{{identifier}}{{left_expression_end_lookahead}}'
+    - match: '{{identifier_name}}{{left_expression_end_lookahead}}'
       scope: variable.annotation.js
       pop: true
 
@@ -943,7 +943,7 @@ contexts:
     - match: (?={{reserved_word}})
       pop: true
 
-    - match: (?={{identifier}}{{function_assignment_lookahead}})
+    - match: (?={{identifier_name}}{{function_assignment_lookahead}})
       set:
         - function-name-meta
         - literal-variable
@@ -1063,7 +1063,7 @@ contexts:
         - include: string-content
 
   tagged-template:
-    - match: '{{identifier}}(?=\s*`)'
+    - match: '{{identifier_name}}(?=\s*`)'
       scope: variable.function.tagged-template.js
       pop: true
 
@@ -1157,7 +1157,7 @@ contexts:
           captures:
             1: punctuation.dollar.js
           pop: true
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.type.js
           pop: true
         - include: else-pop
@@ -1338,7 +1338,7 @@ contexts:
 
     - match: |-
         (?x)(?=
-          \#? {{identifier}}
+          \#? {{identifier_name}}
           \s* = \s*
           {{either_func_lookahead}}
         )
@@ -1549,7 +1549,7 @@ contexts:
       set:
         - clear_scopes: 1
         - meta_scope: meta.function.parameters.js
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.parameter.function.js
           pop: true
     - include: function-declaration-parameters
@@ -1577,7 +1577,7 @@ contexts:
         - include: function-parameter-binding-list
 
   label:
-    - match: '({{identifier}})\s*(:)'
+    - match: '({{identifier_name}})\s*(:)'
       captures:
         1: entity.name.label.js
         2: punctuation.separator.js
@@ -1610,7 +1610,7 @@ contexts:
     - match: (?=\*)
       push: method-declaration
 
-    - match: '{{identifier}}(?=\s*(?:[},]|$|//|/\*))'
+    - match: '{{identifier_name}}(?=\s*(?:[},]|$|//|/\*))'
       scope: variable.other.readwrite.js
 
     - match: (?=(?:get|set|async){{identifier_break}})
@@ -1655,7 +1655,7 @@ contexts:
     - include: literal-string
     - include: literal-number
 
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       pop: true
 
     - include: else-pop
@@ -1685,10 +1685,10 @@ contexts:
       captures:
         1: punctuation.dollar.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: entity.name.function.js
       pop: true
-    - match: '(#){{identifier}}'
+    - match: '(#){{identifier_name}}'
       scope: entity.name.function.js
       captures:
         1: punctuation.definition.js
@@ -1731,7 +1731,7 @@ contexts:
       captures:
         1: punctuation.dollar.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       pop: true
     - match: "'"
@@ -1760,7 +1760,7 @@ contexts:
           scope: invalid.illegal.newline.js
           pop: true
         - include: string-content
-    - match: (#)({{identifier}})
+    - match: (#)({{identifier_name}})
       captures:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
@@ -1837,7 +1837,7 @@ contexts:
     - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
       push:
-        - match: '(?={{identifier}}\s*(?:{{dot_accessor}})?\()'
+        - match: '(?={{identifier_name}}\s*(?:{{dot_accessor}})?\()'
           set:
             - call-method-meta
             - function-call-arguments
@@ -1917,13 +1917,13 @@ contexts:
       pop: true
 
   literal-call:
-    - match: (?={{identifier}}\s*(?:{{dot_accessor}})?\()
+    - match: (?={{identifier_name}}\s*(?:{{dot_accessor}})?\()
       set:
         - call-function-meta
         - function-call-arguments
         - literal-variable
 
-    - match: (?={{identifier}}\s*(?:{{dot_accessor}}\s*#?{{identifier}}\s*)+(?:{{dot_accessor}})?\()
+    - match: (?={{identifier_name}}\s*(?:{{dot_accessor}}\s*#?{{identifier_name}}\s*)+(?:{{dot_accessor}})?\()
       set:
         - call-method-meta
         - function-call-arguments
@@ -1950,17 +1950,17 @@ contexts:
     - match: '{{dollar_only_identifier}}'
       scope: variable.function.js variable.other.dollar.only.js punctuation.dollar.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.function.js
       pop: true
     - include: else-pop
 
   call-method-name:
     - include: support-property
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.function.js
       pop: true
-    - match: '(#){{identifier}}'
+    - match: '(#){{identifier_name}}'
       scope: variable.function.js
       captures:
         1: punctuation.definition.js
@@ -1992,13 +1992,13 @@ contexts:
     - match: '{{constant_identifier}}'
       scope: variable.other.constant.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       pop: true
     - include: literal-private-variable
 
   literal-private-variable:
-    - match: (#)({{identifier}})
+    - match: (#)({{identifier_name}})
       captures:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
@@ -2384,12 +2384,12 @@ contexts:
   object-property:
     - include: support-property
 
-    - match: (?=\#?{{identifier}}{{function_assignment_lookahead}})
+    - match: (?=\#?{{identifier_name}}{{function_assignment_lookahead}})
       set:
         - function-name-meta
         - object-property-base
 
-    - match: '(?=#?{{identifier}}\s*(?:{{dot_accessor}})?\()'
+    - match: '(?=#?{{identifier_name}}\s*(?:{{dot_accessor}})?\()'
       set: call-method-name
 
     - include: object-property-base
@@ -2404,13 +2404,13 @@ contexts:
       captures:
         1: punctuation.dollar.js
       pop: true
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: meta.property.object.js
       pop: true
     - match: '{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.illegal-identifier.js
       pop: true
-    - match: (#)({{identifier}})
+    - match: (#)({{identifier_name}})
       captures:
         1: punctuation.definition.variable.js
         2: meta.property.object.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -12,7 +12,7 @@ variables:
 
   function_call_lookahead: >-
     (?x:(?=
-      {{identifier}}
+      {{identifier_name}}
       \s*
       (?:
         <
@@ -93,7 +93,7 @@ contexts:
     - match: \!\.
       scope: punctuation.accessor.js
       push:
-        - match: '(?={{identifier}}\s*(?:\.\?)?\()'
+        - match: '(?={{identifier_name}}\s*(?:\.\?)?\()'
           set:
             - call-method-meta
             - function-call-arguments
@@ -189,7 +189,7 @@ contexts:
     - include: immediately-pop
 
   ts-interface-name:
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: entity.name.interface.js
       pop: true
     - include: else-pop
@@ -233,7 +233,7 @@ contexts:
           - match: \]
             scope: punctuation.section.brackets.end.js
             pop: true
-          - match: '{{identifier}}'
+          - match: '{{identifier_name}}'
             scope: variable.other.readwrite.js
             push:
               - match: in{{identifier_break}}
@@ -251,7 +251,7 @@ contexts:
         - function-declaration-expect-parameters
         - ts-type-parameter-list
 
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       push:
         - - match: (?=[<(])
@@ -277,7 +277,7 @@ contexts:
     - include: immediately-pop
 
   ts-enum-name:
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: entity.name.enum.js
       pop: true
     - include: else-pop
@@ -293,7 +293,7 @@ contexts:
         - include: comma-separator
         - match: (?=['"])
           push: literal-string
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.other.readwrite.js
           push: initializer
 
@@ -303,7 +303,7 @@ contexts:
     - include: immediately-pop
 
   ts-type-alias-name:
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: entity.name.type.js
       pop: true
     - include: else-pop
@@ -331,7 +331,7 @@ contexts:
     - include: immediately-pop
 
   ts-namespace-name:
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: entity.name.namespace.js
       pop: true
     - include: else-pop
@@ -369,7 +369,7 @@ contexts:
         - match: \>
           scope: punctuation.definition.generic.end.js
           pop: true
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.parameter.generic.js
           push:
             - ts-type-parameter-default
@@ -559,7 +559,7 @@ contexts:
     - match: \.
       scope: punctuation.separator.accessor.js
       push:
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: support.class.js
           set: ts-type-expression-end-no-line-terminator
 
@@ -708,7 +708,7 @@ contexts:
         - include: comma-separator
         - match: ;
           scope: punctuation.separator.semicolon.js
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.other.readwrite.js
           push:
             - ts-type-annotation
@@ -755,7 +755,7 @@ contexts:
       pop: true
 
   ts-type-basic:
-    - match: '{{identifier}}'
+    - match: '{{identifier_name}}'
       scope: support.class.js
       pop: true
 
@@ -790,7 +790,7 @@ contexts:
                 - ts-type-expression-begin
             - include: else-pop
         - include: comma-separator
-        - match: '{{identifier}}'
+        - match: '{{identifier_name}}'
           scope: variable.other.readwrite.js
           push:
             - ts-type-annotation

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1849,6 +1849,14 @@ const abc = new Set
 if (true) {};
 // <- keyword.control.conditional
 
+    const x =
+    const y = 1; // Better highlighting while typing.
+//  ^^^^^ storage.type
+
+    let x =
+    const y = 1; // Better highlighting while typing.
+//  ^^^^^ storage.type
+
 var o = {
     a,
     b,

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -470,6 +470,9 @@ var obj = {
 //            ^^^^^^^^^^^^ meta.function
     },
 
+    class: null, // Keys are IdentifierNames, not merely Identifiers
+//  ^^^^^ meta.mapping.key
+
     [true==false ? 'one' : 'two']: false,
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key
 //  ^ punctuation.section.brackets.begin
@@ -1003,6 +1006,9 @@ class MyClass extends TheirClass {
 //  ^ punctuation.definition.variable
 //   ^ entity.name.function variable.other.readwrite
 //       ^^^^^^^^^^^^^ meta.function
+
+    class = null;
+//  ^^^^^ variable.other.readwrite
 
     static x = 42;
 //  ^^^^^^ storage.modifier.js

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -181,4 +181,7 @@
 //     ^ - punctuation
     }
 //  ^ punctuation.definition.interpolation.end
-</foo>
+</foo>;
+
+    <class />;
+//   ^^^^^ entity.name.tag


### PR DESCRIPTION
If we encounter an unexpected reserved word while parsing an expression, bail out of the expression. This should improve highlighting while typing in some cases.

In strict mode, additional words are reserved, but handling this would require duplicating the expression contexts, so it's not worth it.