### PR TITLE
C++ typedef improvement

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -842,9 +842,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.c++
           pop: true
-        - match: \b(struct)\s+({{identifier}})\b
-          captures:
-            1: keyword.declaration.struct.c++
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions-minus-generic-type
 
   parens:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -785,9 +785,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.c
           pop: true
-        - match: \b(struct)\s+({{identifier}})
-          captures:
-            1: keyword.declaration.struct.c
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions
 
   function-call:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -1028,3 +1028,11 @@ label:
   return 123;
   /* <- keyword.control.flow.return */
 }
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c */
+/*      ^^^^^^ keyword.declaration.struct.type.c */
+/*             ^^^^^^^^^^^ entity.name.struct.c */
+/*                         ^ punctuation.section.block.begin.c */
+/*                          ^ punctuation.section.block.end.c */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2753,3 +2753,11 @@ void sayHi()
 /**
       *
 /*    ^ comment.block.c punctuation.definition.comment.c */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c++ */
+/*      ^^^^^^ keyword.declaration.struct.type.c++ */
+/*             ^^^^^^^^^^^ entity.name.struct.c++ */
+/*                         ^ punctuation.section.block.begin.c++ */
+/*                          ^ punctuation.section.block.end.c++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -835,9 +835,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.objc++
           pop: true
-        - match: \b(struct)\s+({{identifier}})\b
-          captures:
-            1: keyword.declaration.struct.objc++
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions-minus-generic-type
 
   parens:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -2757,3 +2757,11 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c++ */
+/*      ^^^^^^ keyword.declaration.struct.c++ */
+/*             ^^^^^^^^^^^ entity.name.struct.c++ */
+/*                         ^ punctuation.section.block.begin.c++ */
+/*                          ^ punctuation.section.block.end.c++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */


### PR DESCRIPTION
`typedef`s of `struct|class|enum|union` are detected wiser, target defined types are recognized as types rather than nothing  

Changes are applied to C++ and ObjC++ syntaxes