### PR TITLE
[ShellScript] Fix test expressions with groups

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1800,9 +1800,10 @@ contexts:
 
   expansions-pattern-set-body:
     - meta_scope: meta.set.regexp.shell
-    - match: (?:-)?(\])
+    - match: -?(\])([*?+]*)
       captures:
         1: punctuation.definition.set.end.regexp.shell
+        2: keyword.operator.quantifier.regexp.shell
       pop: 1
     - match: ((\.)[[:word:]](\.))(\])
       captures:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -672,46 +672,77 @@ contexts:
 
   cmd-test-args:
     - meta_content_scope: meta.function-call.arguments.shell
+    - include: redirections
+    - include: cmd-test-args-common
+    - include: eoc-pop
+
+  cmd-test-args-common:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: cmd-test-args-group-body
     - match: (=~)\s*
       captures:
         1: keyword.operator.binary.shell
-      push: cmd-test-pattern
+      push: cmd-test-args-pattern
     - match: ([=!]=)\s*
       captures:
         1: keyword.operator.comparison.shell
-      push: cmd-test-pattern
-    - include: test-expressions
-    - include: redirections
+      push: cmd-test-args-pattern
+    - include: test-expression-common
+
+  cmd-test-args-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - include: cmd-test-args-common
     - include: eoc-pop
 
-  cmd-test-pattern:
+  cmd-test-args-pattern:
     - meta_content_scope: meta.pattern.regexp.shell
-    - include: test-pattern
+    - include: test-pattern-common
     - include: eoc-pop
 
   test-expression-body:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: test-expression-group-body
     - match: (=~)\s*
       captures:
         1: keyword.operator.binary.shell
-      push: test-pattern
+      push: test-expression-pattern
     - match: ([=!]=)\s*
       captures:
         1: keyword.operator.comparison.shell
-      push: test-pattern
-    - include: test-expressions
+      push: test-expression-pattern
+    - include: test-expression-common
 
-  test-pattern:
+  test-expression-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - include: test-expression-body
+
+  test-expression-pattern:
     - meta_content_scope: meta.pattern.regexp.shell
+    - include: test-pattern-common
+    - match: (?=\))
+      pop: 1
+
+  test-pattern-common:
     - match: (?=\s)
       pop: 1
