### PR TITLE
[Markdown] Update to sublime syntax version 2

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1,18 +1,21 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# This definition aims to meet CommonMark specifications http://spec.commonmark.org/
+# with GitHub Formatted Markdown extensions              https://github.github.com/gfm/
+# and has a few extras like Markdown Extra's footnotes   https://michelf.ca/projects/php-markdown/extra/#footnotes
+# the scope suffix should indicate which flavor of Markdown the feature came from, to help make this syntax definition easier to maintain
+#
+# http://www.sublimetext.com/docs/syntax.html
 name: Markdown
+scope: text.html.markdown
+version: 2
+
 file_extensions:
   - md
   - mdown
   - markdown
   - markdn
-scope: text.html.markdown
-comment: |-
-  this definition aims to meet CommonMark specifications http://spec.commonmark.org/
-  with GitHub Formatted Markdown extensions              https://github.github.com/gfm/
-  and has a few extras like Markdown Extra's footnotes   https://michelf.ca/projects/php-markdown/extra/#footnotes
-  the scope suffix should indicate which flavor of Markdown the feature came from, to help make this syntax definition easier to maintain
+
 variables:
     thematic_break: |-
         (?x:
@@ -183,7 +186,9 @@ variables:
     #     (\1)      # the backtick/tilde combination that opened the code fence
     #     \s*$      # any amount of whitespace until EOL
     #   )
+
 contexts:
+
   file-start:
     - match: (---)\s*
       captures:
@@ -472,7 +477,7 @@ contexts:
         - match: \*\*
           scope: punctuation.definition.bold.end.markdown
           set:
-            - meta_content_scope: markup.italic.markdown
+            - meta_scope: markup.italic.markdown
             - match: '{{setext_escape}}'
               pop: true
             - match: |-
@@ -481,13 +486,13 @@ contexts:
                 |   [ \t]+\*\*+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
                 |   ^\*\*           # emphasis can't be closed at the start of the line
             - match: \*
-              scope: markup.italic.markdown punctuation.definition.italic.end.markdown
+              scope: punctuation.definition.italic.end.markdown
               pop: true
             - include: inline
             - include: bold
             - include: bold-italic-trailing
         - match: \*
-          scope: punctuation.definition.italic.end.markdown
+          scope: markup.italic.markdown punctuation.definition.italic.end.markdown
           set:
             - meta_content_scope: markup.bold.markdown
             - match: '{{setext_escape}}'
@@ -541,7 +546,7 @@ contexts:
             2: punctuation.definition.bold.end.markdown
           pop: true
         - match: _\b
-          scope: punctuation.definition.italic.end.markdown
+          scope: markup.italic.markdown punctuation.definition.italic.end.markdown
           set:
             - meta_content_scope: markup.bold.markdown
             - match: |-
@@ -558,14 +563,14 @@ contexts:
         - match: __\b
           scope: punctuation.definition.bold.end.markdown
           set:
-            - meta_content_scope: markup.italic.markdown
+            - meta_scope: markup.italic.markdown
             - match: |-
                   (?x)
                       [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
                   |   [ \t]+__+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
                   |   ^__           # emphasis can't be closed at the start of the line
             - match: _\b
-              scope: markup.italic.markdown punctuation.definition.italic.end.markdown
+              scope: punctuation.definition.italic.end.markdown
               pop: true
             - include: inline
             - include: bold
@@ -1094,7 +1099,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.clojure
-      embed_scope: markup.raw.code-fence.clojure.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.clojure.markdown-gfm
+        source.clojure.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.clojure.markdown-gfm
@@ -1109,7 +1116,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:text.xml
-      embed_scope: markup.raw.code-fence.xml.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.xml.markdown-gfm
+        text.xml.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.xml.markdown-gfm
@@ -1124,7 +1133,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.sql
-      embed_scope: markup.raw.code-fence.sql.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.sql.markdown-gfm
+        source.sql.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.sql.markdown-gfm
@@ -1139,7 +1150,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.python
-      embed_scope: markup.raw.code-fence.python.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.python.markdown-gfm
+        source.python.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.python.markdown-gfm
@@ -1154,7 +1167,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.dot
-      embed_scope: markup.raw.code-fence.graphviz.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.graphviz.markdown-gfm
+        source.dot.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.graphviz.markdown-gfm
@@ -1169,7 +1184,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.js
-      embed_scope: markup.raw.code-fence.javascript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.javascript.markdown-gfm
+        source.js.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.javascript.markdown-gfm
@@ -1184,7 +1201,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.json
-      embed_scope: markup.raw.code-fence.json.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.json.markdown-gfm
+        source.json.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.json.markdown-gfm
@@ -1199,7 +1218,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.ts
-      embed_scope: markup.raw.code-fence.typescript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.typescript.markdown-gfm
+        source.ts.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.typescript.markdown-gfm
@@ -1214,7 +1235,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.java
-      embed_scope: markup.raw.code-fence.java.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.java.markdown-gfm
+        source.java.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.java.markdown-gfm
@@ -1229,7 +1252,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:text.html.jsp
-      embed_scope: markup.raw.code-fence.jsp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.jsp.markdown-gfm
+        text.html.jsp.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.jsp.markdown-gfm
@@ -1244,7 +1269,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.cs
-      embed_scope: markup.raw.code-fence.csharp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.csharp.markdown-gfm
+        source.cs.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.csharp.markdown-gfm
@@ -1259,7 +1286,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.perl
-      embed_scope: markup.raw.code-fence.perl.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.perl.markdown-gfm
+        source.perl.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.perl.markdown-gfm
@@ -1274,7 +1303,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.rust
-      embed_scope: markup.raw.code-fence.rust.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.rust.markdown-gfm
+        source.rust.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.rust.markdown-gfm
@@ -1289,7 +1320,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.shell.bash
-      embed_scope: markup.raw.code-fence.shell-script.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.shell-script.markdown-gfm
+        source.shell.bash.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.shell-script.markdown-gfm
@@ -1304,7 +1337,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.php
-      embed_scope: markup.raw.code-fence.php.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.php.markdown-gfm
+        source.php.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.php.markdown-gfm
@@ -1319,7 +1354,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:embedding.php
-      embed_scope: markup.raw.code-fence.html-php.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.html-php.markdown-gfm
+        embedding.php.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.html-php.markdown-gfm
@@ -1334,7 +1371,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.r
-      embed_scope: markup.raw.code-fence.r.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.r.markdown-gfm
+        source.r.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.r.markdown-gfm
@@ -1349,7 +1388,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.go
-      embed_scope: markup.raw.code-fence.go.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.go.markdown-gfm
+        source.go.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.go.markdown-gfm
@@ -1364,7 +1405,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.ruby
-      embed_scope: markup.raw.code-fence.ruby.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.ruby.markdown-gfm
+        source.ruby.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.ruby.markdown-gfm
@@ -1379,7 +1422,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.objc
-      embed_scope: markup.raw.code-fence.objc.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.objc.markdown-gfm
+        source.objc.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.objc.markdown-gfm
@@ -1394,7 +1439,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.objc++
-      embed_scope: markup.raw.code-fence.objc++.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.objc++.markdown-gfm
+        source.objc++.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.objc++.markdown-gfm
@@ -1409,7 +1456,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.c
-      embed_scope: markup.raw.code-fence.c.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.c.markdown-gfm
+        source.c.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.c.markdown-gfm
@@ -1424,7 +1473,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.c++
-      embed_scope: markup.raw.code-fence.c++.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.c++.markdown-gfm
+        source.c++.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.c++.markdown-gfm
@@ -1439,7 +1490,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.yaml
-      embed_scope: markup.raw.code-fence.yaml.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.yaml.markdown-gfm
+        source.yaml.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.yaml.markdown-gfm
@@ -1454,7 +1507,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.regexp
-      embed_scope: markup.raw.code-fence.regexp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.regexp.markdown-gfm
+        source.regexp.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.regexp.markdown-gfm
@@ -1469,7 +1524,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.erlang
-      embed_scope: markup.raw.code-fence.erlang.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.erlang.markdown-gfm
+        source.erlang.embedded.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.erlang.markdown-gfm
@@ -1672,22 +1729,22 @@ contexts:
   table:
     - match: ^(?={{table_first_row}})
       push:
-        - meta_content_scope: meta.table.header.markdown-gfm
+        - meta_scope: meta.table.header.markdown-gfm
         - match: \|
           scope: punctuation.separator.table-cell.markdown
         - include: inline-bold-italic
-        - match: $\n?
+        - match: \n
           set:
             - match: ^
               set:
-                - meta_content_scope: meta.table.header-separator.markdown-gfm
+                - meta_scope: meta.table.header-separator.markdown-gfm
                 - match: \|
                   scope: punctuation.separator.table-cell.markdown
                 - match: ':'
                   scope: punctuation.definition.table-cell-alignment.markdown
                 - match: -+
                   scope: punctuation.section.table-header.markdown
-                - match: $\n?
+                - match: \n
                   set:
                     - meta_content_scope: meta.table.markdown-gfm
                     - match: |- # The table is broken at the first empty line, or beginning of another block-level structure

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -227,7 +227,7 @@ contexts:
         - include: thematic-break
         - include: table
         - match: ''
-          pop: true
+          pop: 1
     - match: ^([ ]{0,3})([*+-])( (\[[ xX]\]))?(?=\s)
       captures:
         1: markup.list.unnumbered.markdown
@@ -237,7 +237,7 @@ contexts:
       push:
         - meta_content_scope: markup.list.unnumbered.markdown
         - match: ^(?=\S)
-          pop: true
+          pop: 1
         - include: list-paragraph
     - match: '^([ ]{0,3})(\d+(\.))(?=\s)'
       captures:
@@ -247,7 +247,7 @@ contexts:
       push:
         - meta_content_scope: markup.list.numbered.markdown
         - match: ^(?=\S)
-          pop: true
+          pop: 1
         - include: list-paragraph
     - match: '^[ ]{0,3}(?=<((?i:pre))\b)'
       comment: Markdown formatting is disabled inside block-level tags.
@@ -281,7 +281,7 @@ contexts:
       push:
         - meta_scope: meta.link.reference.def.footnote.markdown-extra
         - match: ^(?![ ]{4}|$)
-          pop: true
+          pop: 1
         - include: inline-bold-italic
     - match: |-
         (?x:
@@ -329,7 +329,7 @@ contexts:
                 )
             )
         )
