### PR TITLE
[Markdown] Add keybindings for `, _ and *

### DIFF
--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -19,7 +19,7 @@
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
-    // If we have two asterisks with the cursor betweem them, then a backspace removes both
+    // If we have two asterisks with the cursor between them, then a backspace removes both
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
             { "key": "setting.auto_match_enabled" },
@@ -49,7 +49,7 @@
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
-    // If we have two underscores with the cursor betweem them, then a backspace removes both
+    // If we have two underscores with the cursor between them, then a backspace removes both
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
             { "key": "setting.auto_match_enabled" },
@@ -80,7 +80,7 @@
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
-    // If we have two backticks with the cursor betweem them, then a backspace removes both
+    // If we have two backticks with the cursor between them, then a backspace removes both
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
             { "key": "setting.auto_match_enabled" },

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -18,6 +18,16 @@
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
+    // If we have two asterisks with the cursor betweem them, then a backspace removes both
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown - markup.raw" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\*", "match_all": true }
+        ]
+    },
 
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
@@ -37,5 +47,15 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
-    }
+    },
+    // If we have two backticks with the cursor betweem them, then a backspace removes both
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "punctuation.definition.raw.begin.markdown" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
 ]

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -5,8 +5,7 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\w", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
         ]
     },
     {
@@ -26,8 +25,7 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\w", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
         ]
     },
     {

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -30,6 +30,36 @@
         ]
     },
 
+    // Auto-pair underscore
+    { "keys": ["_"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
+        [
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+        ]
+    },
+    {
+        "keys": ["_"],
+        "command": "insert_snippet",
+        "args": {"contents": "_${0:$SELECTION}_"},
+        "context": [
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selection_empty", "operand": false, "match_all": true },
+        ]
+    },
+    // If we have two asterisks with the cursor betweem them, then a backspace removes both
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown - markup.raw" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "_$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^_", "match_all": true }
+        ]
+    },
+
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
         [

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -38,4 +38,4 @@
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
         ]
     }
-
+]

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -2,9 +2,10 @@
     // Auto-pair asterisks
     { "keys": ["*"], "command": "insert_snippet", "args": {"contents": "*$0*"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\w", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
         ]
     },
@@ -13,18 +14,19 @@
         "command": "insert_snippet",
         "args": {"contents": "*${0:$SELECTION}*"},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
 
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\w", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
         ]
     },
@@ -33,9 +35,9 @@
         "command": "insert_snippet",
         "args": {"contents": "`${0:$SELECTION}`"},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "setting.auto_match_enabled"},
+            { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     }
 ]

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -1,0 +1,41 @@
+[
+    // Auto-pair asterisks
+    { "keys": ["*"], "command": "insert_snippet", "args": {"contents": "*$0*"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+        ]
+    },
+    {
+        "keys": ["*"],
+        "command": "insert_snippet",
+        "args": {"contents": "*${0:$SELECTION}*"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+        ]
+    },
+
+    // Auto-pair backticks
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+        ]
+    },
+    {
+        "keys": ["`"],
+        "command": "insert_snippet",
+        "args": {"contents": "`${0:$SELECTION}`"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+        ]
+    }
+

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -6,6 +6,7 @@
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
         ]
     },
     {
@@ -36,6 +37,7 @@
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
         ]
     },
     {

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -5,7 +5,7 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S", "match_all": true },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
         ]
     },
@@ -66,7 +66,7 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selector", "operand": "text.html.markdown - markup.raw" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\S", "match_all": true },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
         ]
     },

--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -49,7 +49,7 @@
             { "key": "selection_empty", "operand": false, "match_all": true },
         ]
     },
-    // If we have two asterisks with the cursor betweem them, then a backspace removes both
+    // If we have two underscores with the cursor betweem them, then a backspace removes both
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
             { "key": "setting.auto_match_enabled" },


### PR DESCRIPTION
These keybindings will create a pair of asterisks, underscores or back ticks when you type a single one, or will surround the selection with asterisks, underscores or back ticks as appropriate.

This PR is solely concerned with making Markdown's surrounding asterisk, underscore and back tick characters behave similar to how surrounding quotation mark and brace characters work in other language files.

Fixes #2689 