### PR TITLE
[Ruby] Patch Monokai Color Scheme

### DIFF
--- a/Ruby/Monokai.sublime-color-scheme
+++ b/Ruby/Monokai.sublime-color-scheme
@@ -1,0 +1,10 @@
+{
+	"rules":
+	[
+		{
+			"name": "Declaration Keywords",
+			"scope": "source.ruby keyword.declaration",
+			"foreground": "var(red2)"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #2841

This commit adds syntax specific patch to bring back old tinting of declaration keywords, which used to be scoped `keyword.control` in ST3.