### PR TITLE
[XML] Enhance inheritability

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -534,17 +534,15 @@ contexts:
         3: entity.other.attribute-name.xml punctuation.separator.namespace.xml
         4: entity.other.attribute-name.localname.xml
         5: invalid.illegal.bad-attribute-name.xml
-      push: tag-attribute-separator-key-value
-
-  tag-attribute-separator-key-value:
     - match: =
       scope: punctuation.separator.key-value.xml
-      set:
-        - include: string-quoted-pop
-        - match: '[^?/<>\s]+'
-          scope: invalid.illegal.bad-attribute-value.xml
-          pop: 1
-        - include: tag-else-pop
+      push: tag-attribute-value
+
+  tag-attribute-value:
+    - include: string-quoted-pop
+    - match: '[^?/<>\s]+'
+      scope: invalid.illegal.bad-attribute-value.xml
+      pop: 1
     - include: tag-else-pop
 
   tag-else-pop:

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -225,7 +225,7 @@ contexts:
     - include: dtd-notation
     - include: dtd-subset
     - include: dtd-unknown
-    - include: entity-parameter
+    - include: dtd-constants
     - include: preprocessor
 
 ###[ DTD ENTITY ]#############################################################
@@ -293,7 +293,7 @@ contexts:
     - match: \(
       scope: punctuation.definition.group.begin.xml
       set: dtd-element-parens
-    - include: entity-parameter
+    - include: dtd-constants
     - include: dtd-content-quoted
 
   dtd-element-parens:
@@ -308,7 +308,7 @@ contexts:
       scope: keyword.operator.xml
     - match: '[,|]'
       scope: punctuation.separator.xml
-    - include: entity-parameter
+    - include: dtd-constants
     - include: entity
     - include: should-be-entity
     - include: string-unquoted
@@ -336,7 +336,7 @@ contexts:
     - include: dtd-end
 
   dtd-attlist-content:
-    - include: entity-parameter
+    - include: dtd-constants
     - include: dtd-attlist-parens
     - match: \b(?:CDATA|ENTITY|ENTITIES|IDREFS?|ID|NMTOKENS?|NOTATION)\b
       scope: storage.type.attribute.xml
@@ -360,7 +360,7 @@ contexts:
       pop: 1
     - match: \|
       scope: punctuation.separator.logical.xml
-    - include: entity-parameter
+    - include: dtd-constants
     - include: entity
     - include: should-be-entity
     - include: string-unquoted
@@ -454,6 +454,17 @@ contexts:
       pop: 1
     - include: dtd-else-pop
 
+  dtd-constants:
+    - match: (#)P?CDATA
+      scope: constant.other.placeholder.xml
+      captures:
+        1: punctuation.definition.constant.xml
+    - match: (%){{name}}(;)
+      scope: variable.parameter.xml
+      captures:
+        1: punctuation.definition.parameter.xml
+        2: punctuation.terminator.parameter.xml
+
   dtd-content-unquoted:
     - include: string-unquoted
     - include: dtd-else-pop
@@ -487,17 +498,6 @@ contexts:
       pop: 1
     - match: \S
       scope: invalid.illegal.unexpected.xml
-
-  entity-parameter:
-    - match: (#)P?CDATA
-      scope: constant.other.placeholder.xml
-      captures:
-        1: punctuation.definition.constant.xml
-    - match: (%){{name}}(;)
-      scope: variable.parameter.xml
-      captures:
-        1: punctuation.definition.parameter.xml
-        2: punctuation.terminator.parameter.xml
 
 ###[ XML PREPROCESSOR ]#######################################################
 

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -158,27 +158,31 @@ contexts:
         1: punctuation.definition.tag.begin.xml
         2: keyword.declaration.cdata.xml
         3: punctuation.definition.tag.begin.xml
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.sgml.cdata.xml
-        - meta_content_scope: meta.string.xml string.unquoted.cdata.xml
-        - match: ']]>'
-          scope: punctuation.definition.tag.end.xml
-          pop: 1
+      push: cdata-content
+
+  cdata-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.sgml.cdata.xml
+    - meta_content_scope: meta.string.xml string.unquoted.cdata.xml
+    - match: ']]>'
+      scope: punctuation.definition.tag.end.xml
+      pop: 1
 
 ###[ COMMENT ]################################################################
 
   comment:
     - match: <!--
       scope: punctuation.definition.comment.begin.xml
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.block.xml
-        - match: -->
-          scope: punctuation.definition.comment.end.xml
-          pop: 1
-        - match: -{2,}
-          scope: invalid.illegal.double-hyphen-within-comment.xml
+      push: comment-content
+
+  comment-content:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.xml
+    - match: -->
+      scope: punctuation.definition.comment.end.xml
+      pop: 1
+    - match: -{2,}
+      scope: invalid.illegal.double-hyphen-within-comment.xml
 
 ###[ DOCTYPE DECLARATION ]####################################################
 
@@ -296,11 +300,7 @@ contexts:
     - meta_scope: meta.group.xml
     - match: \)
       scope: punctuation.definition.group.end.xml
-      set:
-        - match: '[*?+]'
-          scope: keyword.operator.xml
-          pop: 1
-        - include: dtd-else-pop
+      set: dtd-element-operator
     - match: \(
       scope: punctuation.definition.group.begin.xml
       push: dtd-element-parens
@@ -312,6 +312,12 @@ contexts:
     - include: entity
     - include: should-be-entity
     - include: string-unquoted
+
+  dtd-element-operator:
+    - match: '[*?+]'
+      scope: keyword.operator.xml
+      pop: 1
+    - include: dtd-else-pop
 
 ###[ DTD ATTLIST ]############################################################
 
@@ -345,17 +351,19 @@ contexts:
   dtd-attlist-parens:
     - match: \(
       scope: punctuation.definition.group.begin.xml
-      push:
-        - meta_scope: meta.group.enumerated.xml
-        - match: \)
-          scope: punctuation.definition.group.end.xml
-          pop: 1
-        - match: \|
-          scope: punctuation.separator.logical.xml
-        - include: entity-parameter
-        - include: entity
-        - include: should-be-entity
-        - include: string-unquoted
+      push: dtd-attlist-parens-content
+
+  dtd-attlist-parens-content:
+    - meta_scope: meta.group.enumerated.xml
+    - match: \)
+      scope: punctuation.definition.group.end.xml
+      pop: 1
+    - match: \|
+      scope: punctuation.separator.logical.xml
+    - include: entity-parameter
+    - include: entity
+    - include: should-be-entity
+    - include: string-unquoted
 
 ###[ DTD NOTATION ]###########################################################
 
@@ -409,13 +417,15 @@ contexts:
   dtd-subset-brackets:
     - match: \[
       scope: punctuation.section.brackets.begin.xml
-      set:
-        - meta_scope: meta.brackets.xml meta.internal-subset.xml
-        - match: \]
-          scope: punctuation.section.brackets.end.xml
-          pop: 1
-        - include: dtd
+      set: dtd-subset-brackets-content
     - include: dtd-else-pop
+
+  dtd-subset-brackets-content:
+    - meta_scope: meta.brackets.xml meta.internal-subset.xml
+    - match: \]
+      scope: punctuation.section.brackets.end.xml
+      pop: 1
+    - include: dtd
 
 ###[ DTD UNKNOWN ]############################################################
 
@@ -424,9 +434,11 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.xml
         2: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.sgml.unknown.xml
-        - include: dtd-end
+      push: dtd-unknown-content
+
+  dtd-unknown-content:
+    - meta_scope: meta.tag.sgml.unknown.xml
+    - include: dtd-end
 
 ###[ DTD PROTOTYPES ]#########################################################
 
@@ -510,20 +522,24 @@ contexts:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.xml
         3: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.preprocessor.xml
-        - include: preprocessor-end
-        - include: tag-end-missing-pop
-        - include: tag-attribute
+      push: prolog-content
     # Processing instructions like <?...?>
     # meta tag without internal highlighting
     - match: (<\?)({{name}})\b
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.xml
-      push:
-        - meta_scope: meta.tag.preprocessor.xml
-        - include: preprocessor-end
+      push: preprocessor-content
+
+  prolog-content:
+    - meta_scope: meta.tag.preprocessor.xml
+    - include: preprocessor-end
+    - include: tag-end-missing-pop
+    - include: tag-attribute
+
+  preprocessor-content:
+    - meta_scope: meta.tag.preprocessor.xml
+    - include: preprocessor-end
 
   preprocessor-end:
     - match: \?>
@@ -542,17 +558,7 @@ contexts:
         4: entity.name.tag.xml punctuation.separator.namespace.xml
         5: entity.name.tag.localname.xml
         6: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.xml
-        - match: '>'
-          scope: punctuation.definition.tag.end.xml
-          pop: 1
-        - include: tag-end-missing-pop
-        - match: '[/\?]>'
-          scope: invalid.illegal.bad-tag-end.xml
-          pop: 1
-        - match: \S
-          scope: invalid.illegal.unexpected-attribute.xml
+      push: end-tag-content
     # opening maybe self-closing tag with optional attributes
     - match: (<){{qualified_tag_name}}
       captures:
@@ -562,16 +568,30 @@ contexts:
         4: entity.name.tag.xml punctuation.separator.namespace.xml
         5: entity.name.tag.localname.xml
         6: invalid.illegal.bad-tag-name.xml
-      push:
-        - meta_scope: meta.tag.xml
-        - match: /?>
-          scope: punctuation.definition.tag.end.xml
-          pop: 1
-        - match: \?>
-          scope: invalid.illegal.bad-tag-end.xml
-          pop: 1
-        - include: tag-end-missing-pop
-        - include: tag-attribute
+      push: begin-tag-content
+
+  begin-tag-content:
+    - meta_scope: meta.tag.xml
+    - match: /?>
+      scope: punctuation.definition.tag.end.xml
+      pop: 1
+    - match: \?>
+      scope: invalid.illegal.bad-tag-end.xml
+      pop: 1
+    - include: tag-end-missing-pop
+    - include: tag-attribute
+
+  end-tag-content:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      pop: 1
+    - include: tag-end-missing-pop
+    - match: '[/\?]>'
+      scope: invalid.illegal.bad-tag-end.xml
+      pop: 1
+    - match: \S
+      scope: invalid.illegal.unexpected-attribute.xml
 
   tag-attribute:
     - match: '{{qualified_attribute_name}}'

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -118,7 +118,7 @@ contexts:
         - meta_content_scope: string.unquoted.cdata.xml
         - match: ']]>'
           scope: punctuation.definition.tag.end.xml
-          pop: true
+          pop: 1
 
 ###[ COMMENT ]################################################################
 
@@ -129,7 +129,7 @@ contexts:
         - meta_scope: comment.block.xml
         - match: -->
           scope: punctuation.definition.comment.end.xml
-          pop: true
+          pop: 1
         - match: -{2,}
           scope: invalid.illegal.double-hyphen-within-comment.xml
 
@@ -160,7 +160,7 @@ contexts:
         3: variable.other.documentroot.xml punctuation.separator.namespace.xml
         4: variable.other.documentroot.localname.xml
         5: invalid.illegal.bad-tag-name.xml
-      pop: true
+      pop: 1
     - include: dtd-else-pop
 
 ###[ DTD TAGS ]###############################################################
@@ -198,13 +198,13 @@ contexts:
   dtd-entity-punctuation:
     - match: '%'
       scope: punctuation.definition.entity.xml
-      pop: true
+      pop: 1
     - include: dtd-else-pop
 
   dtd-entity-name:
     - match: '{{qualified_dtd_name}}'
       scope: variable.other.entity.xml
-      pop: true
+      pop: 1
     - include: dtd-common-name
 
   dtd-entity-content:
@@ -232,13 +232,13 @@ contexts:
   dtd-element-name:
     - match: '{{qualified_dtd_name}}'
       scope: variable.other.element.xml
-      pop: true
+      pop: 1
     - include: dtd-common-name
 
   dtd-element-content:
     - match: \b(?:EMPTY|ANY)\b
       scope: constant.other.xml
-      pop: true
+      pop: 1
     - match: \(
       scope: punctuation.definition.group.begin.xml
       set: dtd-element-parens
@@ -252,7 +252,7 @@ contexts:
       set:
         - match: '[*?+]'
           scope: keyword.operator.xml
-          pop: true
+          pop: 1
         - include: dtd-else-pop
     - match: \(
       scope: punctuation.definition.group.begin.xml
@@ -302,7 +302,7 @@ contexts:
         - meta_scope: meta.group.enumerated.xml
         - match: \)
           scope: punctuation.definition.group.end.xml
-          pop: true
+          pop: 1
         - match: \|
           scope: punctuation.separator.logical.xml
         - include: entity-parameter
@@ -330,7 +330,7 @@ contexts:
   dtd-notation-name:
     - match: '{{qualified_dtd_name}}'
       scope: variable.other.notation.xml
-      pop: true
+      pop: 1
     - include: dtd-common-name
 
 ###[ DTD SUBSET ]#############################################################
@@ -347,16 +347,16 @@ contexts:
     - meta_scope: meta.tag.sgml.subset.xml
     - match: \]>
       scope: punctuation.definition.tag.end.xml
-      pop: true
+      pop: 1
     - match: '[/\?]?>'
       scope: invalid.illegal.bad-tag-end.xml
-      pop: true
+      pop: 1
     - include: tag-end-missing-pop
 
   dtd-subset-name:
     - match: '{{qualified_dtd_name}}'
       scope: variable.other.subset.xml
-      pop: true
+      pop: 1
     - include: dtd-common-name
 
   dtd-subset-brackets:
@@ -366,7 +366,7 @@ contexts:
         - meta_scope: meta.brackets.xml meta.internal-subset.xml
         - match: \]
           scope: punctuation.section.brackets.end.xml
