### PR TITLE
[Clojure] Fix floating point numbers and number signs

### DIFF
--- a/Clojure/Clojure.sublime-syntax
+++ b/Clojure/Clojure.sublime-syntax
@@ -24,12 +24,12 @@ variables:
   # Similar to the number regexps in the Clojure reader.
   # This doesn't include evil octals and dot-terminated decimals.
   sign: '[-+]?'
-  exponent: (?:[eE]{{sign}}\d+)
+  dec_exponent: (?:[eE]{{sign}}\d+)
   dec_integer: ({{sign}})(\d+)(N?)(?=[{{non_number_chars}}])
   hex_integer: ({{sign}})(0[Xx])(\h+)(N?)(?=[{{non_number_chars}}])
   other_integer: ({{sign}})((?:[2-9]|[1-9]\d+)[Rr])([0-9A-Za-z]+)(?=[{{non_number_chars}}])
   rational: ({{sign}})(\d+)(/)(\d+)(?=[{{non_number_chars}}])
-  float: ({{sign}})(\d+)(?:(?:(\.)(\d+)({{exponent}})?|({{exponent}}))(M)?|(M))(?=[{{non_number_chars}}])
+  float: ({{sign}})(\d+)(?:((\.)\d+{{dec_exponent}}?|{{dec_exponent}})(M)?|(M))(?=[{{non_number_chars}}])
 
 contexts:
   main:
@@ -78,40 +78,38 @@ contexts:
     - match: '{{dec_integer}}'
       scope: meta.number.integer.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
         3: constant.numeric.suffix.clojure
     - match: '{{hex_integer}}'
       scope: meta.number.integer.hexadecimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.base.clojure
         3: constant.numeric.value.clojure
         4: constant.numeric.suffix.clojure
     - match: '{{other_integer}}'
       scope: meta.number.integer.other.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.base.clojure
         3: constant.numeric.value.clojure
     - match: '{{rational}}'
       scope: meta.number.rational.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
         3: punctuation.separator.rational.clojure
         4: constant.numeric.value.clojure
     - match: '{{float}}'
       scope: meta.number.float.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
-        3: punctuation.separator.decimal.clojure
-        4: constant.numeric.value.clojure
-        5: constant.numeric.value.exponent.clojure
-        6: constant.numeric.value.exponent.clojure
-        7: constant.numeric.suffix.clojure
-        8: constant.numeric.suffix.clojure
+        3: constant.numeric.value.clojure
+        4: punctuation.separator.decimal.clojure
+        5: constant.numeric.suffix.clojure
+        6: constant.numeric.suffix.clojure
     - match: '{{atom}}'
 
   pop-expr:
@@ -162,14 +160,14 @@ contexts:
     - match: '{{dec_integer}}'
       scope: meta.number.integer.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
         3: constant.numeric.suffix.clojure
       pop: true
     - match: '{{hex_integer}}'
       scope: meta.number.integer.hexadecimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.base.clojure
         3: constant.numeric.value.clojure
         4: constant.numeric.suffix.clojure
@@ -177,14 +175,14 @@ contexts:
     - match: '{{other_integer}}'
       scope: meta.number.integer.other.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.base.clojure
         3: constant.numeric.value.clojure
       pop: true
     - match: '{{rational}}'
       scope: meta.number.rational.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
         3: punctuation.separator.rational.clojure
         4: constant.numeric.value.clojure
@@ -192,14 +190,12 @@ contexts:
     - match: '{{float}}'
       scope: meta.number.float.decimal.clojure
       captures:
-        1: punctuation.definition.numeric.sign.clojure
+        1: keyword.operator.arithmetic.clojure
         2: constant.numeric.value.clojure
