### PR TITLE
[Ruby] Fix << assignment operator scopes

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -620,6 +620,10 @@ contexts:
     - match: ':(?!:)'
       scope: keyword.operator.conditional.ruby
       pop: true
+    - match: \s*(<<)
+      captures:
+        1: keyword.operator.assignment.augmented.ruby
+      pop: true
     - match: ''
       pop: true
 

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -196,6 +196,7 @@ contexts:
     # constant definition, handles multiple definitions on a single line 'APPLE, ORANGE= 1, 2'
     - match: '\b([[:upper:]]\w*)(?=(\s*,\s*[[:upper:]]\w*)*\s*=(?![=\>]))'
       scope: meta.constant.ruby entity.name.constant.ruby
+      push: after-constant
     # Ruby 1.9 symbols
     - match: '{{identifier}}[?!]?(:)(?!:)'
       scope: constant.other.symbol.ruby
@@ -204,8 +205,10 @@ contexts:
       push: try-regex
     - match: '\b(nil|true|false)\b(?![?!])'
       scope: constant.language.ruby
+      push: after-constant
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby
+      push: after-constant
     # hexadecimal imaginary numbers: 0xAi, 0xAri
     - match: '\b(0[xX])({{hex_digits}})(r?i(r)?)\b'
       scope: meta.number.imaginary.hexadecimal.ruby
@@ -214,6 +217,7 @@ contexts:
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
+      push: after-constant
     # octal imaginary numbers: 0o1i, 0o1ri, 01i, 01ri
     - match: '\b(0[oO]?)({{oct_digits}})(r?i(r)?)\b'
       scope: meta.number.imaginary.octal.ruby
@@ -222,6 +226,7 @@ contexts:
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
+      push: after-constant
     # binary imaginary numbers: 0b1i, 0b1ri
     - match: '\b(0[bB])({{bin_digits}})(r?i(r)?)\b'
       scope: meta.number.imaginary.binary.ruby
@@ -230,6 +235,7 @@ contexts:
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
         4: invalid.illegal.numeric.ruby
