### PR TITLE
[Scala] Fix floating point number scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -274,23 +274,20 @@ contexts:
     - match: |-
         (?x:
           # 1.1, 1.1e1, 1.1e-1, 1.1d, 1.1e1d, 1.1e-1d, 1.e1d | 1e1 1e1d | 1d
-          \b(\d+) (?: (?: (\.) (\d+) ([eE][-+]?\d+)? | ([eE][-+]?\d+) ) ([dDfF])? | ([dDfF]) )
+          \b(\d+) (?: ( (\.) \d+ (?:[eE][-+]?\d+)? | [eE][-+]?\d+ ) ([dDfF])? | ([dDfF]) )
           # .1, .1e1, .1e-1
-          | (\.) (\d+) ([eE][-+]?\d+)? ([dDfF])?
+          | ( (\.) \d+ (?:[eE][-+]?\d+)? ) ([dDfF])?
         )\b
       scope: meta.number.float.decimal.scala
       captures:
         1: constant.numeric.value.scala
-        2: punctuation.separator.decimal.scala
-        3: constant.numeric.value.scala
-        4: constant.numeric.value.exponent.scala
-        5: constant.numeric.value.exponent.scala
-        6: constant.numeric.suffix.scala
-        7: constant.numeric.suffix.scala
-        8: punctuation.separator.decimal.scala
-        9: constant.numeric.value.scala
-        10: constant.numeric.value.exponent.scala
-        11: constant.numeric.suffix.scala
+        2: constant.numeric.value.scala
+        3: punctuation.separator.decimal.scala
+        4: constant.numeric.suffix.scala
+        5: constant.numeric.suffix.scala
+        6: constant.numeric.value.scala
+        7: punctuation.separator.decimal.scala
+        8: constant.numeric.suffix.scala
     # source: http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#integer-literals
     - match: \b(0[xX])(\h+)([lL]?)\b
       scope: meta.number.integer.hexadecimal.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -201,118 +201,93 @@ type Foo = Bar[A] forSome { type A }
 
    .045 .045e2 .045e-2 .045e+2 .045e2f .045e-2f .045e+2f
 //^ - meta.number
-// ^ punctuation.separator.decimal.scala
 // ^^^^ meta.number.float.decimal.scala
-//  ^^^ constant.numeric.value.scala
+// ^^^^ constant.numeric.value.scala
+// ^ punctuation.separator.decimal.scala
 //     ^ - meta.number
 //      ^^^^^^ meta.number.float.decimal.scala
 //      ^ punctuation.separator.decimal.scala
-//       ^^^ constant.numeric.value.scala
-//          ^^ constant.numeric.value.exponent.scala
+//      ^^^^^^ constant.numeric.value.scala
 //            ^ - meta.number
 //             ^^^^^^^ meta.number.float.decimal.scala
 //             ^ punctuation.separator.decimal.scala
-//              ^^^ constant.numeric.value.scala
-//                 ^^^ constant.numeric.value.exponent.scala
+//             ^^^^^^^ constant.numeric.value.scala
 //                    ^ - meta.number
 //                     ^^^^^^^ meta.number.float.decimal.scala
 //                     ^ punctuation.separator.decimal.scala
-//                      ^^^ constant.numeric.value.scala
-//                         ^^^ constant.numeric.value.exponent.scala
+//                     ^^^^^^^ constant.numeric.value.scala
 //                            ^ - meta.number
 //                             ^^^^^^^ meta.number.float.decimal.scala
 //                             ^ punctuation.separator.decimal.scala
-//                              ^^^ constant.numeric.value.scala
-//                                 ^^ constant.numeric.value.exponent.scala
+//                             ^^^^^^ constant.numeric.value.scala
 //                                   ^ constant.numeric.suffix.scala
 //                                    ^ - meta.number
 //                                     ^^^^^^^^ meta.number.float.decimal.scala
 //                                     ^ punctuation.separator.decimal.scala
-//                                      ^^^ constant.numeric.value.scala
-//                                         ^^^ constant.numeric.value.exponent.scala
+//                                     ^^^^^^^ constant.numeric.value.scala
 //                                            ^ constant.numeric.suffix.scala
 //                                             ^ - meta.number
 //                                              ^^^^^^^^ meta.number.float.decimal.scala
 //                                              ^ punctuation.separator.decimal.scala
-//                                               ^^^ constant.numeric.value.scala
-//                                                  ^^^ constant.numeric.value.exponent.scala
+//                                              ^^^^^^^ constant.numeric.value.scala
 //                                                     ^ constant.numeric.suffix.scala
 //                                                      ^ - meta.number
 
    0.045 0.045e2 0.045e-2 0.045e+2 0.045e2f 0.045e-2f 0.045e+2f
 //^ - meta.number
 // ^^^^^ meta.number.float.decimal.scala
