### PR TITLE
[JavaScript] Handle type argument in JSDoc documentation

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -193,7 +193,7 @@ contexts:
       pop: 1
     - match: '^\s*\*'
     - match: \.
-      scope: meta.type.js punctuation.accessor.js
+      scope: meta.type.js punctuation.accessor.dot.js
     - match: '\{'
       scope: meta.type.js
       push: jsdoc-type-expression-body-nested

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -107,7 +107,7 @@ variables:
   # '@' followed by a pattern like \S but excluding literal '*' and '@'.
   jsdoc_block_tag: \@[^\n\t\f\v *@]+
   # Tags that are optionally followed by a type expression.
-  jsdoc_block_tag_with_type: \@(?:arg(?:ument|)|param|type(?:def|)|returns?|prop(?:erty|)|enum|implements|member|module|namespace|(?:pr(?:ivate|otected))|template|this|throws|exception|yields?|var)\b
+  jsdoc_block_tag_with_type: \@(?:arg(?:ument)?|param|typedef|type|returns?|prop(?:erty)?|enum|implements|member|module|namespace|private|protected|template|this|throws|exception|yields?|var)\b
 
 contexts:
   main:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -193,16 +193,16 @@ contexts:
       pop: 1
     - match: '^\s*\*'
     - match: \.
-      scope: support.type.js punctuation.accessor.js
+      scope: meta.type.js punctuation.accessor.js
     - match: '\{'
-      scope: support.type.js
+      scope: meta.type.js
       push: jsdoc-type-expression-body-nested
     - match: '(?:(?!\*\/|^\s*\*|\}|\{|\.).)*'
-      scope: support.type.js
+      scope: meta.type.js
 
   jsdoc-type-expression-body-nested:
     - match: '\}'
-      scope: support.type.js
+      scope: meta.type.js
       pop: 1
     - include: jsdoc-type-expression-body
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -106,6 +106,8 @@ variables:
 
   # '@' followed by a pattern like \S but excluding literal '*' and '@'.
   jsdoc_block_tag: \@[^\n\t\f\v *@]+
+  # Tags that are optionally followed by a type expression.
+  jsdoc_block_tag_with_type: \@(?:arg(?:ument|)|param|type(?:def|)|returns?|prop(?:erty|)|enum|implements|member|module|namespace|(?:pr(?:ivate|otected))|template|this|throws|exception|yields?|var)\b
 
 contexts:
   main:
@@ -164,11 +166,45 @@ contexts:
       push: jsdoc-block-tag
 
   jsdoc-block-tag:
+    - match: '{{jsdoc_block_tag_with_type}}'
+      scope: entity.other.attribute-name.documentation.js
+      set:
+        - match: '\s+(?=\{)'
+          set: jsdoc-type-expression
+        - match: ''
+          pop: 1
     - match: '{{jsdoc_block_tag}}'
       scope: entity.other.attribute-name.documentation.js
       pop: 1
     - match: (?=\S)|$
       pop: 1
+
+  jsdoc-type-expression:
+    - match: '\{'
+      scope: punctuation.definition.type.begin.js, meta.tag.jsdoc
+      set:
+        - match: '\}'
+          scope: punctuation.definition.type.end.js, meta.tag.jsdoc
+          pop: 1
+        - include: jsdoc-type-expression-body
+
+  jsdoc-type-expression-body:
+    - match: (?=\*/)
+      pop: 1
+    - match: '^\s*\*'
+    - match: \.
+      scope: support.type.js punctuation.accessor.js
+    - match: '\{'
+      scope: support.type.js
+      push: jsdoc-type-expression-body-nested
+    - match: '(?:(?!\*\/|^\s*\*|\}|\{|\.).)*'
+      scope: support.type.js
+
+  jsdoc-type-expression-body-nested:
+    - match: '\}'
+      scope: support.type.js
+      pop: 1
+    - include: jsdoc-type-expression-body
 
   line-comments:
     - match: /{4,}

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -197,7 +197,17 @@ contexts:
     - match: '\{'
       scope: meta.type.js
       push: jsdoc-type-expression-body-nested
-    - match: '(?:(?!\*\/|^\s*\*|\}|\{|\.).)*'
+    - match: |-
+        (?x:
+          (?! # break on patterns handled explicitly above
+            \*\/|
+            ^\s*\*|
+            \}|
+            \{|
+            \.
+          ).
+        # consume as many consecutive characters as possible to not break the ligatures
+        )*
       scope: meta.type.js
 
   jsdoc-type-expression-body-nested:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -191,7 +191,9 @@ contexts:
   jsdoc-type-expression-body:
     - match: (?=\*/)
       pop: 1
-    - match: '^\s*\*'
+    - match: '^\s*(\*)'
+      captures:
+        1: punctuation.definition.comment.js
     - match: \.
       scope: meta.type.js punctuation.accessor.dot.js
     - match: '\{'

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -184,7 +184,7 @@ contexts:
       scope: punctuation.definition.type.begin.js, meta.tag.jsdoc
       set:
         - match: '\}'
-          scope: punctuation.definition.type.end.js, meta.tag.jsdoc
+          scope: meta.tag.jsdoc punctuation.definition.type.end.js
           pop: 1
         - include: jsdoc-type-expression-body
 

--- a/JavaScript/tests/syntax_test_js_jsdoc.js
+++ b/JavaScript/tests/syntax_test_js_jsdoc.js
@@ -56,13 +56,17 @@
   /**
    * @param {{
 //           ^ meta.type
+// ^ comment.block.documentation punctuation.definition.comment
    *   foo: A.B
+// ^ comment.block.documentation punctuation.definition.comment
 //^^ - meta.type
 //  ^^^^^^^^^^^ meta.type
 //           ^ punctuation.accessor.dot
    * }} foo
 //  ^^ meta.type
 //    ^^^^^ - meta.type
+   *
+// ^ comment.block.documentation punctuation.definition.comment
    */
 
 /** @type{string} */

