### PR TITLE
[Lua] Add support for a few new syntax features introduced in Lua 5.4 and a couple improvements.

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -646,7 +646,7 @@ contexts:
           set:
             - match: |-
                 (?x:
-                  create|isyieldable|resume|running|status|wrap|yield
+                  create|isyieldable|resume|running|status|wrap|yield|close
                 ){{identifier_break}}
               scope: meta.property.lua support.function.builtin.lua
               pop: true

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -307,8 +307,7 @@ contexts:
   variable-modifier:
     - match: '<'
       scope: punctuation.definition.modifier.begin.lua
-      push:
-        - variable-modifier-body
+      push: variable-modifier-body
 
   variable-modifier-body:
     - meta_scope: meta.modifier.lua
@@ -417,10 +416,7 @@ contexts:
       pop: true
 
   builtin:
-    - match: true{{identifier_break}}
-      scope: constant.language.boolean.lua
-      pop: true
-    - match: false{{identifier_break}}
+    - match: (?:true|false){{identifier_break}}
       scope: constant.language.boolean.lua
       pop: true
     - match: nil{{identifier_break}}

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -272,7 +272,6 @@ contexts:
         - function-arguments-meta
         - function-arguments
 
-    - include: variable-modifier
     - include: infix-operator
     - include: accessor
 
@@ -286,6 +285,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.comma.lua
       push: expression-begin
+    - include: variable-modifier
     - include: expression-end
 
   expression-begin:
@@ -305,18 +305,19 @@ contexts:
     - include: else-pop
 
   variable-modifier:
-    - match: \<(?=\b(?:const|close)\b)
+    - match: '<'
       scope: punctuation.definition.modifier.begin.lua
       push:
         - variable-modifier-body
 
   variable-modifier-body:
     - meta_scope: meta.modifier.lua
-    - match: \>
+    - match: '>'
       scope: punctuation.definition.modifier.end.lua
       pop: 1
     - match: (?:const|close){{identifier_break}}
       scope: storage.modifier.lua
+    - include: else-pop
 
   infix-operator:
     - match: (?:[=<>~]=)
@@ -498,8 +499,7 @@ contexts:
   single-quoted-string:
     - match: \'
       scope: punctuation.definition.string.begin.lua
-      set:
-        - single-quoted-string-body
+      set: single-quoted-string-body
 
   single-quoted-string-body:
     - meta_include_prototype: false
@@ -512,8 +512,7 @@ contexts:
   double-quoted-string:
     - match: \"
       scope: punctuation.definition.string.begin.lua
-      set:
-        - double-quoted-string-body
+      set: double-quoted-string-body
 
   double-quoted-string-body:
     - meta_include_prototype: false
