### PR TITLE
[TypeScript] Fix a bug when deciding whether a colon is a ternary operator or type annotation.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -683,6 +683,8 @@ contexts:
             - ts-type-expression-begin
 
   ts-type-expression-begin:
+    - match: (?=<)
+      pop: 3
     - match: keyof{{identifier_break}}
       scope: keyword.operator.type.js
     - match: typeof{{identifier_break}}

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -39,3 +39,9 @@ if (a < b || c <= d) {}
 //    ^ keyword.operator.comparison
 //        ^^ keyword.operator.logical
 //             ^^ keyword.operator.comparison
+
+    x ? (y) : <T foo={``}> => z</T>;
+//       ^ variable.other.readwrite - variable.parameter
+//          ^ keyword.operator.ternary
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.jsx
+//                                 ^ punctuation.terminator.statement


### PR DESCRIPTION
Fix #2929.

In a case like `a ? (b) : …`, the colon can be either the second ternary operator (`a ? (b) : c`) or a type annotation (`a ? (b) : T => {} : c`). Whenever we see a colon after a (conjectured) parenthesized expression, we try to parse it as a type annotation. If it works, and we see `=>`, then we backtrack before the parenthesized expression. If it doesn't work, we backtrack before the colon. (Yes, unfortunately, we backtrack either way.)

Part of the reason this works is that value expressions and type expressions are similar enough that the parser won't “get lost” when speculatively parsing a value expression as a type expression. But the linked issue provides an example of a place where the parser does get lost:

```tsx
conditionalValue ? (x) : <div className={`${y}`} />;
```

The basic problem there is that it tries to parse the initial `<` as type arguments, but it's actually JSX, and the two are syntactically very different.

Fortunately, type arguments aren't actually legal there. Our general approach when we see an invalid token in a type expression is to pop and let the parent context handle it, which generally works best with invalid code or while the user is typing. In this specific case, it breaks highlighting. This PR modifies that approach. When we see `<` at the beginning of a type expression, we bail out of the entire type expression. Valid code should not be affected (other than fixing the above bug).