### PR TITLE
[Markdown] Fix atx headings

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -27,6 +27,8 @@ variables:
     setext_escape: ^(?=\s{0,3}(?:---+|===+)\s*$)
     block_quote: (?:[ ]{,3}>(?:.|$))             # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
     atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))  # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
+    atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
+    atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?) # \n is optional so ## is matched as end punctuation in new document (at eof)
     indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
     list_item: (?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s) # between 0 and 3 spaces, followed by either: at least one integer and a full stop, or (a star, plus or dash), followed by whitespace
     escape: '\\[-`*_#+.!(){}\[\]\\>|~<]'
@@ -588,27 +590,27 @@ contexts:
     #   starts with first non-whitespace character,
     #   but don't do so if directly followed by closing hashes
     #   as terminator pattern requires them to match then.
-    - match: '[ \t]{,3}(#{1})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{1}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading1-content
-    - match: '[ \t]{,3}(#{2})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{2}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading2-content
-    - match: '[ \t]{,3}(#{3})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{3}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading3-content
-    - match: '[ \t]{,3}(#{4})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{4}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading4-content
-    - match: '[ \t]{,3}(#{5})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{5}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading5-content
-    - match: '[ \t]{,3}(#{6})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
+    - match: '[ ]{,3}(#{6}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading6-content
@@ -644,7 +646,7 @@ contexts:
     - include: atx-heading-content
 
   atx-heading-content:
