### PR TITLE
[JavaScript] Refine ternary conditional sub scope

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1259,14 +1259,14 @@ contexts:
 
   ternary-operator:
     - match: '\?(?=[^.]|\.[0-9])'
-      scope: keyword.operator.ternary.js
+      scope: keyword.operator.conditional.ternary.js
       set:
         - ternary-operator-expect-colon
         - expression-no-comma
 
   ternary-operator-expect-colon:
     - match: ':'
-      scope: keyword.operator.ternary.js
+      scope: keyword.operator.conditional.ternary.js
       set: expression-no-comma
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -195,7 +195,7 @@ tag `template`;
 
 x ? y // y is a template tag!
 `template` : z;
-//         ^ keyword.operator.ternary
+//         ^ keyword.operator.conditional.ternary
 
     1``
     /a/;
@@ -1342,9 +1342,9 @@ var query = {
     type: type==undefined ? null : {$in: type.split(',')}
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
 //              ^^^^^^^^^ constant.language.undefined
-//                        ^ keyword.operator.ternary
+//                        ^ keyword.operator.conditional.ternary
 //                          ^^^^ constant.language.null
-//                               ^ keyword.operator.ternary
+//                               ^ keyword.operator.conditional.ternary
 //                                 ^ punctuation.section.block.begin
 //                                   ^^ meta.mapping.key.js
 //                                     ^ punctuation.separator.key-value.js
@@ -1523,9 +1523,9 @@ debugger
 //    ^^^ keyword.operator.assignment.augmented
 
     a ?.5 : .7;
-//    ^ keyword.operator.ternary
+//    ^ keyword.operator.conditional.ternary
 //     ^^ constant.numeric
-//        ^ keyword.operator.ternary
+//        ^ keyword.operator.conditional.ternary
 
     a?.b?.c;
 //   ^^ punctuation.accessor

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -361,26 +361,26 @@ function f(this : any) {}
 
     x ? (y) : z;
 //  ^ variable.other.readwrite
-//    ^ keyword.operator.ternary
+//    ^ keyword.operator.conditional.ternary
 //      ^^^ meta.group
 //       ^ variable.other.readwrite
-//          ^ keyword.operator.ternary
+//          ^ keyword.operator.conditional.ternary
 
     x ? (y) : T => r : z;
 //  ^ variable.other.readwrite
-//    ^ keyword.operator.ternary
+//    ^ keyword.operator.conditional.ternary
 //      ^^^^^^^^^^^^^ meta.function
 //       ^ meta.binding.name variable.parameter.function
 //          ^ punctuation.separator.type
 //            ^ meta.type support.class
 //              ^^ keyword.declaration.function.arrow
 //                 ^meta.block variable.other.readwrite
-//                   ^ keyword.operator.ternary
+//                   ^ keyword.operator.conditional.ternary
 //                     ^ variable.other.readwrite
 
     x ? y : T => z;
 //      ^ variable.other.readwrite - variable.parameter
-//        ^ keyword.operator.ternary
+//        ^ keyword.operator.conditional.ternary
 //          ^^^^^^ meta.function
 //          ^ variable.parameter.function
 //            ^^ keyword.declaration.function.arrow
@@ -397,11 +397,11 @@ function f(this : any) {}
     x ? async (y) : T => r : z;
 //      ^^^^^^^^^^^^^^^^^^ meta.function
 //                ^ punctuation.separator.type
-//                         ^ keyword.operator.ternary
+//                         ^ keyword.operator.conditional.ternary
 
     x ? async (y) : T;
 //      ^^^^^ variable.function
-//                ^ keyword.operator.ternary
+//                ^ keyword.operator.conditional.ternary
 
 /* Assertions */
 


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.