### PR TITLE
[HTML] Exclude prototypes from attribute value starts

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -291,6 +291,7 @@ contexts:
     - include: else-pop
 
   tag-generic-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope:
         meta.string.html string.quoted.double.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -368,6 +368,7 @@ contexts:
     - include: else-pop
 
   tag-class-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope:
         meta.string.html string.quoted.double.html
@@ -481,6 +482,7 @@ contexts:
     - include: else-pop
 
   tag-href-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope:
         meta.string.html string.quoted.double.html
@@ -550,6 +552,7 @@ contexts:
     - include: else-pop
 
   tag-id-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope:
         meta.string.html string.quoted.double.html


### PR DESCRIPTION
This commit adds some `meta_include_prototype: false` rules to attribute value contexts, which may contain unquoted values.

Without this rule any ordinary `prototype` context can be injected between assignment operator and beginning of an unquoted value. As a result the unquoted value starts after this injected context is popped or doesn't match anything anymore.

What we want is to first push into unquoted-value context and than let inherited syntaxes apply normal string interpolation to maintain proper value boundaries.

Note: It's hard to test without a inheriting syntax at hand.

It is discussed at https://discord.com/channels/280102180189634562/280157067396775936/867802732482920458

Created a Gist with an example at https://gist.github.com/deathaxe/dabcd7575951174d08882b46842dd44a

If contexts in `HTML BUGFIX` section are commented out highlighting fails in combination with ST 4113.