### PR TITLE
[C#] rework tuple scopes to match Python

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1366,8 +1366,8 @@ contexts:
     - match: (?=\()
       branch_point: tuple_or_group
       branch:
-        - group-begin
-        - tuple-begin
+        - group_begin
+        - tuple_begin
     - match: \{
       scope: punctuation.section.block.begin.cs
       set:
@@ -1378,13 +1378,13 @@ contexts:
     - match: (?=[]}>,]|{{reserved}})
       pop: true
 
-  group-begin:
+  group_begin:
     - meta_include_prototype: false
     - match: \(
       scope: punctuation.section.group.begin.cs
       set: group
 
-  tuple-begin:
+  tuple_begin:
     - meta_include_prototype: false
     - match: \(
       scope: punctuation.section.sequence.begin.cs
@@ -1457,7 +1457,7 @@ contexts:
 
   function_call_arguments:
     - meta_content_scope: meta.function-call.cs meta.group.cs
-    - match: '\)'
+    - match: \)
       scope: meta.function-call.cs meta.group.cs punctuation.section.group.end.cs
       pop: true
     - match: ''

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1366,12 +1366,8 @@ contexts:
     - match: (?=\()
       branch_point: tuple_or_group
       branch:
-        - - match: \(
-            scope: punctuation.section.group.begin.cs
-            set: group
-        - - match: \(
-            scope: punctuation.section.sequence.begin.cs
-            set: tuple
+        - group-begin
+        - tuple-begin
     - match: \{
       scope: punctuation.section.block.begin.cs
       set:
@@ -1381,6 +1377,18 @@ contexts:
         - include: code_block_in
     - match: (?=[]}>,]|{{reserved}})
       pop: true
+
+  group-begin:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.group.begin.cs
+      set: group
+
+  tuple-begin:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.sequence.begin.cs
+      set: tuple
 
   tuple:
     - meta_scope: meta.sequence.tuple.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1525,9 +1525,8 @@ contexts:
       scope: punctuation.section.sequence.begin.cs
       set:
         - meta_scope: meta.sequence.tuple.cs
-        - match: (\))
-          captures:
-            1: punctuation.section.sequence.end.cs
+        - match: \)
+          scope: punctuation.section.sequence.end.cs
           pop: true
         - match: ','
           scope: punctuation.separator.sequence.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1226,6 +1226,8 @@ contexts:
     - match: ';'
       scope: punctuation.terminator.statement.cs
       pop: true
+    - match: (?=\))
+      pop: true
 
   line_of_code_in_no_semicolon:
     - match: \b(value)\b
@@ -1361,12 +1363,15 @@ contexts:
             2: punctuation.separator.cs
             3: punctuation.section.brackets.end.cs
             4: keyword.operator.pointer.cs
-    - match: \(
-      scope: punctuation.section.group.begin.cs
+    - match: (?=\()
       branch_point: tuple_or_group
       branch:
-        - group
-        - tuple
+        - - match: \(
+            scope: punctuation.section.group.begin.cs
+            set: group
+        - - match: \(
+            scope: punctuation.section.sequence.begin.cs
+            set: tuple
     - match: \{
       scope: punctuation.section.block.begin.cs
       set:
@@ -1374,16 +1379,16 @@ contexts:
           scope: punctuation.section.block.end.cs
           pop: true
         - include: code_block_in
-    - match: (?=\}|\)|>|\]|,|{{reserved}})
+    - match: (?=[]}>,]|{{reserved}})
       pop: true
 
   tuple:
-    - meta_scope: meta.group.tuple.cs
+    - meta_scope: meta.sequence.tuple.cs
     - match: \)
-      scope: punctuation.section.group.end.cs
+      scope: punctuation.section.sequence.end.cs
       pop: true
     - match: ','
-      scope: punctuation.separator.tuple.cs
+      scope: punctuation.separator.sequence.cs
     - match: ':'
       scope: keyword.operator.assignment.cs
     - match: _\b
