### PR TITLE
[Git Formats] Add support for Git Log HEAD line

### DIFF
--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -13,24 +13,23 @@ contexts:
   main:
     # 1st header line
     # commit d9d9fb804f5d61c13ba2f8746af33a9f3c609075
-    - match: \b(commit)\s+(\h{7,})
-      scope: meta.header.git.commit markup.raw.block.git.log
+    - match: ^(commit)\s+(\h{7,})
       captures:
         1: keyword.other.commit.git.log
         2: constant.other.hash.git.log
       push:
+        - meta_scope: meta.header.git.commit markup.raw.block.git.log
         - match: $\n?
           scope: meta.header.git.commit markup.raw.block.git.log
+          pop: true
           embed: commit-header
           escape: (?=^commit\s)
-          pop: true
-        - match: \s*(\()(HEAD)\s*(->)
+        - match: (\()(HEAD)\s*(->)
           captures:
             1: punctuation.section.parens.begin.git.log
             2: support.type.git.log
             3: punctuation.separator.mapping.git.log
           push:
-            - meta_scope: meta.header.git.commit markup.raw.block.git.log
             - match: \)
               scope: punctuation.section.parens.end.git.log
               pop: true

--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -13,13 +13,33 @@ contexts:
   main:
     # 1st header line
     # commit d9d9fb804f5d61c13ba2f8746af33a9f3c609075
-    - match: (?:(commit)\s+(\h{7,}))?\s*\n
+    - match: \b(commit)\s+(\h{7,})
       scope: meta.header.git.commit markup.raw.block.git.log
       captures:
         1: keyword.other.commit.git.log
         2: constant.other.hash.git.log
-      embed: commit-header
-      escape: (?=^commit\s)
+      push:
+        - match: $\n?
+          scope: meta.header.git.commit markup.raw.block.git.log
+          embed: commit-header
+          escape: (?=^commit\s)
+          pop: true
+        - match: \s*(\()(HEAD)\s*(->)
+          captures:
+            1: punctuation.section.parens.begin.git.log
+            2: support.type.git.log
+            3: punctuation.separator.mapping.git.log
+          push:
+            - meta_scope: meta.header.git.commit markup.raw.block.git.log
+            - match: \)
+              scope: punctuation.section.parens.end.git.log
+              pop: true
+            - match: \bmaster\b
+              scope: entity.other.branch-name.master.git.log
+            - match: (\w+)(?:(/)(\w+))?
+              scope: entity.other.branch-name.git.log
+            - match: ','
+              scope: punctuation.separator.sequence.git.log
 
   commit-header:
     # All header attributes are mappings of `key: value` format.

--- a/Git Formats/tests/syntax_test_git_log
+++ b/Git Formats/tests/syntax_test_git_log
@@ -45,3 +45,32 @@ Date:   Thu Sep 21 22:53:04 2017 +0200
 #                                 ^ punctuation.separator.reference.issue.git
 #                                       ^ punctuation.definition.reference.issue.git
 
+commit e2077c6e006acfd2f060aef03c4ef8f89c4db362 (HEAD -> branch_name, origin/branch_name)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.git markup.raw.block.git
+#                                               ^ punctuation.section.parens.begin.git
+#                                                ^^^^ support.type.git
+#                                                     ^^ punctuation.separator.mapping.git
+#                                                        ^^^^^^^^^^^ entity.other.branch-name.git
+#                                                                   ^ punctuation.separator.sequence.git
+#                                                                     ^^^^^^^^^^^^^^^^^^ entity.other.branch-name.git
+#                                                                                       ^ punctuation.section.parens.end.git
+Author: username <user-name.last@host.com>
+# <- meta.header.git.commit markup.raw.block.git.log keyword.other.header.git.log
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.git.commit markup.raw.block.git.log
+#^^^^^^^ - string.unquoted.log
+#^^^^^ keyword.other.header.git.log
+#     ^ punctuation.separator.mapping.pair.git.log - keyword.other.header.git.log
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.log
+#                ^ punctuation.definition.reference.email.begin.git
+#                ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.reference.email.git
+#                 ^^^^^^^^^^^^^^^^^^^^^^^ entity.name.reference.email.git
+#                               ^ punctuation.separator.email.git
+#                                    ^ punctuation.separator.domain.git
+#                                        ^ punctuation.definition.reference.email.end.git
+Date:   Thu Sep 21 22:53:04 2017 +0200
+# <- meta.header.git.commit markup.raw.block.git.log keyword.other.header.git.log
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.git.commit markup.raw.block.git.log
+#^^^^^^^ - string.unquoted.log
+#^^^ keyword.other.header.git.log
+#   ^ punctuation.separator.mapping.pair.git.log - keyword.other.header.git.log
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.log


### PR DESCRIPTION
This allows Sublime to highlight the Git Log more like "regular `git log`" output in the case of the HEAD entry.
First reported at https://github.com/sharkdp/bat/issues/1632

Honestly, I wasn't too sure about what scopes to use, so if someone with more experience with the Git Formats syntaxes could chime in, it'd be much appreciated. :)