### PR TITLE
[Markdown] Refactor fenced code blocks

### DIFF
--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -344,6 +344,12 @@
 			"details": "Specifies <code>TypeScript</code> code highlighting"
 		},
 		{
+			"trigger": "tsx",
+			"annotation": "TypeScript React",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>TypeScript React</code> code highlighting"
+		},
+		{
 			"trigger": "typescript",
 			"annotation": "TypeScript",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -92,6 +92,12 @@
 			"details": "Specifies <code>Haskell</code> code highlighting"
 		},
 		{
+			"trigger": "html",
+			"annotation": "HTML",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>HTML</code> code highlighting"
+		},
+		{
 			"trigger": "html+php",
 			"annotation": "PHP",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -101,7 +101,7 @@
 			"trigger": "html+php",
 			"annotation": "PHP",
 			"kind": ["markup", "s", "Syntax"],
-			"details": "Specifies <code>PHP</code> code highlighting"
+			"details": "Specifies <code>HTML+PHP</code> code highlighting"
 		},
 		{
 			"trigger": "inc",

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -158,6 +158,12 @@
 			"details": "Specifies <code>Lisp</code> code highlighting"
 		},
 		{
+			"trigger": "lua",
+			"annotation": "Lua",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Lua</code> code highlighting"
+		},
+		{
 			"trigger": "obj-c",
 			"annotation": "Objective-C",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -308,6 +308,12 @@
 			"details": "Specifies <code>Rust</code> code highlighting"
 		},
 		{
+			"trigger": "scala",
+			"annotation": "Scala",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Scala</code> code highlighting"
+		},
+		{
 			"trigger": "sh",
 			"annotation": "ShellScript",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -56,6 +56,12 @@
 			"details": "Specifies <code>C#</code> code highlighting"
 		},
 		{
+			"trigger": "diff",
+			"annotation": "Diff",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Diff</code> code highlighting"
+		},
+		{
 			"trigger": "erlang",
 			"annotation": "Erlang",
 			"kind": ["markup", "s", "Syntax"],
@@ -180,6 +186,12 @@
 			"annotation": "Objective-C++",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>Objective-C++</code> code highlighting"
+		},
+		{
+			"trigger": "patch",
+			"annotation": "Patch",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Patch</code> code highlighting"
 		},
 		{
 			"trigger": "perl",

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -146,6 +146,11 @@
 			"details": "Specifies <code>Java Server Pages</code> code highlighting"
 		},
 		{
+			"trigger": "JSX",
+			"annotation": "JavaScript React",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>JavaScript React</code> code highlighting"
+		},		{
 			"trigger": "obj-c",
 			"annotation": "Objective-C",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -326,6 +326,12 @@
 			"details": "Specifies <code>ShellScript</code> code highlighting"
 		},
 		{
+			"trigger": "shell",
+			"annotation": "ShellScript",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>ShellScript</code> code highlighting"
+		},
+		{
 			"trigger": "shell-script",
 			"annotation": "ShellScript",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -150,7 +150,14 @@
 			"annotation": "JavaScript React",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>JavaScript React</code> code highlighting"
-		},		{
+		},
+		{
+			"trigger": "lisp",
+			"annotation": "Lisp",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Lisp</code> code highlighting"
+		},
+		{
 			"trigger": "obj-c",
 			"annotation": "Objective-C",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -164,6 +164,12 @@
 			"details": "Specifies <code>Lua</code> code highlighting"
 		},
 		{
+			"trigger": "matlab",
+			"annotation": "MatLab",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>MatLab</code> code highlighting"
+		},
+		{
 			"trigger": "obj-c",
 			"annotation": "Objective-C",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -218,6 +218,12 @@
 			"details": "Specifies <code>Objective-C++</code> code highlighting"
 		},
 		{
+			"trigger": "ocaml",
+			"annotation": "OCaml",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>OCaml</code> code highlighting"
+		},
+		{
 			"trigger": "patch",
 			"annotation": "Patch",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -86,6 +86,12 @@
 			"details": "Specifies <code>GraphViz</code> code highlighting"
 		},
 		{
+			"trigger": "haskell",
+			"annotation": "Haskell",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Haskell</code> code highlighting"
+		},
+		{
 			"trigger": "html+php",
 			"annotation": "PHP",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -318,14 +318,15 @@ contexts:
       pop: true
 
   paragraph:
-      - meta_scope: meta.paragraph.markdown
-      - match: ^\s{0,3}===+\s*$
-        fail: heading1-branch
-      - match: ^\s{0,3}---+\s*$
-        fail: heading2-branch
-      - include: not-paragraph
-      - include: inline-bold-italic-linebreak
-      - include: scope:text.html.basic
+    - meta_scope: meta.paragraph.markdown
+    - match: ^\s{0,3}===+\s*$
+      fail: heading1-branch
+    - match: ^\s{0,3}---+\s*$
+      fail: heading2-branch
+    - include: not-paragraph
+    - include: fenced-code-blocks
+    - include: inline-bold-italic-linebreak
+    - include: scope:text.html.basic
 
   heading1:
     - meta_scope: markup.heading.1.markdown
@@ -737,7 +738,7 @@ contexts:
     - include: ampersand
     - include: ligatures
     - include: bracket
-    - include: raw
+    - include: code-span
     - include: image-inline
     - include: link-inline
     - include: autolink-inet
@@ -1041,11 +1042,7 @@ contexts:
         - include: block-quote
         - match: $
           pop: true
-    - match: '^(?={{fenced_code_block_start}})'
-      push:
-        - include: fenced-code-block
-        - match: ''
-          pop: true
+    - include: fenced-code-blocks
     - include: reference-link-definition
     - match: \s+(?=\S)
       push:
@@ -1080,11 +1077,7 @@ contexts:
       pop: true
   list-content:
     - meta_content_scope: meta.paragraph.list.markdown
-    - match: ^(?={{fenced_code_block_start}})
-      push:
-        - match: $
-          pop: true
-        - include: fenced-code-block
+    - include: fenced-code-blocks
     - match: ^
       pop: true
     - include: thematic-break
@@ -1097,7 +1090,17 @@ contexts:
         - match: $
           pop: true
 
-  fenced-code-block:
+  fenced-code-blocks:
+    - match: ^(?={{fenced_code_block_start}})
+      push: fenced-code-block-content
+
+  fenced-code-block-content:
+    - match: $
+      pop: true
+    - include: fenced-syntaxes
+    - include: fenced-raw
+
+  fenced-syntaxes:
     - include: fenced-clojure
     - include: fenced-c
     - include: fenced-cpp
@@ -1134,7 +1137,6 @@ contexts:
     - include: fenced-typescript
     - include: fenced-xml
     - include: fenced-yaml
-    - include: fenced-other
 
   fenced-clojure:
     - match: |-
@@ -1748,7 +1750,7 @@ contexts:
         0: meta.code-fence.definition.end.yaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
 
-  fenced-other:
+  fenced-raw:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1780,13 +1782,6 @@ contexts:
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
-  raw:
-    - match: ^(?={{fenced_code_block_start}})
-      push:
-        - match: $
-          pop: true
-        - include: fenced-code-block
-    - include: code-span
   thematic-break:
     - match: '(?={{thematic_break}})'
       push:
@@ -1836,7 +1831,7 @@ contexts:
     - match: \b\*\*?(?=[^]*]+\]) # eat asterisks where there is no pair before the end of the square brackets - it's not a formatting mark
     - include: escape
     - include: ampersand
