### PR TITLE
[OCaml] Fix floating point numbers and number signs

### DIFF
--- a/OCaml/OCaml.sublime-syntax
+++ b/OCaml/OCaml.sublime-syntax
@@ -414,31 +414,25 @@ contexts:
 
     # http://caml.inria.fr/pub/docs/manual-ocaml/lex.html
     # hexadecimal floats
-    - match: ({{sign}})(0[xX])(_*)({{hex_integer}})(?:(\.)({{hex_digit}}*)({{hex_exponent}})?|({{hex_exponent}}))
+    - match: ({{sign}})(0[xX])((_*){{hex_integer}}(?:(\.){{hex_digit}}*{{hex_exponent}}?|{{hex_exponent}}))
       scope: meta.number.float.hexadecimal.ocaml
       captures:
         1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.base.ocaml
-        3: invalid.illegal.numeric.ocaml
-        4: constant.numeric.value.ocaml
+        3: constant.numeric.value.ocaml
+        4: invalid.illegal.numeric.ocaml
         5: punctuation.separator.decimal.ocaml
-        6: constant.numeric.value.ocaml
-        7: constant.numeric.value.exponent.ocaml
-        8: invalid.illegal.numeric.ocaml
-        9: constant.numeric.value.exponent.ocaml
-        10: invalid.illegal.numeric.ocaml
+        6: invalid.illegal.numeric.ocaml
+        7: invalid.illegal.numeric.ocaml
     # decimal floats
-    - match: ({{sign}})({{dec_integer}})(?:(\.)({{dec_digit}}*)({{dec_exponent}})?|({{dec_exponent}}))
+    - match: ({{sign}})({{dec_integer}}(?:(\.){{dec_digit}}*{{dec_exponent}}?|{{dec_exponent}}))
       scope: meta.number.float.decimal.ocaml
       captures:
         1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.value.ocaml
         3: punctuation.separator.decimal.ocaml
-        4: constant.numeric.value.ocaml
-        5: constant.numeric.value.exponent.ocaml
-        6: invalid.illegal.numeric.ocaml
-        7: constant.numeric.value.exponent.ocaml
-        8: invalid.illegal.numeric.ocaml
+        4: invalid.illegal.numeric.ocaml
+        5: invalid.illegal.numeric.ocaml
     # hexadecimal integers
     - match: ({{sign}})(0[xX])(_*)({{hex_integer}}*)({{suffix}})
       scope: meta.number.integer.hexadecimal.ocaml

--- a/OCaml/OCaml.sublime-syntax
+++ b/OCaml/OCaml.sublime-syntax
@@ -417,7 +417,7 @@ contexts:
     - match: ({{sign}})(0[xX])(_*)({{hex_integer}})(?:(\.)({{hex_digit}}*)({{hex_exponent}})?|({{hex_exponent}}))
       scope: meta.number.float.hexadecimal.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: constant.numeric.value.ocaml
@@ -431,7 +431,7 @@ contexts:
     - match: ({{sign}})({{dec_integer}})(?:(\.)({{dec_digit}}*)({{dec_exponent}})?|({{dec_exponent}}))
       scope: meta.number.float.decimal.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.value.ocaml
         3: punctuation.separator.decimal.ocaml
         4: constant.numeric.value.ocaml
@@ -443,7 +443,7 @@ contexts:
     - match: ({{sign}})(0[xX])(_*)({{hex_integer}}*)({{suffix}})
       scope: meta.number.integer.hexadecimal.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: constant.numeric.value.ocaml
@@ -452,7 +452,7 @@ contexts:
     - match: ({{sign}})(0[oO])(_*)({{oct_integer}}*)({{suffix}})
       scope: meta.number.integer.octal.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: constant.numeric.value.ocaml
@@ -461,7 +461,7 @@ contexts:
     - match: ({{sign}})(0[bB])(_*)({{bin_integer}}*)({{suffix}})
       scope: meta.number.integer.binary.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.base.ocaml
         3: invalid.illegal.numeric.ocaml
         4: constant.numeric.value.ocaml
