### PR TITLE
[SQL] Add support for build-in MariaDB/MySQL/PostgreSQL functions

### DIFF
--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -1,0 +1,80 @@
+%YAML 1.2
+---
+name: MySQL
+scope: source.sql.mysql
+version: 2
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  main:
+    - meta_append: true
+    - match: (?i)\b(AGAINST|ASCII|BIN|BIT_LENGTH|CAST|CHAR_LENGTH|CHARACTER_LENGTH|CHR|CONCAT|CONCAT_WS|ELT|EXPORT_SET|EXTRACTVALUE|FIELD|FIND_IN_SET|FORMAT|FROM_BASE64|HEX|INSTR|LCASE|LEFT|LENGTH|LENGTHB|LOAD_FILE|LOCATE|LPAD|LPAD_ORACLE|LTRIM|LTRIM_ORACLE|MAKE_SET|MATCH|MID|OCTET_LENGTH|ORD|POSITION|QUOTE|REPEAT|REPLACE|REVERSE|RIGHT|RPAD|RTRIM|SOUNDEX|SPACE|STRCMP|SUBSTR|SUBSTRING_INDEX|TO_BASE64|TRIM_ORACLE|UCASE|UNHEX|UPDATEXML|WEIGHT_STRING)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/string-functions/
+      scope: support.function.string.sql
+    - match: (?i)\b(REGEXP_INSTR|REGEXP_REPLACE|REGEXP_SUBSTR)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/regular-expressions-functions/
+      scope: support.function.string.regexp.sql
+    - match: (?i)\b(ADDDATE|ADDTIME|CONVERT_TZ|CURDATE|CURTIME|DATE_ADD|DATE_FORMAT|DATE_SUB|DATEDIFF|DAY|DAYNAME|DAYOFMONTH|DAYOFWEEK|DAYOFYEAR|EXTRACT|FROM_DAYS|FROM_UNIXTIME|GET_FORMAT|HOUR|LAST_DAY|LOCALTIME|LOCALTIMESTAMP|MAKEDATE|MAKETIME|MICROSECOND|MINUTE|MONTH|MONTHNAME|NOW|PERIOD_ADD|PERIOD_DIFF|QUARTER|SEC_TO_TIME|SECOND|STR_TO_DATE|SUBDATE|SUBTIME|TIME_FORMAT|TIME_TO_SEC|TIMEDIFF|TIMESTAMPADD|TIMESTAMPDIFF|TO_DAYS|TO_SECONDS|UNIX_TIMESTAMP|UTC_DATE|UTC_TIME|UTC_TIMESTAMP|WEEK|WEEKDAY|WEEKOFYEAR|YEAR|YEARWEEK)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/date-time-functions/
+      scope: support.function.time.sql
+    - match: (?i)\b(BIT_AND|BIT_OR|BIT_XOR|GROUP_CONCAT|JSON_ARRAYAGG|JSON_OBJECTAGG|STD|STDDEV|STDDEV_POP|STDDEV_SAMP|VAR_POP|VAR_SAMP|VARIANCE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/aggregate-functions/
+      scope: support.function.aggregate.sql
+    - match: (?i)\b(ABS|ACOS|ASIN|ATAN|ATAN2|CEIL|CEILING|CONV|COS|COT|CRC32|DEGREES|EXP|FLOOR|GREATEST|LEAST|LN|LOG|LOG10|LOG2|MOD|OCT|PI|POW|POWER|RADIANS|RAND|ROUND|SIGN|SIN|SQRT|TAN)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/numeric-functions/
+      scope: support.function.numeric.sql
+    - match: (?i)\b(IFNULL|NULLIF)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/control-flow-functions/
+      scope: support.function.controlflow.sql
+    - match: (?i)\b(BIT_COUNT)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/bit-functions-and-operators/
+      scope: support.function.bit.sql
+    - match: (?i)\b(AES_DECRYPT|AES_ENCRYPT|COMPRESS|DECODE|DES_DECRYPT|DES_ENCRYPT|ENCODE|ENCRYPT|MD5|OLD_PASSWORD|PASSWORD|SHA1|SHA2|UNCOMPRESS|UNCOMPRESSED_LENGTH)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/encryption-hashing-and-compression-functions/
+      scope: support.function.encryption.sql
+    - match: (?i)\b(BENCHMARK|BINLOG_GTID_POS|CHARSET|COERCIBILITY|COLLATION|CONNECTION_ID|CURRENT_ROLE|DATABASE|DECODE_HISTOGRAM|FOUND_ROWS|LAST_INSERT_ID|LAST_VALUE|ROW_COUNT|SCHEMA|USER|VERSION)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/information-functions/
+      scope: support.function.information.sql
+    - match: (?i)\b(GET_LOCK|INET6_ATON|INET6_NTOA|INET_ATON|INET_NTOA|IS_FREE_LOCK|IS_IPV4|IS_IPV4_COMPAT|IS_IPV4_MAPPED|IS_IPV6|IS_USED_LOCK|MASTER_GTID_WAIT|MASTER_POS_WAIT|NAME_CONST|RELEASE_ALL_LOCKS|RELEASE_LOCK|SLEEP|UUID|UUID_SHORT)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/miscellaneous-functions/
+      scope: support.function.other.sql
+    - match: (?i)\b(COLUMN_ADD|COLUMN_CHECK|COLUMN_CREATE|COLUMN_DELETE|COLUMN_EXISTS|COLUMN_GET|COLUMN_JSON|COLUMN_LIST)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/dynamic-columns-functions/
+      scope: support.function.columns.sql
+    - match: (?i)\b(JSON_ARRAY|JSON_ARRAY_APPEND|JSON_ARRAY_INSERT|JSON_COMPACT|JSON_CONTAINS|JSON_CONTAINS_PATH|JSON_DEPTH|JSON_DETAILED|JSON_EXISTS|JSON_EXTRACT|JSON_INSERT|JSON_KEYS|JSON_LENGTH|JSON_LOOSE|JSON_MERGE|JSON_MERGE_PATCH|JSON_MERGE_PRESERVE|JSON_OBJECT|JSON_QUERY|JSON_QUOTE|JSON_REMOVE|JSON_REPLACE|JSON_SEARCH|JSON_SET|JSON_TYPE|JSON_UNQUOTE|JSON_VALID|JSON_VALUE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/json-functions/
+      scope: support.function.json.sql
+    - match: (?i)\b(SPIDER_BG_DIRECT_SQL|SPIDER_COPY_TABLES|SPIDER_DIRECT_SQL|SPIDER_FLUSH_TABLE_MON_CACHE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/spider-functions/
+      scope: support.function.spider.sql
+    - match: (?i)\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|LAG|LEAD|MEDIAN|NTH_VALUE|NTILE|PERCENT_RANK|PERCENTILE_CONT|PERCENTILE_DISC|RANK|ROW_NUMBER)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/window-functions/
+      scope: support.function.window.sql
+    - match: (?i)\b(BUFFER|ConvexHull|GeometryCollection|LineString|MultiLineString|MultiPoint|MultiPolygon|PointOnSurface|ST_BUFFER|ST_ConvexHull|ST_PointOnSurface|ST_INTERSECTION|ST_SYMDIFFERENCE|ST_UNION)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-constructors/
+      scope: support.function.geographic.geometry.constructor.sql
+    - match: (?i)\b(BOUNDARY|DIMENSION|ENVELOPE|GeometryN|GeometryType|IsClosed|IsEmpty|IsRing|IsSimple|NumGeometries|SRID|ST_BOUNDARY|ST_DIMENSION|ST_ENVELOPE|ST_GeometryN|ST_GeometryType|ST_IsClosed|ST_IsEmpty|ST_IsRing|ST_IsSimple|ST_NumGeometries|ST_Relate|ST_SRID)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-properties/
+      scope: support.function.geographic.property.geometry.sql
+    - match: (?i)\b(CONTAINS|CROSSES|DISJOINT|EQUALS|INTERSECTS|OVERLAPS|ST_CONTAINS|ST_CROSSES|ST_DIFFERENCE|ST_DISJOINT|ST_DISTANCE|ST_EQUALS|ST_INTERSECTS|ST_LENGTH|ST_OVERLAPS|ST_TOUCHES|ST_WITHIN|TOUCHES|WITHIN)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-relations/
+      scope: support.function.geographic.geometry.relation.sql
+    - match: (?i)\b(EndPoint|GLength|NumPoints|PointN|ST_EndPoint|ST_NumPoints|ST_PointN|ST_StartPoint|StartPoint)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/linestring-properties/
+      scope: support.function.geographic.linestring.sql
+    - match: (?i)\b(MBRContains|MBRDisjoint|MBREqual|MBRIntersects|MBROverlaps|MBRTouches|MBRWithin)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/mbr-minimum-bounding-rectangle/
+      scope: support.function.geographic.mbr.sql
+    - match: (?i)\b(ST_X|ST_Y|X|Y)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/point-properties/
+      scope: support.function.geographic.property.point.sql
+    - match: (?i)\b(Area|Centroid|ExteriorRing|InteriorRingN|NumInteriorRings|ST_Area|ST_Centroid|ST_ExteriorRing|ST_InteriorRingN|ST_NumInteriorRings)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/polygon-properties/
+      scope: support.function.geographic.property.polygon.sql
+    - match: (?i)\b(AsBinary|AsWKB|GeomCollFromWKB|GeometryCollectionFromWKB|GeometryFromWKB|GeomFromWKB|LineFromWKB|LineStringFromWKB|MLineFromWKB|MPointFromWKB|MPolyFromWKB|MultiLineStringFromWKB|MultiPointFromWKB|MultiPolygonFromWKB|PointFromWKB|PolyFromWKB|PolygonFromWKB|ST_AsBinary|ST_AsWKB|ST_GeomCollFromWKB|ST_GeometryCollectionFromWKB|ST_GeometryFromWKB|ST_GeomFromWKB|ST_LineFromWKB|ST_LineStringFromWKB|ST_PointFromWKB|ST_PolyFromWKB|ST_PolygonFromWKB)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkb/
+      scope: support.function.geographic.wkb.sql
+    - match: (?i)\b(AsText|AsWKT|GeomCollFromText|GeometryCollectionFromText|GeometryFromText|GeomFromText|LineFromText|LineStringFromText|MLineFromText|MPointFromText|MPolyFromText|MultiLineStringFromText|MultiPointFromText|MultiPolygonFromText|PointFromText|PolyFromText|PolygonFromText|ST_AsText|ST_AsWKT|ST_GeomCollFromText|ST_GeometryCollectionFromText|ST_GeometryFromText|ST_GeomFromText|ST_LineFromText|ST_LineStringFromText|ST_PointFromText|ST_PolyFromText|ST_PolygonFromText)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkt/
+      scope: support.function.geographic.wkt.sql

--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -10,71 +10,71 @@ contexts:
   main:
     - meta_append: true
     - match: (?i)\b(AGAINST|ASCII|BIN|BIT_LENGTH|CAST|CHAR_LENGTH|CHARACTER_LENGTH|CHR|CONCAT|CONCAT_WS|ELT|EXPORT_SET|EXTRACTVALUE|FIELD|FIND_IN_SET|FORMAT|FROM_BASE64|HEX|INSTR|LCASE|LEFT|LENGTH|LENGTHB|LOAD_FILE|LOCATE|LPAD|LPAD_ORACLE|LTRIM|LTRIM_ORACLE|MAKE_SET|MATCH|MID|OCTET_LENGTH|ORD|POSITION|QUOTE|REPEAT|REPLACE|REVERSE|RIGHT|RPAD|RTRIM|SOUNDEX|SPACE|STRCMP|SUBSTR|SUBSTRING_INDEX|TO_BASE64|TRIM_ORACLE|UCASE|UNHEX|UPDATEXML|WEIGHT_STRING)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/string-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/string-functions/
       scope: support.function.string.sql
     - match: (?i)\b(REGEXP_INSTR|REGEXP_REPLACE|REGEXP_SUBSTR)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/regular-expressions-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/regular-expressions-functions/
       scope: support.function.string.regexp.sql
     - match: (?i)\b(ADDDATE|ADDTIME|CONVERT_TZ|CURDATE|CURTIME|DATE_ADD|DATE_FORMAT|DATE_SUB|DATEDIFF|DAY|DAYNAME|DAYOFMONTH|DAYOFWEEK|DAYOFYEAR|EXTRACT|FROM_DAYS|FROM_UNIXTIME|GET_FORMAT|HOUR|LAST_DAY|LOCALTIME|LOCALTIMESTAMP|MAKEDATE|MAKETIME|MICROSECOND|MINUTE|MONTH|MONTHNAME|NOW|PERIOD_ADD|PERIOD_DIFF|QUARTER|SEC_TO_TIME|SECOND|STR_TO_DATE|SUBDATE|SUBTIME|TIME_FORMAT|TIME_TO_SEC|TIMEDIFF|TIMESTAMPADD|TIMESTAMPDIFF|TO_DAYS|TO_SECONDS|UNIX_TIMESTAMP|UTC_DATE|UTC_TIME|UTC_TIMESTAMP|WEEK|WEEKDAY|WEEKOFYEAR|YEAR|YEARWEEK)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/date-time-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/date-time-functions/
       scope: support.function.time.sql
     - match: (?i)\b(BIT_AND|BIT_OR|BIT_XOR|GROUP_CONCAT|JSON_ARRAYAGG|JSON_OBJECTAGG|STD|STDDEV|STDDEV_POP|STDDEV_SAMP|VAR_POP|VAR_SAMP|VARIANCE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/aggregate-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/aggregate-functions/
       scope: support.function.aggregate.sql
     - match: (?i)\b(ABS|ACOS|ASIN|ATAN|ATAN2|CEIL|CEILING|CONV|COS|COT|CRC32|DEGREES|EXP|FLOOR|GREATEST|LEAST|LN|LOG|LOG10|LOG2|MOD|OCT|PI|POW|POWER|RADIANS|RAND|ROUND|SIGN|SIN|SQRT|TAN)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/numeric-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/numeric-functions/
       scope: support.function.numeric.sql
     - match: (?i)\b(IFNULL|NULLIF)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/control-flow-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/control-flow-functions/
       scope: support.function.controlflow.sql
     - match: (?i)\b(BIT_COUNT)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/bit-functions-and-operators/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/bit-functions-and-operators/
       scope: support.function.bit.sql
     - match: (?i)\b(AES_DECRYPT|AES_ENCRYPT|COMPRESS|DECODE|DES_DECRYPT|DES_ENCRYPT|ENCODE|ENCRYPT|MD5|OLD_PASSWORD|PASSWORD|SHA1|SHA2|UNCOMPRESS|UNCOMPRESSED_LENGTH)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/encryption-hashing-and-compression-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/encryption-hashing-and-compression-functions/
       scope: support.function.encryption.sql
     - match: (?i)\b(BENCHMARK|BINLOG_GTID_POS|CHARSET|COERCIBILITY|COLLATION|CONNECTION_ID|CURRENT_ROLE|DATABASE|DECODE_HISTOGRAM|FOUND_ROWS|LAST_INSERT_ID|LAST_VALUE|ROW_COUNT|SCHEMA|USER|VERSION)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/information-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/information-functions/
       scope: support.function.information.sql
     - match: (?i)\b(GET_LOCK|INET6_ATON|INET6_NTOA|INET_ATON|INET_NTOA|IS_FREE_LOCK|IS_IPV4|IS_IPV4_COMPAT|IS_IPV4_MAPPED|IS_IPV6|IS_USED_LOCK|MASTER_GTID_WAIT|MASTER_POS_WAIT|NAME_CONST|RELEASE_ALL_LOCKS|RELEASE_LOCK|SLEEP|UUID|UUID_SHORT)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/miscellaneous-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/miscellaneous-functions/
       scope: support.function.other.sql
     - match: (?i)\b(COLUMN_ADD|COLUMN_CHECK|COLUMN_CREATE|COLUMN_DELETE|COLUMN_EXISTS|COLUMN_GET|COLUMN_JSON|COLUMN_LIST)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/dynamic-columns-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/dynamic-columns-functions/
       scope: support.function.columns.sql
     - match: (?i)\b(JSON_ARRAY|JSON_ARRAY_APPEND|JSON_ARRAY_INSERT|JSON_COMPACT|JSON_CONTAINS|JSON_CONTAINS_PATH|JSON_DEPTH|JSON_DETAILED|JSON_EXISTS|JSON_EXTRACT|JSON_INSERT|JSON_KEYS|JSON_LENGTH|JSON_LOOSE|JSON_MERGE|JSON_MERGE_PATCH|JSON_MERGE_PRESERVE|JSON_OBJECT|JSON_QUERY|JSON_QUOTE|JSON_REMOVE|JSON_REPLACE|JSON_SEARCH|JSON_SET|JSON_TYPE|JSON_UNQUOTE|JSON_VALID|JSON_VALUE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/json-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/json-functions/
       scope: support.function.json.sql
     - match: (?i)\b(SPIDER_BG_DIRECT_SQL|SPIDER_COPY_TABLES|SPIDER_DIRECT_SQL|SPIDER_FLUSH_TABLE_MON_CACHE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/spider-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/spider-functions/
       scope: support.function.spider.sql
     - match: (?i)\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|LAG|LEAD|MEDIAN|NTH_VALUE|NTILE|PERCENT_RANK|PERCENTILE_CONT|PERCENTILE_DISC|RANK|ROW_NUMBER)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/window-functions/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/window-functions/
       scope: support.function.window.sql
     - match: (?i)\b(BUFFER|ConvexHull|GeometryCollection|LineString|MultiLineString|MultiPoint|MultiPolygon|PointOnSurface|ST_BUFFER|ST_ConvexHull|ST_PointOnSurface|ST_INTERSECTION|ST_SYMDIFFERENCE|ST_UNION)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-constructors/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-constructors/
       scope: support.function.geographic.geometry.constructor.sql
     - match: (?i)\b(BOUNDARY|DIMENSION|ENVELOPE|GeometryN|GeometryType|IsClosed|IsEmpty|IsRing|IsSimple|NumGeometries|SRID|ST_BOUNDARY|ST_DIMENSION|ST_ENVELOPE|ST_GeometryN|ST_GeometryType|ST_IsClosed|ST_IsEmpty|ST_IsRing|ST_IsSimple|ST_NumGeometries|ST_Relate|ST_SRID)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-properties/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-properties/
       scope: support.function.geographic.property.geometry.sql
     - match: (?i)\b(CONTAINS|CROSSES|DISJOINT|EQUALS|INTERSECTS|OVERLAPS|ST_CONTAINS|ST_CROSSES|ST_DIFFERENCE|ST_DISJOINT|ST_DISTANCE|ST_EQUALS|ST_INTERSECTS|ST_LENGTH|ST_OVERLAPS|ST_TOUCHES|ST_WITHIN|TOUCHES|WITHIN)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-relations/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-relations/
       scope: support.function.geographic.geometry.relation.sql
     - match: (?i)\b(EndPoint|GLength|NumPoints|PointN|ST_EndPoint|ST_NumPoints|ST_PointN|ST_StartPoint|StartPoint)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/linestring-properties/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/linestring-properties/
       scope: support.function.geographic.linestring.sql
     - match: (?i)\b(MBRContains|MBRDisjoint|MBREqual|MBRIntersects|MBROverlaps|MBRTouches|MBRWithin)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/mbr-minimum-bounding-rectangle/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/mbr-minimum-bounding-rectangle/
       scope: support.function.geographic.mbr.sql
     - match: (?i)\b(ST_X|ST_Y|X|Y)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/point-properties/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/point-properties/
       scope: support.function.geographic.property.point.sql
     - match: (?i)\b(Area|Centroid|ExteriorRing|InteriorRingN|NumInteriorRings|ST_Area|ST_Centroid|ST_ExteriorRing|ST_InteriorRingN|ST_NumInteriorRings)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/polygon-properties/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/polygon-properties/
       scope: support.function.geographic.property.polygon.sql
     - match: (?i)\b(AsBinary|AsWKB|GeomCollFromWKB|GeometryCollectionFromWKB|GeometryFromWKB|GeomFromWKB|LineFromWKB|LineStringFromWKB|MLineFromWKB|MPointFromWKB|MPolyFromWKB|MultiLineStringFromWKB|MultiPointFromWKB|MultiPolygonFromWKB|PointFromWKB|PolyFromWKB|PolygonFromWKB|ST_AsBinary|ST_AsWKB|ST_GeomCollFromWKB|ST_GeometryCollectionFromWKB|ST_GeometryFromWKB|ST_GeomFromWKB|ST_LineFromWKB|ST_LineStringFromWKB|ST_PointFromWKB|ST_PolyFromWKB|ST_PolygonFromWKB)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkb/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkb/
       scope: support.function.geographic.wkb.sql
     - match: (?i)\b(AsText|AsWKT|GeomCollFromText|GeometryCollectionFromText|GeometryFromText|GeomFromText|LineFromText|LineStringFromText|MLineFromText|MPointFromText|MPolyFromText|MultiLineStringFromText|MultiPointFromText|MultiPolygonFromText|PointFromText|PolyFromText|PolygonFromText|ST_AsText|ST_AsWKT|ST_GeomCollFromText|ST_GeometryCollectionFromText|ST_GeometryFromText|ST_GeomFromText|ST_LineFromText|ST_LineStringFromText|ST_PointFromText|ST_PolyFromText|ST_PolygonFromText)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkt/
+      # List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkt/
       scope: support.function.geographic.wkt.sql

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -10,62 +10,62 @@ contexts:
   main:
     - meta_append: true
     - match: (?i)\b(abs|cbrt|ceil|ceiling|degrees|div|exp|floor|ln|log|mod|pi|power|radians|round|sign|sqrt|trunc|width_bucket)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
       scope: support.function.numeric.sql
     - match: (?i)\b(random|setseed)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
       scope: support.function.numeric.random.sql
     - match: (?i)\b(acos|asin|atan|atan2|cos|cot|sin|tan)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
       scope: support.function.numeric.trigonometric.sql
     - match: (?i)\b(bit_length|char_length|octet_length|overlay|position)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html
       scope: support.function.string.sql
     - match: (?i)\b(ascii|btrim|chr|concat|concat_ws|convert_from|convert_to|decode|encode|format|get_bit|get_byte|initcap|left|length|lpad|ltrim|md5|pg_client_encoding|quote_ident|quote_literal|quote_nullable|regexp_matches|regexp_replace|regexp_split_to_array|regexp_split_to_table|repeat|replace|reverse|right|rpad|rtrim|set_bit|set_byte|split_part|strpos|substr|to_ascii|to_hex)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html and https://www.postgresql.org/docs/9.4/functions-binarystring.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html and https://www.postgresql.org/docs/9.4/functions-binarystring.html
       scope: support.function.string.other.sql
     - match: (?i)\b(age|clock_timestamp|date_part|date_trunc|extract|isfinite|justify_days|justify_hours|justify_interval|localtime|localtimestamp|make_date|make_interval|make_time|make_timestamp|make_timestamptz|now|statement_timestamp|timeofday|to_char|to_date|to_number|to_timestamp|transaction_timestamp)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-formatting.html and https://www.postgresql.org/docs/9.4/functions-datetime.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-formatting.html and https://www.postgresql.org/docs/9.4/functions-datetime.html
       scope: support.function.time.sql
     - match: (?i)\b(enum_first|enum_last|enum_range|enum_range)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-enum.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-enum.html
       scope: support.function.enum.sql
     - match: (?i)\b(area|center|diameter|height|isclosed|isopen|length|npoints|pclose|popen|radius|width)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-geometry.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-geometry.html
       scope: support.function.geographic.geometry.sql
     - match: (?i)\b(abbrev|broadcast|family|host|hostmask|masklen|netmask|network|set_masklen)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-net.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-net.html
       scope: support.function.network.sql
     - match: (?i)\b(cursor_to_xml|cursor_to_xmlschema|database_to_xml|database_to_xml_and_xmlschema|database_to_xmlschema|query_to_xml|query_to_xml_and_xmlschema|query_to_xmlschema|schema_to_xml|schema_to_xml_and_xmlschema|schema_to_xmlschema|table_to_xml|table_to_xml_and_xmlschema|table_to_xmlschema|xml_is_well_formed|xmlagg|xmlcomment|xmlconcat|xmlelement|xmlexists|xmlforest|xmlpi|xmlroot|xpath)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-xml.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-xml.html
       scope: support.function.xml.sql
     - match: (?i)\b(array_to_json|json_array_elements|json_array_elements_text|json_array_length|json_build_array|json_build_object|json_each|json_each_text|json_extract_path|json_extract_path_text|json_object|json_object_keys|json_populate_record|json_populate_recordset|json_to_record|json_to_recordset|json_typeof|row_to_json|to_json)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-json.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-json.html
       scope: support.function.json.sql
     - match: (?i)\b(currval|lastval|nextval|setval)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-sequence.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-sequence.html
       scope: support.function.sequence.sql
     - match: (?i)\b(coalesce|greatest|least|nullif)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-conditional.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-conditional.html
       scope: support.function.controlflow.sql
     - match: (?i)\b(array_append|array_cat|array_dims|array_fill|array_length|array_lower|array_ndims|array_prepend|array_remove|array_replace|array_to_string|array_upper|cardinality|string_to_array|unnest|unnest)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-array.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-array.html
       scope: support.function.array.sql
     - match: (?i)\b(isempty|lower_inc|lower_inf|upper_inc|upper_inf)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-range.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-range.html
       scope: support.function.range.sql
     - match: (?i)\b(array_agg|bit_and|bit_or|bool_and|bool_or|corr|covar_pop|covar_samp|cume_dist|dense_rank|every|json_agg|json_object_agg|mode|percent_rank|percentile_cont|percentile_disc|rank|regr_avgx|regr_avgy|regr_count|regr_intercept|regr_r2|regr_slope|regr_sxx|regr_sxy|regr_syy|stddev|stddev_pop|stddev_samp|string_agg|var_pop|var_samp|variance)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-aggregate.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-aggregate.html
       scope: support.function.aggregate.sql
     - match: (?i)\b(first_value|lag|last_value|lead|nth_value|ntile|row_number)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-window.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-window.html
       scope: support.function.window.sql
     - match: (?i)\b(generate_series|generate_subscripts)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-srf.html
+      # List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-srf.html
       scope: support.function.set.sql
     - match: (?i)\b(col_description|current_catalog|current_database|current_query|current_role|current_schema|current_schemas|format_type|has_any_column_privilege|has_column_privilege|has_database_privilege|has_foreign_data_wrapper_privilege|has_function_privilege|has_language_privilege|has_schema_privilege|has_sequence_privilege|has_server_privilege|has_table_privilege|has_tablespace_privilege|has_type_privilege|inet_client_addr|inet_client_port|inet_server_addr|inet_server_port|obj_description|pg_backend_pid|pg_collation_is_visible|pg_conf_load_time|pg_conversion_is_visible|pg_describe_object|pg_function_is_visible|pg_get_constraintdef|pg_get_expr|pg_get_function_arguments|pg_get_function_identity_arguments|pg_get_function_result|pg_get_functiondef|pg_get_indexdef|pg_get_keywords|pg_get_ruledef|pg_get_serial_sequence|pg_get_triggerdef|pg_get_userbyid|pg_get_viewdef|pg_has_role|pg_identify_object|pg_is_other_temp_schema|pg_listening_channels|pg_my_temp_schema|pg_opclass_is_visible|pg_operator_is_visible|pg_opfamily_is_visible|pg_options_to_table|pg_postmaster_start_time|pg_table_is_visible|pg_tablespace_databases|pg_tablespace_location|pg_trigger_depth|pg_ts_config_is_visible|pg_ts_dict_is_visible|pg_ts_parser_is_visible|pg_ts_template_is_visible|pg_type_is_visible|pg_typeof|shobj_description|to_regclass|to_regoper|to_regoperator|to_regproc|to_regprocedure|to_regtype|txid_current|txid_current_snapshot|txid_snapshot_xip|txid_snapshot_xmax|txid_snapshot_xmin|txid_visible_in_snapshot|user|version|xip_list|xmax|xmin)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL
+      # List of built-in functions for PostgreSQL
       scope: support.function.information.sql
     - match: (?i)\b(current_setting|pg_advisory_lock|pg_advisory_lock_shared|pg_advisory_unlock|pg_advisory_unlock_all|pg_advisory_unlock_shared|pg_advisory_xact_lock|pg_advisory_xact_lock_shared|pg_backup_start_time|pg_cancel_backend|pg_column_size|pg_create_logical_replication_slot|pg_create_physical_replication_slot|pg_create_restore_point|pg_current_xlog_insert_location|pg_current_xlog_location|pg_database_size|pg_drop_replication_slot|pg_export_snapshot|pg_filenode_relation|pg_indexes_size|pg_is_in_backup|pg_is_in_recovery|pg_is_xlog_replay_paused|pg_last_xact_replay_timestamp|pg_last_xlog_receive_location|pg_last_xlog_replay_location|pg_logical_slot_get_binary_changes|pg_logical_slot_get_changes|pg_logical_slot_peek_binary_changes|pg_logical_slot_peek_changes|pg_ls_dir|pg_read_binary_file|pg_read_file|pg_relation_filenode|pg_relation_filepath|pg_relation_size|pg_reload_conf|pg_rotate_logfile|pg_size_pretty|pg_start_backup|pg_stat_file|pg_stop_backup|pg_switch_xlog|pg_table_size|pg_tablespace_size|pg_terminate_backend|pg_total_relation_size|pg_try_advisory_lock|pg_try_advisory_lock_shared|pg_try_advisory_xact_lock|pg_try_advisory_xact_lock_shared|pg_xlog_location_diff|pg_xlog_replay_pause|pg_xlog_replay_resume|pg_xlogfile_name|pg_xlogfile_name_offset|set_config)(?=\s*\()
-      comment: List of built-in functions for PostgreSQL https://www.postgresql.org/docs/9.4/functions-admin.html
+      # List of built-in functions for PostgreSQL https://www.postgresql.org/docs/9.4/functions-admin.html
       scope: support.function.admin.sql

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -1,0 +1,71 @@
+%YAML 1.2
+---
+name: PostgreSQL
+scope: source.sql.postgresql
+version: 2
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  main:
+    - meta_append: true
+    - match: (?i)\b(abs|cbrt|ceil|ceiling|degrees|div|exp|floor|ln|log|mod|pi|power|radians|round|sign|sqrt|trunc|width_bucket)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      scope: support.function.numeric.sql
+    - match: (?i)\b(random|setseed)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      scope: support.function.numeric.random.sql
+    - match: (?i)\b(acos|asin|atan|atan2|cos|cot|sin|tan)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-math.html
+      scope: support.function.numeric.trigonometric.sql
+    - match: (?i)\b(bit_length|char_length|octet_length|overlay|position)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html
+      scope: support.function.string.sql
+    - match: (?i)\b(ascii|btrim|chr|concat|concat_ws|convert_from|convert_to|decode|encode|format|get_bit|get_byte|initcap|left|length|lpad|ltrim|md5|pg_client_encoding|quote_ident|quote_literal|quote_nullable|regexp_matches|regexp_replace|regexp_split_to_array|regexp_split_to_table|repeat|replace|reverse|right|rpad|rtrim|set_bit|set_byte|split_part|strpos|substr|to_ascii|to_hex)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-string.html and https://www.postgresql.org/docs/9.4/functions-binarystring.html
+      scope: support.function.string.other.sql
+    - match: (?i)\b(age|clock_timestamp|date_part|date_trunc|extract|isfinite|justify_days|justify_hours|justify_interval|localtime|localtimestamp|make_date|make_interval|make_time|make_timestamp|make_timestamptz|now|statement_timestamp|timeofday|to_char|to_date|to_number|to_timestamp|transaction_timestamp)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-formatting.html and https://www.postgresql.org/docs/9.4/functions-datetime.html
+      scope: support.function.time.sql
+    - match: (?i)\b(enum_first|enum_last|enum_range|enum_range)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-enum.html
+      scope: support.function.enum.sql
+    - match: (?i)\b(area|center|diameter|height|isclosed|isopen|length|npoints|pclose|popen|radius|width)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-geometry.html
+      scope: support.function.geographic.geometry.sql
+    - match: (?i)\b(abbrev|broadcast|family|host|hostmask|masklen|netmask|network|set_masklen)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-net.html
+      scope: support.function.network.sql
+    - match: (?i)\b(cursor_to_xml|cursor_to_xmlschema|database_to_xml|database_to_xml_and_xmlschema|database_to_xmlschema|query_to_xml|query_to_xml_and_xmlschema|query_to_xmlschema|schema_to_xml|schema_to_xml_and_xmlschema|schema_to_xmlschema|table_to_xml|table_to_xml_and_xmlschema|table_to_xmlschema|xml_is_well_formed|xmlagg|xmlcomment|xmlconcat|xmlelement|xmlexists|xmlforest|xmlpi|xmlroot|xpath)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-xml.html
+      scope: support.function.xml.sql
+    - match: (?i)\b(array_to_json|json_array_elements|json_array_elements_text|json_array_length|json_build_array|json_build_object|json_each|json_each_text|json_extract_path|json_extract_path_text|json_object|json_object_keys|json_populate_record|json_populate_recordset|json_to_record|json_to_recordset|json_typeof|row_to_json|to_json)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-json.html
+      scope: support.function.json.sql
+    - match: (?i)\b(currval|lastval|nextval|setval)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-sequence.html
+      scope: support.function.sequence.sql
+    - match: (?i)\b(coalesce|greatest|least|nullif)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-conditional.html
+      scope: support.function.controlflow.sql
+    - match: (?i)\b(array_append|array_cat|array_dims|array_fill|array_length|array_lower|array_ndims|array_prepend|array_remove|array_replace|array_to_string|array_upper|cardinality|string_to_array|unnest|unnest)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-array.html
+      scope: support.function.array.sql
+    - match: (?i)\b(isempty|lower_inc|lower_inf|upper_inc|upper_inf)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-range.html
+      scope: support.function.range.sql
+    - match: (?i)\b(array_agg|bit_and|bit_or|bool_and|bool_or|corr|covar_pop|covar_samp|cume_dist|dense_rank|every|json_agg|json_object_agg|mode|percent_rank|percentile_cont|percentile_disc|rank|regr_avgx|regr_avgy|regr_count|regr_intercept|regr_r2|regr_slope|regr_sxx|regr_sxy|regr_syy|stddev|stddev_pop|stddev_samp|string_agg|var_pop|var_samp|variance)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-aggregate.html
+      scope: support.function.aggregate.sql
+    - match: (?i)\b(first_value|lag|last_value|lead|nth_value|ntile|row_number)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-window.html
+      scope: support.function.window.sql
+    - match: (?i)\b(generate_series|generate_subscripts)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL from https://www.postgresql.org/docs/9.4/functions-srf.html
+      scope: support.function.set.sql
+    - match: (?i)\b(col_description|current_catalog|current_database|current_query|current_role|current_schema|current_schemas|format_type|has_any_column_privilege|has_column_privilege|has_database_privilege|has_foreign_data_wrapper_privilege|has_function_privilege|has_language_privilege|has_schema_privilege|has_sequence_privilege|has_server_privilege|has_table_privilege|has_tablespace_privilege|has_type_privilege|inet_client_addr|inet_client_port|inet_server_addr|inet_server_port|obj_description|pg_backend_pid|pg_collation_is_visible|pg_conf_load_time|pg_conversion_is_visible|pg_describe_object|pg_function_is_visible|pg_get_constraintdef|pg_get_expr|pg_get_function_arguments|pg_get_function_identity_arguments|pg_get_function_result|pg_get_functiondef|pg_get_indexdef|pg_get_keywords|pg_get_ruledef|pg_get_serial_sequence|pg_get_triggerdef|pg_get_userbyid|pg_get_viewdef|pg_has_role|pg_identify_object|pg_is_other_temp_schema|pg_listening_channels|pg_my_temp_schema|pg_opclass_is_visible|pg_operator_is_visible|pg_opfamily_is_visible|pg_options_to_table|pg_postmaster_start_time|pg_table_is_visible|pg_tablespace_databases|pg_tablespace_location|pg_trigger_depth|pg_ts_config_is_visible|pg_ts_dict_is_visible|pg_ts_parser_is_visible|pg_ts_template_is_visible|pg_type_is_visible|pg_typeof|shobj_description|to_regclass|to_regoper|to_regoperator|to_regproc|to_regprocedure|to_regtype|txid_current|txid_current_snapshot|txid_snapshot_xip|txid_snapshot_xmax|txid_snapshot_xmin|txid_visible_in_snapshot|user|version|xip_list|xmax|xmin)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL
+      scope: support.function.information.sql
+    - match: (?i)\b(current_setting|pg_advisory_lock|pg_advisory_lock_shared|pg_advisory_unlock|pg_advisory_unlock_all|pg_advisory_unlock_shared|pg_advisory_xact_lock|pg_advisory_xact_lock_shared|pg_backup_start_time|pg_cancel_backend|pg_column_size|pg_create_logical_replication_slot|pg_create_physical_replication_slot|pg_create_restore_point|pg_current_xlog_insert_location|pg_current_xlog_location|pg_database_size|pg_drop_replication_slot|pg_export_snapshot|pg_filenode_relation|pg_indexes_size|pg_is_in_backup|pg_is_in_recovery|pg_is_xlog_replay_paused|pg_last_xact_replay_timestamp|pg_last_xlog_receive_location|pg_last_xlog_replay_location|pg_logical_slot_get_binary_changes|pg_logical_slot_get_changes|pg_logical_slot_peek_binary_changes|pg_logical_slot_peek_changes|pg_ls_dir|pg_read_binary_file|pg_read_file|pg_relation_filenode|pg_relation_filepath|pg_relation_size|pg_reload_conf|pg_rotate_logfile|pg_size_pretty|pg_start_backup|pg_stat_file|pg_stop_backup|pg_switch_xlog|pg_table_size|pg_tablespace_size|pg_terminate_backend|pg_total_relation_size|pg_try_advisory_lock|pg_try_advisory_lock_shared|pg_try_advisory_xact_lock|pg_try_advisory_xact_lock_shared|pg_xlog_location_diff|pg_xlog_replay_pause|pg_xlog_replay_resume|pg_xlogfile_name|pg_xlogfile_name_offset|set_config)(?=\s*\()
+      comment: List of built-in functions for PostgreSQL https://www.postgresql.org/docs/9.4/functions-admin.html
+      scope: support.function.admin.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -126,6 +126,75 @@ contexts:
       scope: support.function.aggregate.sql
     - match: (?i)\b(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
+    - match: (?i)\b(AGAINST|ASCII|BIN|BIT_LENGTH|CAST|CHAR_LENGTH|CHARACTER_LENGTH|CHR|CONCAT|CONCAT_WS|ELT|EXPORT_SET|EXTRACTVALUE|FIELD|FIND_IN_SET|FORMAT|FROM_BASE64|HEX|INSTR|LCASE|LEFT|LENGTH|LENGTHB|LOAD_FILE|LOCATE|LPAD|LPAD_ORACLE|LTRIM|LTRIM_ORACLE|MAKE_SET|MATCH|MID|OCTET_LENGTH|ORD|POSITION|QUOTE|REPEAT|REPLACE|REVERSE|RIGHT|RPAD|RTRIM|SOUNDEX|SPACE|STRCMP|SUBSTR|SUBSTRING_INDEX|TO_BASE64|TRIM_ORACLE|UCASE|UNHEX|UPDATEXML|WEIGHT_STRING)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/string-functions/
+      scope: support.function.string.sql
+    - match: (?i)\b(REGEXP_INSTR|REGEXP_REPLACE|REGEXP_SUBSTR)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/regular-expressions-functions/
+      scope: support.function.string.regexp.sql
+    - match: (?i)\b(ADDDATE|ADDTIME|CONVERT_TZ|CURDATE|CURTIME|DATE_ADD|DATE_FORMAT|DATE_SUB|DATEDIFF|DAY|DAYNAME|DAYOFMONTH|DAYOFWEEK|DAYOFYEAR|EXTRACT|FROM_DAYS|FROM_UNIXTIME|GET_FORMAT|HOUR|LAST_DAY|LOCALTIME|LOCALTIMESTAMP|MAKEDATE|MAKETIME|MICROSECOND|MINUTE|MONTH|MONTHNAME|NOW|PERIOD_ADD|PERIOD_DIFF|QUARTER|SEC_TO_TIME|SECOND|STR_TO_DATE|SUBDATE|SUBTIME|TIME_FORMAT|TIME_TO_SEC|TIMEDIFF|TIMESTAMPADD|TIMESTAMPDIFF|TO_DAYS|TO_SECONDS|UNIX_TIMESTAMP|UTC_DATE|UTC_TIME|UTC_TIMESTAMP|WEEK|WEEKDAY|WEEKOFYEAR|YEAR|YEARWEEK)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/date-time-functions/
+      scope: support.function.time.sql
+    - match: (?i)\b(BIT_AND|BIT_OR|BIT_XOR|GROUP_CONCAT|JSON_ARRAYAGG|JSON_OBJECTAGG|STD|STDDEV|STDDEV_POP|STDDEV_SAMP|VAR_POP|VAR_SAMP|VARIANCE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/aggregate-functions/
+      scope: support.function.aggregate.sql
+    - match: (?i)\b(ABS|ACOS|ASIN|ATAN|ATAN2|CEIL|CEILING|CONV|COS|COT|CRC32|DEGREES|EXP|FLOOR|GREATEST|LEAST|LN|LOG|LOG10|LOG2|MOD|OCT|PI|POW|POWER|RADIANS|RAND|ROUND|SIGN|SIN|SQRT|TAN)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/numeric-functions/
+      scope: support.function.numeric.sql
+    - match: (?i)\b(IFNULL|NULLIF)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/control-flow-functions/
+      scope: support.function.controlflow.sql
+    - match: (?i)\b(BIT_COUNT)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/bit-functions-and-operators/
+      scope: support.function.bit.sql
+    - match: (?i)\b(AES_DECRYPT|AES_ENCRYPT|COMPRESS|DECODE|DES_DECRYPT|DES_ENCRYPT|ENCODE|ENCRYPT|MD5|OLD_PASSWORD|PASSWORD|SHA1|SHA2|UNCOMPRESS|UNCOMPRESSED_LENGTH)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/encryption-hashing-and-compression-functions/
+      scope: support.function.encryption.sql
+    - match: (?i)\b(BENCHMARK|BINLOG_GTID_POS|CHARSET|COERCIBILITY|COLLATION|CONNECTION_ID|CURRENT_ROLE|DATABASE|DECODE_HISTOGRAM|FOUND_ROWS|LAST_INSERT_ID|LAST_VALUE|ROW_COUNT|SCHEMA|USER|VERSION)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/information-functions/
+      scope: support.function.information.sql
+    - match: (?i)\b(GET_LOCK|INET6_ATON|INET6_NTOA|INET_ATON|INET_NTOA|IS_FREE_LOCK|IS_IPV4|IS_IPV4_COMPAT|IS_IPV4_MAPPED|IS_IPV6|IS_USED_LOCK|MASTER_GTID_WAIT|MASTER_POS_WAIT|NAME_CONST|RELEASE_ALL_LOCKS|RELEASE_LOCK|SLEEP|UUID|UUID_SHORT)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/miscellaneous-functions/
+      scope: support.function.other.sql
+    - match: (?i)\b(COLUMN_ADD|COLUMN_CHECK|COLUMN_CREATE|COLUMN_DELETE|COLUMN_EXISTS|COLUMN_GET|COLUMN_JSON|COLUMN_LIST)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/dynamic-columns-functions/
+      scope: support.function.columns.sql
+    - match: (?i)\b(JSON_ARRAY|JSON_ARRAY_APPEND|JSON_ARRAY_INSERT|JSON_COMPACT|JSON_CONTAINS|JSON_CONTAINS_PATH|JSON_DEPTH|JSON_DETAILED|JSON_EXISTS|JSON_EXTRACT|JSON_INSERT|JSON_KEYS|JSON_LENGTH|JSON_LOOSE|JSON_MERGE|JSON_MERGE_PATCH|JSON_MERGE_PRESERVE|JSON_OBJECT|JSON_QUERY|JSON_QUOTE|JSON_REMOVE|JSON_REPLACE|JSON_SEARCH|JSON_SET|JSON_TYPE|JSON_UNQUOTE|JSON_VALID|JSON_VALUE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/json-functions/
+      scope: support.function.json.sql
+    - match: (?i)\b(SPIDER_BG_DIRECT_SQL|SPIDER_COPY_TABLES|SPIDER_DIRECT_SQL|SPIDER_FLUSH_TABLE_MON_CACHE)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/spider-functions/
+      scope: support.function.spider.sql
+    - match: (?i)\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|LAG|LEAD|MEDIAN|NTH_VALUE|NTILE|PERCENT_RANK|PERCENTILE_CONT|PERCENTILE_DISC|RANK|ROW_NUMBER)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/window-functions/
+      scope: support.function.window.sql
+    - match: (?i)\b(BUFFER|ConvexHull|GeometryCollection|LineString|MultiLineString|MultiPoint|MultiPolygon|PointOnSurface|ST_BUFFER|ST_ConvexHull|ST_PointOnSurface|ST_INTERSECTION|ST_SYMDIFFERENCE|ST_UNION)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-constructors/
+      scope: support.function.geographic.geometry.constructor.sql
+    - match: (?i)\b(BOUNDARY|DIMENSION|ENVELOPE|GeometryN|GeometryType|IsClosed|IsEmpty|IsRing|IsSimple|NumGeometries|SRID|ST_BOUNDARY|ST_DIMENSION|ST_ENVELOPE|ST_GeometryN|ST_GeometryType|ST_IsClosed|ST_IsEmpty|ST_IsRing|ST_IsSimple|ST_NumGeometries|ST_Relate|ST_SRID)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-properties/
+      scope: support.function.geographic.property.geometry.sql
+    - match: (?i)\b(CONTAINS|CROSSES|DISJOINT|EQUALS|INTERSECTS|OVERLAPS|ST_CONTAINS|ST_CROSSES|ST_DIFFERENCE|ST_DISJOINT|ST_DISTANCE|ST_EQUALS|ST_INTERSECTS|ST_LENGTH|ST_OVERLAPS|ST_TOUCHES|ST_WITHIN|TOUCHES|WITHIN)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-relations/
+      scope: support.function.geographic.geometry.relation.sql
+    - match: (?i)\b(EndPoint|GLength|NumPoints|PointN|ST_EndPoint|ST_NumPoints|ST_PointN|ST_StartPoint|StartPoint)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/linestring-properties/
+      scope: support.function.geographic.linestring.sql
+    - match: (?i)\b(MBRContains|MBRDisjoint|MBREqual|MBRIntersects|MBROverlaps|MBRTouches|MBRWithin)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/mbr-minimum-bounding-rectangle/
+      scope: support.function.geographic.mbr.sql
+    - match: (?i)\b(ST_X|ST_Y|X|Y)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/point-properties/
+      scope: support.function.geographic.property.point.sql
+    - match: (?i)\b(Area|Centroid|ExteriorRing|InteriorRingN|NumInteriorRings|ST_Area|ST_Centroid|ST_ExteriorRing|ST_InteriorRingN|ST_NumInteriorRings)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/polygon-properties/
+      scope: support.function.geographic.property.polygon.sql
+    - match: (?i)\b(AsBinary|AsWKB|GeomCollFromWKB|GeometryCollectionFromWKB|GeometryFromWKB|GeomFromWKB|LineFromWKB|LineStringFromWKB|MLineFromWKB|MPointFromWKB|MPolyFromWKB|MultiLineStringFromWKB|MultiPointFromWKB|MultiPolygonFromWKB|PointFromWKB|PolyFromWKB|PolygonFromWKB|ST_AsBinary|ST_AsWKB|ST_GeomCollFromWKB|ST_GeometryCollectionFromWKB|ST_GeometryFromWKB|ST_GeomFromWKB|ST_LineFromWKB|ST_LineStringFromWKB|ST_PointFromWKB|ST_PolyFromWKB|ST_PolygonFromWKB)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkb/
+      scope: support.function.geographic.wkb.sql
+    - match: (?i)\b(AsText|AsWKT|GeomCollFromText|GeometryCollectionFromText|GeometryFromText|GeomFromText|LineFromText|LineStringFromText|MLineFromText|MPointFromText|MPolyFromText|MultiLineStringFromText|MultiPointFromText|MultiPolygonFromText|PointFromText|PolyFromText|PolygonFromText|ST_AsText|ST_AsWKT|ST_GeomCollFromText|ST_GeometryCollectionFromText|ST_GeometryFromText|ST_GeomFromText|ST_LineFromText|ST_LineStringFromText|ST_PointFromText|ST_PolyFromText|ST_PolygonFromText)(?=\s*\()
+      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkt/
+      scope: support.function.geographic.wkt.sql
     - match: \b(\w+?)\.(\w+)\b
       captures:
         1: constant.other.database-name.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -120,10 +120,10 @@ contexts:
     - match: \|\|
       scope: keyword.operator.concatenator.sql
     - match: (?i)\b(CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
-      comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
+      # List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.scalar.sql
     - match: (?i)\b(AVG|COUNT|MIN|MAX|SUM)(?=\s*\()
-      comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
+      # List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.aggregate.sql
     - match: (?i)\b(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
@@ -134,7 +134,7 @@ contexts:
     - include: strings
     - include: regexps
     - match: (\()(\))
-      comment: Allow for special ↩ behavior
+      # Allow for special ↩ behavior
       scope: meta.block.sql
       captures:
         1: punctuation.section.scope.begin.sql
@@ -173,7 +173,7 @@ contexts:
         - match: \\/
           scope: constant.character.escape.slash.sql
     - match: '%r\{'
-      comment: We should probably handle nested bracket pairs!?! -- Allan
+      # We should probably handle nested bracket pairs!?! -- Allan
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_scope: string.regexp.modr.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -6,6 +6,7 @@ file_extensions:
   - ddl
   - dml
 scope: source.sql
+version: 2
 
 variables:
   end_identifier: (?=[ \t]*(?:[^\w'"`. \t]|$))
@@ -126,75 +127,6 @@ contexts:
       scope: support.function.aggregate.sql
     - match: (?i)\b(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
-    - match: (?i)\b(AGAINST|ASCII|BIN|BIT_LENGTH|CAST|CHAR_LENGTH|CHARACTER_LENGTH|CHR|CONCAT|CONCAT_WS|ELT|EXPORT_SET|EXTRACTVALUE|FIELD|FIND_IN_SET|FORMAT|FROM_BASE64|HEX|INSTR|LCASE|LEFT|LENGTH|LENGTHB|LOAD_FILE|LOCATE|LPAD|LPAD_ORACLE|LTRIM|LTRIM_ORACLE|MAKE_SET|MATCH|MID|OCTET_LENGTH|ORD|POSITION|QUOTE|REPEAT|REPLACE|REVERSE|RIGHT|RPAD|RTRIM|SOUNDEX|SPACE|STRCMP|SUBSTR|SUBSTRING_INDEX|TO_BASE64|TRIM_ORACLE|UCASE|UNHEX|UPDATEXML|WEIGHT_STRING)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/string-functions/
-      scope: support.function.string.sql
-    - match: (?i)\b(REGEXP_INSTR|REGEXP_REPLACE|REGEXP_SUBSTR)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/regular-expressions-functions/
-      scope: support.function.string.regexp.sql
-    - match: (?i)\b(ADDDATE|ADDTIME|CONVERT_TZ|CURDATE|CURTIME|DATE_ADD|DATE_FORMAT|DATE_SUB|DATEDIFF|DAY|DAYNAME|DAYOFMONTH|DAYOFWEEK|DAYOFYEAR|EXTRACT|FROM_DAYS|FROM_UNIXTIME|GET_FORMAT|HOUR|LAST_DAY|LOCALTIME|LOCALTIMESTAMP|MAKEDATE|MAKETIME|MICROSECOND|MINUTE|MONTH|MONTHNAME|NOW|PERIOD_ADD|PERIOD_DIFF|QUARTER|SEC_TO_TIME|SECOND|STR_TO_DATE|SUBDATE|SUBTIME|TIME_FORMAT|TIME_TO_SEC|TIMEDIFF|TIMESTAMPADD|TIMESTAMPDIFF|TO_DAYS|TO_SECONDS|UNIX_TIMESTAMP|UTC_DATE|UTC_TIME|UTC_TIMESTAMP|WEEK|WEEKDAY|WEEKOFYEAR|YEAR|YEARWEEK)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/date-time-functions/
-      scope: support.function.time.sql
-    - match: (?i)\b(BIT_AND|BIT_OR|BIT_XOR|GROUP_CONCAT|JSON_ARRAYAGG|JSON_OBJECTAGG|STD|STDDEV|STDDEV_POP|STDDEV_SAMP|VAR_POP|VAR_SAMP|VARIANCE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/aggregate-functions/
-      scope: support.function.aggregate.sql
-    - match: (?i)\b(ABS|ACOS|ASIN|ATAN|ATAN2|CEIL|CEILING|CONV|COS|COT|CRC32|DEGREES|EXP|FLOOR|GREATEST|LEAST|LN|LOG|LOG10|LOG2|MOD|OCT|PI|POW|POWER|RADIANS|RAND|ROUND|SIGN|SIN|SQRT|TAN)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/numeric-functions/
-      scope: support.function.numeric.sql
-    - match: (?i)\b(IFNULL|NULLIF)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/control-flow-functions/
-      scope: support.function.controlflow.sql
-    - match: (?i)\b(BIT_COUNT)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/bit-functions-and-operators/
-      scope: support.function.bit.sql
-    - match: (?i)\b(AES_DECRYPT|AES_ENCRYPT|COMPRESS|DECODE|DES_DECRYPT|DES_ENCRYPT|ENCODE|ENCRYPT|MD5|OLD_PASSWORD|PASSWORD|SHA1|SHA2|UNCOMPRESS|UNCOMPRESSED_LENGTH)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/encryption-hashing-and-compression-functions/
-      scope: support.function.encryption.sql
-    - match: (?i)\b(BENCHMARK|BINLOG_GTID_POS|CHARSET|COERCIBILITY|COLLATION|CONNECTION_ID|CURRENT_ROLE|DATABASE|DECODE_HISTOGRAM|FOUND_ROWS|LAST_INSERT_ID|LAST_VALUE|ROW_COUNT|SCHEMA|USER|VERSION)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/information-functions/
-      scope: support.function.information.sql
-    - match: (?i)\b(GET_LOCK|INET6_ATON|INET6_NTOA|INET_ATON|INET_NTOA|IS_FREE_LOCK|IS_IPV4|IS_IPV4_COMPAT|IS_IPV4_MAPPED|IS_IPV6|IS_USED_LOCK|MASTER_GTID_WAIT|MASTER_POS_WAIT|NAME_CONST|RELEASE_ALL_LOCKS|RELEASE_LOCK|SLEEP|UUID|UUID_SHORT)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/miscellaneous-functions/
-      scope: support.function.other.sql
-    - match: (?i)\b(COLUMN_ADD|COLUMN_CHECK|COLUMN_CREATE|COLUMN_DELETE|COLUMN_EXISTS|COLUMN_GET|COLUMN_JSON|COLUMN_LIST)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/dynamic-columns-functions/
-      scope: support.function.columns.sql
-    - match: (?i)\b(JSON_ARRAY|JSON_ARRAY_APPEND|JSON_ARRAY_INSERT|JSON_COMPACT|JSON_CONTAINS|JSON_CONTAINS_PATH|JSON_DEPTH|JSON_DETAILED|JSON_EXISTS|JSON_EXTRACT|JSON_INSERT|JSON_KEYS|JSON_LENGTH|JSON_LOOSE|JSON_MERGE|JSON_MERGE_PATCH|JSON_MERGE_PRESERVE|JSON_OBJECT|JSON_QUERY|JSON_QUOTE|JSON_REMOVE|JSON_REPLACE|JSON_SEARCH|JSON_SET|JSON_TYPE|JSON_UNQUOTE|JSON_VALID|JSON_VALUE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/json-functions/
-      scope: support.function.json.sql
-    - match: (?i)\b(SPIDER_BG_DIRECT_SQL|SPIDER_COPY_TABLES|SPIDER_DIRECT_SQL|SPIDER_FLUSH_TABLE_MON_CACHE)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/spider-functions/
-      scope: support.function.spider.sql
-    - match: (?i)\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|LAG|LEAD|MEDIAN|NTH_VALUE|NTILE|PERCENT_RANK|PERCENTILE_CONT|PERCENTILE_DISC|RANK|ROW_NUMBER)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/window-functions/
-      scope: support.function.window.sql
-    - match: (?i)\b(BUFFER|ConvexHull|GeometryCollection|LineString|MultiLineString|MultiPoint|MultiPolygon|PointOnSurface|ST_BUFFER|ST_ConvexHull|ST_PointOnSurface|ST_INTERSECTION|ST_SYMDIFFERENCE|ST_UNION)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-constructors/
-      scope: support.function.geographic.geometry.constructor.sql
-    - match: (?i)\b(BOUNDARY|DIMENSION|ENVELOPE|GeometryN|GeometryType|IsClosed|IsEmpty|IsRing|IsSimple|NumGeometries|SRID|ST_BOUNDARY|ST_DIMENSION|ST_ENVELOPE|ST_GeometryN|ST_GeometryType|ST_IsClosed|ST_IsEmpty|ST_IsRing|ST_IsSimple|ST_NumGeometries|ST_Relate|ST_SRID)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-properties/
-      scope: support.function.geographic.property.geometry.sql
-    - match: (?i)\b(CONTAINS|CROSSES|DISJOINT|EQUALS|INTERSECTS|OVERLAPS|ST_CONTAINS|ST_CROSSES|ST_DIFFERENCE|ST_DISJOINT|ST_DISTANCE|ST_EQUALS|ST_INTERSECTS|ST_LENGTH|ST_OVERLAPS|ST_TOUCHES|ST_WITHIN|TOUCHES|WITHIN)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/geometry-relations/
-      scope: support.function.geographic.geometry.relation.sql
-    - match: (?i)\b(EndPoint|GLength|NumPoints|PointN|ST_EndPoint|ST_NumPoints|ST_PointN|ST_StartPoint|StartPoint)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/linestring-properties/
-      scope: support.function.geographic.linestring.sql
-    - match: (?i)\b(MBRContains|MBRDisjoint|MBREqual|MBRIntersects|MBROverlaps|MBRTouches|MBRWithin)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/mbr-minimum-bounding-rectangle/
-      scope: support.function.geographic.mbr.sql
-    - match: (?i)\b(ST_X|ST_Y|X|Y)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/point-properties/
-      scope: support.function.geographic.property.point.sql
-    - match: (?i)\b(Area|Centroid|ExteriorRing|InteriorRingN|NumInteriorRings|ST_Area|ST_Centroid|ST_ExteriorRing|ST_InteriorRingN|ST_NumInteriorRings)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/polygon-properties/
-      scope: support.function.geographic.property.polygon.sql
-    - match: (?i)\b(AsBinary|AsWKB|GeomCollFromWKB|GeometryCollectionFromWKB|GeometryFromWKB|GeomFromWKB|LineFromWKB|LineStringFromWKB|MLineFromWKB|MPointFromWKB|MPolyFromWKB|MultiLineStringFromWKB|MultiPointFromWKB|MultiPolygonFromWKB|PointFromWKB|PolyFromWKB|PolygonFromWKB|ST_AsBinary|ST_AsWKB|ST_GeomCollFromWKB|ST_GeometryCollectionFromWKB|ST_GeometryFromWKB|ST_GeomFromWKB|ST_LineFromWKB|ST_LineStringFromWKB|ST_PointFromWKB|ST_PolyFromWKB|ST_PolygonFromWKB)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkb/
-      scope: support.function.geographic.wkb.sql
-    - match: (?i)\b(AsText|AsWKT|GeomCollFromText|GeometryCollectionFromText|GeometryFromText|GeomFromText|LineFromText|LineStringFromText|MLineFromText|MPointFromText|MPolyFromText|MultiLineStringFromText|MultiPointFromText|MultiPolygonFromText|PointFromText|PolyFromText|PolygonFromText|ST_AsText|ST_AsWKT|ST_GeomCollFromText|ST_GeometryCollectionFromText|ST_GeometryFromText|ST_GeomFromText|ST_LineFromText|ST_LineStringFromText|ST_PointFromText|ST_PolyFromText|ST_PolygonFromText)(?=\s*\()
-      comment: List of built-in functions for MariaDB/MySQL from https://mariadb.com/kb/en/wkt/
-      scope: support.function.geographic.wkt.sql
     - match: \b(\w+?)\.(\w+)\b
       captures:
         1: constant.other.database-name.sql


### PR DESCRIPTION
This PR adds support for the build-in MariaDB/MySQL functions listed in:
https://mariadb.com/kb/en/built-in-functions/

Due to possible conflicts, the following functions are not included: CHAR, DATE, DEFAULT, DISTINCT, IF, INSERT, POINT, POLYGON, SYSDATE, TIME, TIMESTAMP, TRUNCATE, VALUE, VALUES

Those functions were already included: AVG, CONVERT, COUNT, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_USER, LOWER, MAX, MIN, SESSION_USER, SUBSTRING, SUM, SYSTEM_USER, TRIM, UPPER