### PR TITLE
[Lua] Fix left angle is treated as modifier in some cases

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -285,7 +285,11 @@ contexts:
     - match: ','
       scope: punctuation.separator.comma.lua
       push: expression-begin
-    - include: variable-modifier
+    - match: (?=<(?![<=]))
+      branch_point: left-angle
+      branch:
+        - left-angle-is-variable-modifier
+        - left-angle-is-less-than
     - include: expression-end
 
   expression-begin:
@@ -304,10 +308,15 @@ contexts:
 
     - include: else-pop
 
-  variable-modifier:
+  left-angle-is-less-than:
+    - match: '<'
+      scope: keyword.operator.comparison.lua
+      pop: true
+
+  left-angle-is-variable-modifier:
     - match: '<'
       scope: punctuation.definition.modifier.begin.lua
-      push: variable-modifier-body
+      set: variable-modifier-body
 
   variable-modifier-body:
     - meta_scope: meta.modifier.lua
@@ -316,7 +325,8 @@ contexts:
       pop: 1
     - match: (?:const|close){{identifier_break}}
       scope: storage.modifier.lua
-    - include: else-pop
+    - match: (?=\S)
+      fail: left-angle
 
   infix-operator:
     - match: (?:[=<>~]=)

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -598,9 +598,16 @@
     return;
 --  ^^^^^^ keyword.control.return
 
-    return foo;
+    return foo or a < b and a <= b;
 --  ^^^^^^ keyword.control.return
 --         ^^^ variable.other
+--             ^^ keyword.operator.logical.lua
+--                  ^ keyword.operator.comparison.lua
+--                      ^^^ keyword.operator.logical.lua
+--                            ^^ keyword.operator.comparison.lua
+
+    return a << b;
+--           ^^ keyword.operator.bitwise.lua
 
     local x = 1, y = 2;
 --  ^^^^^ storage.modifier
@@ -631,10 +638,17 @@
 --                                 ^ keyword.operator.assignment.lua
 --                                      ^ meta.number.integer.decimal.lua constant.numeric.value.lua
 
+    local t = a >= b and b <= a
+--  ^^^^^ storage.modifier.lua
+--          ^ keyword.operator.assignment.lua
+--              ^^ keyword.operator.comparison.lua
+--                   ^^^ keyword.operator.logical.lua
+--                         ^^ keyword.operator.comparison.lua
+
     local text <const = "Hello, World";
 --  ^^^^^ storage.modifier.lua
 --        ^^^^ variable.other.lua
---             ^^^^^^ meta.modifier.lua
+--              ^^^^^ - storage.modifier.lua
 --                    ^ keyword.operator.assignment.lua - meta.modifier
 --                      ^ punctuation.definition.string.begin.lua - meta.modifier
 --                       ^^^^^^^^^^^^ meta.string.lua string.quoted.double.lua


### PR DESCRIPTION
```lua
return 1 <= 2
return 1 << 2
local t = a >= b and b <= a
```

![image](https://user-images.githubusercontent.com/6594915/111481640-1e556f80-876e-11eb-83b7-0efd8cd3e711.png)
