### PR TITLE
[CSS] Add auto-pair keybindings to /*|*/ <=> /* | */

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -73,6 +73,26 @@
 		]
 	},
 
+	// Expand /*|*/ to /* | */ when space is pressed
+	{ "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css comment", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "/\\*$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\*/", "match_all": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css comment", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "/\\* $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\*/", "match_all": true }
+		]
+	},
+
 	// Auto-pair double quotes (also if followed by comma or semicolon)
 	// Example: key: |; -> key: "|";
 	{ "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":


### PR DESCRIPTION
This PR proposes to improve auto-pairing user experience by automatically adding or removing space to the left and right of caret in new/empty block comments.

**Note:**

This keybinding could also be implemented in Default.sublime-package by just removing `source.css` from selector. The remaining `comment` would ensure the key binding is triggered only within block comments. This would enable this enhancement to all syntaxes which support this style of block cumments such as: C, C++, ObjC, ObjC++, Java, JavaScript, JSON and probably numerous more.