-    - include: raw
+    - include: code-span
     - match: \[ # nested square brackets are allowed
       push:
         - include: link-text

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1565,6 +1565,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:tsx))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.tsx.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.tsx
+      embed_scope: markup.raw.code-fence.tsx.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.tsx.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:typescript|ts))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -279,6 +279,7 @@ contexts:
           pop: true
         - include: inline-bold-italic
     - include: reference-link-definition
+    - include: fenced-code-blocks
     - match: '^(?=\S)(?![=-]{3,}\s*$)'
       branch_point: heading2-branch
       branch:
@@ -324,7 +325,6 @@ contexts:
     - match: ^\s{0,3}---+\s*$
       fail: heading2-branch
     - include: not-paragraph
-    - include: fenced-code-blocks
     - include: inline-bold-italic-linebreak
     - include: scope:text.html.basic
 

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1220,6 +1220,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:haskell))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.haskell.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.haskell
+      embed_scope: markup.raw.code-fence.haskell.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.haskell.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:html\+php))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1697,7 +1697,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:shell-script|sh|bash|zsh))
+          ((?i:shell(?:-script)?|sh|bash|zsh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.shell-script.markdown-gfm

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1520,6 +1520,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:scala))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.scala.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.scala
+      embed_scope: markup.raw.code-fence.scala.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.scala.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:shell-script|sh|bash|zsh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1612,7 +1612,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:regexp|regex))
+          ((?i:regexp?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.regexp.markdown-gfm

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1355,6 +1355,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:matlab))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.matlab.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.matlab
+      embed_scope: markup.raw.code-fence.matlab.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.matlab.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1160,6 +1160,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:diff|patch))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.diff.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.diff
+      embed_scope: markup.raw.code-fence.diff.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.diff.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:erlang|escript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1310,6 +1310,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:jsx))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.jsx.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.jsx
+      embed_scope: markup.raw.code-fence.jsx.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.jsx.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1325,6 +1325,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:lisp))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.lisp.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.lisp
+      embed_scope: markup.raw.code-fence.lisp.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.lisp.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1340,6 +1340,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:lua))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.lua.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.lua
+      embed_scope: markup.raw.code-fence.lua.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.lua.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1400,6 +1400,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:ocaml))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.ocaml.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.ocaml
+      embed_scope: markup.raw.code-fence.ocaml.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.ocaml.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:perl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1760,13 +1760,15 @@ contexts:
         0: meta.code-fence.definition.begin.text.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      push:
