### PR TITLE
[HTML] Fix toggle html comments in css/js tags

### DIFF
--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -38,6 +38,56 @@
     '                                ^^^^^^^^^^^^^^^ support.class.collection.asp
     '                                                              ^^ punctuation.section.embedded.end.asp - source.asp
     '                                                                ^^^^^^^^ meta.tag
+
+    <script> var i = 0; </script>
+    '  ^^^^^ meta.tag - source
+    '       ^^^^^^^^^^^^ source.js.embedded.html
+    '                   ^^^^^^^^^ meta.tag - source
+    '
+
+    <script> <!-- var i = 0; --> </script>
+    '       ^^^^^ - source - meta.tag
+    '        ^^^^ punctuation.definition.comment.begin.html
+    '            ^^^^^^^^^^^^ source.js.embedded.html
+    '                        ^^^^ - source - meta.tag
+    '                        ^^^ comment.block.html punctuation.definition.comment.end.html
+    '
+
+    <script>
+        <!--
+    '  ^^^^^ - source - meta.tag
+    '   ^^^^ punctuation.definition.comment.begin.html
+        var i = 0;
+    '  ^^^^^^^^^^^^ source.js.embedded.html
+        -->
+    '   ^^^^ - source - meta.tag
+    '   ^^^ comment.block.html punctuation.definition.comment.end.html
+        var i = 0;
+    '  ^^^^^^^^^^^^ - source
+    </script>
+
+    <style type="text/css"> <!-- h1 {} --> </style>
+    '  ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+    '                      ^ - meta.tag - comment - source
+    '                       ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+    '                           ^^^^^^^ source.css.embedded.html
+    '                                  ^^^ comment.block.html punctuation.definition.comment.end.html - source
+    '                                     ^ - meta.tag - comment - source
+    '                                      ^^^^^^^^ meta.tag - comment - source
+
+    <style type="text/css">
+        <!--
+    '  ^ - meta.tag - comment - source
+    '   ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+    '       ^ source.css.embedded.html - comment
+            h1 {}
+    '      ^^^^^^^ source.css.embedded.html
+        -->
+    '  ^ source.css.embedded.html - comment
+    '   ^^^ comment.block.html punctuation.definition.comment.end.html - source
+    '      ^ - meta.tag - comment - source
+    </style>
+    '  ^^^^^ meta.tag - comment - source
 </head>
 <body>
     <%
@@ -45,10 +95,10 @@
     'this is a comment
    '^ punctuation.definition.comment.asp
    '^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.asp
-    
+
     Option Explicit
    '^^^^^^^^^^^^^^^ keyword
-    
+
     Class TestClass
    '^^^^^^^^^^^^^^^ meta.class.asp meta.class.identifier.asp - meta.class.body.asp
    '^^^^^ storage.type.asp

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -173,7 +173,7 @@ contexts:
 
   script-javascript-content:
     - meta_include_prototype: false
-    # Note: This context is to be overridden to replace embedded css syntax.
+    # Note: This context is to be overridden to replace embedded js syntax.
     #       It is stripped from as most implementation details as possible.
     #       Maybe simplified once core issue #3787 is resolved.
     - match: ''

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,9 +43,9 @@ variables:
       | text/livescript
     )
 
-  script_content_begin: <!--|(?=\s*(?!<!--)\S)
+  script_content_begin: (?:\s*(<!--)|(?=\s*(?:(?!<!--)\S|^)))
   script_content_end: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}}|^\s*-->\s*$)
-  style_content_begin: <!--|(?=\s*(?!<!--)\S)
+  style_content_begin: (?:\s*(<!--)|(?=\s*(?:(?!<!--)\S|^)))
   style_content_end: (?=(?:-->\s*)?</(?i:style){{tag_name_break_char}}|^\s*-->\s*$)
 
 ###############################################################################
@@ -168,7 +168,8 @@ contexts:
   script-javascript-begin:
     - meta_include_prototype: false
     - match: '{{script_content_begin}}'
-      scope: comment.block.html punctuation.definition.comment.begin.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
       set: script-javascript-content
 
   script-javascript-content:
@@ -279,7 +280,8 @@ contexts:
   style-css-begin:
     - meta_include_prototype: false
     - match: '{{style_content_begin}}'
-      scope: comment.block.html punctuation.definition.comment.begin.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
       set: style-css-content
 
   style-css-content:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,8 +43,10 @@ variables:
       | text/livescript
     )
 