-          pop: true
+          pop: 1
         - include: dtd
     - include: dtd-else-pop
 
@@ -389,10 +389,10 @@ contexts:
       captures:
         1: punctuation.definition.parameter.xml
         2: punctuation.terminator.parameter.xml
-      pop: true
+      pop: 1
     - match: '{{invalid_dtd_name}}'
       scope: invalid.illegal.bad-identifier.xml
-      pop: true
+      pop: 1
     - include: dtd-else-pop
 
   dtd-content-unquoted:
@@ -406,26 +406,26 @@ contexts:
   dtd-content-type:
     - match: (?:PUBLIC|SYSTEM)\b
       scope: storage.type.external-content.xml
-      pop: true
+      pop: 1
     - include: dtd-else-pop
 
   dtd-else-pop:
     # try to keep one whitespace if the end of a subset is detected
     # in order to scope it as `invalid.illegal.missing-tag-end`
     - match: (?=\s?\])
-      pop: true
+      pop: 1
     - include: tag-else-pop
 
   dtd-end:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
-      pop: true
+      pop: 1
     - match: \s?(?=[<\]])
       scope: invalid.illegal.missing-tag-end.xml
-      pop: true
+      pop: 1
     - match: '[/\?]>'
       scope: invalid.illegal.bad-tag-end.xml
