### PR TITLE
[Scala] Tweak declaration keyword scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -388,13 +388,13 @@ contexts:
       push: val-simple-body
     - match: '\b(package)\s+(object)\s+({{id}})'
       captures:
-        1: keyword.control.scala
+        1: keyword.declaration.namespace.scala
         2: storage.type.class.scala
         3: entity.name.class.scala
       push: class-inheritance-extends
     - match: '\b(package)\s+({{id}}(?:\.{{id}})*)\s*(\{)'
       captures:
-        1: keyword.control.scala
+        1: keyword.declaration.namespace.scala
         2: entity.name.namespace.scoped.scala
         3: punctuation.section.block.begin.scala
       push:
@@ -406,7 +406,7 @@ contexts:
     - match: '\b(package)\s+({{id}}(?:\.{{id}})*)'
       scope: meta.namespace.scala
       captures:
-        1: keyword.control.scala
+        1: keyword.declaration.namespace.scala
         2: entity.name.namespace.header.scala
     # what follows is identical to case-pattern, except it goes to case-body-first
     - match: '\bcase\b(?!\s+class\b)'
@@ -1049,7 +1049,7 @@ contexts:
     - match: \bvar\b
       scope: storage.type.volatile.scala
     - match: \bpackage\b
-      scope: keyword.control.scala
+      scope: keyword.declaration.namespace.scala
 
   late-operators:
     # catch all valid identifiers and let them fall through

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -350,8 +350,8 @@ contexts:
     - match: '\b(?:(case)\s+)?(class|trait|object)(?:\s+({{id}}))'
       scope: meta.class.identifier.scala
       captures:
-        1: storage.type.class.scala
-        2: storage.type.class.scala
+        1: keyword.declaration.class.scala
+        2: keyword.declaration.class.scala
         3: entity.name.class.scala
       push: class-type-parameter-list
     - match: '\b(type)\s+({{id}})'
@@ -389,7 +389,7 @@ contexts:
     - match: '\b(package)\s+(object)\s+({{id}})'
       captures:
         1: keyword.declaration.namespace.scala
-        2: storage.type.class.scala
+        2: keyword.declaration.class.scala
         3: entity.name.class.scala
       push: class-inheritance-extends
     - match: '\b(package)\s+({{id}}(?:\.{{id}})*)\s*(\{)'
@@ -1040,8 +1040,8 @@ contexts:
       scope: invalid.keyword.dangling-with.scala
     - match: \bforSome\b
       scope: keyword.declaration.scala
-    - match: '\b(?:(?:case\s+)?class|trait|object)\b'
-      scope: storage.type.class.scala
+    - match: \b(?:(?:case\s+)?class|trait|object)\b
+      scope: keyword.declaration.class.scala
     - match: \bdef\b
       scope: keyword.declaration.function.scala
     - match: \btype\b

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -410,7 +410,7 @@ contexts:
         2: entity.name.namespace.header.scala
     # what follows is identical to case-pattern, except it goes to case-body-first
     - match: '\bcase\b(?!\s+class\b)'
-      scope: keyword.other.declaration.scala
+      scope: keyword.declaration.other.scala
       push:
         - meta_content_scope: meta.pattern.scala
         - match: '(?=\bclass\b)'
@@ -459,7 +459,7 @@ contexts:
   # this exists to clear the meta_scope from first or non-first
   case-pattern:
     - match: '\bcase\b'
-      scope: keyword.other.declaration.scala
+      scope: keyword.declaration.other.scala
       set:
         - meta_content_scope: meta.pattern.scala
         - match: '\bif\b'
@@ -718,7 +718,7 @@ contexts:
       scope: invalid.keyword.with-before-extends.scala
       pop: true
     - match: \bextends\b
-      scope: keyword.declaration.scala
+      scope: storage.modifier.extends.scala
       set: class-inheritance-extends-token
     - match: '(?=\{)'
       pop: true
@@ -817,7 +817,7 @@ contexts:
       scope: invalid.keyword.extends-after-extends.scala
       pop: true
     - match: \bwith\b
