### PR TITLE
[ShellScript] Improve Automatching backticks

### DIFF
--- a/ShellScript/Default.sublime-keymap
+++ b/ShellScript/Default.sublime-keymap
@@ -3,27 +3,39 @@
     // Command Interpolation
     //
 
-    // Auto-pair backticks: `|`
+    // Auto-pair backticks: | -> `|`
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
         [
             { "key": "setting.auto_match_enabled", "operand": true },
             { "key": "selector", "operand": "source.shell - meta.interpolation.command" },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "`$", "match_all": true },
-            { "key": "following_text", "operator": "not_regex_contains", "operand": "^`", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|,|;|'|\"|\\||&|<|>|$)", "match_all": true }
         ]
     },
-    // Remove backticks when backspace is pressed
+    // Move over existing backtick |` -> `|
+    {
+        "keys": ["`"],
+        "command": "move",
+        "args": {"by": "characters", "forward": true},
+        "context": [
+            { "key": "setting.auto_match_enabled", "operand": true },
+            { "key": "selector", "operand": "source.shell" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+    // Remove backticks when backspace is pressed `|` -> |
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
             { "key": "setting.auto_match_enabled", "operand": true },
-            { "key": "selector", "operand": "source.shell  meta.interpolation.command" },
+            { "key": "selector", "operand": "source.shell" },
             { "key": "selection_empty", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
 
-    // Auto-pair parentheses: $(|)
+    // Auto-pair parentheses: $| -> $(|)
     { "keys": ["("], "command": "insert_snippet", "args": {"contents": "($0)"}, "context":
         [
             { "key": "setting.auto_match_enabled", "operand": true },
@@ -57,7 +69,7 @@
     // Parameter Interpolation
     //
 
-    // Auto-pair braces: ${|}
+    // Auto-pair braces: $| -> ${|}
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
             { "key": "setting.auto_match_enabled", "operand": true },


### PR DESCRIPTION
This PR...

1. restricts auto-pairing backticks.  
   Only add if followed by "metachar" `(space, | & < > ; ...)` which are known to finish expressions.
2. adds a binding to move caret over closing backtick.

see: https://forum.sublimetext.com/t/st4-issues-i-found-but-have-no-time-to-write-proper-bug-reports-yet/59226