### PR TITLE
[Python] Add support for PEP 635 structural pattern matching

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -49,6 +49,15 @@ variables:
     )
   strftime_spec: '(?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))'
 
+  builtin_types: |-
+    \b(?x:
+      bool | bytearray | bytes | complex | dict | float | frozenset | int
+    | list | memoryview | object | set | slice | str | tuple
+    # Python 2 types
+    | basestring | long | unicode
+    # Python 2 types prone to conflicts
+    # | buffer | file
+    )\b
 
 contexts:
   main:
@@ -337,6 +346,269 @@ contexts:
         - match: $\n?
           pop: true
         - include: expression-in-a-statement
+    - include: case-statements
+    - include: match-statements
+
+###[ CASE STATEMENTS ]########################################################
+
+  case-statements:
+    # https://www.python.org/dev/peps/pep-0634
+    - match: (?=\bcase\b)
+      branch_point: case-statements
+      branch:
+        - case-statement
+        - structural-pattern-fallback
+
+  case-statement:
+    - match: case
+      scope:
+        meta.statement.conditional.case.python
+        keyword.control.conditional.case.python
+      set:
+        - case-statement-pattern
+        - case-statement-begin
+
+  case-statement-begin:
+    - include: case-statement-fail
+    - include: allow-unpack-operators
+
+  case-statement-end:
+    - match: ':(?!=)'
+      scope:
+        meta.statement.conditional.case.python
+        punctuation.section.block.conditional.case.python
+      pop: true
+
+  case-statement-fail:
+    - match: (?=$|#|;)
+      fail: case-statements
+
+  case-statement-guard:
+    - meta_content_scope: meta.statement.conditional.case.guard.python
+    - include: case-statement-end
+    - include: case-statement-fail
+    - include: expression-in-a-statement
+
+  case-statement-pattern:
+    - meta_content_scope: meta.statement.conditional.case.patterns.python
+    - match: (?=\bif\b)
+      set: case-statement-guard
+    - include: case-statement-end
+    - include: case-statement-fail
+    - include: case-pattern-expressions
+
+  case-pattern-expressions:
+    - include: case-pattern-capture-targets
+    - include: case-pattern-classes
+    - include: case-pattern-dictionaries
+    - include: case-pattern-groups-or-tuples
+    - include: case-pattern-lists
+    - include: case-pattern-operators
+    - include: sequence-separators
+    - include: comments
+    - include: booleans
+    - include: nones
+    - include: numbers
+    - include: strings
+    - include: illegal-names
+    - include: qualified-name
+    - include: illegal-stray-brackets
+    - include: line-continuation
+
+  case-pattern-capture-targets:
+    - match: \bas\b
+      scope: keyword.control.conditional.case.as.python
+      push: case-pattern-capture-target
+
+  case-pattern-capture-target:
+    - include: wildcard-variable
+    - include: illegal-name
+    - include: generic-name
+    - match: (?=\S)
+      pop: true
+
+  case-pattern-classes:
+    - match: (?=(\.\s*)?{{path}}\s*\()
+      push:
+        - case-pattern-class-wrapper
+        - qualified-name-until-leaf
+
+  case-pattern-class-wrapper:
+    - meta_scope: meta.function-call.python meta.qualified-name.python
+    - include: line-continuation
+    - match: (?:({{illegal_names}})|({{builtin_types}})|({{identifier}}))\s*(?=\()
+      captures:
+        1: invalid.illegal.name.python
+        2: support.type.python
+        3: storage.type.class.python
+      set: case-pattern-class-arguments-begin
+    - match: \.
+      scope: punctuation.accessor.dot.python
+
+  case-pattern-class-arguments-begin:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.arguments.begin.python
+      set:
+        - case-pattern-class-arguments-body
+        - allow-unpack-operators
+
+  case-pattern-class-arguments-body:
+    - meta_scope: meta.function-call.arguments.python
+    - match: \)
+      scope: punctuation.section.arguments.end.python
+      pop: true
+    - match: (?:({{illegal_names}})|({{identifier}}))\s*(=)
+      captures:
+        1: invalid.illegal.name.python
+        2: variable.parameter.python
+        3: keyword.operator.assignment.python
+      push: allow-unpack-operators
+    - include: argument-separators
+    - include: case-pattern-expressions
+
+  case-pattern-operators:
+    - match: '[-+]'
+      scope: keyword.operator.arithmetic.python
+    - match: \|
+      scope: keyword.operator.logical.python
+
+  case-pattern-dictionaries:
+    - include: empty-dictionaries
+    - match: \{
+      scope: punctuation.section.mapping.begin.python
+      push: case-pattern-dictionary-body
+
+  case-pattern-dictionary-body:
+    - meta_scope: meta.mapping.python
+    - include: comments
+    - match: \}
+      scope: punctuation.section.mapping.end.python
+      pop: true
+    - match: ','
+      scope: punctuation.separator.mapping.pair.python
+    - match: \*\*
+      scope: keyword.operator.unpacking.mapping.python
+      push: case-pattern-dictionary-patterns
+    - match: ':'
+      scope: meta.mapping.python punctuation.separator.mapping.key-value.python
+      push:
+        - case-pattern-dictionary-value
+        - allow-unpack-operators
+    - match: (?=\S)
+      push: case-pattern-dictionary-key
+
+  case-pattern-dictionary-key:
+    - clear_scopes: 1
+    - meta_content_scope: meta.mapping.key.python
+    - include: case-pattern-dictionary-patterns
+
+  case-pattern-dictionary-value:
+    - clear_scopes: 1
+    - meta_content_scope: meta.mapping.value.python
+    - include: case-pattern-dictionary-patterns
+
+  case-pattern-dictionary-patterns:
+    - match: (?=[,:}])
+      pop: true
+    - include: case-pattern-expressions
+
+  case-pattern-groups-or-tuples:
+    - include: empty-tuples
+    - match: (?=\()
+      branch_point: case-pattern-groups-or-tuples
+      branch:
+        - case-pattern-group
+        - case-pattern-tuple
+
+  case-pattern-group:
+    - match: \(
+      scope: punctuation.section.group.begin.python
+      set: case-pattern-group-body
+
+  case-pattern-group-body:
+    - meta_scope: meta.group.python
+    - match: \)
+      scope: punctuation.section.group.end.python
+      pop: true
+    - match: (?=,)
+      fail: case-pattern-groups-or-tuples
+    - include: case-pattern-expressions
+
+  case-pattern-lists:
+    - include: empty-lists
+    - match: \[
+      scope: punctuation.section.sequence.begin.python
+      push:
+        - case-pattern-list-body
+        - allow-unpack-operators
+
+  case-pattern-list-body:
+    - meta_scope: meta.sequence.list.python
+    - match: \]
+      scope: punctuation.section.sequence.end.python
+      pop: true
+    - include: case-pattern-expressions
+
+  case-pattern-tuple:
+    - match: \(
+      scope: punctuation.section.sequence.begin.python
+      set:
+        - case-pattern-tuple-body
+        - allow-unpack-operators
+
+  case-pattern-tuple-body:
+    - meta_scope: meta.sequence.tuple.python
+    - match: \)
+      scope: punctuation.section.sequence.end.python
+      pop: true
+    - include: case-pattern-expressions
+
+###[ MATCH STATEMENTS ]#######################################################
+
+  match-statements:
+    - match: (?=\bmatch\b)
+      branch_point: match-statements
+      branch:
+        - match-statement
+        - structural-pattern-fallback
+
+  match-statement:
+    - match: match
+      scope: keyword.control.conditional.match.python
+      set:
+        - match-statement-body
+        - match-statement-begin
+
+  match-statement-begin:
+    - include: match-statement-fail
+    - include: allow-unpack-operators
+
+  match-statement-body:
+    - meta_scope: meta.statement.conditional.match.python
+    - include: match-statement-end
+    - include: match-statement-fail
+    - include: expression-in-a-statement
+
+  match-statement-end:
+    - match: ':(?!=)'
+      scope: punctuation.section.block.conditional.match.python
+      pop: true
+
+  match-statement-fail:
+    - match: (?=$|#|;)
+      fail: match-statements
+
+  structural-pattern-fallback:
+    # Fallback context, which is used if `match` or `case` don't seem to
+    # start a structural match pattern statement.
+    - match: (?={{path}}\s*\()
+      set:
+        - function-call-wrapper
+        - qualified-name-until-leaf
+    - include: generic-name
+
+###[ WITH STATEMENTS ]########################################################
 
   with-body:
     - meta_scope: meta.statement.with.python
@@ -380,12 +652,7 @@ contexts:
     - include: lists
     - include: dictionaries-and-sets
     - include: generators-groups-and-tuples
-    - match: \)
-      scope: invalid.illegal.stray.brace.round.python
-    - match: \]
-      scope: invalid.illegal.stray.brace.square.python
-    - match: \}
-      scope: invalid.illegal.stray.brace.curly.python
+    - include: illegal-stray-brackets
     - include: line-continuation
 
   # Always include these last and only one at a time!
@@ -398,7 +665,7 @@ contexts:
     # - invalid-name matches will pop the current context
     # - assignment expressions
     - include: expressions-common
-    - include: illegal-names-pop
+    - include: illegal-name
     - include: qualified-name
     - include: assignment-expression
 
@@ -461,10 +728,20 @@ contexts:
           pop: true
 
   constants:
-    - match: \b(None|True|False|Ellipsis|NotImplemented|__debug__)\b
+    - include: booleans
+    - include: nones
+    - match: \b(?:Ellipsis|NotImplemented|__debug__)\b
       scope: constant.language.python
     - match: \.{3}(?!\w)
       scope: constant.language.python
+
+  booleans:
+    - match: \b(?:True|False)\b
+      scope: constant.language.boolean.python
+
+  nones:
+    - match: \bNone\b
+      scope: constant.language.null.python
 
   numbers:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
@@ -594,8 +871,12 @@ contexts:
       scope: keyword.operator.logical.python
     - match: '@'
       scope: keyword.operator.matrix.python
+    - include: sequence-separators
+
+  sequence-separators:
     - match: ','
       scope: punctuation.separator.sequence.python
+      push: allow-unpack-operators
 
   allow-unpack-operators:
     # Match unpacking operators, if present
@@ -646,7 +927,7 @@ contexts:
               pop: true
             - match: ','
               scope: punctuation.separator.inheritance.python
-            - include: illegal-names-pop
+            - include: illegal-name
             - match: ({{identifier}}) *(=)
               captures:
                 1: variable.parameter.class-inheritance.python
@@ -910,16 +1191,18 @@ contexts:
 
   arguments:
     - include: keyword-arguments
+    - include: argument-separators
+    - include: inline-for
+    - include: expression-in-a-group
+
+  argument-separators:
     - match: ','
       scope: punctuation.separator.arguments.python
       push: allow-unpack-operators
-    - include: inline-for
-    - include: expression-in-a-group
 
   keyword-arguments:
     - match: '(?={{identifier}}\s*=(?!=))'
       push:
-        - include: line-continuation-or-pop
         - match: '='
           scope: keyword.operator.assignment.python
           set:
@@ -969,14 +1252,7 @@ contexts:
       scope: invalid.illegal.expected-parameter.python
 
   generators-groups-and-tuples:
-    # We don't know for certain, whether a parenthesized expression is a tuple,
-    # so try looking ahead.
-    - match: (\()\s*(\))
-      scope: meta.sequence.tuple.empty.python
-      captures:
-        1: punctuation.section.sequence.begin.python
-        2: punctuation.section.sequence.end.python
-      push: after-expression
+    - include: empty-tuples
     - match: (?=\()
       branch_point: generators-groups-and-tuples
       branch:
@@ -1021,22 +1297,23 @@ contexts:
     - match: \)
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - match: ','
-      scope: punctuation.separator.sequence.python
-      push: allow-unpack-operators
     - match: (?=\bfor\b)
       fail: generators-groups-and-tuples
+    - include: sequence-separators
     - include: expression-in-a-group
     - match: '='
       scope: invalid.illegal.unexpected-assignment-in-tuple.python
 
-  lists:
-    - match: (\[)\s*(\])
-      scope: meta.sequence.list.empty.python
+  empty-tuples:
+    - match: (\()\s*(\))
+      scope: meta.sequence.tuple.empty.python
       captures:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
       push: after-expression
+
+  lists:
+    - include: empty-lists
     - match: \[
       scope: punctuation.section.sequence.begin.python
       push: [inside-list, allow-unpack-operators]
@@ -1052,15 +1329,16 @@ contexts:
     - include: inline-for
     - include: expression-in-a-group
 
-  dictionaries-and-sets:
-    # Dictionaries and set literals use the same punctuation,
-    # so we try looking ahead to determine whether we have a dict or a set.
-    - match: '(\{)\s*(\})'
-      scope: meta.mapping.empty.python
+  empty-lists:
+    - match: (\[)\s*(\])
+      scope: meta.sequence.list.empty.python
       captures:
-        1: punctuation.section.mapping.begin.python
-        2: punctuation.section.mapping.end.python
+        1: punctuation.section.sequence.begin.python
+        2: punctuation.section.sequence.end.python
       push: after-expression
+
+  dictionaries-and-sets:
+    - include: empty-dictionaries
     - match: (?=\{)
       branch_point: dictionaries-and-sets
       branch:
@@ -1163,6 +1441,22 @@ contexts:
     - include: inline-for
     - include: expression-in-a-group
 
+  empty-dictionaries:
+    - match: (\{)\s*(\})
+      scope: meta.mapping.empty.python
+      captures:
+        1: punctuation.section.mapping.begin.python
+        2: punctuation.section.mapping.end.python
+      push: after-expression
+
+  illegal-stray-brackets:
+    - match: \)
+      scope: invalid.illegal.stray.brace.round.python
+    - match: \]
+      scope: invalid.illegal.stray.brace.square.python
+    - match: \}
+      scope: invalid.illegal.stray.brace.curly.python
+
   builtin-exceptions:
     - match: |-
         (?x)\b(
@@ -1198,15 +1492,7 @@ contexts:
       scope: support.function.builtin.python
 
   builtin-types:
-    - match: |-
-        (?x)\b(?:
-          bool|bytearray|bytes|complex|dict|float|frozenset|int|
-          list|memoryview|object|set|slice|str|tuple
-          # Python 2 types
-          |basestring|long|unicode
-          # Python 2 types prone to conflicts
-          # |buffer|file
-        )\b
+    - match: '{{builtin_types}}'
       scope: support.type.python
 
   name:
@@ -1280,7 +1566,8 @@ contexts:
     - include: illegal-names
     - include: magic-function-names
     - include: magic-variable-names
-    - include: language-variables
+    - include: class-variables
+    - include: wildcard-variables
 
   dotted-name-specials:
     - include: magic-function-names
@@ -1300,20 +1587,32 @@ contexts:
     - match: '{{identifier}}'
       scope: meta.generic-name.python
 
+  generic-name:
+    - match: '{{identifier}}'
+      scope: meta.generic-name.python
+      pop: true
+
   illegal-names:
     - match: \b{{illegal_names}}\b
       scope: invalid.illegal.name.python
 
-  illegal-names-pop:
+  illegal-name:
     - match: \b{{illegal_names}}\b
       scope: invalid.illegal.name.python
       pop: true
 
-  language-variables:
+  class-variables:
     - match: \b(self|cls)\b
       scope: variable.language.python
+
+  wildcard-variables:
     - match: _(?!{{identifier_continue}})
       scope: variable.language.python
+
+  wildcard-variable:
+    - match: _(?!{{identifier_continue}})
+      scope: variable.language.python
+      pop: true
 
   line-continuation:
     - match: (\\)(.*)$\n?
@@ -2302,7 +2601,7 @@ contexts:
         - match: '(?=[)\]}])'
           scope: invalid.illegal.missing-in.python
           pop: true
-        - include: illegal-names-pop
+        - include: illegal-name
         - include: target-list
 
   inline-if:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -500,7 +500,7 @@ def _():
 #        ^ keyword.operator.assignment
 #          ^ punctuation.section.function.begin
 #           ^^^^^ meta.function.inline.body
-#            ^^^^ constant.language.python
+#            ^^^^ constant.language.boolean.python
 
     lambda as, in=2: 0
 #          ^^ invalid.illegal.name
@@ -847,7 +847,7 @@ def _():
         pass
     elif False :
 #   ^^^^^^^^^^^^ meta.statement.conditional.elseif.python
-#        ^^^^^ constant.language
+#        ^^^^^ constant.language.boolean.python
 #              ^ punctuation.section.block.conditional.elseif.python
         pass
     else  :
@@ -858,7 +858,7 @@ def _():
     if \
         True:
 #       ^^^^^ meta.statement.conditional.if.python
-#       ^^^^ constant.language.python
+#       ^^^^ constant.language.boolean.python
 #           ^ punctuation.section.block.conditional.if.python
 #
 
@@ -879,6 +879,427 @@ def _():
 #   ^^^^^^ keyword.control.flow.return.python
     raise
 #   ^^^^^ keyword.control.flow.raise.python
+
+
+##################
+# Structural Pattern Matching
+##################
+
+    match
+#   ^^^^^ meta.generic-name.python
+
+    match expr
+#   ^^^^^^^^^^ - meta.statement.conditional
+#   ^^^^^ meta.generic-name.python
+#         ^^^^ meta.qualified-name.python meta.generic-name.python
+
+    match expr:
+#   ^^^^^^^^^^^ meta.statement.conditional.match.python
+#   ^^^^^ keyword.control.conditional.match.python
+#         ^^^^ meta.qualified-name.python meta.generic-name.python
+#             ^ punctuation.section.block.conditional.match.python
+
+    match(expr,)
+#   ^^^^^^^^^^^^ meta.function-call
+#   ^^^^^ variable.function.python - keyword
+#
+
+    match(expr,):
+#   ^^^^^ meta.statement.conditional.match.python - meta.sequence
+#        ^^^^^^^ meta.statement.conditional.match.python meta.sequence.tuple.python
+#               ^ meta.statement.conditional.match.python - meta.sequence
+#   ^^^^^ keyword.control.conditional.match.python
+#         ^^^^ meta.qualified-name.python meta.generic-name.python
+#             ^ punctuation.separator.sequence.python
+#              ^ punctuation.section.sequence.end.python
+#               ^ punctuation.section.block.conditional.match.python
+
+    match *named_expr, other:
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.match.python
+#   ^^^^^ keyword.control.conditional.match.python
+#         ^ keyword.operator.unpacking.sequence.python
+#          ^^^^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                    ^ punctuation.separator.sequence.python
+#                      ^^^^^ meta.qualified-name.python meta.generic-name.python
+#                           ^ punctuation.section.block.conditional.match.python
+
+    match http_code:
+#   ^^^^^^^^^^^^^^^^ meta.statement.conditional.match.python
+#   ^^^^^ keyword.control.conditional.match.python
+#         ^^^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                  ^ punctuation.section.block.conditional.match.python
+    case "200":
+#   ^^^^ meta.statement.conditional.case.python
+#       ^^^^^^ meta.statement.conditional.case.patterns.python
+#             ^ meta.statement.conditional.case.python
+#              ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^^ string.quoted.double.python
+#             ^ punctuation.section.block.conditional.case.python
+        print("OK")
+
+    case ["403",
+#   ^^^^ meta.statement.conditional.case.python
+#       ^^^^^^^^^ meta.statement.conditional.case.patterns.python
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^^^^^^ meta.sequence.list.python
+#        ^ punctuation.section.sequence.begin.python
+#         ^^^^^ string.quoted.double.python
+#              ^ punctuation.separator.sequence.python
+        "404"]:
+#      ^^^^^^^ meta.statement.conditional.case.patterns.python meta.sequence.list.python
+#             ^ meta.statement.conditional.case.python - meta.sequence
+#       ^^^^^ string.quoted.double.python
+#            ^ punctuation.section.sequence.end.python
+#             ^ punctuation.section.block.conditional.case.python
+        print("Not Found")
+
+    case \
+        418: ; print("I'm a teapot")
+#      ^^^^ meta.statement.conditional.case.patterns.python
+#          ^ meta.statement.conditional.case.python - meta.sequence
+#           ^^^ - meta.statement
+#       ^^^ meta.number.integer.decimal.python constant.numeric.value.python
+#          ^ punctuation.section.block.conditional.case.python
+#            ^ punctuation.terminator.statement.python
+#              ^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+
+    case -408+203:
+#   ^^^^ meta.statement.conditional.case.python
+#       ^^^^^^^^^ meta.statement.conditional.case.patterns.python
+#                ^ meta.statement.conditional.case.python - meta.sequence
+#                 ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ keyword.operator.arithmetic.python
+#         ^^^ constant.numeric.value.python
+#            ^ keyword.operator.arithmetic.python
+#             ^^^ constant.numeric.value.python
+#                ^ punctuation.section.block.conditional.case.python
+
+    case _: # comment
+#   ^^^^ meta.statement.conditional.case.python
+#       ^^ meta.statement.conditional.case.patterns.python
+#         ^ meta.statement.conditional.case.python
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ variable.language.python
+#         ^ punctuation.section.block.conditional.case.python
+#           ^^^^^^^^^^ comment.line.number-sign.python
+        print("Code not found")
+
+    case *expr:
+#   ^^^^ meta.statement.conditional.case.python
+#       ^^^^^^ meta.statement.conditional.case.patterns.python
+#             ^ meta.statement.conditional.case.python
+#        ^ keyword.operator.unpacking.sequence.python
+#         ^^^^ meta.generic-name.python
+#             ^ punctuation.section.block.conditional.case.python
+
+    case () if foo is True:
+#   ^^^^ meta.statement.conditional.case.python - meta.sequence
+#       ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#        ^^ meta.statement.conditional.case.patterns.python meta.sequence.tuple.empty.python
+#          ^ meta.statement.conditional.case.patterns.python
+#           ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python
+#                         ^ meta.statement.conditional.case.python
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ punctuation.section.sequence.begin.python
+#         ^ punctuation.section.sequence.end.python
+#           ^^ keyword.control.conditional.if.python
+#              ^^^ meta.generic-name.python
+#                  ^^ keyword.operator.logical.python
+#                     ^^^^ constant.language.boolean.python
+#                         ^ punctuation.section.block.conditional.case.python
+
+    case (,) if foo in ('bar', 'baz'):
+#   ^^^^ meta.statement.conditional.case.python - meta.sequence
+#       ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#        ^^^ meta.statement.conditional.case.patterns.python meta.sequence.tuple.python
+#           ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#            ^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.sequence.tuple
+#                      ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python meta.sequence.tuple.python
+#                                    ^ meta.statement.conditional.case.python - meta.sequence.tuple
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ punctuation.section.sequence.begin.python
+#         ^ punctuation.separator.sequence.python
+#          ^ punctuation.section.sequence.end.python
+#            ^^ keyword.control.conditional.if.python
+#               ^^^ meta.generic-name.python
+#                   ^^ keyword.operator.logical.python
+#                      ^ punctuation.section.sequence.begin.python
+#                       ^^^^^ string.quoted.single.python
+#                            ^ punctuation.separator.sequence.python
+#                              ^^^^^ string.quoted.single.python
+#                                   ^ punctuation.section.sequence.end.python
+#                                    ^ punctuation.section.block.conditional.case.python
+
+    case [] if foo in ['bar', 'baz']:
+#   ^^^^ meta.statement.conditional.case.python - meta.sequence
+#       ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#        ^^ meta.statement.conditional.case.patterns.python meta.sequence.list.empty.python
+#          ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#           ^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.sequence
+#                     ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python meta.sequence.list.python
+#                                   ^ meta.statement.conditional.case.python - meta.sequence.list
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ punctuation.section.sequence.begin.python
+#         ^ punctuation.section.sequence.end.python
+#           ^^ keyword.control.conditional.if.python
+#              ^^^ meta.generic-name.python
+#                  ^^ keyword.operator.logical.python
+#                     ^ punctuation.section.sequence.begin.python
+#                      ^^^^^ string.quoted.single.python
+#                           ^ punctuation.separator.sequence.python
+#                             ^^^^^ string.quoted.single.python
+#                                  ^ punctuation.section.sequence.end.python
+#                                   ^ punctuation.section.block.conditional.case.python
+
+    case [*expr, (*foo, *bar), *baz]:
+#   ^^^^ meta.statement.conditional.case.python - meta.sequence
+#       ^ meta.statement.conditional.case.patterns.python - meta.sequence
+#        ^^^^^^^^ meta.statement.conditional.case.patterns.python meta.sequence.list.python - meta.sequence meta.sequence
+#                ^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.sequence.list.python meta.sequence.tuple.python
+#                            ^^^^^^^ meta.statement.conditional.case.patterns.python meta.sequence.list.python - meta.sequence meta.sequence
+#                                   ^ meta.statement.conditional.case.python - meta.sequence
+
+    case {} if foo is True:
+#   ^^^^ meta.statement.conditional.case.python - meta.mapping
+#       ^ meta.statement.conditional.case.patterns.python - meta.mapping
+#        ^^ meta.statement.conditional.case.patterns.python meta.mapping.empty.python
+#          ^ meta.statement.conditional.case.patterns.python - meta.mapping
+#           ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python
+#                         ^ meta.statement.conditional.case.python
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ punctuation.section.mapping.begin.python
+#         ^ punctuation.section.mapping.end.python
+#           ^^ keyword.control.conditional.if.python
+#              ^^^ meta.generic-name.python
+#                  ^^ keyword.operator.logical.python
+#                     ^^^^ constant.language.boolean.python
+#                         ^ punctuation.section.block.conditional.case.python
+
+    case {s_key: 'value', num.key: 100, **pattern} if foo in {'foo', 'bar'}:
+#   ^^^^ meta.statement.conditional.case.python - meta.mapping
+#       ^ meta.statement.conditional.case.patterns.python - meta.mapping
+#        ^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#         ^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
+#              ^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#               ^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
+#                       ^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                         ^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
+#                                ^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                                 ^^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
+#                                     ^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                                                 ^ meta.statement.conditional.case.patterns.python - meta.mapping
+#                                                  ^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.set
+#                                                            ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python meta.set.python
+#                                                                          ^ meta.statement.conditional.case.python - meta.set
+#   ^^^^ keyword.control.conditional.case.python
+#        ^ punctuation.section.mapping.begin.python
+#         ^^^^^ meta.qualified-name.python meta.generic-name.python
+#              ^ punctuation.separator.mapping.key-value.python
+#                ^^^^^^^ string.quoted.single.python
+#                       ^ punctuation.separator.mapping.pair.python
+#                         ^^^^^^^ meta.qualified-name.python
+#                                ^ punctuation.separator.mapping.key-value.python
+#                                  ^^^ constant.numeric.value.python
+#                                     ^ punctuation.separator.mapping.pair.python
+#                                       ^^ keyword.operator.unpacking.mapping.python
+#                                         ^^^^^^^ meta.generic-name.python
+#                                                ^ punctuation.section.mapping.end.python
+#                                                  ^^ keyword.control.conditional.if.python
+#                                                     ^^^ meta.generic-name.python
+#                                                         ^^ keyword.operator.logical.python
+#                                                            ^ punctuation.section.set.begin.python
+#                                                             ^^^^^ string.quoted.single.python
+#                                                                  ^ punctuation.separator.set.python
+#                                                                    ^^^^^ string.quoted.single.python
+#                                                                         ^ punctuation.section.set.end.python
+#                                                                          ^ punctuation.section.block.conditional.case.python
+
+    case int():
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#           ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#             ^ meta.statement.conditional.case.python - meta.function-call
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^ support.type.python
+#           ^ punctuation.section.arguments.begin.python
+#            ^ punctuation.section.arguments.end.python
+#             ^ punctuation.section.block.conditional.case.python
+
+    case else():
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#            ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#              ^ meta.statement.conditional.case.python - meta.function-call
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^ invalid.illegal.name.python
+#            ^ punctuation.section.arguments.begin.python
+#             ^ punctuation.section.arguments.end.python
+#              ^ punctuation.section.block.conditional.case.python
+
+    case name(*pattern, *expr):
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#            ^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#                             ^ meta.statement.conditional.case.python - meta.function-call
+#                              ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^ storage.type.class.python
+#            ^ punctuation.section.arguments.begin.python
+#             ^ keyword.operator.unpacking.sequence.python
+#              ^^^^^^^ meta.generic-name.python
+#                     ^ punctuation.separator.arguments.python
+#                       ^ keyword.operator.unpacking.sequence.python
+#                        ^^^^ meta.generic-name.python
+#                            ^ punctuation.section.arguments.end.python
+#                             ^ punctuation.section.block.conditional.case.python
+
+    case name(key = pattern):
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#            ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#                           ^ meta.statement.conditional.case.python - meta.function-call
+#                            ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^ storage.type.class.python
+#            ^ punctuation.section.arguments.begin.python
+#             ^^^ variable.parameter.python
+#                 ^ keyword.operator.assignment.python
+#                   ^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                          ^ punctuation.section.arguments.end.python
+#                           ^ punctuation.section.block.conditional.case.python
+
+    case path.name(key = pattern):
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#                 ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#                                ^ meta.statement.conditional.case.python - meta.function-call
+#                                 ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^^^^^^^ meta.qualified-name.python
+#        ^^^^ meta.generic-name.python
+#            ^ punctuation.accessor.dot.python
+#             ^^^^ storage.type.class.python
+#                 ^ punctuation.section.arguments.begin.python
+#                  ^^^ variable.parameter.python
+#                      ^ keyword.operator.assignment.python
+#                        ^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                               ^ punctuation.section.arguments.end.python
+#                                ^ punctuation.section.block.conditional.case.python
+
+    case path \
+        . \
+        name(key = pattern):
+#   ^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python
+#       ^^^^ meta.function-call.python meta.qualified-name.python
+#           ^^^^^^^^^^^^^^^ meta.function-call.arguments.python
+#                          ^ meta.statement.conditional.case.python
+#       ^^^^ storage.type.class.python
+#           ^ punctuation.section.arguments.begin.python
+#            ^^^ variable.parameter.python
+#                ^ keyword.operator.assignment.python
+#                  ^^^^^^^ meta.generic-name.python
+#                         ^ punctuation.section.arguments.end.python
+#                          ^ punctuation.section.block.conditional.case.python
+
+    case int(), MyClass(keyword=('('|')') as foo, if=*args), else() if foo is None:
+#  ^ - meta.statement
+#   ^^^^ meta.statement.conditional.case.python - meta.function-call
+#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#           ^^ meta.statement.conditional.case.patterns.python  meta.function-call.arguments.python
+#             ^^ meta.statement.conditional.case.patterns.python - meta.function-call
+#               ^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#                      ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python - meta.group
+#                               ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python meta.group.python
+#                                        ^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python - meta.group
+#                                                          ^^ meta.statement.conditional.case.patterns.python - meta.function-call
+#                                                            ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#                                                                ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
+#                                                                  ^ meta.statement.conditional.case.patterns.python - meta.function-call
+#                                                                   ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.function-call
+#                                                                                 ^ meta.statement.conditional.case.python
+#                                                                                  ^ - meta.statement
+#   ^^^^ keyword.control.conditional.case.python
+#        ^^^ support.type.python
+#           ^ punctuation.section.arguments.begin.python
+#            ^ punctuation.section.arguments.end.python
+#             ^ punctuation.separator.sequence.python
+#               ^^^^^^^ storage.type.class.python
+#                      ^ punctuation.section.arguments.begin.python
+#                       ^^^^^^^ variable.parameter.python
+#                              ^ keyword.operator.assignment.python
+#                               ^ punctuation.section.group.begin.python
+#                                ^^^ string.quoted.single.python
+#                                   ^ keyword.operator.logical.python
+#                                    ^^^ string.quoted.single.python
+#                                       ^ punctuation.section.group.end.python
+#                                         ^^ keyword.control.conditional.case.as.python
+#                                            ^^^ meta.generic-name.python
+#                                               ^ punctuation.separator.arguments.python
+#                                                 ^^ invalid.illegal.name.python
+#                                                   ^ keyword.operator.assignment.python
+#                                                    ^ keyword.operator.unpacking.sequence.python
+#                                                     ^^^^ meta.generic-name.python
+#                                                         ^ punctuation.section.arguments.end.python
+#                                                          ^ punctuation.separator.sequence.python
+#                                                            ^^^^ invalid.illegal.name.python
+#                                                                ^ punctuation.section.arguments.begin.python
+#                                                                 ^ punctuation.section.arguments.end.python
+#                                                                   ^^ keyword.control.conditional.if.python
+#                                                                      ^^^ meta.generic-name.python
+#                                                                          ^^ keyword.operator.logical.python
+#                                                                             ^^^^ constant.language.null.python
+#                                                                                 ^ punctuation.section.block.conditional.case.python
+
+    case *expr as _:
+#              ^^ keyword.control.conditional.case.as.python
+#                 ^ variable.language.python
+
+    case *expr as isinstance:
+#              ^^ keyword.control.conditional.case.as.python
+#                 ^^^^^^^^^^ meta.generic-name.python
+
+    case *expr as elif:
+#              ^^ keyword.control.conditional.case.as.python
+#                 ^^^^ invalid.illegal.name.python
+
+    if not case:
+#          ^^^^ meta.generic-name.python - keyword
+        case = 10
+#       ^^^^ meta.generic-name.python - keyword
+        g = case.foo(1)
+#           ^^^^ meta.generic-name.python - keyword
+        e = case + foo
+#           ^^^^ meta.generic-name.python - keyword
+        case.case
+#       ^^^^ meta.generic-name.python - keyword
+#           ^ punctuation.accessor.dot.python
+#            ^^^^ meta.generic-name.python - keyword
+        case()
+#       ^^^^ variable.function.python - keyword
+
+    match = re.match(r"^.*$")
+#   ^^^^^ meta.generic-name.python - keyword
+#              ^^^^^ meta.function-call.python variable.function.python
+    if match:
+#      ^^^^^ meta.generic-name.python - keyword
+        g = match.group(1)
+#           ^^^^^ meta.generic-name.python - keyword
+        e = match + foo
+#           ^^^^^ meta.generic-name.python - keyword
+        match()
+#       ^^^^^ variable.function.python - keyword
+        match.match
+#       ^^^^^ meta.generic-name.python - keyword
+#            ^ punctuation.accessor.dot.python
+#             ^^^^^ meta.generic-name.python - keyword
 
 
 ##################


### PR DESCRIPTION
Not sure if we see any progress on #2826 and release date is not too far in the future (3.10.0 final: Monday, 2021-10-04).

So here's another attempt to implement structural pattern matching.

Patterns differ from normal expressions slightly, so a complete new tree of contexts is created.

Some of the existing contexts are modified to re-use as much as possible.