### PR TITLE
[CSS] Add support for `:is` and `:where` pseudo class

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1308,7 +1308,7 @@ contexts:
 
   # Functional Pseudo Classes with selector list
   pseudo-class-function-with-selector-args:
-    - match: (?i:matches|not|has)(?=\()
+    - match: (?i:matches|is|not|has)(?=\()
       scope: meta.function-call.identifier.css entity.other.pseudo-class.css
       set:
         - meta_include_prototype: false

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -30,7 +30,7 @@ variables:
   #    matching (?!{{escape}}) which also effects performance negative.
   break: (?=[[^-_[:alnum:]\\]&&[[:ascii:]]]|\Z)
 
-  # Identifiers  
+  # Identifiers
   # https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
   # https://www.w3.org/TR/css3-selectors/#lex
   ident: (?:{{custom_ident}}|{{generic_ident}})
@@ -605,13 +605,13 @@ variables:
   # https://www.w3.org/TR/CSS22/fonts.html#font-shorthand
   font_property_constants: |-
     \b(?xi:
-      caption | icon | menu | message-box | small-caption | status-bar 
+      caption | icon | menu | message-box | small-caption | status-bar
     ){{break}}
 
   # https://www.w3.org/TR/CSS22/fonts.html#font-size-props
   font_size_constants: |-
     \b(?xi:
-      larger | large | medium | small | smaller | x{1,2}-(?: large | small ) 
+      larger | large | medium | small | smaller | x{1,2}-(?: large | small )
     ){{break}}
 
   # https://www.w3.org/TR/CSS22/fonts.html#font-boldness
@@ -619,7 +619,7 @@ variables:
   # https://www.w3.org/TR/CSS22/fonts.html#small-caps
   font_style_constants: |-
     \b(?xi:
-      normal | bold | bolder | lighter | italic | oblique | small-caps 
+      normal | bold | bolder | lighter | italic | oblique | small-caps
     ){{break}}
 
 ###############################################################################
@@ -1308,7 +1308,7 @@ contexts:
 
   # Functional Pseudo Classes with selector list
   pseudo-class-function-with-selector-args:
-    - match: (?i:matches|is|not|has)(?=\()
+    - match: (?i:matches|is|where|not|has)(?=\()
       scope: meta.function-call.identifier.css entity.other.pseudo-class.css
       set:
         - meta_include_prototype: false

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1257,7 +1257,7 @@
 }
 /* <- meta.at-rule.counter-style.css meta.property-list.css meta.block.css punctuation.section.block.end.css */
 
-.test-var-functions { 
+.test-var-functions {
     --test-var: arial;
 /*  ^^^^^^^^^^ entity.other.custom-property.css */
 /*            ^ punctuation.separator.key-value.css*/
@@ -1604,6 +1604,11 @@
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^ entity.other.pseudo-class.css */
 /*                        ^ variable.language.wildcard.asterisk.css */
+
+.test-pseudo-class-tag:where(*) {}
+/*                    ^ punctuation.definition.pseudo-class.css - entity */
+/*                     ^^^^^ entity.other.pseudo-class.css */
+/*                           ^ variable.language.wildcard.asterisk.css */
 
 .test-pseudo-elements::before {}
 /*                   ^^ punctuation.definition.pseudo-element.css - entity */
@@ -2328,7 +2333,7 @@
 /*       ^^^^^ support.function.transform.css */
 /*             ^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*              ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
-    
+
     top: skew(1deg, 2turn);
 /*       ^^^^ support.function.transform.css */
 /*            ^ meta.number.integer.decimal.css constant.numeric.value.css */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1600,6 +1600,11 @@
 /*                     ^^^ entity.other.pseudo-class.css */
 /*                         ^ variable.language.wildcard.asterisk.css */
 
+.test-pseudo-class-tag:is(*) {}
+/*                    ^ punctuation.definition.pseudo-class.css - entity */
+/*                     ^^ entity.other.pseudo-class.css */
+/*                        ^ variable.language.wildcard.asterisk.css */
+
 .test-pseudo-elements::before {}
 /*                   ^^ punctuation.definition.pseudo-element.css - entity */
 /*                     ^^^^^^ entity.other.pseudo-element.css */


### PR DESCRIPTION
`:matches` is officially renamed to `:is`.

https://developer.mozilla.org/en-US/docs/Web/CSS/:is