-      pop: true
+      pop: 1
 
   not-heading2:
     - include: not-paragraph
@@ -339,7 +339,7 @@ contexts:
         - paragraph
         - heading1
     - match: ''
-      pop: true
+      pop: 1
 
   paragraph:
       - meta_scope: meta.paragraph.markdown
@@ -358,7 +358,7 @@ contexts:
       captures:
         1: markup.heading.1.setext.markdown punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
 
   heading2:
     - meta_scope: markup.heading.2.markdown
@@ -367,7 +367,7 @@ contexts:
       captures:
         1: markup.heading.2.setext.markdown punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
 
   ampersand:
     - match: (?!{{html_entity}})&
@@ -405,14 +405,14 @@ contexts:
             |    {{thematic_break}}
             |    {{block_quote}}
             )
-          pop: true
+          pop: 1
         - match: |-
             (?x)
             (?=  {{block_quote}}
             )
           push:
             - match: ^
-              pop: true
+              pop: 1
             - include: block-quote
         - match: |-
             (?x)
@@ -443,12 +443,12 @@ contexts:
                 - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown
                 - include: list-content
             - match: ^
-              pop: true
+              pop: 1
             - include: list-paragraph
         - match: ''
           push:
             - match: $|^
-              pop: true
+              pop: 1
             - include: inline-bold-italic-linebreak
 
   indented-code-block:
