### PR TITLE
[Markdown] Add Support for JSON front-matter

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -184,21 +184,33 @@ variables:
     #     \s*$      # any amount of whitespace until EOL
     #   )
 contexts:
-  file-start:
-    - match: (---)\s*
+
+  main:
+    - include: front-matter
+    - match: ''
+      set: markdown
+
+  front-matter:
+    - match: (---)\s*((?i:json)\b)
+      captures:
+        0: meta.frontmatter.markdown
+        1: punctuation.section.block.begin.frontmatter.json.markdown
+        2: constant.other.language-name.markdown
+      embed: scope:source.json
+      embed_scope: meta.frontmatter.markdown source.json.embedded
+      escape: ^(---|\.{3})\s*$  # pandoc requires the remainder of the line to be blank
+      escape_captures:
+        1: meta.frontmatter.markdown punctuation.section.block.end.frontmatter.json.markdown
+    - match: (---)\s*((?i:yaml)\b)?
       captures:
         0: meta.frontmatter.markdown
         1: punctuation.section.block.begin.frontmatter.yaml.markdown
+        2: constant.other.language-name.markdown
       embed: scope:source.yaml
       embed_scope: meta.frontmatter.markdown source.yaml.embedded
       escape: ^(---|\.{3})\s*$  # pandoc requires the remainder of the line to be blank
       escape_captures:
         1: meta.frontmatter.markdown punctuation.section.block.end.frontmatter.yaml.markdown
-
-  main:
-    - include: file-start
-    - match: ''
-      set: markdown
 
   markdown:
     - match: |-


### PR DESCRIPTION
While YAML keeps default front-matter syntax adding a `json` language tag enables json highlighting within front-matter.

```
--- json
{
    "key": "value"
}
---
# Markdown
```

For consistency reasons `yaml` language tag is supported, too.
```
--- yaml
key: value
---
# Markdown
```

Note: This PR is an attempt to sync this aspect with MarkdownEditing, which supports CoffeScript/JSON/YAML front-matter.