### PR TITLE
[C#] Use keyword.declaration.function.arrow

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -729,7 +729,7 @@ contexts:
       scope: storage.modifier.other.cs
       push: type_constraint
     - match: (=>)
-      scope: keyword.declaration.function.anonymous.cs
+      scope: keyword.declaration.function.arrow.cs
       set:
         - meta_content_scope: meta.method.cs
         - include: line_of_code_in
@@ -780,7 +780,7 @@ contexts:
           scope: storage.modifier.access.cs
         - include: attribute
     - match: '=>'
-      scope: keyword.declaration.function.anonymous.cs
+      scope: keyword.declaration.function.arrow.cs
       set:
         - meta_content_scope: meta.method.cs
         - include: line_of_code_in
@@ -979,7 +979,7 @@ contexts:
     - match: ({{name}})\s+(=>)\s*
       captures:
         1: variable.parameter.cs
-        2: keyword.declaration.function.anonymous.cs
+        2: keyword.declaration.function.arrow.cs
       push:
         - meta_scope: meta.function.anonymous.cs
         - match: '(?=;)'
@@ -999,7 +999,7 @@ contexts:
         - match: (\))\s*(=>)
           captures:
             1: meta.group.cs punctuation.section.group.end.cs
-            2: keyword.declaration.function.anonymous.cs
+            2: keyword.declaration.function.arrow.cs
           set:
             - meta_content_scope: meta.function.anonymous.cs
             - match: '(?=;)'

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -564,7 +564,7 @@ class Foo {
 ///                                                   ^^^^ variable.other
 ///                                                        ^ keyword.operator.assignment.variable
 ///                                                          ^ variable.parameter
-///                                                            ^^ keyword.declaration.function.anonymous
+///                                                            ^^ keyword.declaration.function.arrow
 ///                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 ///                                                               ^ punctuation.section.group.begin
 ///                                                                ^^^^^^^^ variable.other
@@ -764,7 +764,7 @@ public class MyClass {
     public MyClass () => obj = null;
 ///        ^^^^^^^ meta.method.constructor entity.name.function.constructor
 ///               ^^^^^^^^^^^^^^^^^ meta.class.body meta.block meta.method
-///                   ^^ keyword.declaration.function.anonymous.cs
+///                   ^^ keyword.declaration.function.arrow.cs
 ///                      ^^^ variable.other
 ///                          ^ keyword.operator.assignment
 ///                            ^^^^ constant.language
@@ -789,7 +789,7 @@ public class Person // https://stackoverflow.com/a/41974829/4473405
 ///                                ^^^ variable.parameter
 ///                                   ^ punctuation.section.parameters.end
 ///                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method
-///                                     ^^ keyword.declaration.function.anonymous.cs
+///                                     ^^ keyword.declaration.function.arrow.cs
 ///                                        ^ meta.group punctuation.section.group.begin
 ///                                         ^^^^ meta.group variable.other
 ///                                             ^ meta.group punctuation.separator.tuple

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -22,7 +22,7 @@ interface ILogger
 {
     void Log(LogLevel level, string message);
     void Log(Exception ex) => Log(LogLevel.Error, ex.ToString()); // New overload
-///                        ^^ keyword.declaration.function.anonymous
+///                        ^^ keyword.declaration.function.arrow
 }
 
 public static decimal CalculateToll(object vehicle) =>

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -19,7 +19,7 @@ public record Person
         get => lastName;
         init => lastName = (value ?? throw new ArgumentNullException(nameof(LastName)));
 ///     ^^^^ keyword.declaration.function.accessor.set
-///          ^^ keyword.declaration.function.anonymous
+///          ^^ keyword.declaration.function.arrow
 ///             ^^^^^^^^ variable.other
     }
 }

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -71,7 +71,7 @@ namespace YourNamespace
 ///                         ^^^^ support.type
 ///                              ^^^^^ variable.parameter
 ///                                   ^ punctuation.section.parameters.end
-///                                     ^^ keyword.declaration.function.anonymous.cs
+///                                     ^^ keyword.declaration.function.arrow.cs
 ///                                        ^^^^ variable.language
 ///                                             ^^ keyword.operator.reflection
 ///                                                ^^^^^ support.type
@@ -120,7 +120,7 @@ namespace YourNamespace
 ///                     ^^^^^^^^^^^^^^^^^^^^ meta.method
 ///                     ^^^^^^^^^ entity.name.function
 ///                              ^^ meta.method.parameters
-///                                 ^^ keyword.declaration.function.anonymous.cs
+///                                 ^^ keyword.declaration.function.arrow.cs
 ///                                    ^^^^^ constant.language
     }
 
@@ -829,24 +829,24 @@ namespace TestNamespace.Test
 ///              ^^^ variable.other
 ///                    ^ keyword.operator.assignment
 ///                        ^^^^^^^^ meta.function.anonymous
-///                        ^^ keyword.declaration.function.anonymous
+///                        ^^ keyword.declaration.function.arrow
             Func<float, float> times2 = x => x + x;
 ///         ^^^ support.type
 ///                            ^^^ variable.other
 ///                                   ^ keyword.operator.assignment
 ///                                     ^^^^^^^^^^ meta.function.anonymous
