### PR TITLE
the “#“ alone initiates an end-of-line comment, but the “!“ does not. (Comments.tmP…)

### DIFF
--- a/AppleScript/Comments.tmPreferences
+++ b/AppleScript/Comments.tmPreferences
@@ -19,7 +19,7 @@
 				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
-				<string>#!</string>
+				<string>#</string>
 			</dict>
 			<dict>
 				<key>name</key>


### PR DESCRIPTION
hej, see
https://github.com/sublimehq/Packages/pull/2683

