### PR TITLE
[TypeScript] Add interface names to symbol list.

### DIFF
--- a/JavaScript/Symbol List.tmPreferences
+++ b/JavaScript/Symbol List.tmPreferences
@@ -3,8 +3,7 @@
 <dict>
 	<key>scope</key>
 	<string>
-		source.js entity.name.function,
-		source.js meta.class entity.name.class
+		entity.name.interface.js
 	</string>
 	<key>settings</key>
 	<dict>


### PR DESCRIPTION
Fix #2717.

The existing lines were redundant because the Default symbol list already provides them. (This is fortunate, because they were never updated for JSX, TypeScript, and TSX.)