### PR TITLE
[Makefile] [Perl] [Ruby] [ShellScript] Do not require only whitespace before -*-

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -24,7 +24,7 @@ file_extensions:
 first_line_match: |-
   (?xi:
     ^\#! .* \bmake\b |                     # shebang
-    ^\# \s* -\*- [^*]* makefile [^*]* -\*- # editorconfig
+    ^\# .* -\*- [^*]* makefile [^*]* -\*-  # editorconfig
   )
 scope: source.makefile
 #-------------------------------------------------------------------------------

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -12,7 +12,7 @@ file_extensions:
 first_line_match: |-
   (?xi:
     ^\#! .* \bperl\b |                     # shebang
-    ^\# \s* -\*- [^*]* perl [^*]* -\*-     # editorconfig
+    ^\# .* -\*- [^*]* perl [^*]* -\*-      # editorconfig
   )
 scope: source.perl
 

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -63,7 +63,7 @@ file_extensions:
 first_line_match: |-
   (?xi:
     ^\#! .* \bj?ruby\b |                # shebang
-    ^\# \s* -\*- [^*]* ruby [^*]* -\*-  # editorconfig
+    ^\# .* -\*- [^*]* ruby [^*]* -\*-   # editorconfig
   )
 scope: source.ruby
 variables:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -38,7 +38,7 @@ hidden_file_extensions:
 first_line_match: |-
   (?x:
     ^\#! .* \b(bash|zsh|sh|tcsh|ash)\b |        # shebang
-    ^\# \s* -\*- [^*]* shell-script [^*]* -\*-  # editorconfig
+    ^\# .* -\*- [^*]* shell-script [^*]* -\*-   # editorconfig
   )
 
 ###############################################################################


### PR DESCRIPTION
Any characters are valid before the first `-*-`. Another `-*-` before the one we're interested in may throw detection off, but that's not easy to avoid with a regex, and it's unlikely to cause blatantly false positives, so accept everything there.

Lots of sample files that are affected and associate fine with shell script mode in Emacs are available at https://github.com/scop/bash-completion/tree/master/completions