### PR TITLE
[TypeScript] [TSX] Fix arrow function type parameter tests for TSX.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -551,26 +551,6 @@ contexts:
       scope: keyword.operator.comparison.js
       set: expression-begin
 
-  # expression-begin:
-  #   - meta_prepend: true
-  #   - match: (?=\<(?!<))
-  #     pop: true
-  #     branch_point: ts-old-type-assertion
-  #     branch:
-  #       - ts-old-type-assertion
-  #       - arrow-function-declaration
-
-  # ts-old-type-assertion:
-  #   - match: \<
-  #     scope: punctuation.definition.assertion.begin.js
-  #     set:
-  #       - immediately-pop
-  #       - ts-old-type-assertion-check
-  #       - ts-old-type-assertion-end
-  #       - ts-type-expression-end
-  #       - ts-type-expression-end-no-line-terminator
-  #       - ts-type-expression-begin
-
   ts-old-type-assertion-end:
     - meta_scope: meta.assertion.js
     - match: \>
@@ -580,35 +560,10 @@ contexts:
   ts-old-type-assertion-check:
     - match: (?=\()
       set:
-        # - detect-parenthesized-arrow-2
         - detect-arrow
         - ts-detect-arrow-function-return-type
         - parenthesized-expression
     - include: else-pop
-
-  # detect-parenthesized-arrow-2:
-  #   - match: (?=:)
-  #     pop: true
-  #     branch_point: ts-arrow-function-return-type-2
-  #     branch:
-  #       - ts-detect-arrow-function-return-type-2
-  #       - immediately-pop
-  #   - match: (?==>)
-  #     fail: ts-old-type-assertion
-  #   - include: else-pop
-
-  # ts-detect-arrow-function-return-type-2:
-  #   - meta_include_prototype: false
-  #   - match: ''
-  #     push:
-  #       - ts-detect-arrow-after-return-type-2
-  #       - ts-type-annotation
-
-  # ts-detect-arrow-after-return-type-2:
-  #   - match: (?==>)
-  #     fail: ts-old-type-assertion
-  #   - match: (?=\S)
-  #     fail: ts-arrow-function-return-type-2
 
   ts-type-assertion:
     - match: '!(?![.=])'

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -46,6 +46,11 @@ if (a < b || c <= d) {}
 //            ^^^^^^^^^^^^^^^^^^^^^ meta.jsx
 //                                 ^ punctuation.terminator.statement
 
+    <T>() => {};</T>;
+//  ^^^^^^^^^^^^^^^^ meta.jsx
+//  ^^^ meta.tag
+//              ^^ meta.tag
+
     <T,>(): U => {}; // </T>;
 //  ^^^^^^^^^^^^^^^ meta.function
 //  ^^^^ meta.generic

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -952,16 +952,17 @@ const f = (): any => {};
 //    ^ meta.binding.name entity.name.function variable.other.readwrite
 //     ^^^^^^^^^^^^^^^^^^ - entity.name.function
 
-const f = <T>(): U => {};
-//        ^^^^^^^^^^^^^^ meta.function
+const f = <T,>(): U => {};
+//        ^^^^^^^^^^^^^^^ meta.function
 //        ^^^ meta.generic
 //        ^ punctuation.definition.generic.begin
 //         ^ variable.parameter.generic
-//          ^ punctuation.definition.generic.end
-//           ^^ meta.function.parameters
-//             ^ punctuation.separator.type
-//               ^ support.class
-//                 ^^ keyword.declaration.function.arrow
+//          ^ punctuation.separator.comma
+//           ^ punctuation.definition.generic.end
+//            ^^ meta.function.parameters
+//              ^ punctuation.separator.type
+//                ^ support.class
+//                  ^^ keyword.declaration.function.arrow
 
     a != b;
 //    ^^ keyword.operator.comparison

--- a/JavaScript/tests/syntax_test_typescript_not_tsx.ts
+++ b/JavaScript/tests/syntax_test_typescript_not_tsx.ts
@@ -25,3 +25,12 @@
 let strLength: number = (<string>someValue).length; // </string>
 //                       ^^^^^^^^ meta.assertion - meta.tag
 //                                                     ^^^^^^^^^ comment - meta.tag
+
+    <T>() => {};
+//  ^^^^^^^^^^^ meta.function
+//  ^^^ meta.generic
+//  ^ punctuation.definition.generic.begin
+//   ^ variable.parameter.generic
+//    ^ punctuation.definition.generic.end
+//     ^^ meta.function.parameters
+//        ^^ keyword.declaration.function.arrow


### PR DESCRIPTION
One of the new tests added in #2923 is correct for plain TypeScript, but wrong for TSX. (#3998 would have caught the bug.)

This PR modifies that test to also be valid for TSX and adds new tests for plain TypeScript and for TSX.

It also deletes some commented code that doesn't need to exist.