@@ -465,7 +465,7 @@ contexts:
         - meta_scope: markup.bold.markdown
         - meta_content_scope: markup.italic.markdown
         - match: '{{setext_escape}}'
-          pop: true
+          pop: 1
         - match: |-
             (?x)
                 [ \t]*\*{4,}    # if there are more than 3 its not applicable to be bold or italic
@@ -475,13 +475,13 @@ contexts:
           captures:
             1: markup.italic.markdown punctuation.definition.italic.end.markdown
             2: punctuation.definition.bold.end.markdown
-          pop: true
+          pop: 1
         - match: \*\*
           scope: punctuation.definition.bold.end.markdown
           set:
             - meta_scope: markup.italic.markdown
             - match: '{{setext_escape}}'
-              pop: true
+              pop: 1
             - match: |-
                 (?x)
                     [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
@@ -489,7 +489,7 @@ contexts:
                 |   ^\*\*           # emphasis can't be closed at the start of the line
             - match: \*
               scope: punctuation.definition.italic.end.markdown
-              pop: true
+              pop: 1
             - include: inline
             - include: bold
             - include: bold-italic-trailing
@@ -498,7 +498,7 @@ contexts:
           set:
             - meta_content_scope: markup.bold.markdown
             - match: '{{setext_escape}}'
-              pop: true
+              pop: 1
             - match: |-
                 (?x)
                     [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
@@ -506,7 +506,7 @@ contexts:
                 |   ^\*\*           # emphasis can't be closed at the start of the line
             - match: \*\*
               scope: markup.bold.markdown punctuation.definition.bold.end.markdown
-              pop: true
+              pop: 1
             - include: inline
             - include: italic
             - include: bold-italic-trailing
@@ -524,7 +524,7 @@ contexts:
         - match: (?:_)?(\*\*)
           captures:
             1: punctuation.definition.bold.end.markdown
-          pop: true
+          pop: 1
         - include: inline
         - match: \b_(?=[^\s_])(?=[^*_]*\*\*)
           comment: eat the underscore that has no corresponding underscore before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
@@ -546,7 +546,7 @@ contexts:
           captures:
             1: markup.italic.markdown punctuation.definition.italic.end.markdown
             2: punctuation.definition.bold.end.markdown
-          pop: true
+          pop: 1
         - match: _\b
           scope: markup.italic.markdown punctuation.definition.italic.end.markdown
           set:
@@ -558,7 +558,7 @@ contexts:
                   |   ^__           # emphasis can't be closed at the start of the line
             - match: __\b
               scope: markup.bold.markdown punctuation.definition.bold.end.markdown
-              pop: true
+              pop: 1
             - include: inline
             - include: italic
             - include: bold-italic-trailing
@@ -573,7 +573,7 @@ contexts:
                   |   ^__           # emphasis can't be closed at the start of the line
             - match: _\b
               scope: punctuation.definition.italic.end.markdown
-              pop: true
+              pop: 1
             - include: inline
             - include: bold
             - include: bold-italic-trailing
@@ -591,7 +591,7 @@ contexts:
         - match: (?:\*)?(__\b)
           captures:
             1: punctuation.definition.bold.end.markdown
-          pop: true
+          pop: 1
         - include: inline
         - match: \*(?=[^\s*])(?=[^*_]*__\b)
           comment: eat the asterisk that has no corresponding asterisk before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
@@ -614,7 +614,7 @@ contexts:
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
 
   atx-heading:
     - match: '(#)(?!#)\s*(?=\S)'
@@ -685,7 +685,7 @@ contexts:
     - include: link-text
     - match: \]
       scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
-      pop: true
+      pop: 1
 
   image-inline-after-text:
     - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
@@ -696,7 +696,7 @@ contexts:
         - meta_scope: meta.image.inline.markdown
         - match: \)
           scope: punctuation.definition.metadata.end.markdown
