### PR TITLE
[HTML] add `viewport` meta tag to `html` snippet; fixes #2697

### DIFF
--- a/HTML/Snippets/html (begin tag).sublime-snippet
+++ b/HTML/Snippets/html (begin tag).sublime-snippet
@@ -3,6 +3,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>$1</title>
 </head>
 <body>

--- a/HTML/Snippets/html.sublime-snippet
+++ b/HTML/Snippets/html.sublime-snippet
@@ -3,6 +3,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>$1</title>
 </head>
 <body>


### PR DESCRIPTION
Fixes #2697.