-        3: punctuation.separator.decimal.clojure
-        4: constant.numeric.value.clojure
-        5: constant.numeric.value.exponent.clojure
-        6: constant.numeric.value.exponent.clojure
-        7: constant.numeric.suffix.clojure
-        8: constant.numeric.suffix.clojure
+        3: constant.numeric.value.clojure
+        4: punctuation.separator.decimal.clojure
+        5: constant.numeric.suffix.clojure
+        6: constant.numeric.suffix.clojure
       pop: true
     - match: '{{atom}}'
       pop: true

--- a/Clojure/tests/syntax_test_clojure.clj
+++ b/Clojure/tests/syntax_test_clojure.clj
@@ -84,20 +84,20 @@
 ;          ^ constant.numeric.suffix.clojure
 ;           ^ - meta.number
 ;            ^^^^^ meta.number.integer.decimal.clojure
-;            ^ punctuation.definition.numeric.sign.clojure
+;            ^ keyword.operator.arithmetic.clojure
 ;             ^^^^ constant.numeric.value.clojure
 ;                 ^ - meta.number
 ;                  ^^^^^^ meta.number.integer.decimal.clojure
-;                  ^ punctuation.definition.numeric.sign.clojure
+;                  ^ keyword.operator.arithmetic.clojure
 ;                   ^^^^ constant.numeric.value.clojure
 ;                       ^ constant.numeric.suffix.clojure
 ;                        ^ - meta.number
 ;                         ^^^^^ meta.number.integer.decimal.clojure
-;                         ^ punctuation.definition.numeric.sign.clojure
+;                         ^ keyword.operator.arithmetic.clojure
 ;                          ^^^^ constant.numeric.value.clojure
 ;                              ^ - meta.number
 ;                               ^^^^^^ meta.number.integer.decimal.clojure
-;                               ^ punctuation.definition.numeric.sign.clojure
+;                               ^ keyword.operator.arithmetic.clojure
 ;                                ^^^^ constant.numeric.value.clojure
 ;                                    ^ constant.numeric.suffix.clojure
   0x1234af 0x1234afN 0X1234AF 0X1234AFN
@@ -120,45 +120,45 @@
 ;                                     ^ constant.numeric.suffix.clojure
   +0x1234af +0x1234afN +0X1234AF +0X1234AFN
 ; ^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^ constant.numeric.base.clojure
 ;    ^^^^^^ constant.numeric.value.clojure
 ;          ^ - meta.number
 ;           ^^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;           ^ punctuation.definition.numeric.sign.clojure
+;           ^ keyword.operator.arithmetic.clojure
 ;            ^^ constant.numeric.base.clojure
 ;              ^^^^^^ constant.numeric.value.clojure
 ;                    ^ constant.numeric.suffix.clojure
 ;                     ^ - meta.number
 ;                      ^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;                      ^ punctuation.definition.numeric.sign.clojure
+;                      ^ keyword.operator.arithmetic.clojure
 ;                       ^^ constant.numeric.base.clojure
 ;                         ^^^^^^ constant.numeric.value.clojure
 ;                               ^ - meta.number
 ;                                ^^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;                                ^ punctuation.definition.numeric.sign.clojure
+;                                ^ keyword.operator.arithmetic.clojure
 ;                                 ^^ constant.numeric.base.clojure
 ;                                   ^^^^^^ constant.numeric.value.clojure
 ;                                         ^ constant.numeric.suffix.clojure
   -0x1234af -0x1234afN -0X1234AF -0X1234AFN
 ; ^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^ constant.numeric.base.clojure
 ;    ^^^^^^ constant.numeric.value.clojure
 ;          ^ - meta.number
 ;           ^^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;           ^ punctuation.definition.numeric.sign.clojure
+;           ^ keyword.operator.arithmetic.clojure
 ;            ^^ constant.numeric.base.clojure
 ;              ^^^^^^ constant.numeric.value.clojure
 ;                    ^ constant.numeric.suffix.clojure
 ;                     ^ - meta.number
 ;                      ^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;                      ^ punctuation.definition.numeric.sign.clojure
