### PR TITLE
[Markdown] Fix YAML front matter ending to allow `...`.

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -191,7 +191,7 @@ contexts:
         1: punctuation.section.block.begin.frontmatter.yaml.markdown
       embed: scope:source.yaml
       embed_scope: meta.frontmatter.markdown source.yaml.embedded
-      escape: ^(---)\s*$  # pandoc requires the remainder of the line to be blank
+      escape: ^(---|\.{3})\s*$  # pandoc requires the remainder of the line to be blank
       escape_captures:
         1: meta.frontmatter.markdown punctuation.section.block.end.frontmatter.yaml.markdown
 


### PR DESCRIPTION
This PR fixes the markdown YAML front matter ending to allow the use of `...` as well.

This is as per the YAML spec where the document ending could either be a `---` or a `...`

See: https://yaml.org/spec/1.2/spec.html#id2760395

P.S. I guess I can't write any tests for it because as per the current syntax definition, YAML front matter needs to be at the start of a file (which is also the case for the syntax test header, so conflicts).