### PR TITLE
[PHP] Add expression bailouts

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -12,6 +12,33 @@ variables:
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b
   visibility_modifier: '\b(?:var|public|private|protected)\b'
 
+  # a pattern which terminates an incomplete expression at any point
+  expression_end: (?=;|\s*\?>|{{keywords}})
+
+  keywords: |-
+    (?x:
+      {{keywords_control}}
+    | {{keywords_flow}}
+    | {{keywords_declaration}}
+    | {{visibility_modifier}}
+    )
+
+  keywords_declaration: |-
+    (?x:
+      class | declare | enddeclare | function | global | import | include
+    | include_once | interface | namespace | require | use
+    )\b
+
+  keywords_control: |-
+    (?x:
+      case | catch | default | (?: end )? (?: for | foreach | if | while )
+    | else | elsif | finally | switch | try
+    )\b
+
+  keywords_flow: |-
+    (?x: break | continue | exit | finally | return | throw | yield )\b
+
+
 contexts:
   main:
     - include: statements
@@ -112,6 +139,10 @@ contexts:
           pop: 1
         - include: statements
 
+  nested-expressions:
+    - include: expression-end-pop
+    - include: expressions
+
   expressions:
     - include: attributes
     - include: comments
@@ -121,9 +152,9 @@ contexts:
       push:
         - meta_scope: meta.include.php
         # "\s*\?>" is for fixing one-liner ( https://github.com/sublimehq/Packages/issues/1545 )
-        - match: (?=;|\)|\]|\s*\?>)
+        - match: (?=\)|\])
           pop: 1
-        - include: expressions
+        - include: nested-expressions
     # yield from ( http://php.net/manual/en/language.generators.syntax.php#control-structures.yield.from )
     - match: \byield\b
       scope: keyword.control.php
@@ -146,6 +177,7 @@ contexts:
         2: punctuation.section.group.begin.php
       push:
         - meta_scope: meta.catch.php
+        - include: expression-end-pop
         - include: attributes
         - include: comments
         - include: identifier-parts-as-path
@@ -221,7 +253,7 @@ contexts:
         - match: \)
           scope: punctuation.section.array.end.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
     - match: (?i)\s*\(\s*(array|real|double|float|int(eger)?|bool(ean)?|string|object|binary|unset)\s*\)
       captures:
         1: storage.type.php
@@ -277,7 +309,7 @@ contexts:
     - match: \?
       scope: keyword.operator.ternary.php
       push:
-        - include: expressions
+        - include: nested-expressions
         - match: ':'
           scope: keyword.operator.ternary.php
           pop: 1
@@ -309,7 +341,7 @@ contexts:
         - match: '\]'
           scope: punctuation.section.array.end.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
     - include: constants
     - match: \(
       scope: punctuation.section.group.begin.php
@@ -318,7 +350,7 @@ contexts:
         - match: \)
           scope: punctuation.section.group.end.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
 
   after-identifier:
     - include: item-access
@@ -338,7 +370,7 @@ contexts:
         - match: '\]'
           scope: meta.item-access.php punctuation.section.brackets.end.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
 
   type-hint:
     # https://wiki.php.net/rfc/union_types_v2
@@ -388,12 +420,13 @@ contexts:
             - match: ','
               scope: punctuation.separator.php
             - include: function-call-named-parameters
-            - include: expressions
+            - include: nested-expressions
         - match: \]
           scope: punctuation.definition.attribute.end.php
           pop: 1
         - match: ','
           scope: punctuation.separator.php
+        - include: expression-end-pop
 
   class-builtin:
     - match: |-
@@ -447,10 +480,11 @@ contexts:
         - match: '(?=\S)'
           set: use-statement-ns-class
         # Escape during typing
-        - match: '(?=$\n)'
+        - match: '(?=\n)'
           pop: 1
 
   use-statement-common:
+    - include: expression-end-pop
     - include: attributes
     - include: comments
     - match: (?i)\bas\b
@@ -570,8 +604,7 @@ contexts:
       push: class-definition
 
   class-definition:
-    - match: "(?=;)"
-      pop: 1
+    - include: expression-end-pop
     - match: \{
       scope: meta.block.php punctuation.section.block.begin.php
       set: class-body
@@ -781,6 +814,7 @@ contexts:
 
   function-parameters:
     - meta_scope: meta.function.parameters.php meta.group.php
+    - include: expression-end-pop
     - match: \)
       scope: punctuation.section.group.end.php
       set:
@@ -820,7 +854,7 @@ contexts:
       push:
         - match: (?=,|\))
           pop: 1
-        - include: expressions
+        - include: nested-expressions
 
   function-use:
     - meta_scope: meta.function.closure.use.php
@@ -849,8 +883,7 @@ contexts:
 
   function-return-type:
     - meta_scope: meta.function.return-type.php
-    - match: '(?=;)'
-      pop: 1
+    - include: expression-end-pop
     - match: \{
       scope: meta.block.php punctuation.section.block.begin.php
       set: function-body
@@ -1180,7 +1213,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.php
         - include: function-call-named-parameters
-        - include: expressions
+        - include: nested-expressions
   function-call-named-parameters:
     # https://wiki.php.net/rfc/named_params
     - match: ({{identifier}})\s*(:)(?!:)
@@ -1188,7 +1221,7 @@ contexts:
         1: variable.parameter.named.php
         2: punctuation.definition.variable.php
       push:
-        - include: expressions
+        - include: nested-expressions
         - match: ''
           pop: 1
   heredoc:
@@ -1375,7 +1408,7 @@ contexts:
           captures:
             1: punctuation.definition.expression.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
     # Handles: "foo${bar}baz"
     - match: '(\$\{){{identifier}}(\})'
       scope: variable.other.php
@@ -1390,7 +1423,7 @@ contexts:
           captures:
             1: punctuation.definition.variable.php
           pop: 1
-        - include: expressions
+        - include: nested-expressions
     # Handles: $foo, $foo[0], $foo[$bar], $foo->bar
     - match: |-
         (?x:
@@ -1417,6 +1450,7 @@ contexts:
             - match: '\]'
               scope: punctuation.section.brackets.end.php
               pop: 1
+            - include: expression-end-pop
             - include: numbers
             - include: variables
             - match: '{{identifier}}'
@@ -1514,6 +1548,7 @@ contexts:
         - match: \)
           scope: punctuation.section.array.end.php
           pop: 1
+        - include: expression-end-pop
         - include: parameter-default-types
     - include: instantiation
     - match: \s*(?={{path}}(::)({{identifier}})?)
@@ -2545,3 +2580,9 @@ contexts:
           set: after-identifier
         - match: ''
           pop: 1
+
+###[ PROTOTYPES ]#############################################################
+
+  expression-end-pop:
+    - match: '{{expression_end}}'
+      pop: 1

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -12,8 +12,9 @@ variables:
   sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b
   visibility_modifier: '\b(?:var|public|private|protected)\b'
 
-  # a pattern which terminates an incomplete expression at any point
-  expression_end: (?=;|\s*\?>|{{keywords}})
+  # A pattern which terminates an incomplete expression at any point.
+  # `\s*\?>` is for fixing one-liner ( https://github.com/sublimehq/Packages/issues/1545 )
+  expression_end: (?=;|}|\s*\?>|{{keywords}})
 
   keywords: |-
     (?x:
@@ -151,7 +152,6 @@ contexts:
         1: keyword.control.import.include.php
       push:
         - meta_scope: meta.include.php
-        # "\s*\?>" is for fixing one-liner ( https://github.com/sublimehq/Packages/issues/1545 )
         - match: (?=\)|\])
           pop: 1
         - include: nested-expressions

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -32,7 +32,7 @@ variables:
   keywords_control: |-
     (?x:
       case | catch | default | (?: end )? (?: for | foreach | if | while )
-    | else | elsif | finally | switch | try
+    | else | elseif | finally | switch | try
     )\b
 
   keywords_flow: |-

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -941,6 +941,11 @@ $anon = new class{};
 //               ^ punctuation.section.block.begin.php - meta.class meta.class
 //                ^ punctuation.section.block.end.php
 
+$anon = new class};
+//      ^ keyword.other.new.php
+//          ^ storage.type.class.php
+//               ^ punctuation.section.block.end.php - meta.class - meta.block
+
 $anon = new class($param1, $param2) extends Test1 implements Countable {};
 //      ^ keyword.other.new.php
 //          ^ storage.type.class.php
