### PR TITLE
[Markdown] Fix refs/links after footnotes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -743,9 +743,9 @@ contexts:
     - include: autolink-inet
     - include: autolink-email
     - include: image-ref
+    - include: link-ref-footnote
     - include: link-ref-literal
     - include: link-ref
-    - include: link-ref-footnote
   inline-bold-italic:
     - include: inline
     - include: bold

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -119,6 +119,12 @@ Here is a [blank reference link][]{}.
 |                                 ^ punctuation.definition.attributes.begin.markdown
 |                                  ^ punctuation.definition.attributes.end.markdown
 
+Here is a footnote[^1][link][] or long[^longnote][link][].
+|                 ^^^^ meta.link.reference.footnote.markdown-extra
+|                     ^^^^^^^^ meta.link.reference.literal
+|                                     ^^^^^^^^^^^ meta.link.reference.footnote.markdown-extra
+|                                                ^^^^^^^^ meta.link.reference.literal
+
 Here is a ![](https://example.com/cat.gif).
 |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
 |          ^ punctuation.definition.image.begin


### PR DESCRIPTION
This commit fixes a syntax highlighting issue which causes inline links or references not to be highlighted correctly if those directly follow a footnote.

The footnote was highlighted as reference causing the reference description to be highlighted as url. The reference's url was not
highlighted at all.

The reason is footnotes not having an url-part. So they must be matched before literal references.