@@ -526,8 +525,7 @@ contexts:
   multiline-string:
     - match: \[(=*)\[
       scope: punctuation.definition.string.begin.lua
-      set:
-        - multiline-string-body
+      set: multiline-string-body
 
   multiline-string-body:
     - meta_scope: meta.string.lua string.quoted.multiline.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -417,10 +417,10 @@ contexts:
 
   builtin:
     - match: true{{identifier_break}}
-      scope: constant.language.boolean.true.lua
+      scope: constant.language.boolean.lua
       pop: true
     - match: false{{identifier_break}}
-      scope: constant.language.boolean.true.lua
+      scope: constant.language.boolean.lua
       pop: true
     - match: nil{{identifier_break}}
       scope: constant.language.null.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -272,6 +272,7 @@ contexts:
         - function-arguments-meta
         - function-arguments
 
+    - include: variable-modifier
     - include: infix-operator
     - include: accessor
 
@@ -302,6 +303,20 @@ contexts:
     - include: function-literal
 
     - include: else-pop
+
+  variable-modifier:
+    - match: \<(?=\b(?:const|close)\b)
+      scope: punctuation.definition.modifier.begin.lua
+      push:
+        - variable-modifier-body
+
+  variable-modifier-body:
+    - meta_scope: meta.modifier.lua
+    - match: \>
+      scope: punctuation.definition.modifier.end.lua
+      pop: 1
+    - match: (?:const|close){{identifier_break}}
+      scope: storage.modifier.lua
 
   infix-operator:
     - match: (?:[=<>~]=)

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -491,34 +491,50 @@ contexts:
       pop: true
 
   string:
+    - include: single-quoted-string
+    - include: double-quoted-string
+    - include: multiline-string
+
+  single-quoted-string:
     - match: \'
       scope: punctuation.definition.string.begin.lua
       set:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.single.lua
-        - include: string-content
-        - match: \'
-          scope: punctuation.definition.string.end.lua
-          pop: true
+        - single-quoted-string-body
 
+  single-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.lua string.quoted.single.lua
+    - include: string-content
+    - match: \'
+      scope: punctuation.definition.string.end.lua
+      pop: 1
+
+  double-quoted-string:
     - match: \"
       scope: punctuation.definition.string.begin.lua
       set:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.double.lua
-        - include: string-content
-        - match: \"
-          scope: punctuation.definition.string.end.lua
-          pop: true
+        - double-quoted-string-body
 
+  double-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.lua string.quoted.double.lua
+    - include: string-content
+    - match: \"
+      scope: punctuation.definition.string.end.lua
+      pop: 1
+
+  multiline-string:
     - match: \[(=*)\[
       scope: punctuation.definition.string.begin.lua
       set:
-        - meta_scope: string.quoted.multiline.lua
-        - meta_include_prototype: false
-        - match: \]\1\]
-          scope: punctuation.definition.string.end.lua
-          pop: true
+        - multiline-string-body
+
+  multiline-string-body:
+    - meta_scope: meta.string.lua string.quoted.multiline.lua
+    - meta_include_prototype: false
+    - match: \]\1\]
+      scope: punctuation.definition.string.end.lua
+      pop: 1
 
   string-content:
     - match: \\[abfnrtv\\'"\[\]\n]

--- a/Lua/Snippets/for-i-v-in-ipairs().sublime-snippet
+++ b/Lua/Snippets/for-i-v-in-ipairs().sublime-snippet
@@ -3,6 +3,6 @@
 	${0:print(i,v)}
 end]]></content>
 	<tabTrigger>fori</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>for i,v in ipairs()</description>
 </snippet>

--- a/Lua/Snippets/for-i=1-10.sublime-snippet
+++ b/Lua/Snippets/for-i=1-10.sublime-snippet
@@ -3,6 +3,6 @@
 	${0:print(i)}
 end]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>for i=1,10</description>
 </snippet>

--- a/Lua/Snippets/for-k-v-in-pairs().sublime-snippet
+++ b/Lua/Snippets/for-k-v-in-pairs().sublime-snippet
@@ -3,6 +3,6 @@
 	${0:print(k,v)}
 end]]></content>
 	<tabTrigger>forp</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>for k,v in pairs()</description>
 </snippet>

--- a/Lua/Snippets/function-(fun).sublime-snippet
+++ b/Lua/Snippets/function-(fun).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:-- body}
 end]]></content>
 	<tabTrigger>fun</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>function</description>
 </snippet>

--- a/Lua/Snippets/function-(function).sublime-snippet
+++ b/Lua/Snippets/function-(function).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:-- body}
 end]]></content>
 	<tabTrigger>function</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>function</description>
 </snippet>

--- a/Lua/Snippets/local-x-=-1.sublime-snippet
+++ b/Lua/Snippets/local-x-=-1.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[local ${1:x} = ${0:1}]]></content>
 	<tabTrigger>local</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>local x = 1</description>
 </snippet>

--- a/Lua/Snippets/table.concat.sublime-snippet
+++ b/Lua/Snippets/table.concat.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[table.concat( ${1:tablename}${2:, ", "}${3:, start_index}${4:, end_index} )]]></content>
 	<tabTrigger>table.concat</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>table.concat</description>
 </snippet>

--- a/Lua/Snippets/table.sort.sublime-snippet
+++ b/Lua/Snippets/table.sort.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[table.sort( ${1:tablename}${2:, sortfunction} )]]></content>
 	<tabTrigger>table.sort</tabTrigger>
-	<scope>source.lua</scope>
+	<scope>source.lua - comment - string</scope>
 	<description>table.sort</description>
 </snippet>

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -131,34 +131,34 @@
 --                       ^ punctuation.separator.decimal
 
     'foo';
