### PR TITLE
[JavaScript] Scope arrow as anonymous function

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -987,7 +987,7 @@ contexts:
 
   arrow-function-expect-arrow-or-fail-async:
     - match: '=>'
-      scope: keyword.declaration.function.arrow.js
+      scope: keyword.declaration.function.anonymous.js
       pop: true
     - match: (?=\S)
       fail: async-arrow-function
@@ -1530,7 +1530,7 @@ contexts:
 
   arrow-function-expect-arrow:
     - match: '=>'
-      scope: keyword.declaration.function.arrow.js
+      scope: keyword.declaration.function.anonymous.js
       pop: true
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1226,7 +1226,7 @@ class{}/**/
 //  ^^ meta.function.parameters
 //  ^ punctuation.section.group.begin
 //   ^ punctuation.section.group.end
-//     ^^ keyword.declaration.function.arrow
+//     ^^ keyword.declaration.function.anonymous
 //        ^^ meta.block
 //        ^ punctuation.section.block
 //         ^ punctuation.section.block
@@ -1263,19 +1263,19 @@ class{}/**/
 //        ^^^ meta.binding.name
     => 42;
 //  ^^^^^ meta.function
-//  ^^ keyword.declaration.function.arrow
+//  ^^ keyword.declaration.function.anonymous
 
     foo
 //  ^^^ meta.function.parameters variable.parameter.function
     => 42;
 //  ^^^^^ meta.function
-//  ^^ keyword.declaration.function.arrow
+//  ^^ keyword.declaration.function.anonymous
 
     async x => y;
 //  ^^^^^^^^^^^^ meta.function
 //  ^^^^^ keyword.declaration.async
 //        ^ meta.function.parameters variable.parameter.function
-//          ^^ keyword.declaration.function.arrow
+//          ^^ keyword.declaration.function.anonymous
 //             ^ variable.other.readwrite
 
     async (x) => y;
@@ -1283,13 +1283,13 @@ class{}/**/
 //  ^^^^^ keyword.declaration.async
 //        ^^^ meta.function.parameters
 //         ^ variable.parameter.function
-//            ^^ keyword.declaration.function.arrow
+//            ^^ keyword.declaration.function.anonymous
 //               ^ variable.other.readwrite
 
     async => {};
 //  ^^^^^^^^^^^ meta.function
 //  ^^^^^ meta.function.parameters variable.parameter.function
-//        ^^ keyword.declaration.function.arrow
+//        ^^ keyword.declaration.function.anonymous
 
     async;
 //  ^^^^^ variable.other.readwrite
@@ -1317,13 +1317,13 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
 ([a,
   b]) => { return x; }
 //    ^^^^^^^^^^^^^^^^ meta.function
-//    ^^ keyword.declaration.function.arrow
+//    ^^ keyword.declaration.function.anonymous
 //         ^^^^^^ meta.block keyword.control.flow
 
 (
     ()
     => { return; }
-//  ^^ keyword.declaration.function.arrow
+//  ^^ keyword.declaration.function.anonymous
 //     ^^^^^^^^^^^ meta.block - meta.mapping
 //       ^^^^^^ keyword.control.flow
 );
@@ -1336,7 +1336,7 @@ const test = ({a, b, c=()=>({active:false}) }) => {};
     b,
 //   ^ punctuation.separator.parameter - keyword.operator.comma
 }) => null;
-// ^^ keyword.declaration.function.arrow
+// ^^ keyword.declaration.function.anonymous
 
 MyClass.foo = function() {}
 // ^ support.class
@@ -1360,12 +1360,12 @@ var simpleArrow = foo => bar;
 //   ^ entity.name.function
 //                ^^^^^^^^^^ meta.function
 //                ^^^ variable.parameter.function
-//                    ^^ keyword.declaration.function.arrow
+//                    ^^ keyword.declaration.function.anonymous
 
 var Proto = () => {
 //   ^ entity.name.function
 //          ^^^^^^^ meta.function
-//             ^ keyword.declaration.function.arrow
+//             ^ keyword.declaration.function.anonymous
     this._var = 1;
 }
 
@@ -1377,7 +1377,7 @@ Proto.prototype.getVar = () => this._var;
 // ^ support.class
 //     ^ support.constant.prototype
 //                ^ entity.name.function
-//                           ^ keyword.declaration.function.arrow
+//                           ^ keyword.declaration.function.anonymous
 
 Class3.prototype = function() {
 // ^ support.class

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -350,7 +350,7 @@ function f(this : any) {}
 //  ^^^^^^^^^^^^^^ meta.function
 //    ^ punctuation.separator.type
 //      ^^^ meta.type support.type.any
-//           ^^ keyword.declaration.function.arrow
+//           ^^ keyword.declaration.function.anonymous
 
     x ? (y) : z;
 //  ^ variable.other.readwrite
@@ -366,7 +366,7 @@ function f(this : any) {}
 //       ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.type
 //            ^ meta.type support.class
-//              ^^ keyword.declaration.function.arrow
+//              ^^ keyword.declaration.function.anonymous
 //                 ^meta.block variable.other.readwrite
 //                   ^ keyword.operator.ternary
 //                     ^ variable.other.readwrite
@@ -376,7 +376,7 @@ function f(this : any) {}
 //        ^ keyword.operator.ternary
 //          ^^^^^^ meta.function
 //          ^ variable.parameter.function
-//            ^^ keyword.declaration.function.arrow
+//            ^^ keyword.declaration.function.anonymous
 
     async (x): T => y;
 //  ^^^^^^^^^^^^^^^^^ meta.function
@@ -384,7 +384,7 @@ function f(this : any) {}
 //         ^ meta.binding.name variable.parameter.function
 //           ^ punctuation.separator.type
 //             ^ meta.type support.class
-//               ^^ keyword.declaration.function.arrow
+//               ^^ keyword.declaration.function.anonymous
 //                  ^ meta.block variable.other.readwrite
 
     x ? async (y) : T => r : z;


### PR DESCRIPTION
This commit scopes the `=>` as `keyword.declaration.function.anonymous`.

It was applied to C#, D recently and will be used in Java an Python as a common alternative to the existing variants of defining anonymous functions.

We currently have:

- keyword.declaration.function.anonymous
- keyword.declaration.function.arrow
- keyword.declaration.function.inline
- keyword.declaration.function.lambda