### PR TITLE
[Go] use the `keyword.declaration` convention

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -126,7 +126,7 @@ contexts:
         3: meta.punctuation.accessor.colon.go
         4: meta.variable.function.go
       push:
-        - meta_scope: comment.line.go meta.annotation.go
+        - meta_scope: meta.annotation.go comment.line.go
         - match: \S+
           scope: meta.variable.parameter.go
         # End the annotation scope at EOL, but stretch the comment scope
@@ -614,7 +614,7 @@ contexts:
 
   match-keyword-const:
     - match: \bconst\b
-      scope: storage.type.keyword.const.go
+      scope: keyword.declaration.const.go
       push:
         - match: \(
           scope: punctuation.section.parens.begin.go
@@ -680,7 +680,7 @@ contexts:
 
   match-keyword-func:
     - match: \bfunc\b
-      scope: storage.type.keyword.function.go
+      scope: keyword.declaration.function.go
       push:
         - include: match-comments
 
@@ -721,7 +721,6 @@ contexts:
 
   match-keyword-interface:
     - match: (?=\binterface\b)
-      scope: storage.type.keyword.interface.go
       push: pop-interface
 
   match-keyword-map:
@@ -760,7 +759,7 @@ contexts:
 
   match-keyword-type:
     - match: \btype\b
-      scope: storage.type.keyword.type.go
+      scope: keyword.declaration.type.go
       push:
         - include: match-comments
 
@@ -795,7 +794,7 @@ contexts:
 
   match-keyword-var:
     - match: \bvar\b
-      scope: storage.type.keyword.var.go
+      scope: keyword.declaration.var.go
       push:
         - match: \(
           scope: punctuation.section.parens.begin.go
@@ -985,7 +984,7 @@ contexts:
     - match: (?=\bstruct\b)
       set: pop-struct
     - match: \bfunc\b
-      scope: storage.type.keyword.function.go
+      scope: keyword.declaration.function.go
       set: pop-func-parameter-and-return-lists
     - match: (?={{ident}})
       set: pop-named-type
@@ -1000,7 +999,7 @@ contexts:
 
   pop-struct:
     - match: \bstruct\b
-      scope: storage.type.keyword.struct.go
+      scope: keyword.declaration.struct.go
       set:
         - include: match-comments
         - match: \{
@@ -1042,7 +1041,7 @@ contexts:
 
   pop-interface:
     - match: \binterface\b
-      scope: storage.type.keyword.interface.go
+      scope: keyword.declaration.interface.go
       set:
         - include: match-comments
         - match: \{
@@ -1079,7 +1078,7 @@ contexts:
     # Note: newlines between `map` and `[` are ok, but newlines after `]`
     # terminate the type.
     - match: \bmap\b
-      scope: storage.type.keyword.map.go
+      scope: keyword.declaration.map.go
       set:
         - include: match-comments
         - include: pop-on-semicolon
@@ -1103,7 +1102,7 @@ contexts:
   # perfectly ok.
   pop-chan:
     - match: \bchan\b
-      scope: storage.type.keyword.chan.go
+      scope: keyword.declaration.chan.go
       set: pop-type
 
   pop-named-type:

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -2,7 +2,7 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 
-# The structure and terminology of this syntax reflects the spec:
+# The structure and lexicon of this syntax reflects the Go spec:
 # https://golang.org/ref/spec
 
 # The following is a simplified model of Sublime Text's syntax engine, reverse-
@@ -161,6 +161,9 @@ contexts:
       pop: true
 
   # https://golang.org/ref/spec#Tokens
+  #
+  # Nominally, this should include `match-call-or-type-conversion`; instead,
+  # it's specified in `match-parens` to ensure proper ordering.
   match-tokens:
     - include: match-keywords
     - include: match-identifiers
@@ -199,7 +202,7 @@ contexts:
   # See `match-selector` for field scoping.
   match-identifiers:
     - include: match-predeclared-constants
-    - include: match-call-or-cast
+    - include: match-call-or-type-conversion
     - include: match-short-variable-declarations
     - match: \b_\b
       scope: variable.language.blank.go
@@ -218,12 +221,13 @@ contexts:
     - match: \b(?:true|false|nil)\b
       scope: constant.language.go
 
-  # Note: in Go, calls and casts are syntactically identical. Detecting casts
-  # and scoping them as types is beyond the capabilities of this syntax engine.
+  # Reference: https://golang.org/ref/spec#Predeclared_identifiers
   #
-  # https://golang.org/ref/spec#Predeclared_identifiers
+  # Note: in Go, calls and type conversions are syntactically identical.
+  # Detecting type conversions and scoping them as types is beyond the
+  # capabilities of this syntax engine.
   #
-  # Notes on built-in functions
+  # # Notes on built-in functions
   #
   # Most built-in functions don't need special syntactic support. We scope them
   # for the benefit of the users who prefer to distinguish them from
@@ -237,13 +241,14 @@ contexts:
   # built-in functions ONLY in a function call position. This helps minimize
   # false positives.
   #
-  # Notes on built-in types
+  # # Notes on built-in types
   #
-  # Unlike casts involving a user-defined type, casts involving a built-in
-  # types could be scoped purely as types rather than function calls. However,
-  # we stick to `variable.function.go` to make the treatment of built-ins
-  # purely additive, allowing the user to opt out.
-  match-call-or-cast:
+  # Unlike type conversions involving a user-defined type, type conversions
+  # involving built-in types could be scoped purely as types rather than
+  # function calls, hoping that they haven't been redefined as functions.
+  # However, we stick to `variable.function.go` to make the treatment of
+  # built-ins purely additive, allowing the user to opt out.
+  match-call-or-type-conversion:
     - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
       scope: variable.function.go support.function.builtin.go
       push: pop-arguments-starting-with-type
@@ -254,8 +259,8 @@ contexts:
     - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go
 
-  # See notes on `match-call-or-cast`.
-  pop-call-or-cast:
+  # See notes on `match-call-or-type-conversion`.
+  pop-call-or-type-conversion:
     - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
       scope: variable.function.go support.function.builtin.go
       set: pop-arguments-starting-with-type
@@ -340,13 +345,15 @@ contexts:
         - include: match-comments
         - include: pop-type-assertion
 
-        # Note: calls and casts are syntactically identical.
+        # Note: we can't syntactically distinguish calls from type conversions.
+        # It's also not always possible to distinguish function calls from
+        # method calls.
         - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
           scope: variable.function.go
           pop: true
 
         - include: pop-member
-        # Note: newlines between dot and assertion/field are ok
+        # Note: newlines between dot and assertion/field are ok.
         - include: pop-before-nonblank
 
   match-parens:
@@ -356,7 +363,7 @@ contexts:
         - match: \)
           scope: punctuation.section.parens.end.go
           pop: true
-        - include: pop-call-or-cast
+        - include: pop-call-or-type-conversion
         - include: match-any
     - match: \)
       scope: punctuation.section.parens.end.go
@@ -378,6 +385,15 @@ contexts:
         - include: pop-type-identifier
         - include: pop-before-nonblank
 
+  # TODO: consider detecting composite literals. In principle, it should allow
+  # us to drop the erroneous "meta.block" from composite literals, detect field
+  # names, and also detect labeled statements by disambiguating them from field
+  # names.
+  #
+  # For future reference:
+  #
+  #   https://golang.org/ref/spec#Composite_literals
+  #   https://golang.org/ref/spec#Labeled_statements
   match-braces:
     - match: \{
       scope: punctuation.section.braces.begin.go
@@ -1202,6 +1218,8 @@ contexts:
 
   pop-arguments-starting-with-type:
     - include: match-comments
+    # Go allows functions and types to be wrapped in an arbitrary number of
+    # parens. These are not part of the call.
     - match: \)
       scope: punctuation.section.parens.end.go
     - match: \(

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -61,13 +61,13 @@ You may have to disable Go-specific linters when working on this file.
     //go:
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^ meta.annotation.go comment.line.go
 //       ^ comment.line.go -meta.annotation
 
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //                             ^ comment.line.go -meta.annotation
 
 
@@ -121,32 +121,32 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## chan
 
     chan _
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^ variable.language.blank.go
 
     chan typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^ storage.type.go
 
     chan typ ident
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^ storage.type.go
 //           ^^^^^ variable.other.go
 
     chan ((typ))
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^ punctuation.section.parens.begin.go
 //         ^^^ storage.type.go
 //            ^^ punctuation.section.parens.end.go
 
     chan ident.typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^^^ variable.other.go
 //            ^ punctuation.accessor.dot.go
 //             ^^^ storage.type.go
 
     chan ident.ident.typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^^^ variable.other.go
 //            ^ punctuation.accessor.dot.go
 //             ^^^^^ variable.other.go
@@ -154,7 +154,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                   ^^^ storage.type.go
 
     chan ((ident.ident.typ))
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^ punctuation.section.parens.begin.go
 //         ^^^^^ variable.other.go
 //              ^ punctuation.accessor.dot.go
@@ -165,14 +165,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     <- chan ident.typ
 //  ^^ keyword.operator.assignment.go
-//     ^^^^ storage.type.keyword.chan.go
+//     ^^^^ keyword.declaration.chan.go
 //          ^^^^^ variable.other.go
 //               ^ punctuation.accessor.dot.go
 //                ^^^ storage.type.go
 
     <- chan ident.ident.typ
 //  ^^ keyword.operator.assignment.go
-//     ^^^^ storage.type.keyword.chan.go
+//     ^^^^ keyword.declaration.chan.go
 //          ^^^^^ variable.other.go
 //               ^ punctuation.accessor.dot.go
 //                ^^^^^ variable.other.go
@@ -180,14 +180,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                      ^^^ storage.type.go
 
     chan <- ident.typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^ keyword.operator.assignment.go
 //          ^^^^^ variable.other.go
 //               ^ punctuation.accessor.dot.go
 //                ^^^ storage.type.go
 
     chan <- ident.ident.typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^ keyword.operator.assignment.go
 //          ^^^^^ variable.other.go
 //               ^ punctuation.accessor.dot.go
@@ -196,12 +196,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                      ^^^ storage.type.go
 
     chan
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
     typ
 //  ^^^ storage.type.go
 
     chan
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
     ident /**/ . /**/
 //  ^^^^^ variable.other.go
 //        ^^^^ comment.block.go
@@ -213,7 +213,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     <-
 //  ^^ keyword.operator.assignment.go
     chan
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
     ident /**/ . /**/
 //  ^^^^^ variable.other.go
 //        ^^^^ comment.block.go
@@ -228,7 +228,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^ storage.type.go
 
     chan
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
     <-    /**/
 //  ^^ keyword.operator.assignment.go
 //        ^^^^ comment.block.go
@@ -246,68 +246,68 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^ storage.type.go
 
     chan chan chan typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.chan.go
-//            ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^ keyword.declaration.chan.go
+//            ^^^^ keyword.declaration.chan.go
 //                 ^^^ storage.type.go
 
     chan *chan **chan ***typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^ keyword.operator.go
-//        ^^^^ storage.type.keyword.chan.go
+//        ^^^^ keyword.declaration.chan.go
 //             ^^ keyword.operator.go
-//               ^^^^ storage.type.keyword.chan.go
+//               ^^^^ keyword.declaration.chan.go
 //                    ^^^ keyword.operator.go
 //                       ^^^ storage.type.go
 
     chan struct{}
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^^^ keyword.declaration.struct.go
 
     chan struct{} ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^^^ keyword.declaration.struct.go
 //                ^^^^^ variable.other.go
 
     chan interface{}
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^^^^^^ keyword.declaration.interface.go
 
     chan interface{} ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^^^^^^ keyword.declaration.interface.go
 //                   ^^^^^ variable.other.go
 
     chan func() func() typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.function.go
-//              ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^ keyword.declaration.function.go
+//              ^^^^ keyword.declaration.function.go
 //                     ^^^ storage.type.go
 
     chan func() func() typ ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.function.go
-//              ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^^ keyword.declaration.function.go
+//              ^^^^ keyword.declaration.function.go
 //                     ^^^ storage.type.go
 //                         ^^^^^ variable.other.go
 
     chan
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
     func() typ
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //         ^^^ storage.type.go
 
     chan []typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //         ^^^ storage.type.go
 
     chan [][][]typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //             ^^^ storage.type.go
 
     chan map[typ]typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.keyword.map.go
+//  ^^^^ keyword.declaration.chan.go
+//       ^^^ keyword.declaration.map.go
 //           ^^^ storage.type.go
 //               ^^^ storage.type.go
 
@@ -320,12 +320,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // function types.
 
     func()
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //      ^ punctuation.section.parens.begin.go
 //       ^ punctuation.section.parens.end.go
 
     func(typ, typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //      ^ punctuation.section.parens.begin.go
 //       ^^^ storage.type.go
 //          ^ punctuation.separator.go
@@ -341,12 +341,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^^ storage.type.go
 
     func()
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
     ident
 //  ^^^^^ variable.other.go -storage
 
     func(true false) (nil iota)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^ variable.parameter.go
 //            ^^^^^ storage.type.go
 //                    ^^^ variable.parameter.go
@@ -358,7 +358,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //               ^^^ storage.type.go
 
     func(param /**/ ... /**/ typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //             ^^^^ comment.block.go
 //                  ^^^ keyword.operator.variadic.go
@@ -366,7 +366,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^^^ storage.type.go
 
     func(param ((typ)), param ...typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //               ^^^ storage.type.go
 //                      ^^^^^ variable.parameter.go
@@ -374,7 +374,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                               ^^^ storage.type.go
 
     func(param, param ((typ)), param, param ...typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //              ^^^^^ variable.parameter.go
 //                      ^^^ storage.type.go
@@ -455,14 +455,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //              ^^^^ storage.type.go
 
     func(...ident.Type)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^ keyword.operator.variadic.go
 //          ^^^^^ variable.other.go
 //               ^ punctuation.accessor.dot.go
 //                ^^^^ storage.type.go
 
     func(...*ident.Type)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^ keyword.operator.variadic.go
 //          ^ keyword.operator.go
 //           ^^^^^ variable.other.go
@@ -479,13 +479,13 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     )
 
     func(param...typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //            ^^^ keyword.operator.variadic.go
 //               ^^^ storage.type.go
 
     func(param...ident.Type)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //            ^^^ keyword.operator.variadic.go
 //               ^^^^^ variable.other.go
@@ -493,7 +493,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^^^^ storage.type.go
 
     func(param...*ident.Type)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ variable.parameter.go
 //            ^^^ keyword.operator.variadic.go
 //               ^ keyword.operator.go
@@ -539,7 +539,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // Deranged case
     func /**/ (
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^ comment.block.go
 //            ^ punctuation.section.parens.begin.go
         /**/
@@ -611,9 +611,9 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //            ^^^ storage.type.go
 
     func() func() func() typ
-//  ^^^^ storage.type.keyword.function.go
-//         ^^^^ storage.type.keyword.function.go
-//                ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
+//         ^^^^ keyword.declaration.function.go
+//                ^^^^ keyword.declaration.function.go
 //                       ^^^ storage.type.go
 
     func() func() func() ((typ))
@@ -621,25 +621,25 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // Deranged case
     func(param func(param func(param ...typ) func() typ) ...func(param typ))
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //      ^ punctuation.section.parens.begin.go
 //       ^^^^^ variable.parameter.go
-//             ^^^^ storage.type.keyword.function.go
+//             ^^^^ keyword.declaration.function.go
 //                 ^ punctuation.section.parens.begin.go
 //                  ^^^^^ variable.parameter.go
-//                        ^^^^ storage.type.keyword.function.go
+//                        ^^^^ keyword.declaration.function.go
 //                            ^ punctuation.section.parens.begin.go
 //                             ^^^^^ variable.parameter.go
 //                                   ^^^ keyword.operator.variadic.go
 //                                      ^^^ storage.type.go
 //                                         ^ punctuation.section.parens.end.go
-//                                           ^^^^ storage.type.keyword.function.go
+//                                           ^^^^ keyword.declaration.function.go
 //                                               ^ punctuation.section.parens.begin.go
 //                                                ^ punctuation.section.parens.end.go
 //                                                  ^^^ storage.type.go
 //                                                     ^ punctuation.section.parens.end.go
 //                                                       ^^^ keyword.operator.variadic.go
-//                                                          ^^^^ storage.type.keyword.function.go
+//                                                          ^^^^ keyword.declaration.function.go
 //                                                              ^ punctuation.section.parens.begin.go
 //                                                               ^^^^^ variable.parameter.go
 //                                                                     ^^^ storage.type.go
@@ -649,12 +649,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## interface
 
     interface{}
-//  ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^^^^^^ keyword.declaration.interface.go
 //           ^ meta.type.go punctuation.section.braces.begin.go
 //            ^ meta.type.go punctuation.section.braces.end.go
 
     interface /**/ {
-//  ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^^^^^^ keyword.declaration.interface.go
 //            ^^^^ comment.block.go
 //                 ^ meta.type.go punctuation.section.braces.begin.go
 
@@ -722,7 +722,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^ meta.type.go punctuation.section.braces.end.go
 
     interface
-//  ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^^^^^^ keyword.declaration.interface.go
     {Method(param typ) typ; Inherit; Method(param typ) typ;}
 //  ^ meta.type.go punctuation.section.braces.begin.go
 //   ^^^^^^ meta.type.go entity.name.function.go
@@ -747,14 +747,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## map
 
     map[typ]typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //     ^ punctuation.section.brackets.begin.go
 //      ^^^ storage.type.go
 //         ^ punctuation.section.brackets.end.go
 //          ^^^ storage.type.go
 
     map[typ]typ ident
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //     ^ punctuation.section.brackets.begin.go
 //      ^^^ storage.type.go
 //         ^ punctuation.section.brackets.end.go
@@ -762,13 +762,13 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //              ^^^^^ variable.other.go -storage
 
     map[typ]
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go
     ident
 //  ^^^^^ variable.other.go
 
     map /**/ [/**/ typ /**/] /**/ typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^^ comment.block.go
 //           ^ punctuation.section.brackets.begin.go
 //            ^^^^ comment.block.go
@@ -779,7 +779,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                ^^^ storage.type.go
 
     map /**/
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^^ comment.block.go
     /**/ [ /**/
 //  ^^^^ comment.block.go
@@ -794,63 +794,63 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^^^ storage.type.go
 
     map[typ]map[typ]map[typ]map[typ]typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go
-//          ^^^ storage.type.keyword.map.go
+//          ^^^ keyword.declaration.map.go
 //              ^^^ storage.type.go
-//                  ^^^ storage.type.keyword.map.go
+//                  ^^^ keyword.declaration.map.go
 //                      ^^^ storage.type.go
-//                          ^^^ storage.type.keyword.map.go
+//                          ^^^ keyword.declaration.map.go
 //                              ^^^ storage.type.go
 //                                  ^^^ storage.type.go
 
     map[chan chan typ]chan chan typ ident
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ storage.type.keyword.chan.go
-//           ^^^^ storage.type.keyword.chan.go
+//  ^^^ keyword.declaration.map.go
+//      ^^^^ keyword.declaration.chan.go
+//           ^^^^ keyword.declaration.chan.go
 //                ^^^ storage.type.go
-//                    ^^^^ storage.type.keyword.chan.go
-//                         ^^^^ storage.type.keyword.chan.go
+//                    ^^^^ keyword.declaration.chan.go
+//                         ^^^^ keyword.declaration.chan.go
 //                              ^^^ storage.type.go
 //                                  ^^^^^ variable.other.go
 
     map[<- chan typ] chan <- typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^ keyword.operator.assignment.go
-//         ^^^^ storage.type.keyword.chan.go
+//         ^^^^ keyword.declaration.chan.go
 //              ^^^ storage.type.go
-//                   ^^^^ storage.type.keyword.chan.go
+//                   ^^^^ keyword.declaration.chan.go
 //                        ^^ keyword.operator.assignment.go
 //                           ^^^ storage.type.go
 
     map[func(param typ) typ]func(param typ) typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ storage.type.keyword.function.go
+//  ^^^ keyword.declaration.map.go
+//      ^^^^ keyword.declaration.function.go
 //           ^^^^^ variable.parameter.go
 //                 ^^^ storage.type.go
 //                      ^^^ storage.type.go
-//                          ^^^^ storage.type.keyword.function.go
+//                          ^^^^ keyword.declaration.function.go
 //                               ^^^^^ variable.parameter.go
 //                                     ^^^ storage.type.go
 //                                          ^^^ storage.type.go
 
     map[map[typ]typ]map[typ]typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
+//      ^^^ keyword.declaration.map.go
 //          ^^^ storage.type.go
 //              ^^^ storage.type.go
-//                  ^^^ storage.type.keyword.map.go
+//                  ^^^ keyword.declaration.map.go
 //                      ^^^ storage.type.go
 //                          ^^^ storage.type.go
 
     map[struct{
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^^^ storage.type.keyword.struct.go
+//  ^^^ keyword.declaration.map.go
+//      ^^^^^^ keyword.declaration.struct.go
         field typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
     }] struct {
-//     ^^^^^^ storage.type.keyword.struct.go
+//     ^^^^^^ keyword.declaration.struct.go
 //             ^ meta.type.go
         field typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
@@ -859,14 +859,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
     map[*typ]*typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^ keyword.operator.go
 //       ^^^ storage.type.go
 //           ^ keyword.operator.go
 //            ^^^ storage.type.go
 
     map[ident.Type]ident.Type
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^^^ variable.other.go
 //           ^ punctuation.accessor.dot.go
 //            ^^^^ storage.type.go
@@ -875,7 +875,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^^^^ storage.type.go
 
     map[*ident.Type]*ident.Type
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^ keyword.operator.go
 //       ^^^^^ variable.other.go
 //            ^ punctuation.accessor.dot.go
@@ -886,7 +886,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                         ^^^^ storage.type.go
 
     map[typ]ident /**/ . /**/
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go
 //          ^^^^^ variable.other.go
 //                ^^^^ comment.block.go
@@ -901,14 +901,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^^ storage.type.go
 
     map[[0]typ][0]typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //       ^ meta.number.integer.decimal.go constant.numeric.value.go
 //         ^^^ storage.type.go
 //              ^ meta.number.integer.decimal.go constant.numeric.value.go
 //                ^^^ storage.type.go
 
     map[/**/ [0] /**/ typ /**/ ] /**/ [0] /**/ typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^^ comment.block.go
 //            ^ meta.number.integer.decimal.go constant.numeric.value.go
 //               ^^^^ comment.block.go
@@ -923,35 +923,35 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## struct
 
     struct{}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //        ^ meta.type.go punctuation.section.braces.begin.go
 //         ^ meta.type.go punctuation.section.braces.end.go
 
     struct {field typ}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //          ^^^^^ meta.type.go variable.other.member.declaration.go
 //                ^^^ meta.type.go storage.type.go
 
     struct {field typ;}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //          ^^^^^ meta.type.go variable.other.member.declaration.go
 //                ^^^ meta.type.go storage.type.go
 
     struct {true nil}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //          ^^^^ meta.type.go variable.other.member.declaration.go
 //               ^^^ meta.type.go storage.type.go
 
     struct {embed}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //          ^^^^^ meta.type.go entity.other.inherited-class.go
 
     struct {embed;}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //          ^^^^^ meta.type.go entity.other.inherited-class.go
 
     struct {embed; field typ; *embed; field typ;}
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //         ^ meta.type.go punctuation.section.braces.begin.go
 //          ^^^^^ meta.type.go entity.other.inherited-class.go
 //               ^ meta.type.go punctuation.terminator.go
@@ -967,7 +967,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                              ^ meta.type.go punctuation.section.braces.end.go
 
     struct {
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
         field typ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
@@ -998,7 +998,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
     struct
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
     /**/
 //  ^^^^ comment.block.go
     {
@@ -1062,7 +1062,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
     struct {
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
         /**/ field /**/ typ /**/
 //      ^^^^ meta.type.go comment.block.go
 //           ^^^^^ meta.type.go variable.other.member.declaration.go
@@ -1078,7 +1078,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
     struct {
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
         field, field typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //           ^ meta.type.go punctuation.separator.go
@@ -1095,10 +1095,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
     struct {
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
         field chan typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.chan.go
+//            ^^^^ meta.type.go keyword.declaration.chan.go
 //                 ^^^ meta.type.go storage.type.go
 
         embed
@@ -1107,7 +1107,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
         field <- chan typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^ meta.type.go keyword.operator.assignment.go
-//               ^^^^ meta.type.go storage.type.keyword.chan.go
+//               ^^^^ meta.type.go keyword.declaration.chan.go
 //                    ^^^ meta.type.go storage.type.go
 
         embed
@@ -1115,7 +1115,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field chan <- typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.chan.go
+//            ^^^^ meta.type.go keyword.declaration.chan.go
 //                 ^^ meta.type.go keyword.operator.assignment.go
 //                    ^^^ meta.type.go storage.type.go
 
@@ -1124,7 +1124,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field func(param typ) typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.function.go
+//            ^^^^ meta.type.go keyword.declaration.function.go
 //                ^ meta.type.go punctuation.section.parens.begin.go
 //                 ^^^^^ meta.type.go variable.parameter.go
 //                       ^^^ meta.type.go storage.type.go
@@ -1137,7 +1137,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field func(
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.function.go
+//            ^^^^ meta.type.go keyword.declaration.function.go
             param typ
 //          ^^^^^ meta.type.go variable.parameter.go
 //                ^^^ meta.type.go storage.type.go
@@ -1152,7 +1152,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field map[
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.keyword.map.go
+//            ^^^ meta.type.go keyword.declaration.map.go
             typ
 //          ^^^ meta.type.go storage.type.go
         ] typ
@@ -1163,7 +1163,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field interface{
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^^^^^^ meta.type.go storage.type.keyword.interface.go
+//            ^^^^^^^^^ meta.type.go keyword.declaration.interface.go
             method()
 //          ^^^^^^ meta.type.go meta.type.go entity.name.function.go
         }
@@ -1173,7 +1173,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         field struct{
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^^^ meta.type.go storage.type.keyword.struct.go
+//            ^^^^^^ meta.type.go keyword.declaration.struct.go
             field typ
 //          ^^^^^ meta.type.go meta.type.go variable.other.member.declaration.go
 //                ^^^ meta.type.go meta.type.go storage.type.go
@@ -1262,7 +1262,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^^^ variable.other.go -storage
 
     []func(
-//    ^^^^ storage.type.keyword.function.go
+//    ^^^^ keyword.declaration.function.go
         param typ
 //      ^^^^^ variable.parameter.go
 //            ^^^ storage.type.go
@@ -1274,17 +1274,17 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // ## type
 
     type _ typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^ variable.language.blank.go
 //         ^^^ storage.type.go
 
     type Type typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
 //            ^^^ storage.type.go
 
     type
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
     /**/
 //  ^^^^ comment.block.go
     Type /**/ * /**/ * /**/ ident /**/ . /**/
@@ -1309,46 +1309,46 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //           ^^^^ storage.type.go
 
     type Type
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
     ident
 //  ^^^^^ variable.other.go
 
     type Type; ident
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
 //           ^ punctuation.terminator.go
 //             ^^^^^ variable.other.go
 
     type Type chan typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
+//            ^^^^ keyword.declaration.chan.go
 //                 ^^^ storage.type.go
 
     type Type <- chan typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
 //            ^^ keyword.operator.assignment.go
-//               ^^^^ storage.type.keyword.chan.go
+//               ^^^^ keyword.declaration.chan.go
 //                    ^^^ storage.type.go
 
     type Type chan <- typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
+//            ^^^^ keyword.declaration.chan.go
 //                 ^^ keyword.operator.assignment.go
 //                    ^^^ storage.type.go
 
     type Type chan typ ident
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
+//            ^^^^ keyword.declaration.chan.go
 //                 ^^^ storage.type.go
 //                     ^^^^^ variable.other.go
 
     type Type func(
-//            ^^^^ storage.type.keyword.function.go
+//            ^^^^ keyword.declaration.function.go
         param typ
 //      ^^^^^ variable.parameter.go
 //            ^^^ storage.type.go
@@ -1357,21 +1357,21 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //        ^^^^^ variable.other.go
 
     type Type map[typ]typ ident
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
-//            ^^^ storage.type.keyword.map.go
+//            ^^^ keyword.declaration.map.go
 //                ^^^ storage.type.go
 //                    ^^^ storage.type.go
 //                        ^^^^^ variable.other.go
 
     type Type []typ ident
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^^^^ entity.name.type.go
 //              ^^^ storage.type.go
 //                  ^^^^^ variable.other.go
 
     type Type interface {
-//            ^^^^^^^^^ storage.type.keyword.interface.go
+//            ^^^^^^^^^ keyword.declaration.interface.go
         Method()
 //      ^^^^^^ meta.type.go entity.name.function.go
         Inherit
@@ -1380,7 +1380,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //    ^^^^^ variable.other.go
 
     type Type struct {
-//            ^^^^^^ storage.type.keyword.struct.go
+//            ^^^^^^ keyword.declaration.struct.go
         field typ
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
@@ -1406,12 +1406,12 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         Type func(
 //      ^^^^ entity.name.type.go
-//           ^^^^ storage.type.keyword.function.go
+//           ^^^^ keyword.declaration.function.go
         )
 
         Type map
 //      ^^^^ entity.name.type.go
-//           ^^^ storage.type.keyword.map.go
+//           ^^^ keyword.declaration.map.go
         [typ]typ
 //       ^^^ storage.type.go
 //           ^^^ storage.type.go
@@ -1422,14 +1422,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
         Type interface {
 //      ^^^^ entity.name.type.go
-//           ^^^^^^^^^ storage.type.keyword.interface.go
+//           ^^^^^^^^^ keyword.declaration.interface.go
             Method()
 //          ^^^^^^ meta.type.go entity.name.function.go
         }
 
         Type struct {
 //      ^^^^ entity.name.type.go
-//           ^^^^^^ storage.type.keyword.struct.go
+//           ^^^^^^ keyword.declaration.struct.go
             field typ
 //          ^^^^^ meta.type.go variable.other.member.declaration.go
 //                ^^^ meta.type.go storage.type.go
@@ -1445,14 +1445,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // or variables.
 
     const _ = 10
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^ variable.language.blank.go
 //          ^ keyword.operator.assignment.go
 //            ^^ meta.number.integer.decimal.go constant.numeric.value.go
 
     /**/ const
 //  ^^^^ comment.block.go
-//       ^^^^^ storage.type.keyword.const.go
+//       ^^^^^ keyword.declaration.const.go
     /**/ ident /**/ typ /**/ = /**/ iota /**/
 //  ^^^^ comment.block.go
 //       ^^^^^ variable.other.constant.declaration.go
@@ -1465,27 +1465,27 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                       ^^^^ comment.block.go
 
     const ident, ident = 10, 20
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //             ^ punctuation.separator.go
 //               ^^^^^ variable.other.constant.declaration.go
 
     const ident, ident typ
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //             ^ punctuation.separator.go
 //               ^^^^^ variable.other.constant.declaration.go
 //                     ^^^ storage.type.go
 
     const ident,
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //             ^ punctuation.separator.go
           ident = 10, 20
 //        ^^^^^ variable.other.constant.declaration.go
 
     const ident,
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //             ^ punctuation.separator.go
           ident typ
@@ -1494,7 +1494,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     /**/ const
 //  ^^^^ comment.block.go
-//       ^^^^^ storage.type.keyword.const.go
+//       ^^^^^ keyword.declaration.const.go
     (
 //  ^ punctuation.section.parens.begin.go
         /**/ ident /**/ typ /**/ = /**/ iota + iota /**/
@@ -1594,7 +1594,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     )
 
     const ident typ = ident +
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //              ^^^ storage.type.go
 //                  ^ keyword.operator.assignment.go
@@ -1610,7 +1610,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //      ^^^^^ variable.other.go
 
     const (
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
         ident typ = ident +
 //      ^^^^^ variable.other.constant.declaration.go
 //            ^^^ storage.type.go
@@ -1632,19 +1632,19 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // iota is predefined only in constant declarations. It's not a reserved word.
     func _() {
         var iota = 0
-//      ^^^ storage.type.keyword.var.go
+//      ^^^ keyword.declaration.var.go
 //          ^^^^ variable.declaration.go
 //               ^ keyword.operator.assignment.go
 //                 ^ meta.number.integer.decimal.go constant.numeric.value.go
         var _ = iota
-//      ^^^ storage.type.keyword.var.go
+//      ^^^ keyword.declaration.var.go
 //          ^ variable.language.blank.go
 //            ^ keyword.operator.assignment.go
 //              ^^^^ variable.other.go -constant
     }
 
     var _ = log.Println
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^ variable.language.blank.go
 //        ^ keyword.operator.assignment.go
 //          ^^^ variable.other.go
@@ -1653,7 +1653,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     /**/ var
 //  ^^^^ comment.block.go
-//       ^^^ storage.type.keyword.var.go
+//       ^^^ keyword.declaration.var.go
     /**/ ident /**/ typ /**/ = /**/ 10 /**/
 //  ^^^^ comment.block.go
 //       ^^^^^ variable.declaration.go
@@ -1666,27 +1666,27 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                     ^^^^ comment.block.go
 
     var ident, ident = 10, 20
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //           ^ punctuation.separator.go
 //             ^^^^^ variable.declaration.go
 
     var ident, ident typ
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //           ^ punctuation.separator.go
 //             ^^^^^ variable.declaration.go
 //                   ^^^ storage.type.go
 
     var ident,
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //           ^ punctuation.separator.go
         ident = 10, 20
 //      ^^^^^ variable.declaration.go
 
     var ident,
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //           ^ punctuation.separator.go
         ident typ
@@ -1695,7 +1695,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     /**/ var
 //  ^^^^ comment.block.go
-//       ^^^ storage.type.keyword.var.go
+//       ^^^ keyword.declaration.var.go
     (
 //  ^ punctuation.section.parens.begin.go
         /**/ ident /**/ typ /**/ = /**/ ident /**/ + /**/ 20 /**/
@@ -2501,7 +2501,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     ident.(chan typ)
 //  ^^^^^ variable.other.go
 //       ^ punctuation.accessor.dot.go
-//         ^^^^ storage.type.keyword.chan.go
+//         ^^^^ keyword.declaration.chan.go
 //              ^^^ storage.type.go
 
     ident.(***ident)
@@ -2652,18 +2652,18 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     (*chan typ)(ident)
 //   ^ keyword.operator.go
-//    ^^^^ storage.type.keyword.chan.go
+//    ^^^^ keyword.declaration.chan.go
 //         ^^^ storage.type.go
 //              ^^^^^ variable.other.go
 
     map[typ]typ(ident)
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go
 //          ^^^ storage.type.go
 //              ^^^^^ variable.other.go
 
     (map[typ]typ)(ident)
-//   ^^^ storage.type.keyword.map.go
+//   ^^^ keyword.declaration.map.go
 //       ^^^ storage.type.go
 //           ^^^ storage.type.go
 //                ^^^^^ variable.other.go
@@ -2720,14 +2720,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 // declarations, anonymous functions, and function types.
 
     func() {}
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //      ^ punctuation.section.parens.begin.go
 //       ^ punctuation.section.parens.end.go
 //         ^ meta.block.go punctuation.section.braces.begin.go
 //          ^ meta.block.go punctuation.section.braces.end.go
 
     func ident() {}
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ entity.name.function.go
 //            ^ punctuation.section.parens.begin.go
 //             ^ punctuation.section.parens.end.go
@@ -2735,17 +2735,17 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                ^ meta.block.go punctuation.section.braces.end.go
 
     func ident /**/ () {}
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ entity.name.function.go
 //             ^^^^ comment.block.go
 
     func ident /* * */ () {}
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ entity.name.function.go
 //             ^^^^^^^ comment.block.go
 
     func ident(
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^^ entity.name.function.go
         param typ
 //      ^^^^^ variable.parameter.go
@@ -2765,7 +2765,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                          ^ punctuation.section.parens.end.go
 
     func (Type) Method() {}
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^ meta.function.declaration.go punctuation.section.parens.begin.go
 //        ^^^^ meta.function.declaration.go storage.type.go
 //            ^ meta.function.declaration.go punctuation.section.parens.end.go
@@ -2774,7 +2774,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ punctuation.section.parens.end.go
 
     func /**/
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^^ comment.block.go
     ( /**/ self /**/ * /**/ ident /**/ . /**/ Type /**/ ) /**/ Method /**/ (
 //  ^ meta.function.declaration.go punctuation.section.parens.begin.go
@@ -2821,49 +2821,49 @@ every type individually.
 */
 
     chan typ
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^ storage.type.go -support
 
     chan int
-//  ^^^^ storage.type.keyword.chan.go
+//  ^^^^ keyword.declaration.chan.go
 //       ^^^ storage.type.go support.type.builtin.go
 
     func(typ)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^ storage.type.go -support
 
     func(int)
-//  ^^^^ storage.type.keyword.function.go
+//  ^^^^ keyword.declaration.function.go
 //       ^^^ storage.type.go support.type.builtin.go
 
     map[typ]typ
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go -support
 //          ^^^ storage.type.go -support
 
     map[int]int
-//  ^^^ storage.type.keyword.map.go
+//  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go support.type.builtin.go
 //          ^^^ storage.type.go support.type.builtin.go
 
     struct { ident typ; typ }
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //           ^^^^^ meta.type.go variable.other.member.declaration.go
 //                 ^^^ meta.type.go storage.type.go -support
 //                      ^^^ meta.type.go entity.other.inherited-class.go -support
 
     struct { ident int; int }
-//  ^^^^^^ storage.type.keyword.struct.go
+//  ^^^^^^ keyword.declaration.struct.go
 //           ^^^^^ meta.type.go variable.other.member.declaration.go
 //                 ^^^ meta.type.go storage.type.go support.type.builtin.go
 //                      ^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
 
     interface { typ }
-//  ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^^^^^^ keyword.declaration.interface.go
 //              ^^^ meta.type.go entity.other.inherited-class.go -support
 
     interface { error }
-//  ^^^^^^^^^ storage.type.keyword.interface.go
+//  ^^^^^^^^^ keyword.declaration.interface.go
 //              ^^^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
 
     [...]typ
@@ -2881,32 +2881,32 @@ every type individually.
 //    ^^^ storage.type.go support.type.builtin.go
 
     type _ typ
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^ variable.language.blank.go
 //         ^^^ storage.type.go -support
 
     type _ int
-//  ^^^^ storage.type.keyword.type.go
+//  ^^^^ keyword.declaration.type.go
 //       ^ variable.language.blank.go
 //         ^^^ storage.type.go support.type.builtin.go
 
     const ident typ
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //              ^^^ storage.type.go -support
 
     const ident int
-//  ^^^^^ storage.type.keyword.const.go
+//  ^^^^^ keyword.declaration.const.go
 //        ^^^^^ variable.other.constant.declaration.go
 //              ^^^ storage.type.go support.type.builtin.go
 
     var ident typ
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //            ^^^ storage.type.go -support
 
     var ident int
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go
 //            ^^^ storage.type.go support.type.builtin.go
 
@@ -2969,7 +2969,7 @@ every type individually.
 //  ^^^^ variable.other.go -support
 
     var make
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^ variable.declaration.go -support
 
     new(typ, ident)
@@ -3014,7 +3014,7 @@ every type individually.
 //  ^^^ variable.other.go -support
 
     var new
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^ variable.declaration.go -support
 
 // ## Other Functions
@@ -3047,7 +3047,7 @@ every function individually.
 //  ^^^^^ variable.other.go -support
 
     var close
-//  ^^^ storage.type.keyword.var.go
+//  ^^^ keyword.declaration.var.go
 //      ^^^^^ variable.declaration.go -support
 
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -2562,7 +2562,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
 // ## Parens
 
-// Note: we can't syntactically disambiguate calls and casts.
+// Note: we can't syntactically disambiguate calls and type conversions.
 
     ident()
 //  ^^^^ variable.function.go


### PR DESCRIPTION
Changed every occurrence of `storage.type.keyword` to `keyword.declaration` to accommodate this newer convention.

Additionally, corrected the scope order "non-meta meta" to "meta non-meta" for `go:` annotations. (Meta scopes usually go first.)