---  ^^^^^ string.quoted.single
+--  ^^^^^ meta.string string.quoted.single
 --  ^ punctuation.definition.string.begin
 --      ^ punctuation.definition.string.end
 
 --STRINGS
 
     'foo';
---  ^^^^^ string.quoted.single
+--  ^^^^^ meta.string string.quoted.single
 --  ^ punctuation.definition.string.begin
 --      ^ punctuation.definition.string.end
 
     '-- [[';
---  ^^^^^^^ string.quoted.single - comment
+--  ^^^^^^^ meta.string string.quoted.single - comment
 
     "foo";
---  ^^^^^ string.quoted.double
+--  ^^^^^ meta.string string.quoted.double
 --  ^ punctuation.definition.string.begin
 --      ^ punctuation.definition.string.end
 
     "-- [[";
---  ^^^^^^^ string.quoted.double - comment
+--  ^^^^^^^ meta.string string.quoted.double - comment
 
     '\a\b\f\n\r\t\v\\\'\"\[\]';
---  ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
 --   ^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape
 
     '\x1ff';
---   ^^^^ constant.character.escape.hexadecimal
+--   ^^^^ meta.string constant.character.escape.hexadecimal
 --       ^ - constant
 
     '\0 \123 \1234';
@@ -196,39 +196,39 @@
 --   ^ invalid.illegal.unclosed-string
 
     "foo\"\'";
---  ^^^^^^^^^ string.quoted.double
+--  ^^^^^^^^^ meta.string string.quoted.double
 --  ^ punctuation.definition.string.begin
 --      ^^^^ constant.character.escape
 --          ^ punctuation.definition.string.end
 
     [[ Foo! ]];
---  ^^^^^^^^^^ string.quoted.multiline
+--  ^^^^^^^^^^ meta.string string.quoted.multiline
 --  ^^ punctuation.definition.string.begin
 --          ^^ punctuation.definition.string.end
 
     [[ -- [[ ]];
---  ^^^^^^^^^^^ string.quoted.multiline - comment
+--  ^^^^^^^^^^^ meta.string string.quoted.multiline - comment
 
     [[ Foo! \a \]];
---  ^^^^^^^^^^^^^^ string.quoted.multiline
+--  ^^^^^^^^^^^^^^ meta.string string.quoted.multiline
 --  ^^ punctuation.definition.string.begin
 --          ^^^^ - constant
 --              ^^ punctuation.definition.string.end
 
     [=[ Foo! ]] ]=];
---  ^^^^^^^^^^^^^^^ string.quoted.multiline
+--  ^^^^^^^^^^^^^^^ meta.string string.quoted.multiline
 --  ^^^ punctuation.definition.string.begin
 --           ^^ - punctuation
 --              ^^^ punctuation.definition.string.end
 
     [=[
---  ^^^ string.quoted.multiline punctuation.definition.string.begin
+--  ^^^ meta.string string.quoted.multiline punctuation.definition.string.begin
         ]]
---      ^^^ string.quoted.multiline - punctuation
+--      ^^^ meta.string string.quoted.multiline - punctuation
         ]==]
---      ^^^^ string.quoted.multiline - punctuation
+--      ^^^^ meta.string string.quoted.multiline - punctuation
     ]=];
---  ^^^ string.quoted.multiline punctuation.definition.string.end
+--  ^^^ meta.string string.quoted.multiline punctuation.definition.string.end
 
 --OPERATORS
 
@@ -313,7 +313,7 @@
 --                ^ meta.mapping variable.other
 
     {[[actually a string]], [=[this too]=]}
---   ^^ meta.mapping.lua string.quoted.multiline.lua punctuation.definition.string.begin.lua
+--   ^^ meta.mapping.lua meta.string string.quoted.multiline.lua punctuation.definition.string.begin.lua
 --                          ^^^ meta.mapping.lua string.quoted.multiline.lua punctuation.definition.string.begin.lua
 
     {some = 2}, {some == 2}
@@ -408,15 +408,15 @@
 
     f "argument";
 --  ^ meta.function-call variable.function
---    ^^^^^^^^^^ meta.function-call.arguments string.quoted.double
+--    ^^^^^^^^^^ meta.function-call.arguments meta.string string.quoted.double
 
     f
     'argument';