-          pop: true
+          pop: 1
         - match: <(?=[^>)]*>)
           scope: punctuation.definition.link.begin.markdown
           push:
@@ -713,7 +713,7 @@ contexts:
               scope: markup.underline.link.image.markdown
             - match: \)
               scope: punctuation.definition.metadata.end.markdown
-              pop: true
+              pop: 1
             - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
@@ -750,7 +750,7 @@ contexts:
     - include: link-text
     - match: \]
       scope: meta.image.reference.markdown punctuation.definition.image.end.markdown
-      pop: true
+      pop: 1
 
   image-ref-after-text:
     - match: '[ ]?(\[)([^\]]+)(\])'
@@ -759,7 +759,7 @@ contexts:
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
       scope: meta.image.reference.markdown
-      pop: true
+      pop: 1
 
   image-ref-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
@@ -802,7 +802,7 @@ contexts:
       push:
         - meta_scope: markup.italic.markdown
         - match: '{{setext_escape}}'
-          pop: true
+          pop: 1
         - match: |-
               (?x)
                   [ \t]*\*{4,}   # if there are more than 3 its not applicable to be bold or italic
@@ -810,7 +810,7 @@ contexts:
               |   ^\*(?!\*)      # emphasis can't be closed at the start of the line
         - match: \*(?!\*[^*])
           scope: punctuation.definition.italic.end.markdown
-          pop: true
+          pop: 1
         - include: inline
         - include: bold
         - match: '\*+'
@@ -820,7 +820,7 @@ contexts:
       push:
         - meta_scope: markup.italic.markdown
         - match: '{{setext_escape}}'
-          pop: true
+          pop: 1
         - match: |-
               (?x)
                   [ \t]*_{4,}   # if there are more than 3 its not applicable to be bold or italic
@@ -828,7 +828,7 @@ contexts:
               |   ^_(?!_)       # emphasis can't be closed at the start of the line
         - match: _\b
           scope: punctuation.definition.italic.end.markdown
-          pop: true
+          pop: 1
         - include: inline
         - include: bold
         - include: bold-italic-trailing
@@ -841,7 +841,7 @@ contexts:
         - meta_scope: markup.strikethrough.markdown-gfm
         - match: ~+
           scope: punctuation.definition.strikethrough.end.markdown
-          pop: true
+          pop: 1
         - include: inline
         - include: bold
         - include: italic
@@ -850,12 +850,12 @@ contexts:
   bold-italic-trailing:
     - include: scope:text.html.basic
     - match: '{{setext_escape}}'
-      pop: true
+      pop: 1
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.bold-italic.markdown
-      pop: true
+      pop: 1
     - match: '^(?={{list_item}})'
-      pop: true
+      pop: 1
     - include: hard-line-break
 
   hard-line-break:
@@ -887,18 +887,18 @@ contexts:
       scope: markup.underline.link.markdown-gfm
       push: # After a valid domain, zero or more non-space non-< characters may follow
         - match: (?=[?!.,:*_~]*[\s<]) # Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be considered part of the autolink, though they may be included in the interior of the link
-          pop: true
+          pop: 1
         - match: (?={{html_entity}}[?!.,:*_~]*[\s<]) # If an autolink ends in a semicolon (;), we check to see if it appears to resemble an entity reference; if the preceding text is & followed by one or more alphanumeric characters. If so, it is excluded from the autolink
-          pop: true
+          pop: 1
         - match: \( # When an autolink ends in ), we scan the entire autolink for the total number of parentheses. If there is a greater number of closing parentheses than opening ones, we don’t consider the last character part of the autolink, in order to facilitate including an autolink inside a parenthesis
           push:
             - meta_scope: markup.underline.link.markdown-gfm
             - match: (?=[?!.,:*_~]*[\s<])
-              pop: true
+              pop: 1
             - match: \)
-              pop: true
+              pop: 1
         - match: (?=\)[?!.,:*_~]*[\s<])
-          pop: true
+          pop: 1
         - match: '[^?!.,:*_~\s<&()]+|\S'
           scope: markup.underline.link.markdown-gfm
 
@@ -925,7 +925,7 @@ contexts:
         - meta_scope: meta.link.inline.markdown
         - match: \)
           scope: punctuation.definition.metadata.end.markdown
-          pop: true
+          pop: 1
         - match: <(?=[^>)]*>)
           scope: punctuation.definition.link.begin.markdown
           push:
@@ -941,7 +941,7 @@ contexts:
               scope: markup.underline.link.markdown
             - match: \)
               scope: punctuation.definition.metadata.end.markdown
