### PR TITLE
[Go] Fix XML error in indentation rules.

### DIFF
--- a/Go/Indention Rules.tmPreferences
+++ b/Go/Indention Rules.tmPreferences
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
 Note: with the current API, it seems impossible to make rules that would
@@ -5,8 +6,6 @@ batch-reindent real-world code without wrecking it. As such, these rules are
 optimized for convenience while typing, not for batch reindentation.
 
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
 	<key>scope</key>


### PR DESCRIPTION
The XML declaration must be at the beginning of the file, before any comments. This PR fixes an error when parsing the file with `plistlib`.