### PR TITLE
[Markdown] Refactor SETEXT headings vs. paragraphs

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -330,15 +330,16 @@ contexts:
 
   paragraph-end:
     - match: |-
-        (?x)                       # pop out of this context if one of the following conditions are met:
+        (?x)                            # pop out of this context if one of the following conditions are met:
         ^(?=
-          \s*$                     # the line is blank (or only contains whitespace)
-          | {{atx_heading}}        # an ATX heading begins the line
-          | {{block_quote}}        # line is a blockquote
-          | {{thematic_break}}     # line is a thematic beak
-          | [ ]{,3}1[.)]\s         # an ordered list item with number "1" begins the line
-          | [ ]{,3}[*+-]\s         # an unordered list item begins the line
-          | [ ]{,3} < (?:          # all types of HTML blocks except type 7 may interrupt a paragraph
+          \s*$                          # the line is blank (or only contains whitespace)
+          | {{atx_heading}}             # an ATX heading begins the line
+          | {{block_quote}}             # a blockquote begins the line
+          | {{fenced_code_block_start}} # a fenced codeblock begins the line
+          | {{thematic_break}}          # line is a thematic beak
+          | [ ]{,3}1[.)]\s              # an ordered list item with number "1" begins the line
+          | [ ]{,3}[*+-]\s              # an unordered list item begins the line
+          | [ ]{,3}<(?:                 # all types of HTML blocks except type 7 may interrupt a paragraph
               {{html_tag_block_end_at_close_tag}}   # 1
             | !--                                   # 2
             | \?                                    # 3

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -24,7 +24,7 @@ variables:
             )
             [ \t]*$                          # followed by any number of tabs or spaces, followed by the end of the line
         )
