### PR TITLE
[SQL] Improve handling of LIKE keyword

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -96,8 +96,14 @@ contexts:
         1: keyword.operator.logical.sql
         2: keyword.operator.logical.sql
         3: constant.language.sql
-    - match: (?i:\b(and|or|like|having|exists|between|in)\b)
+    - match: (?i:\b(and|or|having|exists|between|in)\b)
       scope: keyword.operator.logical.sql
+    - match: (?i:\blike\b)
+      scope: keyword.operator.logical.sql
+      push: like_string
+    - match: (?i:\bescape\b)
+      scope: keyword.operator.sql
+      push: like_escape
     - match: (?i:\bvalues\b)
       scope: keyword.other.DML.II.sql
     - match: (?i:\b(begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b)
@@ -243,3 +249,31 @@ contexts:
       # Handle situations where the schema and . 
     - match: '{{end_identifier}}'
       pop: true
+  like_escape:
+    - match: (\')([^'])(\')
+      captures:
+        0: meta.string.escape.sql string.quoted.single.sql
+        1: punctuation.definition.string.begin.sql
+        2: constant.character.escape.sql
+        3: punctuation.definition.string.end.sql
+      pop: true
+    - match: (?=\S)
+      pop: true
+  like_string:
+    - match: \'
+      scope: punctuation.definition.string.begin.sql
+      set: inside_like_single_quoted_string
+    - match: (?=\S)
+      pop: true
+  inside_like_single_quoted_string:
+    - meta_scope: meta.string.like.sql string.quoted.single.sql
+    - match: \'
+      scope: punctuation.definition.string.end.sql
+      pop: true
+    - match: (\[)(?:.|[^]']+?)(\])
+      scope: meta.set.like.sql
+      captures:
+        1: keyword.control.set.begin.sql
+        2: keyword.control.set.end.sql
+    - match: '[%_]'
+      scope: keyword.other.any.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
       scope: keyword.operator.logical.sql
       push: like_string
     - match: (?i:\bescape\b)
-      scope: keyword.operator.sql
+      scope: keyword.operator.word.sql
       push: like_escape
     - match: (?i:\bvalues\b)
       scope: keyword.other.DML.II.sql
@@ -270,10 +270,17 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.sql
       pop: true
-    - match: (\[)(?:.|[^]']+?)(\])
+    - match: |-
+        (?x)
+        (\[)(\^)?
+        (?:.|[^]'-]+?)
+        (?:(-)[^]'-]*)?
+        (\])
       scope: meta.set.like.sql
       captures:
         1: keyword.control.set.begin.sql
-        2: keyword.control.set.end.sql
+        2: keyword.control.set.negation.sql
+        3: constant.other.range.sql
+        4: keyword.control.set.end.sql
     - match: '[%_]'
-      scope: keyword.other.any.sql
+      scope: keyword.operator.wildcard.sql

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -173,3 +173,49 @@ WHERE   f.a IS NULL
 --              ^^ keyword.operator.logical.sql
 --                 ^^^ keyword.operator.logical.sql
 --                     ^^^^ constant.language.sql
+
+
+SELECT columns FROM table WHERE
+    column LIKE '%[[]SQL Server Driver]%'
+--         ^^^^ keyword.operator.logical
+--              ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.like string.quoted.single
+--              ^ punctuation.definition.string.begin
+--               ^ keyword.other.any
+--                ^^^ meta.set.like
+--                ^ keyword.control.set.begin
+--                  ^ keyword.control.set.end
+--                   ^^^^^^^^^^^^^^^^^^ - constant - keyword
+--                                     ^ keyword.other.any
+--                                      ^ punctuation.definition.string.end
+--                                       ^^ - meta.string - string
+
+SELECT columns FROM table WHERE
+    column LIKE '%[SQL Server Driver]%'
+--         ^^^^ keyword.operator.logical
+--              ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.like string.quoted.single
+--              ^ punctuation.definition.string.begin
+--               ^ keyword.other.any
+--                ^^^^^^^^^^^^^^^^^^^ meta.set.like
+--                ^ keyword.control.set.begin
+--                                  ^ keyword.control.set.end
+--                   ^^^^^^^^^^^^^^^ - constant - keyword
+--                                   ^ keyword.other.any
+--                                    ^ punctuation.definition.string.end
+--                                     ^^ - meta.string - string
+
+SELECT columns FROM table WHERE
+    column LIKE 'hello_world'
+--         ^^^^ keyword.operator.logical
+--              ^^^^^^^^^^^^ meta.string.like string.quoted.single
+--              ^ punctuation.definition.string.begin
+--                    ^ keyword.other.any
+--                          ^ punctuation.definition.string.end
+--                           ^^ - meta.string - string
+
+SELECT columns FROM table WHERE
+    column LIKE '%\[SQL Server Driver]%' ESCAPE '\'
+--                                       ^^^^^^ keyword.operator
+--                                              ^^^ string.quoted.single
+--                                              ^ punctuation.definition.string.begin
+--                                               ^ constant.character.escape
+--                                                ^ punctuation.definition.string.end

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -180,12 +180,12 @@ SELECT columns FROM table WHERE
 --         ^^^^ keyword.operator.logical
 --              ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.like string.quoted.single
 --              ^ punctuation.definition.string.begin
---               ^ keyword.other.any
+--               ^ keyword.operator.wildcard
 --                ^^^ meta.set.like
 --                ^ keyword.control.set.begin
 --                  ^ keyword.control.set.end
 --                   ^^^^^^^^^^^^^^^^^^ - constant - keyword
---                                     ^ keyword.other.any
+--                                     ^ keyword.operator.wildcard
 --                                      ^ punctuation.definition.string.end
 --                                       ^^ - meta.string - string
 
@@ -194,27 +194,42 @@ SELECT columns FROM table WHERE
 --         ^^^^ keyword.operator.logical
 --              ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.like string.quoted.single
 --              ^ punctuation.definition.string.begin
---               ^ keyword.other.any
+--               ^ keyword.operator.wildcard
 --                ^^^^^^^^^^^^^^^^^^^ meta.set.like
 --                ^ keyword.control.set.begin
 --                                  ^ keyword.control.set.end
 --                   ^^^^^^^^^^^^^^^ - constant - keyword
---                                   ^ keyword.other.any
+--                                   ^ keyword.operator.wildcard
 --                                    ^ punctuation.definition.string.end
 --                                     ^^ - meta.string - string
+
+SELECT columns FROM table WHERE
+    column LIKE '%[^a-f]%'
+--         ^^^^ keyword.operator.logical
+--              ^^^^^^^^^^ meta.string.like string.quoted.single
+--              ^ punctuation.definition.string.begin
+--               ^ keyword.operator.wildcard
+--                ^^^^^^ meta.set.like
+--                ^ keyword.control.set.begin
+--                 ^ keyword.control.set.negation
+--                   ^ constant.other.range
+--                     ^ keyword.control.set.end
+--                      ^ keyword.operator.wildcard
+--                       ^ punctuation.definition.string.end
+--                        ^^ - meta.string - string
 
 SELECT columns FROM table WHERE
     column LIKE 'hello_world'
 --         ^^^^ keyword.operator.logical
 --              ^^^^^^^^^^^^ meta.string.like string.quoted.single
 --              ^ punctuation.definition.string.begin
---                    ^ keyword.other.any
+--                    ^ keyword.operator.wildcard
 --                          ^ punctuation.definition.string.end
 --                           ^^ - meta.string - string
 
 SELECT columns FROM table WHERE
     column LIKE '%\[SQL Server Driver]%' ESCAPE '\'
---                                       ^^^^^^ keyword.operator
+--                                       ^^^^^^ keyword.operator.word
 --                                              ^^^ string.quoted.single
 --                                              ^ punctuation.definition.string.begin
 --                                               ^ constant.character.escape


### PR DESCRIPTION
Scope escape characters inside single quoted strings after a LIKE keyword. Also, scope `ESCAPE` and the character after it. Fixes https://github.com/sublimehq/Packages/issues/630#issuecomment-910532251.

We could improve on this in a follow-up PR to use branching to detect a strict set of escape characters (specifically, `\`) so that the scoping inside the `LIKE` string would be correct.