-      pop: true
+      pop: 1
     - match: \S
       scope: invalid.illegal.unexpected.xml
 
@@ -481,7 +481,7 @@ contexts:
   preprocessor-end:
     - match: \?>
       scope: punctuation.definition.tag.end.xml
-      pop: true
+      pop: 1
 
 ###[ XML TAGS ]###############################################################
 
@@ -499,11 +499,11 @@ contexts:
         - meta_scope: meta.tag.xml
         - match: '>'
           scope: punctuation.definition.tag.end.xml
-          pop: true
+          pop: 1
         - include: tag-end-missing-pop
         - match: '[/\?]>'
           scope: invalid.illegal.bad-tag-end.xml
-          pop: true
+          pop: 1
         - match: \S
           scope: invalid.illegal.unexpected-attribute.xml
     # opening maybe self-closing tag with optional attributes
@@ -519,10 +519,10 @@ contexts:
         - meta_scope: meta.tag.xml
         - match: /?>
           scope: punctuation.definition.tag.end.xml
-          pop: true
+          pop: 1
         - match: \?>
           scope: invalid.illegal.bad-tag-end.xml
-          pop: true
+          pop: 1
         - include: tag-end-missing-pop
         - include: tag-attribute
 
@@ -543,21 +543,21 @@ contexts:
         - include: string-quoted-pop
         - match: '[^?/<>\s]+'
           scope: invalid.illegal.bad-attribute-value.xml
-          pop: true
+          pop: 1
         - include: tag-else-pop
     - include: tag-else-pop
 
   tag-else-pop:
     # pop, if nothing else matched and ensure `tag-end-missing-pop` works
     - match: (?=\s?<|\S)
