### PR TITLE
[Ruby] Identify constants defined with `||=`

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -194,7 +194,7 @@ contexts:
 
   constants:
     # constant definition, handles multiple definitions on a single line 'APPLE, ORANGE= 1, 2'
-    - match: '\b([[:upper:]]\w*)(?=(\s*,\s*[[:upper:]]\w*)*\s*=(?![=\>]))'
+    - match: '\b([[:upper:]]\w*)(?=(\s*,\s*[[:upper:]]\w*)*\s*(\|\|)?=(?![=\>]))'
       scope: meta.constant.ruby entity.name.constant.ruby
     # Ruby 1.9 symbols
     - match: '{{identifier}}[?!]?(:)(?!:)'

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -573,6 +573,8 @@ UpperCamelCase = 3
 # ^^^^^^^^^^^^ meta.constant.ruby entity.name.constant.ruby
 UPPER_SNAKE_CASE = 4
 # ^^^^^^^^^^^^^^ meta.constant.ruby entity.name.constant.ruby
+UPPER_SNAKE_CASE ||= 5
+# ^^^^^^^^^^^^^^ meta.constant.ruby entity.name.constant.ruby
 A, B, C = 0
 # <- entity.name.constant
 #  ^ entity.name.constant


### PR DESCRIPTION
This is a valid constant definition in Ruby:

```ruby
CONSTANT ||= 'value'
```

Here's an example from Discourse: https://github.com/discourse/discourse/blob/599327658c4abb97a77aac22ff9c16ec8c7708e7/lib/discourse.rb#L693