-    setext_escape: ^(?=\s{0,3}(?:---+|===+)\s*$)
+    setext_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$) # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
     block_quote: (?:[ ]{,3}>(?:.|$))         # between 0 and 3 spaces, followed by a greater than sign, followed by any character or the end of the line
     atx_heading: (?:[#]{1,6}\s+)             # between 1 and 6 hashes, followed by at least one whitespace
     indented_code_block: (?:[ ]{4}|\t)       # 4 spaces or a tab
@@ -279,70 +279,73 @@ contexts:
           pop: true
         - include: inline-bold-italic
     - include: reference-link-definition
-    - match: '^(?=\S)(?![=-]{3,}\s*$)'
-      branch_point: heading2-branch
-      branch:
-        - not-heading2
-        - heading2
+    - include: setext-heading-or-paragraph
 
-  not-paragraph:
-    - match: |-
-        (?x)                         # pop out of this context when one of the following conditions are met:
-        ^(?:
-            \s*$                     # the line is blank (or only contains whitespace)
-        |   (?=
-                {{block_quote}}      # a block quote begins the line
-            |   [ ]{,3}[*+-][ ]      # an unordered list item begins the line
-            |   [ ]{,3}1[.][ ]       # an ordered list item with number "1" begins the line
-            |   \#                   # an ATX heading begins the line
-            |   [ ]{,3}<(            # all types of HTML blocks except type 7 may interrupt a paragraph
-                  {{html_tag_block_end_at_close_tag}}   # 1
-                | !--                                   # 2
-                | \?                                    # 3
-                | ![A-Z]                                # 4
-                | !\[CDATA\[                            # 5
-                | {{html_tag_block_end_at_blank_line}}  # 6
-                )
-            )
-        )
-      pop: true
-
-  not-heading2:
-    - include: not-paragraph
-    - match: (?=\S)
-      branch_point: heading1-branch
+  setext-heading-or-paragraph:
+    # A paragraph may start with a line of equal signs which must not be matched
+    # as heading underline. This is achieved by consuming them here, which also
+    # applies `meta.paragraph` scope as expected.
+    # A line of dashes is already matched as thematic break and thus ignored.
+    - match: ^[ ]{,3}(?:=+|(?=\S))
+      branch_point: setext-heading-or-paragraph
       branch:
         - paragraph
-        - heading1
-    - match: ''
+        - setext-heading2
+        - setext-heading1
+
+  setext-heading1:
+    # https://spec.commonmark.org/0.30/#setext-headings
+    - meta_scope: markup.heading.1.markdown
+    - match: ^[ ]{,3}(=+)[ \t]*$(\n?)
+      captures:
+        1: punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
       pop: true
+    - include: setext-heading-content
+
+  setext-heading2:
+    # https://spec.commonmark.org/0.30/#setext-headings
+    - meta_scope: markup.heading.2.markdown
+    - match: ^[ ]{,3}(-+)[ \t]*$(\n?)
+      captures:
+        1: punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
+      pop: true
+    - include: setext-heading-content
+
+  setext-heading-content:
+    - match: '{{setext_escape}}'
+      fail: setext-heading-or-paragraph
+    - include: inline-bold-italic
+    - include: scope:text.html.basic
 
   paragraph:
-      - meta_scope: meta.paragraph.markdown
-      - match: ^\s{0,3}===+\s*$
-        fail: heading1-branch
-      - match: ^\s{0,3}---+\s*$
-        fail: heading2-branch
-      - include: not-paragraph
-      - include: inline-bold-italic-linebreak
-      - include: scope:text.html.basic
-
-  heading1:
-    - meta_scope: markup.heading.1.markdown
+    # https://spec.commonmark.org/0.30/#paragraphs
+    - meta_scope: meta.paragraph.markdown
+    - match: '{{setext_escape}}'
+      fail: setext-heading-or-paragraph
+    - include: paragraph-end
     - include: inline-bold-italic-linebreak
-    - match: '^[ \t]{0,3}(={3,})(?=[ \t]*$)(\n?)'
-      captures:
-        1: markup.heading.1.setext.markdown punctuation.definition.heading.setext.markdown
-        2: meta.whitespace.newline.markdown
-      pop: true
+    - include: scope:text.html.basic
 
-  heading2:
-    - meta_scope: markup.heading.2.markdown
-    - include: inline-bold-italic-linebreak
-    - match: '^[ \t]{0,3}(-{3,})(?=[ \t]*$)(\n?)'
-      captures:
-        1: markup.heading.2.setext.markdown punctuation.definition.heading.setext.markdown
-        2: meta.whitespace.newline.markdown
+  paragraph-end:
+    - match: |-
+        (?x)                       # pop out of this context if one of the following conditions are met:
+        ^(?=
+          \s*$                     # the line is blank (or only contains whitespace)
+          | {{atx_heading}}        # an ATX heading begins the line
+          | {{block_quote}}        # line is a blockquote
+          | {{thematic_break}}     # line is a thematic beak
+          | [ ]{,3}1[.)]\s         # an ordered list item with number "1" begins the line
+          | [ ]{,3}[*+-]\s         # an unordered list item begins the line
+          | [ ]{,3} < (?:          # all types of HTML blocks except type 7 may interrupt a paragraph
+              {{html_tag_block_end_at_close_tag}}   # 1
+            | !--                                   # 2
+            | \?                                    # 3
+            | ![A-Z]                                # 4
+            | !\[CDATA\[                            # 5
+            | {{html_tag_block_end_at_blank_line}}  # 6
+          ) )
       pop: true
 
   ampersand:
@@ -1503,6 +1506,7 @@ contexts:
             0: meta.code-fence.definition.end.text.markdown-gfm
             1: punctuation.definition.raw.code-fence.end.markdown
           pop: true
+
   code-span:
     - match: (`+)(?!`)
       scope: punctuation.definition.raw.begin.markdown
@@ -1512,11 +1516,11 @@ contexts:
           scope: punctuation.definition.raw.end.markdown
           pop: true
         - match: '`+'
-        - match: '^(?={{list_item}})'
-          pop: true
-        - match: ^\s*$\n?
+        - match: ^\s*$
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
+        - include: paragraph-end
+
   raw:
     - match: ^(?={{fenced_code_block_start}})
       push:
@@ -1524,14 +1528,16 @@ contexts:
           pop: true
         - include: fenced-code-block
     - include: code-span
+
   thematic-break:
-    - match: '(?={{thematic_break}})'
+    - match: (?={{thematic_break}})
       push:
         - meta_scope: meta.separator.thematic-break.markdown
         - match: '[-_*]+'
           scope: punctuation.definition.thematic-break.markdown
         - match: '$\n?'
           pop: true
+
   disable-markdown:
     - include: scope:text.html.basic
   disable-markdown-pop-at-tag:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1516,7 +1516,7 @@ contexts:
           scope: punctuation.definition.raw.end.markdown
           pop: true
         - match: '`+'
-        - match: ^\s*$
+        - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
         - include: paragraph-end

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -24,26 +24,249 @@ http://spec.commonmark.org/0.28/#example-44
 | <- - markup.heading
 |^^^^^^^^^^^^ - markup.heading
 
-Alternate Heading
-| <- markup.heading.1
+SETEXT Heading Level 1
+| <- markup.heading.1.markdown
 =================
-|^^^^^^^^^^^^^^^^ markup.heading.1 punctuation.definition
-|                ^ meta.whitespace.newline
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|^^^^^^^^^^^^^^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|                ^ markup.heading.1.markdown meta.whitespace.newline.markdown
 
-heading underlined with dashes
-| <- markup.heading.2
+SETEXT Heading Level 2
+| <- markup.heading.2.markdown
 ------------------------------
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2 punctuation.definition.heading
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|                             ^ markup.heading.2.markdown meta.whitespace.newline.markdown - punctuation
 
 underlined heading followed by a separator
 -------------------
 ------
-| <- meta.block-level meta.separator - markup.heading
+| <- meta.separator.thematic-break.markdown - markup.heading
 
 underlined heading followed by another one that should be treated as a normal paragraph
 ==================
 =====
-| <- - markup.heading
+| <- meta.paragraph.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-80
+
+Foo *bar*
+| <- markup.heading.1.markdown
+|^^^^^^^^^ markup.heading.1.markdown
+|   ^^^^^ markup.italic.markdown
+=========
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|^^^^^^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|        ^ markup.heading.1.markdown meta.whitespace.newline.markdown
+
+Foo *bar*
+| <- markup.heading.2.markdown
+|^^^^^^^^^ markup.heading.2.markdown
+|   ^^^^^ markup.italic.markdown
+---------
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|        ^ markup.heading.2.markdown meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-81
+
+Foo *bar
+baz*
+| <- markup.heading.1.markdown markup.italic.markdown
+|^^^ markup.heading.1.markdown markup.italic.markdown
+|   ^ markup.heading.1.markdown - markup.italic
+====
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|   ^ markup.heading.1.markdown meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-82
+
+  Foo *bar
+baz*  
+| <- markup.heading.1.markdown markup.italic.markdown
+|^^^ markup.heading.1.markdown markup.italic.markdown
+|   ^^ markup.heading.1.markdown - markup.italic
+====
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|   ^ markup.heading.1.markdown meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-83
+
+Foo
+=
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|^ markup.heading.1.markdown meta.whitespace.newline.markdown
+
+Foo
+-
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^ markup.heading.2.markdown meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-84
+
+   Foo
+---
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|  ^ markup.heading.2.markdown meta.whitespace.newline.markdown
+
+  Foo
+-----
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|    ^ markup.heading.2.markdown meta.whitespace.newline.markdown
+
+  Foo
+  ===
+| <- markup.heading.1.markdown - punctuation
+|^ markup.heading.1.markdown - punctuation
+| ^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+|    ^ markup.heading.1.markdown meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-85
+
+    Foo
+    ---
+|^^^^^^^ markup.raw.block.markdown
+
+    Foo
+---
+| <- meta.separator.thematic-break.markdown - markup.heading
+|^^^ meta.separator.thematic-break.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-86
+
+Foo
+   ----      
+|^^^^^^^^^^^^^ markup.heading.2.markdown
+|^^ - punctuation
+|  ^^^^ punctuation.definition.heading.setext.markdown
+|      ^^^^^^^ - punctuation
+|            ^ meta.whitespace.newline.markdown
+
+https://spec.commonmark.org/0.30/#example-87
+
+Foo
+    ---
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^ meta.paragraph.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-88
+
+Foo
+= =
+| <- meta.paragraph.markdown - markup.heading
+|^^^ meta.paragraph.markdown - markup.heading
+
+Foo
+--- -
+| <- meta.separator.thematic-break.markdown - markup.heading
+|^^^^^ meta.separator.thematic-break.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-89
+
+Foo  
+|  ^^ markup.heading.2.markdown - meta.hard-line-break
+-----
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+https://spec.commonmark.org/0.30/#example-90
+
+Foo\
+|  ^ markup.heading.2.markdown - meta.hard-line-break
+----
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+https://spec.commonmark.org/0.30/#example-91
+
+`Foo
+----
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+`Foo`
+----
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+https://spec.commonmark.org/0.30/#example-92
+
+> Foo
+---
+| <- meta.separator.thematic-break.markdown - markup.heading
+|^^^ meta.separator.thematic-break.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-93
+
+> foo
+bar
+===
+| <- markup.quote.markdown - markup.heading
+|^^^ markup.quote.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-94
+- Foo
+---
+| <- meta.separator.thematic-break.markdown - markup.heading
+|^^^ meta.separator.thematic-break.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-95
+
+Foo
+Bar
+---
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+https://spec.commonmark.org/0.30/#example-96
+
+---
+Foo
+---
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+---
+Foo
+---
+Bar
+---
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+Baz
+
+---
+Foo
+---
+Bar
+---
+Baz
+| <- meta.paragraph.markdown
+|^^^ meta.paragraph.markdown
+
+https://spec.commonmark.org/0.30/#example-97
+
+====
+| <- meta.paragraph.markdown
+|^^^^ meta.paragraph.markdown
+
+https://spec.commonmark.org/0.30/#example-98
+
+---
+---
+| <- meta.separator.thematic-break.markdown - markup.heading
+|^^^ meta.separator.thematic-break.markdown - markup.heading
+
+https://spec.commonmark.org/0.30/#example-102
+
+\> foo
+------
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 
 Paragraph of text that should be scoped as meta.paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
@@ -2119,7 +2342,7 @@ var_dump(expression);
 (?x)
 \s+
 ```
-|^^^ meta.paragraph meta.code-fence.definition.end.regexp - markup
+|^^^ meta.code-fence.definition.end.regexp - markup
 |^^ punctuation.definition.raw.code-fence.end
 
 ```bash
@@ -2156,7 +2379,7 @@ end
 |^ constant.character.escape
 
   -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta - constant - keyword - variable - punctuation
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant - keyword - variable
 
     -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
 |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block-level markup.raw - constant - keyword - variable - punctuation

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1537,6 +1537,12 @@ __test!*test__ Issue 1163
 |      ^ - punctuation.definition.italic
 |           ^^ punctuation.definition.bold.end
 
+Paragraph is terminated by fenced code blocks.
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
 ```js
 | <- punctuation.definition.raw.code-fence.begin
 |  ^^ constant.other.language-name


### PR DESCRIPTION
This PR refactors SETEXT heading maching in order to comply with https://spec.commonmark.org/0.30/#setext-headings and provide proper bailouts. This should fix (or workaround) https://github.com/sublimehq/sublime_text/issues/4746.

Note: This PR causes some merge conflicts with #2925.