### PR TITLE
[Regular Expressions] Scope contents of \Q...\E as literal and allow quantifiers after \E

### DIFF
--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -294,7 +294,14 @@ contexts:
     - match: '\\[bBAZzG><]|[\^$]'
       scope: keyword.control.anchors.regexp
       push: unexpected-quantifier-pop
-    - match: '\\[QEK]'
+    - match: '\\Q'
+      scope: keyword.control.regexp
+      push:
+        - meta_content_scope: meta.literal.regexp
+        - match: '\\E'
+          scope: keyword.control.regexp
+          pop: true
+    - match: '\\K'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
     - match: \\[kg](?:(<)([^>]+)(>)|(')([^']+)(')|(\{)([^}]+)(\})|(-?\d+))

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -600,3 +600,12 @@ where escape characters are ignored.\).
 (*FA)
 #^ invalid.illegal.unexpected-quantifier.regexp
 (?-x)
+
+ \Qtext.here.is\dliteral)\E{1,2}{1,2}
+#^^ keyword.control
+#  ^^^^^^^^^^^^^^^^^^^^^^ meta.literal - keyword
+#                        ^^ keyword.control
+#                          ^^^^^ keyword.operator.quantifier
+#                               ^^^^^ invalid.illegal.unexpected-quantifier
+ \K
+#^^ keyword.control


### PR DESCRIPTION
[Regular Expressions] Scope contents of `\Q`...`\E` as literal and allow quantifiers after `\E`. This is valid syntax in ST's Find panel.