+;                      ^ keyword.operator.arithmetic.clojure
 ;                       ^^ constant.numeric.base.clojure
 ;                         ^^^^^^ constant.numeric.value.clojure
 ;                               ^ - meta.number
 ;                                ^^^^^^^^^^ meta.number.integer.hexadecimal.clojure
-;                                ^ punctuation.definition.numeric.sign.clojure
+;                                ^ keyword.operator.arithmetic.clojure
 ;                                 ^^ constant.numeric.base.clojure
 ;                                   ^^^^^^ constant.numeric.value.clojure
 ;                                         ^ constant.numeric.suffix.clojure
@@ -188,62 +188,62 @@
 ;                                                ^^^^^^ constant.numeric.value.clojure
   +2r1010 +16r1234af +32r1234az +2R1010 +16R1234AF +32R1234AZ
 ; ^^^^^^^ meta.number.integer.other.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^ constant.numeric.base.clojure
 ;    ^^^^ constant.numeric.value.clojure
 ;        ^ - meta.number
 ;         ^^^^^^^^^^ meta.number.integer.other.clojure
-;         ^ punctuation.definition.numeric.sign.clojure
+;         ^ keyword.operator.arithmetic.clojure
 ;          ^^^ constant.numeric.base.clojure
 ;             ^^^^^^ constant.numeric.value.clojure
 ;                   ^ - meta.number
 ;                    ^^^^^^^^^^ meta.number.integer.other.clojure
-;                    ^ punctuation.definition.numeric.sign.clojure
+;                    ^ keyword.operator.arithmetic.clojure
 ;                     ^^^ constant.numeric.base.clojure
 ;                        ^^^^^^ constant.numeric.value.clojure
 ;                              ^ - meta.number
 ;                               ^^^^^^^ meta.number.integer.other.clojure
-;                               ^ punctuation.definition.numeric.sign.clojure
+;                               ^ keyword.operator.arithmetic.clojure
 ;                                ^^ constant.numeric.base.clojure
 ;                                  ^^^^ constant.numeric.value.clojure
 ;                                      ^ - meta.number
 ;                                       ^^^^^^^^^^ meta.number.integer.other.clojure
-;                                       ^ punctuation.definition.numeric.sign.clojure
+;                                       ^ keyword.operator.arithmetic.clojure
 ;                                        ^^^ constant.numeric.base.clojure
 ;                                           ^^^^^^ constant.numeric.value.clojure
 ;                                                 ^ - meta.number
 ;                                                  ^^^^^^^^^^ meta.number.integer.other.clojure
-;                                                  ^ punctuation.definition.numeric.sign.clojure
+;                                                  ^ keyword.operator.arithmetic.clojure
 ;                                                   ^^^ constant.numeric.base.clojure
 ;                                                      ^^^^^^ constant.numeric.value.clojure
   -2r1010 -16r1234af -32r1234az -2R1010 -16R1234AF -32R1234AZ
 ; ^^^^^^^ meta.number.integer.other.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^ constant.numeric.base.clojure
 ;    ^^^^ constant.numeric.value.clojure
 ;        ^ - meta.number
 ;         ^^^^^^^^^^ meta.number.integer.other.clojure
-;         ^ punctuation.definition.numeric.sign.clojure
+;         ^ keyword.operator.arithmetic.clojure
 ;          ^^^ constant.numeric.base.clojure
 ;             ^^^^^^ constant.numeric.value.clojure
 ;                   ^ - meta.number
 ;                    ^^^^^^^^^^ meta.number.integer.other.clojure
-;                    ^ punctuation.definition.numeric.sign.clojure
+;                    ^ keyword.operator.arithmetic.clojure
 ;                     ^^^ constant.numeric.base.clojure
 ;                        ^^^^^^ constant.numeric.value.clojure
 ;                              ^ - meta.number
 ;                               ^^^^^^^ meta.number.integer.other.clojure
-;                               ^ punctuation.definition.numeric.sign.clojure
+;                               ^ keyword.operator.arithmetic.clojure
 ;                                ^^ constant.numeric.base.clojure
 ;                                  ^^^^ constant.numeric.value.clojure
 ;                                      ^ - meta.number
 ;                                       ^^^^^^^^^^ meta.number.integer.other.clojure
