### PR TITLE
[Ruby] Fix module names in index

### DIFF
--- a/Ruby/Symbol List - Classes, Modules.tmPreferences
+++ b/Ruby/Symbol List - Classes, Modules.tmPreferences
@@ -4,7 +4,7 @@
 	<key>scope</key>
 	<string>
 		source.ruby entity.name.class,
-		source.ruby entity.name.module
+		source.ruby entity.name.namespace
 	</string>
 	<key>settings</key>
 	<dict>


### PR DESCRIPTION
Since https://github.com/sublimehq/Packages/pull/2156, `entity.name.namespace` is used instead of `entity.name.module`.

This fixes go to definition for such namespaces because `symbolIndexTransformation` is now applied properly.