-              pop: true
+              pop: 1
             - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
@@ -962,7 +962,7 @@ contexts:
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
 
   link-ref:
     - match: |-
@@ -985,7 +985,7 @@ contexts:
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.markdown punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
 
   link-ref-after-text:
     - match: '[ ]?(\[)([^\]]+)(\])'
@@ -994,7 +994,7 @@ contexts:
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
       scope: meta.link.reference.markdown
-      pop: true
+      pop: 1
 
   link-ref-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
@@ -1027,7 +1027,7 @@ contexts:
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.literal.markdown punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
 
   link-ref-literal-after-text:
     - match: '[ ]?(\[)(\])'
@@ -1035,7 +1035,7 @@ contexts:
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: punctuation.definition.constant.end.markdown
-      pop: true
+      pop: 1
 
   link-ref-literal-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
@@ -1065,21 +1065,21 @@ contexts:
       push:
         - include: indented-code-block
         - match: $
-          pop: true
+          pop: 1
     - match: '^(?=\s+{{block_quote}})'
       push:
         - include: block-quote
         - match: $
-          pop: true
+          pop: 1
     - match: '^(?={{fenced_code_block_start}})'
       push:
         - include: fenced-code-block
         - match: ''
-          pop: true
+          pop: 1
     - match: \s+(?=\S)
       push:
         - match: ^\s*$
-          pop: true
+          pop: 1
         - match: ([ ]*)([*+-])( (\[[ xX]\]))?(?=\s)
           captures:
             1: markup.list.unnumbered.markdown
@@ -1102,30 +1102,30 @@ contexts:
         - match: \s+
           scope: meta.paragraph.list.markdown
         - match: (?=^{{atx_heading}})
-          pop: true
+          pop: 1
         - match: '(?=\S)'
           push: list-content
     - match: '(?=\S)'
-      pop: true
+      pop: 1
 
   list-content:
     - meta_content_scope: meta.paragraph.list.markdown
     - match: ^(?={{fenced_code_block_start}})
       push:
         - match: $
-          pop: true
+          pop: 1
         - include: fenced-code-block
     - match: ^
-      pop: true
+      pop: 1
     - include: thematic-break
     - match: (?=\S)(?!{{list_item}})
       push:
         - match: (?={{list_item}})
-          pop: true
+          pop: 1
         - include: inline-bold-italic-linebreak
         - include: scope:text.html.basic
         - match: $
-          pop: true
+          pop: 1
 
   fenced-code-block:
     - match: |-
@@ -1585,7 +1585,7 @@ contexts:
           captures:
             0: meta.code-fence.definition.end.text.markdown-gfm
             1: punctuation.definition.raw.code-fence.end.markdown
-          pop: true
+          pop: 1
 
   code-span:
     - match: (`+)(?!`)
