### PR TITLE
[TSX] Fix regression in JSX tag where spread props follow tag name.

### DIFF
--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -36,12 +36,12 @@ contexts:
     - match: 'extends{{jsx_identifier_break}}'
       scope: entity.other.attribute-name.js
       set:
-        - match: (?={{identifier_start}})
-          fail: arrow-function
-        - match: (?=\S)
+        - match: (?=>)
           pop: true
+        - match: (?=\S)
+          fail: arrow-function
 
-    - match: (?=/|>|{{identifier_start}}|\{)
+    - match: (?=[/>{]|{{identifier_start}})
       pop: true
     - match: (?=\S)
       fail: arrow-function

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -105,6 +105,13 @@ if (a < b || c <= d) {}
 //     ^^^^^^^ meta.tag.attributes entity.other.attribute-name
 //            ^ punctuation.definition.tag.end
 
+    <T extends {}>() => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^^ meta.function meta.generic
+//   ^ variable.parameter.generic
+//     ^^^^^^^ storage.modifier.extends
+//             ^^ meta.function meta.generic meta.block
+
     <T {...}>() => {};</T>;
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
 //  ^^^^^^^^^ meta.tag


### PR DESCRIPTION
Fix #2993.

The bug is presumably a regression due to #2923. When speculatively parsing a JSX tag in an expression context, if a non-whitespace character other than `/`, `>`, or a JSX identifier start character was encountered, then it would fail the JSX tag and reparse from the `<` as an arrow function with type parameters. Missing from that list of characters was `{`, which should unambiguously signal a JSX tag and not arrow function type parameters. This PR fixes that.