### PR TITLE
[Python] use branching to detect set vs dict and for tuples vs expression

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -929,9 +929,6 @@ contexts:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
       push: after-expression
-    - match: \((?=\s*\*{{path}})
-      scope: punctuation.section.sequence.begin.python
-      push: inside-tuple
     - match: (?=\()
       branch_point: generators-groups-and-tuples
       branch:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1004,34 +1004,21 @@ contexts:
         1: punctuation.section.mapping.begin.python
         2: punctuation.section.mapping.end.python
       push: after-expression
-    - match: \{(?={{simple_expression}}:|\s*\*\*)
-      scope: punctuation.section.mapping.begin.python
-      push: inside-dictionary
-    - match: \{(?={{simple_expression}}[,}]|\s*\*)
-      scope: punctuation.section.set.begin.python
-      push: inside-set
-    # If the expression is "more complex" or on the next line,
-    # fall back to default and determine later.
+    - match: (?=\{)
+      branch_point: dictionaries-and-sets
+      branch:
+        - try-set
+        - try-dictionary
+
+  try-set:
     - match: \{
-      scope: punctuation.section.mapping-or-set.begin.python
-      push:
-        - meta_scope: meta.mapping-or-set.python
-        - match: \}
-          scope: punctuation.section.mapping-or-set.end.python
-          set: after-expression
-        - match: (?={{simple_expression}}:|\s*\*\*)
-          set: inside-dictionary
-        - match: (?={{simple_expression}}[,}]|\s*\*)
-          set: inside-set
-        - match: ','
-          scope: punctuation.separator.set.python
-          set: inside-set
-        - include: illegal-assignment-expression
-        - match: ':'
-          scope: punctuation.separator.mapping.key-value.python
-          set: inside-directory-value
-        - include: inline-for
-        - include: expression-in-a-group
+      scope: punctuation.section.set.begin.python
+      set: maybe-inside-set
+
+  try-dictionary:
+    - match: \{
+      scope: punctuation.section.mapping.begin.python
+      set: inside-dictionary
 
   inside-dictionary:
     - meta_scope: meta.mapping.python
@@ -1090,6 +1077,14 @@ contexts:
           pop: true
         - include: expression-in-a-group
 
+  maybe-inside-set:
+    - meta_scope: meta.set.python
+    - match: ':|\*\*'
+      fail: dictionaries-and-sets
+    - match: (?=,)
+      set: inside-set
+    - include: inside-set
+
   inside-set:
     - meta_scope: meta.set.python
     - match: \}
@@ -1105,8 +1100,7 @@ contexts:
       push:
         - match: (?=\})
           pop: true
-        - match: ','
-          scope: punctuation.separator.set.python
+        - match: (?=,)
           pop: true
         - include: expression-in-a-group
     - include: inline-for

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -50,19 +50,6 @@ variables:
       [bcdeEfFgGnosxX%]? # type
     )
   strftime_spec: '(?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))'
-  # This can be used in look-aheads to parse simple expressions.
-  # Can't be recursive, because sregex doesn't support that,
-  # so we're skipping parentheses.
-  # Can't parse multiple lines as well, for obvious reasons
-  simple_expression: |-
-    (?x:
-      \s+                      # whitespace
-      | [urfb]*"(?:\\.|[^"])*" # strings
-      | [urfb]*'(?:\\.|[^'])*' # ^
-      | [\d.ej]+               # numerics
-      | [+*/%@-] | // | and | or # operators
-      | {{path}}               # a path
-    )*
 
 
 contexts:
@@ -937,15 +924,17 @@ contexts:
   groups:
     - match: \(
       scope: punctuation.section.group.begin.python
-      push:
-        - meta_scope: meta.group.python
-        - match: \)
-          scope: punctuation.section.group.end.python
-          set: after-expression
-        - match: ','
-          scope: punctuation.separator.tuple.python
-        - include: inline-for
-        - include: expression-in-a-group
+      push: inside-group
+
+  inside-group:
+    - meta_scope: meta.group.python
+    - match: \)
+      scope: punctuation.section.group.end.python
+      set: after-expression
+    - match: ','
+      scope: punctuation.separator.tuple.python
+    - include: inline-for
+    - include: expression-in-a-group
 
   tuples:
     # We don't know for certain, whether a parenthesized expression is a tuple,
