### PR TITLE
[PHP] Refactor string contexts

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1592,15 +1592,25 @@ contexts:
         - string-double-quoted-regexp
         - string-double-quoted-plain
     - match: \"
-      scope: punctuation.definition.string.begin.php
+      scope: string.quoted.double.php punctuation.definition.string.begin.php
       push: string-double-quoted-content
+
+  string-double-quoted-end:
+    - match: \"
+      scope: string.quoted.double.php punctuation.definition.string.end.php
+      pop: 1
 
   string-double-quoted-content:
     - meta_include_prototype: false
-    - meta_scope: meta.string.php string.quoted.double.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: string.quoted.double.php
     - include: string-double-quoted-end
     - match: (?={{sql_indicator}})
-      set: string-double-quoted-sql-content
+      push: string-quoted-sql-content
+      with_prototype:
+        - match: (?=")
+          pop: 1
+        - include: interpolation
     - match: (?=\S)
       set: string-double-quoted-plain-content
 
@@ -1643,11 +1653,6 @@ contexts:
       scope: string.quoted.double.php punctuation.definition.string.begin.php
       set: string-double-quoted-plain-content
 
-  string-double-quoted-end:
-    - match: \"
-      scope: string.quoted.double.php punctuation.definition.string.end.php
-      pop: 1
-
   string-double-quoted-plain-content:
     - meta_include_prototype: false
     - meta_scope: meta.string.php
@@ -1655,17 +1660,6 @@ contexts:
     - include: string-double-quoted-end
     - include: interpolation
 
-  string-double-quoted-sql-content:
-    - meta_include_prototype: false
-    - meta_scope: meta.string.php
-    - meta_content_scope: meta.interpolation.php
-    - include: string-double-quoted-end
-    - match: ''
-      push: scope:source.sql
-      with_prototype:
-        - match: (?=")
-          pop: 1
-        - include: interpolation
 
   strings-single-quoted:
     - match: (?='/)
@@ -1674,15 +1668,26 @@ contexts:
         - string-single-quoted-regexp
         - string-single-quoted-plain
     - match: \'
-      scope: punctuation.definition.string.begin.php
+      scope: string.quoted.single.php punctuation.definition.string.begin.php
       push: string-single-quoted-content
+
+  string-single-quoted-end:
+    - match: \'
+      scope: string.quoted.single.php punctuation.definition.string.end.php
+      pop: 1
 
   string-single-quoted-content:
     - meta_include_prototype: false
-    - meta_scope: meta.string.php string.quoted.single.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: string.quoted.single.php
     - include: string-single-quoted-end
     - match: (?={{sql_indicator}})
-      set: string-single-quoted-sql-content
+      push: string-quoted-sql-content
+      with_prototype:
+        - match: (?=')
+          pop: 1
+        - match: '\\[\\'']'
+          scope: constant.character.escape.php
     - match: (?=\S)
       scope: punctuation.definition.string.begin.php
       set: string-single-quoted-plain-content
@@ -1721,11 +1726,6 @@ contexts:
       scope: string.quoted.single.php punctuation.definition.string.begin.php
       set: string-single-quoted-plain-content
 
-  string-single-quoted-end:
-    - match: \'
-      scope: string.quoted.single.php punctuation.definition.string.end.php
-      pop: 1
-
   string-single-quoted-plain-content:
     - meta_include_prototype: false
     - meta_scope: meta.string.php
@@ -1734,18 +1734,12 @@ contexts:
     - match: \\[\\'']
       scope: constant.character.escape.php
 
-  string-single-quoted-sql-content:
+  string-quoted-sql-content:
+    - clear_scopes: 1
     - meta_include_prototype: false
-    - meta_scope: meta.string.php
-    - meta_content_scope: meta.interpolation.php
-    - include: string-single-quoted-end
-    - match: ''
-      push: scope:source.sql
-      with_prototype:
-        - match: (?=')
-          pop: 1
-        - match: '\\[\\'']'
-          scope: constant.character.escape.php
+    - meta_content_scope: meta.interpolation.php source.sql.embedded.php
+    - include: scope:source.sql
+      apply_prototype: true
 
 ###[ BUILTINS ]###############################################################
 

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -296,7 +296,6 @@ contexts:
       captures:
         1: keyword.control.goto.php
         2: support.other.php
-    - include: string-backtick
     - match: '(\[)\s*(\])'
       scope: meta.array.empty.php
       captures:
@@ -1497,7 +1496,6 @@ contexts:
   parameter-default-types:
     - include: strings
     - include: numbers
-    - include: string-backtick
     - include: variables
     - match: "=>"
       scope: keyword.operator.key.php
@@ -1563,154 +1561,196 @@ contexts:
       scope: meta.tag.inline.phpdoc.php
       captures:
         1: keyword.other.phpdoc.php
-  regex-double-quoted-branch:
+
+###[ STRINGS ]################################################################
+
+  strings:
+    - include: strings-backtick-quoted
+    - include: strings-double-quoted
+    - include: strings-single-quoted
+
+
+  strings-backtick-quoted:
+    - match: \`
+      scope: punctuation.definition.string.begin.php
+      push: string-backtick-quoted-content
+
+  string-backtick-quoted-content:
+    - meta_scope: string.interpolated.php
+    - match: \`
+      scope: punctuation.definition.string.end.php
+      pop: 1
+    - match: \\.
+      scope: constant.character.escape.php
+    - include: interpolation
+
+
+  strings-double-quoted:
+    - match: (?="/)
+      branch_point: branch-point-double-quoted
+      branch:
+        - string-double-quoted-regexp
+        - string-double-quoted-plain
+    - match: \"
+      scope: punctuation.definition.string.begin.php
+      push: string-double-quoted-content
+
+  string-double-quoted-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.double.php
+    - meta_content_scope: meta.string-contents.quoted.double.php
+    - include: string-double-quoted-end
+    - match: (?={{sql_indicator}})
+      set: string-double-quoted-sql-content
+    - match: (?=\S)
+      set: string-double-quoted-plain-content
+
+  string-double-quoted-regexp:
     - match: (")(/)
       captures:
         1: punctuation.definition.string.begin.php
         2: punctuation.definition.string.regex-delimiter.begin.php
-      push:
-        - meta_scope: meta.string.php string.quoted.double.php
-        - match: (/)({{regex_modifier}})(")
+      set: string-double-quoted-regexp-content
+
+  string-double-quoted-regexp-content:
+    - meta_scope: meta.string.php string.quoted.double.php
+    - match: (/)({{regex_modifier}})(")
+      captures:
+        1: punctuation.definition.string.regex-delimiter.end.php
+        2: meta.regex.modifier.php
+        3: punctuation.definition.string.end.php
+      pop: 1
+    - match: \"
+      fail: branch-point-double-quoted
+    - match: ''
+      push: scope:source.regexp.php
+      with_prototype:
+        - match: (?=/{{regex_modifier}}"|")
+          pop: 1
+        # workaround for greedy scope "$" as punctuation.definition.variable
+        # dangling "$" in regex means EOL, but not variable definition...
+        - match: \$+(?!{{identifier}})
+          scope: keyword.control.anchor.regexp
+        - include: interpolation
+        - match: \\"
+          scope: constant.character.escape
+        - match: \s(#)([^"]*)$
           captures:
-            1: punctuation.definition.string.regex-delimiter.end.php
-            2: meta.regex.modifier.php
-            3: punctuation.definition.string.end.php
-          pop: 2 # branch successful matched
+            1: comment.regexp.php punctuation.definition.comment.regexp.php
+            2: comment.regexp.php
+
+  string-double-quoted-plain:
+    - match: \"
+      scope: punctuation.definition.string.begin.php
+      set: string-double-quoted-plain-content
+
+  string-double-quoted-end:
+    - match: \"
+      scope: punctuation.definition.string.end.php
+      pop: 1
+
+  string-double-quoted-plain-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.double.php
+    - meta_content_scope: meta.string-contents.quoted.double.php
+    - include: string-double-quoted-end
+    - include: interpolation
+
+  string-double-quoted-sql-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.double.php
+    - meta_content_scope: meta.string-contents.quoted.double.php
+    - include: string-double-quoted-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
         - match: (?=")
           pop: 1
-        - match: ''
-          push: scope:source.regexp.php
-          with_prototype:
-            - match: (?=(/)({{regex_modifier}})(")|")
-              pop: 1
-            # workaround for greedy scope "$" as punctuation.definition.variable
-            # dangling "$" in regex means EOL, but not variable definition...
-            - match: \$+(?!{{identifier}})
-              scope: keyword.control.anchor.regexp
-            - include: interpolation
-            - match: \\"
-              scope: constant.character.escape
-            - match: \s(#)([^"]*)$
-              captures:
-                1: comment.regexp.php punctuation.definition.comment.regexp.php
-                2: comment.regexp.php
-    - match: ''
-      fail: branch-point-double-quoted
-  regex-single-quoted-branch:
+        - include: interpolation
+
+  strings-single-quoted:
+    - match: (?='/)
+      branch_point: branch-point-single-quoted
+      branch:
+        - string-single-quoted-regexp
+        - string-single-quoted-plain
+    - match: \'
+      scope: punctuation.definition.string.begin.php
+      push: string-single-quoted-content
+
+  string-single-quoted-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.single.php
+    - meta_content_scope: meta.string-contents.quoted.single.php
+    - include: string-single-quoted-end
+    - match: (?={{sql_indicator}})
+      set: string-single-quoted-sql-content
+    - match: (?=\S)
+      scope: punctuation.definition.string.begin.php
+      set: string-single-quoted-plain-content
+
+  string-single-quoted-regexp:
     - match: (')(/)
       captures:
         1: punctuation.definition.string.begin.php
         2: punctuation.definition.string.regex-delimiter.begin.php
-      push:
-        - meta_scope: meta.string.php string.quoted.single.php
-        - match: (/)({{regex_modifier}})(')
+      set: string-single-quoted-regexp-content
+
+  string-single-quoted-regexp-content:
+    - meta_scope: meta.string.php string.quoted.single.php
+    - match: (/)({{regex_modifier}})(')
+      captures:
+        1: punctuation.definition.string.regex-delimiter.end.php
+        2: meta.regex.modifier.php
+        3: punctuation.definition.string.end.php
+      pop: 1
+    - match: \'
+      fail: branch-point-single-quoted
+    - match: ''
+      push: scope:source.regexp.php
+      with_prototype:
+        - match: (?=/{{regex_modifier}}'|')
+          pop: 1
+        - match: \\'
+          scope: constant.character.escape
+        - match: \s((#)[^']*)$
           captures:
-            1: punctuation.definition.string.regex-delimiter.end.php
-            2: meta.regex.modifier.php
-            3: punctuation.definition.string.end.php
-          pop: 2 # branch successful matched
+            1: comment.regexp.php
+            2: punctuation.definition.comment.regexp.php
+
+  string-single-quoted-plain:
+    - match: \'
+      scope: punctuation.definition.string.begin.php
+      set: string-single-quoted-plain-content
+
+  string-single-quoted-end:
+    - match: \'
+      scope: punctuation.definition.string.end.php
+      pop: 1
+
+  string-single-quoted-plain-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.single.php
+    - meta_content_scope: meta.string-contents.quoted.single.php
+    - include: string-single-quoted-end
+    - match: \\[\\'']
+      scope: constant.character.escape.php
+
+  string-single-quoted-sql-content:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.single.php
+    - meta_content_scope: meta.string-contents.quoted.single.php
+    - include: string-single-quoted-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
         - match: (?=')
           pop: 1
-        - match: ''
-          push: scope:source.regexp.php
-          with_prototype:
-            - match: (?=(/)({{regex_modifier}})(')|')
-              pop: 1
-            - match: \\'
-              scope: constant.character.escape
-            - match: \s(#)([^']*)$
-              captures:
-                1: comment.regexp.php punctuation.definition.comment.regexp.php
-                2: comment.regexp.php
-    - match: ''
-      fail: branch-point-single-quoted
-  string-double-quoted-branch:
-    - include: string-double-quoted
-    - match: ''
-      pop: 1
-  string-single-quoted-branch:
-    - include: string-single-quoted
-    - match: ''
-      pop: 1
-  string-backtick:
-    - match: "`"
-      scope: punctuation.definition.string.begin.php
-      push:
-        - meta_scope: string.interpolated.php
-        - match: "`"
-          scope: punctuation.definition.string.end.php
-          pop: 1
-        - match: \\.
+        - match: '\\[\\'']'
           scope: constant.character.escape.php
-        - include: interpolation
-  string-double-quoted:
-    - match: '"'
-      scope: punctuation.definition.string.begin.php
-      push:
-        - meta_scope: string.quoted.double.php
-        - meta_content_scope: meta.string-contents.quoted.double.php
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: string.quoted.double.php
-            - meta_content_scope: meta.string-contents.quoted.double.php
-            - match: '"'
-              scope: punctuation.definition.string.end.php
-              pop: 1
-            - match: ''
-              with_prototype:
-                - match: '(?=")'
-                  pop: 1
-                - include: interpolation
-              push: 'scope:source.sql'
-        - match: '(?=\S)'
-          set:
-            - meta_scope: string.quoted.double.php
-            - meta_content_scope: meta.string-contents.quoted.double.php
-            - match: '"'
-              scope: punctuation.definition.string.end.php
-              pop: 1
-            - include: interpolation
-  string-single-quoted:
-    - match: "'"
-      scope: punctuation.definition.string.begin.php
-      push:
-        - meta_scope: string.quoted.single.php
-        - meta_content_scope: meta.string-contents.quoted.single.php
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: string.quoted.single.php
-            - meta_content_scope: meta.string-contents.quoted.single.php
-            - match: "'"
-              scope: punctuation.definition.string.end.php
-              pop: 1
-            - match: ''
-              with_prototype:
-                - match: "(?=')"
-                  pop: 1
-                - match: '\\[\\'']'
-                  scope: constant.character.escape.php
-              push: 'scope:source.sql'
-        - match: '(?=\S)'
-          set:
-            - meta_scope: string.quoted.single.php
-            - meta_content_scope: meta.string-contents.quoted.single.php
-            - match: "'"
-              scope: punctuation.definition.string.end.php
-              pop: 1
-            - match: '\\[\\'']'
-              scope: constant.character.escape.php
 
-  strings:
-    - match: (?=")
-      branch_point: branch-point-double-quoted
-      branch:
-        - regex-double-quoted-branch
-        - string-double-quoted-branch
-    - match: (?=')
-      branch_point: branch-point-single-quoted
-      branch:
-        - regex-single-quoted-branch
-        - string-single-quoted-branch
+###[ BUILTINS ]###############################################################
+
   support:
     - match: |-
         \b(?xi:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1576,7 +1576,7 @@ contexts:
       push: string-backtick-quoted-content
 
   string-backtick-quoted-content:
-    - meta_scope: string.interpolated.php
+    - meta_scope: meta.string.php string.quoted.other.php
     - match: \`
       scope: punctuation.definition.string.end.php
       pop: 1
@@ -1597,8 +1597,7 @@ contexts:
 
   string-double-quoted-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.php
-    - meta_content_scope: meta.string-contents.quoted.double.php
+    - meta_scope: meta.string.php string.quoted.double.php
     - include: string-double-quoted-end
     - match: (?={{sql_indicator}})
       set: string-double-quoted-sql-content
@@ -1641,25 +1640,25 @@ contexts:
 
   string-double-quoted-plain:
     - match: \"
-      scope: punctuation.definition.string.begin.php
+      scope: string.quoted.double.php punctuation.definition.string.begin.php
       set: string-double-quoted-plain-content
 
   string-double-quoted-end:
     - match: \"
-      scope: punctuation.definition.string.end.php
+      scope: string.quoted.double.php punctuation.definition.string.end.php
       pop: 1
 
   string-double-quoted-plain-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.php
-    - meta_content_scope: meta.string-contents.quoted.double.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: string.quoted.double.php
     - include: string-double-quoted-end
     - include: interpolation
 
   string-double-quoted-sql-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.php
-    - meta_content_scope: meta.string-contents.quoted.double.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: meta.interpolation.php
     - include: string-double-quoted-end
     - match: ''
       push: scope:source.sql
@@ -1680,8 +1679,7 @@ contexts:
 
   string-single-quoted-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.single.php
-    - meta_content_scope: meta.string-contents.quoted.single.php
+    - meta_scope: meta.string.php string.quoted.single.php
     - include: string-single-quoted-end
     - match: (?={{sql_indicator}})
       set: string-single-quoted-sql-content
@@ -1720,26 +1718,26 @@ contexts:
 
   string-single-quoted-plain:
     - match: \'
-      scope: punctuation.definition.string.begin.php
+      scope: string.quoted.single.php punctuation.definition.string.begin.php
       set: string-single-quoted-plain-content
 
   string-single-quoted-end:
     - match: \'
-      scope: punctuation.definition.string.end.php
+      scope: string.quoted.single.php punctuation.definition.string.end.php
       pop: 1
 
   string-single-quoted-plain-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.single.php
-    - meta_content_scope: meta.string-contents.quoted.single.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: string.quoted.single.php
     - include: string-single-quoted-end
     - match: \\[\\'']
       scope: constant.character.escape.php
 
   string-single-quoted-sql-content:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.single.php
-    - meta_content_scope: meta.string-contents.quoted.single.php
+    - meta_scope: meta.string.php
+    - meta_content_scope: meta.interpolation.php
     - include: string-single-quoted-end
     - match: ''
       push: scope:source.sql

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1059,11 +1059,11 @@ $test = "\0 \12 \345g \x0f \u{a} \u{9999} \u{999}";
 //       ^^ constant.character.escape.octal.php
 //          ^^^ constant.character.escape.octal.php
 //              ^^^^ constant.character.escape.octal.php
-//                  ^ meta.string-contents.quoted.double.php
+//                  ^ - constant.character.escape
 //                    ^^^^ constant.character.escape.hex.php
 //                         ^^^^^ constant.character.escape.unicodepoint.php
 //                               ^^^^^^^^ constant.character.escape.unicodepoint.php
-//                                        ^^^^^^^ meta.string-contents.quoted.double.php
+//
 
 "$a then $b->c or ${d} with {$e} then $f[0] followed by $g[$h] or $i[k] and finally {$l . $m->n . o}"
  // <- variable.other punctuation.definition.variable
@@ -1556,62 +1556,67 @@ $statement = match ($this->lexer->lookahead['type']) {
 };
 
 $non_sql = "NO SELECT HIGHLIGHTING!";
-//         ^ string.quoted.double punctuation.definition.string.begin - meta.string-contents
-//          ^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.double.php - meta.interpolation
+//         ^ punctuation.definition.string.begin
 //             ^ - source.sql
-//                                 ^ string.quoted.double punctuation.definition.string.end - meta.string-contents
+//                                 ^ punctuation.definition.string.end
 
 $sql = "CREATE TABLE version";
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//      ^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
+//                          ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
 //      ^^^^^^ keyword.other.create.sql
 
 $sql = "
     CREATE TABLE `version`...
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //  ^^^^^^ keyword.other.create.sql
 ";
 
 $sql = "SELECT * FROM users WHERE first_name = 'Eric'";
-//     ^ string.quoted.double punctuation.definition.string.begin - meta.string-contents
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //      ^ keyword.other.DML
 //                                             ^^^^^^ string.quoted.single.sql
-//                                                   ^ string.quoted.double punctuation.definition.string.end - meta.string-contents
+//                                                   ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
 
 // Ensure we properly exist from SQL when hitting PHP end-of-string
 $sql = "SELECT * FROM users WHERE first_name = 'Eric";
-//     ^ string.quoted.double punctuation.definition.string.begin - meta.string-contents
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //      ^ keyword.other.DML
 //                                             ^^^^^ string.quoted.single.sql
-//                                                  ^ string.quoted.double punctuation.definition.string.end - meta.string-contents
+//                                                  ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
 
 $sql = "
     SELECT * FROM users WHERE first_name = 'Eric'
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //  ^ keyword.other.DML
 //                                         ^^^^^^ string.quoted.single.sql
 ";
-// <- string.quoted.double punctuation.definition.string.end - meta.string-contents
+// <- meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
 
 $non_sql = 'NO SELECT HIGHLIGHTING!';
-//         ^ string.quoted.single punctuation.definition.string.begin - meta.string-contents
-//          ^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation
+//         ^ punctuation.definition.string.begin
 //             ^ - source.sql
-//                                 ^ string.quoted.single punctuation.definition.string.end - meta.string-contents
+//                                 ^ punctuation.definition.string.end
 
 $sql = 'SELECT * FROM users WHERE first_name = \'Eric\'';
-//     ^ string.quoted.single punctuation.definition.string.begin - meta.string-contents
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql
+//     ^ meta.string.php string.quoted.single.php punctuation.definition.string.begin.php - meta.interpolation
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.single.php
 //      ^ keyword.other.DML
 //                                             ^^ constant.character.escape.php
-//                                                     ^ string.quoted.single punctuation.definition.string.end - meta.string-contents
+//                                                   ^^ constant.character.escape.php
+//                                                     ^ meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation
 
 $sql = '
     SELECT * FROM users WHERE first_name = \'Eric\'
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.single.php
 //  ^ keyword.other.DML
 //                                         ^^ constant.character.escape.php
 ';
-// <- string.quoted.single punctuation.definition.string.end - meta.string-contents
+// <- meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation
 
 preg_replace('/[a-zSOME_CHAR]*+\'\n  $justTxt  \1  \\1/m');
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1556,15 +1556,15 @@ $statement = match ($this->lexer->lookahead['type']) {
 };
 
 $non_sql = "NO SELECT HIGHLIGHTING!";
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.double.php - meta.interpolation
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.double.php - meta.interpolation - string string
 //         ^ punctuation.definition.string.begin
 //             ^ - source.sql
 //                                 ^ punctuation.definition.string.end
 
 $sql = "CREATE TABLE version";
-//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation - string string
 //      ^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
-//                          ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
+//                          ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation - string string
 //      ^^^^^^ keyword.other.create.sql
 
 $sql = "
@@ -1574,19 +1574,19 @@ $sql = "
 ";
 
 $sql = "SELECT * FROM users WHERE first_name = 'Eric'";
-//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation - string string
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //      ^ keyword.other.DML
 //                                             ^^^^^^ string.quoted.single.sql
-//                                                   ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
+//                                                   ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation - string string
 
 // Ensure we properly exist from SQL when hitting PHP end-of-string
 $sql = "SELECT * FROM users WHERE first_name = 'Eric";
-//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation
+//     ^ meta.string.php string.quoted.double.php punctuation.definition.string.begin.php - meta.interpolation - string string
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.double.php
 //      ^ keyword.other.DML
 //                                             ^^^^^ string.quoted.single.sql
-//                                                  ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
+//                                                  ^ meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation - string string
 
 $sql = "
     SELECT * FROM users WHERE first_name = 'Eric'
@@ -1594,21 +1594,21 @@ $sql = "
 //  ^ keyword.other.DML
 //                                         ^^^^^^ string.quoted.single.sql
 ";
-// <- meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation
+// <- meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation - string string
 
 $non_sql = 'NO SELECT HIGHLIGHTING!';
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation - string string
 //         ^ punctuation.definition.string.begin
 //             ^ - source.sql
 //                                 ^ punctuation.definition.string.end
 
 $sql = 'SELECT * FROM users WHERE first_name = \'Eric\'';
-//     ^ meta.string.php string.quoted.single.php punctuation.definition.string.begin.php - meta.interpolation
+//     ^ meta.string.php string.quoted.single.php punctuation.definition.string.begin.php - meta.interpolation - string string
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.single.php
 //      ^ keyword.other.DML
 //                                             ^^ constant.character.escape.php
 //                                                   ^^ constant.character.escape.php
-//                                                     ^ meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation
+//                                                     ^ meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation - string string
 
 $sql = '
     SELECT * FROM users WHERE first_name = \'Eric\'
@@ -1616,7 +1616,7 @@ $sql = '
 //  ^ keyword.other.DML
 //                                         ^^ constant.character.escape.php
 ';
-// <- meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation
+// <- meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation - string string
 
 preg_replace('/[a-zSOME_CHAR]*+\'\n  $justTxt  \1  \\1/m');
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single


### PR DESCRIPTION
This PR is part 2 to address https://github.com/sublimehq/sublime_text/issues/4763.

It refactors string related contexts in order to 

1. reduce application of branch_points and avoid as many context switches as possible.  
   It results in huge performance improvements when recovering from incomplete quoted strings in large files.
   While closing a quoted string at the beginning of a file of 500k lines took 16-19s before, it completes within 200-300ms with this PR merged.
2. apply proper `meta.string meta.interpolation` scopes as already done in other syntaxes.

Also loading such a huge file completes much faster as switching back to ST does after modifying the file externally.

While it required 16 seconds for ST do display again, it now completes nearly immediatelly.