-        - meta_content_scope: markup.raw.code-fence.markdown-gfm
-        - match: '{{code_fence_escape}}'
-          captures:
-            0: meta.code-fence.definition.end.text.markdown-gfm
-            1: punctuation.definition.raw.code-fence.end.markdown
-          pop: true
+      push: fenced-raw-content
+
+  fenced-raw-content:
+    - meta_content_scope: markup.raw.code-fence.markdown-gfm
+    - match: '{{code_fence_escape}}'
+      captures:
+        0: meta.code-fence.definition.end.text.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+      pop: true
 
   code-span:
     - match: (`+)(?!`)

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1096,7 +1096,47 @@ contexts:
         - include: scope:text.html.basic
         - match: $
           pop: true
+
   fenced-code-block:
+    - include: fenced-clojure
+    - include: fenced-c
+    - include: fenced-cpp
+    - include: fenced-csharp
+    - include: fenced-diff
+    - include: fenced-erlang
+    - include: fenced-graphviz
+    - include: fenced-golang
+    - include: fenced-haskell
+    - include: fenced-html-php
+    - include: fenced-html
+    - include: fenced-java
+    - include: fenced-javascript
+    - include: fenced-jsonc
+    - include: fenced-jspx
+    - include: fenced-jsx
+    - include: fenced-lisp
+    - include: fenced-lua
+    - include: fenced-matlab
+    - include: fenced-objc
+    - include: fenced-objcpp
+    - include: fenced-ocaml
+    - include: fenced-perl
+    - include: fenced-php
+    - include: fenced-python
+    - include: fenced-regexp
+    - include: fenced-rscript
+    - include: fenced-ruby
+    - include: fenced-rust
+    - include: fenced-scala
+    - include: fenced-shell-script
+    - include: fenced-sql
+    - include: fenced-tsx
+    - include: fenced-typescript
+    - include: fenced-xml
+    - include: fenced-yaml
+    - include: fenced-other
+
+  fenced-clojure:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1112,6 +1152,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.clojure.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-c:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1127,6 +1169,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.c.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-cpp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1142,6 +1186,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.c++.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-csharp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1157,6 +1203,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.csharp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-diff:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1172,6 +1220,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.diff.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-erlang:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1187,6 +1237,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.erlang.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-graphviz:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1202,6 +1254,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.graphviz.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-golang:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1217,6 +1271,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.go.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-haskell:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1232,6 +1288,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.haskell.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-html-php:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1247,6 +1305,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.html-php.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-html:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1262,6 +1322,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.html.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-java:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1277,6 +1339,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.java.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-javascript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1292,6 +1356,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.javascript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-jsonc:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1307,6 +1373,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.json.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-jspx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1322,6 +1390,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.jsp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-jsx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1337,6 +1407,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.jsx.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-lisp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1352,6 +1424,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.lisp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-lua:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1367,6 +1441,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.lua.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-matlab:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1382,6 +1458,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.matlab.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-objc:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1397,6 +1475,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.objc.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-objcpp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1412,6 +1492,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.objc++.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-ocaml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1427,6 +1509,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.ocaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-perl:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1442,6 +1526,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.perl.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-php:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1457,6 +1543,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.php.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-python:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1472,6 +1560,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.python.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-regexp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1487,6 +1577,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.regexp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-rscript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1502,6 +1594,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.r.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-ruby:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1517,6 +1611,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.ruby.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-rust:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1532,6 +1628,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.rust.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-scala:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1547,6 +1645,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.scala.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-shell-script:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1562,6 +1662,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.shell-script.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-sql:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1577,6 +1679,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.sql.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-tsx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1592,6 +1696,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.tsx.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-typescript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1607,6 +1713,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.typescript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-xml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1622,6 +1730,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.xml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-yaml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1637,6 +1747,8 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.yaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-other:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -1653,6 +1765,7 @@ contexts:
             0: meta.code-fence.definition.end.text.markdown-gfm
             1: punctuation.definition.raw.code-fence.end.markdown
           pop: true