-      pop: true
+      pop: 1
 
   tag-end-missing-pop:
     # pop, if the next opening tag is following, while scoping the
     # preceding space to give a hint about the unclosed tag
     - match: \s?(?=<)
       scope: invalid.illegal.missing-tag-end.xml
-      pop: true
+      pop: 1
 
 ###[ CONSTANTS ]##############################################################
 
@@ -591,7 +591,7 @@ contexts:
   string-unquoted-pop:
     - match: '{{name}}'
       scope: string.unquoted.xml
-      pop: true
+      pop: 1
 
   string-quoted:
     - include: string-double-quoted
@@ -615,7 +615,7 @@ contexts:
     - meta_scope: string.quoted.double.xml
     - match: \"
       scope: punctuation.definition.string.end.xml
-      pop: true
+      pop: 1
     - include: tag-end-missing-pop
     - include: entity
     - include: should-be-entity
@@ -634,7 +634,7 @@ contexts:
     - meta_scope: string.quoted.single.xml
     - match: \'
       scope: punctuation.definition.string.end.xml
-      pop: true
+      pop: 1
     - include: tag-end-missing-pop
     - include: entity
     - include: should-be-entity

--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -1,7 +1,52 @@
 %YAML 1.2
 ---
+###############################################################################
+#
+# NOTES
+#
+#  1 STRING INTERPOLATION
+#
+#    The syntax definition excludes prototypes from quoted strings by default
+#    to kindly ask an inherited syntax definition to explicitly handle string
+#    interpolation.
+#
+#    An inherited syntax might most likely want to define a `prototype` to
+#    inject its templating patterns in all (appropriate) contexts which are
+#    already defined by this base syntax definition. That's basically fine.
+#
+#    What we want is replacing `string` scope by `meta.interpolation` in case
+#    of injecting template patterns into a string, which can't be achieved
+#    using prototype context. Interpolation requires special patterns which
+#    push into contexts with `- clear_scope: 1`.
+#
+#    Example:
+#
+#      prototype:
+#        - meta_prepend: true
+#        - include: jspx-tags
+#
+#      string-common-content:
+#        - meta_prepend: true
+#        - include: jspx-interpolations
+#
+#      jspx-interpolations:
+#        - match: <%
+#          scope: punctuation.section.embedded.begin.xml
+#          push: jspx-tag-content
+#
+#      jspx-tag-content:
+#        - clear_scopes: 1
+#        - meta_scope: meta.interpolation.xml
+#        - meta_content_scope: source.jspx.embedded.xml
+#        - match: '%>'
+#          scope: punctuation.section.embedded.end.xml
+#          pop: 1
+#        - ...
+#
+###############################################################################
 # https://www.sublimetext.com/docs/syntax.html
 # https://www.w3.org/XML/
+###############################################################################
 name: XML
 scope: text.xml
 version: 2
@@ -114,8 +159,9 @@ contexts:
         2: keyword.declaration.cdata.xml
         3: punctuation.definition.tag.begin.xml
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.sgml.cdata.xml
-        - meta_content_scope: string.unquoted.cdata.xml
+        - meta_content_scope: meta.string.xml string.unquoted.cdata.xml
         - match: ']]>'
           scope: punctuation.definition.tag.end.xml
           pop: 1
@@ -126,6 +172,7 @@ contexts:
     - match: <!--
       scope: punctuation.definition.comment.begin.xml
       push:
+        - meta_include_prototype: false
         - meta_scope: comment.block.xml
         - match: -->
           scope: punctuation.definition.comment.end.xml
@@ -584,11 +631,11 @@ contexts:
 
   string-unquoted:
     - match: '{{name}}'
-      scope: string.unquoted.xml
+      scope: meta.string.xml string.unquoted.xml
 
   string-unquoted-pop:
     - match: '{{name}}'
-      scope: string.unquoted.xml
+      scope: meta.string.xml string.unquoted.xml
       pop: 1
 
   string-quoted:
@@ -610,13 +657,12 @@ contexts:
       set: string-double-quoted-body
 
   string-double-quoted-body:
-    - meta_scope: string.quoted.double.xml
+    - meta_include_prototype: false
+    - meta_scope: meta.string.xml string.quoted.double.xml
     - match: \"
       scope: punctuation.definition.string.end.xml
       pop: 1
-    - include: tag-end-missing-pop
-    - include: entity
-    - include: should-be-entity
+    - include: string-common-content
 
   string-single-quoted:
     - match: \'
@@ -629,10 +675,14 @@ contexts:
       set: string-single-quoted-body
 
   string-single-quoted-body:
-    - meta_scope: string.quoted.single.xml
+    - meta_include_prototype: false
+    - meta_scope: meta.string.xml string.quoted.single.xml
     - match: \'
       scope: punctuation.definition.string.end.xml
       pop: 1
+    - include: string-common-content
+
+  string-common-content:
     - include: tag-end-missing-pop
     - include: entity
     - include: should-be-entity

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -1305,6 +1305,20 @@
 ##                            ^ punctuation.definition.string.end
 ##                             ^ punctuation.definition.tag.end
 
+     <ns:tagname ="uri">
+##  ^ - meta.tag
+##   ^^^^^^^^^^^^^^^^^^^ meta.tag
+##                      ^ - meta.tag
+##   ^ punctuation.definition.tag.begin
+##      ^ punctuation.separator.namespace
+##       ^^^^^^^ entity.name.tag.localname
+##              ^ - entity
+##               ^ punctuation.separator.key-value
+##                ^ punctuation.definition.string.begin
+##                ^^^^^ string.quoted
+##                    ^ punctuation.definition.string.end
+##                     ^ punctuation.definition.tag.end
+
      <ns:tagname
 ##  ^ - meta.tag - invalid.illegal
 ##   ^ punctuation.definition.tag.begin

