### PR TITLE
[ShellScript] Fix test command termination

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -630,7 +630,7 @@ contexts:
           captures:
             1: support.function.double-brace.end.shell
           pop: 1
-        - include: cmd-test-body
+        - include: test-expression-body
     - match: \[(?=\s)
       scope: support.function.test.begin.shell
       push:
@@ -639,7 +639,7 @@ contexts:
           captures:
             1: support.function.test.end.shell
           pop: 1
-        - include: cmd-test-body
+        - include: test-expression-body
     - match: test{{cmd_break}}
       scope:
         meta.function-call.identifier.shell
@@ -648,19 +648,46 @@ contexts:
 
   cmd-test-args:
     - meta_content_scope: meta.function-call.arguments.shell
-    - include: cmd-test-body
+    - match: (=~)\s*
+      captures:
+        1: keyword.operator.binary.shell
+      push: cmd-test-pattern
+    - match: ([=!]=)\s*
+      captures:
+        1: keyword.operator.comparison.shell
+      push: cmd-test-pattern
+    - include: test-expressions
     - include: redirections
     - include: eoc-pop
 
-  cmd-test-body:
+  cmd-test-pattern:
+    - meta_content_scope: meta.pattern.regexp.shell
+    - include: test-pattern
+    - include: eoc-pop
+
+  test-expression-body:
+    - match: (=~)\s*
+      captures:
+        1: keyword.operator.binary.shell
+      push: test-pattern
+    - match: ([=!]=)\s*
+      captures:
+        1: keyword.operator.comparison.shell
+      push: test-pattern
+    - include: test-expressions
+
+  test-pattern:
+    - meta_content_scope: meta.pattern.regexp.shell
+    - match: (?=\s)
+      pop: 1
+    - include: boolean
+    - include: number
+    - include: expansions-and-strings
+
+  test-expressions:
     - match: \(
       scope: punctuation.section.group.begin.shell
-      push:
-        - meta_scope: meta.group.shell
-        - match: \)
-          scope: punctuation.section.group.end.shell
-          pop: 1
-        - include: cmd-test-body
+      push: test-group-body
     - match: ([-+])[aobcdefghknoprstuvwxzGLNORS]{{opt_break}}(?!\s*([=!]=|=~))
       scope:
         meta.parameter.option.shell
@@ -673,14 +700,6 @@ contexts:
         variable.parameter.option.shell
       captures:
         1: punctuation.definition.parameter.shell
-    - match: (=~)\s*
-      captures:
-        1: keyword.operator.binary.shell
-      push: cmd-test-pattern
-    - match: ([=!]=)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push: cmd-test-pattern
     - match: '<=?|>=?'
       scope: keyword.operator.comparison.shell
     - match: '&&|\|\||!'
@@ -694,13 +713,12 @@ contexts:
     - include: variables
     - include: line-continuations
 
-  cmd-test-pattern:
-    - meta_content_scope: meta.pattern.regexp.shell
-    - match: (?=\s)
+  test-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
       pop: 1
-    - include: boolean
-    - include: number
-    - include: expansions-and-strings
+    - include: test-expression-body
 
 ###[ UNALIAS BUILTINS ]########################################################
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1847,6 +1847,19 @@ if test expr -a expr ; then echo "success"; fi
 #                                         ^ punctuation.terminator.statement.shell
 #                                           ^^ keyword.control.conditional.end.shell
 
+if test "$VAR" != ";";then;fi
+# ^ - meta.function-call
+#  ^^^^ meta.function-call.identifier.shell support.function.test.shell
+#      ^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#       ^^^^^^ meta.string.shell
+#              ^^ keyword.operator.comparison.shell
+#                 ^^^ meta.string.shell string.quoted.double.shell
+#                    ^^^^^^^^ - meta.function-call
+#                    ^ punctuation.terminator.statement.shell
+#                     ^^^^ keyword.control.conditional.then.shell
+#                         ^ punctuation.terminator.statement.shell
+#                          ^^ keyword.control.conditional.end.shell
+
 let test -z $2 && { }
 #^^ meta.function-call.identifier.shell support.function.let.shell
 #  ^ meta.function-call.arguments.shell - meta.function-call mete.function-call
@@ -4227,6 +4240,17 @@ if [[ $- != *i* ]] ; then echo shell is not interactive; fi
 #                         ^^^^ support.function.echo.shell
 #                                                      ^ punctuation.terminator.statement.shell
 #                                                        ^^ keyword.control.conditional.end.shell
+
+if [[ "$ERL_TOP" != ";"; ]];then;fi
+#^ keyword.control.conditional.if.shell
+#  ^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#  ^^^^^^^^^^^^^^^^^ - meta.pattern
+#                   ^^^^ meta.pattern.regexp.shell
+#                       ^^^ - meta.pattern
+#                          ^ punctuation.terminator.statement.shell
+#                           ^^^^ keyword.control.conditional.then.shell
+#                               ^ punctuation.terminator.statement.shell
+#                                ^^ keyword.control.conditional.end.shell
 
 if [[ ! -z "$PLATFORM" ]] && ! cmd || ! cmd2; then PLATFORM=docker; fi
 #^ keyword.control.conditional.if


### PR DESCRIPTION
This commit fixes an issue with `;` in `test <expr> <op> <pattern>;` not terminating the statement correctly if it is not preceded by whitespace.