### PR TITLE
[CSS] Add highlighting for conic-gradient()

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -2094,10 +2094,33 @@ contexts:
   # Gradient Functions
   # https://drafts.csswg.org/css-images-3/#gradients
   gradient-functions:
+    # conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient()
+    # repeating-conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-conic-gradient()
+    - match: \b((?:repeating-)?conic-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:at|from){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|center|left|right|top){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: angle-constants
+            - include: length-constants
+            - include: percentage-constants
+
     # linear-gradient()
-    # https://drafts.csswg.org/css-images-3/#linear-gradients
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient()
     # repeating-linear-gradient()
-    # https://drafts.csswg.org/css-images-3/#funcdef-repeating-linear-gradient
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-linear-gradient()
     - match: \b((?:repeating-)?linear-gradient)(?=\()
       scope: meta.function-call.identifier.css support.function.gradient.css
       push:
@@ -2110,7 +2133,7 @@ contexts:
             - include: comma-delimiters
             - match: \b(?i:to){{break}}
               scope: keyword.other.gradient.css
-            - match: \b(?i:top|right|bottom|left){{break}}
+            - match: \b(?i:bottom|left|right|top){{break}}
               scope: support.constant.property-value.css
             - include: color-values
             - include: angle-constants
@@ -2118,9 +2141,9 @@ contexts:
             - include: percentage-constants
 
     # radial-gradient()
-    # https://drafts.csswg.org/css-images-3/#radial-gradients
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/radial-gradient()
     # repeating-radial-gradient()
-    # https://drafts.csswg.org/css-images-3/#funcdef-repeating-radial-gradient
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-radial-gradient()
     - match: \b((?:repeating-)?radial-gradient)(?=\()
       scope: meta.function-call.identifier.css support.function.gradient.css
       push:
@@ -2133,7 +2156,7 @@ contexts:
             - include: comma-delimiters
             - match: \b(?i:at|circle|ellipse){{break}}
               scope: keyword.other.gradient.css
-            - match: \b(?i:left|center|right|top|bottom|(closest|farthest)-(corner|side)){{break}}
+            - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
               scope: support.constant.property-value.css
             - include: color-values
             - include: length-constants

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -126,6 +126,14 @@ def get_properties():
         'generic_name': [
             'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'
         ],
+        'gradient': [
+            ['conic-gradient()', 'conic-gradient($1)'],
+            ['linear-gradient()', 'linear-gradient($1)'],
+            ['radial-gradient()', 'radial-gradient($1)'],
+            ['repeating-conic-gradient()', 'repeating-conic-gradient($1)'],
+            ['repeating-linear-gradient()', 'repeating-linear-gradient($1)'],
+            ['repeating-radial-gradient()', 'repeating-radial-gradient($1)']
+        ],
         'grid': [
             ['repeat()', 'repeat(${1:2}, ${2:1fr})'],
             ['minmax()', 'minmax(${1:100px}, ${2:1fr})'],
@@ -199,8 +207,8 @@ def get_properties():
         'animation-play-state': ['running', 'paused'],
         'backface-visibility': ['visible', 'hidden'],
         'background': [
-            '<color>', '<uri>', 'repeat', 'repeat-x', 'repeat-y', 'no-repeat',
-            'scroll', 'fixed', '<position>'
+            '<color>', '<gradient>', '<position>', '<uri>',
+            'repeat', 'repeat-x', 'repeat-y', 'no-repeat', 'scroll', 'fixed'
         ],
         'background-attachment': ['fixed', 'local', 'scroll'],
         'background-blend-mode': ['<blend_mode>'],

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2734,6 +2734,13 @@
 }
 
 .test-gradient-functions {
+    top: conic-gradient(from 0.25turn at 50% 30%, #f69d3c, 10deg, #3f87a6, 350deg, #ebf8e1);
+/*       ^^^^^^^^^^^^^^ support.function.gradient.css */
+/*                      ^^^^ keyword.other.gradient.css */
+/*                           ^^^^ meta.number.float.decimal.css constant.numeric.value.css */
+/*                               ^^^^ meta.number.float.decimal.css constant.numeric.suffix.css */
+/*                                    ^^ keyword.other.gradient.css */
+
     top: linear-gradient();
 /*       ^^^^^^^^^^^^^^^ support.function.gradient.css */
 


### PR DESCRIPTION
This commit adds conic-gradient() to the list of supported functions.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient()

_Note: Also sorts some values alphabetically in other gradient functions._