### PR TITLE
[C#] Refine ternary conditional sub scope

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1298,10 +1298,10 @@ contexts:
     - match: '@'
       scope: invalid.illegal.reserved-char.cs
     - match: \?
-      scope: keyword.operator.ternary.cs
+      scope: keyword.operator.conditional.ternary.cs
       push:
         - match: ':'
-          scope: keyword.operator.ternary.cs
+          scope: keyword.operator.conditional.ternary.cs
           pop: true
         - include: line_of_code_in
     - match: '(\()\s*(\*)\s*({{name}})\s*(\))'

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -681,10 +681,10 @@ void TestFoo() => Foo ("hello", 123, new Point (2, 3));
 
 // https://msdn.microsoft.com/en-us/magazine/mt814808.aspx
 Span<byte> bytes = length > 128 ? new byte[length] : stackalloc byte[length];
-///                             ^ keyword.operator.ternary
+///                             ^ keyword.operator.conditional.ternary
 ///                               ^^^ keyword.operator.new
 ///                               ^^^^^^^^^^^^^^^^ meta.instance
-///                                                ^ keyword.operator.ternary - meta.instance
+///                                                ^ keyword.operator.conditional.ternary - meta.instance
 ///                                                  ^^^^^^^^^^ storage.modifier
 ///                                                             ^^^^ storage.type
 ///                                                                 ^ punctuation.section.brackets.begin

--- a/C#/tests/syntax_test_Operators.cs
+++ b/C#/tests/syntax_test_Operators.cs
@@ -70,8 +70,8 @@ A?.B?.C?[0] == E;
 ///       ^^ keyword.operator
 
 condition ? first_expression : second_expression;
-///       ^ keyword.operator.ternary
-///                          ^ keyword.operator.ternary
+///       ^ keyword.operator.conditional.ternary
+///                          ^ keyword.operator.conditional.ternary
 
     ((Test.Example . State)item.State).ToString();
 ///  ^^^^^^^^^^^^^^^^^^^^^^ meta.cast


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.