### PR TITLE
[ShellScript] Add support for dash shebang

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -37,7 +37,7 @@ hidden_file_extensions:
 
 first_line_match: |-
   (?x:
-    ^\#! .* \b(bash|zsh|sh|tcsh|ash|dash)\b |        # shebang
+    ^\#! .* \b(bash|zsh|sh|tcsh|ash|dash)\b |   # shebang
     ^\# \s* -\*- [^*]* shell-script [^*]* -\*-  # editorconfig
   )
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -37,7 +37,7 @@ hidden_file_extensions:
 
 first_line_match: |-
   (?x:
-    ^\#! .* \b(bash|zsh|sh|tcsh|ash)\b |        # shebang
+    ^\#! .* \b(bash|zsh|sh|tcsh|ash|dash)\b |        # shebang
     ^\# \s* -\*- [^*]* shell-script [^*]* -\*-  # editorconfig
   )
 


### PR DESCRIPTION
This is a patch to `Bash.sublime-syntax` that adds support for shebangs explicitly calling for dash, e.g., `#!/usr/bin/env dash`. Proposed in sharkdp/bat#1654.

I have not modified the Bash syntax test file since the dash shell supports less features than Bash.