### PR TITLE
[CSS] Fix @counter-style property names

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -257,6 +257,14 @@ variables:
       | upper-alpha | upper-armenian | upper-latin | upper-roman
     ){{break}}
 
+  # @counter-style Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style
+  counter_style_property_names: |-
+    \b(?xi:
+      additive-symbols | negative | pad | prefix | range
+    | suffix | symbols (?# | fallback | speak-as | system )
+    ){{break}}
+
   # Predefined Counter Speak As Property Constants
   # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
   counter_speak_as_constants: |-
@@ -400,17 +408,16 @@ variables:
     | math-superscript-shift-style | start
     # END OF QUERY RESULTS
     # BEGIN OF legacy properties which existed before the last query
-    | box-direction | line-box-contain
-    | prefix | mask-image | mask-origin | flex-order | system | speak-as
+    | box-direction | line-box-contain | mask-image | mask-origin | flex-order
     | font-synthesis | line-clamp | flex-negative | blend-mode
     | font-variant-position | flex-align | column-break-before | negative
     | flex-item-align | azimuth | user-drag | range | mask-repeat | box-flex
-    | flex-preferred-size | font-language-override | box-align | pad
+    | flex-preferred-size | font-language-override | box-align
     | text-emphasis-color | box-ordinal-group | mask-composite
     | transform-origin-y | pause | tap-highlight-color | text-fill-color
     | suffix | text-emphasis-style | transform-origin-x | text-emphasis-position
-    | box-pack | box-decoration-break | box-orient | additive-symbols
-    | text-emphasis | symbols | mask-clip | nbsp-mode | pause-after | pitch
+    | box-pack | box-decoration-break | box-orient
+    | text-emphasis | mask-clip | nbsp-mode | pause-after | pitch
     | text-height | mask-position | flex-line-pack | perspective-origin-x
     | mask-size | font-variant-alternates | perspective-origin-y
     | font-smoothing | overflow-scrolling | flex-positive | pitch-range
@@ -699,15 +706,34 @@ contexts:
 
   at-counter-style-content:
     - meta_scope: meta.at-rule.counter-style.css
-    - include: rule-list
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-counter-style-block-content
     - include: at-counter-style-names
     - include: at-rule-end
+
+  at-counter-style-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-counter-style-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
 
   at-counter-style-names:
     - match: '{{counter_style_illegal_names}}'
       scope: invalid.illegal.identifier.css
     - match: '{{ident}}'
       scope: entity.other.counter-style-name.css
+
+  at-counter-style-property-names:
+    - include: counter-style-fallback-properties
+    - include: counter-style-system-properties
+    - include: counter-style-speak-as-properties
+    - match: '{{counter_style_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
 
   # @custom-media
   # https://??
@@ -1398,9 +1424,6 @@ contexts:
     - include: vendor-prefixes
     # specific properties with special treatment
     - include: counter-property
-    - include: counter-style-fallback-property
-    - include: counter-style-system-property
-    - include: counter-style-speak-as-property
     - include: font-property
     # common properties
     - include: builtin-property
@@ -1516,10 +1539,10 @@ contexts:
 
   # Counter Style Fallback
   # https://drafts.csswg.org/css-counter-styles-3/#counter-style-fallback
-  counter-style-fallback-property:
+  counter-style-fallback-properties:
     - match: \b(?i:fallback){{break}}
-      scope: support.type.property-name.css
-      set: counter-style-fallback-property-value
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-fallback-property-value
 
   counter-style-fallback-property-value:
     - match: ':'
@@ -1544,10 +1567,10 @@ contexts:
 
   # Counter Style System
   # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
-  counter-style-system-property:
+  counter-style-system-properties:
     - match: \b(?i:system){{break}}
-      scope: support.type.property-name.css
-      set: counter-style-system-property-value
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-system-property-value
 
   counter-style-system-property-value:
     - match: ':'
@@ -1579,10 +1602,10 @@ contexts:
 
   # Counter Style Speak As
   # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
-  counter-style-speak-as-property:
+  counter-style-speak-as-properties:
     - match: \b(?i:speak-as){{break}}
-      scope: support.type.property-name.css
-      set: counter-style-speak-as-property-value
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-speak-as-property-value
 
   counter-style-speak-as-property-value:
     - match: ':'

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -410,12 +410,12 @@ variables:
     # BEGIN OF legacy properties which existed before the last query
     | box-direction | line-box-contain | mask-image | mask-origin | flex-order
     | font-synthesis | line-clamp | flex-negative | blend-mode
-    | font-variant-position | flex-align | column-break-before | negative
-    | flex-item-align | azimuth | user-drag | range | mask-repeat | box-flex
+    | font-variant-position | flex-align | column-break-before
+    | flex-item-align | azimuth | user-drag | mask-repeat | box-flex
     | flex-preferred-size | font-language-override | box-align
     | text-emphasis-color | box-ordinal-group | mask-composite
     | transform-origin-y | pause | tap-highlight-color | text-fill-color
-    | suffix | text-emphasis-style | transform-origin-x | text-emphasis-position
+    | text-emphasis-style | transform-origin-x | text-emphasis-position
     | box-pack | box-decoration-break | box-orient
     | text-emphasis | mask-clip | nbsp-mode | pause-after | pitch
     | text-height | mask-position | flex-line-pack | perspective-origin-x

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1022,6 +1022,12 @@
 /*   ^^^^^^^^^^^^^ keyword.control.directive.css - punctuation */
 /*                 ^^^^ entity.other.counter-style-name.css */
 
+    additive-symbols: ;
+/* ^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.counter-style.css meta.property-list.css meta.block.css */
+/*  ^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                  ^ punctuation.separator.key-value.css */
+/*                    ^ punctuation.terminator.rule.css*/
+
     system: extends disc;
 /* ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.counter-style.css meta.property-list.css meta.block.css */
 /* ^ - meta.property-name - meta.property-value */


### PR DESCRIPTION
This PR adds a dedicated context for @counter-style property-lists. 

The goal is to tidy common/ordinary property lists from special at-rule stuff and highlight only those properties in at-rules which are valid.

A positive side effect is slightly improved parsing performance.