### PR TITLE
[HTML] Fix curly braces indentation

### DIFF
--- a/HTML/Indentation Rules.tmPreferences
+++ b/HTML/Indentation Rules.tmPreferences
@@ -44,8 +44,8 @@
 				| <\?(?!.*?\?>)
 				# sections that don't close themselves on the same line
 				| <\%(?!.*?\%>)
-				# open curly braces that don't have close braces or string punctuation after them
-				| \{(?![}"'])
+				# open curly braces at the end of a line with comments allowed
+				| \{(?=\s*(?:<!--.*)?$)
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>

--- a/HTML/syntax_test_html_indentation.html
+++ b/HTML/syntax_test_html_indentation.html
@@ -20,5 +20,18 @@
     </div>
 
     <script type="text/javascript" src="/some_script.js"></script>
+
+    <!-- Curly braces -->
+    foo {
+        bar { <!-- comment -->
+            baz
+        }
+    }
+    text
+    { <p></p> }
+    text
+    {{template}}
+    text
+
 </body>
 </html>


### PR DESCRIPTION
This commit fixes an issue which caused lines after self-closing curly braces such as template tags to be indented.

## Example

### before

   ```
  <p>
    {{template}}
      |             <- the indented caret
  </p>
   ```

### after

   ```
  <p>
    {{template}}
    |               <- the un-indented caret
  </p>
   ```
