### PR TITLE
[ShellScript] Fix declare/typedef function scopes

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -938,8 +938,8 @@ contexts:
   cmd-args-functions-chars:
     - meta_scope: meta.variable.shell
     - match: '{{identifier_char}}+'
-      scope: entity.name.function.shell
-    - include: entity-function-expansions
+      scope: variable.function.shell
+    - include: variable-function-expansions
     - include: immediately-pop
 
   cmd-args-end-of-options-then-variables:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -288,8 +288,8 @@ echo git rev-list "$(echo --all)" | grep -P 'c354a80'
 #                                           ^^^^^^^^^ meta.string.shell string.quoted.single.shell
 
 ' echo '
-# <- meta.function-call.identifier.shell meta.string.shell 
-#^^^^^^^ meta.function-call.identifier.shell meta.string.shell 
+# <- meta.function-call.identifier.shell meta.string.shell
+#^^^^^^^ meta.function-call.identifier.shell meta.string.shell
 # <- variable.function.shell punctuation.definition.string.begin.shell
 #^^^^^^^ variable.function.shell
 #      ^ punctuation.definition.string.end.shell
@@ -297,7 +297,7 @@ echo git rev-list "$(echo --all)" | grep -P 'c354a80'
 
 e'cho'o
 # <- meta.function-call.identifier.shell - meta.string
-#^^^^^ meta.function-call.identifier.shell meta.string.shell 
+#^^^^^ meta.function-call.identifier.shell meta.string.shell
 #     ^ meta.function-call.identifier.shell - meta.string
 # <- variable.function.shell
 #^^^^^^ variable.function.shell
@@ -305,7 +305,7 @@ e'cho'o
 
 e' cho'o
 # <- meta.function-call.identifier.shell - meta.string
-#^^^^^^ meta.function-call.identifier.shell meta.string.shell 
+#^^^^^^ meta.function-call.identifier.shell meta.string.shell
 #      ^ meta.function-call.identifier.shell - meta.string
 # <- variable.function.shell
 #^^^^^^^ variable.function.shell
@@ -612,7 +612,7 @@ sleep 2 & jobs
 subdir/./myscript.sh --option arg1 arg2 -x
 # <- meta.function-call.identifier.shell variable.function.shell
 #^^^^^^^^^^^^^^^^^^^ meta.function-call.identifier.shell variable.function.shell
-#                   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell 
+#                   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #                    ^^^^^^^^ meta.parameter.option.shell variable.parameter.option.shell
 #                            ^^^^^^^^^^^ - string
 #                                       ^^ meta.parameter.option.shell variable.parameter.option.shell
@@ -706,7 +706,7 @@ cd foo/bar2345
 # ^^ meta.compound.shell meta.compound.shell
 # ^ punctuation.section.compound.begin.shell
     foo args
-#^^^^^^^^^^^^ meta.compound.shell meta.compound.shell    
+#^^^^^^^^^^^^ meta.compound.shell meta.compound.shell
 #   ^^^ meta.function-call.identifier.shell variable.function.shell
 #      ^^^^^ meta.function-call.arguments.shell
   } 2>> "$stderr_log"
