### PR TITLE
[Matlab] Disable auto-pair of single quote when used as transpose operator

### DIFF
--- a/Matlab/Default.sublime-keymap
+++ b/Matlab/Default.sublime-keymap
@@ -1,0 +1,10 @@
+[
+    // Disable auto-pair for single quote when used as transpose operator
+    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.matlab" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\.$", "match_all": true }
+        ]
+    }
+]

--- a/Matlab/Default.sublime-keymap
+++ b/Matlab/Default.sublime-keymap
@@ -1,10 +1,10 @@
 [
     // Disable auto-pair for single quote when used as transpose operator
-    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
+    { "keys": ["'"], "command": "insert", "args": {"characters": "'"}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "source.matlab" },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "[\\.)}\\]]$", "match_all": true }
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "[])}.]$", "match_all": true }
         ]
     }
 ]

--- a/Matlab/Default.sublime-keymap
+++ b/Matlab/Default.sublime-keymap
@@ -4,7 +4,7 @@
         [
             { "key": "selector", "operator": "equal", "operand": "source.matlab" },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\.$", "match_all": true }
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "[\\.)}\\]]$", "match_all": true }
         ]
     }
 ]


### PR DESCRIPTION
A single quote directly following a dot `.'` is the transpose operator in Matlab and a single quoted string after a dot (without whitespace in between) would be syntax error afaik.