### PR TITLE
[Markdown] Add `rs` for marking Rust code blocks

### DIFF
--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -236,6 +236,12 @@
 			"details": "Specifies <code>Regular Expressions</code> code highlighting"
 		},
 		{
+			"trigger": "rs",
+			"annotation": "Rust",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Rust</code> code highlighting"
+		},
+		{
 			"trigger": "rscript",
 			"annotation": "R Script",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1267,7 +1267,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:rust))
+          ((?i:rust|rs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.rust.markdown-gfm


### PR DESCRIPTION
Recently GitHub added support for
````
```rs
fn main() {}
```
````
code blocks rendering as Rust:
```rs
fn main() {}
```
where `rs` is a new alternative to the previous keyword `rust`.

I’m not sure what markdown flavor the syntax highlighting files in this repo are supposed to follow, but it this is wanted here’s a PR adding this ```` ```rs```` to highlighting and completions.