### PR TITLE
[Groovy] Refine ternary conditional sub scope

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -174,13 +174,13 @@ contexts:
     - match: (?<=\S)\?\.(?=\S)
       scope: punctuation.accessor.groovy
     - match: \?
-      scope: keyword.operator.ternary.groovy
+      scope: keyword.operator.conditional.ternary.groovy
       push:
         - meta_scope: meta.evaluation.ternary.groovy
         - match: $|(?=\})
           pop: true
         - match: ":"
-          scope: keyword.operator.ternary.expression-separator.groovy
+          scope: keyword.operator.conditional.ternary.groovy
         - include: groovy-code-minus-map-keys
     - match: "==~"
       scope: keyword.operator.match.groovy

--- a/Groovy/syntax_test_groovy.groovy
+++ b/Groovy/syntax_test_groovy.groovy
@@ -59,11 +59,11 @@ def greeting = "Hello ${true ? 'World' : 'Home'}"
 //                      ^^^^ constant.language
 //                           ^^^^^^^^^^^^^^^^^^ meta.evaluation.ternary
 //                                             ^^ - meta.evaluation.ternary
-//                           ^ keyword.operator.ternary
+//                           ^ keyword.operator.conditional.ternary
 //                             ^ punctuation.definition.string.begin
 //                             ^^^^^^^ string.quoted.single
 //                                   ^ punctuation.definition.string.end
-//                                     ^ keyword.operator.ternary.expression-separator
+//                                     ^ keyword.operator.conditional.ternary
 //                                       ^ punctuation.definition.string.begin
 //                                       ^^^^^^ string.quoted.single
 //                                            ^ punctuation.definition.string.end


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.