@@ -1422,19 +1427,31 @@ contexts:
 
   attribute_arguments:
     - meta_content_scope: meta.annotation.cs meta.group.cs
+    - match: \)
+      scope: punctuation.section.group.end.cs
     - match: ''
       set: attribute_in
 
   constructor_arguments:
     - meta_content_scope: meta.instance.cs meta.group.cs
-    - match: '(?=[^\s{])'
+    - match: \)
+      scope: punctuation.section.group.end.cs
+      set: maybe_constructor_initializer
+    - include: maybe_constructor_initializer
+
+  maybe_constructor_initializer:
+    - meta_content_scope: meta.instance.cs meta.group.cs
+    - match: (?=[^\s{])
       pop: true
-    - match: '\{'
+    - match: \{
       scope: punctuation.section.braces.begin.cs
       set: initializer_constructor
 
   function_call_arguments:
     - meta_content_scope: meta.function-call.cs meta.group.cs
+    - match: '\)'
+      scope: meta.function-call.cs meta.group.cs punctuation.section.group.end.cs
+      pop: true
     - match: ''
       pop: true
 
@@ -1464,8 +1481,7 @@ contexts:
       push: line_of_code_in
     - match: ','
       scope: punctuation.separator.argument.cs
-    - match: \)
-      scope: punctuation.section.group.end.cs
+    - match: (?=\))
       pop: true
     - match: ;
       scope: invalid.illegal.expected-close-paren.cs
@@ -1475,7 +1491,7 @@ contexts:
       push:
         - include: lambdas
         - include: line_of_code_in_no_semicolon
-        - match: (?=;)
+        - match: (?=[;)])
           pop: true
 
   accessor_arguments:
@@ -1498,15 +1514,15 @@ contexts:
 
   type_tuple:
     - match: \(
-      scope: punctuation.section.group.begin.cs
+      scope: punctuation.section.sequence.begin.cs
       set:
-        - meta_scope: meta.group.tuple.cs
+        - meta_scope: meta.sequence.tuple.cs
         - match: (\))
           captures:
-            1: punctuation.section.group.end.cs
+            1: punctuation.section.sequence.end.cs
           pop: true
         - match: ','
-          scope: punctuation.separator.tuple.cs
+          scope: punctuation.separator.sequence.cs
         - match: (?=\S)
           push: var_declaration_explicit
 
@@ -2033,14 +2049,14 @@ contexts:
         - match: '\bwhen\b'
           scope: keyword.control.switch.case.when.cs
         - match: \(
-          scope: punctuation.section.group.begin.cs
+          scope: punctuation.section.sequence.begin.cs
           push:
-            - meta_scope: meta.group.tuple.cs
+            - meta_scope: meta.sequence.tuple.cs
             - match: \)
-              scope: punctuation.section.group.end.cs
+              scope: punctuation.section.sequence.end.cs
               pop: true
             - match: ','
-              scope: punctuation.separator.tuple.cs
+              scope: punctuation.separator.sequence.cs
             - match: _\b
               scope: variable.language.deconstruction.discard.cs
             - include: line_of_code_in_no_semicolon # needed for "when" syntax?
@@ -2090,18 +2106,18 @@ contexts:
     - match: (var)\s*(\()
       captures:
         1: storage.type.variable.cs
-        2: meta.group.tuple.cs punctuation.definition.group.begin.cs
+        2: meta.sequence.tuple.cs punctuation.section.sequence.begin.cs
       set:
-        - meta_content_scope: meta.group.tuple.cs
+        - meta_content_scope: meta.sequence.tuple.cs
         - match: \)
-          scope: meta.group.tuple.cs punctuation.definition.group.end.cs
+          scope: meta.sequence.tuple.cs punctuation.section.sequence.end.cs
           pop: true
         - match: _\b
           scope: variable.language.deconstruction.discard.cs
         - match: '{{name}}'
           scope: variable.other.cs
         - match: ','
