### PR TITLE
[ShellScript] Add key bindings for auto-pairing

### DIFF
--- a/ShellScript/Default.sublime-keymap
+++ b/ShellScript/Default.sublime-keymap
@@ -1,0 +1,89 @@
+[
+    //
+    // Command Interpolation
+    //
+
+    // Auto-pair backticks: `|`
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell - meta.interpolation.command" },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "not_regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+    // Remove backticks when backspace is pressed
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell  meta.interpolation.command" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+
+    // Auto-pair parentheses: $(|)
+    { "keys": ["("], "command": "insert_snippet", "args": {"contents": "($0)"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
+        ]
+    },
+    // Expand (|) to ( | ) when space is pressed
+    { "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true }
+        ]
+    },
+    // Collapse ( | ) to (|) when backspace is pressed
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\( $", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^ \\)", "match_all": true }
+        ]
+    },
+
+    //
+    // Parameter Interpolation
+    //
+
+    // Auto-pair braces: ${|}
+    { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
+        ]
+    },
+    // Expand {|} to { | } when space is pressed
+    { "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\{$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true }
+        ]
+    },
+    // Collapse { | } to {|} when backspace is pressed
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\{ $", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^ \\}", "match_all": true }
+        ]
+    },
+]


### PR DESCRIPTION
Fixes #2677

This PR proposes to add key bindings to...

1. Auto-pair command interpolation parentheses

   ```
   $|         -> $(|)
   "$|"       -> "$(|)"
   foo$|baz   -> foo$(|)baz
   "foo$|baz" -> "foo$(|)baz"
   ```

   Note: Removing parens via backspace is handled by default bindings.

2. Auto-pair parameter interpolation braces

   ```
   $|         -> ${|}
   "$|"       -> "${|}"
   foo$|baz   -> foo${|}baz
   "foo$|baz" -> "foo${|}baz"
   ```

   Note: Removing braces via backspace is handled by default bindings.

3. Auto-pair backtick quotes

   ```
   |       -> `|`
   "|"     -> "`|`"
   foo|baz -> foo`|`baz

   `|`      -> |
   ```

4. Expand interpolation brackets

   ```
   (|)  -> ( | )
   {|}  -> { | }
   ```

5. Collapse interpolation brackets

   ```
   ( | )  -> (|)
   { | }  -> {|}
   ```

**Notes:**

All bindings are limited to `source.shell` and `setting.auto_match_enabled`.