### PR TITLE
[Python] Improve auto-pairing behavior

### DIFF
--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -1,25 +1,110 @@
 [
-    // Auto-pair quotes even after string modifiers.
-    // Copied over from the default bindings with modifications to `preceding_text`
-    // and an added selector condition.
-    { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
+    // Suppress default auto-pairing bindings to avoid unwanted interference
+    { "keys": ["\""], "command": "insert", "args": {"characters": "\""}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i)\\b[bfru]+$", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.python" },
-            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true }
         ]
     },
+    // Auto-pair double quotes
+    // - not after escape \| -> \"|
+    // - not after quote "| -> ""|
+    // - after string modifiers: f| -> f"|"
+    // - in front of dots: |.join() -> "|".join()
+    // - in front of commas: |, -> "|",
+    // - in front of colons: |: -> "|":
+    // - in front of semicolons: |; -> "|";
+    { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python - string.quoted.double" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i:^|[^\"\\w\\\\]|\\b[bfru]+)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|\\.|,|:|;|$)", "match_all": true }
+        ]
+    },
+
+    // Suppress default auto-pairing bindings to avoid unwanted interference
+    { "keys": ["'"], "command": "insert", "args": {"characters": "'"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true }
+        ]
+    },
+    // Auto-pair single quotes
+    // - not after escape \| -> \"|
+    // - not after quote '| -> ''|
+    // - after string modifiers: f| -> f"|"
+    // - in front of dots: |.join() -> "|".join()
+    // - in front of commas: |, -> "|",
+    // - in front of colons: |: -> "|":
+    // - in front of semicolons: |; -> "|";
     { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'$0'"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i)\\b[bfru]+$", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.python" },
-            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python - string.quoted.single" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i:^|[^'\\w\\\\]|\\b[bfru]+)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|\\.|,|:|;|$)", "match_all": true }
+        ]
+    },
+
+    // Suppress default auto-pairing bindings to avoid unwanted interference
+    { "keys": ["("], "command": "insert", "args": {"characters": "("}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true }
+        ]
+    },
+    // Auto-pair parens: | -> (|)
+    { "keys": ["("], "command": "insert_snippet", "args": {"contents": "($0)"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |]|}|,|;|'|\"|$)", "match_all": true }
+        ]
+    },
+
+    // Suppress default auto-pairing bindings to avoid unwanted interference
+    { "keys": ["["], "command": "insert", "args": {"characters": "["}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true }
+        ]
+    },
+    // Auto-pair brackets: | -> [|]
+    { "keys": ["["], "command": "insert_snippet", "args": {"contents": "[$0]"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|}|,|;|'|\"|$)", "match_all": true }
+        ]
+    },
+
+    // Suppress default auto-pairing bindings to avoid unwanted interference
+    { "keys": ["{"], "command": "insert", "args": {"characters": "{"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true }
+        ]
+    },
+    // Auto-pair braces: | -> {|},
+    { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|,|;|'|\"|$)", "match_all": true }
         ]
     },
 ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -3,7 +3,7 @@
     { "keys": ["\""], "command": "insert", "args": {"characters": "\""}, "context":
         [
             { "key": "setting.auto_match_enabled" },
-            { "key": "selector", "operand": "source.python" },
+            { "key": "selector", "operand": "source.python - string.quoted.double" },
             { "key": "selection_empty", "match_all": true }
         ]
     },
@@ -29,7 +29,7 @@
     { "keys": ["'"], "command": "insert", "args": {"characters": "'"}, "context":
         [
             { "key": "setting.auto_match_enabled" },
-            { "key": "selector", "operand": "source.python" },
+            { "key": "selector", "operand": "source.python - string.quoted.single" },
             { "key": "selection_empty", "match_all": true }
         ]
     },

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -66,7 +66,7 @@
             { "key": "selector", "operand": "source.python" },
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |]|}|,|;|'|\"|$)", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|}|,|;|'|\"|$)", "match_all": true }
         ]
     },
 
@@ -85,7 +85,7 @@
             { "key": "selector", "operand": "source.python" },
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|}|,|;|'|\"|$)", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|}|,|;|'|\"|$)", "match_all": true }
         ]
     },
 
@@ -104,7 +104,7 @@
             { "key": "selector", "operand": "source.python" },
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|,|;|'|\"|$)", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|}|,|;|'|\"|$)", "match_all": true }
         ]
     },
 ]


### PR DESCRIPTION
Fixes #2888

This commit improves auto-pairing of quotation marks and brackets in `source.python` scope.

To avoid interference all core defaults are overridden before creating new bindings. This is needed to prevent auto-pairing after escapes such as ( `\|` -> `\(|` ).

Auto-pairing is enabled in front of common separators `,`, `:`, `;` to improve editing experience of mappings, sets and lists. It follows behavior of JSON.

Auto-pairing parens/brackets/braces now works within strings and directly in front of quotation marks.

Several other language specific tweaks ...

Note:

A general scheme to order context keys is applied.
1. settings
2. main language selector
3. selection state
4. patterns (preceding_text, following_text)