### PR TITLE
[TypeScript] Implement arrow function type parameters.

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -80,8 +80,7 @@ contexts:
     - match: '/'
       scope: punctuation.definition.tag.begin.js
       set:
-        - - meta_scope: invalid.illegal.unmatched-tag.js
-          - include: immediately-pop
+        - jsx-meta-unmatched-tag
         - jsx-expect-tag-end
         - jsx-tag-name
 
@@ -89,6 +88,11 @@ contexts:
       set:
         - jsx-tag-attributes
         - jsx-tag-name
+
+  jsx-meta-unmatched-tag:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.unmatched-tag.js
+    - include: immediately-pop
 
   jsx-tag-attributes:
     - meta_scope: meta.tag.attributes.js

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -15,7 +15,7 @@ variables:
 contexts:
   expression-begin:
     - meta_prepend: true
-    - include: jsx-tag
+    - include: jsx-tag-hack
 
   jsx-interpolation:
     - match: (?={/\*)
@@ -71,6 +71,9 @@ contexts:
       set:
         - jsx-meta
         - jsx-tag-attributes-top
+
+  jsx-tag-hack: # Ugly hack so that TSX can un-include this in expression-begin
+    - include: jsx-tag
 
   jsx-tag-attributes-top:
     - meta_scope: meta.tag.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -994,11 +994,11 @@ contexts:
 
   branch-possible-arrow-function:
     - meta_include_prototype: false
-    - match: '(?=\()'
+    - match: (?=\()
       set:
         - detect-arrow
         - parenthesized-expression
-    - match: '(?={{identifier_start}})'
+    - match: (?={{identifier_start}})
       set:
         - detect-arrow
         - literal-variable

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -8,3 +8,41 @@ scope: source.tsx
 extends:
   - JSX.sublime-syntax
   - TypeScript.sublime-syntax
+contexts:
+  expression-begin:
+    - meta_prepend: true
+    - match: (?=\<(?!<))
+      branch_point: tsx-element
+      branch:
+        - jsx-tag
+        - arrow-function-declaration
+
+  jsx-tag-attributes-top:
+    - meta_scope: meta.tag.js
+    - match: '/'
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - - meta_scope: invalid.illegal.unmatched-tag.js
+          - include: immediately-pop
+        - jsx-expect-tag-end
+        - jsx-tag-name
+
+    - match: (?=\S)
+      set:
+        - jsx-tag-attributes
+        - tsx-tag-check
+        - jsx-tag-name
+
+  tsx-tag-check:
+    - match: 'extends{{jsx_identifier_break}}'
+      scope: entity.other.attribute-name.js
+      set:
+        - match: (?={{identifier_start}})
+          fail: tsx-element
+        - match: (?=\S)
+          pop: true
+
+    - match: (?=/|>|{{identifier_start}})
+      pop: true
+    - match: (?=\S)
+      fail: tsx-element

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -22,8 +22,7 @@ contexts:
     - match: '/'
       scope: punctuation.definition.tag.begin.js
       set:
-        - - meta_scope: invalid.illegal.unmatched-tag.js
-          - include: immediately-pop
+        - jsx-meta-unmatched-tag
         - jsx-expect-tag-end
         - jsx-tag-name
 

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -9,13 +9,15 @@ extends:
   - JSX.sublime-syntax
   - TypeScript.sublime-syntax
 contexts:
-  expression-begin:
+  branch-possible-arrow-function:
     - meta_prepend: true
-    - match: (?=\<(?!<))
-      branch_point: tsx-element
-      branch:
+
+    - match: (?=<)
+      push:
+        - immediately-pop-2
         - jsx-tag
-        - arrow-function-declaration
+
+  jsx-tag-hack: []
 
   jsx-tag-attributes-top:
     - meta_scope: meta.tag.js
@@ -38,11 +40,11 @@ contexts:
       scope: entity.other.attribute-name.js
       set:
         - match: (?={{identifier_start}})
-          fail: tsx-element
+          fail: arrow-function
         - match: (?=\S)
           pop: true
 
     - match: (?=/|>|{{identifier_start}})
       pop: true
     - match: (?=\S)
-      fail: tsx-element
+      fail: arrow-function

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -13,9 +13,7 @@ contexts:
     - meta_prepend: true
 
     - match: (?=<)
-      push:
-        - immediately-pop-2
-        - jsx-tag
+      set: jsx-tag
 
   jsx-tag-hack: []
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -50,7 +50,6 @@ contexts:
     - match: \<
       scope: punctuation.definition.assertion.begin.js
       set:
-        # - immediately-pop
         - ts-old-type-assertion-check
         - ts-old-type-assertion-end
         - ts-type-expression-end

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -79,6 +79,13 @@ contexts:
         - arrow-function-expect-arrow
         - ts-type-annotation
         - arrow-function-expect-parameters
+        - ts-type-parameter-list
+
+  ts-arrow-function-with-type-parameters:
+    - match: ''
+      set:
+        - arrow-function-declaration
+        - ts-type-parameter-list
 
   ts-import-type:
     - match: type{{identifier_break}}
@@ -532,17 +539,60 @@ contexts:
 
   expression-begin:
     - meta_prepend: true
-    - match: \<(?!<)
+    - match: (?=\<(?!<))
+      pop: true
+      branch_point: ts-old-type-assertion
+      branch:
+        - ts-old-type-assertion
+        - arrow-function-declaration
+
+  ts-old-type-assertion:
+    - match: \<
       scope: punctuation.definition.assertion.begin.js
       set:
-        - - meta_scope: meta.assertion.js
-          - match: \>
-            scope: punctuation.definition.assertion.end.js
-            pop: true
-          - include: else-pop
+        - immediately-pop
+        - ts-old-type-assertion-check
+        - ts-old-type-assertion-end
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin
+
+  ts-old-type-assertion-end:
+    - meta_scope: meta.assertion.js
+    - match: \>
+      scope: punctuation.definition.assertion.end.js
+      pop: true
+
+  ts-old-type-assertion-check:
+    - match: (?=\()
+      set:
+        - detect-parenthesized-arrow-2
+        - parenthesized-expression
+    - include: else-pop
+
+  detect-parenthesized-arrow-2:
+    - match: (?=:)
+      pop: true
+      branch_point: ts-arrow-function-return-type-2
+      branch:
+        - ts-detect-arrow-function-return-type-2
+        - immediately-pop
+    - match: (?==>)
+      fail: ts-old-type-assertion
+    - include: else-pop
+
+  ts-detect-arrow-function-return-type-2:
+    - meta_include_prototype: false
+    - match: ''
+      push:
+        - ts-detect-arrow-after-return-type-2
+        - ts-type-annotation
+
+  ts-detect-arrow-after-return-type-2:
+    - match: (?==>)
+      fail: ts-old-type-assertion
+    - match: (?=\S)
+      fail: ts-arrow-function-return-type-2
 
   ts-type-assertion:
     - match: '!(?![.=])'

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -9,6 +9,7 @@ extends: JavaScript.sublime-syntax
 
 variables:
   dot_accessor: (?:[?!]?\.)
+  possible_arrow_function_begin: (?:\(|{{identifier_start}}|<)
 
   function_call_lookahead: >-
     (?x:(?=
@@ -40,11 +41,21 @@ variables:
 contexts:
   branch-possible-arrow-function:
     - meta_prepend: true
-    - match: '(?=\()'
+    - match: (?=\()
       set:
         - detect-arrow
         - ts-detect-parenthesized-arrow-return-type
         - parenthesized-expression
+
+    - match: \<
+      scope: punctuation.definition.assertion.begin.js
+      set:
+        # - immediately-pop
+        - ts-old-type-assertion-check
+        - ts-old-type-assertion-end
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
 
   ts-detect-parenthesized-arrow-return-type:
     - match: (?=:)
@@ -87,12 +98,6 @@ contexts:
         - arrow-function-expect-arrow
         - ts-type-annotation
         - arrow-function-expect-parameters
-        - ts-type-parameter-list
-
-  ts-arrow-function-with-type-parameters:
-    - match: ''
-      set:
-        - arrow-function-declaration
         - ts-type-parameter-list
 
   ts-import-type:
@@ -545,25 +550,25 @@ contexts:
       scope: keyword.operator.comparison.js
       set: expression-begin
 
-  expression-begin:
-    - meta_prepend: true
-    - match: (?=\<(?!<))
-      pop: true
-      branch_point: ts-old-type-assertion
-      branch:
-        - ts-old-type-assertion
-        - arrow-function-declaration
+  # expression-begin:
+  #   - meta_prepend: true
+  #   - match: (?=\<(?!<))
+  #     pop: true
+  #     branch_point: ts-old-type-assertion
+  #     branch:
+  #       - ts-old-type-assertion
+  #       - arrow-function-declaration
 
-  ts-old-type-assertion:
-    - match: \<
-      scope: punctuation.definition.assertion.begin.js
-      set:
-        - immediately-pop
-        - ts-old-type-assertion-check
-        - ts-old-type-assertion-end
-        - ts-type-expression-end
-        - ts-type-expression-end-no-line-terminator
-        - ts-type-expression-begin
+  # ts-old-type-assertion:
+  #   - match: \<
+  #     scope: punctuation.definition.assertion.begin.js
+  #     set:
+  #       - immediately-pop
+  #       - ts-old-type-assertion-check
+  #       - ts-old-type-assertion-end
+  #       - ts-type-expression-end
+  #       - ts-type-expression-end-no-line-terminator
+  #       - ts-type-expression-begin
 
   ts-old-type-assertion-end:
     - meta_scope: meta.assertion.js
@@ -574,33 +579,35 @@ contexts:
   ts-old-type-assertion-check:
     - match: (?=\()
       set:
-        - detect-parenthesized-arrow-2
+        # - detect-parenthesized-arrow-2
+        - detect-arrow
+        - ts-detect-arrow-function-return-type
         - parenthesized-expression
     - include: else-pop
 
-  detect-parenthesized-arrow-2:
-    - match: (?=:)
-      pop: true
-      branch_point: ts-arrow-function-return-type-2
-      branch:
-        - ts-detect-arrow-function-return-type-2
-        - immediately-pop
-    - match: (?==>)
-      fail: ts-old-type-assertion
-    - include: else-pop
+  # detect-parenthesized-arrow-2:
+  #   - match: (?=:)
+  #     pop: true
+  #     branch_point: ts-arrow-function-return-type-2
+  #     branch:
+  #       - ts-detect-arrow-function-return-type-2
+  #       - immediately-pop
+  #   - match: (?==>)
+  #     fail: ts-old-type-assertion
+  #   - include: else-pop
 
-  ts-detect-arrow-function-return-type-2:
-    - meta_include_prototype: false
-    - match: ''
-      push:
-        - ts-detect-arrow-after-return-type-2
-        - ts-type-annotation
+  # ts-detect-arrow-function-return-type-2:
+  #   - meta_include_prototype: false
+  #   - match: ''
+  #     push:
+  #       - ts-detect-arrow-after-return-type-2
+  #       - ts-type-annotation
 
-  ts-detect-arrow-after-return-type-2:
-    - match: (?==>)
-      fail: ts-old-type-assertion
-    - match: (?=\S)
-      fail: ts-arrow-function-return-type-2
+  # ts-detect-arrow-after-return-type-2:
+  #   - match: (?==>)
+  #     fail: ts-old-type-assertion
+  #   - match: (?=\S)
+  #     fail: ts-arrow-function-return-type-2
 
   ts-type-assertion:
     - match: '!(?![.=])'

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -88,6 +88,7 @@ contexts:
         - arrow-function-expect-arrow-or-fail-async
         - ts-type-annotation
         - arrow-function-expect-parameters
+        - ts-type-parameter-list
 
   arrow-function-declaration:
     - meta_include_prototype: false

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -39,3 +39,33 @@ if (a < b || c <= d) {}
 //    ^ keyword.operator.comparison
 //        ^^ keyword.operator.logical
 //             ^^ keyword.operator.comparison
+
+    <T,>(): U => {}; // </T>;
+//  ^^^^^^^^^^^^^^^ meta.function
+//  ^^^^ meta.generic
+//  ^ punctuation.definition.generic.begin
+//   ^ variable.parameter.generic
+//    ^ punctuation.separator.comma
+//     ^ punctuation.definition.generic.end
+//      ^^ meta.function.parameters
+//        ^ punctuation.separator.type
+//          ^ support.class
+//            ^^ keyword.declaration.function.arrow
+
+
+    <T extends U>() => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^ meta.generic
+//   ^ variable.parameter.generic
+//     ^^^^^^^ storage.modifier.extends
+//             ^ support.class
+//               ^^ meta.function.parameters
+//                  ^^ keyword.declaration.function.arrow
+
+    <T extends>() => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
+//  ^^^^^^^^^^^ meta.tag
+//  ^ punctuation.definition.tag.begin
+//   ^ meta.tag.name entity.name.tag
+//     ^^^^^^^ meta.tag.attributes entity.other.attribute-name
+//            ^ punctuation.definition.tag.end

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -52,6 +52,19 @@ if (a < b || c <= d) {}
 //          ^ support.class
 //            ^^ keyword.declaration.function.arrow
 
+    async <T,>(): U => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^ keyword.declaration.async
+//        ^^^^ meta.generic
+//        ^ punctuation.definition.generic.begin
+//         ^ variable.parameter.generic
+//          ^ punctuation.separator.comma
+//           ^ punctuation.definition.generic.end
+//            ^^ meta.function.parameters
+//              ^ punctuation.separator.type
+//                ^ support.class
+//                  ^^ keyword.declaration.function.arrow
+
 
     <T extends U>() => {}; // </T>;
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.function
@@ -61,6 +74,17 @@ if (a < b || c <= d) {}
 //             ^ support.class
 //               ^^ meta.function.parameters
 //                  ^^ keyword.declaration.function.arrow
+
+
+    async <T extends U>() => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^ keyword.declaration.async
+//        ^^^^^^^^^^^^^ meta.generic
+//         ^ variable.parameter.generic
+//           ^^^^^^^ storage.modifier.extends
+//                   ^ support.class
+//                     ^^ meta.function.parameters
+//                        ^^ keyword.declaration.function.arrow
 
     <T extends>() => {}; // </T>;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -952,6 +952,17 @@ const f = (): any => {};
 //    ^ meta.binding.name entity.name.function variable.other.readwrite
 //     ^^^^^^^^^^^^^^^^^^ - entity.name.function
 
+const f = <T>(): U => {};
+//        ^^^^^^^^^^^^^^ meta.function
+//        ^^^ meta.generic
+//        ^ punctuation.definition.generic.begin
+//         ^ variable.parameter.generic
+//          ^ punctuation.definition.generic.end
+//           ^^ meta.function.parameters
+//             ^ punctuation.separator.type
+//               ^ support.class
+//                 ^^ keyword.declaration.function.arrow
+
     a != b;
 //    ^^ keyword.operator.comparison
 


### PR DESCRIPTION
Fix https://github.com/sublimehq/Packages/issues/2660.

The implementation is a bit of a mess at the moment, largely due to https://github.com/sublimehq/sublime_text/issues/3494 hampering code reuse. 

The implementation differs between plain TypeScript and TSX because in TypeScript, a `<` in `expression-begin` indicates either an arrow function or an old-style type assersion, whereas in TSX it indicates either an arrow function or a JSX element. In ambiguous cases (e.g. `<T extends U>() => {}`), arrow functions seem to win. (Because TypeScript does not have a language spec, I had to reverse-engineer its behavior using AST Explorer. I'm fairly confident I got it right.)