### PR TITLE
[Erlang] Update shebang highlighting

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -245,15 +245,17 @@ contexts:
   shebang:
     - match: ^\#!
       scope: punctuation.definition.comment.shell
-      set:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.shebang.shell
-        # Note: Keep sync with first_line_match!
-        - match: \b(erlang|escript)\b
-          scope: constant.language.erlang
-        - match: \n
-          pop: 1
+      set: shebang-body
     - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
+      pop: 1
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.shell
+    # Note: Keep sync with first_line_match!
+    - match: \b(erlang|escript)\b
+      scope: constant.language.shebang.erlang
+    - match: \n
       pop: 1
 
 ###[ PREPROCESSOR CONTROL ]###################################################


### PR DESCRIPTION
This PR...

1. introduces a named context `shebang-body` for shebang patterns
2. modifies language name scope from `constant.language.erlang` to `constant.language.shebang.erlang` to follow Java/PHP proposals.