---  ^^^^^^^^^^ meta.function-call.arguments string.quoted.single
+--  ^^^^^^^^^^ meta.function-call.arguments meta.string string.quoted.single
 
     f [[ foo ]];
 --  ^ meta.function-call variable.function
---    ^^^^^^^^^ meta.function-call.arguments string.quoted.multiline
+--    ^^^^^^^^^ meta.function-call.arguments meta.string string.quoted.multiline
 
     f {};
 --  ^ meta.function-call variable.function
@@ -644,6 +644,6 @@
 --                       ^^^^ meta.property.lua support.function.builtin.lua
 --                           ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.lua meta.group.lua
 --                           ^ punctuation.section.group.begin.lua
---                            ^^^^^^^^^^^^ string.quoted.double.lua
+--                            ^^^^^^^^^^^^ meta.string string.quoted.double.lua
 --                                        ^ punctuation.separator.comma.lua
 --                                             ^ punctuation.section.group.end.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -612,3 +612,38 @@
 --                 ^ keyword.operator.assignment
 --                   ^ meta.number.integer.decimal constant.numeric.value
 --                    ^ punctuation.terminator.statement
+
+    local x <const> = 1, y <const> = 2;
+--  ^^^^^ storage.modifier.lua
+--        ^ variable.other.lua
+--          ^^^^^^^ meta.modifier.lua
+--          ^ punctuation.definition.modifier.begin.lua
+--                ^ punctuation.definition.modifier.end.lua
+--           ^^^^^ storage.modifier.lua
+--                  ^ keyword.operator.assignment.lua
+--                    ^ meta.number.integer.decimal.lua constant.numeric.value.lua
+--                     ^ punctuation.separator.comma.lua
+--                       ^ variable.other.lua
+--                         ^^^^^^^ meta.modifier.lua
+--                         ^ punctuation.definition.modifier.begin.lua
+--                          ^^^^^ storage.modifier.lua
+--                               ^ punctuation.definition.modifier.end.lua
+--                                 ^ keyword.operator.assignment.lua
+--                                   ^ meta.number.integer.decimal.lua constant.numeric.value.lua
+
+    local f <close> = io.open("/etc/fstab", "r")
+--  ^^^^^ storage.modifier.lua
+--        ^ variable.other.lua
+--          ^^^^^^^ meta.modifier.lua
+--          ^ punctuation.definition.modifier.begin.lua
+--           ^^^^^ storage.modifier.lua
+--                ^ punctuation.definition.modifier.end.lua
+--                  ^ keyword.operator.assignment.lua
+--                    ^^ support.constant.builtin.lua
+--                      ^ punctuation.accessor.lua
+--                       ^^^^ meta.property.lua support.function.builtin.lua
+--                           ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.lua meta.group.lua
+--                           ^ punctuation.section.group.begin.lua
+--                            ^^^^^^^^^^^^ string.quoted.double.lua
+--                                        ^ punctuation.separator.comma.lua
+--                                             ^ punctuation.section.group.end.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -49,10 +49,10 @@
 --CONSTANTS
 
     true;
---  ^^^^ constant.language.boolean.true
+--  ^^^^ constant.language.boolean.lua
 
     false;
---  ^^^^^ constant.language.boolean.true
+--  ^^^^^ constant.language.boolean.lua
 
     nil;
 --  ^^^ constant.language.null
@@ -245,7 +245,7 @@
 
     not true;
 --  ^^^ keyword.operator.logical
---      ^^^^ constant.language.boolean.true
+--      ^^^^ constant.language.boolean.lua
 
     2 + 2 - 2 * 2 / 2 // 2 % 2 ^ 2;
 --    ^ keyword.operator.arithmetic
@@ -393,7 +393,7 @@
     foo[return] foo[false]
 --      ^^^^^^ invalid.unexpected-keyword.lua
 --            ^ - meta.brackets
---                  ^^^^^ constant.language.boolean.true.lua
+--                  ^^^^^ constant.language.boolean.lua
 
     some.return
 --       ^^^^^^ invalid.unexpected-keyword.lua
