### PR TITLE
[SQL] Scope consistency

### DIFF
--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1785,7 +1785,7 @@ echo <<<SQL
 SELECT * FROM users WHERE first_name = 'John' LIMIT $limit
 //^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql
 // <- keyword.other.DML
-//     ^ variable.language.star
+//     ^ variable.language.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
 //                                                  ^^^^^^ variable.other.php
 SQL;
@@ -1798,7 +1798,7 @@ echo <<<'SQL'
 SELECT * FROM users WHERE first_name = 'John'\n
 //^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql
 // <- keyword.other.DML
-//     ^ variable.language.star
+//     ^ variable.language.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
 //                                           ^^ - constant.character.escape.php
 SQL;

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -111,13 +111,13 @@ contexts:
     - match: (?i)\b(asc|desc)\b
       scope: keyword.other.order.sql
     - match: \*
-      scope: variable.language.star.sql
+      scope: variable.language.wildcard.asterisk.sql
     - match: "<=>|[!<>]?=|<>|<|>"
       scope: keyword.operator.comparison.sql
     - match: '-|\+|/'
-      scope: keyword.operator.math.sql
+      scope: keyword.operator.arithmetic.sql
     - match: \|\|
-      scope: keyword.operator.concatenator.sql
+      scope: keyword.operator.concatenation.sql
     - match: (?i)\b(CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
       comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.scalar.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -160,7 +160,7 @@ select
 
 SELECT  *,
 -- ^^^ keyword.other.DML.sql
---      ^ variable.language.star.sql
+--      ^ variable.language.wildcard.asterisk.sql
         f.id AS database_id
 --           ^^ keyword.operator.assignment.alias.sql
 FROM    foo


### PR DESCRIPTION
This PR...

1. scopes `*` `variable.language.wildcard.asterisk` for consistency with Java and Makefile
2. scopes `||` as `keyword.operator.concatenation` for consistency with Lua, D [and Perl].
3. renames `keyword.operator.math` to `keyword.operator.arithmetic` to comply with scope naming guidelines.