### PR TITLE
[LaTeX] Add scope for gnuplottex enviroment

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -765,6 +765,7 @@ contexts:
     - include: pkgcomment
     - include: beamer
     - include: pkgarray
+    - include: gnuplottex
 
   # listings package
   pkglistings:
@@ -1700,3 +1701,29 @@ contexts:
                   pop: true
             - match: ''
               pop: true
+
+
+  gnuplottex:
+    - match: ((\\)begin)(\{)(gnuplot)(\})
+      captures:
+        1: support.function.begin.latex keyword.control.flow.begin.latex
+        2: punctuation.definition.backslash.latex
+        3: punctuation.definition.group.brace.begin.latex
+        4: variable.parameter.function.latex
+        5: punctuation.definition.group.brace.end.latex
+      push:
+        - meta_include_prototype: false
+        - include: general-optional-arguments
+        - meta_scope: meta.environment.verbatim.gnuplottex.latex
+        - match: '((\\)end)(\{)(gnuplot)(\})'
+          captures:
+            1: support.function.end.latex keyword.control.flow.end.latex
+            2: punctuation.definition.backslash.latex
+            3: punctuation.definition.group.brace.begin.latex
+            4: variable.parameter.function.latex
+            5: punctuation.definition.group.brace.end.latex
+          pop: true
+        - match: ''
+          embed:  scope:source.gnuplot
+          embed_scope: meta.environment.embedded.gnuplot.latex source.gnuplot.embedded
+          escape: '(?=\\end\{gnuplot\})'

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -520,6 +520,27 @@ a & b
 \end{tabular}
 
 
+% PACKAGE: gnuplottex
+% The gnuplottex package is used to produce graphs from verbatim
+% gnuplot scripts that are embedded in a gnuplot enviroment.
+
+\begin{gnuplot}[terminal=cairolatex]
+plot sin(x)
+% <- meta.environment.verbatim.gnuplottex.latex
+% <- meta.environment.embedded.gnuplot.latex
+% <- source.gnuplot.embedded
+% <- source.gnuplot
+
+% This is not a tex comment.
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.percentage.tex
+
+# This is single $, to check that it doesn't start a math enviroment.
+#
+% <- - meta.environment.math.block.dollar.latex 
+\end{gnuplot}
+
+
+
 
 \AnyDeclarationCommand{\eq}{\begin{equation}}
 


### PR DESCRIPTION
This commit adds correct scoping for the `gnuplot` enviroment from the [gnuplottex package](https://www.ctan.org/pkg/gnuplottex).

The gnuplottex package allows users to include verbatim gnuplot scripts inside a `gnuplot` enviroment in their LaTeX files, which will be run during compilation and the resulting graphs inserted into the document.
Without proper scoping, ST will try to parse these scripts as LaTeX code. This will not only result in incorrect syntax highlighting inside the enviroment, but potentially also afterwards since gnuplot can use single `$` signs, which start a LaTeX math enviroment.
This commit assigns the proper embedded scope to the code inside a `gnuplot` enviroment, similar to the source code enviroments from the listings or minted package.

Note that per default, ST does not have syntax support for gnuplot code itself, so it will be displayed as plain text (which is still better than interpreting it as LaTeX). However, such support can be installed by the user, e. g. using the  [ST Gnuplot Package](https://packagecontrol.io/packages/Gnuplot)).


<details>
    <summary>Example screenshots</summary>



**Before:**
![](https://user-images.githubusercontent.com/7377247/108099882-73c23200-7085-11eb-80d6-1afa723efb55.png)

**After:**
(with additional gnuplot syntax support curtosy of the [ST Gnuplot Package](https://packagecontrol.io/packages/Gnuplot))
![](https://user-images.githubusercontent.com/7377247/108100007-a0764980-7085-11eb-97f1-a902b7412547.png)
</details>
