### PR TITLE
[Markdown] Highlight task check boxes in block quotes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -410,11 +410,12 @@ contexts:
               push:
                 - meta_content_scope: markup.list.numbered.markdown meta.paragraph.list.markdown
                 - include: list-content
-            - match: ([ ]{,3})([*+-])(\s)
+            - match: ([ ]{,3})([*+-])((?:[ ](\[[ xX]\]))?\s)
               captures:
                 1: markup.list.unnumbered.markdown
                 2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
                 3: markup.list.unnumbered.markdown
+                4: constant.language.checkbox.markdown-gfm
               push:
                 - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown
                 - include: list-content
@@ -1051,7 +1052,7 @@ contexts:
       push:
         - match: ^\s*$
           pop: true
-        - match: ([ ]*)([*+-])( (\[[ xX]\]))?(?=\s)
+        - match: ([ ]*)([*+-])((?:[ ](\[[ xX]\]))?\s)
           captures:
             1: markup.list.unnumbered.markdown
             2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -420,6 +420,34 @@ paragraph
 >==
 | <- punctuation.definition.blockquote.markdown
 
+> * [ ] task
+| ^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^^^ constant.language.checkbox.markdown-gfm
+
+> * [x] task
+| ^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^^^ constant.language.checkbox.markdown-gfm
+
+> * [X] task
+| ^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^^^ constant.language.checkbox.markdown-gfm
+
+> * [X] task
+>   - [ ] task
+| ^^^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown
+|   ^ markup.list.unnumbered.bullet.markdown
+|    ^^^^^^^^^^ markup.list.unnumbered.markdown
+|   ^ punctuation.definition.list_item.markdown
+|     ^^^ constant.language.checkbox.markdown-gfm
 Code block below:
 
     this is code!


### PR DESCRIPTION
This commit adds highlighting for `[X]` check marks in block quoted GFM tasks.