### PR TITLE
[CSS] Add indentation rules

### DIFF
--- a/CSS/Indentation Rules - Comments.tmPreferences
+++ b/CSS/Indentation Rules - Comments.tmPreferences
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.css comment.block</string>
+	<key>settings</key>
+	<dict>
+		<!--
+		This file makes sure to align CSS content after documentation
+		comments with opening /* rather than closing */.
+
+		Example:
+
+		/**
+		 * Doc
+		 **/
+
+		p {
+		}
+		-->
+		<key>preserveIndent</key>
+		<true/>
+		<key>unIndentedLinePattern</key>
+		<string>.</string>
+	</dict>
+</dict>
+</plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.css</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*[)\]}]</string>
+		<key>increaseIndentPattern</key>
+		<string>^.*[(\[{](?:\s*/\*.*\*/)*\s*(?://.*)?$</string>
+		<key>unIndentedLinePattern</key>
+		<string>^\s*((/\*|\*/).*)?$</string>
+	</dict>
+</dict>
+</plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -41,7 +41,7 @@
 			#   ST doesn't apply `Indentation Rules - Comments`, because
 			#   comment scope doesn't cover the whole line. So they need
 			#   to be excluded from indentation engine here.
-			^\s* (?: /\* | \*+/ )
+			^\s* (?: /\*(?!.*\*/) | \*+/ )
 		]]></string>
 	</dict>
 </dict>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -41,7 +41,7 @@
 			#   ST doesn't apply `Indentation Rules - Comments`, because
 			#   comment scope doesn't cover the whole line. So they need
 			#   to be excluded from indentation engine here.
-			^\s* (?: (?: /\* | \*+/ ) .* )?$
+			^\s* (?: /\* | \*+/ )
 		]]></string>
 	</dict>
 </dict>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -8,9 +8,35 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*[)\]}]</string>
 		<key>increaseIndentPattern</key>
-		<string>^.*[(\[{](?:\s*/\*.*\*/)*\s*(?:/\*.*)?$</string>
+		<string><![CDATA[(?x)
+			# any text
+			^.*
+			# follwed by opening bracket
+			[(\[{]
+			# optionally followed by...
+			(?<balanced>
+			# balanced parenthesis
+			  \( (?: \g<balanced> | [^)] )* \)
+			# balanced brackets
+		  	| \[ (?: \g<balanced> | [^]] )* \]
+			# balanced braces
+			| \{ (?: \g<balanced> | [^}] )* \}
+			# double quoted string with ignored escaped quotation marks
+			| \".*(?<![^\\]\\)(?<![\\]{3})\"
+			# single quoted string with ignored escaped quotation marks
+			| \'.*(?<![^\\]\\)\'
+			# block comment
+			| /\*.*?\*/
+			# anything but closing brackets
+			| [^])}]
+			)*
+			# ... until end of line
+			$
+		]]></string>
 		<key>unIndentedLinePattern</key>
-		<string>^\s*((/\*|\*/).*)?$</string>
+		<string>^\s*((?:/\*|\*/).*)?$</string>
+		<key>preserveIndent</key>
+		<true/>
 	</dict>
 </dict>
 </plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -36,7 +36,7 @@
 		<key>preserveIndent</key>
 		<false/>
 		<key>unIndentedLinePattern</key>
-		<string>^\s*(?:(?:/\*|\*+/).*)?$\n?</string>
+		<string>^\s*(?:(?:/\*|\*+/).*)?$</string>
 	</dict>
 </dict>
 </plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -22,11 +22,11 @@
 			# balanced braces
 			| \{ (?: \g<balanced> | [^}] )* \}
 			# double quoted string with ignored escaped quotation marks
-			| \".*(?<![^\\]\\)(?<![\\]{3})\"
+			| \" .*? (?<![^\\]\\)(?<![\\]{3})\"
 			# single quoted string with ignored escaped quotation marks
-			| \'.*(?<![^\\]\\)\'
+			| \' .*? (?<![^\\]\\)\'
 			# block comment
