### PR TITLE
[HTML] Extend and reorganize known html tags

### DIFF
--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1,9 +1,9 @@
 ' SYNTAX TEST "Packages/ASP/HTML (ASP).sublime-syntax"
 <!DOCTYPE html>
 <html>
-'<- meta.tag.structure.any.html punctuation.definition.tag.begin.html - source.asp.embedded.html
-'^^^^ meta.tag.structure.any.html entity.name.tag.structure.any.html
-'    ^ meta.tag.structure.any.html punctuation.definition.tag.end.html
+'<- meta.tag.html.opening.html punctuation.definition.tag.begin.html - source.asp.embedded.html
+'^^^^ meta.tag.html.opening.html entity.name.tag.structure.html
+'    ^ meta.tag.html.opening.html punctuation.definition.tag.end.html
  <%@ TRANSACTION = Required %>
 '^^ punctuation.section.embedded.begin.asp
 '    ^^^^^^^^^^^ constant.language.processing-directive.asp
@@ -890,7 +890,7 @@
     %>
     
     <p>foobar</p>
-   '^^^ text.html.asp meta.tag.block.any.html - source.asp.embedded.html
+   '^^^ text.html.asp meta.tag.html.opening.html - source.asp.embedded.html
     <%='test %>
    '^^^ punctuation.section.embedded.begin.asp - source.asp
    '   ^^^^^^ comment.line.apostrophe.asp
@@ -966,12 +966,12 @@ test = "hello%>
 '              ^ - source.asp.embedded.html
 
 <footer>
-'^^^^^^ text.html.asp meta.tag.block.any.html entity.name.tag.block.any.html
+'^^^^^^ text.html.asp meta.tag.html.opening.html entity.name.tag.block.html
     <% With abc %>
     '  ^^^^ keyword.control.flow.asp
     '           ^^ text.html.asp punctuation.section.embedded.end.inside-block.asp
         <p>Some conditional content in the footer</p>
-        '<- text.html.asp meta.tag.block.any.html punctuation.definition.tag.begin.html
+        '<- text.html.asp meta.tag.html.opening.html punctuation.definition.tag.begin.html
     <% End With %>
    '^^ punctuation.section.embedded.begin.inside-block.asp
    '   ^^^^^^^^ keyword.control.flow.asp
@@ -980,8 +980,8 @@ test = "hello%>
     <% If abc = "def" Then %>
     '                     ^ meta.if.block.asp - meta.if.line.asp
         <span id="span1">Text here</span>
-        '     ^^ text.html.asp meta.tag.inline.any.html meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-        '                         ^^ text.html.asp meta.tag.inline.any.html punctuation.definition.tag.begin.html
+        '     ^^ text.html.asp meta.tag.html.opening.html meta.attribute-with-value.id.html entity.other.attribute-name.id.html
+        '                         ^^ text.html.asp meta.tag.html.closing.html punctuation.definition.tag.begin.html
     <% End If %>
     ' ^ meta.if.block.asp
     '  ^^^^^^ keyword.control.flow.asp
