### PR TITLE
[Markdown] Rewrite MultiMarkdown

### DIFF
--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -1,29 +1,37 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
-version: 2
 name: MultiMarkdown
-first_line_match: (?i)^format:\s*complete\s*$
 scope: text.html.markdown.multimarkdown
+
+extends: Packages/Markdown/Markdown.sublime-syntax
+
+first_line_match: (?i:^format:\s*complete\s*$)
+
 variables:
-  header: ((?=[A-Za-z0-9])[\w -]+)(:)
+  header: ([A-Za-z0-9][\w -]*)(:)
+
 contexts:
   main:
-    - match: '^{{header}}\s*'
+    - match: ^(?={{header}})
+      push: multimarkdown-header
+    - match: ^
+      set: multimarkdown-content
+
+  multimarkdown-header:
+    - match: ^$
+      pop: 1
+    - match: ^(?:{{header}}\s*)?
       captures:
         1: keyword.other.multimarkdown
         2: punctuation.separator.key-value.multimarkdown
-      push:
-        - meta_scope: meta.header.multimarkdown
-        - match: '^$|^(?={{header}})'
-          pop: true
-        - match: .+
-          comment: |
-            The reason for not setting scopeName = "string.unquoted"
-                                    (for the parent rule) is that we do not want
-                                    newlines to be marked as string.unquoted
-          scope: string.unquoted.multimarkdown
-    - match: ''
-      push:
-        - - meta_scope: meta.content.multimarkdown
-        - scope:text.html.markdown
+      push: multimarkdown-header-value
+
+  multimarkdown-header-value:
+    - meta_scope: meta.header.multimarkdown
+    - meta_content_scope: string.unquoted.multimarkdown
+    - match: \n
+      pop: 1
+
+  multimarkdown-content:
+    - meta_scope: meta.content.multimarkdown
+    - include: markdown

--- a/Markdown/syntax_test_multimarkdown.md
+++ b/Markdown/syntax_test_multimarkdown.md
@@ -29,7 +29,8 @@ HTML Header: <style>
              </style>
 T:           ^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
 
-T: <- meta.content.multimarkdown - meta.header.multimarkdown
+T: 
+| <- meta.content.multimarkdown - meta.header.multimarkdown
 # Heading
 | <- markup.heading punctuation.definition.heading
 |^^^^^^^^ markup.heading


### PR DESCRIPTION
This commit rewrites the little MultiMarkdown.sublime-syntax by extending Markdown. 

1. Reduces the number of lookaheads used to find the end of meta data value contexts. Only the first header key needs a lookahead now.
2. Adds named contexts for everything