### PR TITLE
[HTML] Fix duplicated meta scopes in tag attributes

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -242,16 +242,21 @@ contexts:
 
   script-type-attribute:
     - match: (?i:type){{attribute_name_break}}
-      scope: entity.other.attribute-name.html
-      set:
-        - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-            - include: script-type-decider
-        - match: (?=\S)
-          set: script-javascript
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set: script-type-attribute-assignment
+
+  script-type-attribute-assignment:
+    - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+    - match: =
+      scope: punctuation.separator.key-value.html
+      set: script-type-attribute-value
+    - match: (?=\S)
+      set: script-javascript
+
+  script-type-attribute-value:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+    - include: script-type-decider
 
   script-type-decider:
     - match: (?={{javascript_mime_type}}{{unquoted_attribute_break}}|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
@@ -330,16 +335,21 @@ contexts:
 
   style-type-attribute:
     - match: (?i:type){{attribute_name_break}}
-      scope: entity.other.attribute-name.html
-      set:
-        - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-            - include: style-type-decider
-        - match: (?=\S)
-          set: style-css
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set: style-type-attribute-assignment
+
+  style-type-attribute-assignment:
+    - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+    - match: =
+      scope: punctuation.separator.key-value.html
+      set: style-type-attribute-value
+    - match: (?=\S)
+      set: style-css
+
+  style-type-attribute-value:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+    - include: style-type-decider
 
   style-type-decider:
     - match: (?=(?i:text/css{{unquoted_attribute_break}}|'text/css'|"text/css"))

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -93,10 +93,14 @@
         ##           ^ - meta.tag
 
         <script type="text/javascript"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
-        ## ^ entity.name.tag.script - source.js.embedded.html
-        ##            ^ string.quoted.double.html - source.js.embedded.html
+        ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value - source
+        ##      ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value - source
+        ##                            ^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value - source
+        ##                             ^^^^^ - meta.tag  - source
+        ## ^ entity.name.tag.script
+        ##            ^ string.quoted.double.html
         ##                              ^^^^ comment.block.html punctuation.definition.comment.begin.html
+        ##                                  ^ source.js.embedded.html
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
@@ -106,20 +110,25 @@
             ## ^^^ source.js.embedded.html meta.group.js keyword.operator
         --> </script>
         ## <- comment.block.html punctuation.definition.comment.end.html
+        ##  ^^^^^^^^^ meta.tag.script.end.html - source
         ##    ^^^^^^ entity.name.tag.script.html
-        ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
         ##           ^ - meta.tag
 
         <script
         type
+        ## <- meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
         =
+        ## <- meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
         application/jAvAsCrIpT>
+        ## <- meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
             var foo = 100;
         ##  ^^^^^^^^^^^^^^^ source.js.embedded
         </script>
 
         <script type = "text/html"> <!--
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
+        ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value
+        ##      ^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
+        ##                        ^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value
         ## ^ entity.name.tag.script - text.html.embedded.html
         ##             ^ string.quoted.double.html - text.html.embedded.html
         ##                          ^^^^ comment.block.html punctuation
@@ -192,13 +201,26 @@
         ##                                ^^^^^^^^ meta.tag - comment - source
 
         <style type="text/css"> <!-- h1 {} --> </style>
-        ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
+        ##^^^^^ meta.tag.style.begin.html - meta.tag meta.tag - meta.attribute-with-value
+        ##     ^^^^^^^^^^^^^^^ meta.tag.style.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
+        ##                    ^ meta.tag.style.begin.html - meta.tag meta.tag - meta.attribute-with-value
         ##                     ^ - meta.tag - comment - source
         ##                      ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
         ##                          ^^^^^^^ source.css.embedded.html - meta.tag - comment
         ##                                 ^^^ comment.block.html punctuation.definition.comment.end.html - source
         ##                                    ^ - meta.tag - comment - source
-        ##                                     ^^^^^^^^ meta.tag - comment - source
+        ##                                     ^^^^^^^^ meta.tag - meta.tag meta.tag - comment - source
+
+        <style type  =  "text/css"> <!-- h1 {} --> </style>
+        ##^^^^^ meta.tag.style.begin.html - meta.tag meta.tag - meta.attribute-with-value
+        ##     ^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value
+        ##                        ^ meta.tag.style.begin.html - meta.tag meta.tag - meta.attribute-with-value
+        ##                         ^ - meta.tag - comment - source
+        ##                          ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
+        ##                              ^^^^^^^ source.css.embedded.html
+        ##                                     ^^^ comment.block.html punctuation.definition.comment.end.html - source
+        ##                                        ^ - meta.tag - comment - source
+        ##                                         ^^^^^^^^ meta.tag - meta.tag meta.tag - comment - source
 
         <style>
 


### PR DESCRIPTION
This PR fixes duplicated `meta.tag` scopes being applied to parts of style/script tag attributes.