### PR TITLE
[ShellScript] Fix numbers breaking pattern matching it test expressions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -680,11 +680,7 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: cmd-test-args-group-body
-    - match: (=~)\s*
-      captures:
-        1: keyword.operator.binary.shell
-      push: cmd-test-args-pattern
-    - match: ([=!]=)\s*
+    - match: ([=!]=|=~)\s*
       captures:
         1: keyword.operator.comparison.shell
       push: cmd-test-args-pattern
@@ -707,11 +703,7 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: test-expression-group-body
-    - match: (=~)\s*
-      captures:
-        1: keyword.operator.binary.shell
-      push: test-expression-pattern
-    - match: ([=!]=)\s*
+    - match: ([=!]=|=~)\s*
       captures:
         1: keyword.operator.comparison.shell
       push: test-expression-pattern

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -739,7 +739,6 @@ contexts:
         punctuation.definition.group.begin.regexp.shell
       push: expansions-pattern-group-body
     - include: boolean
-    - include: number
     - include: expansions-and-strings
 
   test-expression-common:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1897,7 +1897,7 @@ test ! ($line =~ ^[0-9]+$)
 #    ^ keyword.operator.logical.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
-#             ^^ keyword.operator.binary.shell
+#             ^^ keyword.operator.comparison.shell
 #                ^^^^^^^^ meta.pattern.regexp.shell
 
 test ! ($line =~ ^[0-9]+$) >> /file
@@ -1911,7 +1911,7 @@ test ! ($line =~ ^[0-9]+$) >> /file
 #    ^ keyword.operator.logical.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
-#             ^^ keyword.operator.binary.shell
+#             ^^ keyword.operator.comparison.shell
 #                ^^^^^^^^ meta.pattern.regexp.shell
 #                        ^ punctuation.section.group.end.shell
 #                          ^^ keyword.operator.assignment.redirection.shell
@@ -3687,7 +3687,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                      ^ - meta.conditional
 #^^^^^^^^^^ - meta.pattern.regexp
 #  ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#       ^^ keyword.operator.binary.shell
+#       ^^ keyword.operator.comparison.shell
 #          ^^^^ meta.pattern.regexp.shell - meta.interpolation
 #              ^^^^ meta.pattern.regexp.shell meta.interpolation.parameter.shell
 #                  ^ meta.pattern.regexp.shell - meta.interpolation
@@ -3702,7 +3702,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                        ^^^ meta.group.regexp.shell
 #                            ^^^ - meta.pattern.regexp.shell
 #  ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.binary.shell
+#        ^^ keyword.operator.comparison.shell
 #           ^^ punctuation.definition.set.begin.regexp.shell
 #             ^^^^^^^ constant.other.posix-class.regexp.shell
 #                    ^^ punctuation.definition.set.end.regexp.shell
@@ -3739,7 +3739,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #  ^ keyword.operator.logical.shell
 #    ^ punctuation.section.group.begin.shell
 #     ^^^^^ variable.other.readwrite.shell
-#           ^^ keyword.operator.binary.shell
+#           ^^ keyword.operator.comparison.shell
 #               ^^^^^^^^ meta.group.regexp.shell
 #               ^ punctuation.definition.group.begin.regexp.shell
 #                ^^ constant.character.escape.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1847,9 +1847,11 @@ test+=
 test var != 0
 #<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
+#   ^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
+#           ^ meta.function-call.arguments.shell meta.pattern.regexp.shell
+#            ^ - meta.function-call
 #        ^^ keyword.operator.comparison.shell
-#           ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#           ^ - constant.numeric
 
 test var == true
 #<- meta.function-call.identifier.shell support.function.test.shell
@@ -3707,6 +3709,22 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                      ^^ keyword.operator.quantifier.regexp.shell
 #                        ^ punctuation.definition.group.begin.regexp.shell
 #                          ^ punctuation.definition.group.end.regexp.shell
+
+[[ $line =~ ^0[1-9]$ ]]
+#^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#                      ^ - meta.conditional
+#^^^^^^^^^^^ - meta.pattern.regexp.shell
+#           ^^^^^^^^ meta.pattern.regexp.shell
+#                   ^^^ - meta.pattern.regexp.shell
+
+[[ ! ($line =~ ^0[1-9]$) ]]
+# <- meta.conditional.shell - meta.group
+#^^^^ meta.conditional.shell - meta.group
+#    ^^^^^^^^^^ meta.conditional.shell meta.group.shell - meta.pattern
+#              ^^^^^^^^ meta.conditional.shell meta.group.shell meta.pattern.regexp.shell
+#                      ^ meta.conditional.shell meta.group.shell - meta.pattern
+#                       ^^^ meta.conditional.shell - meta.group
+#                          ^ - meta.conditional - meta.group
 
 [[ ! ($line =~ ^(\([0-9]+)$) ]]
 # <- meta.conditional.shell - meta.group


### PR DESCRIPTION
Fixes #2988 

This PR ...

1. removes `numbers` from right hand side of pattern matching or comparison expressions.
2. scopes `=~` as `keyword.operator.comparison` to match Perl/Ruby.

Note:

According to the bash docs...
1. the `test ...` command doesn't support Perl like pattern matching via `=~` operator.
2. features differ between `[ ... ]`  and `[[ ... ]]` operators.
3. highlighting would probably need to be distinguished between string/pattern matching and arithmetic comparisons in case of `-eq` operators are present.

Those improvements may be part of future improvements.
