### PR TITLE
[PHP] Named arguments syntax not working properly

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1190,7 +1190,7 @@ contexts:
       push:
         - include: expressions
         - match: ''
-          pop: 1
+          pop: true
   heredoc:
     - match: (?=<<<\s*'?({{identifier}})'?\s*$)
       push:


### PR DESCRIPTION
Currently the syntax for name arguments do not work when using more than one argument.

<img width="266" alt="Screen Shot 2021-01-06 at 10 18 34 PM" src="https://user-images.githubusercontent.com/12988164/103820726-20fc6000-506d-11eb-9878-1c18e32102d1.png">

Changing `pop 1` to `pop true` seemed to have done the trick.

<img width="243" alt="Screen Shot 2021-01-06 at 10 19 41 PM" src="https://user-images.githubusercontent.com/12988164/103820826-47ba9680-506d-11eb-8e13-8de0039ad7b0.png">
