### PR TITLE
[TypeScript] Fix bug in function call type arguments.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -483,6 +483,10 @@ contexts:
     - match: \<(?!<)
       scope: punctuation.definition.generic.begin.js
       set:
+        - - match: (?=[\]()};,`])
+            pop: true
+          - match: (?=\S)
+            fail: ts-function-type-arguments
         - - meta_scope: meta.generic.js
           - match: \>
             scope: punctuation.definition.generic.end.js

--- a/JavaScript/tests/syntax_test_typescript_not_tsx.ts
+++ b/JavaScript/tests/syntax_test_typescript_not_tsx.ts
@@ -1,0 +1,22 @@
+// SYNTAX TEST "Packages/JavaScript/TypeScript.sublime-syntax"
+
+    < T > foo;
+//  ^^^^^ meta.assertion
+//  ^ punctuation.definition.assertion.begin
+//    ^ support.class
+//      ^ punctuation.definition.assertion.end
+//        ^^^ variable.other.readwrite
+
+    foo < T > bar;
+//  ^^^ variable.other.readwrite
+//      ^ keyword.operator.logical
+//        ^ variable.other.constant
+//          ^ keyword.operator.logical
+//            ^^^ variable.other.readwrite
+
+    foo
+    < T > bar;
+//  ^ keyword.operator.logical
+//    ^ variable.other.constant
+//      ^ keyword.operator.logical
+//        ^^^ variable.other.readwrite

--- a/JavaScript/tests/syntax_test_typescript_not_tsx.ts
+++ b/JavaScript/tests/syntax_test_typescript_not_tsx.ts
@@ -9,14 +9,14 @@
 
     foo < T > bar;
 //  ^^^ variable.other.readwrite
-//      ^ keyword.operator.logical
+//      ^ keyword.operator.comparison
 //        ^ variable.other.constant
-//          ^ keyword.operator.logical
+//          ^ keyword.operator.comparison
 //            ^^^ variable.other.readwrite
 
     foo
     < T > bar;
-//  ^ keyword.operator.logical
+//  ^ keyword.operator.comparison
 //    ^ variable.other.constant
-//      ^ keyword.operator.logical
+//      ^ keyword.operator.comparison
 //        ^^^ variable.other.readwrite


### PR DESCRIPTION
In some cases, function call type argument detection is overly aggressive. I *think* this should do the right thing in all cases.

I also added JS Custom's old-style type assertion tests. I put them in a separate file so that we can run all of the other TypeScript syntax tests against the TSX syntax without worrying about spurious errors. (This allows JS Custom to run all applicable syntax tests against each syntax, which is how I spotted this bug and the last one.)