@@ -551,7 +551,7 @@
 --      ^^^ invalid.illegal.unexpected-end
     until true;
 --  ^^^^^ keyword.control.loop
---        ^^^^ constant.language.boolean.true
+--        ^^^^ constant.language.boolean.lua
 
     for x = 1, y, z do end
 --  ^^^ keyword.control.loop

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -613,23 +613,33 @@
 --                   ^ meta.number.integer.decimal constant.numeric.value
 --                    ^ punctuation.terminator.statement
 
-    local x <const> = 1, y <const> = 2;
+    local x <const>, y <  const  > = 1, 2;
 --  ^^^^^ storage.modifier.lua
 --        ^ variable.other.lua
 --          ^^^^^^^ meta.modifier.lua
 --          ^ punctuation.definition.modifier.begin.lua
 --                ^ punctuation.definition.modifier.end.lua
 --           ^^^^^ storage.modifier.lua
---                  ^ keyword.operator.assignment.lua
---                    ^ meta.number.integer.decimal.lua constant.numeric.value.lua
---                     ^ punctuation.separator.comma.lua
---                       ^ variable.other.lua
---                         ^^^^^^^ meta.modifier.lua
---                         ^ punctuation.definition.modifier.begin.lua
---                          ^^^^^ storage.modifier.lua
---                               ^ punctuation.definition.modifier.end.lua
 --                                 ^ keyword.operator.assignment.lua
 --                                   ^ meta.number.integer.decimal.lua constant.numeric.value.lua
+--                 ^ punctuation.separator.comma.lua
+--                   ^ variable.other.lua
+--                     ^^^^^^^^^^^ meta.modifier.lua
+--                     ^ punctuation.definition.modifier.begin.lua
+--                        ^^^^^ storage.modifier.lua
+--                               ^ punctuation.definition.modifier.end.lua
+--                                 ^ keyword.operator.assignment.lua
+--                                      ^ meta.number.integer.decimal.lua constant.numeric.value.lua
+
+    local text <const = "Hello, World";
+--  ^^^^^ storage.modifier.lua
+--        ^^^^ variable.other.lua
+--             ^^^^^^ meta.modifier.lua
+--                    ^ keyword.operator.assignment.lua - meta.modifier
+--                      ^ punctuation.definition.string.begin.lua - meta.modifier
+--                       ^^^^^^^^^^^^ meta.string.lua string.quoted.double.lua
+--                                   ^ punctuation.definition.string.end.lua
+--                                    ^ punctuation.terminator.statement.lua
 
     local f <close> = io.open("/etc/fstab", "r")
 --  ^^^^^ storage.modifier.lua

--- a/Lua/tests/syntax_test_lua_support.lua
+++ b/Lua/tests/syntax_test_lua_support.lua
@@ -125,6 +125,11 @@
 --           ^ punctuation.accessor
 --            ^^^^^ meta.property support.function.builtin
 
+    coroutine.close();
+--  ^^^^^^^^^ support.constant.builtin
+--           ^ punctuation.accessor
+--            ^^^^^ meta.property support.function.builtin
+
     package;
 --  ^^^^^^^ support.constant.builtin
 


### PR DESCRIPTION
This PR

1. Adds support for the new [const](https://www.lua.org/manual/5.4/manual.html#3.3.7) and [to-be-closed](https://www.lua.org/manual/5.4/manual.html#3.3.8) variables, introduced in Lua 5.4. The syntax is a bit weird IMO, but it is what it is.
2. Previously, Lua used to have a 4th level scope to identify `true` vs `false` i.e. `constant.language.boolean.true` for `true` & `constant.language.boolean.true` for `false` (which is anyways wrong). Now, it reduces it to only `constant.language.boolean` since there is very little value in having the previous scopes. 
3. Adds `meta.string` scope to strings to comply with the scope naming guidelines. I have also reworked the string contexts to actually `push` or `set` into named contexts instead of anonymous contexts for a better debugging experience (since it is currently not possible to distinguish between anonymous contexts in the `show_scope_name` popup).
4. Lua 5.4 also introduces `coroutine.close()`. Support is added for that function. 
5. The scopes in which snippets are triggered are now more stringent and I have excluded strings & comments since it makes least sense to expand snippets in those scopes anyways.