### PR TITLE
[LaTeX] Allow character escapes and commands in array preamble

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -1612,6 +1612,8 @@ contexts:
         - match: '\}'
           scope: punctuation.definition.group.brace.end.latex
           pop: true
+        - include: general-constants
+        - include: general-commands
         - include: array-preamble
 
     - match: 'l|r|c'

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -519,7 +519,14 @@ a & b
 %                                  ^ meta.environment.tabular meta.function.column-spec
 \end{tabular}
 
+% issue 2238
 
+% \usepackage{dcolumn}
+\begin{tabular}{c|D{\%}{\cdot}{-1}}
+%              ^^^^^^^^^^^^^^^^^^^^ meta.environment.tabular.latex meta.function.column-spec.latex - comment
+%                   ^^ constant.character.escape.tex
+%                       ^^^^^ support.function.general.latex
+\end{tabular}
 
 \AnyDeclarationCommand{\eq}{\begin{equation}}
 


### PR DESCRIPTION
This allows to use character escapes and commands within braces in the array preamble, which might appear in special column specifier arguments, for example as provided by the dcolumn package.

Fixes #2238.