### PR TITLE
[Ruby] Fix duplicated expressions import

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -677,7 +677,6 @@ contexts:
         - match: '\]'
           pop: true
         - include: expressions
-        - include: expressions
     # maybe nested (trailing) constants with uppercase only notation
     - match: '(::)?(\b[[:upper:]_][[:upper:][:digit:]_]*\b)'
       captures:


### PR DESCRIPTION
Was regressed by 359d42a7d2550040fe9c5840ced7419ca5179753