### PR TITLE
[PHP] add some more indentation tests

### DIFF
--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -60,7 +60,7 @@
 		<key>bracketIndentNextLinePattern</key>
 		<string>(?x)
 		^ \s* \b(if|while|else|elseif|foreach)\b [^;]* $
-		| ^ \s* \b(for)\b .* $
+		| ^ \s* \b(for)\b .* [^;]\s*$
 		</string>
 	</dict>
 </dict>

--- a/PHP/tests/syntax_test_indentation.php
+++ b/PHP/tests/syntax_test_indentation.php
@@ -5,6 +5,8 @@ https://github.com/sublimehq/Packages/issues/1924
     asdfadf
 <?php elseif(false): ?>
     asdf
+<?php else: ?>
+    qwfpg
 <?php endif;?>
 
 <?php
@@ -55,4 +57,33 @@ function test()
         ok;
     }
 }
+
+for (expr1; expr2; expr3)
+    statement;
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+
+for ($i = 1; $i <= 10; $i++)
+{
+    echo $i;
+}
+
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+
+$people = array(
+    array('name' => 'Kalle', 'salt' => 856412),
+    array('name' => 'Pierre', 'salt' => 215863)
+);
+
+for($i = 0, $size = count($people); $i < $size; ++$i) {
+    $people[$i]['salt'] = mt_rand(000000, 999999);
+}
+
+for (expr1; expr2; expr3):
+    statement;
+    statement;
+endfor;
+
 ?>


### PR DESCRIPTION
Add some more indentation tests for PHP files, and ensure that an empty `for` statement (i.e. with a semi-colon at the end) doesn't indent the next line.