### PR TITLE
[XML] Add support for XAML files

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -59,6 +59,7 @@ file_extensions:
   - rss
   - opml
   - svg
+  - xaml
 
 hidden_file_extensions:
   - sublime-snippet


### PR DESCRIPTION
XAML is an XML-based language and can use the same output format. This patch adds support for XAML files. Proposed in sharkdp/bat#1590 and sharkdp/bat#1655.

I have not modified the XML test file for now, because I am not too familiar with XAML. If anyone knows of XAML-specific features we can test for, I would be happy to add to the PR.