### PR TITLE
[CSS] Patch Monokai Color Scheme

### DIFF
--- a/CSS/Monokai.sublime-color-scheme
+++ b/CSS/Monokai.sublime-color-scheme
@@ -1,0 +1,10 @@
+{
+	"rules": [
+		{
+			"name": "Numeric Units",
+			"scope": "constant.numeric.suffix.css",
+			"foreground": "var(red2)",
+			"font_style": ""
+		}
+	]
+}


### PR DESCRIPTION
Resolves https://forum.sublimetext.com/t/monokai-color-scheme-of-st3-how-to-setup-in-st4/58159

This commit adds syntax specific patch of Monokai.sublime-color-scheme to bring back old tinting of numeric units which used to be scoped `keyword.other.unit` in ST3.