### PR TITLE
[LaTeX] Apply meta.mapping scopes in BibTeX entries

### DIFF
--- a/LaTeX/Bibtex.sublime-syntax
+++ b/LaTeX/Bibtex.sublime-syntax
@@ -56,12 +56,13 @@ contexts:
           captures:
             0: punctuation.section.entry.end.bibtex
           pop: true
-        - match: '([a-zA-Z]+)\s*(\=)'
+        - match: '([a-zA-Z]+)(\s*(\=)\s*)'
           captures:
-            1: string.unquoted.key.bibtex
-            2: punctuation.separator.key-value.bibtex
+            1: meta.mapping.key.bibtex string.unquoted.key.bibtex
+            2: meta.mapping.bibtex
+            3: punctuation.separator.key-value.bibtex
           push:
-            - meta_scope: meta.key-assignment.bibtex
+            - meta_content_scope: meta.mapping.value.bibtex
             - match: "(?=[,}])"
               pop: true
             - include: string_content
@@ -78,12 +79,13 @@ contexts:
           captures:
             0: punctuation.section.entry.end.bibtex
           pop: true
-        - match: '([a-zA-Z]+)\s*(\=)'
+        - match: '([a-zA-Z]+)(\s*(\=)\s*)'
           captures:
-            1: string.unquoted.key.bibtex
-            2: punctuation.separator.key-value.bibtex
+            1: meta.mapping.key.bibtex string.unquoted.key.bibtex
+            2: meta.mapping.bibtex
+            3: punctuation.separator.key-value.bibtex
           push:
-            - meta_scope: meta.key-assignment.bibtex
+            - meta_content_scope: meta.mapping.value.bibtex
             - match: "(?=[,)])"
               pop: true
             - include: string_content

--- a/LaTeX/Bibtex.sublime-syntax
+++ b/LaTeX/Bibtex.sublime-syntax
@@ -52,21 +52,25 @@ contexts:
         4: entity.name.type.entry-key.bibtex
       push:
         - meta_scope: meta.entry.braces.bibtex
+        - meta_content_scope: meta.mapping.bibtex
         - match: '\}'
           captures:
             0: punctuation.section.entry.end.bibtex
           pop: true
-        - match: '([a-zA-Z]+)(\s*(\=)\s*)'
+        - match: '([a-zA-Z]+)(\s*(=)\s*)'
           captures:
             1: meta.mapping.key.bibtex string.unquoted.key.bibtex
             2: meta.mapping.bibtex
             3: punctuation.separator.key-value.bibtex
           push:
+            - clear_scopes: 1
             - meta_content_scope: meta.mapping.value.bibtex
             - match: "(?=[,}])"
               pop: true
             - include: string_content
             - include: integer
+        - match: \,
+          scope: punctuation.separator.mapping.pair.bibtex
     - match: '((@)[a-zA-Z]+)\s*(\()\s*([^\s,]*)'
       captures:
         1: keyword.other.entry-type.bibtex
@@ -75,21 +79,25 @@ contexts:
         4: entity.name.type.entry-key.bibtex
       push:
         - meta_scope: meta.entry.parenthesis.bibtex
+        - meta_content_scope: meta.mapping.bibtex
         - match: \)
           captures:
             0: punctuation.section.entry.end.bibtex
           pop: true
-        - match: '([a-zA-Z]+)(\s*(\=)\s*)'
+        - match: '([a-zA-Z]+)(\s*(=)\s*)'
           captures:
             1: meta.mapping.key.bibtex string.unquoted.key.bibtex
             2: meta.mapping.bibtex
             3: punctuation.separator.key-value.bibtex
           push:
+            - clear_scopes: 1
             - meta_content_scope: meta.mapping.value.bibtex
             - match: "(?=[,)])"
               pop: true
             - include: string_content
             - include: integer
+        - match: \,
+          scope: punctuation.separator.mapping.pair.bibtex
     - match: '[^@\n]'
       push:
         - meta_scope: comment.block.bibtex

--- a/LaTeX/syntax_test_bibtex.bib
+++ b/LaTeX/syntax_test_bibtex.bib
@@ -11,6 +11,7 @@
 %               ^^^^^^^^^^^^^^^^^ meta.mapping.value.bibtex string.quoted.other.braces.bibtex
 %               ^ punctuation.definition.string.begin.bibtex
 %                               ^ punctuation.definition.string.end.bibtex
+%                                ^ punctuation.separator.mapping.pair.bibtex
     title     = {The Art of Computer Programming, Vol. 1: Fundamental Algorithms},
     edition   = {3},
     publisher = {Addison-Wesley},

--- a/LaTeX/syntax_test_bibtex.bib
+++ b/LaTeX/syntax_test_bibtex.bib
@@ -1,0 +1,19 @@
+% SYNTAX TEST "Packages/LaTeX/Bibtex.sublime-syntax"
+
+@book{knuth97,
+%<- keyword.other.entry-type.bibtex punctuation.definition.keyword.bibtex
+%^^^^ keyword.other.entry-type.bibtex
+%     ^^^^^^^ entity.name.type.entry-key.bibtex
+    author    = {Donald E. Knuth},
+%   ^^^^^^ meta.mapping.key.bibtex string.unquoted.key.bibtex
+%         ^^^^^^ meta.mapping.bibtex
+%             ^ punctuation.separator.key-value.bibtex
+%               ^^^^^^^^^^^^^^^^^ meta.mapping.value.bibtex string.quoted.other.braces.bibtex
+%               ^ punctuation.definition.string.begin.bibtex
+%                               ^ punctuation.definition.string.end.bibtex
+    title     = {The Art of Computer Programming, Vol. 1: Fundamental Algorithms},
+    edition   = {3},
+    publisher = {Addison-Wesley},
+    date      = {1997},
+    isbn      = {978-0-201-89683-1}
+}


### PR DESCRIPTION
To follow the convention from JSON, Git config, and other syntaxes.