### PR TITLE
[C#] Use keyword.declaration.function

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -500,10 +500,10 @@ contexts:
               scope: punctuation.section.block.end.cs
               pop: true
             - match: \b(add)\b
-              scope: storage.type.function.accessor.add.cs
+              scope: keyword.declaration.function.accessor.add.cs
               push: method_body
             - match: \b(remove)\b
-              scope: storage.type.function.accessor.remove.cs
+              scope: keyword.declaration.function.accessor.remove.cs
               push: method_body
         - match: (?==)
           set: member_variables_declaration
@@ -579,7 +579,7 @@ contexts:
       captures:
         1: variable.other.member.cs
         2: meta.method.cs
-        3: storage.type.function.accessor.get.cs
+        3: keyword.declaration.function.accessor.get.cs
       set:
         - meta_scope: meta.property.cs
         - meta_content_scope: meta.method.cs
@@ -771,10 +771,10 @@ contexts:
         - match: (?:\b(readonly)\b\s+)?\b(get)\b
           captures:
             1: storage.modifier.cs
-            2: storage.type.function.accessor.get.cs
+            2: keyword.declaration.function.accessor.get.cs
           push: method_body
         - match: \b(set|init)\b
-          scope: storage.type.function.accessor.set.cs
+          scope: keyword.declaration.function.accessor.set.cs
           push: method_body
         - match: '{{visibility}}'
           scope: storage.modifier.access.cs
@@ -979,7 +979,7 @@ contexts:
     - match: ({{name}})\s+(=>)\s*
       captures:
         1: variable.parameter.cs
-        2: storage.type.function.lambda.cs
+        2: keyword.declaration.function.anonymous.cs
       push:
         - meta_scope: meta.function.anonymous.cs
         - match: '(?=;)'
@@ -999,7 +999,7 @@ contexts:
         - match: (\))\s*(=>)
           captures:
             1: meta.group.cs punctuation.section.group.end.cs