--- a/XML/syntax_test_xml.xml
+++ b/XML/syntax_test_xml.xml
@@ -47,7 +47,7 @@
 ##         ^^^^^^^ entity.other.attribute-name
 ##                ^ punctuation.separator.key-value
 ##                 ^ punctuation.definition.string.begin
-##                 ^^^^^ string.quoted
+##                 ^^^^^ meta.string string.quoted
 ##                     ^ punctuation.definition.string.end
 
      <?xml version="1.0" ?>
@@ -58,7 +58,7 @@
 ##         ^^^^^^^ entity.other.attribute-name
 ##                ^ punctuation.separator.key-value
 ##                 ^ punctuation.definition.string.begin
-##                 ^^^^^ string.quoted
+##                 ^^^^^ meta.string string.quoted
 ##                     ^ punctuation.definition.string.end
 ##                       ^^ punctuation.definition.tag.end
 ##                         ^ - meta.tag.preprocessor
@@ -171,7 +171,7 @@
 ##      ^^^^^^^ entity.other.attribute-name
 ##             ^ punctuation.separator.key-value
 ##              ^ punctuation.definition.string.begin
-##              ^^^^^ string.quoted
+##              ^^^^^ meta.string string.quoted
 ##                  ^ punctuation.definition.string.end
       ?>
 ##    ^^ punctuation.definition.tag.end
@@ -207,7 +207,7 @@
 ##         ^^^^^^^ entity.other.attribute-name
 ##                ^ punctuation.separator.key-value
 ##                 ^ punctuation.definition.string.begin
-##                 ^^^^^ string.quoted
+##                 ^^^^^ meta.string string.quoted
 ##                     ^ punctuation.definition.string.end
 ##                       ^^ punctuation.definition.tag.end
 
@@ -239,7 +239,7 @@
 ##                    ^^^^ entity.other.attribute-name.localname
 ##                        ^ punctuation.separator.key-value
 ##                         ^ punctuation.definition.string.begin
-##                         ^^^^^^^^^^ string.quoted.single
+##                         ^^^^^^^^^^ meta.string string.quoted.single
 ##                                  ^ punctuation.definition.string.end
 ##                                   ^ - string
 
@@ -263,7 +263,7 @@
 ##      ^^^^ entity.other.attribute-name.localname
 ##          ^ punctuation.separator.key-value
 ##           ^ punctuation.definition.string.begin
-##           ^^^^^^^^^^ string.quoted.single
+##           ^^^^^^^^^^ meta.string string.quoted.single
 ##                    ^ punctuation.definition.string.end
 ##                     ^ - string
         href = 'freb.xsl'
@@ -272,7 +272,7 @@
 ##      ^^^^ entity.other.attribute-name.localname
 ##           ^ punctuation.separator.key-value
 ##             ^ punctuation.definition.string.begin
-##             ^^^^^^^^^^ string.quoted.single
+##             ^^^^^^^^^^ meta.string string.quoted.single
 ##                      ^ punctuation.definition.string.end
 ##                       ^ - string
      ?>
@@ -294,7 +294,7 @@
 ##                    ^^^^ entity.other.attribute-name.localname
 ##                        ^ punctuation.separator.key-value
 ##                         ^ punctuation.definition.string.begin
-##                         ^^^^^^^^^^ string.quoted.single
+##                         ^^^^^^^^^^ meta.string string.quoted.single
 ##                                  ^ punctuation.definition.string.end
 ##                                   ^ - string
 
@@ -325,7 +325,7 @@
 ##              ^ - entity
 ##               ^^^^ entity.other.attribute-name.localname
 ##                   ^ punctuation.separator.key-value
-##                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+##                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 ##                                                                                                                                     ^^ punctuation.definition.tag.end
 
      <?xml-model
@@ -336,7 +336,7 @@
         href="http://www.oxygenxml.com/docbook/xml/5.0/rng/dbmathmlsvg.rng"
 ##      ^^^^ entity.other.attribute-name.localname
 ##          ^ punctuation.separator.key-value
-##           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+##           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
         schematypens="http://relaxng.org/ns/structure/1.0"?>
 ##                                                        ^^ punctuation.definition.tag.end
 ##                                                          ^ - meta.tag.preprocessor
@@ -364,7 +364,7 @@
 ##     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag
 ##                                  ^^^^ entity.other.attribute-name
 ##                                       ^ punctuation.separator.key-value
-##                                         ^^^^^ string.quoted.double
+##                                         ^^^^^ meta.string string.quoted.double
 ##                                               ^^ punctuation.definition.tag.end
 
 
@@ -393,7 +393,7 @@
 ##     ^^^^^^^ keyword.declaration.doctype
 ##            ^ - entity - constant - keyword
 ##             ^^^^^^ variable.other.documentroot
-##                    ^^^^^ string.quoted.double
+##                    ^^^^^ meta.string string.quoted.double
 
      <!DOCTYPE SYSTEM SYSTEM
 ##  ^ meta.tag.sgml.doctype invalid.illegal.missing-tag-end
@@ -414,7 +414,7 @@
 ##             ^^^^^^ variable.other.documentroot
 ##                   ^ - constant - keyword
 ##                    ^^^^^^ storage.type.external-content
-##                           ^^^^^ string.quoted.double
+##                           ^^^^^ meta.string string.quoted.double
 
      <!DOCTYPE ns:tag
 ##  ^ meta.tag.sgml.doctype invalid.illegal.missing-tag-end
@@ -449,7 +449,7 @@
 ##                ^^^ variable.other.documentroot.localname
 ##                   ^ - constant - keyword
 ##                    ^^^^^^ storage.type.external-content
