### PR TITLE
[Lua] Fix bug with expressions that don't end in a semicolon.

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -287,6 +287,9 @@ contexts:
     - match: (?=;)
       pop: 1
 
+    - match: (?=::)
+      pop: 1
+
     - match: (?={{function_args_begin}})
       push:
         - function-arguments-meta

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -588,6 +588,10 @@
 --     ^^^ entity.name.label
 --         ^^ punctuation.definition.label.end
 
+    local x = 1
+    ::foo::
+--  ^^ punctuation.definition.label.begin
+
     goto foo;
 --  ^^^^ keyword.control.goto
 --       ^^^ variable.label


### PR DESCRIPTION
Fix #2821.

Ordinarily, the syntax should handle statements without semicolons just fine — when it encounters an unexpected token in an expression, it will pop away the expression. However, when it sees `::`, it greedily matches the first colon as an accessor, which breaks things.

Simply fixing that rule doesn't do it because there's a catch-all rule in `expression-end` that's designed to keep this from happening to improve the highlighting of invalid code. Rather than making that rule more complicated, I added an extra rule specifically to handle `::`.