### PR TITLE
[Common] Remove duplicate case-insensitive extensions

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -13,7 +13,6 @@ file_extensions:
 
 hidden_extensions:
   - Emakefile
-  - emakefile
 
 first_line_match: |-
   (?x:

--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -4,7 +4,6 @@
 name: Graphviz (DOT)
 file_extensions:
   - dot
-  - DOT
   - gv
 scope: source.dot
 contexts:

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -12,11 +12,8 @@ name: Makefile
 file_extensions:
   - make
   - GNUmakefile
-  - makefile
   - Makefile
-  - makefile.am
   - Makefile.am
-  - makefile.in
   - Makefile.in
   - OCamlMakefile
   - mak

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -15,8 +15,6 @@ file_extensions:
   - rpy
   - cpy
   - SConstruct
-  - Sconstruct
-  - sconstruct
   - SConscript
   - gyp
   - gypi

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -3,7 +3,7 @@
 # http://www.sublimetext.com/docs/3/syntax.html
 name: R
 file_extensions:
-  - r
+  - R
   - Rprofile
 scope: source.r
 

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -3,7 +3,6 @@
 # http://www.sublimetext.com/docs/3/syntax.html
 name: R
 file_extensions:
-  - R
   - r
   - Rprofile
 scope: source.r


### PR DESCRIPTION
As per discussions in https://github.com/sublimehq/Packages/pull/2916

Even on Linux/Mac, ST detects file extension in a case-insensitive manner.