-// ^ constant.numeric.value.scala
+// ^^^^^ constant.numeric.value.scala
 //  ^ punctuation.separator.decimal.scala
-//   ^^^ constant.numeric.value.scala
 //      ^ - meta.number
 //       ^^^^^^^ meta.number.float.decimal.scala
-//       ^ constant.numeric.value.scala
+//       ^^^^^^^ constant.numeric.value.scala
 //        ^ punctuation.separator.decimal.scala
-//         ^^^ constant.numeric.value.scala
-//            ^^ constant.numeric.value.exponent.scala
 //              ^ - meta.number
 //               ^^^^^^^^ meta.number.float.decimal.scala
-//               ^ constant.numeric.value.scala
+//               ^^^^^^^^ constant.numeric.value.scala
 //                ^ punctuation.separator.decimal.scala
-//                 ^^^ constant.numeric.value.scala
-//                    ^^^ constant.numeric.value.exponent.scala
 //                       ^ - meta.number
 //                        ^^^^^^^^ meta.number.float.decimal.scala
-//                        ^ constant.numeric.value.scala
+//                        ^^^^^^^^ constant.numeric.value.scala
 //                         ^ punctuation.separator.decimal.scala
-//                          ^^^ constant.numeric.value.scala
-//                             ^^^ constant.numeric.value.exponent.scala
 //                                ^ - meta.number
 //                                 ^^^^^^^^ meta.number.float.decimal.scala
-//                                 ^ constant.numeric.value.scala
+//                                 ^^^^^^^ constant.numeric.value.scala
 //                                  ^ punctuation.separator.decimal.scala
-//                                   ^^^ constant.numeric.value.scala
-//                                      ^^ constant.numeric.value.exponent.scala
 //                                        ^ constant.numeric.suffix.scala
 //                                         ^ - meta.number
 //                                          ^^^^^^^^^ meta.number.float.decimal.scala
-//                                          ^ constant.numeric.value.scala
+//                                          ^^^^^^^^ constant.numeric.value.scala
 //                                           ^ punctuation.separator.decimal.scala
-//                                            ^^^ constant.numeric.value.scala
-//                                               ^^^ constant.numeric.value.exponent.scala
 //                                                  ^ constant.numeric.suffix.scala
 //                                                   ^ - meta.number
 //                                                    ^^^^^^^^^ meta.number.float.decimal.scala
-//                                                    ^ constant.numeric.value.scala
+//                                                    ^^^^^^^^ constant.numeric.value.scala
 //                                                     ^ punctuation.separator.decimal.scala
-//                                                      ^^^ constant.numeric.value.scala
-//                                                         ^^^ constant.numeric.value.exponent.scala
 //                                                            ^ constant.numeric.suffix.scala
 //                                                             ^ - meta.number
 
    1e2 1e-2 1e+2 1e2f 1e-2f 1e+2f
 //^ - meta.number
 // ^^^ meta.number.float.decimal.scala
-// ^ constant.numeric.value.scala
-//  ^^ constant.numeric.value.exponent.scala
+// ^^^ constant.numeric.value.scala
 //    ^ - meta.number
 //     ^^^^ meta.number.float.decimal.scala
-//     ^ constant.numeric.value.scala
-//      ^^^ constant.numeric.value.exponent.scala
+//     ^^^^ constant.numeric.value.scala
 //         ^ - meta.number
 //          ^^^^ meta.number.float.decimal.scala
-//          ^ constant.numeric.value.scala
-//           ^^^ constant.numeric.value.exponent.scala
+//          ^^^^ constant.numeric.value.scala
 //              ^ - meta.number
 //               ^^^^ meta.number.float.decimal.scala
-//               ^ constant.numeric.value.scala
-//                ^^ constant.numeric.value.exponent.scala
+//               ^^^ constant.numeric.value.scala
 //                  ^ constant.numeric.suffix.scala
 //                   ^ - meta.number
 //                    ^^^^^ meta.number.float.decimal.scala
-//                    ^ constant.numeric.value.scala
-//                     ^^^ constant.numeric.value.exponent.scala
+//                    ^^^^ constant.numeric.value.scala
 //                        ^ constant.numeric.suffix.scala
 //                         ^ - meta.number
 //                          ^^^^^ meta.number.float.decimal.scala
-//                          ^ constant.numeric.value.scala
-//                           ^^^ constant.numeric.value.exponent.scala
+//                          ^^^^ constant.numeric.value.scala
 //                              ^ constant.numeric.suffix.scala
 
 // decimal integers


### PR DESCRIPTION
Closes #2630

This commit applies `constant.numeric.value` to the whole value part of floating point numbers without interrupting by decimal point.