### PR TITLE
[Markdown] Remove keybinding for fenced codeblocks

### DIFF
--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -91,19 +91,5 @@
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
-    },
-
-    // Add fenced code block
-    {
-        "keys": ["`", "`"],
-        "command": "insert_snippet",
-        "args": {"contents": "```${0:language}\n\n```"},
-        "context": [
-            { "key": "setting.auto_match_enabled"},
-            { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "text.html.markdown - markup.raw.code-fence - meta.code-fence" },
-            { "key": "preceding_text", "operator": "regex_match", "operand": "^[ \t]*`?$" },
-            { "key": "following_text", "operator": "regex_match", "operand": "^$" }
-        ]
     }
 ]


### PR DESCRIPTION
It appears the removed key binding behaves different depending on keyboard layout (deadkeys). This results in sub-optimal behavior for a reasonable number of users.

It may also jump in if one tries to add inline codeblocks at the beginning of a line.

Attempts to bind ``["`", "`", "`"]`` or tweak `context` have not been successful.

Adding syntax specific settings to gate this binding are probably not worth it.

Hence it's probably better to remove it.

see:
- https://forum.sublimetext.com/t/markdown-fenced-code-snippet/58261/3
- https://discord.com/channels/280102180189634562/280157083356233728/866850636083494963