### PR TITLE
[JavaScript] [TypeScript] Improve parsing of modifiers.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -65,6 +65,8 @@ variables:
       | \#{{identifier_name}}
     )
 
+  modifier: (?:static{{identifier_break}})
+
   # Newline not permitted between `async` and `function`.
   func_lookahead: |-
     (?x:
@@ -568,17 +570,21 @@ contexts:
   function-parameter-binding-spread:
     - match: '\.\.\.'
       scope: keyword.operator.spread.js
-      push: function-parameter-binding-pattern
+      push: function-parameter
 
   function-parameter-binding-list:
     - match: ','
       scope: punctuation.separator.parameter.function.js
     - include: function-parameter-binding-spread
     - match: (?={{binding_pattern_lookahead}})
-      push:
+      push: function-parameter
+    - include: else-pop
+
+  function-parameter:
+    - match: ''
+      set:
         - initializer
         - function-parameter-binding-pattern
-    - include: else-pop
 
   initializer:
     - match: '='
@@ -1332,8 +1338,7 @@ contexts:
         - function-declaration-expect-body
         - function-declaration-expect-parameters
 
-    - match: static{{identifier_break}}
-      scope: storage.modifier.js
+    - include: class-element-modifiers
 
     - match: |-
         (?x)(?=
@@ -1357,6 +1362,22 @@ contexts:
 
     - match: (?={{class_element_name}})
       push: class-element
+
+  class-element-modifiers:
+    - match: (?={{modifier}})
+      branch_point: class-element-modifier
+      branch:
+        - class-element-modifier
+        - class-element
+
+  class-element-modifier:
+    - match: '{{modifier}}'
+      scope: storage.modifier.js
+      set:
+        - match: (?={{class_element_name}}|\*)
+          pop: true
+        - match: (?=\S)
+          fail: class-element-modifier
 
   class-extends:
     - match: extends{{identifier_break}}
@@ -1609,9 +1630,6 @@ contexts:
     - match: (?=\*)
       push: method-declaration
 
-    - match: '{{identifier_name}}(?=\s*(?:[},]|$|//|/\*))'
-      scope: variable.other.readwrite.js
-
     - match: (?=(?:get|set|async){{identifier_break}})
       branch_point: prefixed-object-literal-method
       branch:
@@ -1633,7 +1651,10 @@ contexts:
       push: expression-no-comma
 
   object-literal-element:
-    - match: ''
+    - match: '{{identifier_name}}(?=\s*(?:[},]|$|//|/\*))'
+      scope: variable.other.readwrite.js
+      pop: true
+    - match: (?=\S)
       pop: true
       branch_point: object-literal-property
       branch:
@@ -1777,13 +1798,11 @@ contexts:
         - function-declaration-expect-body
         - function-declaration-expect-parameters
         - method-name
-        - method-declaration-expect-prefix
+        - method-declaration-expect-asterisk
 
-  method-declaration-expect-prefix:
+  method-declaration-expect-asterisk:
     - match: \*
       scope: keyword.generator.asterisk.js
-    - match: (?:get|set){{identifier_break}}(?!\s*\()
-      scope: storage.type.accessor.js
     - include: else-pop
 
   parenthesized-expression:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -35,6 +35,8 @@ variables:
       (?:=>|:)
     )
 
+  modifier: (?:(?:static|readonly|private|public|protected|abstract|declare){{identifier_break}})
+
 contexts:
   detect-parenthesized-arrow:
     - meta_prepend: true
@@ -230,8 +232,7 @@ contexts:
     - match: '\+|-'
       scope: storage.modifier.js
 
-    - match: readonly{{identifier_break}}
-      scope: storage.modifier.js
+    - include: class-element-modifiers
 
     - match: (?=[<(])
       push:
@@ -415,32 +416,40 @@ contexts:
         - ts-type-expression-begin
     - include: else-pop
 
-  function-parameter-binding-pattern:
+  function-parameter:
     - match: ''
       set:
-        - - include: ts-type-annotation
-        - - include: ts-type-annotation-optional
-        - - include: function-parameter-binding-name
-          - include: function-parameter-binding-array-destructuring
-          - include: function-parameter-binding-object-destructuring
-          - include: else-pop
+        - initializer
+        - ts-type-annotation
+        - ts-type-annotation-optional
+        - function-parameter-binding-pattern
 
   function-parameter-binding-list:
     - meta_prepend: true
 
     - include: decorator
 
-    - match: (?:private|public|protected|readonly){{identifier_break}}
-      scope: storage.modifier.js
+    - include: function-parameter-modifiers
 
     - match: this{{identifier_break}}
       scope: variable.language.this.js
       push: ts-type-annotation
 
-  class-body-contents:
-    - meta_prepend: true
-    - match: (?:private|public|protected|readonly|abstract|declare){{identifier_break}}
+  function-parameter-modifiers:
+    - match: (?={{modifier}})
+      branch_point: function-parameter-modifier
+      branch:
+        - function-parameter-modifier
+        - function-parameter
+
+  function-parameter-modifier:
+    - match: '{{modifier}}'
       scope: storage.modifier.js
+      set:
+        - match: (?={{binding_pattern_lookahead}}|\.\.\.)
+          pop: true
+        - match: (?=\S)
+          fail: function-parameter-modifier
 
   class-field:
     - match: ''
@@ -466,8 +475,7 @@ contexts:
         - function-declaration-expect-parameters
         - ts-type-parameter-list
         - method-name
-        - method-declaration-expect-prefix
-        - function-declaration-expect-async
+        - method-declaration-expect-asterisk
 
   expression-end:
     - meta_prepend: true
@@ -857,3 +865,21 @@ contexts:
           push:
             - ts-type-annotation
             - ts-type-annotation-optional
+
+  object-literal-contents:
+    - meta_prepend: true
+
+    - match: (?={{modifier}})
+      branch_point: ts-object-literal-element-modifier
+      branch:
+        - ts-object-literal-element-modifier
+        - object-literal-element
+
+  ts-object-literal-element-modifier:
+    - match: '{{modifier}}'
+      scope: storage.modifier.js
+      set:
+        - match: (?={{property_name}})
+          pop: true
+        - match: (?=\S)
+          fail: ts-object-literal-element-modifier

--- a/JavaScript/tests/syntax_test_js_class.js
+++ b/JavaScript/tests/syntax_test_js_class.js
@@ -97,6 +97,13 @@ class MyClass extends TheirClass {
 //         ^ entity.name.function variable.other.readwrite
 //             ^^^^^^^^^^^^^ meta.function
 
+    static = 42;
+//  ^^^^^^ variable.other.readwrite
+
+    static() {}
+//  ^^^^^^^^^^^ meta.function
+//  ^^^^^^ entity.name.function
+
     foo // You thought I was a field...
     () { return '...but was a method all along!'; }
 //  ^^ meta.class meta.block meta.function
@@ -134,6 +141,8 @@ class MyClass extends TheirClass {
     {
         return this._foo;
     }
+
+    get *foo()
 
     static foo(baz) {
 //  ^^^^^^ storage.modifier
@@ -218,7 +227,13 @@ class MyClass extends TheirClass {
 //  ^^^^^ keyword.declaration.async
 //        ^ keyword.generator.asterisk
 
+    static *foo() {}
+//  ^^^^^^ storage.modifier
+//         ^ keyword.generator.asterisk
+//          ^^^ entity.name.function
+
     static async foo() {}
+//  ^^^^^^ storage.modifier
 //         ^^^^^ keyword.declaration.async
 
     async() {}
@@ -230,6 +245,10 @@ class MyClass extends TheirClass {
 //          ^^ meta.block
 //          ^ punctuation.section.block.begin
 //           ^ punctuation.section.block.end
+
+    static async() {}
+//  ^^^^^^ storage.modifier
+//         ^^^^^ entity.name.function
 }
 // <- meta.block punctuation.section.block.end
 

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -181,10 +181,20 @@
 //      ^^^^^^^^ storage.modifier
 //               ^^^ variable.other.readwrite
 
-        private static foo;
+        readonly;
+//      ^^^^^^^^ variable.other.readwrite
+
+        readonly() {}
+//      ^^^^^^^^^^ meta.function
+//      ^^^^^^^^ entity.name.function
+
+        private static readonly abstract declare public;
 //      ^^^^^^^ storage.modifier
 //              ^^^^^^ storage.modifier
-//                     ^^^ variable.other.readwrite
+//                     ^^^^^^^^ storage.modifier
+//                              ^^^^^^^^ storage.modifier
+//                                       ^^^^^^^ storage.modifier
+//                                               ^^^^^^ variable.other.readwrite
 
         foo(): any {}
 //      ^^^^^^^^^^^^^ meta.function
@@ -209,6 +219,33 @@
         abstract foo;
 //      ^^^^^^^^ storage.modifier
 //               ^^^ variable.other.readwrite
+
+        abstract foo();
+//      ^^^^^^^^ storage.modifier
+//               ^^^ entity.name.function
+
+        abstract *foo();
+//      ^^^^^^^^ storage.modifier
+//               ^ keyword.generator.asterisk
+//                ^^^ entity.name.function
+
+        abstract async foo();
+//      ^^^^^^^^ storage.modifier
+//               ^^^^^ keyword.declaration.async
+//                     ^^^ entity.name.function
+
+        abstract async() {}
+//      ^^^^^^^^ storage.modifier
+//               ^^^^^ entity.name.function
+
+        abstract get foo() {}
+//      ^^^^^^^^ storage.modifier
+//               ^^^ storage.type.accessor
+//                   ^^^ entity.name.function
+
+        abstract get() {}
+//      ^^^^^^^^ storage.modifier
+//               ^^^ entity.name.function
 
     }
 
@@ -293,6 +330,14 @@ function f(public x) {}
 function f(readonly x) {}
 //         ^^^^^^^^ storage.modifier
 //                  ^ meta.binding.name variable.parameter.function
+
+function f(readonly ...x) {}
+//         ^^^^^^^^ storage.modifier
+//                  ^^^keyword.operator.spread
+//                     ^ meta.binding.name variable.parameter.function
+
+function f(readonly) {}
+//         ^^^^^^^^ meta.binding.name variable.parameter.function
 
 function f(x?: any) {}
 //          ^ storage.modifier.optional
@@ -876,3 +921,31 @@ const f = (): any => {};
 
     a != b;
 //    ^^ keyword.operator.comparison
+
+const x = {
+    readonly: true,
+//  ^^^^^^^^ meta.mapping.key
+    readonly readonly: true,
+//  ^^^^^^^^ storage.modifier
+//           ^^^^^^^^ meta.mapping.key
+
+    readonly,
+//  ^^^^^^^^ variable.other.readwrite
+
+    readonly get() {},
+//  ^^^^^^^^ storage.modifier
+//           ^^^ entity.name.function
+
+    readonly get foo() {},
+//  ^^^^^^^^ storage.modifier
+//           ^^^ storage.type.accessor
+//               ^^^ entity.name.function
+
+    readonly get: 42,
+//  ^^^^^^^^ storage.modifier
+//           ^^^ meta.mapping.key
+
+    readonly get,
+//  ^^^^^^^^ storage.modifier
+//           ^^^ variable.other.readwrite
+}


### PR DESCRIPTION
For #2790.

Refactoring and improvements to handle modifiers like `static`, `readonly`, or `abstract`. This should fix various corner cases, including the one in the linked issue.