### PR TITLE
[TypeScript] Fix scope for less (or equal) than operators

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1227,11 +1227,11 @@ contexts:
       push: expression-begin
     - match: |-
         (?x)
-        <=   | # relational      left-to-right   both
-        >=   | # relational      left-to-right   both
-        <    | # relational      left-to-right   both
-        >      # relational      left-to-right   both
-      scope: keyword.operator.relational.js
+        <=   | # comparison      left-to-right   both
+        >=   | # comparison      left-to-right   both
+        <    | # comparison      left-to-right   both
+        >      # comparison      left-to-right   both
+      scope: keyword.operator.comparison.js
       push: expression-begin
     - match: |-
         (?x)

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -473,10 +473,9 @@ contexts:
   expression-end:
     - meta_prepend: true
     - include: ts-type-assertion
-    - match: '<<'
       scope: keyword.operator.bitwise.js
       push: expression-begin
-    - match: (?=<)
+    - match: (?=<(?![<=]))
       branch_point: ts-function-type-arguments
       branch:
         - ts-function-type-arguments
@@ -503,7 +502,7 @@ contexts:
         - ts-type-expression-begin
 
   ts-less-than:
-    - match: '<=?'
+    - match: '<'
       scope: keyword.operator.comparison.js
       set: expression-begin
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -503,8 +503,8 @@ contexts:
         - ts-type-expression-begin
 
   ts-less-than:
-    - match: '<'
-      scope: keyword.operator.logical.js
+    - match: '<=?'
+      scope: keyword.operator.relational.js
       set: expression-begin
 
   expression-begin:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -473,8 +473,6 @@ contexts:
   expression-end:
     - meta_prepend: true
     - include: ts-type-assertion
-      scope: keyword.operator.bitwise.js
-      push: expression-begin
     - match: (?=<(?![<=]))
       branch_point: ts-function-type-arguments
       branch:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -504,7 +504,7 @@ contexts:
 
   ts-less-than:
     - match: '<=?'
-      scope: keyword.operator.relational.js
+      scope: keyword.operator.comparison.js
       set: expression-begin
 
   expression-begin:

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -70,7 +70,7 @@ function foo(){}/**/
 
 x --> y;
 //^^ keyword.operator.arithmetic.js
-//  ^ keyword.operator.relational.js
+//  ^ keyword.operator.comparison.js
 
 #! /usr/bin/env node
 // <- comment.line.shebang punctuation.definition.comment

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -43,9 +43,9 @@
     <foo></foo><bar>
 //  ^^^^^^^^^^^ meta.jsx
 //             ^^^^^ - meta.jsx
-//             ^ keyword.operator.relational
+//             ^ keyword.operator.comparison
 //              ^^^ variable
-//                 ^ keyword.operator.relational
+//                 ^ keyword.operator.comparison
 0;
 
     <>Hello!</>;
@@ -61,9 +61,9 @@
     <foo></foo>
     <bar>
 //  ^^^^^ - meta.jsx
-//  ^ keyword.operator.relational
+//  ^ keyword.operator.comparison
 //   ^^^ variable
-//      ^ keyword.operator.relational
+//      ^ keyword.operator.comparison
 0;
 
     </foo>;

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -36,6 +36,6 @@ var foo = 1 << 0;
 //          ^^ keyword.operator.bitwise
 
 if (a < b || c <= d) {}
-//    ^ keyword.operator.relational
+//    ^ keyword.operator.comparison
 //        ^^ keyword.operator.logical
-//             ^^ keyword.operator.relational
+//             ^^ keyword.operator.comparison

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -35,7 +35,7 @@ let strLength: number = (<string>someValue).length; // </string> );
 var foo = 1 << 0;
 //          ^^ keyword.operator.bitwise
 
-if (a < b || c < d) {}
-//    ^ keyword.operator.logical
+if (a < b || c <= d) {}
+//    ^ keyword.operator.relational
 //        ^^ keyword.operator.logical
-//             ^ keyword.operator.logical
+//             ^^ keyword.operator.relational

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -813,7 +813,7 @@ let x: import ( "foo" ) . Bar ;
 
     foo < bar
 //  ^^^ variable.other.readwrite
-//      ^ keyword.operator.logical
+//      ^ keyword.operator.relational
 //        ^^^ variable.other.readwrite
     ;
 
@@ -834,10 +834,10 @@ var foo = 1 << 0 /x/g;
 //                 ^ keyword.operator.arithmetic
 //                  ^ variable.other.readwrite
 
-if (a < b || c < d) {}
-//    ^ keyword.operator.logical
+if (a < b || c <= d) {}
+//    ^ keyword.operator.relational
 //        ^^ keyword.operator.logical
-//             ^ keyword.operator.logical
+//             ^^ keyword.operator.relational
 
 const f = (): any => {};
 //    ^ meta.binding.name entity.name.function variable.other.readwrite

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -813,7 +813,7 @@ let x: import ( "foo" ) . Bar ;
 
     foo < bar
 //  ^^^ variable.other.readwrite
-//      ^ keyword.operator.relational
+//      ^ keyword.operator.comparison
 //        ^^^ variable.other.readwrite
     ;
 
@@ -835,9 +835,9 @@ var foo = 1 << 0 /x/g;
 //                  ^ variable.other.readwrite
 
 if (a < b || c <= d) {}
-//    ^ keyword.operator.relational
+//    ^ keyword.operator.comparison
 //        ^^ keyword.operator.logical
-//             ^^ keyword.operator.relational
+//             ^^ keyword.operator.comparison
 
 const f = (): any => {};
 //    ^ meta.binding.name entity.name.function variable.other.readwrite


### PR DESCRIPTION
Also noticed that, `<` is wrongly scoped as `keyword.operator.logical` while it should be `keyword.operator.relational`.

Fixes https://github.com/sublimehq/Packages/issues/2732