### PR TITLE
[D] Fix pointer and array type scopes in declarations

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -40,7 +40,7 @@ variables:
   string_lookahead: '(?=`|[rxq]?"|q{)'
 
   definitely_value_lookahead: '(?=!|~|\+|\-|\*|&|\bcast\b|\bdelete\b|\bnew\b|\bimport\b|\bis\b|\b__traits\b|\bfunction\b|\bdelegate\b|[0-9]|\[|\(|{{string_lookahead}}|\b({{language_constant}})\b|\b({{language_variable}})\b)'
-  definitely_declaration_lookahead: '(?=({{name}}|\]|\))(\s+{{name}})|\b({{type_qualifier}})\b)'
+  definitely_declaration_lookahead: '(?=({{name}})(\s+\*|(\*|\[.*\])?\s+)({{name}})|\b({{type_qualifier}})\b)'
 
   type_qualifier: 'const|immutable|inout|shared'
   type_qualifier_lookahead: '(?=\b({{type_qualifier}})\b)'
@@ -2119,6 +2119,9 @@ contexts:
         - match: '\)'
           scope: punctuation.section.parens.end.d
           pop: true
+        - match: ';'
+          scope: punctuation.terminator.d
+          push: first-value
         - include: statement-list-in
     - include: not-whitespace-illegal-pop
 

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2109,6 +2109,16 @@ extern(1)
 //                                           ^^^^^ string.quoted.double.d
 //                                                ^ punctuation.terminator.d
 
+  foo* bar = foo* bar;
+//^^^ storage.type.d
+//   ^ keyword.operator.pointer.d
+//     ^^^ variable.other.d
+//         ^ keyword.operator.assignment.d
+//           ^^^ variable.other.d
+//              ^ keyword.operator.arithmetic.d
+//                ^^^ variable.other.d
+//                   ^ punctuation.terminator.d
+
   foo bar = (baz *var[foo* bar]);
 //^^^ storage.type.d
 //    ^^^ variable.other.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -568,7 +568,7 @@ extern(1)
 //    ^ variable.other.d
 //     ^ punctuation.terminator.d
   foo[string] b = 123;
-//^^^ variable.other.d
+//^^^ storage.type.d
 //   ^ punctuation.section.brackets.begin.d
 //    ^^^^^^ storage.type.d
 //          ^ punctuation.section.brackets.end.d
@@ -577,10 +577,22 @@ extern(1)
 //                ^^^ meta.number.integer.decimal.d
 //                   ^ punctuation.terminator.d
   bar* some_long_Name;
-//^^^ variable.other.d
+//^^^ storage.type.d
 //   ^ keyword.operator.pointer.d
 //     ^^^^^^^^^^^^^^ variable.other.d
 //                   ^ punctuation.terminator.d
+  bar *some_long_Name;
+//^^^ storage.type.d
+//    ^ keyword.operator.pointer.d
+//     ^^^^^^^^^^^^^^ variable.other.d
+//                   ^ punctuation.terminator.d
+  foo[BAR] baz;
+//^^^ storage.type.d
+//   ^ punctuation.section.brackets.begin.d
+//    ^^^ variable.other.d
+//       ^ punctuation.section.brackets.end.d
+//         ^^^ variable.other.d
+//            ^ punctuation.terminator.d
   auto foo = 3;
 //^^^^ storage.modifier.d
 //     ^^^ variable.other.d
@@ -1081,7 +1093,7 @@ extern(1)
     }
   //^ meta.function.d meta.block.d punctuation.section.block.end.d
     T[] map(T, void fn)(T[] array) {
-  //^ variable.other.d
+  //^ storage.type.d
   // ^ punctuation.section.brackets.begin.d
   //  ^ punctuation.section.brackets.end.d
   //    ^^^ meta.function.d entity.name.function.d
@@ -2096,6 +2108,22 @@ extern(1)
 //                                         ^ keyword.operator.concatenation.d
 //                                           ^^^^^ string.quoted.double.d
 //                                                ^ punctuation.terminator.d
+
+  foo bar = (baz *var[foo* bar]);
+//^^^ storage.type.d
+//    ^^^ variable.other.d
+//        ^ keyword.operator.assignment.d
+//          ^ punctuation.section.group.begin.d
+//           ^^^ variable.other.d
+//               ^ keyword.operator.arithmetic.d
+//                ^^^ variable.other.d
+//                   ^ punctuation.section.brackets.begin.d
+//                    ^^^ variable.other.d
+//                       ^ keyword.operator.arithmetic.d
+//                         ^^^ variable.other.d
+//                            ^ punctuation.section.brackets.end.d
+//                             ^ punctuation.section.group.end.d
+//                              ^ punctuation.terminator.d
 
   auto f = foo ? 12 : 15;
 //^^^^ storage.modifier.d


### PR DESCRIPTION
Fixes #2764

It appears D already ensures `a *b` or `a* b` are scoped as arithmetic expressions ( in square brackets or parens ), except `for()` arguments.

This commit therefore refines `definitely_declaration_lookahead` to prefer declaration statements over arithmetic expressions in "statements" contexts and fixes the for arguments context to make sure to match declarations only befor the first semicolon.

With this PR merged, the provided example in issue #2764 looks like

![grafik](https://user-images.githubusercontent.com/16542113/113345568-edab3380-9332-11eb-9b2d-c9b9e3fb1f03.png)
