### PR TITLE
[Ruby] Restrict regex to selected methods

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -659,19 +659,15 @@ contexts:
     # exceptions
     - match: \bcatch\b(?![?!])
       scope: keyword.control.exception.catch.ruby
-      push: function-call-arguments
     # flow
     - match: \b(?:fail|raise|throw)\b(?![?!])
       scope: keyword.control.flow.throw.ruby
-      push: function-call-arguments
     # loop
     - match: \bloop\b(?![?!])
       scope: keyword.control.loop.loop.ruby
-      push: function-call-arguments
     # other
     - match: \b(initialize|new|include|extend|prepend|attr_reader|attr_writer|attr_accessor|attr|module_function|public|protected|private)\b(?![?!])
       scope: keyword.other.special-method.ruby
-      push: function-call-arguments
     - match: \b(require|require_relative|gem)\b
       scope: keyword.control.import.ruby
       push:
@@ -702,7 +698,6 @@ contexts:
           (?![!?=])
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Methods that may be followed by a regex
     - match: |-
         (?x:
@@ -712,6 +707,7 @@ contexts:
           )(!|\b)
           |
           \b(
+            eql|
             match
           )(\?|\b)
           |
@@ -724,12 +720,11 @@ contexts:
           )\b(?![!?=])
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
+      push: try-regex
     # Methods from the Object class not handled elsewhere, ending in punctuation
     - match: |-
         (?x:
           \b(
-            eql\?|
             instance_of\?|
             instance_variable_defined\?|
             is_a\?|
@@ -742,7 +737,6 @@ contexts:
           )
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Methods from the Object class not handled elsewhere
     - match: |-
         (?x:
@@ -784,7 +778,6 @@ contexts:
           (?![!?=])
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Methods from the Kernel class not handled elsewhere, ending in punctuation
     - match: |-
         (?x:
@@ -795,7 +788,6 @@ contexts:
           )
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Methods from the Kernel class not handled elsewhere
     - match: |-
         (?x:
@@ -860,7 +852,6 @@ contexts:
           (?![!?=])
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Methods from the Kernel class not handled elsewhere, ending in punctuation
     - match: |-
         (?x:
@@ -877,11 +868,10 @@ contexts:
           )
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
     # Lambda operator from the Kernel class not handled elsewhere
     - match: '->'
       scope: meta.function.ruby keyword.declaration.function.anonymous.ruby
-      push: function-call-arguments
+      push: try-regex
     # Methods from the Module class not handled elsewhere
     - match: |-
         (?x:
@@ -930,10 +920,6 @@ contexts:
           (?![!?=])
         )
       scope: support.function.builtin.ruby
-      push: function-call-arguments
-
-  function-call-arguments:
-    - include: try-regex
 
   method:
     - match: \bdef\b

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1293,6 +1293,12 @@ a = /=foo/m
 #   ^^ keyword.operator.assignment.augmented.ruby
 #   ^^^^^^^ - string.regexp
 
+a = (File.size().to_f / 1024).ceil.to_s.reverse.scan(/\d/)
+#                     ^ keyword.operator.arithmetic.ruby
+#                                                    ^^^^ meta.string.regexp.ruby string.regexp.classic.ruby
+#                                                    ^ punctuation.definition.string.begin.ruby
+#                                                       ^ punctuation.definition.string.end.ruby
+
 begin
 # <- keyword.control.block.begin
 end while /foo/ =~ bar


### PR DESCRIPTION
Fixes #2859

Partly reverts f3f268b.

This commit matches `/pattern/` only after methods known to support it. Otherwise methods without parentheses may cause division operators to be matched as beginning of a pattern if another slash was found in the same line.