### PR TITLE
[HTML] ease syntax parsing of custom/foreign tags

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -50,26 +50,6 @@ variables:
       | text/livescript
     )
 
-  custom_element_char: |-
-    (?x:
-      # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
-        [-_a-z0-9\x{00B7}]
-      | \\\.
-      | [\x{00C0}-\x{00D6}]
-      | [\x{00D8}-\x{00F6}]
-      | [\x{00F8}-\x{02FF}]
-      | [\x{0300}-\x{037D}]
-      | [\x{037F}-\x{1FFF}]
-      | [\x{200C}-\x{200D}]
-      | [\x{203F}-\x{2040}]
-      | [\x{2070}-\x{218F}]
-      | [\x{2C00}-\x{2FEF}]
-      | [\x{3001}-\x{D7FF}]
-      | [\x{F900}-\x{FDCF}]
-      | [\x{FDF0}-\x{FFFD}]
-      | [\x{10000}-\x{EFFFF}]
-    )
-
   script_close_lookahead: (?i:(?=(?:-->\s*)?</script))
 
 contexts:
@@ -173,11 +153,6 @@ contexts:
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: </?(?=[A-Za-z]{{tag_name_char}}*?-)
-      scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-custom-body
-        - tag-custom-name
     - match: </?(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
@@ -186,20 +161,6 @@ contexts:
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
-
-  tag-custom-name:
-      - meta_content_scope: entity.name.tag.custom.html
-      - match: '{{tag_name_break}}'
-        pop: true
-      - match: '{{custom_element_char}}+'
-        # no scope
-      - match: '{{tag_name_char}}'
-        scope: invalid.illegal.custom-tag-name.html
-
-  tag-custom-body:
-      - meta_scope: meta.tag.custom.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
 
   tag-other-name:
       - meta_content_scope: entity.name.tag.other.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -519,27 +519,19 @@ class="foo"></div>
         ##                      ^ punctuation.definition.tag.end.html
 
         <form-custom-tag><div-custom-tag><span-custom-tag></span-custom-tag></div-custom-tag></form-custom-tag>
-        ##^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                ^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.custom.html
-        ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.html
+        ##^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                ^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                ^^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                                  ^^^^^^^^^^^^^^^ entity.name.tag.other.html
+        ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.custom.html
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.html
         ##              ^^ punctuation.definition.tag.end.html
-        ##                ^ - meta.tag.custom.html - punctuation.definition.tag.end.html
+        ##                ^ - meta.tag.other.html - punctuation.definition.tag.end.html
 
         <body-custom·tag₡name/>
-        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
-
-        <INVALID-custom-TAG></INVALID-CUSTOM-TAG>
-        ## ^^^^^ invalid.illegal.custom-tag-name.html
-        ##       ^^^^^^ - invalid.illegal.custom-tag-name.html
-        ##              ^^^ invalid.illegal.custom-tag-name.html
-        ##                    ^^^^^^^ invalid.illegal.custom-tag-name.html
-        ##                            ^^^^^^ invalid.illegal.custom-tag-name.html
-        ##                                   ^^^ invalid.illegal.custom-tag-name.html
+        ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <form name="formName" type="post">
         ## ^ entity.name.tag.block.form.html

--- a/PHP/syntax_test_php.php
+++ b/PHP/syntax_test_php.php
@@ -1582,9 +1582,9 @@ var_dump(new C(42));
 //                                                   ^^ punctuation.section.embedded.end
 
   <tag-<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.custom.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
 //^ punctuation.definition.tag.begin.html
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.custom.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
 //     ^^^^^ punctuation.section.embedded.begin.php
 //     ^^^^^^^^^^^^^ meta.embedded.line.php
 //                ^^ punctuation.section.embedded.end


### PR DESCRIPTION
The strict parsing of foreign tags or custom tags leads to many unnecessary errors. This PR is a "backport" of #2723 on master and will close #2713 for ST3.