-;                                       ^ punctuation.definition.numeric.sign.clojure
+;                                       ^ keyword.operator.arithmetic.clojure
 ;                                        ^^^ constant.numeric.base.clojure
 ;                                           ^^^^^^ constant.numeric.value.clojure
 ;                                                 ^ - meta.number
 ;                                                  ^^^^^^^^^^ meta.number.integer.other.clojure
-;                                                  ^ punctuation.definition.numeric.sign.clojure
+;                                                  ^ keyword.operator.arithmetic.clojure
 ;                                                   ^^^ constant.numeric.base.clojure
 ;                                                      ^^^^^^ constant.numeric.value.clojure
   0/10 10/20 30/0
@@ -263,37 +263,37 @@
 ;               ^ constant.numeric.value.clojure
   +0/10 +10/20 +30/0
 ; ^^^^^ meta.number.rational.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^ constant.numeric.value.clojure
 ;   ^ punctuation.separator.rational.clojure
 ;    ^^ constant.numeric.value.clojure
 ;      ^ - meta.number
 ;       ^^^^^^ meta.number.rational.decimal.clojure
-;       ^ punctuation.definition.numeric.sign.clojure
+;       ^ keyword.operator.arithmetic.clojure
 ;        ^^ constant.numeric.value.clojure
 ;          ^ punctuation.separator.rational.clojure
 ;           ^^ constant.numeric.value.clojure
 ;             ^ - meta.number
 ;              ^^^^^ meta.number.rational.decimal.clojure
-;              ^ punctuation.definition.numeric.sign.clojure
+;              ^ keyword.operator.arithmetic.clojure
 ;               ^^ constant.numeric.value.clojure
 ;                 ^ punctuation.separator.rational.clojure
 ;                  ^ constant.numeric.value.clojure
   -0/10 -10/20 -30/0
 ; ^^^^^ meta.number.rational.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^ constant.numeric.value.clojure
 ;   ^ punctuation.separator.rational.clojure
 ;    ^^ constant.numeric.value.clojure
 ;      ^ - meta.number
 ;       ^^^^^^ meta.number.rational.decimal.clojure
-;       ^ punctuation.definition.numeric.sign.clojure
+;       ^ keyword.operator.arithmetic.clojure
 ;        ^^ constant.numeric.value.clojure
 ;          ^ punctuation.separator.rational.clojure
 ;           ^^ constant.numeric.value.clojure
 ;             ^ - meta.number
 ;              ^^^^^ meta.number.rational.decimal.clojure
-;              ^ punctuation.definition.numeric.sign.clojure
+;              ^ keyword.operator.arithmetic.clojure
 ;               ^^ constant.numeric.value.clojure
 ;                 ^ punctuation.separator.rational.clojure
 ;                  ^ constant.numeric.value.clojure
@@ -314,206 +314,164 @@
 ;                        ^ constant.numeric.suffix.clojure
   +1234M +1234.0M +1234.1234M
 ; ^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^^^ constant.numeric.value.clojure
 ;      ^ constant.numeric.suffix.clojure
 ;       ^ - meta.number
 ;        ^^^^^^^^ meta.number.float.decimal.clojure
-;        ^ punctuation.definition.numeric.sign.clojure
+;        ^ keyword.operator.arithmetic.clojure
 ;         ^^^^ constant.numeric.value.clojure
 ;             ^ punctuation.separator.decimal.clojure
 ;              ^ constant.numeric.value.clojure
 ;               ^ constant.numeric.suffix.clojure
 ;                ^ - meta.number
 ;                 ^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                 ^ punctuation.definition.numeric.sign.clojure
