### PR TITLE
[D] Fix case statement with comma separated pattern

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1484,17 +1484,25 @@ contexts:
       pop: true
     - match: '(?=\S)'
       set: [value-list-after, value]
-  value-list-no-mapping-key:
-    - match: '(?=\)|}|]|;|:)'
-      pop: true
-    - match: '(?=\S)'
-      set: [value-list-after, value-no-mapping-key]
   value-list-after:
     - match: '(?=\)|}|]|;|:)'
       pop: true
     - match: ','
       scope: punctuation.separator.sequence.d
       set: value-list
+    - include: not-whitespace-illegal-pop
+
+  value-list-no-mapping-key:
+    - match: '(?=\)|}|]|;|:)'
+      pop: true
+    - match: '(?=\S)'
+      set: [value-list-after-no-mapping-key, value-no-mapping-key]
+  value-list-after-no-mapping-key:
+    - match: '(?=\)|}|]|;|:)'
+      pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.d
+      set: value-list-no-mapping-key
     - include: not-whitespace-illegal-pop
 
   value-array-list:

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2236,6 +2236,22 @@ extern(1)
   //       ^^ keyword.operator.arithmetic.d
   //          ^ meta.number.integer.decimal.d
   //           ^ punctuation.separator.case-statement.d
+    case foo:
+  //^^^^ keyword.control.flow.d
+  //     ^^^ meta.path.d variable.other.d
+  //        ^ punctuation.separator.case-statement.d
+      baz();
+  //  ^^^^^ meta.block.d meta.function-call.d
+  //       ^ punctuation.terminator.d
+    case foo, bar:
+  //^^^^ keyword.control.flow.d
+  //     ^^^ meta.path.d variable.other.d
+  //        ^ punctuation.separator.sequence.d
+  //          ^^^ meta.path.d variable.other.d
+  //             ^ punctuation.separator.case-statement.d
+      baz();
+  //  ^^^^^ meta.block.d meta.function-call.d
+  //       ^ punctuation.terminator.d
     case 2, "foo":
   //^^^^ keyword.control.flow.d
   //     ^ meta.number.integer.decimal.d


### PR DESCRIPTION
Fixes #2946

Once the `value-no-mapping-key` context is set on stack by case keyword any following list must continue to use this special value context.

Hence a new `value-list-after-no-mapping-key` is created, which is used by `value-list-no-mapping-key`.