### PR TITLE
[D] Fix decimal point scope in floats

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -194,7 +194,7 @@ contexts:
     - include: integer-opt
     - include: not-whitespace-illegal-pop
   integer-opt:
-    - match: '(0[bB])(_?)({{bin_digits}})({{integer_suffix}})?'
+    - match: (0[bB])(_?)({{bin_digits}})({{integer_suffix}})?
       scope: meta.number.integer.binary.d
       captures:
         1: constant.numeric.base.d
@@ -202,7 +202,7 @@ contexts:
         3: constant.numeric.value.d
         4: constant.numeric.suffix.d
       pop: true
-    - match: '(0[xX])(_?)({{hex_digits}})({{integer_suffix}})?'
+    - match: (0[xX])(_?)({{hex_digits}})({{integer_suffix}})?
       scope: meta.number.integer.hexadecimal.d
       captures:
         1: constant.numeric.base.d
@@ -210,7 +210,7 @@ contexts:
         3: constant.numeric.value.d
         4: constant.numeric.suffix.d
       pop: true
-    - match: '({{dec_integer}})({{integer_suffix}})?'
+    - match: ({{dec_integer}})({{integer_suffix}})?
       scope: meta.number.integer.decimal.d
       captures:
         1: constant.numeric.value.d
@@ -222,77 +222,67 @@ contexts:
     - include: not-whitespace-illegal-pop
   floating-point-opt:
     # decimal imaginary numbers
-    - match: '({{dec_integer}})?(?:(\.)({{dec_digits}})?)?({{dec_exponent}})?({{imaginary_suffix}})'
+    - match: ({{dec_integer}}?(?:(\.){{dec_digits}}?)?{{dec_exponent}}?)({{imaginary_suffix}})
       scope: meta.number.imaginary.decimal.d
       captures:
         1: constant.numeric.value.d
         2: punctuation.separator.decimal.d