+      push: after-constant
     # decimal imaginary numbers: 0d1i, 0d1ri, 1i, 1ri, 1.1i, 1.1ri, 1e1i, 1.1e1i
     - match: |-
         \b(?x:
@@ -252,6 +258,7 @@ contexts:
         8: constant.numeric.suffix.ruby invalid.illegal.numeric.ruby
         9: constant.numeric.suffix.ruby
         10: constant.numeric.suffix.ruby invalid.illegal.numeric.ruby
+      push: after-constant
     # hexadecimal rational numbers: 0xAr
     - match: '\b(0[xX])({{hex_digits}})(r)\b'
       scope: meta.number.rational.hexadecimal.ruby
@@ -259,6 +266,7 @@ contexts:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
+      push: after-constant
     # octal rational numbers: 0o1r, 01r
     - match: '\b(0[oO]?)({{oct_digits}})(r)\b'
       scope: meta.number.rational.octal.ruby
@@ -266,6 +274,7 @@ contexts:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
+      push: after-constant
     # binary rational numbers: 0b1r
     - match: '\b(0[bB])({{bin_digits}})(r)\b'
       scope: meta.number.rational.binary.ruby
@@ -273,6 +282,7 @@ contexts:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
         3: constant.numeric.suffix.ruby
+      push: after-constant
     # decimal rational numbers: 0d1r, 1r, 1.1r
     - match: '\b(0[dD])?({{dec_digits}}|{{dec_digits}}(\.){{dec_digits}})(r)\b'
       scope: meta.number.rational.decimal.ruby
@@ -281,6 +291,7 @@ contexts:
         2: constant.numeric.value.ruby
         3: punctuation.separator.decimal.ruby
         4: constant.numeric.suffix.ruby
+      push: after-constant
     # decimal floating point numbers: 1.1, 1e1, 1.1e1
     - match: '\b({{dec_digits}})(?:((\.){{dec_digits}})|((?:(\.){{dec_digits}})?{{dec_exponent}})(r)?)\b'
       scope: meta.number.float.decimal.ruby
@@ -291,30 +302,35 @@ contexts:
         4: constant.numeric.value.ruby
         5: punctuation.separator.decimal.ruby
         6: constant.numeric.suffix.ruby invalid.illegal.numeric.rational.ruby
+      push: after-constant
     # hexadecimal integer numbers: 0xA
     - match: '\b(0[xX])({{hex_digits}})\b'
       scope: meta.number.integer.hexadecimal.ruby
       captures:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
+      push: after-constant
     # octal integer numbers: 0o1, 01
     - match: '\b(0[oO]?)({{oct_digits}})\b'
       scope: meta.number.integer.octal.ruby
       captures:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
+      push: after-constant
     # binary integer numbers: 0b1
     - match: '\b(0[bB])({{bin_digits}})\b'
       scope: meta.number.integer.binary.ruby
       captures:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
+      push: after-constant
     # decimal integer numbers: 0d1, 1
     - match: '\b(0[dD])?({{dec_digits}})\b'
       scope: meta.number.integer.decimal.ruby
       captures:
         1: constant.numeric.base.ruby
         2: constant.numeric.value.ruby
+      push: after-constant
     # Quoted symbols
     - match: ":'"
       scope: punctuation.definition.constant.ruby
@@ -401,6 +417,9 @@ contexts:
       captures:
         1: punctuation.definition.constant.ruby
         2: invalid.illegal.character.ruby
+
+  after-constant:
+    - include: after-identifier
 
   blocks:
     - match: \bdo\b
@@ -632,14 +651,17 @@ contexts:
       scope: variable.other.readwrite.instance.ruby
       captures:
         1: punctuation.definition.variable.ruby
+      push: after-variable
     - match: '(@@)[a-zA-Z_]\w*'
       scope: variable.other.readwrite.class.ruby
       captures:
         1: punctuation.definition.variable.ruby
+      push: after-variable
     - match: '(\$)[a-zA-Z_]\w*'
       scope: variable.other.readwrite.global.ruby
       captures:
         1: punctuation.definition.variable.ruby
+      push: after-variable
     - match: '(\$)(!|@|&|`|''|\+|\d+|~|=|/|\\|,|;|\.|<|>|_|\*|\$|\?|:|"|-[0adFiIlpv])'
       scope: variable.other.readwrite.global.pre-defined.ruby
       captures:
@@ -656,8 +678,13 @@ contexts:
       captures:
         1: punctuation.accessor.double-colon.ruby
         2: support.class.ruby
+      push: after-variable
     - match: '\b[[:upper:]]\w*\b'
       scope: variable.other.constant.ruby
+      push: after-variable
+
+  after-variable:
+    - include: after-identifier
 
   well-known-methods:
     # exceptions

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -217,6 +217,43 @@ BAR
 #^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #  ^ - meta.string - string.unquoted
 
+bar<<string
+#  ^^ keyword.operator.assignment.augmented.ruby
+#    ^^^^^^^ - meta.tag - entity.name
+bar <<string
+#   ^^ keyword.operator.assignment.augmented.ruby
+#     ^^^^^^^ - meta.tag - entity.name
+bar << string
+#   ^^ keyword.operator.assignment.augmented.ruby
+#      ^^^^^^^ - meta.tag - entity.name
+bar <<'string'
+#   ^^ keyword.operator.assignment.augmented.ruby
+#     ^^^^^^^^ - meta.tag - entity.name
+bar << 'string'
+#   ^^ keyword.operator.assignment.augmented.ruby
+#      ^^^^^^^^ - meta.tag - entity.name
+bar <<"string"
+#   ^^ keyword.operator.assignment.augmented.ruby
+#     ^^^^^^^^ - meta.tag - entity.name
+bar << "string"
+#   ^^ keyword.operator.assignment.augmented.ruby
+#      ^^^^^^^^ - meta.tag - entity.name
+foo.bar <<"string"
+#       ^^ keyword.operator.assignment.augmented.ruby
+#         ^^^^^^^^ - meta.tag - entity.name
+Foo.bar <<"string"
+#       ^^ keyword.operator.assignment.augmented.ruby
+#         ^^^^^^^^ - meta.tag - entity.name
+foo::bar <<"string"
+#        ^^ keyword.operator.assignment.augmented.ruby
+#          ^^^^^^^^ - meta.tag - entity.name
+foo? <<"string"
+#    ^^ keyword.operator.assignment.augmented.ruby
+#      ^^^^^^^^ - meta.tag - entity.name
+foo! <<"string"
+#    ^^ keyword.operator.assignment.augmented.ruby
+#      ^^^^^^^^ - meta.tag - entity.name
+
 ##################
 # Numbers
 ##################

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -253,6 +253,19 @@ foo? <<"string"
 foo! <<"string"
 #    ^^ keyword.operator.assignment.augmented.ruby
 #      ^^^^^^^^ - meta.tag - entity.name
+1<<bit
+# <- meta.number.integer.decimal.ruby constant.numeric.value.ruby
+#^^ keyword.operator.assignment.augmented.ruby
+1 << bit
+# <- meta.number.integer.decimal.ruby constant.numeric.value.ruby
+# ^^ keyword.operator.assignment.augmented.ruby
+@war<<bit
+#   ^^ keyword.operator.assignment.augmented.ruby
+CONST << 10
+#^^^^ variable.other.constant.ruby
+#     ^^ keyword.operator.assignment.augmented.ruby
+#        ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+
 
 ##################
 # Numbers


### PR DESCRIPTION
Fixes #2839
Fixes #2871

This commit matches the first `<<` after an identifier `keyword.operator` to prevent string assignments to be scoped as HEREDOC tags by accident.