@@ -1046,7 +1046,7 @@ f () (
 
 function f (
 # <- meta.function.shell keyword.declaration.function.shell
-#^^^^^^^ meta.function.shell 
+#^^^^^^^ meta.function.shell
 #       ^^^ meta.function.identifier.shell
 #          ^^ meta.function.shell meta.compound.shell
 #^^^^^^^ keyword.declaration.function.shell
@@ -1245,7 +1245,7 @@ function +foo () {
 }
 +foo
 # <- meta.function-call.identifier.shell variable.function.shell
-#^^^ meta.function-call.identifier.shell variable.function.shell 
+#^^^ meta.function-call.identifier.shell variable.function.shell
 
 function =foo () {
 #<- meta.function.shell keyword.declaration.function.shell
@@ -1499,7 +1499,7 @@ declare -a owners=(
 
 declare -f _init_completion > /dev/null && complete -F _upto upto
 # <- meta.declaration.variable.shell keyword.declaration.variable.shell
-#^^^^^^ meta.declaration.variable.shell 
+#^^^^^^ meta.declaration.variable.shell
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.arguments.shell
 #                                      ^^^^ - meta.declaration - meta.function-call
 #                                          ^^^^^^^^ meta.function-call.identifier.shell
@@ -1507,7 +1507,7 @@ declare -f _init_completion > /dev/null && complete -F _upto upto
 #                                                                ^ - meta.function-call
 #^^^^^^ keyword.declaration.variable.shell
 #       ^^ variable.parameter.option.shell
-#          ^^^^^^^^^^^^^^^^ meta.variable.shell entity.name.function.shell
+#          ^^^^^^^^^^^^^^^^ meta.variable.shell variable.function.shell
 #                           ^ keyword.operator.assignment.redirection.shell
 #                                       ^^ keyword.operator.logical.shell
 #                                          ^^^^^^^^ variable.function.shell
@@ -1597,7 +1597,7 @@ export -f foo
 #^^^^^ meta.function-call.identifier.shell support.function.export.shell
 #     ^^^^^^^ meta.function-call.arguments.shell
 #      ^^ meta.parameter.option.shell variable.parameter.option.shell
-#         ^^^ meta.variable.shell entity.name.function.shell
+#         ^^^ meta.variable.shell variable.function.shell
 
 ####################################################################
 # local builtin                                                    #
@@ -1689,7 +1689,7 @@ local -fn foo
 #^^^^ meta.declaration.variable.shell keyword.declaration.variable.shell
 #    ^^^^^^^^ meta.declaration.variable.arguments.shell
 #     ^^^ meta.parameter.option.shell variable.parameter.option.shell
-#         ^^^ meta.variable.shell entity.name.function.shell
+#         ^^^ meta.variable.shell variable.function.shell
 
 f() {
     local -a "$@"
@@ -1758,7 +1758,7 @@ readonly -f foo     # 'foo' is a variable name
 #       ^ - storage - variable
 #        ^^ meta.parameter.option.shell variable.parameter.option.shell
 #          ^ - variable
-#           ^^^ meta.variable.shell entity.name.function.shell
+#           ^^^ meta.variable.shell variable.function.shell
 #              ^ - variable
 
 foo=`readonly x=5`
@@ -1788,7 +1788,7 @@ typeset foo         # 'foo' is a variable name
 
 typeset -f _init_completion > /dev/null && complete -F _upto upto
 # <- meta.declaration.variable.shell keyword.declaration.variable.shell
-#^^^^^^ meta.declaration.variable.shell 
+#^^^^^^ meta.declaration.variable.shell
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.arguments.shell
 #                                      ^^^^ - meta.declaration - meta.function-call
 #                                          ^^^^^^^^ meta.function-call.identifier.shell
@@ -1796,7 +1796,7 @@ typeset -f _init_completion > /dev/null && complete -F _upto upto
 #                                                                ^ - meta.function-call
 #^^^^^^ keyword.declaration.variable.shell
 #       ^^ variable.parameter.option.shell
-#          ^^^^^^^^^^^^^^^^ meta.variable.shell entity.name.function.shell
+#          ^^^^^^^^^^^^^^^^ meta.variable.shell variable.function.shell
 #                           ^ keyword.operator.assignment.redirection.shell
 #                                       ^^ keyword.operator.logical.shell
 #                                          ^^^^^^^^ variable.function.shell
@@ -2074,7 +2074,7 @@ unset -nfv foo
 #^^^^ support.function.unset.shell
 #     ^^^^ meta.parameter.option.shell variable.parameter.option.shell
 #         ^ - variable
-#          ^^^ entity.name.function.shell
+#          ^^^ variable.function.shell
 #             ^ - variable
 
 unset -f -n -v foo b'a'r; unset -vn foo 2>& /dev/null
@@ -2092,9 +2092,9 @@ unset -f -n -v foo b'a'r; unset -vn foo 2>& /dev/null
 #        ^^ meta.parameter.option.shell variable.parameter.option.shell
 #           ^^ meta.parameter.option.shell variable.parameter.option.shell
 #             ^ - variable
-#              ^^^ entity.name.function.shell
+#              ^^^ variable.function.shell
 #                 ^ - variable
-#                  ^^^^^ entity.name.function.shell
+#                  ^^^^^ variable.function.shell
 #                       ^ punctuation.terminator.statement.shell
 #                         ^^^^^ support.function.unset.shell
 #                              ^ - support - variable
@@ -2118,9 +2118,9 @@ unset -f -x +v -- foo bar; unset -vn -- foo
 #           ^^ meta.parameter.option.shell variable.parameter.option.shell
 #             ^^^^ - variable
 #              ^^ keyword.operator.end-of-options.shell
-#                 ^^^ entity.name.function.shell
+#                 ^^^ variable.function.shell
 #                    ^ - variable
-#                     ^^^ entity.name.function.shell
+#                     ^^^ variable.function.shell
 #                        ^ punctuation.terminator.statement.shell
 #                          ^^^^^ support.function.unset.shell
 #                               ^ - support - variable
@@ -2646,7 +2646,7 @@ commits=($(git rev-list --reverse --$abbrev-commit "$latest".. -- "$prefix"))
 #          ^^^ meta.sequence.shell meta.string.shell meta.interpolation.command.shell meta.function-call.identifier.shell - meta.function meta.function
 #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.shell meta.string.shell meta.interpolation.command.shell meta.function-call.arguments.shell  - meta.function meta.function
 #                                 ^^ meta.parameter.option.shell - meta.parameter.option.shell meta.interpolation
-#                                   ^^^^^^^ meta.parameter.option.shell meta.interpolation.parameter.shell 
+#                                   ^^^^^^^ meta.parameter.option.shell meta.interpolation.parameter.shell
 #                                          ^^^^^^^ meta.parameter.option.shell - meta.parameter.option.shell meta.interpolation
 #                                                  ^^^^^^^^^ meta.string.shell
 #                                                                 ^^^^^^^^^ meta.string.shell
@@ -2906,47 +2906,47 @@ ${foo:=bar}
 #    ^ variable.language.shell
 #     ^ punctuation.section.interpolation.end.shell
 : ${#@}
-# ^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ keyword.operator.arithmetic.shell
 #    ^ variable.language.shell
 #     ^ punctuation.section.interpolation.end.shell
 : ${@/bar/baz}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell  
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*/bar/baz}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell  
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${@#pattern}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*#pattern}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${@##pattern}
-# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*##pattern}
-# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${@%pattern}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*%%pattern}
-# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${@,pattern}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*,,pattern}
-# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${@^pattern}
-# ^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${*^^pattern}
-# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell 
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.shell
 : ${foo@Q}
 #      ^ keyword.operator.expansion.shell
@@ -4512,7 +4512,7 @@ case var in
 #^ meta.conditional.case.shell
 # ^^^^^^^ meta.conditional.case.clause.patterns.shell - meta.group
 #        ^^ meta.conditional.case.clause.patterns.shell meta.group.regexp.shell
-#          ^^^^ meta.conditional.case.shell 
+#          ^^^^ meta.conditional.case.shell
 # ^ keyword.control.conditional.patterns.begin.shell
 #        ^ punctuation.definition.group.begin.regexp.shell
 #          ^^^^ meta.conditional.case.shell keyword.control.conditional.end.shell
@@ -4527,7 +4527,7 @@ case   # comment
 #^^^^^^^^^^^^^^^^ meta.conditional.case.shell
 #      ^^^^^^^^^^ comment.line.number-sign.shell
   in   # comment
-#^^^^^^^^^^^^^^^^^ meta.conditional.case.shell  
+#^^^^^^^^^^^^^^^^^ meta.conditional.case.shell
 # ^^ keyword.control.in.shell
 #      ^^^^^^^^^^ comment.line.number-sign.shell
   pattern) # comment


### PR DESCRIPTION
Fixes #2849

This commit scopes function identifiers as reference in commands like

  `declare -f fun_name`

instead of scoping them definition.

_Note: Appears syntax caches contained several trailing spaces._