-			| /\*.*?\*/
+			| /\* .*? \*/
 			# anything but closing brackets
 			| [^])}]
 			)*

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -15,7 +15,7 @@
 			[(\[{]
 			# optionally followed by...
 			(?<balanced>
-			# balanced parenthesis
+			# balanced parentheses
 			  \( (?: \g<balanced> | [^)] )* \)
 			# balanced brackets
 		  	| \[ (?: \g<balanced> | [^]] )* \]
@@ -36,7 +36,13 @@
 		<key>preserveIndent</key>
 		<false/>
 		<key>unIndentedLinePattern</key>
-		<string>^\s*(?:(?:/\*|\*+/).*)?$</string>
+		<string><![CDATA[(?x)
+			# standalone begin or end of block comments
+			#   ST doesn't apply `Indentation Rules - Comments`, because
+			#   comment scope doesn't cover the whole line. So they need
+			#   to be excluded from indentation engine here.
+			^\s* (?: (?: /\* | \*+/ ) .* )?$
+		]]></string>
 	</dict>
 </dict>
 </plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -33,10 +33,10 @@
 			# ... until end of line
 			$
 		]]></string>
-		<key>unIndentedLinePattern</key>
-		<string>^\s*(?:(?:/\*|\*/).*)?$</string>
 		<key>preserveIndent</key>
-		<true/>
+		<false/>
+		<key>unIndentedLinePattern</key>
+		<string>^\s*(?:(?:/\*|\*+/).*)?$\n?</string>
 	</dict>
 </dict>
 </plist>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -8,7 +8,7 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*[)\]}]</string>
 		<key>increaseIndentPattern</key>