@@ -1594,19 +1594,19 @@ contexts:
         - meta_scope: markup.raw.inline.markdown
         - match: \1(?!`)
           scope: punctuation.definition.raw.end.markdown
-          pop: true
+          pop: 1
         - match: '`+'
         - match: '^(?={{list_item}})'
-          pop: true
+          pop: 1
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
-          pop: true
+          pop: 1
 
   raw:
     - match: ^(?={{fenced_code_block_start}})
       push:
         - match: $
-          pop: true
+          pop: 1
         - include: fenced-code-block
     - include: code-span
 
@@ -1617,7 +1617,7 @@ contexts:
         - match: '[-_*]+'
           scope: punctuation.definition.thematic-break.markdown
         - match: '$\n?'
-          pop: true
+          pop: 1
 
   disable-markdown:
     - include: scope:text.html.basic
@@ -1628,39 +1628,39 @@ contexts:
         1: meta.tag.block.any.html punctuation.definition.tag.begin.html
         2: meta.tag.block.any.html entity.name.tag.block.any.html
         3: meta.tag.block.any.html punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disable-markdown-pop-after-tag:
     - match: (?!</?(?i:script|style)\b)
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disable-markdown-pop-at-blank-line:
     - match: ^\s*$
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disable-markdown-pop-after-cdata:
     - match: (?!<!\[CDATA\[)
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disable-markdown-pop-at-php:
     - match: \?>
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disable-markdown-pop-after-html-doctype:
     - match: (?!<!([A-Z]|--))
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   disabled-markdown-pop-at-eol:
     - meta_content_scope: meta.disable-markdown
     - match: $\n?
       scope: meta.disable-markdown
-      pop: true
+      pop: 1
     - include: disable-markdown
 
   link-text:
@@ -1673,7 +1673,7 @@ contexts:
       push:
         - include: link-text
         - match: \]
-          pop: true
+          pop: 1
     - include: bold
     - include: italic
     - include: hard-line-break
@@ -1691,7 +1691,7 @@ contexts:
         - meta_scope: string.other.link.description.title.markdown
         - match: \'
           scope: punctuation.definition.string.end.markdown
-          pop: true
+          pop: 1
         - include: non-terminated-link-title
     - match: \"
       scope: punctuation.definition.string.begin.markdown
@@ -1699,7 +1699,7 @@ contexts:
         - meta_scope: string.other.link.description.title.markdown
         - match: \"
           scope: punctuation.definition.string.end.markdown
-          pop: true
+          pop: 1
         - include: non-terminated-link-title
     - match: \(
       scope: punctuation.definition.string.begin.markdown
@@ -1707,20 +1707,20 @@ contexts:
         - meta_scope: string.other.link.description.title.markdown
         - match: \)
           scope: punctuation.definition.string.end.markdown
-          pop: true
+          pop: 1
         - include: non-terminated-link-title
     - match: $|(?=\S)
-      pop: true
+      pop: 1
 
   non-terminated-link-title:
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.link-title.markdown
-      pop: true
+      pop: 1
 
   link-ref-def-expect-end:
     - meta_scope: meta.link.reference.def.markdown
     - match: $
-      pop: true
+      pop: 1
     - match: \s*\S+
       scope: invalid.illegal.expected-eol.markdown
 
@@ -1732,7 +1732,7 @@ contexts:
     # https://pandoc.org/MANUAL.html#extension-link_attributes
     - match: \}
       scope: punctuation.definition.attributes.end.markdown
-      pop: true
+      pop: 1
     - match: \,
       scope: punctuation.separator.mapping.pair.markdown
     - match: '{{tag_attribute_name_start}}'
@@ -1741,7 +1741,7 @@ contexts:
   tag-attr-name:
     - meta_scope: entity.other.attribute-name.markdown
     - match: '{{tag_attribute_name_break}}'
-      pop: true
+      pop: 1
     - match: '["''`<]'
       scope: invalid.illegal.attribute-name.markdown
 
@@ -1762,19 +1762,19 @@ contexts:
         - meta_scope: string.quoted.double.markdown
         - match: \"
           scope: punctuation.definition.string.end.markdown
-          pop: true
+          pop: 1
     - match: \'
       scope: punctuation.definition.string.begin.markdown
       set:
         - meta_scope: string.quoted.single.markdown
         - match: \'
           scope: punctuation.definition.string.end.markdown
-          pop: true
+          pop: 1
     - match: '{{tag_unquoted_attribute_start}}'
       set:
         - meta_scope: string.unquoted.markdown
         - match: '{{tag_unquoted_attribute_break}}'
-          pop: true
+          pop: 1
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.markdown
     - include: else-pop
@@ -1810,7 +1810,7 @@ contexts:
                           |    {{thematic_break}}
                           |    \s*$
                           )
-                      pop: true
+                      pop: 1
                     - match: \|
                       scope: punctuation.separator.table-cell.markdown
                     - match: (?={{balanced_emphasis}})
@@ -1818,7 +1818,7 @@ contexts:
                         - include: bold
                         - include: italic
                         - match: ''
-                          pop: true
+                          pop: 1
                     - match: |-
                         (?x)
                         (?!{{backticks}})
@@ -1831,8 +1831,8 @@ contexts:
 
   else-pop:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   immediately-pop:
     - match: ''
-      pop: true
+      pop: 1

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -450,9 +450,11 @@ contexts:
             - match: $|^
               pop: true
             - include: inline-bold-italic-linebreak
+
   indented-code-block:
     - match: '{{indented_code_block}}.*$\n?'
       scope: markup.raw.block.markdown
+
   bold:
     - include: ligatures
     - match: '(\*\*)(\*)(?=\S)(?!\*)'
@@ -595,21 +597,25 @@ contexts:
           comment: eat the asterisk that has no corresponding asterisk before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
         - include: italic
         - include: bold-italic-trailing
+
   bracket:
     - match: '<(?![A-Za-z/?!$])'
       comment: |
         Markdown will convert this for us. We match it so that the
                         HTML grammar will not mark it up as invalid.
       scope: meta.other.valid-bracket.markdown
+
   escape:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
+
   atx-heading-terminator:
     - match: '[ ]*(#*)[ ]*($\n?)' # \n is optional so ## is matched as end punctuation in new document (at eof)
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown
       pop: true
+
   atx-heading:
     - match: '(#)(?!#)\s*(?=\S)'
       captures:
@@ -659,6 +665,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
+
   image-inline:
     - match: |-
         (?x:
@@ -672,12 +679,14 @@ contexts:
       captures:
         1: meta.image.inline.markdown punctuation.definition.image.begin.markdown
       push: [image-inline-attr, image-inline-after-text, image-link-text]
+
   image-link-text:
     - meta_content_scope: meta.image.inline.description.markdown
     - include: link-text
     - match: \]
       scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
       pop: true
+
   image-inline-after-text:
     - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
       captures:
@@ -709,6 +718,7 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+
   image-inline-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
       captures:
@@ -718,6 +728,7 @@ contexts:
         - meta_scope: meta.image.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   image-ref:
     - match: |-
         (?x:
@@ -733,12 +744,14 @@ contexts:
       captures:
         1: meta.image.reference.markdown punctuation.definition.image.begin.markdown
       push: [image-ref-attr, image-ref-after-text, image-ref-text]
+
   image-ref-text:
     - meta_content_scope: meta.image.reference.description.markdown
     - include: link-text
     - match: \]
       scope: meta.image.reference.markdown punctuation.definition.image.end.markdown
       pop: true
