### PR TITLE
[HTML] Add scope for path separators

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -564,7 +564,7 @@ contexts:
       scope: constant.character.escape.url.html
       captures:
         1: punctuation.definition.escape.html
-    - match: '[/&?]|://'
+    - match: '[/&?#]|://'
       scope: punctuation.separator.path.html
 
 ###[ ID ATTRIBUTE ]###########################################################

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -559,11 +559,13 @@ contexts:
     - include: tag-attribute-value-unquoted-invalid-char
 
   tag-href-attribute-value-content:
+    - include: tag-attribute-value-content
     - match: (%)\h{2}
       scope: constant.character.escape.url.html
       captures:
         1: punctuation.definition.escape.html
-    - include: tag-attribute-value-content
+    - match: '[/&?]|://'
+      scope: punctuation.separator.path.html
 
 ###[ ID ATTRIBUTE ]###########################################################
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -711,15 +711,17 @@ class="foo"></div>
 ##      ^^^^ - constant.character.entity
 
 
-        <a href="http://google%20api.com/?one=1&amp;two=2"></a>
+        <a href="http://google%20api.com/?one=1&amp;two=2#anchor"></a>
         ##           ^^^ punctuation.separator.path.html
         ##                    ^^^ constant.character.escape.url
         ##                              ^^ punctuation.separator.path.html
         ##                                     ^^^^^ constant.character.entity - punctuation.separator
-        <a href="http://google.com/?one=1&two=2"></a>
+        ##                                               ^ punctuation.separator.path.html
+        <a href="http://google.com/?one=1&two=2#anchor"></a>
         ##           ^^^ punctuation.separator.path.html
         ##                        ^^ punctuation.separator.path.html
         ##                               ^ punctuation.separator.path.html - constant.character.entity
+        ##                                     ^ punctuation.separator.path.html
 
         <hr/><hr />
         ## ^^ meta.tag.block.any punctuation.definition.tag.end

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -712,11 +712,14 @@ class="foo"></div>
 
 
         <a href="http://google%20api.com/?one=1&amp;two=2"></a>
+        ##           ^^^ punctuation.separator.path.html
         ##                    ^^^ constant.character.escape.url
-        ##                                     ^^^^^ constant.character.entity
+        ##                              ^^ punctuation.separator.path.html
+        ##                                     ^^^^^ constant.character.entity - punctuation.separator
         <a href="http://google.com/?one=1&two=2"></a>
-        ##                               ^ - constant.character.entity
-        ##                               ^ - invalid.illegal
+        ##           ^^^ punctuation.separator.path.html
+        ##                        ^^ punctuation.separator.path.html
+        ##                               ^ punctuation.separator.path.html - constant.character.entity
 
         <hr/><hr />
         ## ^^ meta.tag.block.any punctuation.definition.tag.end


### PR DESCRIPTION
This commit aligns syntax highlighting of urls with the implementation used in CSS.sublime-syntax, which scopes `/`, etc. as path separators.