### PR TITLE
[Haskell] Fix various syntax highlighting issues

### DIFF
--- a/Haskell/Haskell.sublime-settings
+++ b/Haskell/Haskell.sublime-settings
@@ -1,0 +1,4 @@
+{
+    // Default word boundaries except: '
+    "word_separators": "./\\()\"-:,.;<>~!@#$%^&*|+=[]{}`~?",
+}

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -372,7 +372,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.comma.haskell
         - include: operator_paren
-        - match: \(.*?\)
+        - match: \({{no_comment_ahead}}.*?\)
           comment: So named because I don't know what to call this.
           scope: meta.other.unknown.haskell
   

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -203,6 +203,8 @@ contexts:
       captures:
         1: punctuation.definition.function.begin.haskell
         2: punctuation.definition.function.end.haskell
+    - match: (`)[^`]*?(?:(`)|{{comment_ahead}})
+      scope: invalid.illegal.operator.haskell
     - match: '\binfix[lr]?\b'
       scope: keyword.operator.haskell
     - match: \b(\d+)(?:(\.)(\d+)([eE][-+]?\d+)?|([eE][-+]?\d+))\b

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -237,7 +237,7 @@ contexts:
       scope: punctuation.definition.string.begin.haskell
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.double.haskell
+        - meta_scope: meta.string.haskell string.quoted.double.haskell
         - match: \"|$|{{comment_ahead}}
           scope: punctuation.definition.string.end.haskell
           pop: true
@@ -257,7 +257,7 @@ contexts:
         )
         ([^']*?)
         (?:(')|{{comment_ahead}})
-      scope: string.quoted.single.haskell
+      scope: meta.string.haskell string.quoted.single.haskell
       captures:
         1: punctuation.definition.string.begin.haskell
         2: constant.character.escape.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -202,11 +202,12 @@ contexts:
       scope: keyword.control.flow.return.haskell
     - match: \b(?:default|otherwise)\b
       scope: keyword.other.haskell
-    - match: \b(?:(if)|(then)|(else))\b
-      captures:
-        1: keyword.control.conditional.if.haskell
-        2: keyword.control.conditional.then.haskell
-        3: keyword.control.conditional.else.haskell
+    - match: \b(?:if)\b
+      scope: keyword.control.conditional.if.haskell
+    - match: \b(?:then)\b
+      scope: keyword.control.conditional.then.haskell
+    - match: \b(?:else)\b
+      scope: keyword.control.conditional.else.haskell
 
   operator:
     - match: (`)[ \w'.]+(`)

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -252,7 +252,7 @@ contexts:
         (?x)
         (')
         (?:
-          [\ -\[\]-~]            # Basic Char
+          ([\ -\[\]-~])          # Basic Char
           | {{escape_sequence}}  # Escapes
         )
         ([^']*?)
@@ -260,13 +260,14 @@ contexts:
       scope: meta.string.haskell string.quoted.single.haskell
       captures:
         1: punctuation.definition.string.begin.haskell
-        2: constant.character.escape.haskell
-        3: constant.character.escape.decimal.haskell
-        4: constant.character.escape.octal.haskell
-        5: constant.character.escape.hexadecimal.haskell
-        6: constant.character.escape.control.haskell
-        7: invalid.illegal.expected-closing-quotation.haskell
-        8: punctuation.definition.string.end.haskell
+        2: constant.character.literal.haskell
+        3: constant.character.escape.haskell
+        4: constant.character.escape.decimal.haskell
+        5: constant.character.escape.octal.haskell
+        6: constant.character.escape.hexadecimal.haskell
+        7: constant.character.escape.control.haskell
+        8: invalid.illegal.expected-closing-quotation.haskell
+        9: punctuation.definition.string.end.haskell
 
   splice:
     - match: '\[(?:|e|d|t|p)\|'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -96,13 +96,16 @@ contexts:
         - include: expression
 
   constant:
-    - match: \(\)
-      scope: constant.language.unit.haskell
     - match: \[\]
       scope: constant.language.empty-list.haskell
+    - include: constant_unit
     - include: number
     - match: '{{con_id}}'
       scope: constant.other.haskell
+
+  constant_unit:
+    - match: \(\)
+      scope: constant.language.unit.haskell
 
   number:
     - match: (0[oO])([0-7]+){{break}}
@@ -429,8 +432,7 @@ contexts:
     - include: operator_big_arrow
     - include: ident_generic_type
     - include: ident_type
-    - match: \(\)
-      scope: support.constant.unit.haskell
+    - include: constant_unit
 
   pragma:
     - match: '\{-#'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -252,11 +252,11 @@ contexts:
   preprocessor:
     # In addition to Haskell's "native" syntax,
     # GHC permits the C preprocessor to be run on a source file.
-    - match: ^\s*(#)\s*(\w+)
+    - match: ^\s*((#)\s*\w+)
       scope: meta.preprocessor.c
       captures:
-        1: punctuation.definition.preprocessor.c
-        2: keyword.directive.other.c
+        1: keyword.directive.other.c
+        2: punctuation.definition.preprocessor.c
     - include: pragma
 
   string:

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -22,15 +22,17 @@ variables:
   operator_parens: '(?:{{no_comment_ahead}}{{operator_infix}}|,+)'
 
   # Identifiers
-  con_id: (?:\b[[:upper:]][\w']*)
-  var_id: (?:\b(?!{{reserved_id}})[[:lower:]][\w']*)
+  con_id: (?:[[:upper:]][\w']*)
+  var_id: (?:(?!{{reserved_id}})[[:lower:]][\w']*)
   reserved_id: |-
     (?x:
       case | class | data | default | deriving | do | else
     | foreign | if | import | in | infix | infixl
     | infixr | instance | let | module | newtype | of
     | then | type | where | _
-    )\b
+    ){{break}}
+
+  break: (?![\w'])
 
   # Escaped Characters
   escape_chars: |-
@@ -103,25 +105,25 @@ contexts:
       scope: constant.other.haskell
 
   number:
-    - match: \b(0[oO])([0-7]+)\b
+    - match: (0[oO])([0-7]+){{break}}
       scope: meta.number.integer.octal.haskell
       captures:
         1: constant.numeric.base.haskell
         2: constant.numeric.value.haskell
-    - match: \b(0[xX])(\h+)\b
+    - match: (0[xX])(\h+){{break}}
       scope: meta.number.integer.hexadecimal.haskell
       captures:
         1: constant.numeric.base.haskell
         2: constant.numeric.value.haskell
-    - match: \b\d+\b
+    - match: \d+{{break}}
       scope: meta.number.integer.decimal.haskell constant.numeric.value.haskell
 
   declaration:
-    - match: \bmodule\b
+    - match: module{{break}}
       scope: keyword.declaration.namespace.haskell
       push:
         - meta_scope: meta.declaration.module.haskell
-        - match: \bwhere\b
+        - match: where{{break}}
           scope: keyword.control.context.haskell
           pop: true
         - match: ({{con_id}})(\.)
@@ -131,26 +133,26 @@ contexts:
         - match: '{{con_id}}'
           scope: entity.name.namespace.haskell
         - include: module_exports
-    - match: \bclass\b
+    - match: class{{break}}
       scope: keyword.declaration.class.haskell
       push:
         - meta_scope: meta.declaration.class.haskell
-        - match: \bwhere\b
+        - match: where{{break}}
           scope: keyword.control.context.haskell
           pop: true
         - match: |-
-            \b(?x:Monad|Monadoid|Functor|Applicative|Foldableble|Traversable
+            (?x:Monad|Monadoid|Functor|Applicative|Foldableble|Traversable
               |Eq|Ord|Read|Show|Num|Fractional|Rational|Enum|Bounded
-              |Real|RealFrac|RealFloat|Integral|Floating)\b
+              |Real|RealFrac|RealFloat|Integral|Floating){{break}}
           scope: support.class.prelude.haskell
         - include: ident_inherited_class
         - include: ident_generic_type
         - include: operator_big_arrow
-    - match: \binstance\b
+    - match: instance{{break}}
       scope: keyword.declaration.haskell
       push:
         - meta_scope: meta.declaration.instance.haskell
-        - match: \bwhere\b|$
+        - match: where|$
           scope: keyword.control.context.haskell
           pop: true
         - include: type_signature
@@ -174,39 +176,39 @@ contexts:
         - include: ident_inherited_class
 
   import:
-    - match: \bimport\b
+    - match: import{{break}}
       scope: keyword.control.import.haskell
       push:
         - meta_scope: meta.import.haskell
         - match: ($|;)
           pop: true
-        - match: (qualified|as|hiding)
+        - match: (?:qualified|as|hiding){{break}}
           scope: keyword.control.import.haskell
         - include: module_name
         - include: module_exports
 
   keyword:
-    - match: \b(?:do|in)\b
+    - match: (?:do|in){{break}}
       scope: keyword.control.context.haskell
-    - match: \b(?:newtype|type)\b
+    - match: (?:newtype|type){{break}}
       scope: keyword.declaration.type.haskell
-    - match: \b(?:data)\b
+    - match: (?:data){{break}}
       scope: keyword.declaration.data.haskell
-    - match: \b(?:deriving)\b
+    - match: (?:deriving){{break}}
       scope: keyword.declaration.data.haskell
-    - match: \b(?:case|of)\b
+    - match: (?:case|of){{break}}
       scope: keyword.control.conditional.select.haskell  # the construct is commonly called "select"
-    - match: \b(?:let|where)\b
+    - match: (?:let|where){{break}}
       scope: keyword.declaration.variable.haskell
-    - match: \breturn\b
+    - match: (?:return){{break}}
       scope: keyword.control.flow.return.haskell
-    - match: \b(?:default|otherwise)\b
+    - match: (?:default|otherwise){{break}}
       scope: keyword.other.haskell
-    - match: \b(?:if)\b
+    - match: (?:if){{break}}
       scope: keyword.control.conditional.if.haskell
-    - match: \b(?:then)\b
+    - match: (?:then){{break}}
       scope: keyword.control.conditional.then.haskell
-    - match: \b(?:else)\b
+    - match: (?:else){{break}}
       scope: keyword.control.conditional.else.haskell
 
   operator:
@@ -219,9 +221,9 @@ contexts:
         2: punctuation.definition.function.end.haskell
     - match: (`)[^`]*?(?:(`)|{{comment_ahead}})
       scope: invalid.illegal.operator.haskell
-    - match: '\binfix[lr]?\b'
+    - match: 'infix[lr]?{{break}}'
       scope: keyword.operator.haskell
-    - match: \b(\d+)(?:(\.)(\d+)([eE][-+]?\d+)?|([eE][-+]?\d+))\b
+    - match: (\d+)(?:(\.)(\d+)([eE][-+]?\d+)?|([eE][-+]?\d+)){{break}}
       scope: meta.number.float.decimal.haskell
       captures:
         1: constant.numeric.value.haskell
@@ -328,7 +330,7 @@ contexts:
 
   ident:
     - match: |-
-        (?x) \b
+        (?x)
         (abs|acos|acosh|all|and|any|appendFile|asTypeOf|asin|asinh|atan|atan2|atanh
         |break
         |ceiling|compare|concat|concatMap|const|cos|cosh|curry|cycle
@@ -355,7 +357,7 @@ contexts:
         |undefined|unlines|until|unwords|unzip|unzip3|userError|words
         |writeFile
         |zip|zip3|zipWith|zipWith3
-        ) \b
+        ){{break}}
       scope: support.function.prelude.haskell
     - match: '[[:lower:]][^\s{{operator_char}}),\]{}]+'
       scope: meta.name.haskell
@@ -437,11 +439,11 @@ contexts:
         - match: '#-\}'
           pop: true
         - match: |-
-            \b(?x:
+            (?x:
               LANGUAGE|OPTIONS_GHC|OPTIONS_HADDOCK|INCLUDE|WARNING|DEPRECATED|MINIMAL
               |UNPACK|NOUNPACK|SOURCE|OVERLAPPING|OVERLAPPABLE|OVERLAPS
               |INCOHERENT|INLINE|NOINLINE|INLINABLE|CONLIKE|LINE|RULES
               |SPECIALIZE|SPECIALISE
-            )\b
+            ){{break}}
           # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#pragmas
           scope: keyword.directive.other.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -143,10 +143,8 @@ contexts:
               |Eq|Ord|Read|Show|Num|Fractional|Rational|Enum|Bounded
               |Real|RealFrac|RealFloat|Integral|Floating)\b
           scope: support.class.prelude.haskell
-        - match: '{{con_id}}'
-          scope: entity.other.inherited-class.haskell
-        - match: '{{var_id}}'
-          scope: variable.other.generic-type.haskell
+        - include: ident_inherited_class
+        - include: ident_generic_type
         - include: operator_big_arrow
     - match: \binstance\b
       scope: keyword.declaration.haskell
@@ -173,8 +171,7 @@ contexts:
         - meta_scope: meta.deriving.haskell
         - match: \)
           pop: true
-        - match: '{{con_id}}'
-          scope: entity.other.inherited-class.haskell
+        - include: ident_inherited_class
 
   import:
     - match: \bimport\b
@@ -361,6 +358,22 @@ contexts:
     - match: '[[:lower:]][^\s{{operator_char}}),\]{}]+'
       scope: meta.name.haskell
 
+  ident_function:
+    - match: '{{var_id}}'
+      scope: variable.function.haskell
+
+  ident_inherited_class:
+    - match: '{{con_id}}'
+      scope: entity.other.inherited-class.haskell
+
+  ident_generic_type:
+    - match: '{{var_id}}'
+      scope: variable.other.generic-type.haskell
+
+  ident_type:
+    - match: '{{con_id}}'
+      scope: storage.type.haskell
+
   comment:
     - match: '(--+)(?:{{comment_first_char}}.*)?$\n?'
       scope: comment.line.double-dash.haskell
@@ -391,10 +404,8 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.haskell
           pop: true
-        - match: '{{var_id}}'
-          scope: variable.function.haskell
-        - match: '{{con_id}}'
-          scope: storage.type.haskell
+        - include: ident_function
+        - include: ident_type
         - match: ','
           scope: punctuation.separator.comma.haskell
         - include: operator_paren
@@ -412,10 +423,8 @@ contexts:
     - include: pragma
     - include: operator_arrow
     - include: operator_big_arrow
-    - match: '{{var_id}}'
-      scope: variable.other.generic-type.haskell
-    - match: '{{con_id}}'
-      scope: storage.type.haskell
+    - include: ident_generic_type
+    - include: ident_type
     - match: \(\)
       scope: support.constant.unit.haskell
 

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -155,7 +155,7 @@ contexts:
       scope: keyword.declaration.haskell
       push:
         - meta_scope: meta.declaration.instance.haskell
-        - match: where|$
+        - match: where{{break}}|$
           scope: keyword.control.context.haskell
           pop: true
         - include: type_signature

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -13,7 +13,7 @@ variables:
   # such as $%^&*.
   operator_char: '[*|!%&$@#?~+:\-.=</>\\]'
   operator_infix: '{{operator_char}}+'
-  operator_parens: '(?:{{operator_infix}}|,+)'
+  operator_parens: '(?:(?!--+\)){{operator_infix}}|,+)'
   module_name: (?:[A-Z][A-Za-z._']*)
   escape_chars: |-
     (?x:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI
@@ -329,14 +329,10 @@ contexts:
       scope: meta.name.haskell
 
   comment:
-    # As of build 4079 the [:punct:] class is missing some ASCII chars that
-    # Unicode considers part of the Symbol category.
-    - match: '--(?![[:punct:]!-/:-@\[-`{-~])'
-      scope: punctuation.definition.comment.haskell
-      push:
-        - meta_scope: comment.line.double-dash.haskell
-        - match: $\n?
-          pop: true
+    - match: '(--+)(?:[ \t\w"''(),;\[\]`{}].*)?$\n?'
+      scope: comment.line.double-dash.haskell
+      captures:
+        1: punctuation.definition.comment.haskell
     - include: block_comment
 
   block_comment:

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -147,6 +147,7 @@ contexts:
           scope: entity.other.inherited-class.haskell
         - match: '{{var_id}}'
           scope: variable.other.generic-type.haskell
+        - include: operator_big_arrow
     - match: \binstance\b
       scope: keyword.declaration.haskell
       push:
@@ -233,6 +234,14 @@ contexts:
     - match: '{{operator_infix}}'
       scope: keyword.operator.haskell
     - include: operator_paren
+
+  operator_arrow:
+    - match: '(?:->|→)'
+      scope: keyword.other.arrow.haskell
+
+  operator_big_arrow:
+    - match: '(?:=>|⇒)'
+      scope: keyword.other.big-arrow.haskell
 
   operator_paren:
     - match: \(({{operator_parens}})\)
@@ -401,10 +410,8 @@ contexts:
   
   type_signature:
     - include: pragma
-    - match: '(?:->|→)'
-      scope: keyword.other.arrow.haskell
-    - match: '(?:=>|⇒)'
-      scope: keyword.other.big-arrow.haskell
+    - include: operator_arrow
+    - include: operator_big_arrow
     - match: '{{var_id}}'
       scope: variable.other.generic-type.haskell
     - match: '{{con_id}}'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -7,13 +7,19 @@ file_extensions:
 scope: source.haskell
 
 variables:
+  # Comments
+  no_comment_ahead: '(?!{{comment_begin}})'
+  comment_ahead: '(?={{comment_begin}})'
+  comment_begin: '--+(?:{{comment_first_char}}|$)'
+  comment_first_char: '[ \t\w"''(),;\[\]`{}]'
+
   # In case this regex seems overly general,
   # note that Haskell permits the definition of new operators
   # which can be nearly any string of punctuation characters,
   # such as $%^&*.
   operator_char: '[*|!%&$@#?~+:\-.=</>\\]'
   operator_infix: '{{operator_char}}+'
-  operator_parens: '(?:(?!--+\)){{operator_infix}}|,+)'
+  operator_parens: '(?:{{no_comment_ahead}}{{operator_infix}}|,+)'
   module_name: (?:[A-Z][A-Za-z._']*)
   escape_chars: |-
     (?x:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI
@@ -227,12 +233,12 @@ contexts:
     - include: pragma
 
   string:
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.haskell
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.haskell
-        - match: $|"
+        - match: \"|$|{{comment_ahead}}
           scope: punctuation.definition.string.end.haskell
           pop: true
         - match: '{{escape_sequence}}'
@@ -249,8 +255,8 @@ contexts:
           [\ -\[\]-~]            # Basic Char
           | {{escape_sequence}}  # Escapes
         )
-        ([^']*)
-        (')
+        ([^']*?)
+        (?:(')|{{comment_ahead}})
       scope: string.quoted.single.haskell
       captures:
         1: punctuation.definition.string.begin.haskell
@@ -329,7 +335,7 @@ contexts:
       scope: meta.name.haskell
 
   comment:
-    - match: '(--+)(?:[ \t\w"''(),;\[\]`{}].*)?$\n?'
+    - match: '(--+)(?:{{comment_first_char}}.*)?$\n?'
       scope: comment.line.double-dash.haskell
       captures:
         1: punctuation.definition.comment.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -249,10 +249,11 @@ contexts:
   preprocessor:
     # In addition to Haskell's "native" syntax,
     # GHC permits the C preprocessor to be run on a source file.
-    - match: ^\s*(#)\s*\w+
+    - match: ^\s*(#)\s*(\w+)
       scope: meta.preprocessor.c
       captures:
         1: punctuation.definition.preprocessor.c
+        2: keyword.directive.other.c
     - include: pragma
 
   string:
@@ -442,4 +443,4 @@ contexts:
               |SPECIALIZE|SPECIALISE
             )\b
           # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#pragmas
-          scope: keyword.other.preprocessor.haskell
+          scope: keyword.directive.other.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -268,7 +268,7 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: meta.string.haskell string.quoted.double.haskell
-        - match: \"|$|{{comment_ahead}}
+        - match: \"|$
           scope: punctuation.definition.string.end.haskell
           pop: true
         - match: '{{escape_sequence}}'

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -20,7 +20,19 @@ variables:
   operator_char: '[*|!%&$@#?~+:\-.=</>\\]'
   operator_infix: '{{operator_char}}+'
   operator_parens: '(?:{{no_comment_ahead}}{{operator_infix}}|,+)'
-  module_name: (?:[A-Z][A-Za-z._']*)
+
+  # Identifiers
+  con_id: (?:\b[[:upper:]][\w']*)
+  var_id: (?:\b(?!{{reserved_id}})[[:lower:]][\w']*)
+  reserved_id: |-
+    (?x:
+      case | class | data | default | deriving | do | else
+    | foreign | if | import | in | infix | infixl
+    | infixr | instance | let | module | newtype | of
+    | then | type | where | _
+    )\b
+
+  # Escaped Characters
   escape_chars: |-
     (?x:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI
       |DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL
@@ -84,10 +96,10 @@ contexts:
   constant:
     - match: \(\)
       scope: constant.language.unit.haskell
-    - match: '\[\]'
+    - match: \[\]
       scope: constant.language.empty-list.haskell
     - include: number
-    - match: '\b[A-Z]\w*\b'
+    - match: '{{con_id}}'
       scope: constant.other.haskell
 
   number:
@@ -112,7 +124,11 @@ contexts:
         - match: \bwhere\b
           scope: keyword.control.context.haskell
           pop: true
-        - match: \b{{module_name}}\b
+        - match: ({{con_id}})(\.)
+          captures:
+            1: variable.namespace.haskell
+            2: punctuation.accessor.dot.haskell
+        - match: '{{con_id}}'
           scope: entity.name.namespace.haskell
         - include: module_exports
     - match: \bclass\b
@@ -127,9 +143,9 @@ contexts:
               |Eq|Ord|Read|Show|Num|Fractional|Rational|Enum|Bounded
               |Real|RealFrac|RealFloat|Integral|Floating)\b
           scope: support.class.prelude.haskell
-        - match: '[A-Z][A-Za-z_'']*'
+        - match: '{{con_id}}'
           scope: entity.other.inherited-class.haskell
-        - match: '\b[a-z][a-zA-Z0-9_'']*\b'
+        - match: '{{var_id}}'
           scope: variable.other.generic-type.haskell
     - match: \binstance\b
       scope: keyword.declaration.haskell
@@ -139,7 +155,7 @@ contexts:
           scope: keyword.control.context.haskell
           pop: true
         - include: type_signature
-    - match: '^(\s*)([a-z_][a-zA-Z0-9_'']*|\(({{operator_parens}})\))\s*(::|∷)'
+    - match: '^(\s*)({{var_id}}|\(({{operator_parens}})\))\s*(::|∷)'
       captures:
         2: entity.name.function.haskell
         3: keyword.operator.infix.haskell
@@ -156,9 +172,8 @@ contexts:
         - meta_scope: meta.deriving.haskell
         - match: \)
           pop: true
-        - match: '\b[A-Z][a-zA-Z_'']*'
+        - match: '{{con_id}}'
           scope: entity.other.inherited-class.haskell
-
 
   import:
     - match: \bimport\b
@@ -291,7 +306,7 @@ contexts:
     - match: \$\(
       comment: Highlight the beginning of a splice.
       scope: keyword.other.splice.haskell
-    - match: '\[[a-zA-Z0-9_'']*\|'
+    - match: '\[[\w'']*\|'
       scope: keyword.other.quasibracket.haskell
       push:
         - meta_scope: meta.other.quasiquote.haskell
@@ -367,9 +382,9 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.haskell
           pop: true
-        - match: '\b[a-z][a-zA-Z_''0-9]*'
+        - match: '{{var_id}}'
           scope: variable.function.haskell
-        - match: '\b[A-Z][A-Za-z_''0-9]*'
+        - match: '{{con_id}}'
           scope: storage.type.haskell
         - match: ','
           scope: punctuation.separator.comma.haskell
@@ -379,8 +394,10 @@ contexts:
           scope: meta.other.unknown.haskell
   
   module_name:
-    - match: '\b{{module_name}}\b'
-      scope: support.other.module.haskell
+    - match: ({{con_id}})(\.)?
+      captures:
+        1: variable.namespace.haskell
+        2: punctuation.accessor.dot.haskell
   
   type_signature:
     - include: pragma
@@ -388,9 +405,9 @@ contexts:
       scope: keyword.other.arrow.haskell
     - match: '(?:=>|⇒)'
       scope: keyword.other.big-arrow.haskell
-    - match: '\b[a-z][a-zA-Z0-9_'']*\b'
+    - match: '{{var_id}}'
       scope: variable.other.generic-type.haskell
-    - match: '\b[A-Z][a-zA-Z0-9_'']*\b'
+    - match: '{{con_id}}'
       scope: storage.type.haskell
     - match: \(\)
       scope: support.constant.unit.haskell

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -196,7 +196,7 @@ contexts:
         3: keyword.control.conditional.else.haskell
 
   operator:
-    - match: (`)[a-zA-Z_'.\d]+(`)
+    - match: (`)[ \w'.]+(`)
       # Haskell allows any ordinary function application (elem 4 [1..10])
       # to be rewritten as an infix expression (4 `elem` [1..10])."
       scope: keyword.operator.function.infix.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -149,12 +149,12 @@
    #if 0
 -- ^^^ meta.preprocessor.c
 -- ^ punctuation.definition.preprocessor.c
---  ^^ keyword.directive.other.c
+-- ^^^ keyword.directive.other.c
 
    #endif
 -- ^^^^^^ meta.preprocessor.c
 -- ^ punctuation.definition.preprocessor.c
---  ^^^^^ keyword.directive.other.c
+-- ^^^^^^ keyword.directive.other.c
 
 -- | Map each element of a structure to an action,
 -- evaluate these actions from left to right, and

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -42,6 +42,85 @@
 --                      ^^ punctuation.definition.comment.end.haskell
 --                        ^ - comment.block.haskell
 
+
+-- COMMENTS STARTING WITH SPECIAL SYMBOL CHARS
+
+   --
+-- ^^^ comment
+   --_
+-- ^^^ comment
+   --"
+-- ^^^ comment
+   --'
+-- ^^^ comment
+   --(
+-- ^^^ comment
+   --)
+-- ^^^ comment
+   --,
+-- ^^^ comment
+   ---
+-- ^^^ comment
+   --;
+-- ^^^ comment
+   --[
+-- ^^^ comment
+   --]
+-- ^^^ comment
+   --`
+-- ^^^ comment
+   --{
+-- ^^^ comment
+   --}
+-- ^^^ comment
+
+
+-- NO COMMENTS
+
+   --!
+-- ^^^ - comment
+   --#
+-- ^^^ - comment
+   --$
+-- ^^^ - comment
+   --%
+-- ^^^ - comment
+   --&
+-- ^^^ - comment
+   --*
+-- ^^^ - comment
+   --+
+-- ^^^ - comment
+   --.
+-- ^^^ - comment
+   --.
+-- ^^^ - comment
+   --/
+-- ^^^ - comment
+   --:
+-- ^^^ - comment
+   --<
+-- ^^^ - comment
+   --=
+-- ^^^ - comment
+   -->
+-- ^^^ - comment
+   --?
+-- ^^^ - comment
+   --\
+-- ^^^ - comment
+   --\
+-- ^^^ - comment
+   --^
+-- ^^^ - comment
+   --|
+-- ^^^ - comment
+   --~
+-- ^^^ - comment
+   --~
+-- ^^^ - comment
+
+
 --DECLARATIONS
 
    module Name where
@@ -138,6 +217,21 @@
 --       ^^^ variable.function.infix.haskell
 --             ^ meta.number.integer.decimal.haskell constant.numeric.value.haskell
 
+   a a = (--) a 2
+--     ^ keyword.operator.haskell
+--       ^^^^ - variable.function.infix
+--       ^ punctuation.section.group.begin.haskell
+--        ^^^^^^^^ comment.line.double-dash.haskell
+         )
+--       ^ punctuation.section.group.end.haskell
+
+   a a = (---) a 2
+--     ^ keyword.operator.haskell
+--       ^^^^^ - variable.function.infix
+--       ^ punctuation.section.group.begin.haskell
+--        ^^^^^^^^^ comment.line.double-dash.haskell
+         )
+--       ^ punctuation.section.group.end.haskell
 
    a `member` x
 --   ^^^^^^^^ keyword.operator.function.infix.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -242,6 +242,28 @@
 --   ^ punctuation.definition.function.begin.haskell
 --           ^ punctuation.definition.function.end.haskell
 
+   5 `f `7`f`"3 'ab'"
+-- ^ constant.numeric.value.haskell
+--   ^^^^ invalid.illegal.operator.haskell
+--       ^ constant.numeric.value.haskell
+--        ^^^ keyword.operator.function.infix.haskell
+--        ^ punctuation.definition.function.begin.haskell
+--          ^ punctuation.definition.function.end.haskell
+--           ^^^^^^^^ meta.string.haskell string.quoted.double.haskell
+--           ^ punctuation.definition.string.begin.haskell
+--            ^^^^^^ - constant - punctuation
+--                  ^ punctuation.definition.string.end.haskell
+
+   a ` f` b
+--   ^^^^ invalid.illegal.operator.haskell
+
+   a `--` b
+--   ^ invalid.illegal.operator.haskell
+--    ^^^^^^ comment.line.double-dash.haskell
+
+   a `
+--   ^ - keyword - operator - punctuation
+
 
 -- Tests for #1320, #1880.
 

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -413,38 +413,38 @@ main = do
 
 
    'ab'
--- ^^^^ string.quoted.single.haskell
+-- ^^^^ meta.string.haskell string.quoted.single.haskell
 -- ^ punctuation.definition.string.begin.haskell
 --   ^ invalid.illegal.expected-closing-quotation.haskell
 --    ^ punctuation.definition.string.end.haskell
 
    '\''
--- ^^^^ string.quoted.single.haskell
+-- ^^^^ meta.string.haskell string.quoted.single.haskell
 -- ^ punctuation.definition.string.begin.haskell
 --  ^^ constant.character.escape.haskell
 --    ^ punctuation.definition.string.end.haskell
 
    '\129x'
--- ^^^^ string.quoted.single.haskell
+-- ^^^^ meta.string.haskell string.quoted.single.haskell
 --  ^^^^ constant.character.escape.decimal.haskell
 --      ^ invalid.illegal.expected-closing-quotation.haskell
 --       ^ punctuation.definition.string.end.haskell
 
    'a--'
--- ^^ string.quoted.single.haskell - comment
+-- ^^ meta.string.haskell string.quoted.single.haskell - comment
 -- ^ punctuation.definition.string.begin.haskell
 --   ^^^^ comment.line.double-dash.haskell - string
 --   ^^ punctuation.definition.comment.haskell
 
    "\o129x\NUL"
--- ^^^^^^^^^^^^ string.quoted.double.haskell
+-- ^^^^^^^^^^^^ meta.string.haskell string.quoted.double.haskell
 --  ^^^^ constant.character.escape.octal.haskell
 --      ^ - constant
 --            ^ punctuation.definition.string.end.haskell
 --        ^^^^ constant.character.escape.haskell
 
    "ok\"()--"'ab'
--- ^^^^^^^ string.quoted.double.haskell - comment
+-- ^^^^^^^ meta.string.haskell string.quoted.double.haskell - comment
 --        ^^^^^^^^ comment.line.double-dash.haskell - string
 -- ^ punctuation.definition.string.begin.haskell
 --    ^^ constant.character.escape.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -323,13 +323,21 @@ import qualified Data.Vector.Mutable as MutableVector
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
 --     ^^^^^^^^^ keyword.control.import.haskell
---               ^^^^^^^^^^^^^^^^^^^ support.other.module.haskell
+--               ^^^^ variable.namespace.haskell - punctuation
+--                   ^ punctuation.accessor.dot.haskell - variable
+--                    ^^^^^^ variable.namespace.haskell - punctuation
+--                          ^ punctuation.accessor.dot.haskell - variable
+--                           ^^^^^^^ variable.namespace.haskell - punctuation
 --                                   ^^ keyword.control.import.haskell
---                                      ^^^^^^^^^^^^^ support.other.module.haskell
+--                                      ^^^^^^^^^^^^^ variable.namespace.haskell
 import Data.List.Split (splitOn)
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                      ^^^^^^^ variable.function.haskell
@@ -337,7 +345,11 @@ import Data.List.Split (splitOn)
 import Data.List.Split (())
 -- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                      ^^ meta.other.unknown.haskell
@@ -345,7 +357,11 @@ import Data.List.Split (())
 import Data.List.Split (--
 -- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                      ^^^ comment.line.double-dash.haskell
@@ -355,7 +371,11 @@ import Data.List.Split (--
 import Data.List.Split (--)
 -- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                      ^^^^ comment.line.double-dash.haskell
@@ -365,7 +385,11 @@ import Data.List.Split (--)
 import Data.List.Split ((--))
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                       ^^^^^ comment.line.double-dash.haskell
@@ -375,7 +399,11 @@ import Data.List.Split ((--))
 import Data.List.Split ((--])
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                       ^^^^^ comment.line.double-dash.haskell
@@ -385,7 +413,11 @@ import Data.List.Split ((--])
 import Data.List.Split ((--")
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
 -- ^^^ keyword.control.import.haskell
---     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--     ^^^^ variable.namespace.haskell - punctuation
+--         ^ punctuation.accessor.dot.haskell - variable
+--          ^^^^ variable.namespace.haskell - punctuation
+--              ^ punctuation.accessor.dot.haskell - variable
+--               ^^^^^ variable.namespace.haskell - punctuation
 --                     ^^^^^^^ meta.declaration.exports.haskell
 --                     ^ punctuation.section.group.begin.haskell
 --                       ^^^^^ comment.line.double-dash.haskell
@@ -535,6 +567,11 @@ main = do
 -- ^ punctuation.definition.string.begin.haskell
 --    ^^ constant.character.escape.haskell
 --        ^^ punctuation.definition.comment.haskell
+
+   A' = A'
+-- ^^ constant.other.haskell - string
+--    ^ keyword.operator.haskell
+--      ^^ constant.other.haskell - string
 
    a' = b'
 -- ^^ meta.name.haskell - string

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -415,6 +415,7 @@ main = do
    'ab'
 -- ^^^^ meta.string.haskell string.quoted.single.haskell
 -- ^ punctuation.definition.string.begin.haskell
+--  ^ constant.character.literal.haskell
 --   ^ invalid.illegal.expected-closing-quotation.haskell
 --    ^ punctuation.definition.string.end.haskell
 
@@ -433,6 +434,7 @@ main = do
    'a--'
 -- ^^ meta.string.haskell string.quoted.single.haskell - comment
 -- ^ punctuation.definition.string.begin.haskell
+--  ^ constant.character.literal.haskell
 --   ^^^^ comment.line.double-dash.haskell - string
 --   ^^ punctuation.definition.comment.haskell
 

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -583,12 +583,12 @@ main = do
 --            ^ punctuation.definition.string.end.haskell
 --        ^^^^ constant.character.escape.haskell
 
-   "ok\"()--"'ab'
--- ^^^^^^^ meta.string.haskell string.quoted.double.haskell - comment
---        ^^^^^^^^ comment.line.double-dash.haskell - string
--- ^ punctuation.definition.string.begin.haskell
---    ^^ constant.character.escape.haskell
---        ^^ punctuation.definition.comment.haskell
+    "ok\"()--"'b'
+--  ^^^^^^^^^^ meta.string.haskell string.quoted.double.haskell - comment
+--            ^^^ meta.string.haskell string.quoted.single.haskell
+--  ^ punctuation.definition.string.begin.haskell
+--     ^^ constant.character.escape.haskell
+--         ^^ - punctuation
 
    A' = A'
 -- ^^ constant.other.haskell - string

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -308,6 +308,64 @@ import Data.List.Split (splitOn)
 --                     ^ punctuation.section.group.begin.haskell
 --                      ^^^^^^^ variable.function.haskell
 --                             ^ punctuation.section.group.end.haskell
+import Data.List.Split (())
+-- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                      ^^ meta.other.unknown.haskell
+--                        ^ punctuation.section.group.end.haskell
+import Data.List.Split (--
+-- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                      ^^^ comment.line.double-dash.haskell
+--                      ^^ punctuation.definition.comment.haskell
+                        )
+--                      ^ punctuation.section.group.end.haskell
+import Data.List.Split (--)
+-- ^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                      ^^^^ comment.line.double-dash.haskell
+--                      ^^ punctuation.definition.comment.haskell
+                        )
+--                      ^ punctuation.section.group.end.haskell
+import Data.List.Split ((--))
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                       ^^^^^ comment.line.double-dash.haskell
+--                       ^^ punctuation.definition.comment.haskell
+                        )
+--                      ^ punctuation.section.group.end.haskell
+import Data.List.Split ((--])
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                       ^^^^^ comment.line.double-dash.haskell
+--                       ^^ punctuation.definition.comment.haskell
+                        )
+--                      ^ punctuation.section.group.end.haskell
+import Data.List.Split ((--")
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.haskell
+-- ^^^ keyword.control.import.haskell
+--     ^^^^^^^^^^^^^^^ support.other.module.haskell
+--                     ^^^^^^^ meta.declaration.exports.haskell
+--                     ^ punctuation.section.group.begin.haskell
+--                       ^^^^^ comment.line.double-dash.haskell
+--                       ^^ punctuation.definition.comment.haskell
+                        )
+--                      ^ punctuation.section.group.end.haskell
 
    deriving instance FromJSON Amount
 -- ^^^^^^^^ keyword.declaration.data.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -281,6 +281,14 @@
    a `
 --   ^ - keyword - operator - punctuation
 
+   'class
+--  ^^^^^ keyword.declaration.class.haskell
+
+   class'
+-- ^^^^^^ - keyword
+
+   if'
+-- ^^^ - keyword
 
 -- Tests for #1320, #1880.
 

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -244,7 +244,9 @@
 
    5 `f `7`f`"3 'ab'"
 -- ^ constant.numeric.value.haskell
---   ^^^^ invalid.illegal.operator.haskell
+--   ^^^^ keyword.operator.function.infix.haskell
+--   ^ punctuation.definition.function.begin.haskell
+--      ^ punctuation.definition.function.end.haskell
 --       ^ constant.numeric.value.haskell
 --        ^^^ keyword.operator.function.infix.haskell
 --        ^ punctuation.definition.function.begin.haskell
@@ -255,7 +257,9 @@
 --                  ^ punctuation.definition.string.end.haskell
 
    a ` f` b
---   ^^^^ invalid.illegal.operator.haskell
+--   ^^^^ keyword.operator.function.infix.haskell
+--   ^ punctuation.definition.function.begin.haskell
+--      ^ punctuation.definition.function.end.haskell
 
    a `--` b
 --   ^ invalid.illegal.operator.haskell

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -418,11 +418,23 @@ main = do
 --   ^ invalid.illegal.expected-closing-quotation.haskell
 --    ^ punctuation.definition.string.end.haskell
 
+   '\''
+-- ^^^^ string.quoted.single.haskell
+-- ^ punctuation.definition.string.begin.haskell
+--  ^^ constant.character.escape.haskell
+--    ^ punctuation.definition.string.end.haskell
+
    '\129x'
 -- ^^^^ string.quoted.single.haskell
 --  ^^^^ constant.character.escape.decimal.haskell
 --      ^ invalid.illegal.expected-closing-quotation.haskell
 --       ^ punctuation.definition.string.end.haskell
+
+   'a--'
+-- ^^ string.quoted.single.haskell - comment
+-- ^ punctuation.definition.string.begin.haskell
+--   ^^^^ comment.line.double-dash.haskell - string
+--   ^^ punctuation.definition.comment.haskell
 
    "\o129x\NUL"
 -- ^^^^^^^^^^^^ string.quoted.double.haskell
@@ -431,8 +443,17 @@ main = do
 --            ^ punctuation.definition.string.end.haskell
 --        ^^^^ constant.character.escape.haskell
 
+   "ok\"()--"'ab'
+-- ^^^^^^^ string.quoted.double.haskell - comment
+--        ^^^^^^^^ comment.line.double-dash.haskell - string
+-- ^ punctuation.definition.string.begin.haskell
+--    ^^ constant.character.escape.haskell
+--        ^^ punctuation.definition.comment.haskell
+
    a' = b'
 -- ^^ meta.name.haskell - string
+--    ^ keyword.operator.haskell
+--      ^^ meta.name.haskell - string
 
 
 -- Infix operators in context

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -281,8 +281,9 @@
    a `
 --   ^ - keyword - operator - punctuation
 
-   'class
+   'class TooMany where
 --  ^^^^^ keyword.declaration.class.haskell
+-- ^ - punctuation - keyword
 
    class'
 -- ^^^^^^ - keyword

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -139,12 +139,22 @@
    {-# MINIMAL traverse | sequenceA LANGUAGE #-}
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.haskell
 --                                              ^ - meta.preprocessor.haskell
---                                   ^^^^^^^ keyword.other.preprocessor.haskell
+--                                   ^^^^^^^ keyword.directive.other.haskell
 
    {-# OPTIONS_HADDOCK not-home #-}
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.haskell
 --                                 ^ - meta.preprocessor.haskell
---     ^^^^^^^^^^^^^^^ keyword.other.preprocessor.haskell
+--     ^^^^^^^^^^^^^^^ keyword.directive.other.haskell
+
+   #if 0
+-- ^^^ meta.preprocessor.c
+-- ^ punctuation.definition.preprocessor.c
+--  ^^ keyword.directive.other.c
+
+   #endif
+-- ^^^^^^ meta.preprocessor.c
+-- ^ punctuation.definition.preprocessor.c
+--  ^^^^^ keyword.directive.other.c
 
 -- | Map each element of a structure to an action,
 -- evaluate these actions from left to right, and

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -132,6 +132,9 @@
    class (Functor t, Foldable t) => Traversable t where
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.class.haskell
 -- ^^^^^ keyword.declaration.class.haskell
+--                               ^^ keyword.other.big-arrow.haskell
+--                                  ^^^^^^^^^^^ support.class.prelude.haskell
+--                                              ^ variable.other.generic-type.haskell
 --                                                ^^^^^ keyword.control.context.haskell
    {-# MINIMAL traverse | sequenceA LANGUAGE #-}
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.haskell


### PR DESCRIPTION
Fixes #2670

According to https://www.haskell.org/onlinereport/haskell2010/haskellch10.html a comment starts with at least 2 dashes followed by `any` character but symbols with some exceptions. The relevant rules are:

```
  comment   -> -- {-} [ any⟨symbol⟩ {any} ] newline
  symbol    -> ascSymbol | uniSymbol⟨special|_|"|'⟩
  special   -> ( | ) | , | ; | [ | ] | ` | { | }
  ascSymbol -> ! | # | $ | % | & | ⋆ | + | . | / | < | = | > | ? | @ | \
             | ^ | | | - | ~ | :
  uniSymbol -> any Unicode symbol or punctuation
```

With:

```
  any       -> graphic | space | tab
  graphic   -> small | large | symbol | digit | special | " | '
```

we can say:

```
  comment   -> -- {-} [
               space | tab | small | large | digit | special | " | '
               {any} ] newline
```

This simplified pattern is implemented in this commit.

Additionally `(--)` and `(---)` are excluded from infix operators.

---

Fixes #2672

Don't want to make another rewrite, but to avoid merge conflicts fixes for issue #2672 had to go in here as well. Details about the changes may be found in the commit messages.