### PR TITLE
[ASP] Fix *.asa file association

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -3,7 +3,6 @@
 # http://www.sublimetext.com/docs/3/syntax.html
 name: ASP
 file_extensions:
-  - asa # asp is handled by HTML-ASP.sublime-syntax
   - vbs # Visual Basic Script
 scope: source.asp
 variables:

--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -9,6 +9,7 @@ extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions:
   - asp
+  - asa
 
 contexts:
 


### PR DESCRIPTION
This commit assigns *.asa extension to HTML (ASP).sublime-syntax as it also requires to wrap VBScript into `<% %>` or `<script type="vbscript">` tags.