### PR TITLE
[Ruby] Index constants

### DIFF
--- a/Ruby/Symbol List - Constants.tmPreferences
+++ b/Ruby/Symbol List - Constants.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.ruby entity.name.constant</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Index constants and include them into the symbol list.

![sublime-discourse-symbols](https://user-images.githubusercontent.com/544537/117011036-19d12000-acf6-11eb-8530-5d2ee499c2eb.png)

This enables go to definition for constants. As a side benefit, go to definition will now work for classes defined like this:

```ruby
Foo = Class.new do
  def bar; end
end
```