### PR TITLE
Highlight BUILD files as python code

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -23,6 +23,7 @@ file_extensions:
   - Snakefile
   - vpy
   - wscript
+  - BUILD
   - bazel
   - bzl
 first_line_match: ^#!\s*/.*\bpython(\d(\.\d)?)?\b


### PR DESCRIPTION
Highlight files named `BUILD` as if they were Python.  These files will almost
universally contain code written in starlark which is a dialect of Python. This
language is used in the popular build system Bazel and it's derivatives like
Pants and Please.

While some build systems, like Bazel, are trying to recommend using a suffix
bazelbuild/bazel#4517 like `BUILD.bazel`, consensus is not universal and there
is a large body of code as well as other build systems like Pants which also
default to the extensionless `BUILD` name.

The motivation here is  provide proper syntax highlighting with the `bat` tool.