### PR TITLE
[Markdown] Fix strikethrough within bold or italic text

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -466,6 +466,7 @@ contexts:
               pop: true
             - include: inline
             - include: bold
+            - include: strikethrough
             - include: bold-italic-trailing
         - match: \*
           scope: punctuation.definition.italic.end.markdown
@@ -483,8 +484,10 @@ contexts:
               pop: true
             - include: inline
             - include: italic
+            - include: strikethrough
             - include: bold-italic-trailing
         - include: inline
+        - include: strikethrough
         - include: bold-italic-trailing
     - match: '\*\*(?=\S)(?!\*\*|\*\s)'
       scope: punctuation.definition.bold.begin.markdown
@@ -503,6 +506,7 @@ contexts:
         - match: \b_(?=[^\s_])(?=[^*_]*\*\*)
           comment: eat the underscore that has no corresponding underscore before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
         - include: italic
+        - include: strikethrough
         - include: bold-italic-trailing
     - match: '\b(__)(_)(?=\S)(?!_)'
       captures:
@@ -535,6 +539,7 @@ contexts:
               pop: true
             - include: inline
             - include: italic
+            - include: strikethrough
             - include: bold-italic-trailing
         - match: __\b
           scope: punctuation.definition.bold.end.markdown
@@ -550,8 +555,10 @@ contexts:
               pop: true
             - include: inline
             - include: bold
+            - include: strikethrough
             - include: bold-italic-trailing
         - include: inline
+        - include: strikethrough
         - include: bold-italic-trailing
     - match: '\b__(?=\S)(?!_[_\s])'
       scope: punctuation.definition.bold.begin.markdown
@@ -570,6 +577,7 @@ contexts:
         - match: \*(?=[^\s*])(?=[^*_]*__\b)
           comment: eat the asterisk that has no corresponding asterisk before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
         - include: italic
+        - include: strikethrough
         - include: bold-italic-trailing
   bracket:
     - match: '<(?![A-Za-z/?!$])'
@@ -772,6 +780,7 @@ contexts:
         - include: inline
         - include: bold
         - match: '\*+'
+        - include: strikethrough
         - include: bold-italic-trailing
     - match: '\b_(?=\S)(?!_)'
       scope: punctuation.definition.italic.begin.markdown
@@ -789,6 +798,7 @@ contexts:
           pop: true
         - include: inline
         - include: bold
+        - include: strikethrough
         - include: bold-italic-trailing
     - match: '[*_]+'
   strikethrough:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1314,6 +1314,98 @@ __test!*test__ Issue 1163
 |      ^ - punctuation.definition.italic
 |           ^^ punctuation.definition.bold.end
 