-        3: constant.numeric.value.d
-        4: constant.numeric.value.exponent.d
-        5: constant.numeric.suffix.d
+        3: constant.numeric.suffix.d
       pop: true
     # decimal floats
     - match: |-
         (?x:
           ({{dec_integer}})
           (?:
-            (?:
+            (
               (\.)
               (?:
                 # 1.1, 1.1e1, 1.1e-1, 1.1f, 1.1e1f, 1.1e-1f, 1.1L, 1.1e1L, 1.1e-1L
-                ({{dec_digits}}) ({{dec_exponent}})?
+                {{dec_digits}} {{dec_exponent}}?
                 # 1.e1, 1.e-1, 1.e1f, 1.e-1f, 1.e1L, 1.e-1L
-                | ({{dec_exponent}})
+                | {{dec_exponent}}
                 # 1., 1.f, 1.L # but not `..` or method/attribute access
                 | (?!\.|\s*[[:alpha:]_]) )
               # 1e1 1e1f 1e1L
-              | ({{dec_exponent}})
+              | {{dec_exponent}}
             ) ({{integer_float_suffix}})?
             # 1f
             | ({{float_suffix}})
           )
           # .1, .1e1, .1e-1, .1f, .1e1f, .1e-1f, .1L, .1e1L, .1e-1L
-          | (\.) ({{dec_digits}}) ({{dec_exponent}})? ({{integer_float_suffix}})?
+          | ( (\.) {{dec_digits}} {{dec_exponent}}? ) ({{integer_float_suffix}})?
         )
       scope: meta.number.float.decimal.d
       captures:
         1: constant.numeric.value.d
-        2: punctuation.separator.decimal.d
-        3: constant.numeric.value.d
-        4: constant.numeric.value.exponent.d
-        5: constant.numeric.value.exponent.d
-        6: constant.numeric.value.exponent.d
-        7: constant.numeric.suffix.d
+        2: constant.numeric.value.d
+        3: punctuation.separator.decimal.d
+        4: constant.numeric.suffix.d
+        5: constant.numeric.suffix.d
+        6: constant.numeric.value.d
+        7: punctuation.separator.decimal.d
         8: constant.numeric.suffix.d
-        9: punctuation.separator.decimal.d
-        10: constant.numeric.value.d
-        11: constant.numeric.value.exponent.d
-        12: constant.numeric.suffix.d
       pop: true
 
     # hexadecimal imaginary numbers
-    - match: (0[xX])(_?)({{hex_digits}})?(?:(\.)({{hex_digits}})?)?({{hex_exponent}})?({{imaginary_suffix}})
+    - match: (0[xX])(_?)({{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}}?)({{imaginary_suffix}})
       scope: meta.number.imaginary.hexadecimal.d
       captures:
         1: constant.numeric.base.d
         2: invalid.illegal.numeric.d
         3: constant.numeric.value.d
         4: punctuation.separator.decimal.d
-        5: constant.numeric.value.d
-        6: constant.numeric.value.exponent.d
-        7: constant.numeric.suffix.d
+        5: constant.numeric.suffix.d
       pop: true
     # hexadecimal floats
-    - match: (0[xX])(_?)({{hex_digits}})?(?:(\.)({{hex_digits}})?)?({{hex_exponent}})({{integer_float_suffix}})?
+    - match: (0[xX])(_?)({{hex_digits}}?(?:(\.){{hex_digits}}?)?{{hex_exponent}})({{integer_float_suffix}})?
       scope: meta.number.float.hexadecimal.d
       captures:
         1: constant.numeric.base.d
         2: invalid.illegal.numeric.d
         3: constant.numeric.value.d
         4: punctuation.separator.decimal.d
-        5: constant.numeric.value.d
-        6: constant.numeric.value.exponent.d
-        7: constant.numeric.suffix.d
+        5: constant.numeric.suffix.d
       pop: true
 
     # binary imaginary numbers

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -233,19 +233,17 @@ imag = 123_45i + 0_.1_i + 12_.e1i;
 //           ^ constant.numeric.suffix.d
 //             ^ keyword.operator.arithmetic.d
 //               ^^^^^^ meta.number.imaginary.decimal.d
-//               ^^ constant.numeric.value.d
+//               ^^^^^ constant.numeric.value.d
 //                 ^ punctuation.separator.decimal.d
-//                  ^^ constant.numeric.value.d
 //                    ^ constant.numeric.suffix.d
 //                        ^^^^^^^ meta.number.imaginary.decimal.d
-//                        ^^^ constant.numeric.value.d
-//                           ^ punctuation.separator.decimal.d
-//                            ^^ constant.numeric.value.exponent.d
-//                              ^ constant.numeric.suffix.d
+//                        ^^^ constant.numeric.value.d - punctuation
+//                           ^ constant.numeric.value.d punctuation.separator.decimal.d
+//                            ^^ constant.numeric.value.d - punctuation
+//                              ^ constant.numeric.suffix.d - punctuation
 imag = 23134723__742e1i;
 //     ^^^^^^^^^^^^^^^^ meta.number.imaginary.decimal.d
-//     ^^^^^^^^^^^^^ constant.numeric.value.d
-//                  ^^ constant.numeric.value.exponent.d
+//     ^^^^^^^^^^^^^^^ constant.numeric.value.d
 //                    ^ constant.numeric.suffix.d
 imag = 0x_3472389742f_i;
 //     ^^^^^^^^^^^^^^^^ meta.number.imaginary.hexadecimal.d
@@ -257,8 +255,7 @@ imag = 0x_34723897p-34i;
 //     ^^^^^^^^^^^^^^^^ meta.number.imaginary.hexadecimal.d
 //     ^^ constant.numeric.base.d
 //       ^ invalid.illegal.numeric.d
-//        ^^^^^^^^ constant.numeric.value.d
-//                ^^^^ constant.numeric.value.exponent.d
+//        ^^^^^^^^^^^^ constant.numeric.value.d
 //                    ^ constant.numeric.suffix.d
 imag = 0x347._23897p-34i;
 //     ^^^^^ meta.number.integer.hexadecimal.d
@@ -277,17 +274,16 @@ imag = 0b_0100_010_00_i;
 
 auto f = 0_.0_;
 //       ^^^^^ meta.number.float.decimal.d
-//       ^^ constant.numeric.value.d
+//       ^^^^^ constant.numeric.value.d
 //         ^ punctuation.separator.decimal.d
-//          ^^ constant.numeric.value.d
 f = 0_.;
 //  ^^^ meta.number.float.decimal.d
-//  ^^ constant.numeric.value.d
-//    ^ punctuation.separator.decimal.d
+//  ^^ constant.numeric.value.d - punctuation
+//    ^ constant.numeric.value.d punctuation.separator.decimal.d
 f = .123_1243;
 //  ^^^^^^^^^ meta.number.float.decimal.d
-//  ^ punctuation.separator.decimal.d
-//   ^^^^^^^^ constant.numeric.value.d
+//  ^ constant.numeric.value.d punctuation.separator.decimal.d
+//   ^^^^^^^^ constant.numeric.value.d - punctuation
 f = ._123_1243 + 1._123;
 //  ^ punctuation.accessor.dot.d
 //   ^^^^^^^^^ variable.other.d
@@ -297,20 +293,18 @@ f = ._123_1243 + 1._123;
 //                 ^^^^ variable.other.d
 f = 3423.2e-45;
 //  ^^^^^^^^^^ meta.number.float.decimal.d
-//  ^^^^ constant.numeric.value.d
-//      ^ punctuation.separator.decimal.d
-//       ^ constant.numeric.value.d
-//        ^^^^ constant.numeric.value.exponent.d
+//  ^^^^ constant.numeric.value.d - punctuation
+//      ^ constant.numeric.value.d punctuation.separator.decimal.d
+//       ^^^^^ constant.numeric.value.d - punctuation
 f = 2.e-45;
 //  ^^^^^^ meta.number.float.decimal.d
-//  ^ constant.numeric.value.d
-//   ^ punctuation.separator.decimal.d
-//    ^^^^ constant.numeric.value.exponent.d
+//  ^ constant.numeric.value.d - punctuation
+//   ^ constant.numeric.value.d punctuation.separator.decimal.d
+//    ^^^^ constant.numeric.value.d - punctuation
 f = .4E+4L;
 //  ^^^^^^ meta.number.float.decimal.d
-//  ^ punctuation.separator.decimal.d
-//   ^ constant.numeric.value.d
-//    ^^^ constant.numeric.value.exponent.d
+//  ^ constant.numeric.value.d punctuation.separator.decimal.d
+//   ^^^^ constant.numeric.value.d - punctuation
 //       ^ constant.numeric.suffix.d
 f =  1f;
 //   ^^ meta.number.float.decimal.d
@@ -319,8 +313,7 @@ f =  1f;
 f = 0x123p2f;
 //  ^^^^^^^^ meta.number.float.hexadecimal.d
 //  ^^ constant.numeric.base.d
-//    ^^^ constant.numeric.value.d
-//       ^^ constant.numeric.value.exponent.d
+//    ^^^^^ constant.numeric.value.d
 //         ^ constant.numeric.suffix.d
 f = 0b10101101f;
 //  ^^^^^^^^^^^ meta.number.float.binary.d
@@ -330,17 +323,14 @@ f = 0b10101101f;
 f = 0x.1aFp2;
 //  ^^^^^^^^ meta.number.float.hexadecimal.d
 //  ^^ constant.numeric.base.d
-//    ^ punctuation.separator.decimal.d
-//     ^ constant.numeric.value.d
-//      ^^ constant.numeric.value.d
-//        ^^ constant.numeric.value.exponent.d
+//    ^ constant.numeric.value.d punctuation.separator.decimal.d
+//     ^^^^^ constant.numeric.value.d - punctuation
 f = 0xF.AP-2f;
 //  ^^^^^^^^^ meta.number.float.hexadecimal.d
 //  ^^ constant.numeric.base.d
-//    ^ constant.numeric.value.d
-//     ^ punctuation.separator.decimal.d
-//      ^ constant.numeric.value.d
-//       ^^^ constant.numeric.value.exponent.d
+//    ^ constant.numeric.value.d - punctuation
+//     ^ constant.numeric.value.d punctuation.separator.decimal.d
+//      ^^^^ constant.numeric.value.d - punctuation
 //          ^ constant.numeric.suffix.d
 
   @foo:


### PR DESCRIPTION
As described in #2630.

Note: I've also removed `exponent` scope to reduce capture groups and because they are not implemented in the majority of syntaxes.