@@ -1977,6 +1982,71 @@ var_dump(new C(42));
 
 <div><?php include 'image.svg' ?></div>
 //                             ^^ punctuation.section.embedded.end.php
+
+// don't break php termination highlighting after incomplete item-access expression
+<?php  { ?> <div> <? $var[9 + ?> </div>
+//^^^^^^^^^ meta.embedded.line.php
+//         ^^^^^^^ - meta.embedded
+//                ^^^^^^^^^^^^^^ meta.embedded.line.php
+//                              ^^^^^^^^ - meta.embedded
+//     ^ punctuation.section.block.begin.php
+//       ^^ punctuation.section.embedded.end.php
+//          ^^^^^ meta.tag
+//                ^^ punctuation.section.embedded.begin.php
+//                   ^^^^ variable.other.php
+//                       ^^^^ meta.item-access
+//                           ^ - meta.item-access
+//                            ^^ punctuation.section.embedded.end.php
+//                               ^^^^^^ meta.tag
+
+// don't break block termination highlighting after incomplete item-access expression
+<?php  { ?> <div> <? $var[9 + } ?> </div>
+//^^^^^^^^^ meta.embedded.line.php
+//         ^^^^^^^ - meta.embedded
+//                ^^^^^^^^^^^^^^^^ meta.embedded.line.php
+//                                ^^^^^^^^ - meta.embedded
+//     ^ punctuation.section.block.begin.php
+//       ^^ punctuation.section.embedded.end.php
+//          ^^^^^ meta.tag
+//                ^^ punctuation.section.embedded.begin.php
+//                   ^^^^ variable.other.php
+//                       ^^^^^ meta.item-access
+//                            ^ punctuation.section.block.end.php
+//                              ^^ punctuation.section.embedded.end.php
+//                                 ^^^^^^ meta.tag
+
+// don't break block termination highlighting after incomplete item-access expression
+<?php  { ?> <div> <? $var[9 + ; ?> </div>
+//^^^^^^^^^ meta.embedded.line.php
+//         ^^^^^^^ - meta.embedded
+//                ^^^^^^^^^^^^^^^^ meta.embedded.line.php
+//                                ^^^^^^^^ - meta.embedded
+//     ^ punctuation.section.block.begin.php
+//       ^^ punctuation.section.embedded.end.php
+//          ^^^^^ meta.tag
+//                ^^ punctuation.section.embedded.begin.php
+//                   ^^^^ variable.other.php
+//                       ^^^^^ meta.item-access
+//                            ^ punctuation.terminator.expression.php
+//                              ^^ punctuation.section.embedded.end.php
+//                                 ^^^^^^ meta.tag
+
+// don't break highlighting after incomplete catch parameter list
+<?php try { ?> <div> <? } catch(  ?> </div>
+//^^^^^^^^^^^^ meta.embedded.line.php
+//            ^^^^^^^ - meta.embedded
+//                   ^^^^^^^^^^^^^^^ meta.embedded.line.php
+//                                  ^^^^^^^^ - meta.embedded
+//    ^^^ keyword.control.exception.php
+//        ^ punctuation.section.block.begin.php
+//          ^^ punctuation.section.embedded.end.php
+//             ^^^^^ meta.tag
+//                   ^^ punctuation.section.embedded.begin.php
+//                      ^ punctuation.section.block.end.php
+//                        ^^^^^ keyword.control.exception.catch.php
+//                             ^ punctuation.section.group.begin.php
+//                                ^^ punctuation.section.embedded.end.php
+//                                   ^^^^^^ meta.tag
 
 <div attr-<?= $bar ?>-true=va<? $baz ?>l?ue></div>
 //   ^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name


### PR DESCRIPTION
Addresses https://github.com/sublimehq/sublime_text/issues/4763

Missing bailouts can cause large portions of or the whole document to be re-lexed if single expressions are incomplete during editing.

It may cause the whole application to freeze several seconds after each key stroke because of PHPs complexity.

This commit therefore adds a pattern, which causes any nested expression context to be popped off stack, once a token is matched which is known to start a new statement.

Note: The strategy of adding a 2nd-level bailout to limit broken syntax highlighting due to invalid/incomplete expressions is heavily made use of in "Java Rewrite" PR and other syntaxes such as Erlang, already.