### PR TITLE
[JSX] Improve commenting behavior.

### DIFF
--- a/JavaScript/Comments.tmPreferences
+++ b/JavaScript/Comments.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>source.js, source.jsx, source.ts, source.tsx</string>
+	<string>source.js, source.jsx, source.ts, source.tsx, meta.jsx meta.tag.name, meta.jsx meta.tag.attributes</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/JavaScript/JSX Comments.tmPreferences
+++ b/JavaScript/JSX Comments.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>JSX Comments</string>
     <key>scope</key>
-    <string>source.jsx meta.jsx - source.jsx.embedded.jsx, source.tsx meta.jsx - source.tsx.embedded.jsx</string>
+    <string>source.jsx meta.jsx - source.jsx.embedded.jsx - meta.tag.attributes - meta.tag.name, source.tsx meta.jsx - source.tsx.embedded.jsx - meta.tag.attributes - meta.tag.name</string>
     <key>settings</key>
     <dict>
         <key>shellVariables</key>

--- a/JavaScript/JSX Comments.tmPreferences
+++ b/JavaScript/JSX Comments.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>JSX Comments</string>
     <key>scope</key>
-    <string>source.jsx meta.jsx - source.jsx.embedded.jsx - meta.tag.attributes - meta.tag.name, source.tsx meta.jsx - source.tsx.embedded.jsx - meta.tag.attributes - meta.tag.name</string>
+    <string>meta.jsx</string>
     <key>settings</key>
     <dict>
         <key>shellVariables</key>

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -18,9 +18,34 @@ contexts:
     - include: jsx-tag
 
   jsx-interpolation:
+    - match: (?={/\*)
+      branch_point: jsx-interpolation-comment
+      branch:
+        - jsx-interpolation-comment
+        - jsx-interpolation-plain
+    - match: (?={)
+      push: jsx-interpolation-plain
+
+  jsx-interpolation-comment:
+    - match: '({)(/\*)'
+      captures:
+        1: punctuation.definition.interpolation.begin.js
+        2: punctuation.definition.comment.begin.js
+      set:
+        - meta_include_prototype: false
+        - meta_scope: meta.interpolation.js comment.block.js
+        - match: '(\*/)(})'
+          captures:
+            1: punctuation.definition.comment.end.js
+            2: punctuation.definition.interpolation.end.js
+          pop: true
+        - match: (?=\*/)
+          fail: jsx-interpolation-comment
+
+  jsx-interpolation-plain:
     - match: '{'
       scope: punctuation.definition.interpolation.begin.js
-      push:
+      set:
         - - meta_scope: meta.interpolation.js
           - meta_content_scope: source.js.embedded.jsx
           - match: '}'
@@ -62,7 +87,7 @@ contexts:
         - jsx-tag-name
 
   jsx-tag-attributes:
-    - meta_scope: meta.tag.js
+    - meta_scope: meta.tag.attributes.js
 
     - match: '>'
       scope: punctuation.definition.tag.end.js

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -71,7 +71,7 @@
 
 <foo
     bar
-//  ^^^ meta.jsx meta.tag entity.other.attribute-name
+//  ^^^ meta.jsx meta.tag.attributes entity.other.attribute-name
 
     =
 //  ^ punctuation.separator.key-value
@@ -80,7 +80,7 @@
 //  ^^^^^^ string.quoted.single
 
     baz='test'
-//  ^^^^^^^^^^ meta.jsx meta.tag
+//  ^^^^^^^^^^ meta.jsx meta.tag.attributes
 //  ^^^ entity.other.attribute-name
 //     ^ punctuation.separator.key-value
 //      ^^^^^^ string.quoted.single
@@ -88,7 +88,7 @@
 //           ^ punctuation.definition.string.end
 
     baz="test"
-//  ^^^^^^^^^^ meta.jsx meta.tag
+//  ^^^^^^^^^^ meta.jsx meta.tag.attributes
 //  ^^^ entity.other.attribute-name
 //     ^ punctuation.separator.key-value
 //      ^^^^^^ string.quoted.double
@@ -181,6 +181,24 @@
 //     ^ - punctuation
     }
 //  ^ punctuation.definition.interpolation.end
+
+    {/* foo */}
+//  ^^^^^^^^^^^ meta.jsx meta.interpolation comment.block - source.embedded
+//  ^ punctuation.definition.interpolation.begin
+//   ^^ punctuation.definition.comment.begin
+//          ^^ punctuation.definition.comment.end
+//            ^ punctuation.definition.interpolation.end
+
+    {/* foo */ bar}
+//  ^^^^^^^^^^^^^^^ meta.jsx meta.interpolation
+//   ^^^^^^^^^^^^^ source.js.embedded
+//  ^ punctuation.definition.interpolation.begin - comment
+//   ^^ punctuation.definition.comment.begin
+//          ^^ punctuation.definition.comment.end
+//            ^^^^^ - comment
+//             ^^^ meta.jsx meta.interpolation variable.other.readwrite
+//                ^ punctuation.definition.interpolation.end
+
 </foo>;
 
     <class />;


### PR DESCRIPTION
Should fix #2461.

Given the following:

```js
<foo>
    bar!
</foo>;
```

The `toggle_comment` command will comment the second line as follows:

```js
<foo>
    {/*bar!*/}
</foo>;
```

But when you call it again to uncomment, you get:

```js
<foo>
    {bar!}
</foo>;
```

…instead of the original, which we want. This is due to internal implementation details of `toggle_comment` — it won't remove `{/*`/`*/}`, even though they're specified in `JSX Comments.tmPreferences`, because the comment scope doesn't extend to the braces.

This PR adds a special case to JSX interpolations so that when an interpolation contains only a single block comment, the entire interpolation including the braces will get the `comment` scope, so that the `toggle_comment` command will do what we want. This is not really the correct scoping, but the previous behavior is really annoying and we can't really change `toggle_comment`.

In addition, this PR improves the behavior of commenting attributes. E.g.:

```js
<Foo
  bar={42}
/>
```

…will become:

```js
<Foo
  // bar={42}
/>
```