### PR TITLE
[HTML] Fix HTML snippet selectors

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -208,6 +208,10 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: punctuation.definition.tag.end.html
+    - match: '<'
+      scope: meta.character.less-than.html
+    - match: '>'
+      scope: meta.character.greater-than.html
 
   tag-end:
     - match: '>'

--- a/HTML/Snippets/html (begin tag).sublime-snippet
+++ b/HTML/Snippets/html (begin tag).sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-	<description>html</description>
 	<content><![CDATA[!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
 	<title>$1</title>
 </head>
 <body>
@@ -10,5 +10,6 @@ $0
 </body>
 </html>]]></content>
 	<tabTrigger>html</tabTrigger>
-	<scope>text.html entity.name.tag</scope>
+	<scope>text.html entity.name.tag, text.html meta.character.less-than</scope>
+	<description>html</description>
 </snippet>

--- a/HTML/Snippets/html.sublime-snippet
+++ b/HTML/Snippets/html.sublime-snippet
@@ -10,5 +10,6 @@ $0
 </body>
 </html>]]></content>
 	<tabTrigger>html</tabTrigger>
-	<scope>text.html &amp; (- meta.tag | punctuation.definition.tag.begin)</scope>
+	<scope>text.html - (meta.tag | meta.character.less-than)</scope>
+	<description>html</description>
 </snippet>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -731,9 +731,14 @@ class="foo"></div>
 
         <_notag>
         ##^^^^^ - entity.name.tag
+        ## <- meta.character.less-than.html
 
         <2notag>
         ##^^^^^ - entity.name.tag
+        ## <- meta.character.less-than.html
+
+        <
+        ## <- meta.character.less-than.html
 
         <> < >
         ## <- meta.tag.incomplete.html invalid.illegal.incomplete.html punctuation.definition.tag.begin.html


### PR DESCRIPTION
This commit fixes an issue which caused ST's completion engine to fail selecting correct "HTML" snippet variant in some situations.

The result is an extra `<` in front of the added snippet content:

```
<<!DOCTYPE html>
...
```

**Steps to reproduce:**

1. Open a new view and set its syntax to HTML
2. Type `<`
3. Hit `ctrl+space`
   => ST selects html.sublime-snippet as its selector matches
4. Type `html`
5. Commit completion

Selectors of involved snippet files left a gap of confusion because a single less than sign is not scoped at all. Even if it would be scoped `punctuation.definition.tag.begin` the wrong html.sublime-snippet would be applied due to malformed selector.

As it is allowed to have single `<` within normal text (Firefox, Chrome don't complain about it), it can't be scoped `punctuation`. To be able to address it in snippet or completion selectors, `<` is scoped `meta.character.less-than`. That helps closing the gap and always select the correct snippet no matter how it is triggered.