-    - match: (?:[ \t]+(#+))?[ \t]*($\n?) # \n is optional so ## is matched as end punctuation in new document (at eof)
+    - match: '{{atx_heading_end}}'
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -25,9 +25,9 @@ variables:
             [ \t]*$                          # followed by any number of tabs or spaces, followed by the end of the line
         )
     setext_escape: ^(?=\s{0,3}(?:---+|===+)\s*$)
-    block_quote: (?:[ ]{,3}>(?:.|$))         # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
-    atx_heading: (?:[#]{1,6}\s+)             # between 1 and 6 hashes, followed by at least one whitespace
-    indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
+    block_quote: (?:[ ]{,3}>(?:.|$))             # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
+    atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))  # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
+    indented_code_block: (?:[ ]{4}|\t)           # 4 spaces or a tab
     list_item: (?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s) # between 0 and 3 spaces, followed by either: at least one integer and a full stop, or (a star, plus or dash), followed by whitespace
     escape: '\\[-`*_#+.!(){}\[\]\\>|~<]'
     backticks: |-
@@ -580,14 +580,17 @@ contexts:
   escape:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
+
   atx-heading-terminator:
-    - match: '[ ]*(#*)[ ]*($\n?)' # \n is optional so ## is matched as end punctuation in new document (at eof)
+    - match: (?:[ \t]+(#+))?[ \t]*($\n?) # \n is optional so ## is matched as end punctuation in new document (at eof)
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown
       pop: true
+
   atx-heading:
-    - match: '(#)(?!#)\s*(?=\S)'
+    # https://spec.commonmark.org/0.30/#atx-headings
+    - match: '[ \t]{,3}(#)(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -595,7 +598,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{2})(?!#)\s*(?=\S)'
+    - match: '[ \t]{,3}(#{2})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -603,7 +606,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{3})(?!#)\s*(?=\S)'
+    - match: '[ \t]{,3}(#{3})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -611,7 +614,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{4})(?!#)\s*(?=\S)'
+    - match: '[ \t]{,3}(#{4})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -619,7 +622,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{5})(?!#)\s*(?=\S)'
+    - match: '[ \t]{,3}(#{5})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -627,7 +630,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
-    - match: '(#{6})(?!#)\s*(?=\S)'
+    - match: '[ \t]{,3}(#{6})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push:
@@ -635,6 +638,7 @@ contexts:
         - meta_content_scope: entity.name.section.markdown
         - include: atx-heading-terminator
         - include: inline-bold-italic
+
   image-inline:
     - match: |-
         (?x:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -27,7 +27,7 @@ variables:
     setext_escape: ^(?=\s{0,3}(?:---+|===+)\s*$)
     block_quote: (?:[ ]{,3}>(?:.|$))             # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
     atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))  # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
-    indented_code_block: (?:[ ]{4}|\t)           # 4 spaces or a tab
+    indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
     list_item: (?:[ ]{,3}(?=\d+\.|[*+-])\d*([*+.-])\s) # between 0 and 3 spaces, followed by either: at least one integer and a full stop, or (a star, plus or dash), followed by whitespace
     escape: '\\[-`*_#+.!(){}\[\]\\>|~<]'
     backticks: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -581,63 +581,70 @@ contexts:
     - match: '{{escape}}'
       scope: constant.character.escape.markdown
 
-  atx-heading-terminator:
-    - match: (?:[ \t]+(#+))?[ \t]*($\n?) # \n is optional so ## is matched as end punctuation in new document (at eof)
-      captures:
-        1: punctuation.definition.heading.end.markdown
-        2: meta.whitespace.newline.markdown
-      pop: true
-
   atx-heading:
     # https://spec.commonmark.org/0.30/#atx-headings
     - match: '[ \t]{,3}(#)(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.1.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading1-content
     - match: '[ \t]{,3}(#{2})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.2.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading2-content
     - match: '[ \t]{,3}(#{3})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.3.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading3-content
     - match: '[ \t]{,3}(#{4})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.4.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading4-content
     - match: '[ \t]{,3}(#{5})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.5.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading5-content
     - match: '[ \t]{,3}(#{6})(?=[ \t]|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
-      push:
-        - meta_scope: markup.heading.6.markdown
-        - meta_content_scope: entity.name.section.markdown
-        - include: atx-heading-terminator
-        - include: inline-bold-italic
+      push: atx-heading6-content
+
+  atx-heading1-content:
+    - meta_scope: markup.heading.1.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading2-content:
+    - meta_scope: markup.heading.2.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading3-content:
+    - meta_scope: markup.heading.3.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading4-content:
+    - meta_scope: markup.heading.4.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading5-content:
+    - meta_scope: markup.heading.5.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading6-content:
+    - meta_scope: markup.heading.6.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - include: atx-heading-content
+
+  atx-heading-content:
+    - match: (?:[ \t]+(#+))?[ \t]*($\n?) # \n is optional so ## is matched as end punctuation in new document (at eof)
+      captures:
+        1: punctuation.definition.heading.end.markdown
+        2: meta.whitespace.newline.markdown
+      pop: true
+    - include: inline-bold-italic
 
   image-inline:
     - match: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -583,27 +583,32 @@ contexts:
 
   atx-heading:
     # https://spec.commonmark.org/0.30/#atx-headings
-    - match: '[ \t]{,3}(#)(?=[ \t]|$)'
+    # Note:
+    #   Consume spaces and tabs after opening hashes so entity.name
+    #   starts with first non-whitespace character,
+    #   but don't do so if directly followed by closing hashes
+    #   as terminator pattern requires them to match then.
+    - match: '[ \t]{,3}(#{1})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading1-content
-    - match: '[ \t]{,3}(#{2})(?=[ \t]|$)'
+    - match: '[ \t]{,3}(#{2})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading2-content
-    - match: '[ \t]{,3}(#{3})(?=[ \t]|$)'
+    - match: '[ \t]{,3}(#{3})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading3-content
-    - match: '[ \t]{,3}(#{4})(?=[ \t]|$)'
+    - match: '[ \t]{,3}(#{4})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading4-content
-    - match: '[ \t]{,3}(#{5})(?=[ \t]|$)'
+    - match: '[ \t]{,3}(#{5})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading5-content
-    - match: '[ \t]{,3}(#{6})(?=[ \t]|$)'
+    - match: '[ \t]{,3}(#{6})(?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading6-content

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -2,14 +2,17 @@
 
 # Heading
 | <- markup.heading.1 punctuation.definition.heading
-|^^^^^^^^ markup.heading
-|        ^ meta.whitespace.newline.markdown
+|^^^^^^^^^ markup.heading.1.markdown
+|^ - entity.name.section
+|  ^^^^^^ entity.name.section
+|        ^ meta.whitespace.newline.markdown - entity.name.section
 
 ## Second Heading #
 | <- markup.heading.2 punctuation.definition.heading
-|^^^^^^^^^^^^^^^^ markup.heading
+|^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown
+|^^ - entity.name.section
 |  ^^^^^^^^^^^^^^ entity.name.section
-|                ^ - entity.name.section
+|                ^^ - entity.name.section
 |                 ^ punctuation.definition.heading.end.markdown
 
 https://spec.commonmark.org/0.30/#example-71
@@ -21,7 +24,9 @@ https://spec.commonmark.org/0.30/#example-71
 |   ^^^^^^^^^ - punctuation
 |            ^^ punctuation.definition.heading.end.markdown
 |              ^ - punctuation
+|^^^^ - entity.name.section
 |    ^^^^^^^ entity.name.section.markdown
+|           ^^^^ - entity.name.section
 
 https://spec.commonmark.org/0.30/#example-73
 ## Example 73 (trailing spaces!) #####    
@@ -30,22 +35,29 @@ https://spec.commonmark.org/0.30/#example-73
 
 https://spec.commonmark.org/0.30/#example-74
 ## Example 74 ####    >
-|^^^^^^^^^^^^^^^^^^^^^^ markup.heading
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown
+|^^ - entity.name.section
+|  ^^^^^^^^^^^^^^^^^^^^ entity.name.section.markdown
+|                      ^ - entity.name.section
 
 https://spec.commonmark.org/0.30/#example-75
 # #heading# #
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
 |^^^^^^^^^^^^^ meta.block-level.markdown markup.heading.1.markdown
+|^ - entity.name.section
 | ^^^^^^^^^ entity.name.section.markdown
+|          ^^ - entity.name.section
 |           ^ punctuation.definition.heading.end.markdown
 
 https://spec.commonmark.org/0.30/#example-76
 ## heading \##
 | <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
 |^^^^^^^^^^^^^^ meta.block-level.markdown markup.heading.2.markdown
-| ^^^^^^^^^^^^ entity.name.section.markdown
+|^^ - entity
+|  ^^^^^^^^^^^ entity.name.section.markdown
 |          ^^ constant.character.escape.markdown
 |          ^^^ - punctuation
+|             ^ - entity.name.section
 
 https://spec.commonmark.org/0.30/#example-79
 #
@@ -53,35 +65,39 @@ https://spec.commonmark.org/0.30/#example-79
 
 # #
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
-|^^^ meta.block-level.markdown markup.heading.1.markdown
+|^^^ meta.block-level.markdown markup.heading.1.markdown - entity.name.section
 | ^ punctuation.definition.heading.end.markdown
 
 ## 
-| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
-|^ markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown - entity.name.section
+|^ markup.heading.2.markdown punctuation.definition.heading.begin.markdown - entity.name.section
 
 ## ##
-| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
-|^^^^^ meta.block-level.markdown markup.heading.2.markdown
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown - entity.name.section
+|^^^^^ meta.block-level.markdown markup.heading.2.markdown - entity.name.section
 |^ punctuation.definition.heading.begin.markdown
 |  ^^ punctuation.definition.heading.end.markdown
 
 ### ###
-| <- meta.block-level.markdown markup.heading.3.markdown punctuation.definition.heading.begin.markdown
-|^^^^^^^ meta.block-level.markdown markup.heading.3.markdown
+| <- meta.block-level.markdown markup.heading.3.markdown  - entity.name.sectionpunctuation.definition.heading.begin.markdown
+|^^^^^^^ meta.block-level.markdown markup.heading.3.markdown - entity.name.section
 |^^ punctuation.definition.heading.begin.markdown
 |   ^^^ punctuation.definition.heading.end.markdown
 
 # #### #
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
 |^^^^^^^^ meta.block-level.markdown markup.heading.1.markdown
+|^ - entity.name.section
 | ^^^^ entity.name.section.markdown
+|     ^^ - entity.name.section
 |      ^ punctuation.definition.heading.end.markdown
 
 ## #### ##
 | <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
 |^^^^^^^^^^ meta.block-level.markdown markup.heading.2.markdown
+|^ - entity.name.section
 |  ^^^^ entity.name.section.markdown
+|      ^^^ - entity.name.section
 |       ^^ punctuation.definition.heading.end.markdown
 
 #NotAHeading

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -11,14 +11,78 @@
 |  ^^^^^^^^^^^^^^ entity.name.section
 |                ^ - entity.name.section
 |                 ^ punctuation.definition.heading.end.markdown
-http://spec.commonmark.org/0.28/#example-43
-## Example 43 (trailing spaces!) #####    
+
+https://spec.commonmark.org/0.30/#example-71
+
+  ## Heading ##
+|^^^^^^^^^^^^^^^ meta.block-level.markdown markup.heading.2.markdown
+|^ - punctuation
+| ^^ punctuation.definition.heading.begin.markdown
+|   ^^^^^^^^^ - punctuation
+|            ^^ punctuation.definition.heading.end.markdown
+|              ^ - punctuation
+|    ^^^^^^^ entity.name.section.markdown
+
+https://spec.commonmark.org/0.30/#example-73
+## Example 73 (trailing spaces!) #####    
 |                                    ^ punctuation.definition.heading.end.markdown
 |                                         ^ meta.whitespace.newline.markdown
-http://spec.commonmark.org/0.28/#example-44
-## Example 44 ####    >
+
+https://spec.commonmark.org/0.30/#example-74
+## Example 74 ####    >
 |^^^^^^^^^^^^^^^^^^^^^^ markup.heading
-|             ^ - punctuation.definition.heading.end.markdown
+
+https://spec.commonmark.org/0.30/#example-75
+# #heading# #
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^ meta.block-level.markdown markup.heading.1.markdown
+| ^^^^^^^^^ entity.name.section.markdown
+|           ^ punctuation.definition.heading.end.markdown
+
+https://spec.commonmark.org/0.30/#example-76
+## heading \##
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^ meta.block-level.markdown markup.heading.2.markdown
+| ^^^^^^^^^^^^ entity.name.section.markdown
+|          ^^ constant.character.escape.markdown
+|          ^^^ - punctuation
+
+https://spec.commonmark.org/0.30/#example-79
+#
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+
+# #
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^ meta.block-level.markdown markup.heading.1.markdown
+| ^ punctuation.definition.heading.end.markdown
+
+## 
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^ markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+
+## ##
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^^^^^ meta.block-level.markdown markup.heading.2.markdown
+|^ punctuation.definition.heading.begin.markdown
+|  ^^ punctuation.definition.heading.end.markdown
+
+### ###
+| <- meta.block-level.markdown markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^ meta.block-level.markdown markup.heading.3.markdown
+|^^ punctuation.definition.heading.begin.markdown
+|   ^^^ punctuation.definition.heading.end.markdown
+
+# #### #
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^ meta.block-level.markdown markup.heading.1.markdown
+| ^^^^ entity.name.section.markdown
+|      ^ punctuation.definition.heading.end.markdown
+
+## #### ##
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^ meta.block-level.markdown markup.heading.2.markdown
+|  ^^^^ entity.name.section.markdown
+|       ^^ punctuation.definition.heading.end.markdown
 
 #NotAHeading
 | <- - markup.heading


### PR DESCRIPTION
This PR applies CommonMark specification to ATX headings and reorganizes related contexts.

see: https://spec.commonmark.org/0.30/#atx-heading

Major changes:

1. allow up to 3 spaces in front of atx headings
2. closing punctuation must be preceded by at least one space or tab
3. limit "whitespace" to "tab" and "space"
4. add support for empty headings