### PR TITLE
[Python] Fix comma scope in ordinary expressions

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -560,6 +560,8 @@ contexts:
       scope: keyword.operator.logical.python
     - match: '@'
       scope: keyword.operator.matrix.python
+    - match: ','
+      scope: punctuation.separator.sequence.python
 
   allow-unpack-operators:
     # Match unpacking operators, if present

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1395,6 +1395,9 @@ result = [i async for i in aiter() if i % 2]
 result = [await fun() for fun in funcs]
 #         ^^^^^ keyword.other.await.python
 
+foo, bar = get_vars()
+#  ^ punctuation.separator.sequence.python
+#        ^ keyword.operator.assignment.python
 
 t = (*tuple(), *[1, 2], 3*1)
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python


### PR DESCRIPTION
This PR fixes commas in unpack expressions not being scoped.