### PR TITLE
[Markdown] Fix fenced code blocks in block quotes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -119,9 +119,9 @@ variables:
           )
           $\n?         # ... until EOL
         )
-    code_fence_escape: |-
+    code_fence_escape: ^{{code_fence_end}}
+    code_fence_end: |-
       (?x:
-        ^             # the beginning of the line
         [ \t]*
         (
           \2          # the backtick/tilde combination that opened the code fence
@@ -176,13 +176,7 @@ variables:
     tag_attribute_name_break: (?=[{{ascii_space}}=/>}])
     tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
     tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
-    # code_fence_escape: |-
-    #   (?x:
-    #     ^         # the beginning of the line
-    #     [ ]{0,3}  # up to 3 spaces
-    #     (\1)      # the backtick/tilde combination that opened the code fence
-    #     \s*$      # any amount of whitespace until EOL
-    #   )
+
 contexts:
   file-start:
     - match: (---)\s*
@@ -421,11 +415,40 @@ contexts:
             - match: ^
               pop: true
             - include: list-paragraph
+        - include: block-quote-code-blocks
         - match: ''
           push:
-            - match: $|^
+            - match: ^
               pop: true
             - include: inline-bold-italic-linebreak
+
+  block-quote-code-blocks:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ([\w-]*)     # any number of word characters or dashes
+          .*$\n?       # all characters until EOL
+      captures:
+        0: meta.code-fence.definition.begin.text.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      push: block-quote-code-block-content
+
+  block-quote-code-block-content:
+    - match: '{{code_fence_end}}'
+      captures:
+        0: meta.code-fence.definition.end.text.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+      pop: true
+    - match: '[ ]{,3}(>)[ ]?'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+    - match: ''
+      push:
+        - meta_content_scope: markup.raw.code-fence.markdown-gfm
+        - match: ^
+          pop: true
+
   indented-code-block:
     - match: '{{indented_code_block}}.*$\n?'
       scope: markup.raw.block.markdown

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -410,6 +410,31 @@ paragraph
 | <- punctuation.definition.blockquote
 |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block - markup.quote markup.quote
 
+> Here are fenced code blocks
+> ```
+| <- meta.block-level.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
+| ^^^^ meta.block-level.markdown markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^ punctuation.definition.raw.code-fence.begin.markdown
+> code block
+| <- meta.block-level.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
+| ^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown markup.raw.code-fence.markdown-gfm
+> ```
+| <- meta.block-level.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
+| ^^^^ meta.block-level.markdown markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^ punctuation.definition.raw.code-fence.end.markdown
+> > 2nd level
+> > 
+> > ```
+> > code block ```
+|              ^^^ - punctuation
+> > ```
+| <- meta.block-level.markdown markup.quote.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^ meta.block-level.markdown markup.quote.markdown markup.quote.markdown - meta.code-fence
+|   ^^^^ meta.block-level.markdown markup.quote.markdown markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
+
 >=
 | <- punctuation.definition.blockquote.markdown 
   >=


### PR DESCRIPTION
Fix fenced code blocks breaking syntax highlighting of block quotes

Example:

> ```
> content
> ```

Note:

Syntax highlighting within quoted fenced code blocks is not supported as it would require to extend any embedded syntax to properly scope leading quote punctuation. It wouldn't even be possible for more complex syntaxes.