--- a/JavaScript/tests/syntax_test_js_jsdoc.js
+++ b/JavaScript/tests/syntax_test_js_jsdoc.js
@@ -40,3 +40,38 @@
 /*@a */
 //^^ - entity.other.attribute-name.documentation
 //   ^^ punctuation.definition.comment.end
+
+/** @type {string[]} */
+//         ^^^^^^^^ support.type
+//                 ^^^^ - support.type
+//        ^ punctuation.definition.type.begin
+//                 ^ punctuation.definition.type.end
+
+/** @type {import('fs').FSWatcher} */
+//         ^^^^^^^^^^^^^^^^^^^^^^ support.type
+//                               ^^^^ - support.type
+//                     ^ punctuation.accessor
+//                               ^ punctuation.definition.type.end
+
+  /**
+   * @param {{
+//           ^ support.type
+   *   foo: A.B
+//^^ - support.type
+//  ^^^^^^^^^^^ support.type
+//           ^ punctuation.accessor
+   * }} foo
+//  ^^ support.type
+//    ^^^^^ - support.type
+   */
+
+/** @type{string} */
+//       ^^^^^^^^ - support.type
+
+/** @type {string */
+//         ^^^^^^^ support.type
+//                ^^ punctuation.definition.comment.end - support.type
+
+/** @type {{foo: number */
+//         ^^^^^^^^^^^^^ support.type
+//                      ^^ punctuation.definition.comment.end - support.type

--- a/JavaScript/tests/syntax_test_js_jsdoc.js
+++ b/JavaScript/tests/syntax_test_js_jsdoc.js
@@ -75,3 +75,8 @@
 /** @type {{foo: number */
 //         ^^^^^^^^^^^^^ meta.type
 //                      ^^ punctuation.definition.comment.end - meta.type
+
+// Mostly just for visual inspection to ensure that ligatures are not broken.
+/** @type {p: number => string} */
+//         ^^^^^^^^^^^^^^^^^^^ meta.type
+//                              ^^ punctuation.definition.comment.end - meta.type

--- a/JavaScript/tests/syntax_test_js_jsdoc.js
+++ b/JavaScript/tests/syntax_test_js_jsdoc.js
@@ -42,36 +42,36 @@
 //   ^^ punctuation.definition.comment.end
 
 /** @type {string[]} */
-//         ^^^^^^^^ support.type
-//                 ^^^^ - support.type
+//         ^^^^^^^^ meta.type
+//                 ^^^^ - meta.type
 //        ^ punctuation.definition.type.begin
 //                 ^ punctuation.definition.type.end
 
 /** @type {import('fs').FSWatcher} */
-//         ^^^^^^^^^^^^^^^^^^^^^^ support.type
-//                               ^^^^ - support.type
+//         ^^^^^^^^^^^^^^^^^^^^^^ meta.type
+//                               ^^^^ - meta.type
 //                     ^ punctuation.accessor
 //                               ^ punctuation.definition.type.end
 
   /**
    * @param {{
-//           ^ support.type
+//           ^ meta.type
    *   foo: A.B
-//^^ - support.type
-//  ^^^^^^^^^^^ support.type
+//^^ - meta.type
+//  ^^^^^^^^^^^ meta.type
 //           ^ punctuation.accessor
    * }} foo
-//  ^^ support.type
-//    ^^^^^ - support.type
+//  ^^ meta.type
+//    ^^^^^ - meta.type
    */
 
 /** @type{string} */
-//       ^^^^^^^^ - support.type
+//       ^^^^^^^^ - meta.type
 
 /** @type {string */
-//         ^^^^^^^ support.type
-//                ^^ punctuation.definition.comment.end - support.type
+//         ^^^^^^^ meta.type
+//                ^^ punctuation.definition.comment.end - meta.type
 
 /** @type {{foo: number */
-//         ^^^^^^^^^^^^^ support.type
-//                      ^^ punctuation.definition.comment.end - support.type
+//         ^^^^^^^^^^^^^ meta.type
+//                      ^^ punctuation.definition.comment.end - meta.type

--- a/JavaScript/tests/syntax_test_js_jsdoc.js
+++ b/JavaScript/tests/syntax_test_js_jsdoc.js
@@ -50,7 +50,7 @@
 /** @type {import('fs').FSWatcher} */
 //         ^^^^^^^^^^^^^^^^^^^^^^ meta.type
 //                               ^^^^ - meta.type
-//                     ^ punctuation.accessor
+//                     ^ punctuation.accessor.dot
 //                               ^ punctuation.definition.type.end
 
   /**
@@ -59,7 +59,7 @@
    *   foo: A.B
 //^^ - meta.type
 //  ^^^^^^^^^^^ meta.type
-//           ^ punctuation.accessor
+//           ^ punctuation.accessor.dot
    * }} foo
 //  ^^ meta.type
 //    ^^^^^ - meta.type


### PR DESCRIPTION
Enables parsing of types that can follow some block tags.

The type is scoped with a single scope instead of trying to parse the
type in a "correct" way (how typescript syntax does for types). This is
for one due to the fact that I don't know how to do it "properly" but
even more importantly because typing it properly would make the type
more noisy visually. The only exception is that the dot is scoped as
an accessor so that it triggers completions (especially useful when
using LSP).