### PR TITLE
[ShellScript] Rename ternary operator scopes

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1362,7 +1362,7 @@ contexts:
     - match: \,
       scope: punctuation.separator.sequence.shell
     - match: \:|\?
-      scope: keyword.operator.ternary.shell
+      scope: keyword.operator.conditional.ternary.shell
     # Shell variables are allowed as operands; parameter expansion is performed
     # before the expression is evaluated. Within an expression, shell variables
     # may also be referenced by name without using the parameter expansion

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -3889,8 +3889,8 @@ true false
 #         ^^ keyword.operator.logical.shell
 
 (( a ? 0 : 1 ))
-#    ^ keyword.operator.ternary.shell
-#        ^ keyword.operator.ternary.shell
+#    ^ keyword.operator.conditional.ternary.shell
+#        ^ keyword.operator.conditional.ternary.shell
 (((a>b) ? (a>c?a:c) : (b>c?b:c)))
 # <- meta.arithmetic.shell punctuation.section.arithmetic.begin.shell - meta.group
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.arithmetic.shell
@@ -3904,17 +3904,17 @@ true false
 # ^ punctuation.section.group.begin.shell
 #   ^ keyword.operator.comparison.shell
 #     ^ punctuation.section.group.end.shell
-#       ^ keyword.operator.ternary.shell
+#       ^ keyword.operator.conditional.ternary.shell
 #         ^ punctuation.section.group.begin.shell
 #           ^ keyword.operator.comparison.shell
-#             ^ keyword.operator.ternary.shell
-#               ^ keyword.operator.ternary.shell
+#             ^ keyword.operator.conditional.ternary.shell
+#               ^ keyword.operator.conditional.ternary.shell
 #                 ^ punctuation.section.group.end.shell
-#                   ^ keyword.operator.ternary.shell
+#                   ^ keyword.operator.conditional.ternary.shell
 #                     ^ punctuation.section.group.begin.shell
 #                       ^ keyword.operator.comparison.shell
-#                         ^ keyword.operator.ternary.shell
-#                           ^ keyword.operator.ternary.shell
+#                         ^ keyword.operator.conditional.ternary.shell
+#                           ^ keyword.operator.conditional.ternary.shell
 #                             ^ punctuation.section.group.end.shell
 #                              ^^ punctuation.section.arithmetic.end.shell
 


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.