-##                           ^^^^^^^^^^^^^ string.quoted.double
+##                           ^^^^^^^^^^^^^ meta.string string.quoted.double
 
      <!DOCTYPE root PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/1999/xhtml">
 ##  ^ meta.tag.sgml.doctype string.quoted.double invalid.illegal.missing-tag-end
@@ -462,9 +462,9 @@
 ##                 ^ - constant - keyword
 ##                  ^^^^^^ storage.type.external-content
 ##                        ^ - keyword - string
-##                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+##                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 ##                                                    ^ - string
-##                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+##                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 ##                                                                                   ^ punctuation.definition.tag.end - string
 
      <!DOCTYPE root SYSTEM "url" />
@@ -481,9 +481,9 @@
 ##                                                 ^ - meta.brackets - meta.internal-subset
 ##                                                  ^^^^^^^^^^^^ meta.brackets meta.internal-subset
 ##                                                              ^ - meta.brackets - meta.internal-subset
-##                           ^ string.quoted.double
-##                                 ^ string.quoted.double
-##                                       ^ string.quoted.double
+##                           ^ meta.string string.quoted.double
+##                                 ^ meta.string string.quoted.double
+##                                       ^ meta.string string.quoted.double
 ##                                                  ^ punctuation.section.brackets.begin
 ##                                                             ^ punctuation.section.brackets.end
 ##                                                              ^ punctuation.definition.tag.end
@@ -496,8 +496,8 @@
 ##                                            ^^^^^^^^^^^ meta.brackets meta.internal-subset
 ##                                                       ^ - meta.brackets - meta.internal-subset
 ##                                                        ^ - meta.tag.sgml.doctype
-##                           ^ string.quoted.double
-##                                 ^ string.quoted.double
+##                           ^ meta.string string.quoted.double
+##                                 ^ meta.string string.quoted.double
 ##                                            ^ punctuation.section.brackets.begin
 ##                                                      ^ punctuation.section.brackets.end
 ##                                                       ^ punctuation.definition.tag.end
@@ -552,7 +552,7 @@
 ##  ^^ punctuation.definition.tag.begin
 ##    ^^^^^^ keyword.declaration.entity
 ##           ^^^^ variable.other.entity
-##                ^^^^^^^^ string.quoted.double
+##                ^^^^^^^^ meta.string string.quoted.double
 ##                        ^ punctuation.definition.tag.end
 
     <!ENTITY<!ENTITY <!ENTITY
@@ -626,7 +626,7 @@
 ##           ^ punctuation.definition.entity
 ##             ^^^^^^^^^^ variable.other.entity
 ##                        ^^^^^^ storage.type.external-content
-##                               ^^^^^ string.quoted.double
+##                               ^^^^^ meta.string string.quoted.double
 
     <!ENTITY % enity-name PUBLIC "URL" "uri" NDATA jpeg>
 ## ^ meta.tag.sgml.entity invalid.illegal.missing-tag-end
@@ -637,10 +637,10 @@
 ##           ^ punctuation.definition.entity
 ##             ^^^^^^^^^^ variable.other.entity
 ##                        ^^^^^^ storage.type.external-content
-##                               ^^^^^ string.quoted.double
-##                                     ^^^^^ string.quoted.double
+##                               ^^^^^ meta.string string.quoted.double
+##                                     ^^^^^ meta.string string.quoted.double
 ##                                           ^^^^^ storage.type.ndata
-##                                                 ^^^^ string.unquoted
+##                                                 ^^^^ meta.string string.unquoted
 ##                                                     ^ punctuation.definition.tag.end
 
 
@@ -713,7 +713,7 @@
 ##     ^^^^^^^ keyword.declaration.element
 ##            ^ - keyword - variable
 ##             ^^^^^^^^^ variable.other.element
-##                       ^^^^^^^^^^^^^^^^ string.quoted.double
+##                       ^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 ##                                       ^ punctuation.definition.tag.end
 
      <!ELEMENT elem.name %author.content;>
@@ -743,10 +743,10 @@
 ##                       ^ punctuation.definition.group.begin
 ##                        ^^^^^^^ constant.other.placeholder
 ##                               ^ punctuation.separator
-##                                ^^^ string.unquoted
+##                                ^^^ meta.string string.unquoted
 ##                                   ^ keyword.operator
 ##                                    ^ punctuation.separator
-##                                     ^^^ string.unquoted
+##                                     ^^^ meta.string string.unquoted
 ##                                        ^ keyword.operator
 ##                                         ^ punctuation.separator
 ##                                          ^ punctuation.definition.parameter
@@ -960,7 +960,7 @@
 ##     ^^^^^^^^ keyword.declaration.notation
 ##             ^ - keyword - variable - storage
 ##              ^^^^^^ variable.other.notation
-##                     ^^^^^^^^ string.quoted.double
+##                     ^^^^^^^^ meta.string string.quoted.double
 
      <!NOTATION PUBLIC PUBLIC "public
 ##  ^ meta.tag.sgml.notation invalid.illegal.missing-tag-end
@@ -971,7 +971,7 @@
 ##              ^^^^^^ variable.other.notation
 ##                    ^ - variable - storage
 ##                     ^^^^^^ storage.type.external-content
-##                            ^^^^^^^^ string.quoted.double
+##                            ^^^^^^^^ meta.string string.quoted.double
 
      <!NOTATION name
 ##  ^ meta.tag.sgml.notation invalid.illegal.missing-tag-end
@@ -1000,7 +1000,7 @@
 ##              ^^^^ variable.other.notation
 ##                  ^ - variable - storage
 ##                   ^^^^^^ storage.type.external-content
