### PR TITLE
[Python] Add a helper keybinding for interpolation.

### DIFF
--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -22,4 +22,13 @@
             { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
         ]
     },
+
+    // Helper keybinding for interpolation.
+    { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.python, meta.string", "match_all": true },
+        ]
+    },
 ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -28,7 +28,8 @@
         [
             { "key": "setting.auto_match_enabled" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.python, meta.string", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.python string", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?<![\\\\])([\\\\]{2})*$", "match_all": true },
         ]
     },
 ]


### PR DESCRIPTION
This PR adds a helper key binding for Python interpolation within strings.