-      scope: keyword.declaration.scala
+      scope: storage.modifier.with.scala
       set: class-inheritance-extends-token
     - match: '\n'
       set: class-inheritance-with-newline

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -831,7 +831,7 @@ contexts:
 
   imports:
     - match: \bimport\b
-      scope: keyword.other.import.scala
+      scope: keyword.declaration.import.scala
       push:
         - meta_scope: meta.import.scala
         - match: '(,)[ \t]*\n'    # TODO real newline inference

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -226,7 +226,7 @@ contexts:
     - match: '(?=({{idorunder}}|{{idorunder}}\s*:(\s*{{id}}\s*{{withinbrackets}}?(\s*[\.#]\s*{{id}}\s*{{withinbrackets}}?)*)+|{{idorunder}}\s*:\s*{{withinparens}}|{{withinparens}})\s*(?:{{rightarrow}})(?:/\*|//|[[[:alpha:]]0-9\s\)\]\}]))'
       push:
         - match: '{{rightarrow}}'
-          scope: storage.type.function.arrow.lambda.scala
+          scope: keyword.declaration.function.arrow.lambda.scala
           pop: true
         - include: lambda-declaration
   lambda-declaration-base:
@@ -344,7 +344,7 @@ contexts:
   declarations:
     - match: '\b(def)\s+({{id}})'
       captures:
-        1: storage.type.function.scala
+        1: keyword.declaration.function.scala
         2: entity.name.function.scala
       push: function-type-parameter-list
     - match: '\b(?:(case)\s+)?(class|trait|object)(?:\s+({{id}}))'
@@ -419,14 +419,14 @@ contexts:
           scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
-              scope: storage.type.function.arrow.case.scala
+              scope: keyword.declaration.function.arrow.case.scala
               set: case-body-first
             - include: main-no-lambdas
         # eliminates arrow from the pattern meta scope
         - match: '(?={{rightarrow}})'
           set:
             - match: '{{rightarrow}}'
-              scope: storage.type.function.arrow.case.scala
+              scope: keyword.declaration.function.arrow.case.scala
               set: case-body-first
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
@@ -466,14 +466,14 @@ contexts:
           scope: keyword.control.flow.scala
           set:
             - match: '{{rightarrow}}'
-              scope: storage.type.function.arrow.case.scala
+              scope: keyword.declaration.function.arrow.case.scala
               set: case-body-non-first
             - include: main-no-lambdas
         # eliminates arrow from the pattern meta scope
         - match: '(?={{rightarrow}})'
           set:
             - match: '{{rightarrow}}'
-              scope: storage.type.function.arrow.case.scala
+              scope: keyword.declaration.function.arrow.case.scala
               set: case-body-non-first
         - match: '(?=\}|\bcase\b)'    # makes typing more pleasant
           pop: true
@@ -1043,7 +1043,7 @@ contexts:
     - match: '\b(?:(?:case\s+)?class|trait|object)\b'
       scope: storage.type.class.scala
     - match: \bdef\b
-      scope: storage.type.function.scala
+      scope: keyword.declaration.function.scala
     - match: \btype\b
       scope: storage.type.scala
     - match: \bvar\b

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -2,11 +2,11 @@
 // <- source.scala comment.line.double-slash.scala
 
 package fubar