+
   code-span:
     - match: (`+)(?!`)
       scope: punctuation.definition.raw.begin.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1250,6 +1250,21 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
+          ((?i:html))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.html.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:text.html.basic
+      embed_scope: markup.raw.code-fence.html.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.html.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
           ((?i:java))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1115,47 +1115,62 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:xml))
+          ((?i:c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.xml.markdown-gfm
+        0: meta.code-fence.definition.begin.c.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:text.xml
-      embed_scope: markup.raw.code-fence.xml.markdown-gfm
+      embed: scope:source.c
+      embed_scope: markup.raw.code-fence.c.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.xml.markdown-gfm
+        0: meta.code-fence.definition.end.c.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:sql))
+          ((?i:c\+\+|cpp))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.sql.markdown-gfm
+        0: meta.code-fence.definition.begin.c++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.sql
-      embed_scope: markup.raw.code-fence.sql.markdown-gfm
+      embed: scope:source.c++
+      embed_scope: markup.raw.code-fence.c++.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.sql.markdown-gfm
+        0: meta.code-fence.definition.end.c++.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:python|py))
+          ((?i:csharp|c\#|cs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.python.markdown-gfm
+        0: meta.code-fence.definition.begin.csharp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.python
-      embed_scope: markup.raw.code-fence.python.markdown-gfm
+      embed: scope:source.cs
+      embed_scope: markup.raw.code-fence.csharp.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.python.markdown-gfm
+        0: meta.code-fence.definition.end.csharp.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:erlang|escript))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.erlang.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.erlang
+      embed_scope: markup.raw.code-fence.erlang.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.erlang.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
@@ -1171,6 +1186,51 @@ contexts:
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.graphviz.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:golang))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.go.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.go
+      embed_scope: markup.raw.code-fence.go.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.go.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:html\+php))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.html-php.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:embedding.php
+      embed_scope: markup.raw.code-fence.html-php.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.html-php.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:java))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.java.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.java
+      embed_scope: markup.raw.code-fence.java.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.java.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
@@ -1205,36 +1265,6 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:typescript|ts))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.typescript.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.ts
-      embed_scope: markup.raw.code-fence.typescript.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.typescript.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:java))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.java.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.java
-      embed_scope: markup.raw.code-fence.java.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.java.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
           ((?i:jspx?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
@@ -1246,141 +1276,6 @@ contexts:
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.jsp.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:csharp|c\#|cs))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.csharp.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.cs
-      embed_scope: markup.raw.code-fence.csharp.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.csharp.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:perl))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.perl.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.perl
-      embed_scope: markup.raw.code-fence.perl.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.perl.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:rust|rs))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.rust.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.rust
-      embed_scope: markup.raw.code-fence.rust.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.rust.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:shell-script|sh|bash|zsh))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.shell-script.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.shell.bash
-      embed_scope: markup.raw.code-fence.shell-script.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.shell-script.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:php|inc))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.php.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.php
-      embed_scope: markup.raw.code-fence.php.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.php.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:html\+php))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.html-php.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:embedding.php
-      embed_scope: markup.raw.code-fence.html-php.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.html-php.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:rscript|r|splus))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.r.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.r
-      embed_scope: markup.raw.code-fence.r.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.r.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:golang))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.go.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.go
-      embed_scope: markup.raw.code-fence.go.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.go.markdown-gfm
-        1: punctuation.definition.raw.code-fence.end.markdown
-    - match: |-
-         (?x)
-          {{fenced_code_block_start}}
-          ((?i:ruby|rb|rbx))
-          {{fenced_code_block_trailing_infostring_characters}}
-      captures:
-        0: meta.code-fence.definition.begin.ruby.markdown-gfm
-        2: punctuation.definition.raw.code-fence.begin.markdown
-        5: constant.other.language-name.markdown
-      embed: scope:source.ruby
-      embed_scope: markup.raw.code-fence.ruby.markdown-gfm
-      escape: '{{code_fence_escape}}'
-      escape_captures:
-        0: meta.code-fence.definition.end.ruby.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
@@ -1415,47 +1310,47 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:c))
+          ((?i:perl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c.markdown-gfm
+        0: meta.code-fence.definition.begin.perl.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.c
-      embed_scope: markup.raw.code-fence.c.markdown-gfm
+      embed: scope:source.perl
+      embed_scope: markup.raw.code-fence.perl.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c.markdown-gfm
+        0: meta.code-fence.definition.end.perl.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:c\+\+|cpp))
+          ((?i:php|inc))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c++.markdown-gfm
+        0: meta.code-fence.definition.begin.php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.c++
-      embed_scope: markup.raw.code-fence.c++.markdown-gfm
+      embed: scope:source.php
+      embed_scope: markup.raw.code-fence.php.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c++.markdown-gfm
+        0: meta.code-fence.definition.end.php.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:yaml))
+          ((?i:python|py))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.yaml.markdown-gfm
+        0: meta.code-fence.definition.begin.python.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.yaml
-      embed_scope: markup.raw.code-fence.yaml.markdown-gfm
+      embed: scope:source.python
+      embed_scope: markup.raw.code-fence.python.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.yaml.markdown-gfm
+        0: meta.code-fence.definition.end.python.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)
@@ -1475,17 +1370,122 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:erlang|escript))
+          ((?i:rscript|r|splus))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.erlang.markdown-gfm
+        0: meta.code-fence.definition.begin.r.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.erlang
-      embed_scope: markup.raw.code-fence.erlang.markdown-gfm
+      embed: scope:source.r
+      embed_scope: markup.raw.code-fence.r.markdown-gfm
       escape: '{{code_fence_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.erlang.markdown-gfm