+
   image-ref-after-text:
     - match: '[ ]?(\[)([^\]]+)(\])'
       captures:
@@ -747,6 +760,7 @@ contexts:
         3: punctuation.definition.constant.end.markdown
       scope: meta.image.reference.markdown
       pop: true
+
   image-ref-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
       captures:
@@ -756,6 +770,7 @@ contexts:
         - meta_scope: meta.image.reference.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   inline:
     - include: escape
     - include: ampersand
@@ -770,14 +785,17 @@ contexts:
     - include: link-ref-literal
     - include: link-ref
     - include: link-ref-footnote
+
   inline-bold-italic:
     - include: inline
     - include: bold
     - include: italic
     - include: strikethrough
+
   inline-bold-italic-linebreak:
     - include: inline-bold-italic
     - include: hard-line-break
+
   italic:
     - match: '\*(?=\S)(?!\*)'
       scope: punctuation.definition.italic.begin.markdown
@@ -815,6 +833,7 @@ contexts:
         - include: bold
         - include: bold-italic-trailing
     - match: '[*_]+'
+
   strikethrough:
     - match: '(~+)(?=\S)(?!~)'
       scope: punctuation.definition.strikethrough.begin.markdown
@@ -827,6 +846,7 @@ contexts:
         - include: bold
         - include: italic
         - include: bold-italic-trailing
+
   bold-italic-trailing:
     - include: scope:text.html.basic
     - match: '{{setext_escape}}'
@@ -837,6 +857,7 @@ contexts:
     - match: '^(?={{list_item}})'
       pop: true
     - include: hard-line-break
+
   hard-line-break:
     - match: '[ ]{2,}$'
       scope: meta.hard-line-break.markdown punctuation.definition.hard-line-break.markdown
@@ -844,6 +865,7 @@ contexts:
       scope: meta.hard-line-break.markdown
       captures:
         1: constant.character.escape.markdown
+
   autolink-email:
     - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
       scope: meta.link.email.lt-gt.markdown
@@ -853,6 +875,7 @@ contexts:
         4: punctuation.definition.link.end.markdown
     - match: '[\w.+-]+@[\w-]+(\.((?![._-][\W])[\w_-])+)+(?![_-])'
       scope: markup.underline.link.markdown