@@ -956,11 +945,30 @@ contexts:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
       push: after-expression
-    - match: \((?={{simple_expression}},|\s*\*{{path}})
+    - match: \((?=\s*\*{{path}})
       scope: punctuation.section.sequence.begin.python
       push: inside-tuple
-    # TODO generator
-    # - match: \((?:{{simple_expression}}for)
+    - match: (?=\()
+      branch_point: tuple_or_expression
+      branch:
+        - maybe-group
+        - begin-tuple
+
+  maybe-group:
+    - match: \(
+      scope: punctuation.section.group.begin.python
+      set: maybe-inside-group
+
+  maybe-inside-group:
+    - meta_scope: meta.group.python
+    - match: (?=,)
+      fail: tuple_or_expression
+    - include: inside-group
+
+  begin-tuple:
+    - match: \(
+      scope: punctuation.section.sequence.begin.python
+      set: inside-tuple
 
   inside-tuple:
     - meta_scope: meta.sequence.tuple.python
@@ -972,6 +980,8 @@ contexts:
       push: allow-unpack-operators
     - include: inline-for
     - include: expression-in-a-group
+    - match: '='
+      scope: invalid.illegal.unexpected-assignment-in-tuple.python
 
   lists:
     - match: (\[)\s*(\])

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1283,7 +1283,7 @@ myset = {"key", True, key2, [-1], {}:1}
 #                                     ^ punctuation.section.set.end.python
 
 mapping_or_set = {
-#                ^ meta.mapping-or-set.python punctuation.section.mapping-or-set.begin.python
+#                ^ meta.mapping.python punctuation.section.mapping.begin.python
     1: True
 #   ^ meta.mapping.key.python meta.number.integer.decimal.python constant.numeric.value.python
 #    ^ punctuation.separator.mapping.key-value.python
@@ -1291,8 +1291,7 @@ mapping_or_set = {
 # <- meta.mapping.python punctuation.section.mapping.end.python
 
 complex_mapping = {(): "value"}
-#                 ^^^ meta.mapping-or-set.python
-#                    ^^^^^^^^^^ meta.mapping - meta.mapping-or-set
+#                 ^^^^^^^^^^^^^ meta.mapping
 
 more_complex_mapping = {**{1: 1}, 2: 2}
 #                      ^ meta.mapping.python
@@ -1300,7 +1299,7 @@ more_complex_mapping = {**{1: 1}, 2: 2}
 #                                  ^ meta.mapping.python punctuation.separator.mapping.key-value.python
 
 more_complex_set = {
-#                  ^ meta.mapping-or-set.python
+#                  ^ meta.set.python
     *{1}, 2: 2}
 #   ^ meta.set.python
 #       ^ meta.set.python punctuation.separator.set.python
@@ -1317,7 +1316,7 @@ list_ = [i for i in range(100)]
 #          ^^^ keyword.control.loop.for.generator
 #                ^^ keyword.control.loop.for.in
 set_ = {i for i in range(100)}
-#      ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping-or-set
+#      ^^^^^^^^^^^^^^^^^^^^^^^ meta.set
 #         ^^^^^^^^ meta.expression.generator
 #         ^^^ keyword.control.loop.for.generator
 #               ^^ keyword.control.loop.for.in

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1207,9 +1207,9 @@ also_a_tuple = ()[-1]
 #                ^^^^ meta.item-access
 
 not_a_tuple = (a = 2, b += 3)
-#             ^^^^^^^^^^^^^^^ - meta.sequence
-#                ^ - keyword
-#                        ^ - keyword
+#             ^^^^^^^^^^^^^^^ meta.sequence
+#                ^ invalid.illegal.unexpected-assignment-in-tuple - keyword
+#                        ^ invalid.illegal.unexpected-assignment-in-tuple - keyword
 
 just_a_group = (1)
 #              ^^^ meta.group.python


### PR DESCRIPTION
This allows us to remove the complicated lookaheads / `simple_expression` variable (which have terrible performance in Oniguruma, for non-ST use cases).

To keep the existing approach of detecting set vs dict by/at the first comma, I set away from the context with the `fail` instruction when we reach the comma or colon, which allows us to "succeed" the branch and keep the existing invalid highlighting hints when there's a colon in a set or a comma without a colon in a dict etc. 