### PR TITLE
[Git Formats] Git Attributes maintanance

### DIFF
--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -179,14 +179,10 @@ contexts:
     # double quoted value
     - match: \"
       scope: punctuation.definition.string.begin.git.attributes
-      set:
-        - meta_scope: string.quoted.double.git.attributes
-        - include: string-end
-        - match: \\[\\\"\'fnrst]
-          scope: constant.character.escape.git.attributes
+      set: string-content
     # unquoted value is everything except , and whitespace
     - match: '[^,\s]*'
-      scope: string.unquoted.git.attributes
+      scope: meta.string.git.attributes string.unquoted.git.attributes
       pop: true
     - include: immediately-pop
 
@@ -206,11 +202,18 @@ contexts:
 
 ##[ PROTOTYPES ]#######################################################
 
+  string-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.git.attributes string.quoted.double.git.attributes
+    - include: string-end
+    - match: \\[\\\"\'fnrst]
+      scope: constant.character.escape.git.attributes
+
   string-end:
     - match: \"
       scope: punctuation.definition.string.end.git.attributes
       pop: true
-    - match: $\n?
+    - match: \n
       scope: invalid.illegal.unexpected.eol.git.attributes
       pop: true
 

--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -63,6 +63,7 @@ contexts:
     - include: Git Common.sublime-syntax#fnmatch-body
 
   pattern-attributes:
+    - meta_include_prototype: false
     - match: ''
       set: attributes-list
 
@@ -103,34 +104,42 @@ contexts:
       scope: invalid.illegal.attribute-name.git.attributes
 
   meta-diff:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.diff.git.attributes
     - include: immediately-pop
 
   meta-encoding:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.encoding.git.attributes
     - include: immediately-pop
 
   meta-eol:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.eol.git.attributes
     - include: immediately-pop
 
   meta-filter:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.filter.git.attributes
     - include: immediately-pop
 
   meta-merge:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.merge.git.attributes
     - include: immediately-pop
 
   meta-text:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.text.git.attributes
     - include: immediately-pop
 
   meta-whitespace:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.builtin.whitespace.git.attributes
     - include: immediately-pop
 
   meta-other:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute.other.git.attributes
     - include: immediately-pop
 

--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -104,35 +104,35 @@ contexts:
 
   meta-diff:
     - meta_scope: meta.attribute.builtin.diff.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-encoding:
     - meta_scope: meta.attribute.builtin.encoding.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-eol:
     - meta_scope: meta.attribute.builtin.eol.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-filter:
     - meta_scope: meta.attribute.builtin.filter.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-merge:
     - meta_scope: meta.attribute.builtin.merge.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-text:
     - meta_scope: meta.attribute.builtin.text.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-whitespace:
     - meta_scope: meta.attribute.builtin.whitespace.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   meta-other:
     - meta_scope: meta.attribute.other.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
 ##[ ATTRIBUTE KEY VALUE ]##############################################
 
@@ -140,7 +140,7 @@ contexts:
     - match: \w+[-\w]*\b
       scope: meta.mapping.key.git.attributes variable.language.attribute.git.attributes
       set: attribute-maybe-value-list
-    - include: else-pop
+    - include: immediately-pop
 
   attribute-maybe-value-list:
     - meta_content_scope: meta.mapping.git.attributes
@@ -151,7 +151,7 @@ contexts:
       scope: punctuation.separator.mapping.key-value.git.attributes
       set: attribute-value-expected
     - include: attribute-separator
-    - include: else-pop
+    - include: immediately-pop
 
   attribute-value-list:
     - meta_content_scope: meta.mapping.value.git.attributes
@@ -164,7 +164,7 @@ contexts:
       set: attribute-value-expected
     - match: \S
       scope: invalid.illegal.value.git.attributes
-    - include: else-pop
+    - include: immediately-pop
 
   attribute-value-content:
     # double quoted value
@@ -179,7 +179,7 @@ contexts:
     - match: '[^,\s]*'
       scope: string.unquoted.git.attributes
       pop: true
-    - include: else-pop
+    - include: immediately-pop
 
   attribute-value-expected:
     # Attributes are separated by whitespace
@@ -205,6 +205,6 @@ contexts:
       scope: invalid.illegal.unexpected.eol.git.attributes
       pop: true
 
-  else-pop:
+  immediately-pop:
     - match: ''
       pop: true


### PR DESCRIPTION
This PR adds some maintanance changes to _Git Attributes.sublime-syntax_

1. Fixes the `immediately-pop` context name
2. Excludes prototype from contexts which are not meant to receive one by inheriting syntaxes
3. Adds a named context for quoted `string-content` 
4. Scopes strings `meta.string` in case interpolation is desired at any time.