### PR TITLE
[JavaScript] Refactor arrow function branching logic.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -44,6 +44,7 @@ variables:
 
   non_reserved_identifier: (?:(?!{{reserved_word}}){{identifier_name}})
 
+  possible_arrow_function_begin: (?:\(|{{identifier_start}})
   either_func_lookahead: (?:{{func_lookahead}}|{{arrow_func_lookahead}})
   binding_pattern_lookahead: (?:{{identifier_name}}|\[|\{)
   left_expression_end_lookahead: (?!\s*[.\[\(])
@@ -953,7 +954,7 @@ contexts:
     - include: object-literal
 
     # Newline not allowed between `async` and parameters.
-    - match: (?=async{{identifier_break}}{{nothing}}(?:\(|{{identifier_start}}))
+    - match: (?=async{{identifier_break}}{{nothing}}{{possible_arrow_function_begin}})
       pop: true
       branch_point: async-arrow-function
       branch:
@@ -962,19 +963,12 @@ contexts:
 
     - include: literal-call
 
-    - match: (?={{identifier_start}})
+    - match: (?={{possible_arrow_function_begin}})
       pop: true
-      branch_point: bare-arrow-function
+      branch_point: arrow-function
       branch:
-        - branch-possible-bare-arrow-function
-        - bare-arrow-function-fallback
-
-    - match: (?=\()
-      pop: true
-      branch_point: parenthesized-arrow-function
-      branch:
-        - branch-possible-parenthesized-arrow-function
-        - parenthesized-arrow-function-fallback
+        - branch-possible-arrow-function
+        - arrow-function-declaration
 
     - include: array-literal
 
@@ -998,45 +992,21 @@ contexts:
     - match: (?=\S)
       fail: async-arrow-function
 
-  branch-possible-bare-arrow-function:
+  branch-possible-arrow-function:
     - meta_include_prototype: false
-    - match: ''
-      push:
-        - detect-bare-arrow
+    - match: '(?=\()'
+      set:
+        - detect-arrow
+        - parenthesized-expression
+    - match: '(?={{identifier_start}})'
+      set:
+        - detect-arrow
         - literal-variable
 
-  detect-bare-arrow:
+  detect-arrow:
     - match: (?==>)
-      fail: bare-arrow-function
-    - match: (?=\S)
-      pop: 2
-
-  bare-arrow-function-fallback:
-    - meta_include_prototype: false
-    - match: ''
-      push:
-        - immediately-pop-2
-        - arrow-function-declaration
-
-  branch-possible-parenthesized-arrow-function:
-    - meta_include_prototype: false
-    - match: ''
-      push:
-        - detect-parenthesized-arrow
-        - parenthesized-expression
-
-  detect-parenthesized-arrow:
-    - match: (?==>)
-      fail: parenthesized-arrow-function
-    - match: (?=\S)
-      pop: 2
-
-  parenthesized-arrow-function-fallback:
-    - meta_include_prototype: false
-    - match: ''
-      push:
-        - immediately-pop-2
-        - arrow-function-declaration
+      fail: arrow-function
+    - include: else-pop
 
   literal-string:
     - match: "'"

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -38,25 +38,33 @@ variables:
   modifier: (?:(?:static|readonly|private|public|protected|abstract|declare|override){{identifier_break}})
 
 contexts:
-  detect-parenthesized-arrow:
+  branch-possible-arrow-function:
     - meta_prepend: true
+    - match: '(?=\()'
+      set:
+        - detect-arrow
+        - ts-detect-parenthesized-arrow-return-type
+        - parenthesized-expression
+
+  ts-detect-parenthesized-arrow-return-type:
     - match: (?=:)
       pop: true
       branch_point: ts-arrow-function-return-type
       branch:
         - ts-detect-arrow-function-return-type
-        - immediately-pop-2
+        - immediately-pop
+    - include: else-pop
 
   ts-detect-arrow-function-return-type:
     - meta_include_prototype: false
     - match: ''
-      push:
+      set:
         - ts-detect-arrow-after-return-type
         - ts-type-annotation
 
   ts-detect-arrow-after-return-type:
     - match: (?==>)
-      fail: parenthesized-arrow-function
+      fail: arrow-function
     - match: (?=\S)
       fail: ts-arrow-function-return-type
 


### PR DESCRIPTION
De-duplicate the arrow function branching logic. It was originally duplicated for several reasons: chiefly, sublimehq/sublime_text#3494, but also because there were issues with setting from a branch context. Those latter issues have been fixed.

The basic strategy is to add an extra layer of abstraction. Whenever we see either an open paren or an identifier character in `expression-begin`, we branch into a new `branch-possible-arrow-function` context which then checks for each of those cases individually and sets a different context for each. But since both cases are “under” the same branch point, we can re-use the contexts that contain failure rules.

This requires a slight modification for TypeScript. Only arrow functions with parenthesized argument lists may have return type annotations. Since there are no longer separate arrow-checking contexts for bare and parenthesized arrow functions, we push an extra context that handles them when we see an open paren in `branch-possible-arrow-function`.

This is all slightly simpler for existing behavior, but it also means we won't need to add a *third* copy of the arrow function logic for #2923.