### PR TITLE
[CSS] Update property names from referenced website

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -276,85 +276,144 @@ variables:
     ){{break}}
 
   # Property names are sorted by popularity in descending order.
-  # Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
+  # Note:
+  # 1) Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
+  # 2) Properties starting with `alias-` or `webkit-` are removed
   property_names: |-
     \b(?xi:
-        display | width | background-color | height | position | font-family
-      | font-weight | font | top | opacity | cursor | background-image | right
-      | visibility | box-sizing | user-select | left | float | margin-left
-      | margin-top | line-height | padding-left | z-index | margin-bottom
-      | margin-right | margin | vertical-align | padding-top | white-space
-      | border-radius | padding-bottom | padding-right | padding | bottom | clear
-      | max-width | box-shadow | content | border-color | min-height | min-width
-      | font-style | border-width | border-collapse | background-size
-      | text-overflow | max-height | text-transform | text-shadow | text-indent
-      | border-style | overflow-y | list-style-type | word-wrap | border-spacing
-      | appearance | zoom | overflow-x | border-top-left-radius
-      | border-bottom-left-radius | border-top-color | pointer-events
-      | border-bottom-color | align-items | justify-content | letter-spacing
-      | border-top-right-radius | border-bottom-right-radius | border-right-width
-      | font-smoothing | border-bottom-width | border-right-color | direction
-      | border-top-width | src | border-left-color | border-left-width
-      | tap-highlight-color | table-layout | background-clip | word-break
-      | transform-origin | resize | filter | backface-visibility | text-rendering
-      | box-orient | transition-property | transition-duration | word-spacing
-      | quotes | outline-offset | animation-timing-function | animation-duration
-      | animation-name | transition-timing-function | border-bottom-style
-      | border-bottom | transition-delay | transition | unicode-bidi
-      | border-top-style | border-top | unicode-range | list-style-position
-      | orphans | outline-width | line-clamp | order | flex-direction | box-pack
-      | animation-fill-mode | outline-color | list-style-image | list-style
-      | touch-action | flex-grow | border-left-style | border-left
-      | animation-iteration-count | page-break-inside | box-flex | box-align
-      | page-break-after | animation-delay | widows | border-right-style
-      | border-right | flex-align | outline-style | outline | background-origin
-      | animation-direction | fill-opacity | background-attachment | flex-wrap
-      | transform-style | overflow-wrap | animation-play-state | animation
-      | will-change | box-ordinal-group | image-rendering | marks | mask-image
-      | flex-flow | background-position-y | stroke-width | background-position-x
-      | background-position | background-blend-mode | flex-shrink | flex-basis
-      | flex-order | flex-item-align | flex-line-pack | flex-negative | flex-pack
-      | flex-positive | flex-preferred-size | flex | user-drag | font-stretch
-      | column-count | empty-cells | align-self | caption-side | mask-size
-      | column-gap | mask-repeat | box-direction | font-feature-settings
-      | mask-position | align-content | object-fit | columns | text-fill-color
-      | clip-path | stop-color | font-kerning | page-break-before
-      | stroke-dasharray | size | fill-rule | border-image-slice | column-width
-      | break-inside | column-break-before | border-image-width| stroke-dashoffset
-      | border-image-repeat | border-image-outset | line-break | stroke-linejoin
-      | stroke-linecap | stroke-miterlimit | stroke-opacity | stroke
-      | shape-rendering | border-image-source | border-image | border | tab-size
-      | writing-mode | perspective-origin-y | perspective-origin-x
-      | perspective-origin | perspective | text-align-last | text-align
-      | clip-rule | clip | text-anchor | column-rule-color | box-decoration-break
-      | column-fill | fill | column-rule-style | mix-blend-mode
-      | text-emphasis-color | baseline-shift | dominant-baseline | page
-      | alignment-baseline | column-rule-width | column-rule | break-after
-      | font-variant-ligatures | transform-origin-y | transform-origin-x
-      | transform | object-position | break-before | column-span | isolation
-      | shape-outside | all | color-interpolation-filters | marker | marker-end
-      | marker-start | marker-mid | color-rendering | color-interpolation
-      | background-repeat-x | background-repeat-y | background-repeat
-      | background | mask-type | flood-color | flood-opacity | text-orientation
-      | mask-composite | text-emphasis-style | paint-order | lighting-color
-      | shape-margin | text-emphasis-position | text-emphasis
-      | shape-image-threshold | mask-clip | mask-origin | mask | font-variant-caps
-      | font-variant-alternates | font-variant-east-asian | font-variant-numeric
-      | font-variant-position | font-variant | font-size-adjust | font-size
-      | font-language-override | font-display | font-synthesis | font
-      | line-box-contain | text-justify | text-decoration-color
-      | text-decoration-style | text-decoration-line | text-decoration
-      | text-underline-position | grid-template-rows | grid-template-columns
-      | grid-template-areas | grid-template | rotate | scale | translate
-      | scroll-behavior | grid-column-start | grid-column-end | grid-column-gap
-      | grid-row-start | grid-row-end | grid-auto-rows | grid-area
-      | grid-auto-flow | grid-auto-columns | image-orientation | hyphens
-      | overflow-scrolling | overflow | color-profile | kerning | nbsp-mode
-      | color | image-resolution | grid-row-gap | grid-row | grid-column
-      | blend-mode | azimuth | pause-after | pause-before | pause | pitch-range
-      | pitch | text-height | system | negative | prefix | suffix | range | pad
-      | fallback | additive-symbols | symbols | speak-as | speak | grid-gap | grid
-      | justify-items | justify-self
+      width | height | display | position | padding | border | margin | top
+    | left | margin-top | color | font-size | background-color | text-align
+    | opacity | font-weight | font-family | background | overflow | line-height
+    | float | box-sizing | text-decoration | z-index | cursor | margin-left
+    | border-radius | vertical-align | margin-bottom | margin-right | right
+    | padding-top | padding-left | max-width | box-shadow | bottom | content
+    | padding-right | transform | white-space | min-height | padding-bottom
+    | background-image | border-bottom | visibility | outline
+    | background-position | min-width | transition | border-top | border-color
+    | background-repeat | text-transform | background-size | max-height
+    | list-style | clear | font-style | justify-content | border-left
+    | align-items | border-right | border-width | font | text-overflow
+    | overflow-y | pointer-events | border-style | flex-direction | animation
+    | overflow-x | letter-spacing | flex | word-wrap | flex-wrap | fill
+    | transform-origin | list-style-type | border-collapse
+    | border-top-left-radius | border-bottom-left-radius | user-select | clip
+    | text-shadow | border-bottom-right-radius | word-break | flex-grow
+    | border-top-right-radius | border-bottom-color | border-top-color
+    | flex-shrink | align-self | text-rendering | animation-timing-function
+    | direction | background-clip | zoom | border-spacing | text-indent
+    | outline-offset | border-left-color | transition-property | src
+    | border-right-color | animation-name | stroke | touch-action
+    | animation-duration | transition-delay | filter | overflow-wrap
+    | animation-delay | border-bottom-width | variable | font-variant
+    | flex-basis | transition-duration | border-top-width | animation-fill-mode
+    | object-fit | transition-timing-function | will-change | outline-width
+    | order | outline-style | stroke-width | border-right-width | align-content
+    | resize | table-layout | appearance | animation-iteration-count
+    | border-left-width | flex-flow | stroke-dashoffset | stroke-dasharray
+    | backface-visibility | unicode-bidi | unicode-range | border-bottom-style
+    | text-size-adjust | border-top-style | animation-direction | word-spacing
+    | contain | speak | grid-template-columns | font-feature-settings
+    | perspective | list-style-position | clip-path | image-rendering
+    | font-display | transform-style | border-left-style | outline-color
+    | background-position-x | background-attachment | border-right-style
+    | margin-block-end | background-origin | animation-play-state | hyphens
+    | stroke-linecap | font-stretch | object-position | page-break-inside
+    | column-gap | counter-reset | counter-increment | background-position-y
+    | margin-block-start | size | grid-template-rows | column-count | quotes
+    | padding-inline-end | text-decoration-skip | border-image | all
+    | page-break-after | fill-opacity | font-variant-ligatures
+    | scroll-boundary-behavior | empty-cells | list-style-image | justify-self
+    | overflow-anchor | padding-inline-start | grid-gap | text-decoration-color
+    | margin-inline-start | caret-color | grid-column-gap | aspect-ratio
+    | stroke-opacity | margin-inline-end | grid-column | perspective-origin
+    | caption-side | columns | scroll-behavior | justify-items | line-break
+    | grid-row-gap | column-width | orphans | widows | backdrop-filter
+    | mix-blend-mode | tab-size | stop-color | column-rule | grid-area
+    | stroke-miterlimit | text-align-last | page-break-before
+    | grid-column-start | border-image-slice | border-image-repeat
+    | text-decoration-style | border-image-width | grid-column-end | grid-row
+    | scroll-snap-align | scroll-snap-type | border-image-outset
+    | text-decoration-line | column-fill | border-inline-end-width
+    | border-inline-start-width | grid-row-start | stroke-linejoin
+    | inset-inline-end | inset-inline-start | grid-auto-flow | grid-auto-rows
+    | grid-template-areas | border-image-source | fill-rule | font-kerning
+    | grid-row-end | font-variant-numeric | break-inside | shape-outside
+    | color-scheme | shape-image-threshold | scroll-boundary-behavior-y
+    | text-decoration-skip-ink | page | isolation | background-blend-mode
+    | page-orientation | inset | gap | scroll-snap-margin | column-rule-color
+    | place-items | column-rule-style | shape-rendering | content-visibility
+    | grid-auto-columns | scroll-boundary-behavior-x | writing-mode | clip-rule
+    | font-variant-caps | scroll-padding | text-anchor | mask | row-gap
+    | background-repeat-x | intrinsic-size | text-underline-position
+    | font-variant-east-asian | column-span | vector-effect | dominant-baseline
+    | stop-opacity | break-after | grid-template | break-before | mask-type
+    | scroll-snap-stop | border-inline-start-color | border-inline-end-color | r
+    | alignment-baseline | text-decoration-thickness | column-rule-width | d
+    | image-orientation | rx | text-orientation | cx | baseline-shift
+    | scroll-padding-top | padding-block-start | padding-block-end | cy
+    | min-inline-size | inline-size | background-repeat-y | shape-margin
+    | block-size | marker | min-block-size | paint-order | ry
+    | scroll-snap-margin-top | border-block-end-color | border-block-end-width
+    | border-inline-start-style | border-inline-end-style
+    | border-block-end-style | font-variation-settings
+    | border-block-start-width | border-block-start-color
+    | border-block-start-style | place-content | y | x | ruby-position
+    | text-combine-upright | color-interpolation-filters | color-interpolation
+    | color-rendering | transform-box | marker-end | flood-color | marker-start
+    | marker-mid | flood-opacity | lighting-color | forced-color-adjust
+    | buffered-rendering | place-self | offset-path | scroll-padding-left
+    | offset-distance | offset-rotate | text-underline-offset | max-inline-size
+    | max-block-size | border-inline-end | scroll-snap-margin-inline-start
+    | scroll-padding-inline-start | scroll-snap-margin-block-end
+    | scroll-snap-margin-block-start | scroll-padding-block-end
+    | scroll-snap-margin-inline-end | scroll-padding-block-start
+    | scroll-padding-inline-end | font-optical-sizing | grid
+    | scroll-padding-bottom | scroll-snap-margin-left | inset-block-end
+    | overscroll-behavior-block | overscroll-behavior-inline | inset-block-start
+    | scroll-snap-margin-right | scroll-padding-right
+    | scroll-snap-margin-bottom | border-inline-start | margin-inline
+    | border-end-start-radius | border-end-end-radius | margin-block
+    | border-start-start-radius | border-start-end-radius | padding-inline
+    | counter-set | padding-block | border-block-end | offset
+    | border-block-start | inset-inline | inset-block | scroll-snap-margin-block
+    | scroll-padding-inline | scroll-padding-block | scroll-snap-margin-inline
+    | border-block | offset-rotation | border-inline | border-block-color
+    | border-inline-width | border-inline-color | border-block-style
+    | border-block-width | border-inline-style | motion | motion-offset
+    | motion-path | font-size-adjust | text-justify | scale | scrollbar-gutter
+    | animation-timeline | rotate | translate | snap-height | math-style
+    | math-shift | math-depth | offset-anchor | offset-position
+    | glyph-orientation-vertical | internal-callback | text-line-through
+    | text-line-through-color | text-line-through-mode | text-line-through-style
+    | text-line-through-width | text-overline | text-overline-color
+    | text-overline-mode | text-overline-style | text-overline-width
+    | text-underline | text-underline-color | text-underline-mode
+    | text-underline-style | text-underline-width | shape-inside | shape-padding
+    | enable-background | color-profile | glyph-orientation-horizontal | kerning
+    | image-resolution | max-zoom | min-zoom | orientation | user-zoom
+    | mask-source-type | touch-action-delay | scroll-blocks-on | motion-rotation
+    | scroll-snap-points-x | scroll-snap-points-y | scroll-snap-coordinate
+    | scroll-snap-destination | apply-at-rule | viewport-fit | overflow-block
+    | syntax | content-size | intrinsic-block-size | intrinsic-height
+    | intrinsic-inline-size | intrinsic-width | render-subtree
+    | origin-trial-test-property | subtree-visibility
+    | math-superscript-shift-style | start
+    # END OF QUERY RESULTS
+    # BEGIN OF legacy properties which existed before the last query
+    | box-direction | line-box-contain
+    | prefix | mask-image | mask-origin | flex-order | system | speak-as
+    | font-synthesis | line-clamp | flex-negative | blend-mode
+    | font-variant-position | flex-align | column-break-before | negative
+    | flex-item-align | azimuth | user-drag | range | mask-repeat | box-flex
+    | flex-preferred-size | font-language-override | box-align | pad
+    | text-emphasis-color | box-ordinal-group | mask-composite
+    | transform-origin-y | pause | tap-highlight-color | text-fill-color
+    | suffix | text-emphasis-style | transform-origin-x | text-emphasis-position
+    | box-pack | box-decoration-break | box-orient | additive-symbols
+    | text-emphasis | symbols | mask-clip | nbsp-mode | pause-after | pitch
+    | text-height | mask-position | flex-line-pack | perspective-origin-x
+    | mask-size | font-variant-alternates | perspective-origin-y
+    | font-smoothing | overflow-scrolling | flex-positive | pitch-range
     ){{break}}
 
   property_value_constants: |-


### PR DESCRIPTION
Fixes #2704

This PR...

1. Adds all property names returned by https://www.chromestatus.com at 2021 Jan. 28th except those which begin with `alias-` or `webkit-` in exact the order provided by the page.
2. Properties no longer returned by the web page are appended to that list in case those are still valid or used. They are considered to be of very low usage.

   A comment was added as devider.