+# Strikethrough Tests
+
+__~~bold striked~~__
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.strikethrough
+| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
+|                 ^^ markup.bold.markdown - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^^ punctuation.definition.strikethrough.begin.markdown
+|               ^^ punctuation.definition.strikethrough.end.markdown 
+|                 ^^ punctuation.definition.bold.end.markdown
+
+**~~bold striked~~**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.strikethrough
+| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
+|                 ^^ markup.bold.markdown - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^^ punctuation.definition.strikethrough.begin.markdown
+|               ^^ punctuation.definition.strikethrough.end.markdown 
+|                 ^^ punctuation.definition.bold.end.markdown
+
+_~~italic striked~~_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
+|                  ^ markup.italic.markdown - markup.strikethrough
+|^^ punctuation.definition.strikethrough.begin.markdown
+|                ^^ punctuation.definition.strikethrough.end.markdown 
+|                  ^ punctuation.definition.italic.end.markdown
+
+*~~italic striked~~*
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
+|                  ^ markup.italic.markdown - markup.strikethrough
+|^^ punctuation.definition.strikethrough.begin.markdown
+|                ^^ punctuation.definition.strikethrough.end.markdown 
+|                  ^ punctuation.definition.italic.end.markdown
+
+___~~bold italic striked~~___
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.italic - markup.strikethrough
+| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
+|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^ punctuation.definition.italic.begin.markdown
+|  ^^ punctuation.definition.strikethrough.begin.markdown
+|                       ^^ punctuation.definition.strikethrough.end.markdown 
+|                         ^ punctuation.definition.italic.end.markdown
+|                          ^^ punctuation.definition.bold.end.markdown
+
+***~~bold italic striked~~***
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.italic - markup.strikethrough
+| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
+|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^ punctuation.definition.italic.begin.markdown
+|  ^^ punctuation.definition.strikethrough.begin.markdown
+|                       ^^ punctuation.definition.strikethrough.end.markdown 
+|                         ^ punctuation.definition.italic.end.markdown
+|                          ^^ punctuation.definition.bold.end.markdown
+
+~Hi~ Hello, world!
+| <- punctuation.definition.strikethrough.begin
+|^^^ meta.paragraph markup.strikethrough
+|  ^ punctuation.definition.strikethrough.end
+|   ^^^^^^^^^^^^^^^ meta.paragraph - markup
+
+This ~text~~~~ is ~~~~curious~.
+|    ^^^^^^^^^ meta.paragraph markup.strikethrough
+|                 ^^^^^^^^^^^^ meta.paragraph markup.strikethrough
+|                             ^^ meta.paragraph - markup
+|    ^ punctuation.definition.strikethrough.begin
+|         ^^^^ punctuation.definition.strikethrough.end
+|                 ^^^^ punctuation.definition.strikethrough.begin
+|                            ^ punctuation.definition.strikethrough.end
+
+This ~~has a
+|    ^^^^^^^^ meta.paragraph markup.strikethrough
+
+| <- meta.paragraph markup.strikethrough invalid.illegal.non-terminated.bold-italic
+new paragraph~~.
+|            ^^ meta.paragraph markup.strikethrough punctuation.definition.strikethrough.begin
+
+| <- invalid.illegal.non-terminated.bold-italic
+
+# Fenced Code Block Tests
+
 ```js
 | <- punctuation.definition.raw.code-fence.begin
 |  ^^ constant.other.language-name
@@ -1390,33 +1482,6 @@ http://spec.commonmark.org/0.28/#example-318
 |  ^^^^ constant.other.language-name
   ```
 | ^^^ punctuation.definition.raw.code-fence.end
-
-https://github.github.com/gfm/#example-469
-~Hi~ Hello, world!
-| <- punctuation.definition.strikethrough.begin
-|^^^ meta.paragraph markup.strikethrough
-|  ^ punctuation.definition.strikethrough.end
-|   ^^^^^^^^^^^^^^^ meta.paragraph - markup
-
-https://github.github.com/gfm/#example-470
-This ~text~~~~ is ~~~~curious~.
-|    ^^^^^^^^^ meta.paragraph markup.strikethrough
-|                 ^^^^^^^^^^^^ meta.paragraph markup.strikethrough
-|                             ^^ meta.paragraph - markup
-|    ^ punctuation.definition.strikethrough.begin
-|         ^^^^ punctuation.definition.strikethrough.end
-|                 ^^^^ punctuation.definition.strikethrough.begin
-|                            ^ punctuation.definition.strikethrough.end
-
-https://github.github.com/gfm/#example-471
-This ~~has a
-|    ^^^^^^^^ meta.paragraph markup.strikethrough
-
-| <- meta.paragraph markup.strikethrough invalid.illegal.non-terminated.bold-italic
-new paragraph~~.
-|            ^^ meta.paragraph markup.strikethrough punctuation.definition.strikethrough.begin
-
-| <- invalid.illegal.non-terminated.bold-italic
 
 hello world ````test````
 |           ^^^^^^^^^^^^ markup.raw.inline


### PR DESCRIPTION
This commit fixes missing strikethrough highlighting within bold or italic formatted text.

Some of the existing tests are moved to the new "Strikethrough Tests" section. Existing links to github are removed as those no longer point to correct examples. The existing tests keep otherwise unchanged.