### PR TITLE
[PHP] Do not highlight plain SQL indicator as SQL

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -9,7 +9,7 @@ variables:
   identifier: '\b{{identifier_start}}[[:alnum:]_]*\b'
   path: '\\?({{identifier}}\\)*{{identifier}}'
   regex_modifier: '[eimsuxADJSUX]*'
-  sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\b
+  sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)(?=$|\s)
   visibility_modifier: '\b(?:var|public|private|protected)\b'
 
 contexts:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -9,7 +9,7 @@ variables:
   identifier: '\b{{identifier_start}}[[:alnum:]_]*\b'
   path: '\\?({{identifier}}\\)*{{identifier}}'
   regex_modifier: '[eimsuxADJSUX]*'
-  sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)(?=$|\s)
+  sql_indicator: \s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)(?=\s)
   visibility_modifier: '\b(?:var|public|private|protected)\b'
 
 contexts:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1569,6 +1569,18 @@ $sql = "
 //  ^^^^^^ keyword.other.create.sql
 ";
 
+// Do not highlight plain SQL indicator as SQL
+$sql = "SELECT";
+//      ^^^^^^ - keyword.other.DML
+
+$sql = "
+    SELECT
+//  ^^^^^^ keyword.other.DML
+    *
+    FROM users
+    WHERE first_name = 'Eric'
+";
+
 $sql = "SELECT * FROM users WHERE first_name = 'Eric'";
 //     ^ string.quoted.double punctuation.definition.string.begin - meta.string-contents
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string-contents source.sql


### PR DESCRIPTION
```php
    $sql = "SELECT";
    //      ^^^^^^ - keyword.other.DML
```

Fixes https://github.com/sublimehq/Packages/issues/2956