### PR TITLE
[Diff] Add setting to not trim trailing white space on save

### DIFF
--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,0 +1,3 @@
+{
+    "trim_trailing_white_space_on_save": false,
+}

--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,3 +1,4 @@
 {
     "trim_trailing_white_space_on_save": false,
+    "translate_tabs_to_spaces": false,
 }


### PR DESCRIPTION
When one diffs a file whose name contains a space character, the diff is generated with a trailing tab character at EOL so that the `patch` command line utility will be able to find the file properly. Prior to this PR, ST would automatically trim the trailing whitespace by default, preventing `patch` from working.

Real world example of a patch file which targets a file with a space in the name: https://github.com/sharkdp/bat/pull/1557/files#diff-e8ae3ce548991704395140abe884a9b871bd1a85759a349d50ac84f465a25683R3