### PR TITLE
the “#“ alone initiates an end-of-line comment, but the “!“ does not

### DIFF
--- a/AppleScript/AppleScript.sublime-syntax
+++ b/AppleScript/AppleScript.sublime-syntax
@@ -518,7 +518,7 @@ contexts:
     - match: \b(?i:seconds|minutes|hours|days)\b
       scope: support.class.built-in.time.applescript
   comments:
-    - match: ^\s*(#!).*$\n?
+    - match: ^\s*(#).*$\n?
       scope: comment.line.number-sign.applescript
       captures:
         1: punctuation.definition.comment.applescript


### PR DESCRIPTION
Hallo And Happy New Year!

* http://alvinalexander.com/blog/post/mac-os-x/applescript-use-comments/
* https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/conceptual/ASLR_lexical_conventions.html#//apple_ref/doc/uid/TP40000983-CH214-SW8

Not the sequence ”#!“ but the single character ”#“ initiates an end-of-line comment.
”#“ is treated/handled as/like ”--“.

Ciao