### PR TITLE
[Perl] Fix pattern matching operator scopes

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1152,13 +1152,10 @@ contexts:
     - match: -[rwx0RWXOezsfdlpSbctugkTBMAC]\b
       scope: keyword.operator.filetest.perl
       push: expressions-begin
-    - match: '[!~=]~'
-      scope: keyword.operator.binary.perl
-      push: expressions-begin
     - match: <<|>>
       scope: keyword.operator.bitwise.perl
       push: expressions-begin
-    - match: <=>|==|!=|>=|<=|[<>]
+    - match: <=>|==|!=|>=|<=|[<>]|[!~=]~
       scope: keyword.operator.comparison.perl
       push: expressions-begin
     - match: \&\&|\|\||//|[:!?]

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1010,7 +1010,7 @@ chomp (my $common_end = <<"EOF") =~ s/(.*)/$1/g if $opt_o;
 #^^^^ support.function.perl
 #                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.perl
 #                       ^^ keyword.operator.heredoc.perl
-#                                ^^ keyword.operator.binary.perl
+#                                ^^ keyword.operator.comparison.perl
   foo bar baz
 # <- meta.string.heredoc.perl string.unquoted.heredoc.perl
 # ^^^^^^^^^^^^ meta.string.heredoc.perl string.unquoted.heredoc.perl
@@ -1082,11 +1082,11 @@ EOT
   %
 # ^ keyword.operator.arithmetic.perl
   !~
-# ^^ keyword.operator.binary.perl
+# ^^ keyword.operator.comparison.perl
   =~
-# ^^ keyword.operator.binary.perl
+# ^^ keyword.operator.comparison.perl
   ~~
-# ^^ keyword.operator.binary.perl
+# ^^ keyword.operator.comparison.perl
   <=>
 # ^^^ keyword.operator.comparison.perl
   //
@@ -3724,7 +3724,7 @@ our $VERSION = do {
 #            ^^^^^^^^^^^^^^^ meta.string.perl string.unquoted.perl
 #                      ^^^^ - constant.numeric
 #                           ^ punctuation.section.generic.end.perl
-#                             ^^ keyword.operator.binary.perl
+#                             ^^ keyword.operator.comparison.perl
 #                                ^ punctuation.section.generic.begin.perl
 #                                 ^^^ meta.string.perl string.regexp.perl source.regexp
 #                                    ^ punctuation.section.generic.end.perl


### PR DESCRIPTION
This PR renames scope of `=~`, `!~` and `~~` pattern matching operators to `keyword.operator.comparison` as this is a more appropriate scope name which is already used by Ruby for those.

Note: The inconsistant naming was revealed while working on a fix for Bash's pattern matching.