-  script_close_lookahead: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}})
-  style_close_lookahead: (?=</(?i:style){{tag_name_break_char}})
+  script_content_begin: <!--|(?=\s*(?!<!--)\S)
+  script_content_end: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}}|^\s*-->\s*$)
+  style_content_begin: <!--|(?=\s*(?!<!--)\S)
+  style_content_end: (?=(?:-->\s*)?</(?i:style){{tag_name_break_char}}|^\s*-->\s*$)
 
 ###############################################################################
 
@@ -160,14 +162,36 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
-        - include: script-close-tag
-        - include: script-javascript-content
+        - script-javascript-end
+        - script-javascript-begin
+
+  script-javascript-begin:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      scope: comment.block.html punctuation.definition.comment.begin.html
+      set: script-javascript-content
 
   script-javascript-content:
-    - match: (?=\S)
+    - meta_include_prototype: false
+    # Note: This context is to be overridden to replace embedded css syntax.
+    #       It is stripped from as most implementation details as possible.
+    #       Maybe simplified once core issue #3787 is resolved.
+    - match: ''
+      pop: 1  # make sure to match only once
       embed: scope:source.js
       embed_scope: source.js.embedded.html
-      escape: '{{script_close_lookahead}}'
+      escape: '{{script_content_end}}'
+
+  script-javascript-end:
+    - meta_include_prototype: false
+    # Note: Scopes any remaining whitespace in front of closing comment sign
+    #       source.js.embedded so toggle comment remains working if the last
+    #       caret is in front of it.
+    - match: (\s*)(-->)
+      captures:
+        1: source.js.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+    - include: script-close-tag
 
   script-html:
     - meta_scope: meta.tag.script.begin.html
@@ -176,7 +200,6 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - meta_content_scope: text.html.embedded.html
-        - include: comment
         - include: script-close-tag
         - include: main
 
@@ -188,20 +211,14 @@ contexts:
       set: script-close-tag
 
   script-close-tag:
