### PR TITLE
[Python] Change the default executable to invoke to "python3"

### DIFF
--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -1,5 +1,5 @@
 {
-	"cmd": ["python", "-u", "$file"],
+	"cmd": ["python3", "-u", "$file"],
 	"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
 	"selector": "source.python",
 
@@ -13,7 +13,7 @@
 	[
 		{
 			"name": "Syntax Check",
-			"shell_cmd": "python -m py_compile \"${file}\"",
+			"shell_cmd": "python3 -m py_compile \"${file}\"",
 		}
 	]
 }

--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -7,6 +7,13 @@
 
 	"windows": {
 		"cmd": ["py", "-u", "$file"],
+		"variants":
+		[
+			{
+				"name": "Syntax Check",
+				"cmd": ["py", "-m", "py_compile", "${file}"],
+			}
+		]
 	},
 
 	"variants":

--- a/Python/Python.sublime-build
+++ b/Python/Python.sublime-build
@@ -7,20 +7,17 @@
 
 	"windows": {
 		"cmd": ["py", "-u", "$file"],
-		"variants":
-		[
-			{
-				"name": "Syntax Check",
-				"cmd": ["py", "-m", "py_compile", "${file}"],
-			}
-		]
 	},
 
 	"variants":
 	[
 		{
 			"name": "Syntax Check",
-			"shell_cmd": "python3 -m py_compile \"${file}\"",
+			"cmd": ["python3", "-m", "py_compile", "$file"],
+
+			"windows": {
+				"cmd": ["py", "-m", "py_compile", "$file"],
+			}
 		}
 	]
 }


### PR DESCRIPTION
For the osx and linux platforms, we used to invoke the "python" executable. This
is for all practical purposes the same as invoking Python 2.7. Version 2 has
been EOL'd on January 1st, 2020.