### PR TITLE
[Objective-C] Allow __attribute__ in method declaration

### DIFF
--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -361,6 +361,7 @@ contexts:
             - include: scope:source.objc#protocol_type_qualifier
             - include: expressions
         - include: comments
+        - include: attribute
         - match: '(,)\s+(\.\.\.)\s*'
           captures:
             1: punctuation.separator.objc++
@@ -454,18 +455,7 @@ contexts:
           scope: meta.group.objc++ punctuation.section.group.end.objc++
           pop: true
         - include: expressions
-    - match: \b(__attribute__)\s*(\(\()
-      captures:
-        1: storage.modifier.objc++
-        2: meta.group.objc++ punctuation.section.group.begin.objc++
-      push :
-        - meta_scope: meta.attribute.objc++
-        - meta_content_scope: meta.group.objc++
-        - include: parens
-        - include: strings
-        - match: \)\)
-          scope: meta.group.objc++ punctuation.section.group.end.objc++
-          pop: true
+    - include: attribute
     - match: \b(__declspec)(\()
       captures:
         1: storage.modifier.objc++
@@ -494,6 +484,20 @@ contexts:
               scope: keyword.operator.assignment.objc++
         - match: '\b(appdomain|deprecated|dllimport|dllexport|jintrinsic|naked|noalias|noinline|noreturn|nothrow|novtable|process|restrict|safebuffers|selectany|thread)\b'
           scope: constant.other.objc++
+
+  attribute:
+    - match: \b(__attribute__)\s*(\(\()
+      captures:
+        1: storage.modifier.objc++
+        2: meta.group.objc++ punctuation.section.group.begin.objc++
+      push :
+        - meta_scope: meta.attribute.objc++
+        - meta_content_scope: meta.group.objc++
+        - include: parens
+        - include: strings
+        - match: \)\)
+          scope: meta.group.objc++ punctuation.section.group.end.objc++
+          pop: true
 
   types-parens:
     - match: '\b(decltype)\b\s*(\()'

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -457,6 +457,7 @@ contexts:
             - include: protocol_type_qualifier
             - include: expressions
         - include: comments
+        - include: attribute
         - match: '(,)\s+(\.\.\.)\s*'
           captures:
             1: punctuation.separator.objc
@@ -818,18 +819,7 @@ contexts:
         - include: expressions
 
   modifiers-parens:
-    - match: \b(__attribute__)\s*(\(\()
-      captures:
-        1: storage.modifier.objc
-        2: meta.group.objc punctuation.section.group.begin.objc
-      push :
-        - meta_scope: meta.attribute.objc
-        - meta_content_scope: meta.group.objc
-        - include: parens
-        - include: strings
-        - match: \)\)
-          scope: meta.group.objc punctuation.section.group.end.objc
-          pop: true
+    - include: attribute
     - match: \b(__declspec)(\()
       captures:
         1: storage.modifier.objc
@@ -858,6 +848,20 @@ contexts:
               scope: keyword.operator.assignment.objc
         - match: '\b(appdomain|deprecated|dllimport|dllexport|jintrinsic|naked|noalias|noinline|noreturn|nothrow|novtable|process|restrict|safebuffers|selectany|thread)\b'
           scope: constant.other.objc
+
+  attribute:
+    - match: \b(__attribute__)\s*(\(\()
+      captures:
+        1: storage.modifier.objc
+        2: meta.group.objc punctuation.section.group.begin.objc
+      push :
+        - meta_scope: meta.attribute.objc
+        - meta_content_scope: meta.group.objc
+        - include: parens
+        - include: strings
+        - match: \)\)
+          scope: meta.group.objc punctuation.section.group.end.objc
+          pop: true
 
   keywords-parens:
     - match: '\b(sizeof)\b\s*(\()'

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -2701,6 +2701,10 @@ void sayHi()
 /*                           ^ punctuation.separator.objc           */
 /*                             ^ keyword.other.property.attribute.  */
 /*                                  ^ punctuation.section.scope.end */
+- (NSString*)formatWithPattern:(NSString*)pattern __attribute__((swift_name("format(pattern:)")));
+/*                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.objc++*/
+/*                                                ^^^^^^^^^^^^^ storage.modifier.objc++*/
+/*                                                                          ^^^^^^^^^^^^^^^^^^ string.quoted.double.c*/
 @end
 /* <- storage.type punctuation.definition.storage.type */
 /*^ storage.type */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -622,6 +622,10 @@ func_call(foo
 /*                           ^ punctuation.separator.objc           */
 /*                             ^ keyword.other.property.attribute.  */
 /*                                  ^ punctuation.section.scope.end */
+- (NSString*)formatWithPattern:(NSString*)pattern __attribute__((swift_name("format(pattern:)")));
+/*                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.objc*/
+/*                                                ^^^^^^^^^^^^^ storage.modifier.objc*/
+/*                                                                          ^^^^^^^^^^^^^^^^^^ string.quoted.double.c*/
 @end
 /* <- storage.type punctuation.definition.storage.type */
 /*^ storage.type */


### PR DESCRIPTION
If you add an attribute to a method (which in ObjC comes at the end) the highlight will break:

![image](https://user-images.githubusercontent.com/6729879/125334118-af6ed880-e353-11eb-918a-44bd2e9e6beb.png)
