### PR TITLE
[BATCH] Bugfixing illegal comment syntax

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -391,7 +391,9 @@ contexts:
         - match: \n
           scope: comment.line.rem.dosbatch
           pop: true
-        - match: '[(|)]'
+          # '[(|)]' should create a illegal comment statements, but don't
+          # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490986(v=technet.10)?redirectedfrom=MSDN
+        - match: ''
           scope: invalid.illegal.unexpected-character.dosbatch
 
   strings:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -391,6 +391,10 @@ contexts:
         - match: \n
           scope: comment.line.rem.dosbatch
           pop: true
+        # '[(|)]' should create a illegal comment statements, but don't
+        # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490986(v=technet.10)?redirectedfrom=MSDN
+        - match: ''
+          scope: invalid.illegal.unexpected-character.dosbatch
 
   strings:
     - match: '"'

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -391,10 +391,6 @@ contexts:
         - match: \n
           scope: comment.line.rem.dosbatch
           pop: true
-          # '[(|)]' should create a illegal comment statements, but don't
-          # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490986(v=technet.10)?redirectedfrom=MSDN
-        - match: ''
-          scope: invalid.illegal.unexpected-character.dosbatch
 
   strings:
     - match: '"'


### PR DESCRIPTION
https://github.com/sublimehq/Packages/issues/1301

```
'[(|)]' should create a illegal comment statements, but it don't
https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490986(v=technet.10)?redirectedfrom=MSDN
```