-          scope: punctuation.separator.tuple.cs
+          scope: punctuation.separator.sequence.cs
     - match: '(var)\s+({{name}})\s*'
       captures:
         1: storage.type.variable.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -319,97 +319,97 @@ class Foo {
     // https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#tuples
     public void TupleTest () {
         var letters = ("a", "b");
-///                   ^^^^^^^^^^ meta.group.tuple
-///                   ^ punctuation.section.group.begin
-///                       ^ punctuation.separator.tuple
-///                            ^ punctuation.section.group.end
+///                   ^^^^^^^^^^ meta.sequence.tuple
+///                   ^ punctuation.section.sequence.begin
+///                       ^ punctuation.separator.sequence
+///                            ^ punctuation.section.sequence.end
 ///                             ^ punctuation.terminator.statement
         var (a, b, c) = (1, 2, 3);
 ///     ^^^ storage.type.variable
-///         ^^^^^^^^^ meta.group.tuple
+///         ^^^^^^^^^ meta.sequence.tuple
 ///          ^ variable.other
-///           ^ punctuation.separator.tuple
+///           ^ punctuation.separator.sequence
 ///             ^ variable.other
-///              ^ punctuation.separator.tuple
-///                   ^ keyword.operator.assignment - meta.group
-///                     ^^^^^^^^^ meta.group.tuple
+///              ^ punctuation.separator.sequence
+///                   ^ keyword.operator.assignment - meta.group - meta.sequence
+///                     ^^^^^^^^^ meta.sequence.tuple
 ///                      ^ meta.number.integer.decimal constant.numeric.value
-///                       ^ punctuation.separator.tuple
+///                       ^ punctuation.separator.sequence
         (string Alpha, string Beta) namedLetters = ("a", "b");
-///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///     ^ punctuation.section.group.begin
+///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///     ^ punctuation.section.sequence.begin
 ///      ^^^^^^ storage.type
 ///             ^^^^^ variable.other
-///                  ^ punctuation.separator.tuple
+///                  ^ punctuation.separator.sequence
 ///                    ^^^^^^ storage.type
 ///                           ^^^^ variable.other
-///                               ^ punctuation.section.group.end
+///                               ^ punctuation.section.sequence.end
 ///                                 ^^^^^^^^^^^^ variable.other
 ///                                              ^ keyword.operator.assignment
-///                                                ^ punctuation.section.group.begin
-///                                                    ^ punctuation.separator.tuple
-///                                                         ^ punctuation.section.group.end
+///                                                ^ punctuation.section.sequence.begin
+///                                                    ^ punctuation.separator.sequence
+///                                                         ^ punctuation.section.sequence.end
 ///                                                          ^ punctuation.terminator.statement
 
         (
-///     ^ meta.group.tuple punctuation.section.group.begin
+///     ^ meta.sequence.tuple punctuation.section.sequence.begin
             string Alpha,
 ///         ^^^^^^ storage.type
 ///                ^^^^^ variable.other
-///                     ^ punctuation.separator.tuple
+///                     ^ punctuation.separator.sequence
             string Beta
         ) namedLetters = ("a", "b");
-///     ^ punctuation.section.group.end
+///     ^ punctuation.section.sequence.end
 ///       ^^^^^^^^^^^^ variable.other
 ///                    ^ keyword.operator.assignment
-///                      ^ punctuation.section.group.begin
-///                          ^ punctuation.separator.tuple
-///                               ^ punctuation.section.group.end
+///                      ^ punctuation.section.sequence.begin
+///                          ^ punctuation.separator.sequence
+///                               ^ punctuation.section.sequence.end
 ///                                ^ punctuation.terminator.statement
 
         (SomeType[] Alpha, SomeType<int> Beta) example = (a, b);
-///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///     ^ punctuation.section.group.begin
+///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///     ^ punctuation.section.sequence.begin
 ///      ^^^^^^^^ support.type
 ///              ^ punctuation.section.brackets.begin
 ///               ^ punctuation.section.brackets.end
 ///                 ^^^^^ variable.other
-///                      ^ punctuation.separator.tuple
+///                      ^ punctuation.separator.sequence
 ///                        ^^^^^^^^ support.type
 ///                                ^ punctuation.definition.generic.begin
 ///                                 ^^^ storage.type
 ///                                    ^ punctuation.definition.generic.end
 ///                                      ^^^^ variable.other
-///                                          ^ punctuation.section.group.end
+///                                          ^ punctuation.section.sequence.end
 ///                                            ^^^^^^^ variable.other
 ///                                                    ^ keyword.operator.assignment
-///                                                      ^^^^^^ meta.group.tuple
-///                                                      ^ punctuation.section.group.begin
+///                                                      ^^^^^^ meta.sequence.tuple
+///                                                      ^ punctuation.section.sequence.begin
 ///                                                       ^ variable.other
-///                                                        ^ punctuation.separator.tuple
-///                                                           ^ punctuation.section.group.end
+///                                                        ^ punctuation.separator.sequence
+///                                                           ^ punctuation.section.sequence.end
 ///                                                            ^ punctuation.terminator.statement
         var alphabetStart = (Alpha: "a", Beta: "b");
-///                         ^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///                         ^ punctuation.section.group.begin
+///                         ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///                         ^ punctuation.section.sequence.begin
 ///                          ^^^^^ variable.other
 ///                               ^ keyword.operator.assignment
-///                                    ^ punctuation.separator.tuple
+///                                    ^ punctuation.separator.sequence
 ///                                      ^^^^ variable.other
 ///                                          ^ keyword.operator.assignment
-///                                               ^ punctuation.section.group.end
+///                                               ^ punctuation.section.sequence.end
 ///                                                ^ punctuation.terminator.statement
         var abc = (this as object, input);
-///               ^ punctuation.section.group.begin
+///               ^ punctuation.section.sequence.begin
 ///                ^^^^ variable.language
 ///                     ^^ keyword.operator.reflection
 ///                        ^^^^^^ storage.type
-///                              ^ punctuation.separator.tuple
+///                              ^ punctuation.separator.sequence
 ///                                ^^^^^ variable.other
-///                                     ^ punctuation.section.group.end
+///                                     ^ punctuation.section.sequence.end
 ///                                      ^ punctuation.terminator.statement
         var abc = (example.Alpha as SomeType);
-///               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group - meta.group.tuple
+///               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group - meta.sequence
 ///               ^ punctuation.section.group.begin
 ///                ^^^^^^^ variable.other
 ///                       ^ punctuation.accessor.dot
@@ -420,74 +420,74 @@ class Foo {
 ///                                          ^ punctuation.terminator.statement
         // https://docs.microsoft.com/en-us/dotnet/csharp/deconstruct
         (string city, _, double area) = QueryCityData("New York City");
-///     ^ punctuation.section.group.begin
+///     ^ punctuation.section.sequence.begin
 ///      ^^^^^^ storage.type
 ///             ^^^^ variable.other
-///                 ^ punctuation.separator.tuple
+///                 ^ punctuation.separator.sequence
 ///                   ^ variable.language.deconstruction.discard
-///                    ^ punctuation.separator.tuple
+///                    ^ punctuation.separator.sequence
 ///                      ^^^^^^ storage.type
 ///                             ^^^^ variable.other
-///                                 ^ punctuation.section.group.end
+///                                 ^ punctuation.section.sequence.end
 ///                                   ^ keyword.operator.assignment
         (city, population, _) = QueryCityData("New York City");
-///     ^ punctuation.section.group.begin
+///     ^ punctuation.section.sequence.begin
 ///      ^^^^ variable.other
-///          ^ punctuation.separator.tuple
+///          ^ punctuation.separator.sequence
 ///            ^^^^^^^^^^ variable.other
-///                      ^ punctuation.separator.tuple
+///                      ^ punctuation.separator.sequence
 ///                        ^ variable.language.deconstruction
-///                         ^ punctuation.section.group.end
+///                         ^ punctuation.section.sequence.end
 ///                           ^ keyword.operator.assignment
         var (_, _, _, pop1, _, pop2) = QueryCityDataForYears("New York City", 1960, 2010);
 ///     ^^^ storage.type.variable
-///         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///                                 ^ - meta.group
-///         ^ punctuation.definition.group.begin
+///         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///                                 ^ - meta.sequence
+///         ^ punctuation.section.sequence.begin
 ///          ^ variable.language
-///           ^ punctuation.separator.tuple
+///           ^ punctuation.separator.sequence
 ///             ^ variable.language
-///              ^ punctuation.separator.tuple
+///              ^ punctuation.separator.sequence
 ///                   ^^^^ variable.other
-///                       ^ punctuation.separator.tuple
+///                       ^ punctuation.separator.sequence
 ///                         ^ variable.language
-///                          ^ punctuation.separator.tuple
+///                          ^ punctuation.separator.sequence
 ///                            ^^^^ variable.other
-///                                ^ punctuation.definition.group.end
+///                                ^ punctuation.section.sequence.end
         (Func<int, int> test1, string test2) = ((int d) => d * 2, 5.ToString());
-///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
+///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
 ///      ^^^^ support.type
 ///          ^^^^^^^^^^ meta.generic
 ///                     ^^^^^ variable.other
-///                          ^ punctuation.separator.tuple
+///                          ^ punctuation.separator.sequence
 ///                            ^^^^^^ storage.type
 ///                                   ^^^^^ variable.other
-///                                          ^ keyword.operator.assignment - meta.group
-///                                            ^ meta.group.tuple punctuation.section.group.begin
+///                                          ^ keyword.operator.assignment - meta.sequence
+///                                            ^ meta.sequence.tuple punctuation.section.sequence.begin
 ///                                             ^^^^^^^^^^^^^^^^ meta.function.anonymous
-///                                                             ^ punctuation.separator.tuple - meta.function.anonymous
+///                                                             ^ punctuation.separator.sequence - meta.function.anonymous
 ///                                                               ^ meta.number.integer.decimal constant.numeric.value
 ///                                                                ^ punctuation.accessor.dot
 ///                                                                 ^^^^^^^^ variable.function
 ///                                                                         ^ punctuation.section.group.begin
 ///                                                                          ^ punctuation.section.group.end
-///                                                                           ^ punctuation.section.group.end
+///                                                                           ^ punctuation.section.sequence.end
         (a, b) = (new Random().Next(), 15);
 ///               ^^^ keyword.operator.new
 ///                   ^^^^^^ support.type
-///                                  ^ punctuation.separator.tuple
-///                                    ^^ meta.group.tuple meta.number.integer.decimal constant.numeric.value
-///                                      ^ punctuation.section.group.end
+///                                  ^ punctuation.separator.sequence
+///                                    ^^ meta.sequence.tuple meta.number.integer.decimal constant.numeric.value
+///                                      ^ punctuation.section.sequence.end
 
         var dic = new Dictionary<string, int> { ["Bob"] = 32, ["Alice"] = 17 };
         foreach (var (name, age) in dic.Select(x => (x.Key, x.Value)))
 ///              ^^^ storage.type.variable
-///                  ^^^^^^^^^^^ meta.group.tuple
-///                  ^ punctuation.definition.group.begin
+///                  ^^^^^^^^^^^ meta.sequence.tuple
+///                  ^ punctuation.section.sequence.begin
 ///                   ^^^^ variable.other
-///                       ^ punctuation.separator.tuple
+///                       ^ punctuation.separator.sequence
 ///                         ^^^ variable.other
-///                            ^ punctuation.definition.group.end
+///                            ^ punctuation.section.sequence.end
 ///                              ^^ keyword.control.flow
         {
             Console.WriteLine($"{name} is {age} years old.");
@@ -497,12 +497,12 @@ class Foo {
         foreach (var(x, y) in positions)
 ///             ^ punctuation.section.group.begin
 ///              ^^^storage.type.variable
-///                 ^^^^^^ meta.group.tuple
-///                 ^ punctuation.definition.group.begin
+///                 ^^^^^^ meta.sequence.tuple
+///                 ^ punctuation.section.sequence.begin
 ///                  ^ variable.other
-///                   ^ punctuation.separator.tuple
+///                   ^ punctuation.separator.sequence
 ///                     ^ variable.other
-///                      ^ punctuation.definition.group.end
+///                      ^ punctuation.section.sequence.end
 ///                        ^^ keyword.control.flow
 ///                           ^^^^^^^^^ variable.other
 ///                                    ^ punctuation.section.group.end
@@ -512,15 +512,15 @@ class Foo {
 
         foreach ((var a, var b) in positions)
 ///     ^^^^^^^ meta.class.body meta.block meta.method.body meta.block keyword.control.loop.foreach
-///             ^ punctuation.section.group.begin - meta.group.tuple
-///              ^^^^^^^^^^^^^^ meta.group.tuple
-///              ^ punctuation.section.group.begin
+///             ^ punctuation.section.group.begin - meta.sequence
+///              ^^^^^^^^^^^^^^ meta.sequence.tuple
+///              ^ punctuation.section.sequence.begin
 ///               ^^^ support.type
 ///                   ^ variable.other
-///                    ^ punctuation.separator.tuple
+///                    ^ punctuation.separator.sequence
 ///                      ^^^ support.type
 ///                          ^ variable.other
-///                           ^ punctuation.section.group.end
+///                           ^ punctuation.section.sequence.end
 ///                             ^^ keyword.control.flow
 ///                                ^^^^^^^^^ variable.other
 ///                                         ^ punctuation.section.group.end
@@ -532,13 +532,13 @@ class Foo {
     private static (int Max, int Min) Range(IEnumerable<int> numbers)
 /// ^^^^^^^ storage.modifier.access
 ///         ^^^^^^ storage.modifier
-///                ^ punctuation.section.group.begin
+///                ^ punctuation.section.sequence.begin
 ///                 ^^^ storage.type
 ///                     ^^^ variable.other
-///                        ^ punctuation.separator.tuple
+///                        ^ punctuation.separator.sequence
 ///                          ^^^ storage.type
 ///                              ^^^ variable.other
-///                                 ^ punctuation.section.group.end
+///                                 ^ punctuation.section.sequence.end
 ///                                   ^^^^^ entity.name.function - entity.name.function.constructor
 ///                                        ^ punctuation.section.parameters.begin
 ///                                         ^^^^^^^^^^^ support.type
@@ -557,38 +557,38 @@ class Foo {
         }
         return (max, min);
 ///     ^^^^^^ keyword.control.flow.return
-///            ^ punctuation.section.group.begin
+///            ^ punctuation.section.sequence.begin
 ///             ^^^ variable.other
-///                ^ punctuation.separator.tuple
+///                ^ punctuation.separator.sequence
 ///                  ^^^ variable.other
-///                     ^ punctuation.section.group.end
+///                     ^ punctuation.section.sequence.end
 ///                      ^ punctuation.terminator.statement
 
         Func<string, (string example1, int Example2)> test = s => (example1: "hello", Example2: "world");
 ///     ^^^^ support.type
 ///         ^ punctuation.definition.generic.begin
 ///         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
-///                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///                  ^ punctuation.section.group.begin
+///                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///                  ^ punctuation.section.sequence.begin
 ///                   ^^^^^^ storage.type
 ///                          ^^^^^^^^ variable.other
-///                                  ^ punctuation.separator.tuple
+///                                  ^ punctuation.separator.sequence
 ///                                    ^^^ storage.type
 ///                                        ^^^^^^^^ variable.other
-///                                                ^ punctuation.section.group.end
+///                                                ^ punctuation.section.sequence.end
 ///                                                 ^ punctuation.definition.generic.end
 ///                                                   ^^^^ variable.other
 ///                                                        ^ keyword.operator.assignment.variable
 ///                                                          ^ variable.parameter
 ///                                                            ^^ keyword.declaration.function.arrow
-///                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
-///                                                               ^ punctuation.section.group.begin
+///                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
+///                                                               ^ punctuation.section.sequence.begin
 ///                                                                ^^^^^^^^ variable.other
 ///                                                                        ^ keyword.operator.assignment
-///                                                                                 ^ punctuation.separator
+///                                                                                 ^ punctuation.separator.sequence
 ///                                                                                   ^^^^^^^^ variable.other
 ///                                                                                           ^ keyword.operator.assignment
-///                                                                                                    ^ punctuation.section.group.end
+///                                                                                                    ^ punctuation.section.sequence.end
 ///                                                                                                     ^ punctuation.terminator.statement
     }
 
@@ -603,35 +603,35 @@ class Foo {
 ///             ^^^^^^^ entity.name.function
 ///                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method.parameters
 ///                    ^ punctuation.section.parameters.begin
-///                     ^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///                     ^ punctuation.section.group.begin
+///                     ^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///                     ^ punctuation.section.sequence.begin
 ///                      ^^^ storage.type
 ///                          ^^^ variable.other
-///                             ^ punctuation.separator.tuple
+///                             ^ punctuation.separator.sequence
 ///                               ^^^^^ storage.type
 ///                                     ^^^ variable.other
-///                                        ^ punctuation.section.group.end
+///                                        ^ punctuation.section.sequence.end
 ///                                          ^^^ variable.parameter
 ///                                             ^ punctuation.separator.parameter.function
-///                                               ^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
+///                                               ^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
 ///                                                                     ^^^^^^^^ variable.parameter
 ///                                                                             ^ punctuation.section.parameters.end
     public void Example((int , float ) val, (int, string) otherVal) {}
 ///             ^^^^^^^ entity.name.function
 ///                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method.parameters
-///                     ^^^^^^^^^^^^^^ meta.group.tuple
+///                     ^^^^^^^^^^^^^^ meta.sequence.tuple
 ///                      ^^^ storage.type
-///                          ^ punctuation.separator.tuple
+///                          ^ punctuation.separator.sequence
 ///                            ^^^^^ storage.type
-///                                  ^ punctuation.section.group.end
-///                                    ^^^ variable.parameter - meta.group.tuple
+///                                  ^ punctuation.section.sequence.end
+///                                    ^^^ variable.parameter - meta.sequence
 ///                                       ^ punctuation.separator.parameter.function
-///                                         ^^^^^^^^^^^^^ meta.group.tuple
-///                                         ^ punctuation.section.group.begin
+///                                         ^^^^^^^^^^^^^ meta.sequence.tuple
+///                                         ^ punctuation.section.sequence.begin
 ///                                          ^^^ storage.type
-///                                             ^ punctuation.separator.tuple
+///                                             ^ punctuation.separator.sequence
 ///                                               ^^^^^^ storage.type
-///                                                     ^ punctuation.section.group.end
+///                                                     ^ punctuation.section.sequence.end
 ///                                                       ^^^^^^^^ variable.parameter
 ///                                                               ^ punctuation.section.parameters.end
 }
@@ -784,7 +784,8 @@ public class MyClass {
 ///                      ^^^ variable.other
 ///                          ^ keyword.operator.assignment
 ///                            ^^^^ constant.language
-///                                ^ punctuation.terminator.statement - meta.method
+///                                ^ punctuation.terminator.statement
+///                                 ^ - meta.method
 }
 /// <- meta.class.body meta.block punctuation.section.block.end
 
@@ -806,17 +807,18 @@ public class Person // https://stackoverflow.com/a/41974829/4473405
 ///                                   ^ punctuation.section.parameters.end
 ///                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method
 ///                                     ^^ keyword.declaration.function.arrow.cs
-///                                        ^ meta.group punctuation.section.group.begin
-///                                         ^^^^ meta.group variable.other
-///                                             ^ meta.group punctuation.separator.tuple
-///                                               ^^^ meta.group variable.other
-///                                                  ^ meta.group punctuation.section.group.end
+///                                        ^^^^^^^^^^^ meta.sequence.tuple
+///                                        ^ punctuation.section.sequence.begin
+///                                         ^^^^ variable.other
+///                                             ^ punctuation.separator.sequence
+///                                               ^^^ variable.other
+///                                                  ^ punctuation.section.sequence.end
 ///                                                    ^ keyword.operator.assignment
-///                                                      ^ meta.group punctuation.section.group.begin
-///                                                       ^^^^ meta.group variable.other
-///                                                           ^ punctuation.separator.tuple
-///                                                             ^^^ meta.group variable.other
-///                                                                ^ meta.group punctuation.section.group.end
+///                                                      ^ punctuation.section.sequence.begin
+///                                                       ^^^^ variable.other
+///                                                           ^ punctuation.separator.sequence
+///                                                             ^^^ variable.other
+///                                                                ^ punctuation.section.sequence.end
 ///                                                                 ^ punctuation.terminator.statement
 }
 

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -219,7 +219,7 @@ static Quadrant GetQuadrant(Point point) => point switch
     (0, 0) => Quadrant.Origin,
     var (x, y) when x > 0 && y > 0 => Quadrant.One,
 /// ^^^ storage.type.variable
-///     ^^^^^^ meta.group.tuple
+///     ^^^^^^ meta.sequence.tuple
 ///            ^^^^ keyword.control.switch.case.when
 ///                 ^ variable.other
 ///                   ^ keyword.operator
@@ -238,9 +238,9 @@ static Quadrant GetQuadrant(Point point) => point switch
     var (x, y) when x > 0 && y < 0 => Quadrant.Four,
     var (_, _) => Quadrant.OnBorder,
 /// ^^^ storage.type.variable
-///     ^^^^^^ meta.group.tuple
+///     ^^^^^^ meta.sequence.tuple
 ///      ^ variable.language.deconstruction.discard
-///       ^ punctuation.separator.tuple
+///       ^ punctuation.separator.sequence
 ///         ^ variable.language.deconstruction.discard
     _ => Quadrant.Unknown
 /// ^ variable.language.deconstruction.discard

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -127,18 +127,18 @@ static bool CheckIfCanWalkIntoBank(Bank bank, bool isVip)
 {
     return (bank.Status, isVip) switch
 /// ^^^^^^ keyword.control.flow.return
-///        ^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
+///        ^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
 ///                             ^^^^^^ keyword.control.flow
     {
         (BankBranchStatus.Open, _) => true,
-///     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.tuple
-///     ^ punctuation.section.group.begin
+///     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
+///     ^ punctuation.section.sequence.begin
 ///      ^^^^^^^^^^^^^^^^ variable.other
 ///                      ^ punctuation.accessor.dot
 ///                       ^^^^ variable.other
-///                           ^ punctuation.separator.tuple
+///                           ^ punctuation.separator.sequence
 ///                             ^ variable.language.deconstruction.discard
-///                              ^ punctuation.section.group.end
+///                              ^ punctuation.section.sequence.end
 ///                                ^^ punctuation.separator.case-expression
 ///                                   ^^^^ constant.language
 ///                                       ^ punctuation.terminator.case-expression


### PR DESCRIPTION
Change the meta and punctuation scopes used for tuples in the C# syntax to match the Python syntax definition - from `meta.group.tuple punctuation.section.group.begin` to `meta.sequence.tuple punctuation.section.sequence.begin` etc.
Suggested in https://github.com/sublimehq/Packages/pull/2838#discussion_r690632925