+
   autolink-inet:
     - match: (<)((?:https?|ftp)://.*?)(>)
       scope: meta.link.inet.markdown
@@ -878,6 +901,7 @@ contexts:
           pop: true
         - match: '[^?!.,:*_~\s<&()]+|\S'
           scope: markup.underline.link.markdown-gfm
+
   link-inline:
     - match: |-
         (?x:
@@ -891,6 +915,7 @@ contexts:
       captures:
         1: meta.link.inline.markdown punctuation.definition.link.begin.markdown
       push: [link-inline-attr, link-inline-after-text, link-inline-link-text]
+
   link-inline-after-text:
     - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
       captures:
@@ -921,6 +946,7 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+
   link-inline-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
       captures:
@@ -930,12 +956,14 @@ contexts:
         - meta_scope: meta.link.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-inline-link-text:
     - meta_content_scope: meta.link.inline.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref:
     - match: |-
         (?x:
@@ -951,12 +979,14 @@ contexts:
       captures:
         1: meta.link.reference.markdown punctuation.definition.link.begin.markdown
       push: [link-ref-attr, link-ref-after-text, link-ref-link-text]
+
   link-ref-link-text:
     - meta_content_scope: meta.link.reference.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref-after-text:
     - match: '[ ]?(\[)([^\]]+)(\])'
       captures:
@@ -965,6 +995,7 @@ contexts:
         3: punctuation.definition.constant.end.markdown
       scope: meta.link.reference.markdown
       pop: true
+
   link-ref-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
       captures:
@@ -974,6 +1005,7 @@ contexts:
         - meta_scope: meta.link.reference.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-ref-literal:
     - match: |-
         (?x:
@@ -989,12 +1021,14 @@ contexts:
       captures:
         1: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
       push: [link-ref-literal-attr, link-ref-literal-after-text, link-ref-literal-link-text]
+
   link-ref-literal-link-text:
     - meta_content_scope: meta.link.reference.literal.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.literal.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref-literal-after-text:
     - match: '[ ]?(\[)(\])'
       scope: meta.link.reference.literal.markdown
@@ -1002,6 +1036,7 @@ contexts:
         1: punctuation.definition.constant.begin.markdown
         2: punctuation.definition.constant.end.markdown
       pop: true
+
   link-ref-literal-attr:
     - match: '([ ]*)(\{)(?=[^}]*\})'
       captures:
@@ -1011,6 +1046,7 @@ contexts:
         - meta_scope: meta.link.reference.literal.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-ref-footnote:
     - match: |-
         (?x:
@@ -1023,6 +1059,7 @@ contexts:
         1: punctuation.definition.link.begin.markdown
         2: meta.link.reference.literal.footnote-id.markdown
         3: punctuation.definition.link.end.markdown
+
   list-paragraph:
     - match: '^(?=(?:[ ]{4}|\t){2,}(?![>+*\s-]))(?={{indented_code_block}})'
       push:
@@ -1070,6 +1107,7 @@ contexts:
           push: list-content
     - match: '(?=\S)'
       pop: true
+
   list-content:
     - meta_content_scope: meta.paragraph.list.markdown
     - match: ^(?={{fenced_code_block_start}})
@@ -1088,6 +1126,7 @@ contexts:
         - include: scope:text.html.basic
         - match: $
           pop: true
+
   fenced-code-block:
     - match: |-
          (?x)
@@ -1547,6 +1586,7 @@ contexts:
             0: meta.code-fence.definition.end.text.markdown-gfm
             1: punctuation.definition.raw.code-fence.end.markdown
           pop: true
+
   code-span:
     - match: (`+)(?!`)
       scope: punctuation.definition.raw.begin.markdown
@@ -1561,6 +1601,7 @@ contexts:
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
+
   raw:
     - match: ^(?={{fenced_code_block_start}})
       push:
@@ -1568,6 +1609,7 @@ contexts:
           pop: true
         - include: fenced-code-block
     - include: code-span
+
   thematic-break:
     - match: '(?={{thematic_break}})'
       push:
@@ -1576,8 +1618,10 @@ contexts:
           scope: punctuation.definition.thematic-break.markdown
         - match: '$\n?'
           pop: true
+
   disable-markdown:
     - include: scope:text.html.basic
+
   disable-markdown-pop-at-tag:
     - match: (</)(\1)(>)
       captures:
@@ -1586,32 +1630,39 @@ contexts:
         3: meta.tag.block.any.html punctuation.definition.tag.end.html
       pop: true
     - include: disable-markdown
+
   disable-markdown-pop-after-tag:
     - match: (?!</?(?i:script|style)\b)
       pop: true
     - include: disable-markdown
+
   disable-markdown-pop-at-blank-line:
     - match: ^\s*$
       pop: true
     - include: disable-markdown
+
   disable-markdown-pop-after-cdata:
     - match: (?!<!\[CDATA\[)
       pop: true
     - include: disable-markdown
+
   disable-markdown-pop-at-php:
     - match: \?>
       pop: true
     - include: disable-markdown
+
   disable-markdown-pop-after-html-doctype:
     - match: (?!<!([A-Z]|--))
       pop: true
     - include: disable-markdown
+
   disabled-markdown-pop-at-eol:
     - meta_content_scope: meta.disable-markdown
     - match: $\n?
       scope: meta.disable-markdown
       pop: true
     - include: disable-markdown
+
   link-text:
     - match: \b__?(?=[^]_]+\]) # eat underscores where there is no pair before the end of the square brackets - it's not a formatting mark
     - match: \b\*\*?(?=[^]*]+\]) # eat asterisks where there is no pair before the end of the square brackets - it's not a formatting mark
@@ -1627,10 +1678,12 @@ contexts:
     - include: italic
     - include: hard-line-break
     - include: scope:text.html.basic
+
   link-text-allow-image:
     - include: link-text
     - include: image-inline
     - include: image-ref
+
   link-title:
     - match: \'
       scope: punctuation.definition.string.begin.markdown
@@ -1658,10 +1711,12 @@ contexts:
         - include: non-terminated-link-title
     - match: $|(?=\S)
       pop: true
+
   non-terminated-link-title:
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.link-title.markdown
       pop: true
+
   link-ref-def-expect-end:
     - meta_scope: meta.link.reference.def.markdown
     - match: $

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -226,8 +226,7 @@ contexts:
         - include: atx-heading
         - include: thematic-break
         - include: table
-        - match: ''
-          pop: 1
+        - include: immediately-pop
     - match: ^([ ]{0,3})([*+-])( (\[[ xX]\]))?(?=\s)
       captures:
         1: markup.list.unnumbered.markdown
@@ -338,8 +337,7 @@ contexts:
       branch:
         - paragraph
         - heading1
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   paragraph:
       - meta_scope: meta.paragraph.markdown
@@ -1074,8 +1072,7 @@ contexts:
     - match: '^(?={{fenced_code_block_start}})'
       push:
         - include: fenced-code-block
-        - match: ''
-          pop: 1
+        - include: immediately-pop
     - match: \s+(?=\S)
       push:
         - match: ^\s*$
@@ -1817,8 +1814,7 @@ contexts:
                       push:
                         - include: bold
                         - include: italic
-                        - match: ''
-                          pop: 1
+                        - include: immediately-pop
                     - match: |-
                         (?x)
                         (?!{{backticks}})


### PR DESCRIPTION
This PR proposes to update Markdown.sublime-syntax to version 2.

It appears to be of interest for 3rd party packages and should probably be updated to version 2 before any official release of ST in order to prevent breaking packages which `extend` Markdown later on.

This PR therefore contains the least required changes to fix backward incompatible changes and some formattings.

This PR does not change syntax behavior.

Changes are grouped by commits.