### PR TITLE
[TypeScript] Slightly improve function assignment detection.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -24,6 +24,17 @@ variables:
       \(
     ))
 
+  arrow_func_lookahead: |-
+    (?x:
+      (?:async\s*)?
+      (?:
+        {{identifier}}
+        | \( ( [^()] | \( [^()]* \) )* \)
+      )
+      \s*
+      (?:=>|:)
+    )
+
 contexts:
   detect-parenthesized-arrow:
     - meta_prepend: true

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -809,3 +809,6 @@ if (a < b || c < d) {}
 //    ^ keyword.operator.logical
 //        ^^ keyword.operator.logical
 //             ^ keyword.operator.logical
+
+const f = (): any => {};
+//    ^ entity.name.function meta.binding.name variable.other.readwrite


### PR DESCRIPTION
For #2634.

This is a quick fix. It should work most of the time and improve upon the previous behavior. However, it's still an approximate lookahead and there could be false positives and negatives. When it fails, the identifier will be highlighted wrong, but everything else should still work.

This is the same implementation that I attempted in #2574. However, I ran into problems there because the lookahead was used for other purposes. #2577 fixed that, so the lookahead is now only used for detection function assignments.

In the long term, I would still like to implement #2267. However, I have not yet found an implementation that would not involve a great deal of code duplication (see https://github.com/sublimehq/sublime_text/issues/3494).