### PR TITLE
[JavaScript] Scope methods that are template tags

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1982,7 +1982,7 @@ contexts:
         - function-name-meta
         - literal-variable-base
 
-    - match: '{{identifier_name}}(?=\s*`)'
+    - match: '{{identifier_name}}(?={{nothing}}`)'
       scope: variable.function.tagged-template.js
       pop: true
 
@@ -2407,7 +2407,7 @@ contexts:
     - match: '(?=#?{{identifier_name}}\s*(?:{{dot_accessor}})?\()'
       set: call-method-name
 
-    - match: '{{identifier_name}}(?=\s*`)'
+    - match: '{{identifier_name}}(?={{nothing}}`)'
       scope: variable.function.tagged-template.js
       pop: true
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -193,6 +193,9 @@ tag `template`;
 // <- variable.function.tagged-template
 //  ^^^^^^^^^^ meta.string string.quoted.other
 
+tag/**/`template`;
+// <- variable.function.tagged-template
+
 x ? y // y is a template tag!
 `template` : z;
 //         ^ keyword.operator.ternary
@@ -890,6 +893,9 @@ foo
 //  ^ punctuation.accessor
 //   ^^^ variable.function.tagged-template
 //      ^^ meta.string string.quoted.other punctuation.definition.string
+
+foo.tag/**/``;
+//  ^^^ variable.function.tagged-template
 
 return new Promise(resolve => preferenceObject.set({value}, resolve));
 //                                                                  ^ meta.function-call.constructor punctuation.section.group.end


### PR DESCRIPTION
Reported by Mitranim on Discord.

E.g.:

```js
foo.tag``;
```

It seems weird using `variable.function` on a property, but that's what we're doing for methods. If we ever rationalize variable scopes, this might change.

This PR also improves the lookahead to handle comments.