### PR TITLE
[C/ObjC/C++/ObjC++] improved syntax, typedef detection improvement

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -842,9 +842,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.c++
           pop: true
-        - match: \b(struct)\s+({{identifier}})\b
-          captures:
-            1: keyword.declaration.struct.c++
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions-minus-generic-type
 
   parens:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -785,9 +785,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.c
           pop: true
-        - match: \b(struct)\s+({{identifier}})
-          captures:
-            1: keyword.declaration.struct.c
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions
 
   function-call:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -294,6 +294,14 @@ typedef struct mystruct {
 } mystruct;
 /* ^ entity.name.type.typedef.c */
 
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c */
+/*      ^^^^^^ keyword.declaration.struct.c */
+/*             ^^^^^^^^^^^ entity.name.struct.c */
+/*                         ^ punctuation.section.block.begin.c */
+/*                          ^ punctuation.section.block.end.c */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c */
+
 /////////////////////////////////////////////
 // Data structures and return values
 /////////////////////////////////////////////
@@ -1029,11 +1037,3 @@ label:
   return 123;
   /* <- keyword.control.flow.return */
 }
-
-typedef struct MyStructure {} MyStructure_t;
-/* <- keyword.declaration.type.c */
-/*      ^^^^^^ keyword.declaration.struct.c */
-/*             ^^^^^^^^^^^ entity.name.struct.c */
-/*                         ^ punctuation.section.block.begin.c */
-/*                          ^ punctuation.section.block.end.c */
-/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -289,9 +289,10 @@ typedef int myint;
 
 typedef struct mystruct {
 /* <- keyword.declaration */
-/*             ^ - entity */
+/*      ^ keyword.declaration.struct.c */
+/*             ^ entity.name.struct.c */
 } mystruct;
-/* ^ entity.name.type */
+/* ^ entity.name.type.typedef.c */
 
 /////////////////////////////////////////////
 // Data structures and return values
@@ -1028,3 +1029,11 @@ label:
   return 123;
   /* <- keyword.control.flow.return */
 }
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c */
+/*      ^^^^^^ keyword.declaration.struct.c */
+/*             ^^^^^^^^^^^ entity.name.struct.c */
+/*                         ^ punctuation.section.block.begin.c */
+/*                          ^ punctuation.section.block.end.c */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -415,6 +415,14 @@ typedef struct Books {
 } Book;
 /*^ entity.name.type */
 
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c++ */
+/*      ^^^^^^ keyword.declaration.struct.type.c++ */
+/*             ^^^^^^^^^^^ entity.name.struct.c++ */
+/*                         ^ punctuation.section.block.begin.c++ */
+/*                          ^ punctuation.section.block.end.c++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */
+
 using Alias = Foo;
 /* <- keyword.control */
 /*    ^^^^^ entity.name.type.using */
@@ -2753,11 +2761,3 @@ void sayHi()
 /**
       *
 /*    ^ comment.block.c punctuation.definition.comment.c */
-
-typedef struct MyStructure {} MyStructure_t;
-/* <- keyword.declaration.type.c++ */
-/*      ^^^^^^ keyword.declaration.struct.type.c++ */
-/*             ^^^^^^^^^^^ entity.name.struct.c++ */
-/*                         ^ punctuation.section.block.begin.c++ */
-/*                          ^ punctuation.section.block.end.c++ */
-/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2753,3 +2753,11 @@ void sayHi()
 /**
       *
 /*    ^ comment.block.c punctuation.definition.comment.c */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c++ */