-    - match: <!--
-      scope: comment.block.html punctuation.definition.comment.begin.html
-    - match: '{{script_close_lookahead}}'
+    - match: (</)((?i:script){{tag_name_break}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
       set:
-        - match: -->
-          scope: comment.block.html punctuation.definition.comment.end.html
-        - match: (</)((?i:script){{tag_name_break}})
-          captures:
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-          set:
-            - meta_scope: meta.tag.script.end.html
-            - include: tag-end
-            - include: tag-attributes
+        - meta_scope: meta.tag.script.end.html
+        - include: tag-end
+        - include: tag-attributes
 
   script-common:
     - include: script-type-attribute
@@ -256,14 +273,36 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
-        - include: style-close-tag
-        - include: style-css-content
+        - style-css-end
+        - style-css-begin
+
+  style-css-begin:
+    - meta_include_prototype: false
+    - match: '{{style_content_begin}}'
+      scope: comment.block.html punctuation.definition.comment.begin.html
+      set: style-css-content
 
   style-css-content:
+    - meta_include_prototype: false
+    # Note: This context is to be overridden to replace embedded css syntax.
+    #       It is stripped from as most implementation details as possible.
+    #       Maybe simplified once core issue #3787 is resolved.
     - match: ''
+      pop: 1  # make sure to match only once
       embed: scope:source.css
       embed_scope: source.css.embedded.html
-      escape: '{{style_close_lookahead}}'
+      escape: '{{style_content_end}}'
+
+  style-css-end:
+    - meta_include_prototype: false
+    # Note: Scopes any remaining whitespace in front of closing comment sign
+    #       source.js.embedded so toggle comment remains working if the last
+    #       caret is in front of it.
+    - match: (\s*)(-->)
+      captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+    - include: style-close-tag
 
   style-other:
     - meta_scope: meta.tag.style.begin.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -163,21 +163,13 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - script-javascript-end
-        - script-javascript-begin
+        - script-javascript-content
 
-  script-javascript-begin:
+  script-javascript-content:
     - meta_include_prototype: false
     - match: '{{script_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
-      set: script-javascript-content
-
-  script-javascript-content:
-    - meta_include_prototype: false
-    # Note: This context is to be overridden to replace embedded js syntax.
-    #       It is stripped from as most implementation details as possible.
-    #       Maybe simplified once core issue #3787 is resolved.
-    - match: ''
       pop: 1  # make sure to match only once
       embed: scope:source.js
       embed_scope: source.js.embedded.html
@@ -275,21 +267,13 @@ contexts:
       scope: punctuation.definition.tag.end.html
       set:
         - style-css-end
-        - style-css-begin
+        - style-css-content
 
-  style-css-begin:
+  style-css-content:
     - meta_include_prototype: false
     - match: '{{style_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
-      set: style-css-content
-
-  style-css-content:
-    - meta_include_prototype: false
-    # Note: This context is to be overridden to replace embedded css syntax.
-    #       It is stripped from as most implementation details as possible.
-    #       Maybe simplified once core issue #3787 is resolved.
-    - match: ''
       pop: 1  # make sure to match only once
       embed: scope:source.css
       embed_scope: source.css.embedded.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,10 +43,38 @@ variables:
       | text/livescript
     )
 
-  script_content_begin: (?:\s*(<!--)|(?=\s*(?:(?!<!--)\S|^)))
-  script_content_end: (?=(?:-->\s*)?</(?i:script){{tag_name_break_char}}|^\s*-->\s*$)
-  style_content_begin: (?:\s*(<!--)|(?=\s*(?:(?!<!--)\S|^)))
-  style_content_end: (?=(?:-->\s*)?</(?i:style){{tag_name_break_char}}|^\s*-->\s*$)
+  # Embedded script and style syntaxes may be wrapped into html comments for
+  # historical reasons. The following patterns match them, while maintaining
+  # correct boundaries of embedded source scopes. That's required to enable
+  # embedded syntax's comment toggling in the first and last line.
+  #
+  # see:
+  # - https://github.com/sublimehq/Packages/issues/2322
+  # - https://github.com/sublimehq/sublime_text/issues/4701
+  script_content_begin: |-
+    (?x:
+    # whitespace followed by opening html comment begin punctuation
+      \s*(<!--)
+    # or any other non-whitespace character ahead
+    | (?=\s*(?!<!--)\S)
+    # or beginning of a line
+    | ^
+    )
+  script_content_end: |-
+    (?x:
+    # optional html comment end punctuation followed by </script> tag
+      (?: (\s*) (-->) \s* )? (?=</(?i:script){{tag_name_break_char}})
+    # or standalone html comment end punctuation in a line
+    |   ^ (\s*) (-->) \s* $
+    )
+  style_content_begin: '{{script_content_begin}}'
+  style_content_end: |-
+    (?x:
+    # optional html comment end punctuation followed by </style> tag
+      (?: (\s*) (-->) \s* )? (?=</(?i:style){{tag_name_break_char}})
+    # or standalone html comment end punctuation in a line
+    |   ^ (\s*) (-->) \s* $
+    )
 
 ###############################################################################
 
@@ -162,7 +190,7 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
-        - script-javascript-end
+        - script-close-tag
         - script-javascript-content
 
   script-javascript-content:
@@ -174,17 +202,11 @@ contexts:
       embed: scope:source.js
       embed_scope: source.js.embedded.html
       escape: '{{script_content_end}}'
-
-  script-javascript-end:
-    - meta_include_prototype: false
-    # Note: Scopes any remaining whitespace in front of closing comment sign
-    #       source.js.embedded so toggle comment remains working if the last
-    #       caret is in front of it.
-    - match: (\s*)(-->)
-      captures:
+      escape_captures:
         1: source.js.embedded.html
         2: comment.block.html punctuation.definition.comment.end.html
-    - include: script-close-tag
+        3: source.js.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
 
   script-html:
     - meta_scope: meta.tag.script.begin.html
@@ -266,7 +288,7 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set:
-        - style-css-end
+        - style-close-tag
         - style-css-content
 
   style-css-content:
@@ -278,17 +300,11 @@ contexts:
       embed: scope:source.css
       embed_scope: source.css.embedded.html
       escape: '{{style_content_end}}'
-
-  style-css-end:
-    - meta_include_prototype: false
-    # Note: Scopes any remaining whitespace in front of closing comment sign
-    #       source.js.embedded so toggle comment remains working if the last
-    #       caret is in front of it.
-    - match: (\s*)(-->)
-      captures:
+      escape_captures:
         1: source.css.embedded.html
         2: comment.block.html punctuation.definition.comment.end.html
-    - include: style-close-tag
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
 
   style-other:
     - meta_scope: meta.tag.style.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -30,6 +30,33 @@
     <head>
         <title>Test HTML</title>
 
+        <script> var i = 0; </script>
+        ## ^^^^^ meta.tag - source
+        ##      ^^^^^^^^^^^^ source.js.embedded.html
+        ##                  ^^^^^^^^^ meta.tag - source
+        ##
+
+        <script> <!-- var i = 0; --> </script>
+        ##      ^^^^^ - source - meta.tag
+        ##       ^^^^ punctuation.definition.comment.begin.html
+        ##           ^^^^^^^^^^^^ source.js.embedded.html
+        ##                       ^^^^ - source - meta.tag
+        ##                       ^^^ comment.block.html punctuation.definition.comment.end.html
+        ##
+
+        <script>
+            <!--
+        ## ^^^^^ - source - meta.tag
+        ##  ^^^^ punctuation.definition.comment.begin.html
+            var i = 0;
+        ## ^^^^^^^^^^^^ source.js.embedded.html
+            -->
+        ##  ^^^^ - source - meta.tag
+        ##  ^^^ comment.block.html punctuation.definition.comment.end.html
+            var i = 0;
+        ## ^^^^^^^^^^^^ - source
+        </script>
+
         <script> <!--
         ## ^^^^^ meta.tag.script.begin.html
         ## ^ entity.name.tag.script - source.js.embedded.html
@@ -111,23 +138,53 @@
         >
         ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
 
+        <style type="text/css"> <!-- h1 {} --> </style>
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+        ##                     ^ - meta.tag - comment - source
+        ##                      ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+        ##                          ^^^^^^^ source.css.embedded.html
+        ##                                 ^^^ comment.block.html punctuation.definition.comment.end.html - source
+        ##                                    ^ - meta.tag - comment - source
+        ##                                     ^^^^^^^^ meta.tag - comment - source
+
+        <style type="text/css">
+            <!--
+        ## ^ - meta.tag - comment - source
+        ##  ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+        ##      ^ source.css.embedded.html - comment
+                h1 {}
+        ##     ^^^^^^^ source.css.embedded.html
+            -->
+        ## ^ source.css.embedded.html - comment
+        ##  ^^^ comment.block.html punctuation.definition.comment.end.html - source
+        ##     ^ - meta.tag - comment - source
+        </style>
+        ## ^^^^^ meta.tag - comment - source
+
         <style type="text/css"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html
-        ## ^ entity.name.tag.style.html
-        ## ^^^^^^^^^^^^^^^^^^^^ - source.css.embedded.html
-        ##      ^ entity.other.attribute-name
-        ##                     ^ - meta.tag
-        ##                      ^^^^ - comment
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html - source.css
+        ##                     ^^^^^ - meta.tag - source.css
+        ##                          ^ source.css.embedded.html
+        ## ^^^ entity.name.tag.style.html
+        ##    ^ - entity
+        ##     ^^^^ entity.other.attribute-name
+        ##         ^ punctuation.separator.key-value.html
+        ##          ^^^^^^^^^^ meta.string.html string.quoted.double.html
+        ##                    ^ punctuation.definition.tag.end.html
+        ##                      ^^^^ comment.block.html punctuation.definition.comment.begin.html
             h2 {
-            ## <- entity.name.tag.html.css
 ## <- source.css.embedded.html - source.css source.css
+            ## <- entity.name.tag.html.css
                 font-family: "Arial";
                 ##             ^ string.quoted.double.css
             }
         --> </style>
-        ## <- - comment
-        ##  ^^^^^^^^ meta.tag.style.end.html - source.css.embedded.html
+        ## <- comment.block.html punctuation.definition.comment.end.html
+        ## ^ - source.css - meta.tag - comment
+        ##  ^^^^^^^^ meta.tag.style.end.html - source.css
+        ##  ^^ punctuation.definition.tag.begin.html
         ##    ^^^^^ entity.name.tag.style.html
+        ##         ^ punctuation.definition.tag.end.html
         ##          ^ - meta.tag
 
         <style

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -121,6 +121,23 @@
 ##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.script.end
 ##               ^ text.html.basic - text.html.embedded.html
 
+        <script>
+            <!-- i = 0;
+##      ^^^^^^^^ - source
+##          ^^^^ punctuation.definition.comment.begin.html
+##              ^^^^^^^ source.js.embedded.html
+            -->
+##      ^^^^ source.js.embedded.html
+##          ^^^^ - source
+##          ^^^ comment.block.html punctuation.definition.comment.end.html
+        </script>
+
+        <script>
+
+## <- source.js.embedded.html
+## ^^^^^^^^^^^^^ source.js.embedded.html
+        </script>
+
         <script>42</script >
 ##      ^^^^^^^^ meta.tag.script.begin
 ##              ^^ source.js.embedded.html - source.js source.js
@@ -146,6 +163,12 @@
         ##                                 ^^^ comment.block.html punctuation.definition.comment.end.html - source
         ##                                    ^ - meta.tag - comment - source
         ##                                     ^^^^^^^^ meta.tag - comment - source
+
+        <style>
+
+## <- source.css.embedded.html
+## ^^^^^^^^^^^^^ source.css.embedded.html
+        </style>
 
         <style type="text/css">
             <!--

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -32,30 +32,47 @@
 
         <script> var i = 0; </script>
         ## ^^^^^ meta.tag - source
-        ##      ^^^^^^^^^^^^ source.js.embedded.html
+        ##      ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
         ##                  ^^^^^^^^^ meta.tag - source
-        ##
+
+        <script> var i = 0; --> </script>
+        ## ^^^^^ meta.tag - source
+        ##      ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+        ##                  ^^^^ - meta.tag - source
+        ##                  ^^^ comment.block.html punctuation.definition.comment.end.html
+        ##                      ^^^^^^^^^ meta.tag - source
+
+        <script> <!-- var i = 0; </script>
+        ## ^^^^^ meta.tag - source
+        ##      ^^^^^ - meta.tag - source
+        ##           ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+        ##                       ^^^^^^^^^ meta.tag - source
+        ##       ^^^^ punctuation.definition.comment.begin.html
 
         <script> <!-- var i = 0; --> </script>
-        ##      ^^^^^ - source - meta.tag
+        ## ^^^^^ meta.tag - source
+        ##      ^^^^^ - meta.tag - source
         ##       ^^^^ punctuation.definition.comment.begin.html
-        ##           ^^^^^^^^^^^^ source.js.embedded.html
-        ##                       ^^^^ - source - meta.tag
+        ##           ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+        ##                       ^^^^ - meta.tag - source
         ##                       ^^^ comment.block.html punctuation.definition.comment.end.html
-        ##
+        ##                           ^^^^^^^^^ meta.tag - source
 
         <script>
             <!--
-        ## ^^^^^ - source - meta.tag
-        ##  ^^^^ punctuation.definition.comment.begin.html
+        ## ^^^^^ - meta.tag - source
+        ##  ^^^^ comment.block.html punctuation.definition.comment.begin.html
+        ##      ^ source.js.embedded.html - meta.tag - comment
             var i = 0;
-        ## ^^^^^^^^^^^^ source.js.embedded.html
+        ## ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
             -->
+        ##^^ source.js.embedded.html - meta.tag - comment
         ##  ^^^^ - source - meta.tag
         ##  ^^^ comment.block.html punctuation.definition.comment.end.html
             var i = 0;
         ## ^^^^^^^^^^^^ - source
         </script>
+        ## ^^^^^^ meta.tag - source
 
         <script> <!--
         ## ^^^^^ meta.tag.script.begin.html
@@ -155,11 +172,30 @@
         >
         ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
 
+        <style type="text/css"> h1 {} </style>
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+        ##                     ^^^^^^^ source.css.embedded.html - meta.tag - comment
+        ##                            ^^^^^^^^ meta.tag - comment - source
+
+        <style type="text/css"> <!-- h1 {} </style>
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+        ##                     ^ - meta.tag - comment - source
+        ##                      ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+        ##                          ^^^^^^^ source.css.embedded.html - meta.tag - comment
+        ##                                 ^^^^^^^^ meta.tag - comment - source
+
+        <style type="text/css"> h1 {} --> </style>
+        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+        ##                     ^^^^^^^ source.css.embedded.html - meta.tag - comment
+        ##                            ^^^ comment.block.html punctuation.definition.comment.end.html - source
+        ##                               ^ - meta.tag - comment - source
+        ##                                ^^^^^^^^ meta.tag - comment - source
+
         <style type="text/css"> <!-- h1 {} --> </style>
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
         ##                     ^ - meta.tag - comment - source
         ##                      ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
-        ##                          ^^^^^^^ source.css.embedded.html
+        ##                          ^^^^^^^ source.css.embedded.html - meta.tag - comment
         ##                                 ^^^ comment.block.html punctuation.definition.comment.end.html - source
         ##                                    ^ - meta.tag - comment - source
         ##                                     ^^^^^^^^ meta.tag - comment - source


### PR DESCRIPTION
Fixes #2322
Fixes sublimehq/sublime_text#4701

In order to enable comment toggling using rules of embedded syntax definitions it is important to maintain its main scope at the beginning of first and last line.

The challenge is to also support CSS/JS being wrapped into HTML comment markers.

Another goal is to keep as many implementation details away from contexts which may need to be overridden by inheriting syntax definitions such as ASP/JSP/PHP to keep dependencies low. Some little changes are required though at this point to accomplish that.

_Note: This commit includes the assumption that JavaScript won't contain a standalone `-->` on a single line._

Also note this PR may have infuence on implementation details in #2654, #2789 and #2797