### PR TITLE
[CSS] Add clamp()/min()/max() functions

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1771,6 +1771,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: percentage-constants
             - include: scalar-constants
 
@@ -1788,6 +1789,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: angle-constants
             - include: percentage-constants
             - include: scalar-constants
@@ -1804,6 +1806,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: percentage-constants
             - include: scalar-constants
 
@@ -1819,6 +1822,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: color-adjuster-functions # must be included before `color-values`
             - include: color-values
             - include: percentage-constants
@@ -1836,6 +1840,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: color-adjuster-functions # must be included before `color-values`
             - include: color-values
             - include: angle-constants
@@ -1854,6 +1859,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: color-adjuster-operators
             - include: percentage-constants
             - include: scalar-constants
@@ -1868,6 +1874,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: color-adjuster-operators
             - include: angle-constants
 
@@ -1881,6 +1888,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: color-adjuster-operators
             - include: percentage-constants
 
@@ -1896,6 +1904,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: percentage-constants
 
     # blend(), blenda() - Not yet implemented by browsers
@@ -1908,6 +1917,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: color-values
             - include: percentage-constants
             - match: \b(?i:rgb|hsl|hwb){{break}}
@@ -1946,6 +1956,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: length-constants
 
     # brightness(), contrast(), grayscale(), invert(), opacity(), saturate(), sepia()
@@ -1959,6 +1970,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: percentage-constants
             - include: scalar-constants
 
@@ -1973,6 +1985,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: color-values
             - include: length-constants
 
@@ -1987,6 +2000,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: angle-constants
 
 ###[ BUILTIN GRID FUNCTIONS ]##################################################
@@ -2004,6 +2018,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: grid-constants
             - include: length-constants
             - include: percentage-constants
@@ -2023,6 +2038,7 @@ contexts:
             - include: comma-delimiters
             - match: \b(?i:auto-fill|auto-fit){{break}}
               scope: keyword.other.grid.css
+            - include: calc-functions
             - include: minmax-functions
             - include: grid-constants
             - include: length-constants
@@ -2157,6 +2173,7 @@ contexts:
             - include: function-arguments-common
             - match: \b(?i:auto){{break}}
               scope: support.constant.property-value.css
+            - include: calc-functions
             - include: length-constants
 
     # inset()
@@ -2172,6 +2189,7 @@ contexts:
             - include: function-arguments-common
             - match: \b(?i:round){{break}}
               scope: keyword.other.shape.css
+            - include: calc-functions
             - include: length-constants
             - include: percentage-constants
 
@@ -2192,6 +2210,7 @@ contexts:
               scope: keyword.other.shape.css
             - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
               scope: support.constant.property-value.css
+            - include: calc-functions
             - include: length-constants
             - include: percentage-constants
 
@@ -2230,6 +2249,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: scalar-constants
 
     # steps()
@@ -2244,6 +2264,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - match: \b(?i:end|middle|start){{break}}
               scope: keyword.other.timing.css
             - include: scalar-integer-constants
@@ -2265,6 +2286,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: scalar-constants
 
     # transform functions with comma separated <number> or <length> types
@@ -2279,6 +2301,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: percentage-constants
             - include: length-constants
             - include: scalar-constants
@@ -2294,6 +2317,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: percentage-constants
             - include: length-constants
             - include: scalar-constants
@@ -2309,6 +2333,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: angle-constants
 
     # transform functions with comma separated <angle> types
@@ -2323,6 +2348,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: angle-constants
 
     # transform functions with a single <length> type
@@ -2336,6 +2362,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
+            - include: calc-functions
             - include: length-constants
 
     # transform functions with a comma separated <number> or <angle> types
@@ -2350,6 +2377,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: angle-constants
             - include: scalar-constants
 
@@ -2365,6 +2393,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: scalar-constants
 
 ###[ BUILTIN VALUE FUNCTIONS ]#################################################
@@ -2403,9 +2432,9 @@ contexts:
     - include: generic-font-names
     - include: numeric-constants
 
-  # calc()
-  # https://www.w3.org/TR/css3-values/#funcdef-calc
   calc-functions:
+    # calc()
+    # https://www.w3.org/TR/css3-values/#funcdef-calc
     - match: \b(?i:calc)(?=\()
       scope: meta.function-call.identifier.css support.function.calc.css
       push:
@@ -2415,6 +2444,23 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: calc-function-arguments-content
+
+    # clamp()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()
+    # max()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/max()
+    # min()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/min()
+    - match: \b(?i:clamp|max|min)(?=\()
+      scope: meta.function-call.identifier.css support.function.calc.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: calc-function-arguments-content
+            - include: comma-delimiters
 
   calc-function-arguments-content:
     - meta_scope: meta.group.css
@@ -2460,6 +2506,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: comma-delimiters
+            - include: calc-functions
             - include: vendor-prefixes
             - include: color-values
             - include: common-constants
@@ -2529,6 +2576,8 @@ contexts:
       set:
         - meta_scope: meta.function-call.arguments.css meta.group.css
         - include: function-arguments-common
+        - include: comma-delimiters
+        - include: calc-functions
         - include: quoted-strings
         - include: numeric-constants
         - include: other-constants

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1416,6 +1416,40 @@
     /*           ^ keyword.operator.arithmetic.css */
 }
 
+.text-calc-clamp-max-min {
+    top: clamp(1*5pt, calc(12/5), 100rem);
+/*       ^^^^^ support.function.calc.css */
+/*             ^ constant.numeric.value.css */
+/*              ^ keyword.operator.arithmetic.css */
+/*               ^ constant.numeric.value.css */
+/*                ^^ constant.numeric.suffix.css */
+/*                  ^ punctuation.separator.sequence.css */
+/*                    ^^^^ support.function.calc.css */
+/*                         ^^ constant.numeric.value.css */
+/*                           ^ keyword.operator.arithmetic.css */
+/*                            ^ constant.numeric.value.css */
+/*                              ^ punctuation.separator.sequence.css */
+/*                                ^^^ constant.numeric.value.css */
+/*                                   ^^^ constant.numeric.suffix.css */
+
+    top: max(5*6, min(10 + 5, calc(var(--size) / 5)));
+/*       ^^^ support.function.calc.css */
+/*           ^ constant.numeric.value.css */
+/*            ^ keyword.operator.arithmetic.css */
+/*             ^ constant.numeric.value.css */
+/*              ^ punctuation.separator.sequence.css */
+/*                ^^^ support.function.calc.css */
+/*                    ^^ constant.numeric.value.css */
+/*                       ^ keyword.operator.arithmetic.css */
+/*                         ^ constant.numeric.value.css */
+/*                          ^ punctuation.separator.sequence.css */
+/*                            ^^^^ support.function.calc.css */
+/*                                 ^^^ support.function.var.css */
+/*                                             ^ keyword.operator.arithmetic.css */
+/*                                               ^ constant.numeric.value.css */
+}
+
+
 .test-important {
     top: 1px !important;
 /*           ^^^^^^^^^^ keyword.other.important.css */


### PR DESCRIPTION
This PR ...

1. adds support for clamp(), min() and max() functions. The patterns are added to `calc-functions` context.
2. The `calc-functions` context is included into all other function arguments contexts which are related with numeric values as MDN states:

   ```
   The ... function can be used anywhere a <length>, <frequency>,
   <angle>, <time>, <percentage>, <number>, or <integer> is allowed.
   ```
   for all those functions.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()