-##                          ^^^^^^^^ string.quoted.double
+##                          ^^^^^^^^ meta.string string.quoted.double
 
      <!NOTATION m$me PUBLIC "public
 ##  ^ meta.tag.sgml.notation invalid.illegal.missing-tag-end
@@ -1010,7 +1010,7 @@
 ##             ^ - keyword - variable - storage
 ##              ^^^^ invalid.illegal.bad-identifier
 ##                   ^^^^^^ storage.type.external-content
-##                          ^^^^^^^^ string.quoted.double
+##                          ^^^^^^^^ meta.string string.quoted.double
 
      <!NOTATION name PUBLIC "public_ID" "URI">
 ##  ^ meta.tag.sgml.notation invalid.illegal.missing-tag-end
@@ -1019,8 +1019,8 @@
 ##   ^^ punctuation.definition.tag.begin
 ##     ^^^^^^^^ keyword.declaration.notation
 ##                   ^^^^^^ storage.type.external-content
-##                          ^^^^^^^^^^^ string.quoted.double
-##                                      ^^^^^ string.quoted.double
+##                          ^^^^^^^^^^^ meta.string string.quoted.double
+##                                      ^^^^^ meta.string string.quoted.double
 ##                                           ^ punctuation.definition.tag.end
 
 
@@ -1109,7 +1109,7 @@
 ##                     ^^^^^^^ keyword.declaration.element
 ##                             ^^^^^^^^^^^^ variable.other.element
 ##                                          ^ punctuation.definition.string.begin
-##                                          ^^^^^^ string.quoted.single
+##                                          ^^^^^^ meta.string string.quoted.single
 ##                                                ^ punctuation.definition.string.end
 ##                                                 ^ punctuation.definition.tag.end
 ##                                                  ^^^^^^^^^^^^^^^^ comment.block
@@ -1284,7 +1284,7 @@
 ##                     ^^ entity.other.attribute-name.localname
 ##                       ^ punctuation.separator.key-value
 ##                        ^ punctuation.definition.string.begin
-##                        ^^^^^ string.quoted
+##                        ^^^^^ meta.string string.quoted
 ##                            ^ punctuation.definition.string.end
 
      <ns:tagname xmlns:ns="uri">
@@ -1301,7 +1301,7 @@
 ##                     ^^ entity.other.attribute-name.localname
 ##                       ^ punctuation.separator.key-value
 ##                        ^ punctuation.definition.string.begin
-##                        ^^^^^ string.quoted
+##                        ^^^^^ meta.string string.quoted
 ##                            ^ punctuation.definition.string.end
 ##                             ^ punctuation.definition.tag.end
 
@@ -1315,7 +1315,7 @@
 ##              ^ - entity
 ##               ^ punctuation.separator.key-value
 ##                ^ punctuation.definition.string.begin
-##                ^^^^^ string.quoted
+##                ^^^^^ meta.string string.quoted
 ##                    ^ punctuation.definition.string.end
 ##                     ^ punctuation.definition.tag.end
 
@@ -1389,7 +1389,7 @@
       =
       "uri"
 ##    ^ punctuation.definition.string.begin
-##    ^^^^^ string.quoted
+##    ^^^^^ meta.string string.quoted
 ##        ^ punctuation.definition.string.end
      >
 ##   ^ punctuation.definition.tag.end
@@ -1462,7 +1462,7 @@
 ##    ^^^ entity.name.tag.localname
 ##        ^^^ entity.other.attribute-name.localname
 ##           ^ punctuation.separator.key-value
-##            ^^^^^ string.quoted.double
+##            ^^^^^ meta.string string.quoted.double
 ##                ^ invalid.illegal.missing-tag-end
 ##                 ^^^^ punctuation.definition.comment.begin
 ##                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block
@@ -1480,7 +1480,7 @@
 ##    ^^^ entity.name.tag.localname
 ##        ^^^ entity.other.attribute-name.localname
 ##           ^ punctuation.separator.key-value
-##            ^^^^^ string.quoted.double
+##            ^^^^^ meta.string string.quoted.double
 ##                 ^ invalid.illegal.missing-tag-end
 ##                  ^^^^ punctuation.definition.comment.begin
 ##                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block
@@ -1533,7 +1533,7 @@
        bar="baz"
 ##     ^^^ entity.other.attribute-name.localname
 ##        ^ punctuation.separator.key-value
-##         ^^^^^ string.quoted.double
+##         ^^^^^ meta.string string.quoted.double
        <!-- a comment is a next tag -->
 ##    ^ invalid.illegal.missing-tag-end
 ##     ^^^^ punctuation.definition.comment.begin
@@ -1557,7 +1557,7 @@
 ##   ^^^ punctuation.definition.tag.begin
 ##      ^^^^^ keyword.declaration.cdata
 ##           ^ punctuation.definition.tag.begin
