### PR TITLE
[Ruby] More specific language constant scopes.

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -203,8 +203,11 @@ contexts:
       captures:
         1: punctuation.definition.constant.ruby
       push: try-regex
-    - match: '\b(nil|true|false)\b(?![?!])'
-      scope: constant.language.ruby
+    - match: '\b(nil)\b(?![?!])'
+      scope: constant.language.null.ruby
+      push: after-constant
+    - match: '\b(true|false)\b(?![?!])'
+      scope: constant.language.boolean.ruby
       push: after-constant
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1126,15 +1126,17 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 #                  ^^^^^ variable.parameter
   end
 
-  def keyword_args a: nil, b: true
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-#                  ^^^^^^^^^^^^^^^ meta.function.parameters
+  def keyword_args a: nil, b: true, c: false
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 #                   ^^^^^ meta.function.parameters.default-value
 #                   ^ punctuation.separator
-#                     ^^^ constant.language
+#                     ^^^ constant.language.null
 #                        ^ punctuation.separator
 #                           ^ punctuation.separator
-#                             ^^^^ constant.language
+#                             ^^^^ constant.language.boolean
+#                                 ^ punctuation.separator.ruby
+#                                      ^^^^^ constant.language.boolean.ruby
   end
 
   def multiline_args(a, # a comment


### PR DESCRIPTION
This PR assigns more specific scopes for boolean constants `true` & `false` from `constant.language` to `constant.language.boolean` & `nil` from `constant.language` to ~~`constant.language.nil`~~ `constant.language.null`.

Related PR's 
1. #2785 