-// ^^^^ keyword.control
+// ^^^^ keyword.declaration.namespace.scala
 //      ^^^^^ entity.name.namespace.header.scala
 
 package fubar {
-// ^^^^ keyword.control.scala
+// ^^^^ keyword.declaration.namespace.scala
 //      ^^^^^ entity.name.namespace.scoped.scala
 //            ^ punctuation.section.block.begin.scala
 // <- meta.namespace.scala
@@ -557,7 +557,7 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^^^ keyword.other.import.scala
 
    package
-// ^^^^^^^ keyword.control.scala
+// ^^^^^^^ keyword.declaration.namespace.scala
 
    private
 // ^^^^^^^ storage.modifier.access

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -19,7 +19,7 @@ import fubar.{Unit, Foo}
 //                ^ punctuation.separator.scala
 
 def foo: Baz = 42
-//^ storage.type.function.scala
+//^ keyword.declaration.function.scala
 //  ^^^ entity.name.function.scala
 //       ^^^ support.class
 //           ^ keyword.operator.assignment.scala
@@ -33,7 +33,7 @@ def foo: Baz => Bar = 42;
 
 
 def foo(a: Int, b: Bar): Baz = 42
-//^ storage.type.function.scala
+//^ keyword.declaration.function.scala
 //  ^^^ entity.name.function.scala
 //      ^ variable.parameter
 //         ^^^ storage.type.primitive.scala
@@ -43,35 +43,35 @@ def foo(a: Int, b: Bar): Baz = 42
 //                             ^^ meta.number.integer.decimal.scala
 
    def +(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^ entity.name.function.scala
 
    def `this is a test`(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^^^^^^^^^^^^ entity.name.function.scala
 
    def ::(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^ entity.name.function.scala
 
    def foo_+(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^ entity.name.function.scala
 
    def foo_2(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^ entity.name.function.scala
 
    def foo42_+(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^^^ entity.name.function.scala
 
    def __many_underscores__+(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^^^^^^^^^^^^^^^^^ entity.name.function.scala
 
    def foo42_+_abc(a: Int)
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^^^^^ entity.name.function.scala
 //            ^^^^ - entity.name.function
 
@@ -79,7 +79,7 @@ def foo(a: Int, b: Bar): Baz = 42
 //      ^^^^ - entity.name.function
 
    def foo[A]
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^ entity.name.function.scala
 //         ^ support.class
 
@@ -545,7 +545,7 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^^^ storage.type.class.scala
 
    def
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 
    val
 // ^^^ storage.type.stable.scala
@@ -609,14 +609,14 @@ type Foo = Bar[A] forSome { type A }
 //            ^^^ support.class
 //                 ^^^ variable.parameter
 //                       ^ variable.language.underscore.scala
-//                          ^^ storage.type.function.arrow.case.scala
+//                          ^^ keyword.declaration.function.arrow.case.scala
 
    case abc @ `abc` =>
 //      ^^^ variable.parameter
 //          ^ keyword.operator.at.scala
 //            ^ punctuation.definition.identifier.scala
 //                ^ punctuation.definition.identifier.scala
-//                  ^^ storage.type.function.arrow.case.scala
+//                  ^^ keyword.declaration.function.arrow.case.scala
 //            ^^^^^ - variable.parameter
 
    case foo: (Int => Boolean) :: _ =>
@@ -987,7 +987,7 @@ type Foo >: Bar
 //     ^^^ storage.type.primitive.scala
 //          ^ variable.parameter
 //             ^^^ storage.type.primitive.scala
-//                  ^ storage.type.function.arrow
+//                  ^ keyword.declaration.function.arrow
 
    a => ???
 // ^ variable.parameter
@@ -1000,7 +1000,7 @@ type Foo >: Bar
    case _ if thing =>
 // ^^^^ keyword.other.declaration.scala
 //           ^^^^^ - variable.parameter
-//                 ^^ - keyword
+//                 ^^ keyword.declaration.function.arrow
 }
 
    a =>a
@@ -1050,7 +1050,7 @@ foo(())()
 
    () => 42
 // ^^ - constant.language.scala
-//    ^^ storage.type.function.arrow
+//    ^^ keyword.declaration.function.arrow
 
 "testing /*comments*/"
 //       ^^^^^^^^^^^^ string.quoted.double
@@ -1059,7 +1059,7 @@ foo(())()
    cb: ((Throwable \/ Unit) => Unit) => 42
 // ^^ variable.parameter
 //                 ^^ support.type.scala
-//                                   ^^ storage.type.function.arrow
+//                                   ^^ keyword.declaration.function.arrow
 
 def foo(a: A <:< B)
 //           ^^^ support.type.scala
@@ -1176,11 +1176,11 @@ foo_
 
 foo({ _ => () })
 //    ^ variable.language.underscore.scala
-//      ^^ storage.type.function.arrow
+//      ^^ keyword.declaration.function.arrow
 
 foo({ _: Unit => () })
 //    ^ variable.language.underscore.scala
-//            ^^ storage.type.function.arrow
+//            ^^ keyword.declaration.function.arrow
 
   stuff: _*
 //       ^^ keyword.operator.varargs.scala
@@ -1224,7 +1224,7 @@ val A: Foo = stuff
 //  ^ variable.other.constant.scala
 
 type Maybe[A] = { type Inner = A; def x: Int }
-//                                ^^ storage.type.function.scala
+//                                ^^ keyword.declaration.function.scala
 //                                    ^ entity.name.function.scala
 
    for {
@@ -1283,7 +1283,7 @@ val Stuff(thing, other) = ???
 
    x: List[Int] => ()
 // ^ variable.parameter.scala
-//              ^^ storage.type.function.arrow.lambda.scala
+//              ^^ keyword.declaration.function.arrow.lambda.scala
 
 /** private */ class Foo
 //             ^^^^^ storage.type.class
@@ -1429,18 +1429,18 @@ def test
 // the following test is paired together
    def foo: Map[Bar]
    def connectionMap: Unit
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 
 def foo: Map[Bar]=42
 //                ^^ meta.number.integer.decimal.scala
 
    x: Foo.Bar => ()
 // ^ variable.parameter.scala
-//            ^^ storage.type.function.arrow.lambda.scala
+//            ^^ keyword.declaration.function.arrow.lambda.scala
 
    x: Foo#Bar => ()
 // ^ variable.parameter.scala
-//            ^^ storage.type.function.arrow.lambda.scala
+//            ^^ keyword.declaration.function.arrow.lambda.scala
 
     object Stuff {
       case
@@ -1453,18 +1453,18 @@ def foo: Map[Bar]=42
 
    def thing(): Other
    def boo: Int
-// ^^^ storage.type.function.scala
+// ^^^ keyword.declaration.function.scala
 //     ^^^ entity.name.function.scala
 
 for {
   abc = () => 42
-//         ^^ storage.type.function.arrow.lambda.scala
+//         ^^ keyword.declaration.function.arrow.lambda.scala
 }
 
 
 for (
   abc = () => 42
-//         ^^ storage.type.function.arrow.lambda.scala
+//         ^^ keyword.declaration.function.arrow.lambda.scala
 )
 
 new {
@@ -1845,12 +1845,12 @@ package object foo extends Bar with Baz
 new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }
 //                     ^^^^ keyword.declaration.scala
 //                          ^^^^^^^^^^ support.class.scala
-//                                       ^^^ storage.type.function.scala
+//                                       ^^^ keyword.declaration.function.scala
 
    implicit def M: Monad[M]
    implicit def Monad
 // ^^^^^^^^ storage.modifier.other.scala
-//          ^^^ storage.type.function.scala
+//          ^^^ keyword.declaration.function.scala
 //              ^ entity.name.function.scala
 
   type Foo =
@@ -2077,15 +2077,15 @@ val x: Nothing
 //     ^^^^^^^ storage.type.primitive.scala
 
 fold(a => b, { case c => d })
-//     ^^ storage.type.function.arrow.lambda.scala
-//                    ^^ storage.type.function.arrow.case.scala
+//     ^^ keyword.declaration.function.arrow.lambda.scala
+//                    ^^ keyword.declaration.function.arrow.case.scala
 
 gzis =>/* foo */
-//   ^^ storage.type.function.arrow.lambda.scala
+//   ^^ keyword.declaration.function.arrow.lambda.scala
 //     ^^^^^^^^^ comment.block.scala
 
 gzis =>// foo
-//   ^^ storage.type.function.arrow.lambda.scala
+//   ^^ keyword.declaration.function.arrow.lambda.scala
 //     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala
 
 s"testing '$foo' bar"

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -14,7 +14,7 @@ package fubar {
 // ^ punctuation.section.block.end.scala
 
 import fubar.{Unit, Foo}
-// ^^^ keyword.other.import
+// ^^^ keyword.declaration.import
 // <- meta.import.scala
 //                ^ punctuation.separator.scala
 
@@ -554,7 +554,7 @@ type Foo = Bar[A] forSome { type A }
 // ^^^ storage.type.volatile.scala
 
    import
-// ^^^^^^ keyword.other.import.scala
+// ^^^^^^ keyword.declaration.import.scala
 
    package
 // ^^^^^^^ keyword.declaration.namespace.scala
@@ -1101,7 +1101,7 @@ import foo, bar
 
 import foo; import bar
 //        ^ punctuation.terminator.scala
-//          ^^^^^^ keyword.other.import.scala
+//          ^^^^^^ keyword.declaration.import.scala
 
 import foo.bar
 //        ^ punctuation.accessor.dot.scala
@@ -1717,7 +1717,7 @@ var foo: Thing =42
 
 class Foo extends Bar with {
    import Thing._
-// ^^^^^^ keyword.other.import.scala
+// ^^^^^^ keyword.declaration.import.scala
 }
 
 class Foo extends Bar.Baz with bin.Baz
@@ -2131,7 +2131,7 @@ s"testing '$foo' bar"
 
    new DataCodec {
      import PreciseKeys._
-//   ^^^^^^ meta.import.scala keyword.other.import.scala
+//   ^^^^^^ meta.import.scala keyword.declaration.import.scala
 //          ^^^^^^^^^^^ meta.import.scala
 //                     ^ meta.import.scala punctuation.accessor.dot.scala
 //                      ^ meta.import.scala variable.language.underscore.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -108,9 +108,9 @@ def foo(a: Int, b: Bar): Baz = 42
 //           ^ support.class
 //              ^ variable.parameter
 //                 ^^^ support.class
-//                      ^^^^^^^ keyword.declaration.scala
+//                      ^^^^^^^ storage.modifier.extends.scala
 //                              ^^^ entity.other.inherited-class.scala
-//                                  ^^^^ keyword.declaration.scala
+//                                  ^^^^ storage.modifier.with.scala
 //                                       ^^^ entity.other.inherited-class.scala
 
    class Foo private[this] (a: Int)(b: String)
@@ -687,14 +687,14 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^ keyword.declaration.class.scala
 //      ^^^^^^ keyword.declaration.class.scala
 //             ^^^^^^ entity.name.class.scala
-//                    ^^^^^^^ keyword.declaration.scala
+//                    ^^^^^^^ storage.modifier.extends.scala
 //                            ^^^^^ entity.other.inherited-class.scala
 
    case object Thingy extends (Foo => Bar)
 // ^^^^ keyword.declaration.class.scala
 //      ^^^^^^ keyword.declaration.class.scala
 //             ^^^^^^ entity.name.class.scala
-//                    ^^^^^^^ keyword.declaration.scala
+//                    ^^^^^^^ storage.modifier.extends.scala
 //                             ^^^ support.class
 
 {
@@ -709,7 +709,7 @@ type Foo = Bar[A] forSome { type A }
 //      ^^^^^ keyword.declaration.class.scala
 //            ^^^^^^ entity.name.class.scala
 //                   ^^^ variable.parameter
-//                             ^^^^^^^ keyword.declaration.scala
+//                             ^^^^^^^ storage.modifier.extends.scala
 //                                     ^^^^^ entity.other.inherited-class.scala
 //
 
@@ -888,12 +888,12 @@ new (Foo ~> Bar)
 
   class Foo(val bar: Baz) extends AnyVal
 //          ^^^ storage.type.scala
-//                        ^^^^^^^ keyword.declaration.scala
+//                        ^^^^^^^ storage.modifier.extends.scala
 //                                ^^^^^^ entity.other.inherited-class.scala
 
   class Foo(implicit bar: Baz) extends AnyVal
 //          ^^^^^^^^ storage.modifier.other
-//                             ^^^^^^^ keyword.declaration.scala
+//                             ^^^^^^^ storage.modifier.extends.scala
 //                                     ^^^^^^ entity.other.inherited-class.scala
 
    val Stuff(f1, v1) = ???
@@ -1605,14 +1605,16 @@ class Foo extends Bar[A with B](42)
 class Foo extends Bar { val x = 42 } with Baz
 //                    ^ punctuation.section.braces.begin.scala
 //                                 ^ punctuation.section.braces.end.scala
-//                                   ^^^^ keyword.declaration.scala
+//                                   ^^^^ storage.modifier.with.scala
 //                                        ^^^ entity.other.inherited-class.scala
 
 class Foo { val x = 42 } extends Bar with Baz
 //        ^ punctuation.section.braces.begin.scala
 //                     ^ punctuation.section.braces.end.scala
-//                       ^^^^^^^ keyword.declaration.scala
+//                       ^^^^^^^ storage.modifier.extends.scala
 //                               ^^^ entity.other.inherited-class.scala
+//                                   ^^^^ storage.modifier.with.scala
+//                                        ^^^ entity.other.inherited-class.scala
 
 class Foo {
 
@@ -1683,18 +1685,18 @@ match {
 
 class Foo
     extends Bar
-//  ^^^^^^^ keyword.declaration.scala
+//  ^^^^^^^ storage.modifier.extends.scala
 //          ^^^ entity.other.inherited-class.scala
 
 class Foo extends Bar
     with Baz
-//  ^^^^ keyword.declaration.scala
+//  ^^^^ storage.modifier.with.scala
 //       ^^^ entity.other.inherited-class.scala
 
 class Foo extends Bar
     with Baz
     with Bin
-//  ^^^^ keyword.declaration.scala
+//  ^^^^ storage.modifier.with.scala
 //       ^^^ entity.other.inherited-class.scala
 
 def foo
@@ -1837,9 +1839,9 @@ abc match {
 //              ^^^ entity.name.class.scala
 
 package object foo extends Bar with Baz
-//                 ^^^^^^^ keyword.declaration.scala
+//                 ^^^^^^^ storage.modifier.extends.scala
 //                         ^^^ entity.other.inherited-class.scala
-//                             ^^^^ keyword.declaration.scala
+//                             ^^^^ storage.modifier.with.scala
 //                                  ^^^ entity.other.inherited-class.scala
 
 new RangeColumn(range) with LongColumn { def apply(row: Int) = a + row }

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -496,7 +496,7 @@ type Foo = Bar[A] forSome { type A }
 
 {
    case =>
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ keyword.declaration.other.scala
 }
 
    macro
@@ -604,7 +604,7 @@ type Foo = Bar[A] forSome { type A }
 
 {
    case (abc: Foo, cba @ _) =>
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ keyword.declaration.other.scala
 //       ^^^ variable.parameter
 //            ^^^ support.class
 //                 ^^^ variable.parameter
@@ -998,7 +998,7 @@ type Foo >: Bar
 
 {
    case _ if thing =>
-// ^^^^ keyword.other.declaration.scala
+// ^^^^ keyword.declaration.other.scala
 //           ^^^^^ - variable.parameter
 //                 ^^ keyword.declaration.function.arrow
 }

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -102,7 +102,7 @@ def foo(a: Int, b: Bar): Baz = 42
 
    class Foo[A](a: Bar) extends Baz with Bin
 // ^^^^^^^^^ meta.class.identifier.scala
-// ^^^^^ storage.type.class.scala
+// ^^^^^ keyword.declaration.class.scala
 //      ^ - storage - entity
 //       ^^^ entity.name.class
 //           ^ support.class
@@ -114,7 +114,7 @@ def foo(a: Int, b: Bar): Baz = 42
 //                                       ^^^ entity.other.inherited-class.scala
 
    class Foo private[this] (a: Int)(b: String)
-// ^^^^^ storage.type.class.scala
+// ^^^^^ keyword.declaration.class.scala
 //      ^ - storage - entity
 //       ^^^ entity.name.class
 //          ^ - storage - entity
@@ -134,11 +134,11 @@ def foo(x: Int = 42)
 //               ^^ meta.number
 
 trait Foo
-// ^^ storage.type.class.scala
+// ^^ keyword.declaration.class.scala
 //    ^^^ entity.name.class
 
 object Foo
-// ^^^ storage.type.class.scala
+// ^^^ keyword.declaration.class.scala
 //     ^^^ entity.name.class
 
    type Foo = Bar
@@ -536,13 +536,13 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^ invalid.keyword.dangling-with.scala
 
    class
-// ^^^^^ storage.type.class.scala
+// ^^^^^ keyword.declaration.class.scala
 
    trait
-// ^^^^^ storage.type.class.scala
+// ^^^^^ keyword.declaration.class.scala
 
    object
-// ^^^^^^ storage.type.class.scala
+// ^^^^^^ keyword.declaration.class.scala
 
    def
 // ^^^ keyword.declaration.function.scala
@@ -684,29 +684,29 @@ type Foo = Bar[A] forSome { type A }
 //                   ^ - keyword
 
    case object Thingy extends Other
-// ^^^^ storage.type.class.scala
-//      ^^^^^^ storage.type.class.scala
+// ^^^^ keyword.declaration.class.scala
+//      ^^^^^^ keyword.declaration.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                            ^^^^^ entity.other.inherited-class.scala
 
    case object Thingy extends (Foo => Bar)
-// ^^^^ storage.type.class.scala
-//      ^^^^^^ storage.type.class.scala
+// ^^^^ keyword.declaration.class.scala
+//      ^^^^^^ keyword.declaration.class.scala
 //             ^^^^^^ entity.name.class.scala
 //                    ^^^^^^^ keyword.declaration.scala
 //                             ^^^ support.class
 
 {
    case class
-// ^^^^ storage.type.class.scala
-//      ^^^^^ storage.type.class.scala
+// ^^^^ keyword.declaration.class.scala
+//      ^^^^^ keyword.declaration.class.scala
 }
 
    case class Thingy(abc: Int) extends Other
 // ^^^^^^^^^^^^^^^^^ meta.class.identifier.scala
-// ^^^^ storage.type.class.scala
-//      ^^^^^ storage.type.class.scala
+// ^^^^ keyword.declaration.class.scala
+//      ^^^^^ keyword.declaration.class.scala
 //            ^^^^^^ entity.name.class.scala
 //                   ^^^ variable.parameter
 //                             ^^^^^^^ keyword.declaration.scala
@@ -1286,7 +1286,7 @@ val Stuff(thing, other) = ???
 //              ^^ keyword.declaration.function.arrow.lambda.scala
 
 /** private */ class Foo
-//             ^^^^^ storage.type.class
+//             ^^^^^ keyword.declaration.class.scala
 
    foo
 // ^^^ - comment
@@ -1655,7 +1655,7 @@ class Foo extends Bar[Int]
 //                       ^ punctuation.definition.generic.end.scala
 
    object Underscore_
-// ^^^^^^ storage.type.class.scala
+// ^^^^^^ keyword.declaration.class.scala
 //        ^^^^^^^^^^^ entity.name.class.scala
 
 match {
@@ -1802,7 +1802,7 @@ for {
 //     ^ punctuation.definition.tag.end
 
    case class
-// ^^^^ storage.type.class.scala
+// ^^^^ keyword.declaration.class.scala
 
 new Monad[Catenable] with Traverse
 //       ^ punctuation.definition.generic.begin.scala
@@ -1814,7 +1814,7 @@ new Monad[Catenable] with Traverse
    final class A
    final class B[A[_] <: B](a: B)
 // ^^^^^ storage.modifier.other.scala
-//       ^^^^^ storage.type.class.scala
+//       ^^^^^ keyword.declaration.class.scala
 //             ^ entity.name.class.scala
 //              ^^^^^^^^^^^ meta.generic.scala
 //              ^ punctuation.definition.generic.begin.scala
@@ -1833,7 +1833,7 @@ abc match {
    sealed trait Foo
    sealed trait Bar
 // ^^^^^^ storage.modifier.other.scala
-//        ^^^^^ storage.type.class.scala
+//        ^^^^^ keyword.declaration.class.scala
 //              ^^^ entity.name.class.scala
 
 package object foo extends Bar with Baz


### PR DESCRIPTION
This PR modifies some keyword scopes to (hopefully) align them better to recently aggreed scope naming guidelines.

It mainly addresses `storage.type` vs. `keyword.declaration` use cases.