### PR TITLE
[JSON] Patch Monokai Color Scheme

### DIFF
--- a/JSON/Monokai.sublime-color-scheme
+++ b/JSON/Monokai.sublime-color-scheme
@@ -1,0 +1,9 @@
+{
+	"rules": [
+		{
+			"name": "JSON Key Names",
+			"scope": "source.json meta.mapping.key string - punctuation",
+			"foreground": "var(red2)"
+		}
+	]
+}


### PR DESCRIPTION
This commit adds syntax specific patch for Monokai.sublime-color-scheme to highlight JSON keys red to make them stand out compared to values.

**Before**

![grafik](https://user-images.githubusercontent.com/16542113/120065939-330a8980-c074-11eb-82ad-30d058a7ab1e.png)

**After**

![grafik](https://user-images.githubusercontent.com/16542113/120065926-271ec780-c074-11eb-9790-ad5e4f24bfdc.png)
