### PR TITLE
[HTML] Fix foreign tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,25 +43,6 @@ variables:
       | text/livescript
     )
 
-  custom_element_char: |-
-    (?x:
-      # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
-        [-._a-z0-9\x{00B7}]
-      | [\x{00C0}-\x{00D6}]
-      | [\x{00D8}-\x{00F6}]
-      | [\x{00F8}-\x{02FF}]
-      | [\x{0300}-\x{037D}]
-      | [\x{037F}-\x{1FFF}]
-      | [\x{200C}-\x{200D}]
-      | [\x{203F}-\x{2040}]
-      | [\x{2070}-\x{218F}]
-      | [\x{2C00}-\x{2FEF}]
-      | [\x{3001}-\x{D7FF}]
-      | [\x{F900}-\x{FDCF}]
-      | [\x{FDF0}-\x{FFFD}]
-      | [\x{10000}-\x{EFFFF}]
-    )
-
   script_close_lookahead: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}})
   style_close_lookahead: (?=</(?i:style){{tag_name_break_char}})
 
@@ -71,7 +52,7 @@ contexts:
 
   tag:
     - include: tag-html
-    - include: tag-custom
+    - include: tag-other
     - include: tag-incomplete
 
 ###[ HTML TAGS ]##############################################################
@@ -152,33 +133,14 @@ contexts:
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
 
-###[ CUSTOM TAG ]#############################################################
+###[ OTHER TAG ]##############################################################
 
-  tag-custom:
-    - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
-      scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-custom-content
-        - tag-custom-name
+  tag-other:
     - match: </?(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
         - tag-other-content
         - tag-other-name
-
-  tag-custom-name:
-      - meta_content_scope: entity.name.tag.custom.html
-      - match: '{{tag_name_break}}'
-        pop: 1
-      - match: '{{custom_element_char}}+'
-        # no scope
-      - match: '{{tag_name_char}}'
-        scope: invalid.illegal.custom-tag-name.html
-
-  tag-custom-content:
-      - meta_scope: meta.tag.custom.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
 
   tag-other-name:
       - meta_content_scope: entity.name.tag.other.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -616,30 +616,55 @@ class="foo"></div>
         ##                      ^ punctuation.definition.tag.end.html
 
         <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
-        ##^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                ^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                ^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                ^^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.custom.html - invalid
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
-        ##                ^ - meta.tag.custom.html - punctuation.definition.tag.end.html
+        ##                ^ - meta.tag.other.html - punctuation.definition.tag.end.html
 
         <body-custom·tag₡name/>
-        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html - invalid
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
 
         <body.tag-custom.name/>
-        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html - invalid
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
+
+        <svg:p d=M232.233,220/>
+        ## ^^^ entity.name.tag.other.html - invalid
+        ##     ^ entity.other.attribute-name.html
+        ##      ^ punctuation.separator.key-value.html
+        ##       ^^^^^^^^^^^^ meta.string.html string.unquoted.html
+        ##                   ^^ punctuation.definition.tag.end.html
 
         <INVALID-custom-TAG></INVALID-CUSTOM-TAG>
-        ## ^^^^^ invalid.illegal.custom-tag-name.html
-        ##       ^^^^^^ - invalid.illegal.custom-tag-name.html
-        ##              ^^^ invalid.illegal.custom-tag-name.html
-        ##                    ^^^^^^^ invalid.illegal.custom-tag-name.html
-        ##                            ^^^^^^ invalid.illegal.custom-tag-name.html
-        ##                                   ^^^ invalid.illegal.custom-tag-name.html
+        ## ^^^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                    ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
+
+        <body:tag-other.name/>
+        ## ^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
+
+        <A{{template}} {{attr}}={{value}} />
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+        ## ^^^^^^^^^^^ entity.name.tag.other.html
+        ##             ^^^^^^^^ entity.other.attribute-name.html
+        ##                     ^ punctuation.separator.key-value.html
+        ##                      ^^^^^^^^^ meta.string.html string.unquoted.html
+        ##                                ^^ punctuation.definition.tag.end.html
+
+        <!-- Note: Templating syntaxes must handle the following cases on their own! -->
+
+        <{{template}} {{attr}}={{value}} />
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag
+
+        <[[template]] [[attr]]=[[value]] />
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag
+
+        <<?php echo $tagname ?> attr="<? echo value ?>" />
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag
 
         <form name="formName" type="post">
         ## ^ entity.name.tag.block.form.html

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1993,9 +1993,9 @@ var_dump(new C(42));
 //                                                   ^^ punctuation.section.embedded.end
 
   <tag-<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.custom.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
 //^ punctuation.definition.tag.begin.html
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
 //     ^^^^^ punctuation.section.embedded.begin.php
 //     ^^^^^^^^^^^^^ meta.embedded.line.php
 //                ^^ punctuation.section.embedded.end


### PR DESCRIPTION
Fixes #2713

This PR removes strict lower-case custom tag highlighting.

Why?

https://html.spec.whatwg.org/multipage/syntax.html#start-tags doesn't mension custom elements but foreign elements only.

> In the HTML syntax, tag names, even those for foreign elements, may be written with any mix of lower- and uppercase letters that, when converted to all-lowercase, matches the element's tag name; tag names are case-insensitive.

Actually Firefox, Chrome and VS Code accept those colons or seem to fail silently by ignoring the namespace part. Not sure how foreign tags such as SVG or MathML are handled in detail though. They may support namespaces as they are XML.

According to https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state all characters except ascii whitespace and some punctuation are valid in tag names. That's the rule HTML (Plain).sublime-syntax applies in general.

The only thing lost by this commit is illegal highlighting of uppercase letters in unrecognized tags.

**Note:**

During work an edge case which might effect templating syntaxes was found. The first character after `<` must be an ascii, so HTML doesn't push into "tag context" if `<` is directly followed by interpolations such as `{{ ... }}`. That must be handled by the templating syntax as it is the only one to know which kinds of interpolation tags are valid.