### PR TITLE
[LaTeX] Fix duplicated backslashes inserted by snippets

### DIFF
--- a/LaTeX/Snippets/Chapter.sublime-snippet
+++ b/LaTeX/Snippets/Chapter.sublime-snippet
@@ -3,7 +3,7 @@
 \label{cha:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % chapter $2 (end)]]></content>
-	<tabTrigger>cha</tabTrigger>
+	<tabTrigger>\cha</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Chapter</description>
 </snippet>

--- a/LaTeX/Snippets/Description.sublime-snippet
+++ b/LaTeX/Snippets/Description.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-	<content><![CDATA[\\begin{description}
+	<content><![CDATA[\begin{description}
 	\item[$1] $0
-\\end{description}]]></content>
+\end{description}]]></content>
 	<tabTrigger>desc</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Description</description>

--- a/LaTeX/Snippets/Enumerate.sublime-snippet
+++ b/LaTeX/Snippets/Enumerate.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-	<content><![CDATA[\\begin{enumerate}
+	<content><![CDATA[\begin{enumerate}
 	\item $0
-\\end{enumerate}]]></content>
+\end{enumerate}]]></content>
 	<tabTrigger>enum</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Enumerate</description>

--- a/LaTeX/Snippets/Item[description].sublime-snippet
+++ b/LaTeX/Snippets/Item[description].sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[\\item[${1:description}] ${0:item}]]></content>
+	<content><![CDATA[\item[${1:description}] ${0:item}]]></content>
 	<tabTrigger>itd</tabTrigger>
 	<scope>text.tex.latex meta.environment.list</scope>
 	<description>\item[description]</description>

--- a/LaTeX/Snippets/Itemize.sublime-snippet
+++ b/LaTeX/Snippets/Itemize.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-	<content><![CDATA[\\begin{itemize}
+	<content><![CDATA[\begin{itemize}
 	\item $0
-\\end{itemize}]]></content>
+\end{itemize}]]></content>
 	<tabTrigger>item</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Itemize</description>

--- a/LaTeX/Snippets/Paragraph.sublime-snippet
+++ b/LaTeX/Snippets/Paragraph.sublime-snippet
@@ -3,7 +3,7 @@
 \label{par:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % paragraph $2 (end)]]></content>
-	<tabTrigger>par</tabTrigger>
+	<tabTrigger>\par</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Paragraph</description>
 </snippet>

--- a/LaTeX/Snippets/Part.sublime-snippet
+++ b/LaTeX/Snippets/Part.sublime-snippet
@@ -3,7 +3,7 @@
 \label{prt:${2:${1/(\w+)|\W+/(?1:\L$0:_)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % part $2 (end)]]></content>
-	<tabTrigger>part</tabTrigger>
+	<tabTrigger>\part</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Part</description>
 </snippet>

--- a/LaTeX/Snippets/Sub-Paragraph.sublime-snippet
+++ b/LaTeX/Snippets/Sub-Paragraph.sublime-snippet
@@ -3,7 +3,7 @@
 \label{subp:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % subparagraph $2 (end)]]></content>
-	<tabTrigger>subp</tabTrigger>
+	<tabTrigger>\subp</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Sub Paragraph</description>
 </snippet>

--- a/LaTeX/Snippets/Tabular.sublime-snippet
+++ b/LaTeX/Snippets/Tabular.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-	<content><![CDATA[\\begin{${1:t}${1/(t)$|(a)$|(.*)/(?1:abular)(?2:rray)/}}{${2:c}}
+	<content><![CDATA[\begin{${1:t}${1/(t)$|(a)$|(.*)/(?1:abular)(?2:rray)/}}{${2:c}}
 $0${2/((?<=.)c|l|r)|./(?1: & )/g}
-\\end{${1:t}${1/(t)$|(a)$|(.*)/(?1:abular)(?2:rray)/}}]]></content>
+\end{${1:t}${1/(t)$|(a)$|(.*)/(?1:abular)(?2:rray)/}}]]></content>
 	<tabTrigger>tab</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Tabular</description>

--- a/LaTeX/Snippets/begin{}-end{}.sublime-snippet
+++ b/LaTeX/Snippets/begin{}-end{}.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-	<content><![CDATA[\\begin{${1:env}}
-	${1/(enumerate|itemize|list)|(description)|.*/(?1:\\item )(?2:\\item)/}$0
-\\end{${1:env}}]]></content>
-	<tabTrigger>begin</tabTrigger>
+	<content><![CDATA[\begin{${1:env}}
+	${1/(enumerate|itemize|list)|(description)|.*/(?1:\item )(?2:\item)/}$0
+\end{${1:env}}]]></content>
+	<tabTrigger>\begin</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>\begin{}…\end{}</description>
 </snippet>

--- a/LaTeX/Snippets/section-..-(section).sublime-snippet
+++ b/LaTeX/Snippets/section-..-(section).sublime-snippet
@@ -3,7 +3,7 @@
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % section $2 (end)]]></content>
-	<tabTrigger>sec</tabTrigger>
+	<tabTrigger>\sec</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Section</description>
 </snippet>

--- a/LaTeX/Snippets/subsection-..-(sub).sublime-snippet
+++ b/LaTeX/Snippets/subsection-..-(sub).sublime-snippet
@@ -3,7 +3,7 @@
 \label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % subsection $2 (end)]]></content>
-	<tabTrigger>sub</tabTrigger>
+	<tabTrigger>\sub</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Sub Section</description>
 </snippet>

--- a/LaTeX/Snippets/subsubsection-..-(ssub).sublime-snippet
+++ b/LaTeX/Snippets/subsubsection-..-(ssub).sublime-snippet
@@ -3,7 +3,7 @@
 \label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3)/g}}}
 ${0:$TM_SELECTED_TEXT}
 % subsubsection $2 (end)]]></content>
-	<tabTrigger>subs</tabTrigger>
+	<tabTrigger>\subs</tabTrigger>
 	<scope>text.tex.latex</scope>
 	<description>Sub Sub Section</description>
 </snippet>


### PR DESCRIPTION
Fixes #2730

This commit modifies `tabTrigger` of those snippets, whose committed content starts with exactly the same characters.

As a result both, typing:

a) `begin`
b) `\begin`

result in

```latex
  \begin{env}
    |
  \end{env}
```

when hitting tab (twice?!)

Also removes escaped backslashes from content as those seem not to be needed. So \\begin becomes \begin.