-///                                       ^^ keyword.declaration.function.anonymous
+///                                       ^^ keyword.declaration.function.arrow
 
             var changes = refs.ToDictionary(kvp => kvp.key, arg => k + 5);
 ///                                         ^^^^^^^^^^^^^^ meta.function.anonymous.cs
 ///                                         ^^^ variable.parameter.cs
-///                                             ^^ keyword.declaration.function.anonymous.cs
+///                                             ^^ keyword.declaration.function.arrow.cs
 ///                                                ^^^ variable.other.cs
 ///                                                       ^ punctuation.separator.argument.cs
 ///                                                       ^^ - meta.function.anonymous
 ///                                                         ^^^^^^^^^^^^ meta.function.anonymous.cs
 ///                                                         ^^^ variable.parameter.cs
-///                                                             ^^ keyword.declaration.function.anonymous.cs
+///                                                             ^^ keyword.declaration.function.arrow.cs
 ///                                                                ^ variable.other.cs
 ///                                                                  ^ keyword.operator.cs
 ///                                                                    ^ meta.number.integer.decimal.cs
@@ -862,7 +862,7 @@ namespace TestNamespace.Test
 ///                                              ^ punctuation.separator.parameter.function.cs
 ///                                                ^^^^^ variable.parameter.cs
 ///                                                     ^ punctuation.section.group.end.cs
-///                                                       ^^ keyword.declaration.function.anonymous.cs
+///                                                       ^^ keyword.declaration.function.arrow.cs
 ///                                                          ^^^^^ variable.other.cs
 
         }
@@ -1010,7 +1010,7 @@ namespace TestNamespace.Test
 
     void TestMe () {
         a = b => b * 2;
-///           ^^ keyword.declaration.function.anonymous
+///           ^^ keyword.declaration.function.arrow
 ///           ^^^^^^^^ meta.function.anonymous
 ///                   ^ punctuation.terminator.statement - meta.function.anonymous
 
@@ -1031,7 +1031,7 @@ namespace TestNamespace.Test
         }
 
         a = b => { return b * 2; };
-///           ^^ meta.function.anonymous keyword.declaration.function.anonymous
+///           ^^ meta.function.anonymous keyword.declaration.function.arrow
 ///              ^ meta.function.anonymous punctuation.section.block.begin
 ///                              ^ punctuation.section.block.end
 ///                               ^ punctuation.terminator.statement - meta.function.anonymous
@@ -1055,7 +1055,7 @@ namespace TestNamespace.Test
 ///          ^ variable.parameter
 ///           ^ punctuation.separator
 ///             ^ variable.parameter
-///                ^^ keyword.declaration.function.anonymous
+///                ^^ keyword.declaration.function.arrow
 ///                   ^ meta.function.anonymous punctuation.section.block.begin
 ///                                   ^ punctuation.section.block.end
 ///                                    ^ punctuation.terminator.statement - meta.function.anonymous
@@ -1082,7 +1082,7 @@ namespace TestNamespace.Test
 ///                                     ^ variable.parameter
 ///                                      ^ punctuation.separator.parameter.function
 ///                                        ^ variable.parameter
-///                                           ^^ keyword.declaration.function.anonymous
+///                                           ^^ keyword.declaration.function.arrow
 ///                                                     ^ punctuation.terminator.statement
 ///                                                      ^ - meta.function.anonymous
 
@@ -1133,7 +1133,7 @@ namespace TestNamespace.Test
 ///                 ^^^^^^ meta.cast support.type
 ///                        ^ punctuation.section.group.begin
 ///                         ^^ meta.function.anonymous meta.group
-///                            ^^ keyword.declaration.function.anonymous
+///                            ^^ keyword.declaration.function.arrow
 ///                                             ^ punctuation.section.group.end
         test = (Action)(() => {});
 ///            ^^^^^^^^ meta.cast
@@ -1141,7 +1141,7 @@ namespace TestNamespace.Test
 ///                     ^^^^^^^ meta.function.anonymous
 ///                     ^ meta.group punctuation.section.group.begin
 ///                      ^ meta.group punctuation.section.group.end
-///                        ^^ keyword.declaration.function.anonymous
+///                        ^^ keyword.declaration.function.arrow
 ///                           ^ punctuation.section.block.begin
 ///                            ^ punctuation.section.block.end
 ///                             ^ meta.group punctuation.section.group.end


### PR DESCRIPTION
This PR renames lambda function declaration operator to `keyword.declaration.function.arrow` with regards to
https://github.com/sublimehq/Packages/pull/2617#issuecomment-759683664

Notes:

1. The function body is still scoped `meta.function.anonymous` because a lambda function is anonymous regardless the keyword or operator being used to declare it.

2. The sub-scope `anonymous` is chosen, because it may be used as common name for anonymous functions and variables such as `_` in python and others.

3. The main reason for this commit is to provide separate scopes for lambda function operators such as `->` and `=>` and declaration keywords like `lambda` (Python) or `fun` (Erlang).

   Some users might want to assign different colors.