### PR TITLE
[R] Fix scopes for comparison operators

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -150,7 +150,9 @@ contexts:
       scope: keyword.operator.arithmetic.r
     - match: (<-|->)
       scope: keyword.operator.assignment.r
-    - match: (==|!=|<=|>=|<>|&&|\|\|)
+    - match: (==|!=|<>|<=?|>=?)
+      scope: keyword.operator.comparison.r
+    - match: (&&?|\|\|?)
       scope: keyword.operator.logical.r
     - match: :=
       scope: keyword.operator.other.r
@@ -159,7 +161,7 @@ contexts:
       scope: keyword.operator.arithmetic.r
     - match: =
       scope: keyword.operator.assignment.r
-    - match: '[!&|<>]'
+    - match: '!'
       scope: keyword.operator.logical.r
     - match: '[:~@]'
       scope: keyword.other.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -259,13 +259,13 @@ NaN
 #             ^^^ keyword.operator.assignment.r
 
   == != <= >= <> < > && & || | !
-# ^^ keyword.operator.logical.r
-#    ^^ keyword.operator.logical.r
-#       ^^ keyword.operator.logical.r
-#          ^^ keyword.operator.logical.r
-#             ^^ keyword.operator.logical.r
-#                ^ keyword.operator.logical.r
-#                  ^ keyword.operator.logical.r
+# ^^ keyword.operator.comparison.r
+#    ^^ keyword.operator.comparison.r
+#       ^^ keyword.operator.comparison.r
+#          ^^ keyword.operator.comparison.r
+#             ^^ keyword.operator.comparison.r
+#                ^ keyword.operator.comparison.r
+#                  ^ keyword.operator.comparison.r
 #                    ^^ keyword.operator.logical.r
 #                       ^ keyword.operator.logical.r
 #                         ^^ keyword.operator.logical.r
@@ -506,7 +506,7 @@ foo[[bar[1]]] #
 # issue #1120
 sum(x == 1)
 #   ^^^^^^ - variable.parameter.r
-#     ^^ keyword.operator.logical.r
+#     ^^ keyword.operator.comparison.r
 
 function(
   x = 1, # this should be comment


### PR DESCRIPTION
Here's another tweak for operator scopes that I recently found.

Any R user here who knows what `<>` is used for and whether its scope name is correct, because I couldn't find it in the R documentation?