### PR TITLE
[CSS] Fix @font-face property names

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -267,6 +267,15 @@ variables:
   counter_system_constants: |-
     \b(?xi: cyclic | numeric | alphabetic | symbolic | additive | fixed ){{break}}
 
+  # @font-face Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
+  font_face_property_names: |-
+    \b(?xi:
+      ascent-override | descent-override | font-display | (?# font-family | ) src
+    | font-feature-settings | font-variation-settings | font-stretch | font-style
+    | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
+    ){{break}}
+
   # Page Margin Property Names
   # https://www.w3.org/TR/css-page-3/#margin-at-rule
   page_margin_property_names: |-
@@ -301,7 +310,7 @@ variables:
     | border-top-right-radius | border-bottom-color | border-top-color
     | flex-shrink | align-self | text-rendering | animation-timing-function
     | direction | background-clip | zoom | border-spacing | text-indent
-    | outline-offset | border-left-color | transition-property | src
+    | outline-offset | border-left-color | transition-property
     | border-right-color | animation-name | stroke | touch-action
     | animation-duration | transition-delay | filter | overflow-wrap
     | animation-delay | border-bottom-width | variable | font-variant
@@ -310,7 +319,7 @@ variables:
     | order | outline-style | stroke-width | border-right-width | align-content
     | resize | table-layout | appearance | animation-iteration-count
     | border-left-width | flex-flow | stroke-dashoffset | stroke-dasharray
-    | backface-visibility | unicode-bidi | unicode-range | border-bottom-style
+    | backface-visibility | unicode-bidi | border-bottom-style
     | text-size-adjust | border-top-style | animation-direction | word-spacing
     | contain | speak | grid-template-columns | font-feature-settings
     | perspective | list-style-position | clip-path | image-rendering
@@ -760,8 +769,27 @@ contexts:
 
   at-font-face-content:
     - meta_scope: meta.at-rule.font-face.css
-    - include: rule-list
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-font-face-block-content
     - include: at-rule-end
+
+  at-font-face-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-font-face-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+  at-font-face-property-names:
+    - match: \b(?i:font-family){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: font-property-value
+    - match: '{{font_face_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
 
   # @import
   # https://www.w3.org/TR/css-cascade-4/#at-ruledef-import

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -843,6 +843,18 @@
 {
 /* <- meta.at-rule.font-face.css meta.property-list.css meta.block.css punctuation.section.block.begin.css */
 
+    ascent-override: normal;
+/*  ^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                   ^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    descent-override: normal;
+/*  ^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                    ^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-display: swap;
+/*  ^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                ^^^^ meta.property-value.css support.constant.property-value.css */
+
     font-family: monospace,
 /* ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.font-face.css meta.property-list.css meta.block.css */
 /*  ^^^^^^^^^^^ support.type.property-name.css */
@@ -858,6 +870,38 @@
 
     font-family: Gentium Bold;
 /*               ^^^^^^^^^^^^ meta.string.css string.unquoted.css */
+
+    font-feature-settings: normal;
+/*  ^^^^^^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                         ^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-variation-settings: normal;
+/*  ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                           ^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-stretch: expanded;
+/*  ^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                ^^^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-style: oblique;
+/*  ^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*              ^^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-weight: bold;
+/*  ^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*               ^^^^ meta.property-value.css support.constant.property-value.css */
+
+    font-variant: discretionary-ligatures;
+/*  ^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    line-gap-override: normal;
+/*  ^^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                     ^^^^^^ meta.property-value.css support.constant.property-value.css */
+
+    size-adjust: 50%;
+/*  ^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*               ^^^ meta.property-value.css meta.number.integer.decimal.css */
 
     src: format("embedded-opentype");
 /*       ^^^^^^ support.function.font-face.css */
@@ -910,6 +954,12 @@
 /*                ^ punctuation.section.group.begin.css */
 /*                 ^^^^^^^^^^^^ variable.other.custom-property.css */
 /*                             ^^ punctuation.section.group.end.css */
+
+    unicode-range: U+0-10FFFF;
+/*  ^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*               ^ punctuation.separator.key-value.css */
+/*                 ^^^^^^^^^^ meta.property-value.css meta.number.unicode-range.css */
+/*                           ^ punctuation.terminator.rule.css */
 }
 /* <- meta.at-rule.font-face.css meta.property-list.css meta.block.css punctuation.section.block.end.css */
 


### PR DESCRIPTION
This PR creates a dedicated context for @font-face properties and fills the list with all supported property names. Not all of them are supported globally.

Results:

1. Only valid property names are highlighted
2. Missing properties such as `ascent-override` are added.
3. `src` and `unicode-range` are removed from common property names as they are valid only in @font-face context.