+;                 ^ keyword.operator.arithmetic.clojure
 ;                  ^^^^ constant.numeric.value.clojure
 ;                      ^ punctuation.separator.decimal.clojure
 ;                       ^^^^ constant.numeric.value.clojure
 ;                           ^ constant.numeric.suffix.clojure
   -1234M -1234.0M -1234.1234M
 ; ^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
+; ^ keyword.operator.arithmetic.clojure
 ;  ^^^^ constant.numeric.value.clojure
 ;      ^ constant.numeric.suffix.clojure
 ;       ^ - meta.number
 ;        ^^^^^^^^ meta.number.float.decimal.clojure
-;        ^ punctuation.definition.numeric.sign.clojure
+;        ^ keyword.operator.arithmetic.clojure
 ;         ^^^^ constant.numeric.value.clojure
 ;             ^ punctuation.separator.decimal.clojure
 ;              ^ constant.numeric.value.clojure
 ;               ^ constant.numeric.suffix.clojure
 ;                ^ - meta.number
 ;                 ^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                 ^ punctuation.definition.numeric.sign.clojure
+;                 ^ keyword.operator.arithmetic.clojure
 ;                  ^^^^ constant.numeric.value.clojure
 ;                      ^ punctuation.separator.decimal.clojure
 ;                       ^^^^ constant.numeric.value.clojure
 ;                           ^ constant.numeric.suffix.clojure
   1234e10 1234E10M 1234.1234e10M 1234.1234E10M
 ; ^^^^^^^ meta.number.float.decimal.clojure
-; ^^^^ constant.numeric.value.clojure
-;     ^^^ constant.numeric.value.exponent.clojure
+; ^^^^^^^ constant.numeric.value.clojure
 ;        ^ - meta.number
 ;         ^^^^^^^ meta.number.float.decimal.clojure
-;         ^^^^ constant.numeric.value.clojure
-;             ^^^ constant.numeric.value.exponent.clojure
+;         ^^^^^^^ constant.numeric.value.clojure
 ;                ^ constant.numeric.suffix.clojure
 ;                 ^ - meta.number
 ;                  ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                  ^^^^ constant.numeric.value.clojure
+;                  ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                      ^ punctuation.separator.decimal.clojure
-;                       ^^^^ constant.numeric.value.clojure
-;                           ^^^ constant.numeric.value.exponent.clojure
 ;                              ^ constant.numeric.suffix.clojure
 ;                               ^ - meta.number
 ;                                ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                ^^^^ constant.numeric.value.clojure
+;                                ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                    ^ punctuation.separator.decimal.clojure
-;                                     ^^^^ constant.numeric.value.clojure
-;                                         ^^^ constant.numeric.value.exponent.clojure
 ;                                            ^ constant.numeric.suffix.clojure
   +1234e10 +1234E10M +1234.1234e10M +1234.1234E10M
 ; ^^^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
-;  ^^^^ constant.numeric.value.clojure
-;      ^^^ constant.numeric.value.exponent.clojure
+; ^ keyword.operator.arithmetic.clojure
+;  ^^^^^^^ constant.numeric.value.clojure
 ;         ^ - meta.number
 ;          ^^^^^^^^^ meta.number.float.decimal.clojure
-;          ^ punctuation.definition.numeric.sign.clojure
-;           ^^^^ constant.numeric.value.clojure
-;               ^^^ constant.numeric.value.exponent.clojure
+;          ^ keyword.operator.arithmetic.clojure
+;           ^^^^^^^ constant.numeric.value.clojure
 ;                  ^ constant.numeric.suffix.clojure
 ;                   ^ - meta.number
 ;                    ^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                    ^ punctuation.definition.numeric.sign.clojure
-;                     ^^^^ constant.numeric.value.clojure
+;                    ^ keyword.operator.arithmetic.clojure
+;                     ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                         ^ punctuation.separator.decimal.clojure
-;                          ^^^^ constant.numeric.value.clojure
-;                              ^^^ constant.numeric.value.exponent.clojure
 ;                                 ^ constant.numeric.suffix.clojure
 ;                                  ^ - meta.number
 ;                                   ^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                   ^ punctuation.definition.numeric.sign.clojure