+    - match: \(
+      scope:
+        meta.group.regexp.shell
+        punctuation.definition.group.begin.regexp.shell
+      push: expansions-pattern-group-body
     - include: boolean
     - include: number
     - include: expansions-and-strings
 
-  test-expressions:
-    - match: \(
-      scope: punctuation.section.group.begin.shell
-      push: test-group-body
+  test-expression-common:
     - match: ([-+])[aobcdefghknoprstuvwxzGLNORS]{{opt_break}}(?!\s*([=!]=|=~))
       scope:
         meta.parameter.option.shell
@@ -736,13 +767,6 @@ contexts:
     - include: expansions-variables
     - include: variables
     - include: line-continuations
-
-  test-group-body:
-    - meta_scope: meta.group.shell
-    - match: \)
-      scope: punctuation.section.group.end.shell
-      pop: 1
-    - include: test-expression-body
 
 ###[ UNALIAS BUILTINS ]########################################################
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -3720,6 +3720,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                ^^^^^ meta.set.regexp.shell
 #                ^ punctuation.definition.set.begin.regexp.shell
 #                    ^ punctuation.definition.set.end.regexp.shell
+#                     ^ keyword.operator.quantifier.regexp.shell
 #                      ^ punctuation.definition.group.end.regexp.shell
 #                        ^ punctuation.section.group.end.shell
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -3705,11 +3705,11 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                        ^ punctuation.definition.group.begin.regexp.shell
 #                          ^ punctuation.definition.group.end.regexp.shell
 
-[[ ! ($line =~ ^([0-9]+)$) ]]
+[[ ! ($line =~ ^(\([0-9]+)$) ]]
 #^^^^ meta.conditional.shell - meta.group
-#    ^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell meta.group.shell
-#                         ^^^ meta.conditional.shell
-#                            ^ - meta.conditional
+#    ^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell meta.group.shell
+#                           ^^^ meta.conditional.shell
+#                              ^ - meta.conditional
 #  ^ keyword.operator.logical.shell
 #    ^ punctuation.section.group.begin.shell
 #     ^^^^^ variable.other.readwrite.shell
@@ -3717,12 +3717,13 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #              ^^^^^^^^^^ meta.pattern.regexp.shell
 #               ^^^^^^^^ meta.group.regexp.shell
 #               ^ punctuation.definition.group.begin.regexp.shell
-#                ^^^^^ meta.set.regexp.shell
-#                ^ punctuation.definition.set.begin.regexp.shell
-#                    ^ punctuation.definition.set.end.regexp.shell
-#                     ^ keyword.operator.quantifier.regexp.shell
-#                      ^ punctuation.definition.group.end.regexp.shell
-#                        ^ punctuation.section.group.end.shell
+#                ^^ constant.character.escape.shell
+#                  ^^^^^ meta.set.regexp.shell
+#                  ^ punctuation.definition.set.begin.regexp.shell
+#                      ^ punctuation.definition.set.end.regexp.shell
+#                       ^ keyword.operator.quantifier.regexp.shell
+#                        ^ punctuation.definition.group.end.regexp.shell
+#                          ^ punctuation.section.group.end.shell
 
 [[ ' foobar' == [\ ]foo* ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1887,11 +1887,12 @@ test expr -a expr -o expr -- | cmd |& cmd
 
 test ! ($line =~ ^[0-9]+$)
 # <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#                         ^ - meta.function-call
+#^^^ meta.function-call.identifier.shell - meta.function-call.arguments
+#   ^^^ meta.function-call.arguments.shell - meta.function-call.identifier - meta.group
+#      ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.group.shell
+#                         ^ - meta.function-call - meta.group
+#^^^ support.function.test.shell
 #    ^ keyword.operator.logical.shell
-#      ^^^^^^^^^^^^^^^^^^^ meta.group.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
 #             ^^ keyword.operator.binary.shell
@@ -1899,11 +1900,13 @@ test ! ($line =~ ^[0-9]+$)
 
 test ! ($line =~ ^[0-9]+$) >> /file
 # <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#                                  ^ - meta.function-call
+#^^^ meta.function-call.identifier.shell - meta.function-call.arguments
+#   ^^^ meta.function-call.arguments.shell - meta.function-call.identifier - meta.group
+#      ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.group.shell
+#                         ^^^^^^^^^ meta.function-call.arguments.shell - meta.group
+#                                  ^ - meta.function-call - meta.group
+#^^^ support.function.test.shell
 #    ^ keyword.operator.logical.shell
-#      ^^^^^^^^^^^^^^^^^^^ meta.group.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
 #             ^^ keyword.operator.binary.shell
@@ -3706,15 +3709,19 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                          ^ punctuation.definition.group.end.regexp.shell
 
 [[ ! ($line =~ ^(\([0-9]+)$) ]]
+# <- meta.conditional.shell - meta.group
 #^^^^ meta.conditional.shell - meta.group
-#    ^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell meta.group.shell
-#                           ^^^ meta.conditional.shell
-#                              ^ - meta.conditional
+#    ^^^^^^^^^^ meta.conditional.shell meta.group.shell - meta.pattern
+#              ^^^^^^^^^^^^ meta.conditional.shell meta.group.shell meta.pattern.regexp.shell
+#                          ^ meta.conditional.shell meta.group.shell - meta.pattern
+#                           ^^^ meta.conditional.shell - meta.group
+#                              ^ - meta.conditional - meta.group
+# <- support.function.double-brace.begin.shell
+#^ support.function.double-brace.begin.shell
 #  ^ keyword.operator.logical.shell
 #    ^ punctuation.section.group.begin.shell
 #     ^^^^^ variable.other.readwrite.shell
 #           ^^ keyword.operator.binary.shell
-#              ^^^^^^^^^^ meta.pattern.regexp.shell
 #               ^^^^^^^^ meta.group.regexp.shell
 #               ^ punctuation.definition.group.begin.regexp.shell
 #                ^^ constant.character.escape.shell
@@ -3724,6 +3731,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                       ^ keyword.operator.quantifier.regexp.shell
 #                        ^ punctuation.definition.group.end.regexp.shell
 #                          ^ punctuation.section.group.end.shell
+#                            ^^ support.function.double-brace.end.shell
 
 [[ ' foobar' == [\ ]foo* ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1885,6 +1885,32 @@ test expr -a expr -o expr -- | cmd |& cmd
 #                              ^^^ meta.function-call.identifier.shell variable.function.shell
 #                                  ^^ keyword.operator.assignment.pipe.shell
 
+test ! ($line =~ ^[0-9]+$)
+# <- meta.function-call.identifier.shell support.function.test.shell
+#^^^ meta.function-call.identifier.shell support.function.test.shell
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                         ^ - meta.function-call
+#    ^ keyword.operator.logical.shell
+#      ^^^^^^^^^^^^^^^^^^^ meta.group.shell
+#      ^ punctuation.section.group.begin.shell
+#       ^^^^^ variable.other.readwrite.shell
+#             ^^ keyword.operator.binary.shell
+#                ^^^^^^^^ meta.pattern.regexp.shell
+
+test ! ($line =~ ^[0-9]+$) >> /file
+# <- meta.function-call.identifier.shell support.function.test.shell
+#^^^ meta.function-call.identifier.shell support.function.test.shell
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                                  ^ - meta.function-call
+#    ^ keyword.operator.logical.shell
+#      ^^^^^^^^^^^^^^^^^^^ meta.group.shell
+#      ^ punctuation.section.group.begin.shell
+#       ^^^^^ variable.other.readwrite.shell
+#             ^^ keyword.operator.binary.shell
+#                ^^^^^^^^ meta.pattern.regexp.shell
+#                        ^ punctuation.section.group.end.shell
+#                          ^^ keyword.operator.assignment.redirection.shell
+
 if test expr -a expr ; then echo "success"; fi
 # ^ - meta.function-call
 #  ^^^^ meta.function-call.identifier.shell support.function.test.shell
@@ -3644,6 +3670,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 
 [[ $str != ^$'\t' ]]
 #^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#                   ^ - meta.conditional
 #^^^^^^^^^^ - meta.pattern.regexp
 #          ^^^^^^ meta.pattern.regexp.shell - meta.interpolation
 #                ^^^ - meta.pattern.regexp
@@ -3652,6 +3679,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 
 [[ $str =~ ^abc$var$ ]]
 #^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#                      ^ - meta.conditional
 #^^^^^^^^^^ - meta.pattern.regexp
 #  ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #       ^^ keyword.operator.binary.shell
@@ -3662,6 +3690,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 
 [[ $line =~ [[:space:]]*?(a)b ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#                               ^ - meta.conditional
 #^^^^^^^^^^^ - meta.pattern.regexp.shell
 #           ^^^^^^^^^^^^^^^^^ meta.pattern.regexp.shell
 #           ^^^^^^^^^^^ meta.set.regexp.shell
@@ -3676,8 +3705,27 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                        ^ punctuation.definition.group.begin.regexp.shell
 #                          ^ punctuation.definition.group.end.regexp.shell
 
+[[ ! ($line =~ ^([0-9]+)$) ]]
+#^^^^ meta.conditional.shell - meta.group
+#    ^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell meta.group.shell
+#                         ^^^ meta.conditional.shell
+#                            ^ - meta.conditional
+#  ^ keyword.operator.logical.shell
+#    ^ punctuation.section.group.begin.shell
+#     ^^^^^ variable.other.readwrite.shell
+#           ^^ keyword.operator.binary.shell
+#              ^^^^^^^^^^ meta.pattern.regexp.shell
+#               ^^^^^^^^ meta.group.regexp.shell
+#               ^ punctuation.definition.group.begin.regexp.shell
+#                ^^^^^ meta.set.regexp.shell
+#                ^ punctuation.definition.set.begin.regexp.shell
+#                    ^ punctuation.definition.set.end.regexp.shell
+#                      ^ punctuation.definition.group.end.regexp.shell
+#                        ^ punctuation.section.group.end.shell
+
 [[ ' foobar' == [\ ]foo* ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#                          ^ - meta.conditional
 #^^^^^^^^^^^^^^^ - meta.pattern.regexp.shell
 #               ^^^^ meta.set.regexp.shell
 #               ^^^^^^^^ meta.pattern.regexp.shell


### PR DESCRIPTION
Fixes #2881

This PR fixes test pattern matching enclosed in parentheses.

Before this commit a group context wasn't popped as closing parenthesis was matched as part of pattern on the right hand side of the expression.