@@ -470,7 +470,7 @@ contexts:
     - match: ({{sign}})({{dec_integer}})({{suffix}})
       scope: meta.number.integer.decimal.ocaml
       captures:
-        1: punctuation.definition.numeric.sign.ocaml
+        1: keyword.operator.arithmetic.ocaml
         2: constant.numeric.value.ocaml
         3: constant.numeric.suffix.ocaml
     # invalid numbers

--- a/OCaml/syntax_test_ml.ml
+++ b/OCaml/syntax_test_ml.ml
@@ -48,7 +48,7 @@
 
     -123
 (*  ^^^^ meta.number.integer.decimal.ocaml - keyword.ocaml *)
-(*  ^ punctuation.definition.numeric.sign *)
+(*  ^ keyword.operator.arithmetic.ocaml *)
 (*   ^^^ constant.numeric.value.ocaml *)
 
     0123456789

--- a/OCaml/syntax_test_ml.ml
+++ b/OCaml/syntax_test_ml.ml
@@ -104,27 +104,21 @@
     0xa. 0xa.b  0xa.ep1 0xa.ep-_1
 (*  ^^^^ meta.number.float.hexadecimal.ocaml *)
 (*  ^^ constant.numeric.base.ocaml *)
-(*    ^ constant.numeric.value.ocaml *)
+(*    ^^ constant.numeric.value.ocaml *)
 (*     ^ punctuation.separator.decimal *)
 (*       ^^^^^ meta.number.float.hexadecimal.ocaml *)
 (*       ^^ constant.numeric.base.ocaml *)
-(*         ^ constant.numeric.value.ocaml *)
+(*         ^^^ constant.numeric.value.ocaml *)
 (*          ^ punctuation.separator.decimal *)
-(*           ^ constant.numeric.value.ocaml *)
 (*              ^^^^^^^ meta.number.float.hexadecimal.ocaml *)
 (*              ^^ constant.numeric.base.ocaml *)
-(*                ^ constant.numeric.value.ocaml *)
+(*                ^^^^^ constant.numeric.value.ocaml *)
 (*                 ^ punctuation.separator.decimal *)
-(*                  ^ constant.numeric.value.ocaml *)
-(*                   ^^ constant.numeric.value.exponent.ocaml *)
 (*                      ^^^^^^^^^ meta.number.float.hexadecimal.ocaml *)
 (*                      ^^ constant.numeric.base.ocaml *)
-(*                        ^ constant.numeric.value.ocaml *)
+(*                        ^^^^^^^ constant.numeric.value.ocaml *)
 (*                         ^ punctuation.separator.decimal *)
-(*                          ^ constant.numeric.value.ocaml *)
-(*                           ^^ constant.numeric.value.exponent.ocaml *)
 (*                             ^ invalid.illegal.numeric *)
-(*                              ^ constant.numeric.value.exponent.ocaml *)
 
     0b1.foo
 (*  ^^^^^^^ invalid.illegal.numeric *)
@@ -146,12 +140,9 @@
 
     12345e6_7_8
 (*  ^^^^^^^^^^^ meta.number.float.decimal.ocaml *)
-(*  ^^^^^ constant.numeric.value.ocaml *)
-(*       ^^^^^^ constant.numeric.value.exponent.ocaml *)
+(*  ^^^^^^^^^^^ constant.numeric.value.ocaml *)
 
     123.456e+789
 (*  ^^^^^^^^^^^^ meta.number.float.decimal.ocaml *)
-(*  ^^^ constant.numeric.value.ocaml *)
+(*  ^^^^^^^^^^^^ constant.numeric.value.ocaml *)
 (*     ^ punctuation.separator.decimal *)
-(*      ^^^ constant.numeric.value.ocaml *)
-(*         ^^^^^ constant.numeric.value.exponent.ocaml *)


### PR DESCRIPTION
Addresses #2630

This PR ...

1. This commit applies `constant.numeric.value` to the whole value part of floating point numbers without interrupting by decimal point.
2. Scopes number signs as `keyword.operator.arithmetic` as this is the agreed scope to use.