-;                                    ^^^^ constant.numeric.value.clojure
+;                                   ^ keyword.operator.arithmetic.clojure
+;                                    ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                        ^ punctuation.separator.decimal.clojure
-;                                         ^^^^ constant.numeric.value.clojure
-;                                             ^^^ constant.numeric.value.exponent.clojure
 ;                                                ^ constant.numeric.suffix.clojure
   -1234e10 -1234E10M -1234.1234e10M -1234.1234E10M
 ; ^^^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
-;  ^^^^ constant.numeric.value.clojure
-;      ^^^ constant.numeric.value.exponent.clojure
+; ^ keyword.operator.arithmetic.clojure
+;  ^^^^^^^ constant.numeric.value.clojure
 ;         ^ - meta.number
 ;          ^^^^^^^^^ meta.number.float.decimal.clojure
-;          ^ punctuation.definition.numeric.sign.clojure
-;           ^^^^ constant.numeric.value.clojure
-;               ^^^ constant.numeric.value.exponent.clojure
+;          ^ keyword.operator.arithmetic.clojure
+;           ^^^^^^^ constant.numeric.value.clojure
 ;                  ^ constant.numeric.suffix.clojure
 ;                   ^ - meta.number
 ;                    ^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                    ^ punctuation.definition.numeric.sign.clojure
-;                     ^^^^ constant.numeric.value.clojure
+;                    ^ keyword.operator.arithmetic.clojure
+;                     ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                         ^ punctuation.separator.decimal.clojure
-;                          ^^^^ constant.numeric.value.clojure
-;                              ^^^ constant.numeric.value.exponent.clojure
 ;                                 ^ constant.numeric.suffix.clojure
 ;                                  ^ - meta.number
 ;                                   ^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                   ^ punctuation.definition.numeric.sign.clojure
-;                                    ^^^^ constant.numeric.value.clojure
+;                                   ^ keyword.operator.arithmetic.clojure
+;                                    ^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                        ^ punctuation.separator.decimal.clojure
-;                                         ^^^^ constant.numeric.value.clojure
-;                                             ^^^ constant.numeric.value.exponent.clojure
 ;                                                ^ constant.numeric.suffix.clojure
   1234.1234e+10 1234.1234E+10 1234.1234e-10 1234.1234E-10
 ; ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-; ^^^^ constant.numeric.value.clojure
+; ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;     ^ punctuation.separator.decimal.clojure
-;      ^^^^ constant.numeric.value.clojure
-;          ^^^^ constant.numeric.value.exponent.clojure
 ;              ^ - meta.number
 ;               ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;               ^^^^ constant.numeric.value.clojure
+;               ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                   ^ punctuation.separator.decimal.clojure
-;                    ^^^^ constant.numeric.value.clojure
-;                        ^^^^ constant.numeric.value.exponent.clojure
 ;                            ^ - meta.number
 ;                             ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                             ^^^^ constant.numeric.value.clojure
+;                             ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                 ^ punctuation.separator.decimal.clojure
-;                                  ^^^^ constant.numeric.value.clojure
-;                                      ^^^^ constant.numeric.value.exponent.clojure
 ;                                          ^ - meta.number
 ;                                           ^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                           ^^^^ constant.numeric.value.clojure
+;                                           ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                               ^ punctuation.separator.decimal.clojure
-;                                                ^^^^ constant.numeric.value.clojure
-;                                                    ^^^^ constant.numeric.value.exponent.clojure
   +1234.1234e+10M +1234.1234E+10M +1234.1234e-10M +1234.1234E-10M
 ; ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
-;  ^^^^ constant.numeric.value.clojure
+; ^ keyword.operator.arithmetic.clojure
+;  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;      ^ punctuation.separator.decimal.clojure
-;       ^^^^ constant.numeric.value.clojure
-;           ^^^^ constant.numeric.value.exponent.clojure
 ;               ^ constant.numeric.suffix.clojure
 ;                ^ - meta.number
 ;                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                 ^ punctuation.definition.numeric.sign.clojure
