### PR TITLE
[JavaScript] Use keyword.declaration in for loops.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -769,7 +769,7 @@ contexts:
   for-condition-contents:
     # This could be either type of for loop.
     - match: (?:const|let|var){{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.js
       set:
         - - include: for-of-rest
           - match: (?=\S)

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -88,7 +88,7 @@
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 //      ^ punctuation.section.group
-//       ^^^ storage.type
+//       ^^^ keyword.declaration
 //           ^ meta.binding.name variable.other.readwrite
 //             ^ keyword.operator.assignment
 //               ^ meta.number.integer.decimal constant.numeric.value
@@ -141,14 +141,14 @@
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^^ meta.group
-//       ^^^^^ storage.type
+//       ^^^^^ keyword.declaration
 //               ^^ keyword.operator.word
 
     for (const x of list) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^^ meta.group
-//       ^^^^^ storage.type
+//       ^^^^^ keyword.declaration
 //               ^^ keyword.operator.word
 
     for (x in list) {}


### PR DESCRIPTION
When we changed variable declarations to use `keyword.declaration` instead of `storage.type`, apparently we forgot for loops.