### PR TITLE
[PHP] Refine ternary conditional sub scope

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -275,11 +275,11 @@ contexts:
     - match: \.
       scope: keyword.operator.string.php
     - match: \?
-      scope: keyword.operator.ternary.php
+      scope: keyword.operator.conditional.ternary.php
       push:
         - include: expressions
         - match: ':'
-          scope: keyword.operator.ternary.php
+          scope: keyword.operator.conditional.ternary.php
           pop: 1
     - match: "="
       scope: keyword.operator.assignment.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -238,16 +238,16 @@ function foo(?stinrg ...$args) {}
 //                      ^^^^^ variable.parameter
 
 $a = $b ? $c::MY_CONST : $d * 5;
-//      ^ keyword.operator.ternary
+//      ^ keyword.operator.conditional.ternary
 //        ^^ variable.other
 //          ^^ punctuation.accessor.double-colon
 //            ^^^^^^^^ constant.other.class
-//                     ^ keyword.operator.ternary
+//                     ^ keyword.operator.conditional.ternary
 //                          ^ keyword.operator.arithmetic
 
 $a = $b ? : $c::MY_CONST;
-//      ^ keyword.operator.ternary
-//        ^ keyword.operator.ternary
+//      ^ keyword.operator.conditional.ternary
+//        ^ keyword.operator.conditional.ternary
 //          ^^ variable.other
 //            ^^ punctuation.accessor.double-colon
 //              ^^^^^^^^ constant.other.class


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.