### PR TITLE
[Python] Don't cancel completions for function definitions

### DIFF
--- a/Python/Completion Rules.tmPreferences
+++ b/Python/Completion Rules.tmPreferences
@@ -6,7 +6,12 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>^(.*\b(and|or)$)|(\s*(pass|return|and|or|(class|def)\s*[a-zA-Z_0-9]+)$)</string>
+		<string>(?x)
+		# Prevent completions when typing keywords
+		\b(and|or|pass|return)$
+		| # Prevent completions for class names
+		^\s* class \s+ [a-zA-Z_0-9]+ $
+		</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Other object-oriented languages in the default packages only disable
completions for class/type names, because in object-oriented languages
you can make use of function overloading, including the commonly
defined dunder functions. Most notably, this allows auto-completion
plugins like LSP to function properly.

Aside from that, the regex was merely restructured.

Closes #2404.