### PR TITLE
[CSS] Fix color functions in blend()

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1849,10 +1849,10 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
-            - match: \b(?i:rgb|hsl|hwb){{break}}
-              scope: keyword.other.color-space.css
             - include: color-values
             - include: percentage-constants
+            - match: \b(?i:rgb|hsl|hwb){{break}}
+              scope: keyword.other.color-space.css
 
 ###[ BUILTIN FILTER FUNCTIONS ]################################################
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2195,6 +2195,23 @@
 /*             ^^^ meta.number.float.decimal.css constant.numeric.value.css */
 /*                ^ meta.number.float.decimal.css constant.numeric.suffix.css */
 
+    top: blend(hsl(219, 10%, 6%) 50%);
+/*       ^^^^^ support.function.color.css */
+/*            ^ punctuation.section.group.begin.css */
+/*             ^^^ support.function.color.css */
+/*                ^ punctuation.section.group.begin.css */
+/*                 ^^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                    ^ punctuation.separator.sequence.css */
+/*                      ^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                        ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                         ^ punctuation.separator.sequence.css */
+/*                           ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                            ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                             ^ punctuation.section.group.end.css */
+/*                               ^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                                 ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                                  ^ punctuation.section.group.end.css */
+
     top: blenda(red 50% hsl);
 /*       ^^^^^^ support.function.color.css */
 /*              ^^^ support.constant.color.w3c.standard.css */


### PR DESCRIPTION
This PR fixes an issue which caused rgb(), hsl() functions and friends being highlighted as keywords.