-            2: storage.type.function.lambda.cs
+            2: keyword.declaration.function.anonymous.cs
           set:
             - meta_content_scope: meta.function.anonymous.cs
             - match: '(?=;)'

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -564,7 +564,7 @@ class Foo {
 ///                                                   ^^^^ variable.other
 ///                                                        ^ keyword.operator.assignment.variable
 ///                                                          ^ variable.parameter
-///                                                            ^^ storage.type.function.lambda
+///                                                            ^^ keyword.declaration.function.anonymous
 ///                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 ///                                                               ^ punctuation.section.group.begin
 ///                                                                ^^^^^^^^ variable.other

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -87,7 +87,7 @@ public struct Point3D
 ///                   ^^^^^^^^ storage.modifier
 ///                            ^^^^^^^ support.type
 ///                                    ^^^^^^^ variable.other.member
-///                                           ^^ storage.type.function.accessor.get
+///                                           ^^ keyword.declaration.function.accessor.get
 ///                                              ^^^ keyword.other
 ///                                                  ^^^^^^ variable.other
 ///                                                        ^ punctuation.terminator.statement

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -10,15 +10,15 @@ public record Person
 {
     private readonly string lastName;
     public string FirstName { get; init; }
-///                           ^^^ storage.type.function.accessor.get
+///                           ^^^ keyword.declaration.function.accessor.get
 ///                              ^ punctuation.terminator
-///                                ^^^^ storage.type.function.accessor.set
+///                                ^^^^ keyword.declaration.function.accessor.set
 ///                                    ^ punctuation.terminator
     public string LastName
     {
         get => lastName;
         init => lastName = (value ?? throw new ArgumentNullException(nameof(LastName)));
-///     ^^^^ storage.type.function.accessor.set
+///     ^^^^ keyword.declaration.function.accessor.set
 ///          ^^ keyword.declaration.function.anonymous
 ///             ^^^^^^^^ variable.other
     }

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -46,14 +46,14 @@ namespace YourNamespace
 ///                             ^ meta.property punctuation.section.block.begin
             get {return x;}
 ///         ^^^^^^^^^^^^^^^ meta.property meta.method
-///          ^ storage.type.function.accessor.get
+///          ^ keyword.declaration.function.accessor.get
 ///             ^^^^^^^^^^^ meta.property meta.method.body meta.block
 ///             ^ punctuation.section.block.begin
 ///                      ^ punctuation.terminator
 ///                       ^ punctuation.section.block.end
             set {x = value;}
 ///         ^^^^^^^^^^^^^^^^ meta.property meta.method
-///          ^ storage.type.function.accessor.set
+///          ^ keyword.declaration.function.accessor.set
 ///             ^^^^^^^^^^^^ meta.property meta.method.body meta.block
 ///             ^ punctuation.section.block.begin
 ///              ^ variable.other
@@ -96,7 +96,7 @@ namespace YourNamespace
 ///                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property
 ///                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method
 ///                  ^ variable.other.member
-///                        ^^ storage.type.function.accessor.get
+///                        ^^ keyword.declaration.function.accessor.get
 ///                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 ///                                   ^^^^^^^ support.type
 ///                                          ^^^^^^ meta.generic
@@ -108,9 +108,9 @@ namespace YourNamespace
 ///                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property
 ///                 ^^^^^^^^^^^^^^ variable.other.member
 ///                                ^^^^^^^^^^^^^^^^^^^^ meta.property meta.block
-///                                 ^^^ storage.type.function.accessor.get
+///                                 ^^^ keyword.declaration.function.accessor.get
 ///                                      ^^^^^^^ storage.modifier.access
-///                                              ^^^ storage.type.function.accessor.set
+///                                              ^^^ keyword.declaration.function.accessor.set
 ///                                                     ^ keyword.operator.assignment
 ///                                                       ^^^^^ constant.language
 
@@ -715,8 +715,8 @@ namespace TestNamespace.Test
 ///                           ^ punctuation.section.brackets.end
 ///                    ^^^ storage.type
 ///                        ^^^ variable.parameter
-///                              ^^^ storage.type.function.accessor
-///                                   ^^^ storage.type.function.accessor
+///                              ^^^ keyword.declaration.function.accessor
+///                                   ^^^ keyword.declaration.function.accessor
 
 
         /////////////////////////////
@@ -792,7 +792,7 @@ namespace TestNamespace.Test
 ///     ^^^ storage.type
 ///         ^^^^^^^ variable.other.member
 ///                 ^^^^ meta.method
-///                 ^^ storage.type.function
+///                 ^^ keyword.declaration.function
 ///                    ^ constant.numeric
 ///                     ^ punctuation.terminator
 
@@ -829,24 +829,24 @@ namespace TestNamespace.Test
 ///              ^^^ variable.other
 ///                    ^ keyword.operator.assignment
 ///                        ^^^^^^^^ meta.function.anonymous
-///                        ^^ storage.type.function.lambda
+///                        ^^ keyword.declaration.function.anonymous
             Func<float, float> times2 = x => x + x;
 ///         ^^^ support.type
 ///                            ^^^ variable.other
 ///                                   ^ keyword.operator.assignment
 ///                                     ^^^^^^^^^^ meta.function.anonymous
-///                                       ^^ storage.type.function.lambda
+///                                       ^^ keyword.declaration.function.anonymous
 
             var changes = refs.ToDictionary(kvp => kvp.key, arg => k + 5);
 ///                                         ^^^^^^^^^^^^^^ meta.function.anonymous.cs
 ///                                         ^^^ variable.parameter.cs
-///                                             ^^ storage.type.function.lambda.cs
+///                                             ^^ keyword.declaration.function.anonymous.cs
 ///                                                ^^^ variable.other.cs
 ///                                                       ^ punctuation.separator.argument.cs
 ///                                                       ^^ - meta.function.anonymous
 ///                                                         ^^^^^^^^^^^^ meta.function.anonymous.cs
 ///                                                         ^^^ variable.parameter.cs
-///                                                             ^^ storage.type.function.lambda.cs
+///                                                             ^^ keyword.declaration.function.anonymous.cs
 ///                                                                ^ variable.other.cs
 ///                                                                  ^ keyword.operator.cs
 ///                                                                    ^ meta.number.integer.decimal.cs
@@ -862,7 +862,7 @@ namespace TestNamespace.Test
 ///                                              ^ punctuation.separator.parameter.function.cs
 ///                                                ^^^^^ variable.parameter.cs
 ///                                                     ^ punctuation.section.group.end.cs
-///                                                       ^^ storage.type.function.lambda.cs
+///                                                       ^^ keyword.declaration.function.anonymous.cs
 ///                                                          ^^^^^ variable.other.cs
 
         }
@@ -1010,7 +1010,7 @@ namespace TestNamespace.Test
 
     void TestMe () {
         a = b => b * 2;
-///           ^^ storage.type.function.lambda
+///           ^^ keyword.declaration.function.anonymous
 ///           ^^^^^^^^ meta.function.anonymous
 ///                   ^ punctuation.terminator.statement - meta.function.anonymous
 
@@ -1031,7 +1031,7 @@ namespace TestNamespace.Test
         }
 
         a = b => { return b * 2; };
-///           ^^ meta.function.anonymous storage.type.function.lambda
+///           ^^ meta.function.anonymous keyword.declaration.function.anonymous
 ///              ^ meta.function.anonymous punctuation.section.block.begin
 ///                              ^ punctuation.section.block.end
 ///                               ^ punctuation.terminator.statement - meta.function.anonymous
@@ -1055,7 +1055,7 @@ namespace TestNamespace.Test
 ///          ^ variable.parameter
 ///           ^ punctuation.separator
 ///             ^ variable.parameter
-///                ^^ storage.type.function.lambda
+///                ^^ keyword.declaration.function.anonymous
 ///                   ^ meta.function.anonymous punctuation.section.block.begin
 ///                                   ^ punctuation.section.block.end
 ///                                    ^ punctuation.terminator.statement - meta.function.anonymous
@@ -1082,7 +1082,7 @@ namespace TestNamespace.Test
 ///                                     ^ variable.parameter
 ///                                      ^ punctuation.separator.parameter.function
 ///                                        ^ variable.parameter
-///                                           ^^ storage.type.function.lambda
+///                                           ^^ keyword.declaration.function.anonymous
 ///                                                     ^ punctuation.terminator.statement
 ///                                                      ^ - meta.function.anonymous
 
@@ -1133,7 +1133,7 @@ namespace TestNamespace.Test
 ///                 ^^^^^^ meta.cast support.type
 ///                        ^ punctuation.section.group.begin
 ///                         ^^ meta.function.anonymous meta.group
-///                            ^^ storage.type.function.lambda
+///                            ^^ keyword.declaration.function.anonymous
 ///                                             ^ punctuation.section.group.end
         test = (Action)(() => {});
 ///            ^^^^^^^^ meta.cast
@@ -1141,7 +1141,7 @@ namespace TestNamespace.Test
 ///                     ^^^^^^^ meta.function.anonymous
 ///                     ^ meta.group punctuation.section.group.begin
 ///                      ^ meta.group punctuation.section.group.end
-///                        ^^ storage.type.function.lambda
+///                        ^^ keyword.declaration.function.anonymous
 ///                           ^ punctuation.section.block.begin
 ///                            ^ punctuation.section.block.end
 ///                             ^ meta.group punctuation.section.group.end
@@ -1306,7 +1306,7 @@ public class AfterTopLevelMethod {
     {
 /// ^ punctuation.section.block.begin
         add
-///     ^^^ meta.method storage.type.function.accessor.add
+///     ^^^ meta.method keyword.declaration.function.accessor.add
         {
 ///     ^ punctuation.section.block.begin
             lock (objectLock)
@@ -1319,7 +1319,7 @@ public class AfterTopLevelMethod {
 ///     ^ punctuation.section.block.end
 ///      ^ - meta.method
         remove
-///     ^^^^^^ meta.method storage.type.function.accessor.remove
+///     ^^^^^^ meta.method keyword.declaration.function.accessor.remove
         {
             lock (objectLock)
             {
@@ -1368,7 +1368,7 @@ struct Example
     {
         readonly get => counter;
 ///     ^^^^^^^^ storage.modifier
-///              ^^^ storage.type.function.accessor.get
+///              ^^^ keyword.declaration.function.accessor.get
         set => counter = value;
     }
 }

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -154,7 +154,7 @@ string Frag
 {
 /// <- punctuation.section.block.begin
     get
-/// ^^^ - storage.type.function
+/// ^^^ - keyword.declaration.function
     {
 /// ^ punctuation.section.block.begin
         var list = new List<string>();

--- a/C#/tests/syntax_test_Using.cs
+++ b/C#/tests/syntax_test_Using.cs
@@ -141,7 +141,7 @@ internal sealed partial class Test : sys::Configuration.ApplicationSettingsBase 
 ///     ^^^^^ meta.annotation
 ///       ^ variable.annotation
         get {
-///       ^ storage.type.function.accessor.get
+///       ^ keyword.declaration.function.accessor.get
             return defaultInstance;
         }
     }


### PR DESCRIPTION
This commit scopes all remaining function declaration keywords `keyword.declaration.function`.

This commit scopes the `=>` as `keyword.declaration.function.anonymous`.

It was applied to C#, D recently and will be used in Java an Python as a common alternative to the existing variants of defining anonymous functions.

We currently have:

- keyword.declaration.function.anonymous
- keyword.declaration.function.arrow
- keyword.declaration.function.inline
- keyword.declaration.function.lambda