### PR TITLE
[Python] Clean up built-ins

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1113,24 +1113,24 @@ contexts:
   builtin-exceptions:
     - match: |-
         (?x)\b(
-          (
+          (?:
             Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe|Buffer|ChildProcess|
-            Connection(Aborted|Refused|Reset)?|EOF|Environment|FileExists|
+            Connection(?:Aborted|Refused|Reset)?|EOF|Environment|FileExists|
             FileNotFound|FloatingPoint|Interrupted|IO|IsADirectoryError|
             Import|Indentation|Index|Key|Lookup|Memory|Name|NotADirectory|
             NotImplemented|OS|Overflow|Permission|ProcessLookup|Reference|
             Runtime|Standard|Syntax|System|Tab|Timeout|Type|UnboundLocal|
-            Unicode(Encode|Decode|Translate)?|Value|VMS|Windows|ZeroDivision
+            Unicode(?:Encode|Decode|Translate)?|Value|VMS|Windows|ZeroDivision
           )Error|
-          ((Pending)?Deprecation|Resource|Runtime|Syntax|User|Future|Import|Unicode|Bytes)?Warning|
-          (Base)?Exception|
+          (?:(?:Pending)?Deprecation|Resource|Runtime|Syntax|User|Future|Import|Unicode|Bytes)?Warning|
+          (?:Base)?Exception|
           SystemExit|StopIteration|NotImplemented|KeyboardInterrupt|GeneratorExit
         )\b
       scope: support.type.exception.python
 
   builtin-functions:
     - match: |-
-        (?x)\b(
+        (?x)\b(?:
           __import__|all|abs|any|apply|ascii|bin|callable|chr|classmethod|
           compile|delattr|dir|divmod|enumerate|eval|filter|format|getattr|
           globals|hasattr|hash|help|hex|id|input|isinstance|issubclass|iter|
@@ -1146,7 +1146,7 @@ contexts:
 
   builtin-types:
     - match: |-
-        (?x)\b(
+        (?x)\b(?:
           basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
           list|memoryview|object|set|slice|str|tuple
           # Python 2 types

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -897,7 +897,7 @@ contexts:
 
   lambda:
     - match: \b(lambda)(?=\s|:|$)
-      scope: 
+      scope:
         meta.function.inline.python
         storage.type.function.inline.python
         keyword.declaration.function.inline.python
@@ -1113,38 +1113,38 @@ contexts:
   builtin-exceptions:
     - match: |-
         (?x)\b(
-        	(
-        		Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe|Buffer|ChildProcess|
-        		Connection(Aborted|Refused|Reset)?|EOF|Environment|FileExists|
-        		FileNotFound|FloatingPoint|Interrupted|IO|IsADirectoryError|
-        		Import|Indentation|Index|Key|Lookup|Memory|Name|NotADirectory|
-        		NotImplemented|OS|Overflow|Permission|ProcessLookup|Reference|
-        		Runtime|Standard|Syntax|System|Tab|Timeout|Type|UnboundLocal|
-        		Unicode(Encode|Decode|Translate)?|Value|VMS|Windows|ZeroDivision
-        	)Error|
-        	((Pending)?Deprecation|Resource|Runtime|Syntax|User|Future|Import|Unicode|Bytes)?Warning|
-        	(Base)?Exception|
-        	SystemExit|StopIteration|NotImplemented|KeyboardInterrupt|GeneratorExit
+          (
+            Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe|Buffer|ChildProcess|
+            Connection(Aborted|Refused|Reset)?|EOF|Environment|FileExists|
+            FileNotFound|FloatingPoint|Interrupted|IO|IsADirectoryError|
+            Import|Indentation|Index|Key|Lookup|Memory|Name|NotADirectory|
+            NotImplemented|OS|Overflow|Permission|ProcessLookup|Reference|
+            Runtime|Standard|Syntax|System|Tab|Timeout|Type|UnboundLocal|
+            Unicode(Encode|Decode|Translate)?|Value|VMS|Windows|ZeroDivision
+          )Error|
+          ((Pending)?Deprecation|Resource|Runtime|Syntax|User|Future|Import|Unicode|Bytes)?Warning|
+          (Base)?Exception|
+          SystemExit|StopIteration|NotImplemented|KeyboardInterrupt|GeneratorExit
         )\b
       scope: support.type.exception.python
 
   builtin-functions:
     - match: |-
         (?x)\b(
-        	__import__|all|abs|any|apply|ascii|bin|breakpoint|callable|chr|classmethod|cmp|coerce|
-        	compile|delattr|dir|divmod|enumerate|eval|exec|execfile|filter|format|getattr|
-        	globals|hasattr|hash|help|hex|id|input|intern|isinstance|issubclass|iter|
-        	len|locals|map|max|min|next|oct|open|ord|pow|print|property|range|
-        	raw_input|reduce|reload|repr|reversed|round|setattr|sorted|staticmethod|
-        	sum|super|type|unichr|vars|zip
+          __import__|all|abs|any|apply|ascii|bin|breakpoint|callable|chr|classmethod|cmp|coerce|
+          compile|delattr|dir|divmod|enumerate|eval|exec|execfile|filter|format|getattr|
+          globals|hasattr|hash|help|hex|id|input|intern|isinstance|issubclass|iter|
+          len|locals|map|max|min|next|oct|open|ord|pow|print|property|x?range|
+          raw_input|reduce|reload|repr|reversed|round|setattr|sorted|staticmethod|
+          sum|super|type|unichr|vars|zip
         )\b
       scope: support.function.builtin.python
 
   builtin-types:
     - match: |-
         (?x)\b(
-        	basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
-        	list|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange
+          basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
+          list|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange
           # Old Python 2 types prone to conflicts:
           # buffer
         )\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1143,8 +1143,10 @@ contexts:
   builtin-types:
     - match: |-
         (?x)\b(
-        	basestring|bool|buffer|bytearray|bytes|complex|dict|float|frozenset|int|
+        	basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
         	list|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange
+          # Old Python 2 types prone to conflicts:
+          # buffer
         )\b
       scope: support.type.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1131,14 +1131,14 @@ contexts:
   builtin-functions:
     - match: |-
         (?x)\b(?:
-          __import__|all|abs|any|apply|ascii|bin|callable|chr|classmethod|
+          __import__|all|abs|any|ascii|bin|callable|chr|classmethod|
           compile|delattr|dir|divmod|enumerate|eval|filter|format|getattr|
           globals|hasattr|hash|help|hex|id|input|isinstance|issubclass|iter|
           len|locals|map|max|min|next|oct|open|ord|pow|property|range|
           repr|reversed|round|setattr|sorted|staticmethod|
           sum|super|type|vars|zip
           # Python 2 functions
-          |cmp|coerce|execfile|intern|raw_input|reduce|reload|unichr|xrange
+          |apply|cmp|coerce|execfile|intern|raw_input|reduce|reload|unichr|xrange
           # Python 3 functions
           |breakpoint|exec|print
         )\b
@@ -1147,7 +1147,7 @@ contexts:
   builtin-types:
     - match: |-
         (?x)\b(?:
-          basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
+          bool|bytearray|bytes|complex|dict|float|frozenset|int|
           list|memoryview|object|set|slice|str|tuple
           # Python 2 types
           |basestring|long|unicode

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1131,12 +1131,16 @@ contexts:
   builtin-functions:
     - match: |-
         (?x)\b(
-          __import__|all|abs|any|apply|ascii|bin|breakpoint|callable|chr|classmethod|cmp|coerce|
-          compile|delattr|dir|divmod|enumerate|eval|exec|execfile|filter|format|getattr|
-          globals|hasattr|hash|help|hex|id|input|intern|isinstance|issubclass|iter|
-          len|locals|map|max|min|next|oct|open|ord|pow|print|property|x?range|
-          raw_input|reduce|reload|repr|reversed|round|setattr|sorted|staticmethod|
-          sum|super|type|unichr|vars|zip
+          __import__|all|abs|any|apply|ascii|bin|callable|chr|classmethod|
+          compile|delattr|dir|divmod|enumerate|eval|filter|format|getattr|
+          globals|hasattr|hash|help|hex|id|input|isinstance|issubclass|iter|
+          len|locals|map|max|min|next|oct|open|ord|pow|property|range|
+          repr|reversed|round|setattr|sorted|staticmethod|
+          sum|super|type|vars|zip
+          # Python 2 functions
+          |cmp|coerce|execfile|intern|raw_input|reduce|reload|unichr|xrange
+          # Python 3 functions
+          |breakpoint|exec|print
         )\b
       scope: support.function.builtin.python
 
@@ -1144,9 +1148,11 @@ contexts:
     - match: |-
         (?x)\b(
           basestring|bool|bytearray|bytes|complex|dict|float|frozenset|int|
-          list|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange
-          # Old Python 2 types prone to conflicts:
-          # buffer
+          list|memoryview|object|set|slice|str|tuple
+          # Python 2 types
+          |basestring|long|unicode
+          # Python 2 types prone to conflicts
+          # |buffer|file
         )\b
       scope: support.type.python
 


### PR DESCRIPTION
Just a small cleanup pass on built-in matches, removing the barely-used `buffer` and restructuring the rest.