-##            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.unquoted.cdata
 ##                                          ^ - string.unquoted.cdata
 ##                                          ^^^ punctuation.definition.tag.end
      <![CDATA[
@@ -1566,14 +1566,14 @@
 ##      ^^^^^ keyword.declaration.cdata
 ##           ^ punctuation.definition.tag.begin
         <!DOCTYPE catalog plist "dtd">
-##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.unquoted.cdata
     ]]>
 ##  ^ - string.unquoted.cdata
 ##  ^^^ punctuation.definition.tag.end
 
      <![CDATA[
         <![CDATA[ unparsed! ]]>
-##      ^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##      ^^^^^^^^^^^^^^^^^^^^ meta.string string.unquoted.cdata
 ##      ^^^ - punctuation.definition.tag.begin
 ##         ^^^^^ - keyword.declaration.cdata
 ##              ^ - punctuation.definition.tag.begin
@@ -1595,7 +1595,7 @@
 ##           ^ - entity.name.tag.localname
 ##            ^^^^ entity.other.attribute-name.localname
 ##                ^ punctuation.separator.key-value - entity.other.attribute-name.localname
-##                 ^^^^^^^ string.quoted
+##                 ^^^^^^^ meta.string string.quoted
 ##                        ^ - string.quoted - punctuation.definition
 ##                         ^ punctuation.definition.tag.end
 ##                          ^^^^^^^^ text - meta.tag
@@ -1614,7 +1614,7 @@
 ##              ^ entity.other.attribute-name punctuation.separator.namespace
 ##               ^^^^ entity.other.attribute-name.localname
 ##                    ^ punctuation.separator.key-value
-##                     ^^^^^^^^ string.quoted.single
+##                     ^^^^^^^^ meta.string string.quoted.single
 ##                     ^ punctuation.definition.string.begin
 ##                            ^ punctuation.definition.string.end
 ##                       ^^^^^ constant.character.entity
@@ -1685,12 +1685,12 @@
 ##            ^^^^^^^^^^^^^^^ entity.other.attribute-name.localname
 ##                            ^ punctuation.separator.key-value
 ##                              ^ punctuation.definition.string.begin
-##                              ^^^^^^^ string.quoted.double
+##                              ^^^^^^^ meta.string string.quoted.double
 ##                                    ^ punctuation.definition.string.end
 ##                                      ^^ punctuation.definition.tag.end
 
      <element validinattr="a > b ]]> c"/>
-##                         ^^^^^^^^^^^ string.quoted - punctuation - illegal
+##                         ^^^^^^^^^^^ meta.string string.quoted - punctuation - illegal
 
      <foo
 ##  ^ - meta.tag
@@ -1701,7 +1701,7 @@ bar="baz" />
 ##^^^^^^^^^^ meta.tag
 ##          ^ - meta.tag
 ##^ entity.other.attribute-name.localname
-##  ^^^^^ string.quoted.double
+##  ^^^^^ meta.string string.quoted.double
 ##       ^ - string.quoted.double
 
      <foo
@@ -1713,7 +1713,7 @@ bar="baz" />
 ##^^^^^^^^^^^^^^^^^^ meta.tag
 ##                  ^ - meta.tag
 ##    ^^^ entity.other.attribute-name.localname
-##          ^^^^^ string.quoted.double
+##          ^^^^^ meta.string string.quoted.double
 ##               ^ - string.quoted.double
 ##                ^^ punctuation.definition.tag.end
 
@@ -1729,7 +1729,7 @@ bar="baz" />
       "baz"
 ##^^^^^^^^^^ meta.tag
 ##   ^ - string.quoted.double
-##    ^^^^^ string.quoted.double
+##    ^^^^^ meta.string string.quoted.double
 ##         ^ - string.quoted.double
       />
 ##^^^^^^ meta.tag
@@ -1789,7 +1789,7 @@ bar="baz" />
 ##        ^ - punctuation.definition.entity
 
      <example attr="&quot;test&quot;" />
-##                 ^^^^^^^^^^^^^^^^^^ string.quoted.double
+##                 ^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 ##                                   ^ - string.quoted.double
 ##                  ^^^^^^ constant.character.entity
 ##                            ^^^^^^ constant.character.entity
@@ -1818,9 +1818,9 @@ bar="baz" />
 ##        ^^^^^^^^^^^^ - invalid.illegal - entity.name.tag
 ##         ^^^^^ entity.other.attribute-name.localname
 ##              ^ punctuation.separator.key-value
-##               ^^^^ string.quoted
+##               ^^^^ meta.string string.quoted
 ##                    ^^^^^ invalid.illegal - entity.other.attribute-name.localname
-##                          ^^^^^ string.quoted
+##                          ^^^^^ meta.string string.quoted
 ##                                ^ punctuation.definition.tag.end
 ##                                 ^^ punctuation.definition.tag.begin
 ##                                   ^^^^ invalid.illegal - entity.name.tag
@@ -1844,12 +1844,12 @@ bar="baz" />
 ##              ^ entity.other.attribute-name.xml punctuation.separator.namespace.xml
 ##               ^^^^^^ invalid.illegal.bad-attribute-name - entity.other.attribute-name
 ##                     ^ punctuation.separator.key-value
-##                      ^^^^ string.quoted
+##                      ^^^^ meta.string string.quoted
 ##                           ^^ entity.other.attribute-name.namespace
 ##                             ^ entity.other.attribute-name.xml punctuation.separator.namespace.xml
 ##                              ^^^^^ invalid.illegal.bad-attribute-name - entity.other.attribute-name
 ##                                    ^ punctuation.separator.key-value
-##                                      ^^^^^^ string.quoted
+##                                      ^^^^^^ meta.string string.quoted
 ##                                            ^ punctuation.definition.tag.end
 ##                                             ^^ punctuation.definition.tag.begin
 ##                                               ^^ entity.name.tag.namespace


### PR DESCRIPTION
This PR applies some strategic changes to XML.sublime-syntax after the scheme of HTML.sublime-syntax which intend to help 3rd-party packages with inheriting XML and modifying single aspects of the syntax.

All changes are grouped and described in single commits.

Syntax tests are updated to

1. test for added `meta.string` scopes
2. test missing attribute name situations (only `="value"` present)

--- 
Note:

I wonder whether we also should rename contexts to add a `xml-` prefix. The idea is to make it obvious which contexts are inherit from XML or which are added by an extending syntax definition. It would also "look nice" next to the already existing `dtd-` contexts.

This change is **not** yet part of this PR and may be handled separately because it is a breaking change. PackageDev is known to use some parts of XML, which would break then, but might be fixable easily.