### PR TITLE
[D] Refine ternary conditional sub scope

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1423,7 +1423,7 @@ contexts:
       scope: keyword.operator.arithmetic.d
       set: value-maybe-pointer-after
     - match: '\?'
-      scope: keyword.operator.ternary.d
+      scope: keyword.operator.conditional.ternary.d
       set: [value-condition-after, value-condition]
     - match: '(?=\b(function|delegate)\b)'
       set: [value-after, basic-type2]
@@ -1462,7 +1462,7 @@ contexts:
     - include: value-no-mapping-key
   value-condition-after:
     - match: ':'
-      scope: keyword.operator.ternary.d
+      scope: keyword.operator.conditional.ternary.d
       set: value
     - include: not-whitespace-illegal-pop
   value-parens-after:

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2102,9 +2102,9 @@ extern(1)
 //     ^ variable.other.d
 //       ^ keyword.operator.assignment.d
 //         ^^^ meta.path.d variable.other.d
-//             ^ keyword.operator.ternary.d
+//             ^ keyword.operator.conditional.ternary.d
 //               ^^ meta.number.integer.decimal.d
-//                  ^ keyword.operator.ternary.d
+//                  ^ keyword.operator.conditional.ternary.d
 //                    ^^ meta.number.integer.decimal.d
 //                      ^ punctuation.terminator.d
 
@@ -2113,9 +2113,9 @@ extern(1)
 //    ^ variable.other.d
 //      ^ keyword.operator.assignment.d
 //        ^ meta.path.d variable.other.d
-//          ^ keyword.operator.ternary.d
+//          ^ keyword.operator.conditional.ternary.d
 //            ^ meta.path.d variable.other.d
-//              ^ keyword.operator.ternary.d
+//              ^ keyword.operator.conditional.ternary.d
 //                ^ meta.path.d variable.other.d
 //                 ^ punctuation.terminator.d
 
@@ -2124,9 +2124,9 @@ extern(1)
 //    ^ variable.other.d
 //     ^ keyword.operator.assignment.d
 //      ^ meta.path.d variable.other.d
-//       ^ keyword.operator.ternary.d
+//       ^ keyword.operator.conditional.ternary.d
 //        ^ meta.path.d variable.other.d
-//         ^ keyword.operator.ternary.d
+//         ^ keyword.operator.conditional.ternary.d
 //          ^ meta.path.d variable.other.d
 //           ^ punctuation.terminator.d
 


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.