### PR TITLE
[C/C++] improved syntax, constants are detected in global scope

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -284,19 +284,19 @@ contexts:
       push: global-modifier
     # Take care of comments just before a function definition.
     - match: /\*
-      scope: punctuation.definition.comment.c
+      scope: punctuation.definition.comment.c++
       push:
         - - match: \s*(?=\w)
             set: global-modifier
           - match: ""
             pop: true
-        - - meta_scope: comment.block.c
+        - - meta_scope: comment.block.c++
           - match: \*/
-            scope: punctuation.definition.comment.c
+            scope: punctuation.definition.comment.c++
             pop: true
           - match: ^\s*(\*)(?!/)
             captures:
-              1: punctuation.definition.comment.c
+              1: punctuation.definition.comment.c++
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.c++
@@ -1079,7 +1079,7 @@ contexts:
     - match: '(?=\b({{control_keywords}}|{{operator_keywords}}|{{casts}}|{{memory_operators}}|{{other_keywords}}|operator)\b)'
       pop: true
     - match: '(?=\s)'
-      set: global-maybe-function
+      set: global-maybe-constant-or-function
     # If a class/struct/enum followed by a name that is not a macro or declspec
     # then this is likely a return type of a function. This is uncommon.
     - match: |-
@@ -1097,7 +1097,7 @@ contexts:
       set:
         - include: identifiers
         - match: ''
-          set: global-maybe-function
+          set: global-maybe-constant-or-function
     # The previous match handles return types of struct/enum/etc from a func,
     # there this one exits the context to allow matching an actual struct/class
     - match: '(?=\b({{before_tag}})\b)'
@@ -1130,6 +1130,23 @@ contexts:
     - include: identifiers
     - match: (?=\W)
       pop: true
+
+  global-maybe-constant-or-function:
+    - include: comments
+    - include: types
+    - include: modifiers
+    - include: constants
+    - include: variables
+    - include: scope:source.c#named-constants
+    - match: '\s*(;)'
+      captures:
+        1: punctuation.terminator.c++
+      pop: true
+    - match: '\s*(=)\s*'
+      captures:
+        1: keyword.operator.assignment.c++
+    - match: '(?=\S)'
+      set: global-maybe-function
 
   global-maybe-function:
     - include: comments

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -163,14 +163,17 @@ contexts:
     - match: '\bs[A-Z]\w*\b'
       scope: variable.other.readwrite.static.mac-classic.c
 
+  named-constants:
+    # common C constant naming idiom -- kConstantVariable
+    - match: '\bk[A-Z]\w*\b'
+      scope: constant.other.variable.mac-classic.c
+
   constants:
     - match: \b(__func__|NULL|true|false|TRUE|FALSE)\b
       scope: constant.language.c
     - match: \b(__FILE__|__FUNCTION__|__LINE__)\b
       scope: support.constant.c
-    # common C constant naming idiom -- kConstantVariable
-    - match: '\bk[A-Z]\w*\b'
-      scope: constant.other.variable.mac-classic.c
+    - include: named-constants
     - match: \b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b
       scope: support.constant.mac-classic.c
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2813,7 +2813,16 @@ void sayHi()
 
 /**
       *
-/*    ^ comment.block.c punctuation.definition.comment.c */
+/*    ^ comment.block.c++ punctuation.definition.comment.c++ */
+
+inline constexpr uint16_t kMyConstant = 0x20;
+/* <- storage.modifier.c++ */
+/*     ^^^^^^^^^ storage.modifier.c++ */
+/*               ^^^^^^^^ support.type.stdint.c */
+/*                        ^^^^^^^^^^^ constant.other.variable.mac-classic.c */
+/*                                    ^ keyword.operator.assignment.c++ */
+/*                                      ^^ constant.numeric.base.c++ */
+/*                                        ^^ constant.numeric.value.c++ */
 
 /////////////////////////////////////////////
 // Modules

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -964,7 +964,7 @@ contexts:
     - match: '(?=\b({{control_keywords}}|{{operator_keywords}}|{{casts}}|{{memory_operators}}|{{other_keywords}}|operator)\b)'
       pop: true
     - match: '(?=\s)'
-      set: global-maybe-function
+      set: global-maybe-constant-or-function
     # If a class/struct/enum followed by a name that is not a macro or declspec
     # then this is likely a return type of a function. This is uncommon.
     - match: |-
@@ -982,7 +982,7 @@ contexts:
       set:
         - include: scope:source.c++#identifiers
         - match: ''
-          set: global-maybe-function
+          set: global-maybe-constant-or-function
     # The previous match handles return types of struct/enum/etc from a func,
     # there this one exits the context to allow matching an actual struct/class
     - match: '(?=\b({{before_tag}})\b)'
@@ -1015,6 +1015,23 @@ contexts:
     - include: scope:source.c++#identifiers
     - match: (?=\W)
       pop: true
+
+  global-maybe-constant-or-function:
+    - include: comments
+    - include: types
+    - include: modifiers
+    - include: constants
+    - include: variables
+    - include: scope:source.c#named-constants
+    - match: '\s*(;)'
+      captures:
+        1: punctuation.terminator.objc++
+      pop: true
+    - match: '\s*(=)\s*'
+      captures:
+        1: keyword.operator.assignment.objc++
+    - match: '(?=\S)'
+      set: global-maybe-function
 
   global-maybe-function:
     - include: comments

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -2810,3 +2810,12 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
+
+inline constexpr uint16_t kMyConstant = 0x20;
+/* <- storage.modifier.c++ */
+/*     ^^^^^^^^^ storage.modifier.c++ */
+/*               ^^^^^^^^ support.type.stdint.c */
+/*                        ^^^^^^^^^^^ constant.other.variable.mac-classic.c */
+/*                                    ^ keyword.operator.assignment.objc++ */
+/*                                      ^^ constant.numeric.base.c++ */
+/*                                        ^^ constant.numeric.value.c++ */


### PR DESCRIPTION
C/C++ syntax is improved, constants are detected in global scope

Signed-off-by: Denis Pronin <dannftk@yandex.ru>