-		<string>^.*[(\[{](?:\s*/\*.*\*/)*\s*(?://.*)?$</string>
+		<string>^.*[(\[{](?:\s*/\*.*\*/)*\s*(?:/\*.*)?$</string>
 		<key>unIndentedLinePattern</key>
 		<string>^\s*((/\*|\*/).*)?$</string>
 	</dict>

--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -34,7 +34,7 @@
 			$
 		]]></string>
 		<key>unIndentedLinePattern</key>
-		<string>^\s*((?:/\*|\*/).*)?$</string>
+		<string>^\s*(?:(?:/\*|\*/).*)?$</string>
 		<key>preserveIndent</key>
 		<true/>
 	</dict>

--- a/CSS/syntax_test_indentation.css
+++ b/CSS/syntax_test_indentation.css
@@ -432,3 +432,11 @@ abbr[                           /* ; */ /* ] /* comment
 */
 }                               /* ; */ /* } /* comment
 */
+
+/**
+ * Handle lines with leading block comments as normal code.
+ **/
+.class {
+/**/ color: red;
+/**/ color /**/ : /**/ red /**/ ; /**/
+}

--- a/CSS/syntax_test_indentation.css
+++ b/CSS/syntax_test_indentation.css
@@ -381,7 +381,6 @@ abbr[                           /* ; } */
 }                               /* ; */ /* } /* comment
 */
 
-*/
 .class {                        /* ; */ /* } /* comment
 */
     color: red;                 /* ; */ /* } /* comment
@@ -389,7 +388,6 @@ abbr[                           /* ; } */
 }                               /* ; */ /* } /* comment
 */
 
-*/
 .class { color: red;            /* ; */ /* } /* comment
 */
     background: beige;          /* ; */ /* } /* comment
@@ -397,7 +395,6 @@ abbr[                           /* ; } */
 }                               /* ; */ /* } /* comment
 */
 
-*/
 .class { color: rgb(            /* ) ; */ /* } /* comment
 */
     background: beige;          /* ; */ /* } /* comment
@@ -405,7 +402,6 @@ abbr[                           /* ; } */
 }                               /* ; */ /* } /* comment
 */
 
-*/
 .class { color: rgb(0, 0, 0);   /* ; */ /* } /* comment
 */
     background: beige;          /* ; */ /* } /* comment
@@ -413,7 +409,6 @@ abbr[                           /* ; } */
 }                               /* ; */ /* } /* comment
 */
 
-*/
 abbr[title],                    /* ; */ /* } /* comment
 */
 abbr[                           /* ; */ /* ] /* comment
@@ -427,7 +422,6 @@ abbr[                           /* ; */ /* ] /* comment
 }                               /* ; */ /* } /* comment
 */
 
-*/
 .class a:not(                   /* ; */ /* ) /* comment
 */
     .css_button                 /* ; */ /* } /* comment

--- a/CSS/syntax_test_indentation.css
+++ b/CSS/syntax_test_indentation.css
@@ -196,7 +196,7 @@ abbr[                           /* ] }
 */
 } /**/ .foo /**/ {              /*
 */
-    color: red;                 /*
+    color: /**/ red;            /*
 */
 }                               /*
 */
@@ -239,7 +239,7 @@ abbr[                           /*
 /**
  * Test: Trailing comments spanning to next line
  * and containing closing brackets
- **/
+ **/ .class { color: red; }
 
 .class { color: red; }          /* }
 */

--- a/CSS/syntax_test_indentation.css
+++ b/CSS/syntax_test_indentation.css
@@ -1,17 +1,35 @@
 /* SYNTAX TEST reindent-unchanged "Packages/CSS/CSS.sublime-syntax" */
 
-.class { font-size: 10; }
+.class { color: red; }
 
-.class { font-size: 10;
+.class { color: red;
+}
+
+.class { color: red;
+    background: beige;
+}
+
+.class { color: rgb(
+    background: beige;
+}
+
+.class { color: rgb(0, 0, 0);
+    background: beige;
 }
 
 .class
 {
-    font-size: 10;
+    color: red;
 }
 
 .class {
-    font-size: 10;
+    color: red;
+}
+
+.class {
+    color: red;
+} .foo {
+    color: red;
 }
 
 abbr[title],
@@ -27,51 +45,396 @@ abbr[
     color: red;
 }
 
-.class {            /*
-    font-size: 10;  /*
-}                   /*
+/**
+ * Test: Incomplete trailing comments
+ **/
 
-abbr[title],        /*
-abbr[               /*
-    data-title      /*
-] {                 /*
-    color: red;     /*
-}                   /*
-                    /*
-.class a:not(       /*
-    .css_button     /*
-) {                 /*
-    color: red;     /*
-}                   /*
+.class { color: red; }          /*
+                                /*
+.class { color: red;            /*
+}                               /*
 
-.class {            /* comment */
-    font-size: 10;  /* comment */
-}                   /* comment */
-abbr[title],        /* comment */
-abbr[               /* comment */
-    data-title      /* comment */
-] {                 /* comment */
-    color: red;     /* comment */
-}                   /* comment */
-                    /* comment */
-.class a:not(       /* comment */
-    .css_button     /* comment */
-) {                 /* comment */
-    color: red;     /* comment */
-}                   /* comment */
+.class { color: red;            /*
+    background: beige;          /*
+}                               /*
 
-.class {            /* comment */ /**/ /*
-    font-size: 10;  /* comment */ /**/ /*
-}                   /* comment */ /**/ /*
-abbr[title],        /* comment */ /**/ /*
-abbr[               /* comment */ /**/ /*
-    data-title      /* comment */ /**/ /*
-] {                 /* comment */ /**/ /*
-    color: red;     /* comment */ /**/ /*
-}                   /* comment */ /**/ /*
-                    /* comment */ /**/ /*
-.class a:not(       /* comment */ /**/ /*
-    .css_button     /* comment */ /**/ /*
-) {                 /* comment */ /**/ /*
-    color: red;     /* comment */ /**/ /*
-}                   /* comment */ /**/ /*
+.class { color: rgb(            /*
+    background: beige;          /*
+}                               /*
+
+.class { color: rgb(0, 0, 0);   /*
+    background: beige;          /*
+}                               /*
+
+.class {                        /*
+    color: red;                 /*
+}                               /*
+                                /*
+.class /**/ {                   /*
+    color: red;                 /*
+} /**/ .foo /**/ {              /*
+    color: red;                 /*
+}                               /*
+fix highlighting */ }
+
+.class                          /*
+{                               /*
+    color: red;                 /*
+}                               /*
+
+abbr[title],                    /*
+abbr[                           /*
+    data-title                  /*
+] {                             /*
+    color: red;                 /*
+}                               /*
+                                /*
+.class a:not(                   /*
+    .css_button                 /*
+) {                             /*
+    color: red;                 /*
+}                               /*
+
+
+
+/**
+ * Test: Incomplete trailing comments with closing brackets
+ **/
+
+.class { color: red; }          /* }
+                                /* }
+.class { color: red;            /* }
+}                               /* }
+
+.class { color: red;            /* }
+    background: beige;          /* }
+}                               /* }
+
+.class { color: rgb(            /* ) }
+    background: beige;          /* }
+}                               /* }
+
+.class { color: rgb(0, 0, 0);   /* }
+    background: beige;          /* }
+}                               /* }
+
+.class {                        /* }
+    color: red;                 /* }
+}                               /* }
+                                /* }
+.class /**/ {                   /* }
+    color: red;                 /* }
+} /**/ .foo /**/ {              /* }
+    color: red;                 /* }
+}                               /* }
+fix highlighting */ }
+
+.class                          /* }
+{                               /* }
+    color: red;                 /* }
+}                               /* }
+
+abbr[title],                    /* }
+abbr[                           /* ] }
+    data-title                  /* }
+] {                             /* }
+    color: red;                 /* }
+}                               /* }
+                                /* }
+.class a:not(                   /* ) }
+    .css_button                 /* }
+) {                             /* }
+    color: red;                 /* }
+}                               /* }
+
+
+/**
+ * Test: Trailing comments spanning to next line
+ **/
+
+.class { color: red; }          /*
+*/
+                                /*
+*/
+.class { color: red;            /*
+*/
+}                               /*
+*/
+
+.class { color: red;            /*
+*/
+    background: beige;          /*
+*/
+}                               /*
+*/
+
+.class { color: rgb(            /*
+*/
+    background: beige;          /*
+*/
+}                               /*
+*/
+
+.class { color: rgb(0, 0, 0);   /*
+*/
+    background: beige;          /*
+*/
+}                               /*
+*/
+
+.class {                        /*
+*/
+    color: red;                 /*
+*/
+}                               /*
+*/
+                                /*
+*/
+.class /**/ {                   /*
+*/
+    color: red;                 /*
+*/
+} /**/ .foo /**/ {              /*
+*/
+    color: red;                 /*
+*/
+}                               /*
+*/
+
+.class                          /*
+*/
+{                               /*
+*/
+    color: red;                 /*
+*/
+}                               /*
+*/
+
+abbr[title],                    /*
+*/
+abbr[                           /*
+*/
+    data-title                  /*
+*/
+] {                             /*
+*/
+    color: red;                 /*
+*/
+}                               /*
+*/
+                                /*
+*/
+.class a:not(                   /*
+*/
+    .css_button                 /*
+*/
+) {                             /*
+*/
+    color: red;                 /*
+*/
+}                               /*
+*/
+
+
+/**
+ * Test: Trailing comments spanning to next line
+ * and containing closing brackets
+ **/
+
+.class { color: red; }          /* }
+*/
+                                /* }
+*/
+.class { color: red;            /* }
+*/
+}                               /* }
+*/
+
+.class { color: red;            /* }
+*/
+    background: beige;          /* }
+*/
+}                               /* }
+*/
+
+.class { color: rgb(            /* ) }
+*/
+    background: beige;          /* }
+*/
+}                               /* }
+*/
+
+.class { color: rgb(0, 0, 0);   /* }
+*/
+    background: beige;          /* }
+*/
+}                               /* }
+*/
+
+.class {                        /* }
+*/
+    color: red;                 /* }
+*/
+}                               /* }
+*/
+                                /* }
+*/
+.class /**/ {                   /* }
+*/
+    color: red;                 /* }
+*/
+} /**/ .foo /**/ {              /* }
+*/
+    color: red;                 /* }
+*/
+}                               /* }
+*/
+
+.class                          /* }
+*/
+{                               /* }
+*/
+    color: red;                 /* }
+*/
+}                               /* }
+*/
+
+abbr[title],                    /* }
+*/
+abbr[                           /* ] }
+*/
+    data-title                  /* }
+*/
+] {                             /* }
+*/
+    color: red;                 /* }
+*/
+}                               /* }
+*/
+                                /* }
+*/
+.class a:not(                   /* ) }
+*/
+    .css_button                 /* }
+*/
+) {                             /* }
+*/
+    color: red;                 /* }
+*/
+}                               /* }
+*/
+
+
+/**
+ * Test: Complete trailing comment with braces
+ **/
+
+.class { color: red; }          /* ; } */
+
+.class { color: red;            /* ; } */
+}                               /* ; } */
+
+.class {                        /* ; } */
+    color: red;                 /* ; } */
+}                               /* ; } */
+
+.class { color: red;            /* ; } */
+    background: beige;          /* ; } */
+}                               /* ; } */
+
+/* ignore closing brace in strings and comments */
+.class { font: "\"}";           /* ; } */
+    background: beige;          /* ; } */
+}                               /* ; } */
+
+.class { color: rgb(            /* ) ; } */
+    background: beige;          /* ; } */
+}                               /* ; } */
+
+.class { color: rgb(0, 0, 0);   /* ; } */
+    background: beige;          /* ; } */
+}                               /* ; } */
+
+abbr[title],                    /* ; } */
+abbr[                           /* ; } */
+    data-title                  /* ; } */
+] {                             /* ; } */
+    color: red;                 /* ; } */
+}                               /* ; } */
+
+.class a:not(                   /* ; } */
+    .css_button                 /* ; } */
+) {                             /* ; } */
+    color: red;                 /* ; } */
+}                               /* ; } */
+
+/**
+ * Test: Complete and incomplete trailing comment with braces
+ **/
+
+.class { color: red; }          /* ; */ /* } /* comment
+*/
+                                /* ; */ /* } /* comment
+*/
+.class { color: red;            /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+.class {                        /* ; */ /* } /* comment
+*/
+    color: red;                 /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+.class { color: red;            /* ; */ /* } /* comment
+*/
+    background: beige;          /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+.class { color: rgb(            /* ) ; */ /* } /* comment
+*/
+    background: beige;          /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+.class { color: rgb(0, 0, 0);   /* ; */ /* } /* comment
+*/
+    background: beige;          /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+abbr[title],                    /* ; */ /* } /* comment
+*/
+abbr[                           /* ; */ /* ] /* comment
+*/
+    data-title                  /* ; */ /* } /* comment
+*/
+] {                             /* ; */ /* ] /* comment
+*/
+    color: red;                 /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/
+
+*/
+.class a:not(                   /* ; */ /* ) /* comment
+*/
+    .css_button                 /* ; */ /* } /* comment
+*/
+) {                             /* ; */ /* ) /* comment
+*/
+    color: red;                 /* ; */ /* } /* comment
+*/
+}                               /* ; */ /* } /* comment
+*/

--- a/CSS/syntax_test_indentation.css
+++ b/CSS/syntax_test_indentation.css
@@ -1,0 +1,77 @@
+/* SYNTAX TEST reindent-unchanged "Packages/CSS/CSS.sublime-syntax" */
+
+.class { font-size: 10; }
+
+.class { font-size: 10;
+}
+
+.class
+{
+    font-size: 10;
+}
+
+.class {
+    font-size: 10;
+}
+
+abbr[title],
+abbr[
+    data-title
+] {
+    color: red;
+}
+
+.class a:not(
+    .css_button
+) {
+    color: red;
+}
+
+.class {            /*
+    font-size: 10;  /*
+}                   /*
+
+abbr[title],        /*
+abbr[               /*
+    data-title      /*
+] {                 /*
+    color: red;     /*
+}                   /*
+                    /*
+.class a:not(       /*
+    .css_button     /*
+) {                 /*
+    color: red;     /*
+}                   /*
+
+.class {            /* comment */
+    font-size: 10;  /* comment */
+}                   /* comment */
+abbr[title],        /* comment */
+abbr[               /* comment */
+    data-title      /* comment */
+] {                 /* comment */
+    color: red;     /* comment */
+}                   /* comment */
+                    /* comment */
+.class a:not(       /* comment */
+    .css_button     /* comment */
+) {                 /* comment */
+    color: red;     /* comment */
+}                   /* comment */
+
+.class {            /* comment */ /**/ /*
+    font-size: 10;  /* comment */ /**/ /*
+}                   /* comment */ /**/ /*
+abbr[title],        /* comment */ /**/ /*
+abbr[               /* comment */ /**/ /*
+    data-title      /* comment */ /**/ /*
+] {                 /* comment */ /**/ /*
+    color: red;     /* comment */ /**/ /*
+}                   /* comment */ /**/ /*
+                    /* comment */ /**/ /*
+.class a:not(       /* comment */ /**/ /*
+    .css_button     /* comment */ /**/ /*
+) {                 /* comment */ /**/ /*
+    color: red;     /* comment */ /**/ /*
+}                   /* comment */ /**/ /*


### PR DESCRIPTION
Fixes #1267

This PR adds _Indentation Rules.tmPreferences_ to fix some issues with regards to comments after opening and closing brackets breaking correct indentation.

It borrows some strategies from C/C++ and Java to fully exclude block comments so normal CSS rules are indented correctly even after 

```
  /**
   * comment
   **/
``` 

Before this PR all following rules got vertically aligned to `**/` which resulted in one column off.

It also overrides ST's default bracket indentation to make sure to indent after an opening bracket, even if it is followed by arbritary number of probably nested brackets, while ignoring any bracket in quoted strings.

Maybe some of those rules are rarely needed and probably won't appear in real life code, but the intention is to hopefully find some kind of common pattern, which may be applied to all syntaxes using brackets for indentation.

Furthermore it makes sure to correctly detent closing brackets even if they are followed by comments or other kinds of code.