### PR TITLE
[Ruby] Improve classic multiline regexp patterns

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1411,7 +1411,14 @@ contexts:
     - include: try-regex
 
   after-operator:
-    - include: try-regex
+    # A slash following an operator is most likely the beginning of a regex pattern
+    # if not an incomplete expression.
+    - match: \s*(/)
+      captures:
+        1: punctuation.definition.string.begin.ruby
+      push: regex-body
+    - match: ''
+      pop: true
 
   try-regex:
     # Generally for multiline regexes, one of the %r forms below will be used,
@@ -1419,16 +1426,18 @@ contexts:
     - match: \s*(/)(?=(?!=).*/)
       captures:
         1: punctuation.definition.string.begin.ruby
-      push:
-        - meta_scope: meta.string.regexp.ruby string.regexp.classic.ruby
-        - match: (/)([eimnosux]*)
-          captures:
-            1: punctuation.definition.string.end.ruby
-            2: keyword.other.ruby
-          pop: true
-        - include: regex-sub
+      push: regex-body
     - match: ''
       pop: true
+
+  regex-body:
+    - meta_scope: meta.string.regexp.ruby string.regexp.classic.ruby
+    - match: (/)([eimnosux]*)
+      captures:
+        1: punctuation.definition.string.end.ruby
+        2: keyword.other.ruby
+      pop: true
+    - include: regex-sub
 
   regexes:
     # Needs higher precedence than regular expressions.

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1290,8 +1290,12 @@ a = /?foo*baz/m
 #   ^^^^^^^^^^^ string.regexp
 
 a = /=foo/m
-#   ^^ keyword.operator.assignment.augmented.ruby
-#   ^^^^^^^ - string.regexp
+#   ^^^^^^^ string.regexp
+
+# issue #2703
+a = /(bot\ is\ not\ a\ member\ of\ the\ (super)?group\ chat)|
+     (bot\ can't\ send\ messages\ to\ bots)/x
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.ruby string.regexp.classic.ruby
 
 begin
 # <- keyword.control.block.begin


### PR DESCRIPTION
Fixes #2703

This commit scopes `/` directly followed by an operator as beginning of a regexp pattern.

It can't catch all edge cases though.

Patterns following a keyword keep unchanged as those still might be operators and there's no real solution to distinguish them from patterns.

Maybe `%r{...}` or friends should be used then.