### PR TITLE
[CSS] Add !important property value completion

### DIFF
--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -575,7 +575,7 @@ def get_properties():
 
     for names, values in properties_dict.items():
         # Values that are allowed for all properties
-        allowed_values = ['all', 'inherit', 'initial', 'unset', ['var()', 'var($1)']]
+        allowed_values = ['!important', 'all', 'inherit', 'initial', 'unset', ['var()', 'var($1)']]
 
         # Determine which values are available for the current property name
         for value in values:


### PR DESCRIPTION
Fixes #2905

Due to ST4's new completion engine various tokens are no longer picked up from buffer. Words which have been available as "word completions" before no longer appear.

Effected are all completions which do not start or end with letters or numbers.

This PR therefore adds `!important` to the list of property values in css_completions.py to bring them back for users.