### PR TITLE
[Git Formats] Target the correct scope with the snippet

### DIFF
--- a/Git Formats/Snippets/Git Config - Section.sublime-snippet
+++ b/Git Formats/Snippets/Git Config - Section.sublime-snippet
@@ -4,6 +4,6 @@
 	$0
 ]]></content>
 	<tabTrigger>section</tabTrigger>
-	<scope>source.git.config</scope>
+	<scope>text.git.config</scope>
 	<description>[section]</description>
 </snippet>


### PR DESCRIPTION
`source.git.config` must be outdated, because there's no occurence of it elsewhere in the repo.

