### PR TITLE
[CSS] Add smart_typing setting

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -1,9 +1,34 @@
 [
+	// Add a colon and semicolon after a property name,
+	// if the next following token doesn't look like a value.
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": false },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
+		]
+	},
+	// Add a colon after a property name,
+	// if the next character is a semicolon or the following token looks like a value.
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": false },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
+		]
+	},
 	// Add a colon followed by space and semicolon after a property name,
 	// if the next following token doesn't look like a value.
 	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
@@ -15,6 +40,7 @@
 	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
@@ -44,7 +70,7 @@
 	// This is to not bother with semicolons even though completions end up with the caret directy in front of it.
 	{ "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line.sublime-macro"} , "context":
 		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "auto_complete_visible", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
@@ -56,7 +82,7 @@
 	// Expand {|} to { | } when space is pressed
 	{ "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":
 		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\{$", "match_all": true },
@@ -65,7 +91,7 @@
 	},
 	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
 		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\{ $", "match_all": true },
@@ -76,7 +102,7 @@
 	// Expand /*|*/ to /* | */ when space is pressed
 	{ "keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "}, "context":
 		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css comment", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "/\\*$", "match_all": true },
@@ -85,7 +111,7 @@
 	},
 	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
 		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "selector", "operator": "equal", "operand": "source.css comment", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "/\\* $", "match_all": true },

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -6,7 +6,7 @@
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "setting.smart_typing", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
 		]
@@ -18,7 +18,7 @@
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "setting.smart_typing", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
 		]
@@ -30,7 +30,7 @@
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
 		]
@@ -42,7 +42,7 @@
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "setting.smart_typing", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
 		]

--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -11,18 +11,6 @@
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
 		]
 	},
-	// Add a colon after a property name,
-	// if the next character is a semicolon or the following token looks like a value.
-	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0"}, "context":
-		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.smart_typing", "operator": "equal", "operand": false },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
-		]
-	},
 	// Add a colon followed by space and semicolon after a property name,
 	// if the next following token doesn't look like a value.
 	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -649,32 +649,29 @@ class CSSCompletions(sublime_plugin.EventListener):
         return None
 
     def complete_property_name(self, view, prefix, pt):
+        text = view.substr(sublime.Region(pt, view.line(pt).end()))
+        matches = self.re_value.search(text)
+        if matches:
+            colon, space, value, term = matches.groups()
+        else:
+            colon = ""
+            space = ""
+            value = ""
+            term = ""
+
+        # don't append anything if next character is a colon
         suffix = ""
-
-        # only add colon and semicolon after name if auto-pairing is enabled
-        if view.settings().get("auto_match_enabled"):
-            text = view.substr(sublime.Region(pt, view.line(pt).end()))
-            matches = self.re_value.search(text)
-            if matches:
-                colon, space, value, term = matches.groups()
+        if not colon:
+            # add space after colon if smart typing is enabled
+            smart_typing = view.settings().get("smart_typing")
+            if smart_typing and not space:
+                suffix = ": $0"
             else:
-                colon = ""
-                space = ""
-                value = ""
-                term = ""
+                suffix = ":$0"
 
-            # don't append anything if next character is a colon
-            if not colon:
-                # add space after colon if smart typing is enabled
-                smart_typing = view.settings().get("smart_typing")
-                if smart_typing and not space:
-                    suffix = ": $0"
-                else:
-                    suffix = ":$0"
-
-                # terminate empty value if not within parentheses
-                if not value and not term and not match_selector(view, pt, "meta.group"):
-                    suffix += ";"
+            # terminate empty value if not within parentheses
+            if not value and not term and not match_selector(view, pt, "meta.group"):
+                suffix += ";"
 
         return (
             sublime.CompletionItem(


### PR DESCRIPTION
This commit adds support for `smart_typing` setting to extend scope of `auto_match_enabled` to related but somewhat smarter typing features.

The intention is to satisfy both the lazy and convenient developer and the purist who needs control over every single key stroke.

Due to several requests some input helpers were introduced during last dev cycle, which intend to help keeping focus on content while helping with some nasty repetitive tasks like adding space after colons and move on to next line when hitting enter in front of semi-colons.

Now that those smart behaviors exist, of course, some people complain about it.

With this commit following features are enabled only if `smart_typing` is `true`:

1. Automatically add space after colons.
2. Hitting enter in front of semicolon moves to next line.
3. Hitting space in between brackets adds space to left and right position of caret.

Note:

The `smart_typing` setting is NOT added to CSS.sublime-settings as it is intended to be used for related features in all syntax packages, just like `auto_match_enabled`.

Adding it to CSS would override user defined global settings in Preferences.sublime-settings.

As a result all those smart typing features are disabled by default in case this setting is NOT added to Preferences.sublime-settings of the Default.sublime-package or if it is decided to disable such feature by default.

Note: Alternatively just remove adding space by #2912.