### PR TITLE
[ShellScript] Fix variable parameter expansion

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1587,6 +1587,13 @@ contexts:
         2: keyword.operator.match.shell
 
   expansions-parameter:
+    - match: (\$)(\{)(#)(\})
+      captures:
+        0: meta.interpolation.parameter.shell
+        1: punctuation.definition.variable.shell
+        2: punctuation.section.interpolation.begin.shell
+        3: variable.language.shell
+        4: punctuation.section.interpolation.end.shell
     - match: (\$)(\{)
       captures:
         1: punctuation.definition.variable.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2828,6 +2828,13 @@ ${foo:=bar}
 #           ^ keyword.operator.substitution.shell
 #               ^ punctuation.section.interpolation.end.shell
 
+
+: ${#}  # is the same as $#
+# ^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^ variable.language.shell
+#    ^ punctuation.section.interpolation.end.shell
 : ${#*}
 # ^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell


### PR DESCRIPTION
Addresses one issue of #2635

Bash knows about the special parameter `$#` (number of parameters)
see: https://www.gnu.org/software/bash/manual/bash.html#Special-Parameters

It may be written as parameter expansion `${#}`.

Before this commit the first `#` is always scoped `keyword.operator` as it is meant to be used with `${#foo}`, which returns the length of `foo`'s content.

This commit adds a special pattern to match `${#}` as expansion of a `variable.language`.