-;                  ^^^^ constant.numeric.value.clojure
+;                 ^ keyword.operator.arithmetic.clojure
+;                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                      ^ punctuation.separator.decimal.clojure
-;                       ^^^^ constant.numeric.value.clojure
-;                           ^^^^ constant.numeric.value.exponent.clojure
 ;                               ^ constant.numeric.suffix.clojure
 ;                                ^ - meta.number
 ;                                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                 ^ punctuation.definition.numeric.sign.clojure
-;                                  ^^^^ constant.numeric.value.clojure
+;                                 ^ keyword.operator.arithmetic.clojure
+;                                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                      ^ punctuation.separator.decimal.clojure
-;                                       ^^^^ constant.numeric.value.clojure
-;                                           ^^^^ constant.numeric.value.exponent.clojure
 ;                                               ^ constant.numeric.suffix.clojure
 ;                                                ^ - meta.number
 ;                                                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                                 ^ punctuation.definition.numeric.sign.clojure
-;                                                  ^^^^ constant.numeric.value.clojure
+;                                                 ^ keyword.operator.arithmetic.clojure
+;                                                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                                      ^ punctuation.separator.decimal.clojure
-;                                                       ^^^^ constant.numeric.value.clojure
-;                                                           ^^^^ constant.numeric.value.exponent.clojure
 ;                                                               ^ constant.numeric.suffix.clojure
   -1234.1234e+10M -1234.1234E+10M -1234.1234e-10M -1234.1234E-10M
 ; ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-; ^ punctuation.definition.numeric.sign.clojure
-;  ^^^^ constant.numeric.value.clojure
+; ^ keyword.operator.arithmetic.clojure
+;  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;      ^ punctuation.separator.decimal.clojure
-;       ^^^^ constant.numeric.value.clojure
-;           ^^^^ constant.numeric.value.exponent.clojure
 ;               ^ constant.numeric.suffix.clojure
 ;                ^ - meta.number
 ;                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                 ^ punctuation.definition.numeric.sign.clojure
-;                  ^^^^ constant.numeric.value.clojure
+;                 ^ keyword.operator.arithmetic.clojure
+;                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                      ^ punctuation.separator.decimal.clojure
-;                       ^^^^ constant.numeric.value.clojure
-;                           ^^^^ constant.numeric.value.exponent.clojure
 ;                               ^ constant.numeric.suffix.clojure
 ;                                ^ - meta.number
 ;                                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                 ^ punctuation.definition.numeric.sign.clojure
-;                                  ^^^^ constant.numeric.value.clojure
+;                                 ^ keyword.operator.arithmetic.clojure
+;                                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                      ^ punctuation.separator.decimal.clojure
-;                                       ^^^^ constant.numeric.value.clojure
-;                                           ^^^^ constant.numeric.value.exponent.clojure
 ;                                               ^ constant.numeric.suffix.clojure
 ;                                                ^ - meta.number
 ;                                                 ^^^^^^^^^^^^^^^ meta.number.float.decimal.clojure
-;                                                 ^ punctuation.definition.numeric.sign.clojure
-;                                                  ^^^^ constant.numeric.value.clojure
+;                                                 ^ keyword.operator.arithmetic.clojure
+;                                                  ^^^^^^^^^^^^^ constant.numeric.value.clojure
 ;                                                      ^ punctuation.separator.decimal.clojure
-;                                                       ^^^^ constant.numeric.value.clojure
-;                                                           ^^^^ constant.numeric.value.exponent.clojure
 ;                                                               ^ constant.numeric.suffix.clojure
 
 ; ## Breaks


### PR DESCRIPTION
Addresses #2630

This commit ...

1. This commit applies `constant.numeric.value` to the whole value part of floating point numbers without interrupting by decimal point.
2. Scopes number signs as `keyword.operator.arithmetic` as this is the agreed scope to use.