### PR TITLE
[JavaScript] Fix methods named 'async'.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1778,7 +1778,6 @@ contexts:
         - function-declaration-expect-parameters
         - method-name
         - method-declaration-expect-prefix
-        - function-declaration-expect-async
 
   method-declaration-expect-prefix:
     - match: \*

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -376,6 +376,16 @@ var obj = {
 
     get: 42,
 //  ^^^ meta.mapping.key
+
+    async() {}
+//  ^^^^^^^^^^ meta.function
+//  ^^^^^ entity.name.function
+//       ^^ meta.function.parameters
+//       ^ punctuation.section.group.begin
+//        ^ punctuation.section.group.end
+//          ^^ meta.block
+//          ^ punctuation.section.block.begin
+//           ^ punctuation.section.block.end
 }
 // <- meta.mapping - meta.block
 

--- a/JavaScript/tests/syntax_test_js_class.js
+++ b/JavaScript/tests/syntax_test_js_class.js
@@ -220,6 +220,16 @@ class MyClass extends TheirClass {
 
     static async foo() {}
 //         ^^^^^ keyword.declaration.async
+
+    async() {}
+//  ^^^^^^^^^^ meta.function
+//  ^^^^^ entity.name.function
+//       ^^ meta.function.parameters
+//       ^ punctuation.section.group.begin
+//        ^ punctuation.section.group.end
+//          ^^ meta.block
+//          ^ punctuation.section.block.begin
+//           ^ punctuation.section.block.end
 }
 // <- meta.block punctuation.section.block.end
 


### PR DESCRIPTION
Remove a vestigial line that was messing up highlighting of methods named `async`. Reported by Mitranim on Discord.