### PR TITLE
[Haskell] Fix floating point number scopes

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -85,6 +85,10 @@ contexts:
       scope: constant.other.haskell
 
   number:
+    - match: \b\d+(?:(\.)\d+(?:[eE][-+]?\d+)?|[eE][-+]?\d+)\b
+      scope: meta.number.float.decimal.haskell constant.numeric.value.haskell
+      captures:
+        1: punctuation.separator.decimal.haskell
     - match: \b(0[oO])([0-7]+)\b
       scope: meta.number.integer.octal.haskell
       captures:
@@ -199,14 +203,6 @@ contexts:
         2: punctuation.definition.function.end.haskell
     - match: '\binfix[lr]?\b'
       scope: keyword.operator.haskell
-    - match: \b(\d+)(?:(\.)(\d+)([eE][-+]?\d+)?|([eE][-+]?\d+))\b
-      scope: meta.number.float.decimal.haskell
-      captures:
-        1: constant.numeric.value.haskell
-        2: punctuation.separator.decimal.haskell
-        3: constant.numeric.value.haskell
-        4: constant.numeric.value.exponent.haskell
-        5: constant.numeric.value.exponent.haskell
     - match: '{{operator_infix}}'
       scope: keyword.operator.haskell
     - include: operator_paren

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -284,27 +284,18 @@ main = do
 --   ^ meta.number.integer.decimal.haskell constant.numeric.value.haskell
 
     12.345
---  ^^^^^^ meta.number.float.decimal.haskell
---  ^^ constant.numeric.value.haskell
+--  ^^^^^^ meta.number.float.decimal.haskell constant.numeric.value.haskell
 --    ^ punctuation.separator.decimal
---     ^^^ constant.numeric.value.haskell
 
     1e10
---  ^^^^ meta.number.float.decimal.haskell
---  ^ constant.numeric.value.haskell
---   ^^^ constant.numeric.value.exponent.haskell
+--  ^^^^ meta.number.float.decimal.haskell constant.numeric.value.haskell
 
     0.5e+0
---  ^^^^^^ meta.number.float.decimal.haskell
---  ^ constant.numeric.value.haskell
+--  ^^^^^^ meta.number.float.decimal.haskell constant.numeric.value.haskell
 --   ^ punctuation.separator.decimal.haskell
---    ^ constant.numeric.value.haskell
---     ^^^ constant.numeric.value.exponent.haskell
 
     9e-1
---  ^^^^ meta.number.float.decimal.haskell
---  ^ constant.numeric.value.haskell
---   ^^^ constant.numeric.value.exponent.haskell
+--  ^^^^ meta.number.float.decimal.haskell constant.numeric.value.haskell
 
     0x0
 --  ^^^ meta.number.integer.hexadecimal.haskell


### PR DESCRIPTION
Addresses #2630

This commit applies `constant.numeric.value` to the whole value part of floating point numbers without interrupting by decimal point and moves the pattern to the `number` context.