### PR TITLE
[HTML] Add detection of boolean attributes to avoid empty attribute values

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -18,6 +18,14 @@ KIND_TAG_MARKUP = (sublime.KIND_ID_MARKUP, 't', 'Tag')
 ENABLE_TIMING = False
 
 
+boolean_attributes = {
+    'async', 'autofocus', 'autoplay', 'checked', 'contenteditable', 'controls',
+    'default', 'defer', 'disabled', 'formNoValidate', 'frameborder', 'hidden',
+    'ismap', 'itemscope', 'loop', 'multiple', 'muted', 'nomodule', 'novalidate',
+    'open', 'readonly', 'required', 'reversed', 'scoped', 'selected',
+    'typemustmatch'
+}
+
 def timing(func):
     @wraps(func)
     def wrap(*args, **kw):
@@ -396,7 +404,6 @@ def get_tag_attributes():
 
     return tag_attr_dict
 
-
 class HtmlTagCompletions(sublime_plugin.EventListener):
     """
     Provide tag completions for HTML
@@ -588,7 +595,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
             [
                 sublime.CompletionItem(
                     trigger=attr,
-                    completion=f'{attr}="$1"{suffix}',
+                    completion=f'{attr}{suffix}' if attr in boolean_attributes else f'{attr}="$1"{suffix}',
                     completion_format=sublime.COMPLETION_FORMAT_SNIPPET,
                     kind=KIND_ATTRIBUTE_SNIPPET
                 )


### PR DESCRIPTION
If you type HTML attributes and these are inserted by the auto completion an empty attribute value is added automatically and the cursor jumps to the value so users can start typing.

For boolean attributes like "disabled" this is valid, but not necessary and I think most people use boolean attributes without a value.

This PR removes the value for boolean attributes. I got the list of boolean attributes from this Gist: https://gist.github.com/ArjanSchouten/0b8574a6ad7f5065a5e7#gistcomment-3231272