### PR TITLE
[TypeScript] Use correct scope for accessors in types.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -557,7 +557,7 @@ contexts:
       scope: keyword.operator.word.js
       push: [ts-type-expression-end-no-line-terminator, ts-type-expression-begin]
     - match: \.
-      scope: punctuation.separator.accessor.js
+      scope: punctuation.accessor.js
       push:
         - match: '{{identifier}}'
           scope: support.class.js

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -22,7 +22,7 @@
 let x : T.U<V>;
 //      ^^^^^^ meta.type
 //      ^ support.class
-//       ^ punctuation.separator.accessor
+//       ^ punctuation.accessor
 //        ^ support.class
 //         ^^^ meta.generic
 //          ^ support.class

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -558,7 +558,7 @@ let x: keyof Foo;
 let x: Foo.bar;
 //     ^^^^^^^ meta.type
 //     ^^^ support.class
-//        ^ punctuation.separator.accessor
+//        ^ punctuation.accessor
 //         ^^^ support.class
 
 let x: {
@@ -771,7 +771,7 @@ let x: import ( "foo" ) . Bar ;
 //            ^ punctuation.section.group.begin
 //              ^^^^^ meta.string string.quoted.double
 //                    ^ punctuation.section.group.end
-//                      ^ punctuation.separator.accessor
+//                      ^ punctuation.accessor
 //                        ^^^ support.class
 
     foo < bar > ();


### PR DESCRIPTION
Reported by rafal on Discord. The `punctuation.separator.accessor` scope is nonstandard and apparently interferes with completions.