### PR TITLE
[C/C++] Refine ternary conditional sub scope

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -297,7 +297,7 @@ contexts:
       scope: keyword.operator.assignment.c
     # Negative lookahead prevents match :: when included in C++
     - match: '\?|:(?!:)'
-      scope: keyword.operator.ternary.c
+      scope: keyword.operator.conditional.ternary.c
     - match: '\.\.\.'
       scope: keyword.operator.variadic.c
 

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -77,8 +77,8 @@ struct foo {
  c)  ((a>b) ? (a>c?a:c) : (b>c?b:c))
  /* <- meta.preprocessor.macro meta.group variable.parameter */
   /* <- meta.preprocessor.macro meta.group punctuation.section.group.end */
- /*               ^ keyword.operator.ternary */
- /*                 ^ keyword.operator.ternary */
+ /*               ^ keyword.operator.conditional.ternary */
+ /*                 ^ keyword.operator.conditional.ternary */
 
 #define PACKED __attribute__((aligned(1),packed))
 /*      ^ entity.name.constant */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -157,8 +157,8 @@ some_namespace::some_function(int a_parameter, double another_parameter) {
  c)  ((a>b) ? (a>c?a:c) : (b>c?b:c))
  /* <- meta.preprocessor.macro meta.group variable.parameter */
   /* <- meta.preprocessor.macro meta.group punctuation.section.group.end */
- /*               ^ keyword.operator.ternary */
- /*                 ^ keyword.operator.ternary */
+ /*               ^ keyword.operator.conditional.ternary */
+ /*                 ^ keyword.operator.conditional.ternary */
 
 #if 0
 #ifdef moo

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -157,8 +157,8 @@ some_namespace::some_function(int a_parameter, double another_parameter) {
  c)  ((a>b) ? (a>c?a:c) : (b>c?b:c))
  /* <- meta.preprocessor.macro meta.group variable.parameter */
   /* <- meta.preprocessor.macro meta.group punctuation.section.group.end */
- /*               ^ keyword.operator.ternary */
- /*                 ^ keyword.operator.ternary */
+ /*               ^ keyword.operator.conditional.ternary */
+ /*                 ^ keyword.operator.conditional.ternary */
 
 #if 0
 #ifdef moo

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -77,8 +77,8 @@ struct foo {
  c)  ((a>b) ? (a>c?a:c) : (b>c?b:c))
  /* <- meta.preprocessor.macro meta.group variable.parameter */
   /* <- meta.preprocessor.macro meta.group punctuation.section.group.end */
- /*               ^ keyword.operator.ternary */
- /*                 ^ keyword.operator.ternary */
+ /*               ^ keyword.operator.conditional.ternary */
+ /*                 ^ keyword.operator.conditional.ternary */
 
 #define PACKED __attribute__((aligned(1),packed))
 /*      ^ entity.name.constant */


### PR DESCRIPTION
Refines `keyword.operator.ternary` to `keyword.operator.conditional.ternary` as some syntaxes may require other types of conditional keywords.