### PR TITLE
[Haskell] match (--*) in punctuation.definition.comment.haskell

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -331,7 +331,7 @@ contexts:
   comment:
     # As of build 4079 the [:punct:] class is missing some ASCII chars that
     # Unicode considers part of the Symbol category.
-    - match: '--(?![[:punct:]!-/:-@\[-`{-~])'
+    - match: '--*(?![[:punct:]!-/:-@\[-`{-~])'
       scope: punctuation.definition.comment.haskell
       push:
         - meta_scope: comment.line.double-dash.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -331,7 +331,7 @@ contexts:
   comment:
     # As of build 4079 the [:punct:] class is missing some ASCII chars that
     # Unicode considers part of the Symbol category.
-    - match: '--*(?![[:punct:]!-/:-@\[-`{-~])'
+    - match: '--+(?![[:punct:]!-/:-@\[-`{-~])'
       scope: punctuation.definition.comment.haskell
       push:
         - meta_scope: comment.line.double-dash.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -3,6 +3,9 @@
 23*36  -- single line comment
 --     ^^ punctuation.definition.comment.haskell
 --     ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.haskell
+23*36  --------------------------------------------------- single line comment
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.haskell
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.haskell
 23*36
 -- <- - comment.line.double-dash.haskell
 

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -4,8 +4,8 @@
 --     ^^ punctuation.definition.comment.haskell
 --     ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.haskell
 23*36  --------------------------------------------------- single line comment
---     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.haskell
---     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.haskell
+--    ^ - comment - punctuation
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.haskell punctuation.definition.comment.haskell
 23*36
 -- <- - comment.line.double-dash.haskell
 


### PR DESCRIPTION
/cc @FichteFoll 

Before

![image](https://user-images.githubusercontent.com/287532/99534294-7a1e1080-29a7-11eb-8806-810af583270a.png)

After

![image](https://user-images.githubusercontent.com/287532/99534340-8ace8680-29a7-11eb-996f-73dd295bba1a.png)
