### PR TITLE
[Python] Allow dashes in unicode names.

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1385,7 +1385,7 @@ contexts:
       scope: invalid.deprecated.character.escape.python
 
   escaped-unicode-char:
-    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[a-zA-Z ]+\})'
+    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[-a-zA-Z ]+\})'
       captures:
         1: constant.character.escape.unicode.16-bit-hex.python
         2: constant.character.escape.unicode.32-bit-hex.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -4,7 +4,7 @@
 # Strings and embedded syntaxes
 ###############################
 
-var = "\x00 \xaa \xAF \070 \0 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE}"
+var = "\x00 \xaa \xAF \070 \0 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SPACE} \N{dashed-name}"
 #     ^ meta.string.python
 #      ^^^^ constant.character.escape.hex
 #           ^^^^ constant.character.escape.hex
@@ -23,6 +23,7 @@ var = "\x00 \xaa \xAF \070 \0 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SP
 #                                                        ^^^^^^ constant.character.escape.unicode
 #                                                               ^^^^^^^^^^ constant.character.escape.unicode
 #                                                                          ^^^^^^^^^ constant.character.escape.unicode
+#                                                                                    ^^^^^^^^^^^^^^^ constant.character.escape.unicode
 
 invalid_escapes = "\.  \-"
 #                  ^^ invalid.deprecated.character.escape.python


### PR DESCRIPTION
This PR allows the use of dashes in unicode names.

```python
import unicodedata
unicodedata.lookup("black up-pointing triangle")

>>> '▲'
```

Fixes #2863 