### PR TITLE
[JavaScript] [TypeScript] Implement static blocks.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1376,14 +1376,16 @@ contexts:
       set:
         - match: \{
           scope: punctuation.section.block.begin.js
-          set:
-            - meta_scope: meta.block.js
-            - match: \}
-              scope: punctuation.section.block.end.js
-              pop: true
-            - include: statements
+          set: static-block-body
         - match: (?=\S)
           fail: static-block
+
+  static-block-body:
+    - meta_scope: meta.block.js
+    - match: \}
+      scope: punctuation.section.block.end.js
+      pop: true
+    - include: statements
 
   class-element-modifiers:
     - match: (?={{modifier}})

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1338,7 +1338,14 @@ contexts:
         - function-declaration-expect-body
         - function-declaration-expect-parameters
 
-    - include: class-element-modifiers
+    - match: (?=static{{identifier_break}})
+      branch_point: static-block
+      branch:
+        - static-block
+        - class-element-modifiers
+
+    - match: (?={{modifier}})
+      push: class-element-modifiers
 
     - match: |-
         (?x)(?=
@@ -1363,8 +1370,24 @@ contexts:
     - match: (?={{class_element_name}})
       push: class-element
 
+  static-block:
+    - match: static{{identifier_break}}
+      scope: keyword.declaration.other.js
+      set:
+        - match: \{
+          scope: punctuation.section.block.begin.js
+          set:
+            - meta_scope: meta.block.js
+            - match: \}
+              scope: punctuation.section.block.end.js
+              pop: true
+            - include: statements
+        - match: (?=\S)
+          fail: static-block
+
   class-element-modifiers:
     - match: (?={{modifier}})
+      pop: true
       branch_point: class-element-modifier
       branch:
         - class-element-modifier

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1372,7 +1372,7 @@ contexts:
 
   static-block:
     - match: static{{identifier_break}}
-      scope: keyword.declaration.other.js
+      scope: storage.modifier.js
       set:
         - match: \{
           scope: punctuation.section.block.begin.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1388,7 +1388,7 @@ contexts:
     - include: statements
 
   class-element-modifiers:
-    - match: (?={{modifier}})
+    - match: ''
       pop: true
       branch_point: class-element-modifier
       branch:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -234,7 +234,8 @@ contexts:
     - match: '\+|-'
       scope: storage.modifier.js
 
-    - include: class-element-modifiers
+    - match: (?={{modifier}})
+      push: class-element-modifiers
 
     - match: (?=[<(])
       push:

--- a/JavaScript/tests/syntax_test_js_class.js
+++ b/JavaScript/tests/syntax_test_js_class.js
@@ -98,7 +98,7 @@ class MyClass extends TheirClass {
 //             ^^^^^^^^^^^^^ meta.function
 
     static {
-//  ^^^^^^ keyword.declaration.other
+//  ^^^^^^ storage.modifier
 //         ^ meta.block punctuation.section.block.begin
         this.#foo = 42;
 //      ^^^^ variable.language.this

--- a/JavaScript/tests/syntax_test_js_class.js
+++ b/JavaScript/tests/syntax_test_js_class.js
@@ -97,6 +97,19 @@ class MyClass extends TheirClass {
 //         ^ entity.name.function variable.other.readwrite
 //             ^^^^^^^^^^^^^ meta.function
 
+    static {
+//  ^^^^^^ keyword.declaration.other
+//         ^ meta.block punctuation.section.block.begin
+        this.#foo = 42;
+//      ^^^^ variable.language.this
+//          ^ punctuation.accessor
+//           ^ punctuation.definition.variable
+//            ^^^ meta.property.object
+//                ^ keyword.operator.assignment
+//                  ^^ meta.number.integer.decimal constant.numeric.value
+    }
+//  ^ meta.block punctuation.section.block.end
+
     static = 42;
 //  ^^^^^^ variable.other.readwrite
 


### PR DESCRIPTION
Static blocks are a Stage 3 proposal with an experimental implementation in Firefox. In addition, they're part of TypeScript 4.4, which is at the RC stage.

I use `keyword.declaration` for the `static` keyword in these blocks. I think this is more appropriate than `storage.modifier`, but I could be persuaded otherwise.

- https://github.com/tc39/proposal-class-static-block
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-rc/

As part of this PR, I slightly reshuffled how class element modifiers work. This was necessary to avoid code duplication due to https://github.com/sublimehq/sublime_text/issues/3494.