+/*      ^^^^^^ keyword.declaration.struct.type.c++ */
+/*             ^^^^^^^^^^^ entity.name.struct.c++ */
+/*                         ^ punctuation.section.block.begin.c++ */
+/*                          ^ punctuation.section.block.end.c++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -835,9 +835,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.objc++
           pop: true
-        - match: \b(struct)\s+({{identifier}})\b
-          captures:
-            1: keyword.declaration.struct.objc++
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions-minus-generic-type
 
   parens:

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -879,9 +879,8 @@ contexts:
           captures:
             1: entity.name.type.typedef.objc
           pop: true
-        - match: \b(struct)\s+({{identifier}})
-          captures:
-            1: keyword.declaration.struct.objc
+        - match: '(?=\b({{before_tag}})\b)'
+          push: data-structures
         - include: expressions
 
   function-call:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -414,6 +414,14 @@ typedef struct Books {
 } Book;
 /*^ entity.name.type */
 
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.objc++ */
+/*      ^^^^^^ keyword.declaration.struct.objc++ */
+/*             ^^^^^^^^^^^ entity.name.struct.objc++ */
+/*                         ^ punctuation.section.block.begin.objc++ */
+/*                          ^ punctuation.section.block.end.objc++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.objc++ */
+
 typedef struct Books Book;
 /*             ^ - entity.name.type.struct */
 /*                   ^ entity.name.type.typedef */
@@ -2757,11 +2765,3 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
-
-typedef struct MyStructure {} MyStructure_t;
-/* <- keyword.declaration.type.c++ */
-/*      ^^^^^^ keyword.declaration.struct.c++ */
-/*             ^^^^^^^^^^^ entity.name.struct.c++ */
-/*                         ^ punctuation.section.block.begin.c++ */
-/*                          ^ punctuation.section.block.end.c++ */
-/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -2757,3 +2757,11 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*      ^ punctuation.definition.string.begin */
 /*       ^^^^^^^^ string.quoted.other.lt-gt.include */
 /*               ^ punctuation.definition.string.end */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.c++ */
+/*      ^^^^^^ keyword.declaration.struct.c++ */
+/*             ^^^^^^^^^^^ entity.name.struct.c++ */
+/*                         ^ punctuation.section.block.begin.c++ */
+/*                          ^ punctuation.section.block.end.c++ */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.c++ */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -1041,3 +1041,11 @@ scanf("%ms %as %*[, ]", &buf);
 
 "foo % baz"
 /*   ^ - invalid */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.objc */
+/*      ^^^^^^ keyword.declaration.struct.objc */
+/*             ^^^^^^^^^^^ entity.name.struct.objc */
+/*                         ^ punctuation.section.block.begin.objc */
+/*                          ^ punctuation.section.block.end.objc */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.objc */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -286,9 +286,18 @@ typedef int myint;
 
 typedef struct mystruct {
 /* <- keyword.declaration */
-/*             ^ - entity */
+/*      ^ keyword.declaration.struct.objc */
+/*             ^ entity.name.struct.objc */
 } mystruct;
 /* ^ entity.name.type */
+
+typedef struct MyStructure {} MyStructure_t;
+/* <- keyword.declaration.type.objc */
+/*      ^^^^^^ keyword.declaration.struct.objc */
+/*             ^^^^^^^^^^^ entity.name.struct.objc */
+/*                         ^ punctuation.section.block.begin.objc */
+/*                          ^ punctuation.section.block.end.objc */
+/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.objc */
 
 /////////////////////////////////////////////
 // Data structures and return values
@@ -1041,11 +1050,3 @@ scanf("%ms %as %*[, ]", &buf);
 
 "foo % baz"
 /*   ^ - invalid */
-
-typedef struct MyStructure {} MyStructure_t;
-/* <- keyword.declaration.type.objc */
-/*      ^^^^^^ keyword.declaration.struct.objc */
-/*             ^^^^^^^^^^^ entity.name.struct.objc */
-/*                         ^ punctuation.section.block.begin.objc */
-/*                          ^ punctuation.section.block.end.objc */
-/*                            ^^^^^^^^^^^^^ entity.name.type.typedef.objc */


### PR DESCRIPTION
`typedef`s of `struct|class|enum|union` are detected wiser, target defined types are recognized as types rather than nothing

Changes are applied to C, C++, ObjC, ObjC++ syntaxes