### PR TITLE
[Markdown] Fix backtick auto-pairing

### DIFF
--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -56,7 +56,8 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selection_empty", "match_all": true },
             { "key": "selector", "operand": "text.html.markdown - markup.raw - meta.code-fence" },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?<![\\\\])([\\\\]{2})*$", "match_all": true }
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\\w`]$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|\\.|,|$)", "match_all": true }
         ]
     },
     {


### PR DESCRIPTION
Fixes #2973

This PR...

1. fixes wrong `preceding_text` context pattern, which was originally actually designed for auto-pairing asterisks.
2. adds `following_text` pattern to make sure to auto-pair backticks only when likely.

Auto pairing takes place if following conditions are met:

- caret is not located directly after a word or backtick
- caret is followed by
  - whitespace
  - closing bracket
  - sentence punctuation (comma, full stop)
  - end of line