@@ -989,7 +989,7 @@ test = "hello%>
    
 </footer><% [%><br />
 '            ^^ punctuation.section.embedded.end.asp
-'               ^^ text.html.asp meta.tag.inline.any.html entity.name.tag.inline.any.html
+'               ^^ text.html.asp meta.tag.html.selfclosing.html entity.name.tag.inline.html
 <% Sub InventiveMethodNameHere(list) %>
 '  ^^^ meta.method.identifier.asp storage.type.function.asp
 '                                   ^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp
@@ -1001,7 +1001,7 @@ test = "hello%>
        '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
             %><li><%= item %></li><%
                     '^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp
-           '  ^ meta.tag.inline.any.html punctuation.definition.tag.begin.html
+           '  ^ meta.tag.html.opening.html punctuation.definition.tag.begin.html
            '      ^^^ punctuation.section.embedded.begin.inside-block.asp
            '               ^^ punctuation.section.embedded.end.inside-block.asp
         Next
@@ -1012,8 +1012,9 @@ test = "hello%>
 '  ^^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp storage.type.function.end.asp
 '         ^ - meta.method.asp
  <p class="<% If True Then %>test<% End If %>"></p>
-'^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html
-'                                         ^^^^^^^^^ meta.tag.block.any.html
+'^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.html.opening.html
+'                                         ^^^^^ meta.tag.html.opening.html
+'                                              ^^^^ meta.tag.html.closing.html
 '   ^^^^^ meta.attribute-with-value.class.html entity.other.attribute-name.class.html
 '         ^ meta.attribute-with-value.class.html meta.string.html string.quoted.double.html - meta.interpolation
 '          ^^ meta.attribute-with-value.class.html  meta.string.html meta.interpolation.html - string
@@ -1036,10 +1037,10 @@ test = "hello%>
 '                                             ^ punctuation.definition.tag.end.html
 
  <p <%= "class=""test""" %> id="test1"></p>
-'^^^ meta.tag.block.any.html
-'                          ^^^^^^^^^^^^^^^^ meta.tag.block.any.html
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.html.opening.html
+'                                      ^^^^ meta.tag.html.closing.html
 '^ punctuation.definition.tag.begin.html
-' ^ entity.name.tag.block.any.html
+' ^ entity.name.tag.block.html
 '   ^^^ punctuation.section.embedded.begin.asp
 '       ^^^^^^^^^^^^^^^^ string.quoted.double.asp
 '                        ^^ punctuation.section.embedded.end.asp
@@ -1051,29 +1052,28 @@ test = "hello%>
    Do
  %>
         <span <%= "class=""test""" %> id="test2"></span>
-       '^^^^^^ meta.tag.inline.any.html
+       '^^^^^^ meta.tag.html.opening.html
+       '                                         ^^^^^^^ meta.tag.html.closing.html
        '^ punctuation.definition.tag.begin.html
-       ' ^^^^ entity.name.tag.inline.any.html
+       ' ^^^^ entity.name.tag.inline.html
        '      ^^^ punctuation.section.embedded.begin.inside-block.asp
        '          ^^^^^^^^^^^^^^^^ string.quoted.double.asp
        '                           ^^ punctuation.section.embedded.end.inside-block.asp
-       '                             ^^^^^^^^^^^^ meta.tag
        '                              ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
        '                                  ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
        '                                        ^ punctuation.definition.tag.end.html
-       '                                         ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
        '                                         ^^ punctuation.definition.tag.begin.html
-       '                                           ^^^^ entity.name.tag.inline.any.html
+       '                                           ^^^^ entity.name.tag.inline.html
        '                                               ^ punctuation.definition.tag.end.html
 <% Loop
    End If %>
   '^^^^^^ keyword.control.flow.asp
 
  <span <% If False Then %> class="test" <% End If %> id="test3"></span>
-'^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html
-'                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html
+'^^^^^^ meta.tag.html.opening.html
+'                                                               ^^^^^^^ meta.tag.html.closing.html
 '^ punctuation.definition.tag.begin.html
-' ^^^^ entity.name.tag.inline.any.html
+' ^^^^ entity.name.tag.inline.html
 '      ^^ punctuation.section.embedded.begin.asp
 '         ^^ keyword.control.flow.asp
 '            ^^^^^ meta.between-if-and-then.asp storage.type.asp
@@ -1109,15 +1109,15 @@ test = "hello%>
 '^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
 '    ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '          ^ punctuation.definition.tag.end.html
-'           ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
+'           ^^^^^^^ meta.tag.html.closing.html - meta.tag.after-embedded-asp.any.html
 '           ^^ punctuation.definition.tag.begin.html
-'             ^^^^ entity.name.tag.inline.any.html
+'             ^^^^ entity.name.tag.inline.html
 '                 ^ punctuation.definition.tag.end.html
  <% If True Then %>
 '^^ punctuation.section.embedded.begin.asp
 '                ^^ punctuation.section.embedded.end.inside-block.asp
  <span class="<%= "test" %>" id="test5"></span>
-'^^^^^^^^^^^^^ meta.tag.inline.any.html
+'^^^^^^^^^^^^^ meta.tag.html.opening.html
 '            ^ string.quoted.double.html punctuation.definition.string.begin.html
 '             ^^^ punctuation.section.embedded.begin.inside-block.asp
 '                        ^^ punctuation.section.embedded.end.inside-block.asp
@@ -1126,9 +1126,9 @@ test = "hello%>
 '                            ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
 '                                ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                      ^ punctuation.definition.tag.end.html
-'                                       ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
+'                                       ^^^^^^^ meta.tag.html.closing.html - meta.tag.after-embedded-asp.any.html
 '                                       ^^ punctuation.definition.tag.begin.html
-'                                         ^^^^ entity.name.tag.inline.any.html
+'                                         ^^^^ entity.name.tag.inline.html
 '                                             ^ punctuation.definition.tag.end.html
  <% End If %>
 '^^ punctuation.section.embedded.begin.inside-block.asp
@@ -1145,7 +1145,7 @@ test = "hello%>
 
 '<- - comment - source.asp.embedded.html
  </body>
-'^^^^^^^ meta.tag.structure.any.html
+'^^^^^^^ meta.tag.html.closing.html
 <script type="text/javascript">
 <% If True Then %>var hello = "world";<% End If %>
 </script>

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -142,16 +142,14 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: keyword.declaration.doctype.html
       push:
-        - doctype-meta
+        - doctype-end
         - doctype-content
         - doctype-content-type
         - doctype-name
 
-  doctype-meta:
+  doctype-end:
     - meta_scope: meta.tag.sgml.doctype.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      pop: 1
+    - include: tag-end
 
   doctype-name:
     - match: '{{tag_name}}'
@@ -190,9 +188,7 @@ contexts:
 
   preprocessor-content:
     - meta_scope: meta.tag.preprocessor.xml.html
-    - match: \?>
-      scope: punctuation.definition.tag.end.html
-      pop: 1
+    - include: tag-end-maybe-self-closing
     - include: tag-generic-attribute
     - include: strings
 
@@ -214,8 +210,10 @@ contexts:
       scope: meta.character.greater-than.html
 
   tag-end:
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.punctuation.html
+        2: punctuation.definition.tag.end.html
       pop: 1
 
   tag-end-self-closing:

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -232,29 +232,53 @@ contexts:
   tag-html:
     - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-html-opening
-        - tag-html-name
+      branch_point: tag-html-any
+      branch:
+        - tag-html-any-maybe-opening
+        - tag-html-any-otherwise-selfclosing
     - match: </(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-html-closing
-        - tag-html-name
+        - tag-html-any-closing-content
+        - tag-html-any-name
 
-  tag-html-name:
-    - meta_content_scope: entity.name.tag.html
-    - match: '{{tag_name_break}}'
-      pop: 1
+  tag-html-any-closing-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html.closing.html
+    - include: tag-end
 
-  tag-html-opening:
-    - meta_scope: meta.tag.html.begin.html
-    - include: tag-end-maybe-self-closing
+  tag-html-any-maybe-opening:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html.opening.html
+    - match: ''
+      set:
+        - tag-html-any-opening-content
+        - tag-html-any-name
+
+  tag-html-any-opening-content:
+    - meta_scope: meta.tag.html.opening.html
+    - match: (?=/>)
+      fail: tag-html-any
+    - include: tag-end
     - include: tag-attributes
 
-  tag-html-closing:
+  tag-html-any-otherwise-selfclosing:
     - meta_include_prototype: false
-    - meta_scope: meta.tag.html.end.html
-    - include: tag-end
+    - meta_scope: meta.tag.html.selfclosing.html
+    - match: ''
+      set:
+        - tag-html-any-selfclosing-content
+        - tag-html-any-name
+
+  tag-html-any-selfclosing-content:
+    - meta_scope: meta.tag.html.selfclosing.html
+    - include: tag-end-self-closing
+    - include: tag-attributes
+
+  tag-html-any-name:
+    - meta_content_scope: entity.name.tag.any.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
 ###[ ATTRIBUTES ]#############################################################
 

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -148,6 +148,7 @@ contexts:
         - doctype-name
 
   doctype-end:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.sgml.doctype.html
     - include: tag-end
 
@@ -229,21 +230,31 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - match: </?(?=[A-Za-z])
+    - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-html-content
+        - tag-html-opening
+        - tag-html-name
+    - match: </(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-html-closing
         - tag-html-name
 
   tag-html-name:
-      - meta_content_scope: entity.name.tag.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
-  tag-html-content:
-      - meta_scope: meta.tag.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+  tag-html-opening:
+    - meta_scope: meta.tag.html.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-html-closing:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html.end.html
+    - include: tag-end
 
 ###[ ATTRIBUTES ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -350,10 +350,7 @@ contexts:
           captures:
             1: punctuation.definition.tag.begin.html
             2: entity.name.tag.block.html
-          set:
-            - meta_scope: meta.tag.html.closing.html
-            - include: tag-end
-            - include: tag-attributes
+          set: tag-html-any-closing-content
 
   script-common:
     - include: script-type-attribute
@@ -436,10 +433,7 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.html
-      set:
-        - meta_scope: meta.tag.html.closing.html
-        - include: tag-end
-        - include: tag-attributes
+      set: tag-html-any-closing-content
 
   style-common:
     - include: style-type-attribute

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -28,6 +28,7 @@ variables:
       {{html_text_content_tags}}
     | {{html_section_tags}}
     | {{html_embedded_tags}}
+    | {{html_script_tags}}
     | {{html_web_tags}}
     | {{html_header_tags}}
     | {{html_deprecated_tags}}
@@ -45,7 +46,6 @@ variables:
     | {{html_markup_tags}}
     | {{html_media_tags}}
     | {{html_interactive_tags}}
-    | {{html_script_tags}}
     )
 
   html_inline_tags_selfclosing: |-
@@ -275,11 +275,11 @@ contexts:
     - match: (<)((?i:script)){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
+        2: entity.name.tag.block.html
       push: script-javascript
 
   script-javascript:
-    - meta_scope: meta.tag.script.begin.html
+    - meta_scope: meta.tag.html.opening.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
@@ -294,7 +294,7 @@ contexts:
       escape: '{{script_close_lookahead}}'
 
   script-html:
-    - meta_scope: meta.tag.script.begin.html
+    - meta_scope: meta.tag.html.opening.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
@@ -305,7 +305,7 @@ contexts:
     - include: script-common
 
   script-other:
-    - meta_scope: meta.tag.script.begin.html
+    - meta_scope: meta.tag.html.opening.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-close-tag
@@ -321,9 +321,9 @@ contexts:
         - match: (</)((?i:script){{tag_name_break}})
           captures:
             1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
+            2: entity.name.tag.block.html
           set:
-            - meta_scope: meta.tag.script.end.html
+            - meta_scope: meta.tag.html.closing.html
             - include: tag-end
             - include: tag-attributes
 
@@ -336,11 +336,11 @@ contexts:
     - match: (?i:type){{attribute_name_break}}
       scope: entity.other.attribute-name.html
       set:
-        - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - meta_scope: meta.tag.html.opening.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.html.opening.html meta.attribute-with-value.html
             - include: script-type-decider
         - match: (?=\S)
           set: script-javascript

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -158,152 +158,87 @@ contexts:
     - include: tag-other
     - include: tag-incomplete
 
-###[ HTML TAGS ]##############################################################
-
   tag-html:
-    - include: tag-html-inline
-    - include: tag-html-block
-    - include: tag-html-table
     - include: tag-html-script
     - include: tag-html-style
-    - include: tag-html-form
-    - include: tag-html-structure
+    - include: tag-html-any-closing
+    - include: tag-html-any-opening
+    - include: tag-html-any-selfclosing
 
-  tag-html-block:
-    - match: (<)({{html_block_tags_selfclosing}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.html
-      push:
-        - meta_scope: meta.tag.block.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (<)({{html_block_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.html
-      push:
-        - meta_scope: meta.tag.block.begin.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</)({{html_block_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.block.end.html
-        - include: tag-end
+###[ HTML TAG ]###############################################################
 
-  tag-html-form:
-    - match: (<)({{html_forms_tags_selfclosing}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.form.html
-      push:
-        - meta_scope: meta.tag.form.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (<)({{html_forms_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.form.html
-      push:
-        - meta_scope: meta.tag.form.begin.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</)({{html_forms_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.form.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.form.end.html
-        - include: tag-end
-
-  tag-html-inline:
-    - match: (<)({{html_inline_tags_selfclosing}})
+  tag-html-any-closing:
+    - match: |-
+        (?x)
+        (</)
+        (?:
+          ({{html_inline_tags}})
+        | ({{html_block_tags}})
+        | ({{html_table_tags}})
+        | ({{html_forms_tags}})
+        | ({{html_structure_tags}})
+        )
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.html
-      push:
-        - meta_scope: meta.tag.inline.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (<)({{html_inline_tags}})
+        3: entity.name.tag.block.html
+        4: entity.name.tag.table.html
+        5: entity.name.tag.form.html
+        6: entity.name.tag.structure.html
+      push: tag-html-any-closing-attributes
+
+  tag-html-any-closing-attributes:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html.closing.html
+    - include: tag-end
+
+  tag-html-any-opening:
+    - match: |-
+        (?x)
+        (<)
+        (?:
+          ({{html_inline_tags}})
+        | ({{html_block_tags}})
+        | ({{html_table_tags}})
+        | ({{html_forms_tags}})
+        | ({{html_structure_tags}})
+        )
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.html
-      push:
-        - meta_scope: meta.tag.inline.begin.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</)({{html_inline_tags}})
+        3: entity.name.tag.block.html
+        4: entity.name.tag.table.html
+        5: entity.name.tag.form.html
+        6: entity.name.tag.structure.html
+      push: tag-html-any-opening-attributes
+
+  tag-html-any-opening-attributes:
+    - meta_scope: meta.tag.html.opening.html
+    - include: tag-end
+    - include: tag-attributes
+
+  tag-html-any-selfclosing:
+    - match: |-
+        (?x)
+        (<)
+        (?:
+          ({{html_inline_tags_selfclosing}})
+        | ({{html_block_tags_selfclosing}})
+        | ({{html_table_tags_selfclosing}})
+        | ({{html_forms_tags_selfclosing}})
+        )
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.inline.end.html
-        - include: tag-end
+        3: entity.name.tag.block.html
+        4: entity.name.tag.table.html
+        5: entity.name.tag.form.html
+      push: tag-html-any-selfclosing-attributes
 
-  tag-html-script:
-    - match: (<)((?i:script)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push: script-javascript
-
-  tag-html-style:
-    - match: (<)((?i:style)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push: style-css
-
-  tag-html-structure:
-    - match: (<)({{html_structure_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.structure.html
-      push:
-        - meta_scope: meta.tag.structure.begin.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</)({{html_structure_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.structure.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.structure.end.html
-        - include: tag-end
-
-  tag-html-table:
-    - match: (<)({{html_table_tags_selfclosing}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.table.html
-      push:
-        - meta_scope: meta.tag.table.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (<)({{html_table_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.table.html
-      push:
-        - meta_scope: meta.tag.table.begin.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</)({{html_table_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.table.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.table.end.html
-        - include: tag-end
+  tag-html-any-selfclosing-attributes:
+    - meta_scope: meta.tag.html.selfclosing.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
 
 ###[ OTHER TAG ]##############################################################
 
@@ -325,16 +260,23 @@ contexts:
       pop: 1
 
   tag-other-opening:
-    - meta_scope: meta.tag.other.begin.html
+    - meta_scope: meta.tag.other.opening.html
     - include: tag-end-maybe-self-closing
     - include: tag-attributes
 
   tag-other-closing:
     - meta_include_prototype: false
-    - meta_scope: meta.tag.other.end.html
+    - meta_scope: meta.tag.other.closing.html
     - include: tag-end
 
-###[ SCRIPT TAG ]#############################################################
+###[ HTML SCRIPT TAG ]########################################################
+
+  tag-html-script:
+    - match: (<)((?i:script)){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
+      push: script-javascript
 
   script-javascript:
     - meta_scope: meta.tag.script.begin.html
@@ -430,7 +372,14 @@ contexts:
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
 
-###[ STYLE TAG ]##############################################################
+###[ HTML STYLE TAG ]#########################################################
+
+  tag-html-style:
+    - match: (<)((?i:style)){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+      push: style-css
 
   style-css:
     - meta_scope: meta.tag.style.begin.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -378,11 +378,11 @@ contexts:
     - match: (<)((?i:style)){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
+        2: entity.name.tag.block.html
       push: style-css
 
   style-css:
-    - meta_scope: meta.tag.style.begin.html
+    - meta_scope: meta.tag.html.opening.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
@@ -397,7 +397,7 @@ contexts:
       escape: '{{style_close_lookahead}}'
 
   style-other:
-    - meta_scope: meta.tag.style.begin.html
+    - meta_scope: meta.tag.html.opening.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-close-tag
@@ -407,9 +407,9 @@ contexts:
     - match: (</)((?i:style){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
+        2: entity.name.tag.block.html
       set:
-        - meta_scope: meta.tag.style.end.html
+        - meta_scope: meta.tag.html.closing.html
         - include: tag-end
         - include: tag-attributes
 
@@ -422,11 +422,11 @@ contexts:
     - match: (?i:type){{attribute_name_break}}
       scope: entity.other.attribute-name.html
       set:
-        - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - meta_scope: meta.tag.html.opening.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - meta_content_scope: meta.tag.html.opening.html meta.attribute-with-value.html
             - include: style-type-decider
         - match: (?=\S)
           set: style-css

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -186,9 +186,9 @@ contexts:
         5: entity.name.tag.form.html
         6: entity.name.tag.structure.html
         7: entity.name.tag.deprecated.html
-      push: tag-html-any-closing-attributes
+      push: tag-html-any-closing-content
 
-  tag-html-any-closing-attributes:
+  tag-html-any-closing-content:
     - meta_include_prototype: false
     - meta_scope: meta.tag.html.closing.html
     - include: tag-end
@@ -211,9 +211,9 @@ contexts:
         4: entity.name.tag.table.html
         5: entity.name.tag.form.html
         6: entity.name.tag.structure.html
-      push: tag-html-any-opening-attributes
+      push: tag-html-any-opening-content
 
-  tag-html-any-opening-attributes:
+  tag-html-any-opening-content:
     - meta_scope: meta.tag.html.opening.html
     - include: tag-end
     - include: tag-attributes
@@ -237,9 +237,9 @@ contexts:
         4: entity.name.tag.table.html
         5: entity.name.tag.form.html
         6: entity.name.tag.deprecated.html
-      push: tag-html-any-selfclosing-attributes
+      push: tag-html-any-selfclosing-content
 
-  tag-html-any-selfclosing-attributes:
+  tag-html-any-selfclosing-content:
     - meta_scope: meta.tag.html.selfclosing.html
     - include: tag-end-maybe-self-closing
     - include: tag-attributes

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -191,6 +191,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.block.end.html
         - include: tag-end
 
@@ -216,6 +217,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.form.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.form.end.html
         - include: tag-end
 
@@ -241,6 +243,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.end.html
         - include: tag-end
 
@@ -272,6 +275,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.structure.end.html
         - include: tag-end
 
@@ -297,27 +301,38 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.table.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.table.end.html
         - include: tag-end
 
 ###[ OTHER TAG ]##############################################################
 
   tag-other:
-    - match: </?(?=[A-Za-z])
+    - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-other-content
+        - tag-other-opening
+        - tag-other-name
+    - match: </(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-other-closing
         - tag-other-name
 
   tag-other-name:
-      - meta_content_scope: entity.name.tag.other.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.other.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
-  tag-other-content:
-      - meta_scope: meta.tag.other.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+  tag-other-opening:
+    - meta_scope: meta.tag.other.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-other-closing:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.end.html
+    - include: tag-end
 
 ###[ SCRIPT TAG ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -172,6 +172,14 @@ contexts:
         - meta_scope: meta.tag.block.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
+    - match: (</?)({{html_table_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.table.html
+      push:
+        - meta_scope: meta.tag.block.table.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
     - match: (</?)((?i:form|fieldset){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
@@ -196,14 +204,6 @@ contexts:
         2: entity.name.tag.inline.form.html
       push:
         - meta_scope: meta.tag.inline.form.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)({{html_table_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.table.html
-      push:
-        - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -19,19 +19,94 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 ###############################################################################
 
 variables:
-  block_tag_name: |-
-    (?ix:
-      address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
+  # HTML tags
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  # Note: Sections are sorted by expected frequency.
+
+  html_block_tags: |-
+    (?x:
+      {{html_text_content_tags}}
+    | {{html_section_tags}}
+    | {{html_embedded_tags}}
+    | {{html_web_tags}}
+    | {{html_header_tags}}
+    | {{html_deprecated_tags}}
+    )
+
+  html_inline_tags: |-
+    (?x:
+      {{html_text_semantic_tags}}
+    | {{html_markup_tags}}
+    | {{html_media_tags}}
+    | {{html_interactive_tags}}
+    | {{html_script_tags}}
+    )
+
+  # Aggregates structural root notes from
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#sectioning_root
+  html_structure_tags: |-
+    (?xi: html | head | body ){{tag_name_break}}
+
+  # Note: <head> is moved to `html_structure_tags`
+  html_header_tags: |-
+    (?xi: base | link | meta | script | style | title ){{tag_name_break}}
+
+  html_section_tags: |-
+    (?xi:
+      address | article | aside | footer | header | h1 | h2 | h3 | h4 | h5 | h6
+    | hgroup | main | nav | section
     ){{tag_name_break}}
 
-  inline_tag_name: |-
-    (?ix:
-      abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
+  html_text_content_tags: |-
+    (?xi:
+      blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+    | ol | p | pre | ul
     ){{tag_name_break}}
 
-  form_tag_name: |-
-    (?ix:
-      button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
+  html_text_semantic_tags: |-
+    (?xi:
+      a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+    | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
+    | sub | sup | u | var | wbr
+    ){{tag_name_break}}
+
+  html_media_tags: |-
+    (?xi: area | audio | img | map | track | video ){{tag_name_break}}
+
+  html_embedded_tags: |-
+    (?xi: embed | iframe | object | param | picture | source ){{tag_name_break}}
+
+  html_script_tags: |-
+    (?xi: canvas | noscript  script ){{tag_name_break}}
+
+  html_markup_tags: |-
+    (?xi: del | ins ){{tag_name_break}}
+
+  html_table_tags: |-
+    (?xi:
+      caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+    ){{tag_name_break}}
+
+  html_forms_tags: |-
+    (?xi:
+      button | datalist | option | fieldset | label | form | input | legend
+    | meter | optgroup | select | output | progress | textarea
+    ){{tag_name_break}}
+
+  html_interactive_tags: |-
+    (?xi: details | dialog | menu | summary ){{tag_name_break}}
+
+  html_web_tags: |-
+    (?xi: slot | template ){{tag_name_break}}
+
+  html_deprecated_tags: |-
+    (?xi:
+      acronym | applet | basefont | bgsound | big | blink | center | command
+    | content | dir | element | font | frame | frameset | image | isindex
+    | keygen | listing | marquee | menuitem | multicol | nextid | nobr
+    | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
     ){{tag_name_break}}
 
   javascript_mime_type: |-
@@ -58,17 +133,28 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
+    - include: tag-html-style
+    - include: tag-html-script
+    - include: tag-html-block
+    - include: tag-html-inline
+    - include: tag-html-structure
+
+  tag-html-style:
     - match: (<)((?i:style)){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
       push: style-css
+
+  tag-html-script:
     - match: (<)((?i:script)){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
       push: script-javascript
-    - match: (</?)((?i:body|head|html){{tag_name_break}})
+
+  tag-html-structure:
+    - match: (</?)({{html_structure_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.any.html
@@ -76,15 +162,9 @@ contexts:
         - meta_scope: meta.tag.structure.any.html
         - include: tag-end
         - include: tag-attributes
-    - match: (</?)({{block_tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.any.html
-      push:
-        - meta_scope: meta.tag.block.any.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</?)((?i:hr){{tag_name_break}})
+
+  tag-html-block:
+    - match: (</?)({{html_block_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
@@ -100,7 +180,9 @@ contexts:
         - meta_scope: meta.tag.block.form.html
         - include: tag-end
         - include: tag-attributes
-    - match: (</?)({{inline_tag_name}})
+
+  tag-html-inline:
+    - match: (</?)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
@@ -108,7 +190,7 @@ contexts:
         - meta_scope: meta.tag.inline.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)({{form_tag_name}})
+    - match: (</?)({{html_forms_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
@@ -116,15 +198,7 @@ contexts:
         - meta_scope: meta.tag.inline.form.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:a){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.a.html
-      push:
-        - meta_scope: meta.tag.inline.a.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr){{tag_name_break}})
+    - match: (</?)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -31,7 +31,6 @@ variables:
     | {{html_script_tags}}
     | {{html_web_tags}}
     | {{html_header_tags}}
-    | {{html_deprecated_tags}}
     )
 
   html_block_tags_selfclosing: |-
@@ -177,6 +176,7 @@ contexts:
         | ({{html_table_tags}})
         | ({{html_forms_tags}})
         | ({{html_structure_tags}})
+        | ({{html_deprecated_tags}})
         )
       captures:
         1: punctuation.definition.tag.begin.html
@@ -185,6 +185,7 @@ contexts:
         4: entity.name.tag.table.html
         5: entity.name.tag.form.html
         6: entity.name.tag.structure.html
+        7: entity.name.tag.deprecated.html
       push: tag-html-any-closing-attributes
 
   tag-html-any-closing-attributes:
@@ -226,6 +227,8 @@ contexts:
         | ({{html_block_tags_selfclosing}})
         | ({{html_table_tags_selfclosing}})
         | ({{html_forms_tags_selfclosing}})
+        # don't highlight illegal self-closing punctuation
+        | ({{html_deprecated_tags}})
         )
       captures:
         1: punctuation.definition.tag.begin.html
@@ -233,6 +236,7 @@ contexts:
         3: entity.name.tag.block.html
         4: entity.name.tag.table.html
         5: entity.name.tag.form.html
+        6: entity.name.tag.deprecated.html
       push: tag-html-any-selfclosing-attributes
 
   tag-html-any-selfclosing-attributes:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -64,7 +64,7 @@ variables:
   #  <head> is moved to `html_structure_tags`
   #  <script> and <style> are handled by dedicated matches
   html_header_tags: |-
-    (?xi: base (?# | script | style ) | title ){{tag_name_break}}
+    (?xi: base | script | style | title ){{tag_name_break}}
   html_header_tags_selfclosing: |-
     (?xi: link | meta ){{tag_name_break}}
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -33,6 +33,12 @@ variables:
     | {{html_deprecated_tags}}
     )
 
+  html_block_tags_selfclosing: |-
+    (?x:
+      {{html_text_content_tags_selfclosing}}
+    | {{html_embedded_tags_selfclosing}}
+    )
+
   html_inline_tags: |-
     (?x:
       {{html_text_semantic_tags}}
@@ -42,6 +48,12 @@ variables:
     | {{html_script_tags}}
     )
 
+  html_inline_tags_selfclosing: |-
+    (?x:
+      {{html_text_semantic_tags_selfclosing}}
+    | {{html_media_tags_selfclosing}}
+    )
+
   # Aggregates structural root notes from
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
@@ -49,9 +61,13 @@ variables:
   html_structure_tags: |-
     (?xi: html | head | body ){{tag_name_break}}
 
-  # Note: <head> is moved to `html_structure_tags`
+  # Note:
+  #  <head> is moved to `html_structure_tags`
+  #  <script> and <style> are handled by dedicated matches
   html_header_tags: |-
-    (?xi: base | link | meta | script | style | title ){{tag_name_break}}
+    (?xi: base (?# | script | style ) | title ){{tag_name_break}}
+  html_header_tags_selfclosing: |-
+    (?xi: link | meta ){{tag_name_break}}
 
   html_section_tags: |-
     (?xi:
@@ -61,39 +77,51 @@ variables:
 
   html_text_content_tags: |-
     (?xi:
-      blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+      blockquote | cite | dd | dt | dl | div | figcaption | figure | li
     | ol | p | pre | ul
     ){{tag_name_break}}
+  html_text_content_tags_selfclosing: |-
+    (?xi: hr ){{tag_name_break}}
 
   html_text_semantic_tags: |-
     (?xi:
-      a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+      a | abbr | b | bdi | bdo | code | data | time | dfn | em | i | kbd
     | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
     | sub | sup | u | var | wbr
     ){{tag_name_break}}
+  html_text_semantic_tags_selfclosing: |-
+    (?xi: br ){{tag_name_break}}
 
   html_media_tags: |-
-    (?xi: area | audio | img | map | track | video ){{tag_name_break}}
+    (?xi: audio | map | video ){{tag_name_break}}
+  html_media_tags_selfclosing: |-
+    (?xi: area | img | track ){{tag_name_break}}
 
   html_embedded_tags: |-
-    (?xi: embed | iframe | object | param | picture | source ){{tag_name_break}}
+    (?xi: iframe | object | picture ){{tag_name_break}}
+  html_embedded_tags_selfclosing: |-
+    (?xi: embed | param | source ){{tag_name_break}}
 
   html_script_tags: |-
-    (?xi: canvas | noscript  script ){{tag_name_break}}
+    (?xi: canvas | noscript (?# | script ) ){{tag_name_break}}
 
   html_markup_tags: |-
     (?xi: del | ins ){{tag_name_break}}
 
   html_table_tags: |-
     (?xi:
-      caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+      caption | colgroup | table | tbody | tr | td | tfoot | th | thead
     ){{tag_name_break}}
+  html_table_tags_selfclosing: |-
+    (?xi: col ){{tag_name_break}}
 
   html_forms_tags: |-
     (?xi:
-      button | datalist | option | fieldset | label | form | input | legend
+      button | datalist | option | fieldset | label | form | legend
     | meter | optgroup | select | output | progress | textarea
     ){{tag_name_break}}
+  html_forms_tags_selfclosing: |-
+    (?xi: input ){{tag_name_break}}
 
   html_interactive_tags: |-
     (?xi: details | dialog | menu | summary ){{tag_name_break}}
@@ -133,18 +161,88 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - include: tag-html-style
-    - include: tag-html-script
-    - include: tag-html-block
     - include: tag-html-inline
+    - include: tag-html-block
+    - include: tag-html-table
+    - include: tag-html-script
+    - include: tag-html-style
+    - include: tag-html-form
     - include: tag-html-structure
 
-  tag-html-style:
-    - match: (<)((?i:style)){{tag_name_break}}
+  tag-html-block:
+    - match: (<)({{html_block_tags_selfclosing}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push: style-css
+        2: entity.name.tag.block.html
+      push:
+        - meta_scope: meta.tag.block.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (<)({{html_block_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.html
+      push:
+        - meta_scope: meta.tag.block.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_block_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.html
+      push:
+        - meta_scope: meta.tag.block.end.html
+        - include: tag-end
+
+  tag-html-form:
+    - match: (<)({{html_forms_tags_selfclosing}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (<)({{html_forms_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_forms_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.end.html
+        - include: tag-end
+
+  tag-html-inline:
+    - match: (<)({{html_inline_tags_selfclosing}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.inline.html
+      push:
+        - meta_scope: meta.tag.inline.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (<)({{html_inline_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.inline.html
+      push:
+        - meta_scope: meta.tag.inline.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_inline_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.inline.html
+      push:
+        - meta_scope: meta.tag.inline.end.html
+        - include: tag-end
 
   tag-html-script:
     - match: (<)((?i:script)){{tag_name_break}}
@@ -153,59 +251,54 @@ contexts:
         2: entity.name.tag.script.html
       push: script-javascript
 
+  tag-html-style:
+    - match: (<)((?i:style)){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+      push: style-css
+
   tag-html-structure:
-    - match: (</?)({{html_structure_tags}})
+    - match: (<)({{html_structure_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.structure.any.html
+        2: entity.name.tag.structure.html
       push:
-        - meta_scope: meta.tag.structure.any.html
+        - meta_scope: meta.tag.structure.begin.html
         - include: tag-end
         - include: tag-attributes
+    - match: (</)({{html_structure_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.structure.html
+      push:
+        - meta_scope: meta.tag.structure.end.html
+        - include: tag-end
 
-  tag-html-block:
-    - match: (</?)({{html_block_tags}})
+  tag-html-table:
+    - match: (<)({{html_table_tags_selfclosing}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.any.html
+        2: entity.name.tag.table.html
       push:
-        - meta_scope: meta.tag.block.any.html
+        - meta_scope: meta.tag.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)({{html_table_tags}})
+    - match: (<)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.table.html
+        2: entity.name.tag.table.html
       push:
-        - meta_scope: meta.tag.block.table.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)((?i:form|fieldset){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.form.html
-      push:
-        - meta_scope: meta.tag.block.form.html
+        - meta_scope: meta.tag.table.begin.html
         - include: tag-end
         - include: tag-attributes
-
-  tag-html-inline:
-    - match: (</?)({{html_inline_tags}})
+    - match: (</)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.any.html
+        2: entity.name.tag.table.html
       push:
-        - meta_scope: meta.tag.inline.any.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)({{html_forms_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.form.html
-      push:
-        - meta_scope: meta.tag.inline.form.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
+        - meta_scope: meta.tag.table.end.html
+        - include: tag-end
 
 ###[ OTHER TAG ]##############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -323,12 +323,12 @@ contexts:
 
   script-javascript:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: script-close-tag
         - include: script-javascript-content
+    - include: script-common
 
   script-javascript-content:
     - match: (?=\S)
@@ -338,7 +338,6 @@ contexts:
 
   script-html:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
@@ -346,13 +345,14 @@ contexts:
         - include: comment
         - include: script-close-tag
         - include: main
+    - include: script-common
 
   script-other:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-close-tag
+    - include: script-common
 
   script-close-tag:
     - match: <!--
@@ -373,7 +373,7 @@ contexts:
   script-common:
     - include: script-type-attribute
     - include: tag-attributes
-    - include: tag-end-self-closing
+    - include: tag-end
 
   script-type-attribute:
     - match: (?i:type){{attribute_name_break}}
@@ -419,12 +419,12 @@ contexts:
 
   style-css:
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
         - include: style-close-tag
         - include: style-css-content
+    - include: style-common
 
   style-css-content:
     - match: ''
@@ -434,10 +434,10 @@ contexts:
 
   style-other:
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-close-tag
+    - include: style-common
 
   style-close-tag:
     - match: (</)((?i:style){{tag_name_break}})
@@ -452,7 +452,7 @@ contexts:
   style-common:
     - include: style-type-attribute
     - include: tag-attributes
-    - include: tag-end-self-closing
+    - include: tag-end
 
   style-type-attribute:
     - match: (?i:type){{attribute_name_break}}

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -249,29 +249,53 @@ contexts:
   tag-other:
     - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
-      push:
-        - tag-other-opening
-        - tag-other-name
+      branch_point: tag-other
+      branch:
+        - tag-other-maybe-opening
+        - tag-other-otherwise-selfclosing
     - match: </(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-other-closing
+        - tag-other-closing-content
         - tag-other-name
+
+  tag-other-closing-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.closing.html
+    - include: tag-end
+
+  tag-other-maybe-opening:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.opening.html
+    - match: ''
+      set:
+        - tag-other-opening-content
+        - tag-other-name
+
+  tag-other-opening-content:
+    - meta_scope: meta.tag.other.opening.html
+    - match: (?=/>)
+      fail: tag-other
+    - include: tag-end
+    - include: tag-attributes
+
+  tag-other-otherwise-selfclosing:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.selfclosing.html
+    - match: ''
+      set:
+        - tag-other-selfclosing-content
+        - tag-other-name
+
+  tag-other-selfclosing-content:
+    - meta_scope: meta.tag.other.selfclosing.html
+    - include: tag-end-self-closing
+    - include: tag-attributes
 
   tag-other-name:
     - meta_content_scope: entity.name.tag.other.html
     - match: '{{tag_name_break}}'
       pop: 1
-
-  tag-other-opening:
-    - meta_scope: meta.tag.other.opening.html
-    - include: tag-end-maybe-self-closing
-    - include: tag-attributes
-
-  tag-other-closing:
-    - meta_include_prototype: false
-    - meta_scope: meta.tag.other.closing.html
-    - include: tag-end
 
 ###[ HTML SCRIPT TAG ]########################################################
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -625,7 +625,7 @@ class="foo"></div>
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.other.opening.html - invalid
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.selfclosing.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
         ##                ^ - meta.tag - punctuation.definition.tag
 
@@ -650,7 +650,7 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
 
         <A{{template}} {{attr}}={{value}} />
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.opening.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.selfclosing.html
         ## ^^^^^^^^^^^ entity.name.tag.other.html
         ##             ^^^^^^^^ entity.other.attribute-name.html
         ##                     ^ punctuation.separator.key-value.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -216,7 +216,8 @@
         ##      ^^^^ entity.other.attribute-name
         ##      ^^^^^^^^^^^^^^ meta.attribute-with-value
         ##           ^^^^^^^^^ string.unquoted
-        ##                    ^^ punctuation.definition.tag.end.html
+        ##                    ^ invalid.illegal
+        ##                     ^ punctuation.definition.tag.end.html
 
         <img title/>
         ##  ^ - meta.attribute-with-value

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -113,8 +113,8 @@
         ## <- meta.tag.html.closing.html punctuation.definition.tag.end.html
 
         <style type="text/css"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
-        ## ^ entity.name.tag.style.html
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.html.opening.html
+        ## ^ entity.name.tag.block.html
         ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
         ##      ^ entity.other.attribute-name
         ##                     ^ - meta.tag
@@ -127,8 +127,8 @@
             }
         --> </style>
         ## <- - comment
-        ##  ^^^^^^^^ meta.tag.style.end.html - source.css.embedded.html
-        ##    ^^^^^ entity.name.tag.style.html
+        ##  ^^^^^^^^ meta.tag.html.closing.html - source.css.embedded.html
+        ##    ^^^^^ entity.name.tag.block.html
         ##          ^ - meta.tag
 
         <style
@@ -146,12 +146,12 @@
             div {}
         ##  ^^^^^^ - source.css
         </style
-        ##^^^^^ meta.tag.style.end.html entity.name.tag.style.html
+        ##^^^^^ meta.tag.html.closing.html entity.name.tag.block.html
         >
-        ## <- meta.tag.style.end.html punctuation.definition.tag.end.html
+        ## <- meta.tag.html.closing.html punctuation.definition.tag.end.html
         <style />
         ##       ^ - source.css.embedded.html
-        ## ^ meta.tag.style entity.name.tag.style
+        ## ^ meta.tag.html.opening.html entity.name.tag.block.html
         <script />
         ##        ^ - source.js.embedded.html
         ## ^ meta.tag.html.opening.html entity.name.tag.block.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -82,7 +82,8 @@
             comment -->
         ##  ^^^^^^^^^^^ text.html.embedded.html comment.block.html
             <div></div>
-        ##  ^^^^^^^^^^^ text.html.basic text.html.embedded meta.tag.block.any
+        ##  ^^^^^ text.html.embedded.html meta.tag.block.begin.html
+        ##       ^^^^^^ text.html.embedded.html meta.tag.block.end.html
             <script type=text/javascript>
         ##  ^ text.html.basic text.html.embedded.html - source.js.embedded.html
                 function test() {}
@@ -586,8 +587,8 @@ class="foo"></div>
         ##                   ^ meta.function-call.js support.function
 
         <article><span><othertag></othertag><othertag /></span></article>
-        ## ^^^^^ entity.name.tag.block.any.html
-        ##        ^^^^ entity.name.tag.inline.any.html
+        ## ^^^^^ entity.name.tag.block.html
+        ##        ^^^^ entity.name.tag.inline.html
         ##              ^^^^^^^^ entity.name.tag.other.html
         ##                                           ^ - punctuation.definition.tag.end.html
         ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
@@ -667,38 +668,38 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag
 
         <form name="formName" type="post">
-        ## ^ entity.name.tag.block.form.html
+        ## ^ entity.name.tag.form.html
         ## <- punctuation.definition.tag.begin.html
         ##                               ^ punctuation.definition.tag.end.html
             <label for="inputId">
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
             ##     ^ entity.other.attribute-name.html
             ##        ^ punctuation.separator.key-value.html
             <input id="inputId" type="text" value="value">
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
             ##                   ^ entity.other.attribute-name.html
             <textarea name="texareaName"></textarea>
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
         </form>
 
         <table border="0" cellspacing="0" cellpadding="2" class="editor">
-        ## ^ entity.name.tag.block.table.html
+        ## ^ entity.name.tag.table.html
             <thead>
-            ## ^ entity.name.tag.block.table.html
+            ## ^ entity.name.tag.table.html
                 <tr>
-            ##   ^ entity.name.tag.block.table.html
+            ##   ^ entity.name.tag.table.html
                     <th> </th>
                 </tr>
             </thead>
-            ## ^ entity.name.tag.block.table.html
+            ## ^ entity.name.tag.table.html
             <tfoot>
-            ## ^ entity.name.tag.block.table.html
+            ## ^ entity.name.tag.table.html
                 <tr>
                     <td> </td>
-                    ##^ entity.name.tag.block.table.html
+                    ##^ entity.name.tag.table.html
                 </tr>
             </tfoot>
-            ## ^ entity.name.tag.block.table.html
+            ## ^ entity.name.tag.table.html
             <tbody>
                 <tr>
                     <td> </td>
@@ -749,14 +750,14 @@ class="foo"></div>
         ##                                     ^ punctuation.separator.path.html
 
         <hr/><hr />
-        ## ^^ meta.tag.block.any punctuation.definition.tag.end
-        ##    ^^ entity.name.tag.block.any
+        ## ^^ meta.tag.block punctuation.definition.tag.end
+        ##    ^^ entity.name.tag.block
         ##       ^^ punctuation.definition.tag.end
 
         # make sure to stop tag names before the next < to prevent php
         # and other syntaxes from breaking.
         <article<?php>
-        ##^^^^^^ entity.name.tag.block.any.html
+        ##^^^^^^ entity.name.tag.block.html
         ##      ^^^^^^ - entity.name.tag
 
         <_notag>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -31,8 +31,8 @@
         <title>Test HTML</title>
 
         <script> <!--
-        ## ^^^^^ meta.tag.script.begin.html
-        ## ^ entity.name.tag.script - source.js.embedded.html
+        ## ^^^^^ meta.tag.html.opening.html
+        ## ^ entity.name.tag.block - source.js.embedded.html
         ##       ^^^^ comment.block.html punctuation.definition.comment.begin.html
             var foo = 100;
             ## <- source.js.embedded.html - source.js source.js
@@ -44,13 +44,13 @@
             ## ^^^ source.js.embedded.html meta.group.js keyword.operator
         --> </script>
         ## <- comment.block.html punctuation.definition.comment.end.html
-        ##    ^^^^^^ entity.name.tag.script.html
-        ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##    ^^^^^^ entity.name.tag.block.html
+        ##  ^^^^^^^^^ meta.tag.html.closing.html - source.js.embedded.html
         ##           ^ - meta.tag
 
         <script type="text/javascript"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
-        ## ^ entity.name.tag.script - source.js.embedded.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.html.opening.html
+        ## ^ entity.name.tag.block - source.js.embedded.html
         ##            ^ string.quoted.double.html - source.js.embedded.html
         ##                              ^^^^ comment.block.html punctuation.definition.comment.begin.html
             var foo = 100;
@@ -62,8 +62,8 @@
             ## ^^^ source.js.embedded.html meta.group.js keyword.operator
         --> </script>
         ## <- comment.block.html punctuation.definition.comment.end.html
-        ##    ^^^^^^ entity.name.tag.script.html
-        ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
+        ##    ^^^^^^ entity.name.tag.block.html
+        ##  ^^^^^^^^^ meta.tag.html.closing.html - source.js.embedded.html
         ##           ^ - meta.tag
 
         <script
@@ -75,8 +75,8 @@
         </script>
 
         <script type = "text/html"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
-        ## ^ entity.name.tag.script - text.html.embedded.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.html.opening.html
+        ## ^ entity.name.tag.block - text.html.embedded.html
         ##             ^ string.quoted.double.html - text.html.embedded.html
         ##                          ^^^^ comment.block.html punctuation
             comment -->
@@ -89,16 +89,16 @@
                 function test() {}
         ##  ^ text.html.basic text.html.embedded.html source.js.embedded.html - source.js source.js
             </script>
-        ##  ^^^^^^^^^ text.html.basic text.html.embedded.html meta.tag.script.end
+        ##  ^^^^^^^^^ text.html.basic text.html.embedded.html meta.tag.html.closing
         </script>
 ##     ^ text.html.basic text.html.embedded.html
-##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.script.end
+##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.html.closing
 ##               ^ text.html.basic - text.html.embedded.html
 
         <script>42</script >
-##      ^^^^^^^^ meta.tag.script.begin
+##      ^^^^^^^^ meta.tag.html.opening
 ##              ^^ source.js.embedded.html - source.js source.js
-##                ^^^^^^^^^^ meta.tag.script.end
+##                ^^^^^^^^^^ meta.tag.html.closing
 
         <script
         type
@@ -108,9 +108,9 @@
             var foo = 100;
         ##  ^^^^^^^^^^^^^^^ - source.js
         </script
-        ##^^^^^^ meta.tag.script.end.html entity.name.tag.script.html
+        ##^^^^^^ meta.tag.html.closing.html entity.name.tag.block.html
         >
-        ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
+        ## <- meta.tag.html.closing.html punctuation.definition.tag.end.html
 
         <style type="text/css"> <!--
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
@@ -154,7 +154,7 @@
         ## ^ meta.tag.style entity.name.tag.style
         <script />
         ##        ^ - source.js.embedded.html
-        ## ^ meta.tag.script entity.name.tag.script
+        ## ^ meta.tag.html.opening.html entity.name.tag.block.html
     </head>
     <body>
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -592,7 +592,7 @@ class="foo"></div>
         ##        ^^^^ entity.name.tag.inline.html
         ##              ^^^^^^^^ entity.name.tag.other.html
         ##                                           ^ - punctuation.definition.tag.end.html
-        ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
+        ##                                            ^^ punctuation.definition.tag.end.html
 
         <body·other attrib=1/>
         ## ^^^^^^^^ entity.name.tag.other.html
@@ -625,9 +625,9 @@ class="foo"></div>
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.other.html - invalid
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.begin.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
-        ##                ^ - meta.tag.other.html - punctuation.definition.tag.end.html
+        ##                ^ - meta.tag - punctuation.definition.tag
 
         <body-custom·tag₡name/>
         ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
@@ -650,7 +650,7 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
 
         <A{{template}} {{attr}}={{value}} />
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.begin.html
         ## ^^^^^^^^^^^ entity.name.tag.other.html
         ##             ^^^^^^^^ entity.other.attribute-name.html
         ##                     ^ punctuation.separator.key-value.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -682,23 +682,23 @@ class="foo"></div>
         </form>
 
         <table border="0" cellspacing="0" cellpadding="2" class="editor">
-        ## ^ entity.name.tag.inline.table.html
+        ## ^ entity.name.tag.block.table.html
             <thead>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.block.table.html
                 <tr>
-            ##   ^ entity.name.tag.inline.table.html
+            ##   ^ entity.name.tag.block.table.html
                     <th> </th>
                 </tr>
             </thead>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.block.table.html
             <tfoot>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.block.table.html
                 <tr>
                     <td> </td>
-                    ##^ entity.name.tag.inline.table.html
+                    ##^ entity.name.tag.block.table.html
                 </tr>
             </tfoot>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.block.table.html
             <tbody>
                 <tr>
                     <td> </td>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -82,8 +82,8 @@
             comment -->
         ##  ^^^^^^^^^^^ text.html.embedded.html comment.block.html
             <div></div>
-        ##  ^^^^^ text.html.embedded.html meta.tag.block.begin.html
-        ##       ^^^^^^ text.html.embedded.html meta.tag.block.end.html
+        ##  ^^^^^ text.html.embedded.html meta.tag.html.opening.html
+        ##       ^^^^^^ text.html.embedded.html meta.tag.html.closing.html
             <script type=text/javascript>
         ##  ^ text.html.basic text.html.embedded.html - source.js.embedded.html
                 function test() {}
@@ -625,7 +625,7 @@ class="foo"></div>
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.other.begin.html - invalid
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.opening.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
         ##                ^ - meta.tag - punctuation.definition.tag
 
@@ -650,7 +650,7 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
 
         <A{{template}} {{attr}}={{value}} />
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.begin.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.opening.html
         ## ^^^^^^^^^^^ entity.name.tag.other.html
         ##             ^^^^^^^^ entity.other.attribute-name.html
         ##                     ^ punctuation.separator.key-value.html
@@ -751,7 +751,9 @@ class="foo"></div>
         ##                                     ^ punctuation.separator.path.html
 
         <hr/><hr />
-        ## ^^ meta.tag.block punctuation.definition.tag.end
+        ##<- meta.tag.html.selfclosing.html
+        ##^^^^^^^^^ meta.tag.html.selfclosing.html
+        ## ^^ punctuation.definition.tag.end
         ##    ^^ entity.name.tag.block
         ##       ^^ punctuation.definition.tag.end
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -152,9 +152,12 @@
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.html.opening.html entity.name.tag.block.html
-        <script />
-        ##        ^ - source.js.embedded.html
-        ## ^ meta.tag.html.opening.html entity.name.tag.block.html
+
+        </style>
+        ## ^ meta.tag.html.closing.html entity.name.tag.block.html
+
+        </script>
+        ## ^ meta.tag.html.closing.html entity.name.tag.block.html
     </head>
     <body>
 

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1524,9 +1524,10 @@ contexts:
   disable-markdown-pop-at-tag:
     - match: (</)(\1)(>)
       captures:
-        1: meta.tag.block.any.html punctuation.definition.tag.begin.html
-        2: meta.tag.block.any.html entity.name.tag.block.any.html
-        3: meta.tag.block.any.html punctuation.definition.tag.end.html
+        0: meta.tag.html.closing.html
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.html
+        3: punctuation.definition.tag.end.html
       pop: true
     - include: disable-markdown
   disable-markdown-pop-after-tag:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -325,7 +325,7 @@ non-disabled markdown
 <div>this is HTML until there are two blank lines
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
 still <span>HTML</span>
-|      ^^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+|      ^^^^ entity.name.tag.inline.html
 </div>
 | ^^^^ meta.disable-markdown
 
@@ -333,14 +333,14 @@ non-disabled markdown
 | <- - meta.disable-markdown
 
 <pre>nested tags don't count <pre>test</pre>
-|                                     ^^^^^^ meta.disable-markdown meta.tag.block.any.html
+|                                     ^^^^^^ meta.disable-markdown meta.tag.html.closing.html
 non-disabled markdown
 | <- - meta.disable-markdown
 
 <div>nested tags don't count <div>test
 |                                 ^^^^^ meta.disable-markdown
 </div>
-| ^^^ meta.disable-markdown entity.name.tag.block.any.html
+| ^^^ meta.disable-markdown entity.name.tag.block.html
 
 non-disabled markdown
 | <- - meta.disable-markdown
@@ -355,7 +355,8 @@ non-disabled markdown
 
 <div>another</div> <span>disable</span> test
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-|                  ^^^^^^ meta.tag.inline.any.html
+|                  ^^^^^^ meta.tag.html.opening.html
+|                               ^^^^^^^ meta.tag.html.closing.html
 disabled markdown
 | <- meta.disable-markdown
 
@@ -646,7 +647,7 @@ because it doesn't begin with the number one:
 
 - `code` - <a name="demo"></a>
 | ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.html
  3. [see `demo`](#demo "demo")
 | ^ punctuation.definition.list_item
 |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
@@ -709,38 +710,38 @@ because it doesn't begin with the number one:
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.html.opening.html
+|                              ^^^^^^^ meta.tag.html.closing.html
 
 _italic text <SPAN>HTML element</SPAN> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.html.opening.html
+|                              ^^^^^^^ meta.tag.html.closing.html
 
 **bold text <span>HTML element</span> end of bold text**
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.html.opening.html
+|                             ^^^^^^^ meta.tag.html.closing.html
 
 __bold text <span>HTML element</span> end of bold text__
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.html.opening.html
+|                             ^^^^^^^ meta.tag.html.closing.html
 
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.html.opening.html
+|                              ^^^^^^^ meta.tag.html.closing.html
 
 _italic text <span>HTML element</span> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.html.opening.html
+|                              ^^^^^^^ meta.tag.html.closing.html
 
 [link [containing] [square] brackets](#backticks)
 |<- punctuation.definition.link.begin
@@ -758,7 +759,7 @@ _italic text <span>HTML element</span> end of italic text_
 |                                                     ^^ punctuation.definition.raw.end
 |                                                       ^ punctuation.definition.link.end
 `inline markup <span></span>`
-|              ^^^^^^^^^^^^^ markup.raw.inline - meta.tag.inline.any.html
+|              ^^^^^^^^^^^^^ markup.raw.inline - meta.tag.html.opening.html
 escaped backtick \`this is not code\`
 |                ^^ constant.character.escape
 |                                  ^^ constant.character.escape
@@ -785,7 +786,7 @@ http://spec.commonmark.org/0.28/#example-324
 
 http://spec.commonmark.org/0.28/#example-325
 <a href="`">`
-| ^^^^^^^^^ meta.tag.inline.a
+| ^^^^^^^^^^ meta.tag.html.opening.html
 |           ^ punctuation.definition.raw.begin
 
 | <- invalid.illegal.non-terminated.raw
@@ -1673,7 +1674,7 @@ abc
 | --- | --- |
 | baz | bim <kbd>Ctrl+C</kbd> |
 | <- meta.block-level meta.table punctuation.separator.table-cell
-|           ^^^^^ meta.tag.inline.any
+|           ^^^^^ meta.tag.html.opening.html
 |                             ^ punctuation.separator.table-cell
 
 | <- - meta.block-level - meta.table
@@ -1858,7 +1859,7 @@ http://spec.commonmark.org/0.28/#example-120
 | ^^^^^^^ meta.paragraph markup.italic - meta.disable-markdown
 
 </DIV>
-| ^^^ meta.disable-markdown meta.tag.block.any.html
+| ^^^ meta.disable-markdown meta.tag.html.closing.html
 
 http://spec.commonmark.org/0.28/#example-127
 
@@ -1886,18 +1887,18 @@ http://spec.commonmark.org/0.28/#example-131
 *bar*
 |^^^^^ meta.disable-markdown
 </Warning>
-| ^^^^^^^ meta.disable-markdown meta.tag.other.html entity.name.tag.other.html
+| ^^^^^^^ meta.disable-markdown meta.tag.other.closing.html entity.name.tag.other.html
 
 http://spec.commonmark.org/0.28/#example-135
 
 <del>
-| ^^ meta.disable-markdown meta.tag.inline.any.html entity.name.tag.inline.any.html
+| ^^ meta.disable-markdown meta.tag.html.opening.html entity.name.tag.inline.html
 
 *foo*
 | ^^ meta.paragraph markup.italic
 
 </del>
-| ^^^ meta.disable-markdown meta.tag.inline.any.html entity.name.tag.inline.any.html
+| ^^^ meta.disable-markdown meta.tag.html.closing.html entity.name.tag.inline.html
 
 <del>
 *foo*
@@ -1907,15 +1908,15 @@ http://spec.commonmark.org/0.28/#example-135
 http://spec.commonmark.org/0.28/#example-136
 
 <del>*foo*</del>
-| ^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+| ^^ meta.tag.html.opening.html entity.name.tag.inline.html
 |    ^^^^^ markup.italic
-|           ^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+|           ^^^ meta.tag.html.closing.html entity.name.tag.inline.html
 |^^^^^^^^^^^^^^^ meta.paragraph - meta.disable-markdown
 
 http://spec.commonmark.org/0.28/#example-137
 
 <pre language="haskell"><code>
-| ^^ meta.disable-markdown meta.tag.block.any.html entity.name.tag.block.any.html
+| ^^ meta.disable-markdown meta.tag.html.opening.html entity.name.tag.block.html
 import Text.HTML.TagSoup
 
 main :: IO ()
@@ -1923,21 +1924,21 @@ main :: IO ()
 main = print $ parseTags tags
 </code></pre>
 | ^^^^^^^^^^^ meta.disable-markdown
-|        ^^^ meta.tag.block.any.html entity.name.tag.block.any.html
+|        ^^^ meta.tag.html.closing.html entity.name.tag.block.html
 okay
 | <- - meta.disable-markdown
 
 http://spec.commonmark.org/0.28/#example-138
 
 <script type="text/javascript">
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.script.begin.html
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.html.opening.html
 // JavaScript example
 | ^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown source.js.embedded.html comment.line.double-slash.js
 
 document.getElementById("demo").innerHTML = "Hello JavaScript!";
 | ^^^^^^ meta.disable-markdown source.js.embedded.html support.type.object.dom.js
 </script>
-| ^^^^^^ meta.disable-markdown meta.tag.script.end.html entity.name.tag.script.html
+| ^^^^^^ meta.disable-markdown meta.tag.html.closing.html entity.name.tag.block.html
 okay
 | <- - meta.disable-markdown
 
@@ -1945,14 +1946,14 @@ http://spec.commonmark.org/0.28/#example-139
 
 <style
   type="text/css">
-| ^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.style.begin.html meta.attribute-with-value.html
+| ^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.html.opening.html meta.attribute-with-value.html
 h1 {color:red;}
 |   ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
 
 p {color:blue;}
 |  ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
 </style>
-| ^^^^^ meta.disable-markdown meta.tag.style.end.html entity.name.tag.style.html
+| ^^^^^ meta.disable-markdown meta.tag.html.closing.html entity.name.tag.block.html
 okay
 | <- - meta.disable-markdown
 
@@ -2103,7 +2104,7 @@ var_dump(expression);
 
 ```html+php
 <div></div>
-|^^^ entity.name.tag.block.any.html
+|^^^ entity.name.tag.block.html
 <?php
 |^^^^ punctuation.section.embedded.begin.php
 var_dump(expression);

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1993,7 +1993,7 @@ var_dump(new C(42));
 //                                                   ^^ punctuation.section.embedded.end
 
   <tag-<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.selfclosing.html
 //^ punctuation.definition.tag.begin.html
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
 //     ^^^^^ punctuation.section.embedded.begin.php
@@ -2010,7 +2010,7 @@ var_dump(new C(42));
 //                                                              ^^ punctuation.definition.tag.end.html
 
   <tag<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.selfclosing.html
 //^ punctuation.definition.tag.begin.html
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
 //    ^^^^^ punctuation.section.embedded.begin.php

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -134,7 +134,7 @@ puts <<-HTML; # comment
 #           ^ punctuation.terminator.statement.ruby - meta.string
 #             ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
   <body>
-# ^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag.structure
+# ^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag
     #{ sym } #@var
 #  ^ meta.string.heredoc.ruby text.html.embedded.ruby - meta.interpolation
 #   ^^^^^^^^ meta.string.heredoc.ruby meta.interpolation.ruby
@@ -147,7 +147,7 @@ puts <<-HTML; # comment
 #            ^^ punctuation.definition.variable.ruby
 #            ^^^^^ variable.other.readwrite.instance.ruby
   </body>
-# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag.structure.any.html
+# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag
   HTML
 # ^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #     ^ - meta.string - string.unquoted


### PR DESCRIPTION
This PR illustrates the ideas of #2772.

1. Missing builtin html tags are added by reusing html tag name variables from CSS.sublime-syntax. The `html_..._tags` variables variables are used to categorize tags according to MDN documentation.

2. Meta scope scheme of tags is changed to `meta.tag.[html|sgml|...|other].[opening|closing|selfclosing]`.
   
   The motivation behind it is, that `meta.tag.[block|inline|structure|...]` don't provide enough details for useful code intelligence features or something like that, while the information about opening or closing tags in general might help in some situations.

   The 3rd level scope `[html|sgml|...|other]` is meant to distinguish between main types of tags.
   
   Not sure if it should be mixed with opening/closing though.

3. New tag scope scheme allows illegal highlighting of self closing tags in those which don't support it (e.g.: `<html/>`).

4. Tag names use `entity.name.tag.[block|form|inline|structure|table]` to provide some possibilities to assign different teg name colors based on category. Current implementation makes it more easy to modify this scheme, if needed.

5. Script/Style tags are modified to match the new scope scheme accordingly.

#### Notes:

1. Some test files needed to be tweaked outside of HTML package
2. The changes don't impact performance.