### PR TITLE
[JavaScript] Add exported variables to indexed symbol list

### DIFF
--- a/JavaScript/Symbol List - Exports.tmPreferences
+++ b/JavaScript/Symbol List - Exports.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>
+		meta.export.js meta.binding.name - meta.export.js meta.function meta.binding.name
+	</string>
+	<key>settings</key>
+	<dict>
+		<key>showInIndexedSymbolList</key>
+		<string>1</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Partial implementation for #2720. Handles e.g.:

```js
export const foo = 42;
```

`foo` will be added to the indexed symbol list, but not the local symbol list.

Function assignments are not affected:

```js
export const f = () => {};
```

`f` is still added to the local symbol list as well as the indexed symbol list.

Ordinary named exports are not implemented:

```js
export foo;
```

`foo` is not indexed. This will probably require a little extra scoping (in another PR).