+        0: meta.code-fence.definition.end.r.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:ruby|rb|rbx))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.ruby.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.ruby
+      embed_scope: markup.raw.code-fence.ruby.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.ruby.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:rust|rs))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.rust.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.rust
+      embed_scope: markup.raw.code-fence.rust.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.rust.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:shell-script|sh|bash|zsh))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.shell-script.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.shell.bash
+      embed_scope: markup.raw.code-fence.shell-script.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.shell-script.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:sql))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.sql.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.sql
+      embed_scope: markup.raw.code-fence.sql.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.sql.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:typescript|ts))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.typescript.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.ts
+      embed_scope: markup.raw.code-fence.typescript.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.typescript.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:xml))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.xml.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:text.xml
+      embed_scope: markup.raw.code-fence.xml.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.xml.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:yaml))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.yaml.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.yaml
+      embed_scope: markup.raw.code-fence.yaml.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.yaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
     - match: |-
          (?x)

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2087,6 +2087,11 @@ okay
 | <- markup.raw.code-fence.lua.markdown-gfm source.lua
 ```
 
+```matlab
+
+| <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2071,6 +2071,12 @@ okay
 | <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
 ```
 
+```html
+  <html>
+| <- markup.raw.code-fence.html.markdown-gfm text.html
+| ^^^^^^ text.html meta.tag
+```
+
 ```jsx
   <Component>
 | <- markup.raw.code-fence.jsx.markdown-gfm source.jsx

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2082,6 +2082,11 @@ okay
 | <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
 ```
 
+```lua
+
+| <- markup.raw.code-fence.lua.markdown-gfm source.lua
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2092,6 +2092,11 @@ okay
 | <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
 ```
 
+```ocaml
+
+| <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2102,6 +2102,12 @@ okay
 | <- markup.raw.code-fence.scala.markdown-gfm source.scala
 ```
 
+```tsx
+  <Component>
+| <- markup.raw.code-fence.tsx.markdown-gfm source.tsx
+| ^^^^^^^^^^^ markup.raw.code-fence.tsx.markdown-gfm source.tsx meta.jsx.js
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2059,6 +2059,13 @@ okay
 ```
 |^^ meta.code-fence.definition.end.clojure punctuation.definition.raw.code-fence.end
 
+```diff
++ inserted
+| <- source.diff markup.inserted.diff punctuation.definition.inserted.diff
+- deleted
+| <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2450,6 +2450,21 @@ okay
 | <- markup.raw.code-fence.scala.markdown-gfm source.scala
 ```
 
+```sh
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+
+```shell
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+
+```shell-script
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+
 ```tsx
   <Component>
 | <- markup.raw.code-fence.tsx.markdown-gfm source.tsx

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2077,6 +2077,11 @@ okay
 | ^^^^^^^^^^^ source.jsx meta.jsx.js
 ```
 
+```lisp
+
+| <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2071,6 +2071,12 @@ okay
 | <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
 ```
 
+```jsx
+  <Component>
+| <- markup.raw.code-fence.jsx.markdown-gfm source.jsx
+| ^^^^^^^^^^^ source.jsx meta.jsx.js
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -45,6 +45,14 @@ underlined heading followed by another one that should be treated as a normal pa
 =====
 | <- - markup.heading
 
+```
+Fenced codeblocks are no no setext heading
+```
+---
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+
 Paragraph of text that should be scoped as meta.paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
 A [link](https://example.com){ :_attr = value }, *italic text* and **bold**.
@@ -2174,7 +2182,7 @@ var_dump(expression);
 (?x)
 \s+
 ```
-|^^^ meta.paragraph meta.code-fence.definition.end.regexp - markup
+|^^^ meta.code-fence.definition.end.regexp - markup
 |^^ punctuation.definition.raw.code-fence.end
 
 ```bash

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2097,6 +2097,11 @@ okay
 | <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
 ```
 
+```scala
+
+| <- markup.raw.code-fence.scala.markdown-gfm source.scala
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2066,6 +2066,11 @@ okay
 | <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
 ```
 
+```haskell
+
+| <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
+```
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name


### PR DESCRIPTION
This PR proposes to 

1. add highlighting support for some more default syntaxes in fenced codeblocks.
2. sort all syntaxes alphabetically.
3. reorganize each syntax in a dedicated context for easier overriding etc. by inherited syntax definitions
4. avoid matching fenced codeblocks in situations they most likely don't appear (e.g. in link texts), which reduces parsing time slightly. It splits inline code-spans from fenced code-blocks.
5. moves fenced-code-blocks out of normal paragraphs as those are separate "leaf blocks" according to CommonMark spec. This fixes #2947.