### PR TITLE
[JavaScript/TypeScript] Improve shebang and comments highlighting

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -124,33 +124,38 @@ contexts:
     - include: comments
 
   comments:
-    - match: /\*\*(?!/)
+    - include: line-comments
+    - include: block-comments
+
+  block-comments:
+    # empty block comments
+    - match: (/\*\*+/)
+      scope: comment.block.empty.java punctuation.definition.comment.java
+    # documentation block comments
+    - match: /\*\*+
       scope: punctuation.definition.comment.begin.js
       push:
-        - jsdoc-comment
+        - jsdoc-comment-body
         - jsdoc-block-tag
+    # normal block comments
     - match: /\*
       scope: punctuation.definition.comment.begin.js
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.block.js
-        - match: \*/
-          scope: punctuation.definition.comment.end.js
-          pop: true
-    - match: //
-      scope: punctuation.definition.comment.js
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.double-slash.js
-        - match: \n
-          pop: true
+      push: block-comment-body
 
-  jsdoc-comment:
+  block-comment-end:
+    - match: \*+/
+      scope: punctuation.definition.comment.end.js
+      pop: true
+
+  block-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.js
+    - include: block-comment-end
+
+  jsdoc-comment-body:
     - meta_include_prototype: false
     - meta_scope: comment.block.documentation.js
-    - match: \*/
-      scope: punctuation.definition.comment.end.js
-      pop: 1
+    - include: block-comment-end
     # JSDoc "block" tags (i.e. @param) are only accepted at the beginning of the documentation
     # line so directly after the '/**' or after the '*' marker on the next lines.
     - match: ^\s*(\*)(?!/)
@@ -163,6 +168,35 @@ contexts:
       scope: entity.other.attribute-name.documentation.js
       pop: 1
     - match: (?=\S)|$
+      pop: 1
+
+  line-comments:
+    - match: /{4,}
+      scope: punctuation.definition.comment.js
+      push: line-comment-other-body
+    - match: /{3}
+      scope: punctuation.definition.comment.js
+      push: line-comment-triple-slash-body
+    - match: /{2}
+      scope: punctuation.definition.comment.js
+      push: line-comment-double-slash-body
+
+  line-comment-double-slash-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.double-slash.js
+    - match: \n
+      pop: 1
+
+  line-comment-triple-slash-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.triple-slash.js
+    - match: \n
+      pop: 1
+
+  line-comment-other-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.other.js
+    - match: \n
       pop: 1
 
   shebang:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -109,7 +109,7 @@ variables:
 
 contexts:
   main:
-    - meta_include_prototype: false # don't match before shebang
+    - meta_include_prototype: false # don't match comments before shebang
     - match: ''
       push: [javascript, shebang]
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -181,23 +181,26 @@ contexts:
       scope: punctuation.definition.comment.js
       push: line-comment-double-slash-body
 
+  line-comment-end:
+    - match: (//+)?\n
+      captures:
+        1: punctuation.definition.comment.js
+      pop: 1
+
   line-comment-double-slash-body:
     - meta_include_prototype: false
     - meta_scope: comment.line.double-slash.js
-    - match: \n
-      pop: 1
+    - include: line-comment-end
 
   line-comment-triple-slash-body:
     - meta_include_prototype: false
     - meta_scope: comment.line.triple-slash.js
-    - match: \n
-      pop: 1
+    - include: line-comment-end
 
   line-comment-other-body:
     - meta_include_prototype: false
     - meta_scope: comment.line.other.js
-    - match: \n
-      pop: 1
+    - include: line-comment-end
 
   shebang:
     - meta_include_prototype: false

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -111,9 +111,9 @@ contexts:
   main:
     - meta_include_prototype: false # don't match comments before shebang
     - match: ''
-      push: [javascript, shebang]
+      push: [script, shebang]
 
-  javascript:
+  script:
     - match: '\)|\}|\]'
       scope: invalid.illegal.stray-bracket-end.js
       # Don't pop or embedding could break.

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -129,8 +129,8 @@ contexts:
 
   block-comments:
     # empty block comments
-    - match: (/\*\*+/)
-      scope: comment.block.empty.java punctuation.definition.comment.java
+    - match: /\*\*+/
+      scope: comment.block.empty.js punctuation.definition.comment.js
     # documentation block comments
     - match: /\*\*+
       scope: punctuation.definition.comment.begin.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -200,6 +200,7 @@ contexts:
       pop: 1
 
   shebang:
+    - meta_include_prototype: false
     - match: ^\#!
       scope: punctuation.definition.comment.js
       set: shebang-body

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -109,8 +109,11 @@ variables:
 
 contexts:
   main:
-    - include: comments-top-level
+    - meta_include_prototype: false # don't match before shebang
+    - match: ''
+      push: [javascript, shebang]
 
+  javascript:
     - match: '\)|\}|\]'
       scope: invalid.illegal.stray-bracket-end.js
       # Don't pop or embedding could break.
@@ -162,11 +165,21 @@ contexts:
     - match: (?=\S)|$
       pop: 1
 
-  comments-top-level:
-    - match: ^(#!).*$\n?
-      scope: comment.line.shebang.js
-      captures:
-        1: punctuation.definition.comment.js
+  shebang:
+    - match: ^\#!
+      scope: punctuation.definition.comment.js
+      set: shebang-body
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
+      pop: 1
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.js
+    # Note: Keep sync with first_line_match!
+    - match: \b(node|js)\b
+      scope: constant.language.shebang.js
+    - match: \n
+      pop: 1
 
   else-pop:
     - match: (?=\S)

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -204,7 +204,7 @@ contexts:
     - match: ^\#!
       scope: punctuation.definition.comment.js
       set: shebang-body
-    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if the syntax is embedded.
       pop: 1
 
   shebang-body:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -53,9 +53,10 @@ contexts:
         1: punctuation.definition.comment.js
       embed: scope:text.xml#tag
       embed_scope: comment.line.triple-slash.js meta.preprocessor.directive.js
-      escape: \n
+      escape: (//+)?\n
       escape_captures:
         0: comment.line.triple-slash.js
+        1: punctuation.definition.comment.js
     - include: comments
     - include: else-pop
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -44,18 +44,6 @@ contexts:
     - match: ''
       push: [javascript, preprocessor, shebang]
 
-  comments:
-    - meta_prepend: true
-    - match: ///(?!/)
-      scope: punctuation.definition.comment.js
-      push: comments-triple-slash-body
-
-  comments-triple-slash-body:
-    - meta_include_prototype: false
-    - meta_scope: comment.line.triple-slash.js
-    - match: \n
-      pop: 1
-
   preprocessor:
     # https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
     - meta_include_prototype: false # don't match before preprocessor directive

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -44,6 +44,18 @@ contexts:
     - match: ''
       push: [javascript, preprocessor, shebang]
 
+  comments:
+    - meta_prepend: true
+    - match: ///(?!/)
+      scope: punctuation.definition.comment.js
+      push: comments-triple-slash-body
+
+  comments-triple-slash-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.triple-slash.js
+    - match: \n
+      pop: 1
+
   preprocessor:
     # https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
     - meta_include_prototype: false # don't match before preprocessor directive

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -39,6 +39,26 @@ variables:
   modifier: (?:(?:static|readonly|private|public|protected|abstract|declare|override){{identifier_break}})
 
 contexts:
+  main:
+    - meta_include_prototype: false # don't match before shebang
+    - match: ''
+      push: [javascript, preprocessor, shebang]
+
+  preprocessor:
+    # https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
+    - meta_include_prototype: false # don't match before preprocessor directive
+    - match: (///)(?!/)\s*
+      captures:
+        0: comment.line.triple-slash.js
+        1: punctuation.definition.comment.js
+      embed: scope:text.xml#tag
+      embed_scope: comment.line.triple-slash.js meta.preprocessor.directive.js
+      escape: \n
+      escape_captures:
+        0: comment.line.triple-slash.js
+    - include: comments
+    - include: else-pop
+
   branch-possible-arrow-function:
     - meta_prepend: true
     - match: (?=\()

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
   main:
     - meta_include_prototype: false # don't match before shebang
     - match: ''
-      push: [javascript, preprocessor, shebang]
+      push: [script, preprocessor, shebang]
 
   preprocessor:
     # https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -46,7 +46,7 @@ contexts:
 
   preprocessor:
     # https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
-    - meta_include_prototype: false # don't match before preprocessor directive
+    - meta_include_prototype: false # don't match comments before preprocessor directive
     - match: (///)(?!/)\s*
       captures:
         0: comment.line.triple-slash.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -73,10 +73,7 @@ x --> y;
 //  ^ keyword.operator.comparison.js
 
 #! /usr/bin/env node
-// <- comment.line.shebang punctuation.definition.comment
-
- #! /usr/bin/env node
-//^^^^^^^^^^^^^^^^^^^ - comment.line.shebang
+//^^^^^^^^^^^^^^^^^^ - comment.line.shebang
 
 /*@if /*/
 //     ^^ punctuation.definition.comment.end
@@ -1560,4 +1557,4 @@ debugger
     a.b?.();
 //  ^^^^^^^ meta.function-call.method
 //    ^ variable.function
-//     
+//

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -30,9 +30,9 @@
 
     /**/ /***/
 // ^ - comment
-//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//  ^^^^ comment.block.empty.js punctuation.definition.comment.js
 //      ^ - comment
-//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//       ^^^^^ comment.block.empty.js punctuation.definition.comment.js
 //            ^ - comment
 
     /** @todo **/

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1,5 +1,76 @@
 // SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
+// comment
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^ comment.line.double-slash.js
+
+/// comment
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^ comment.line.triple-slash.js
+
+/////////////////////////////////////////////////////////////////
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.other.js punctuation.definition.comment.js
+//                                                               ^ comment.line.other.js - punctuation
+
+/* */
+// <- comment.block.js punctuation.definition.comment.begin.js
+//^^^ comment.block.js
+//   ^ - comment
+
+    /**/ /***/
+// ^ - comment
+//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//      ^ - comment
+//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//            ^ - comment
+
+    /** @todo **/
+//  ^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^ punctuation.definition.comment.begin.js
+//      ^^^^^ entity.other.attribute-name.documentation.js
+//            ^^^ punctuation.definition.comment.end.js
+
+    /**
+// ^ - comment
+//  ^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//     ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     **/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^ comment.block.documentation.js
+//      ^ - comment
+
+    /*** @todo ***/
+//  ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^^ punctuation.definition.comment.begin.js
+//       ^^^^^ entity.other.attribute-name.documentation.js
+//             ^^^^ punctuation.definition.comment.end.js
+
+    /***
+// ^ - comment
+//  ^^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//      ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     ***/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^^ comment.block.documentation.js
+//       ^ - comment
+
+/// <foo bar="baz"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - meta.preprocessor
+
+//// <foo bar="baz"/>
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
+
 // This object literal is technically broken since foo() does not have a
 // method body, but we include it here to ensure that highlighting is not
 // broken as the user is typing

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -4,9 +4,19 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+// comment //
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^ comment.line.double-slash.js
+//         ^^ punctuation.definition.comment.js
+
 /// comment
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
 //^^^^^^^^^^ comment.line.triple-slash.js
+
+/// comment ///
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^ comment.line.triple-slash.js
+//          ^^^ punctuation.definition.comment.js
 
 /////////////////////////////////////////////////////////////////
 // <- comment.line.other.js punctuation.definition.comment.js

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -1,5 +1,76 @@
 // SYNTAX TEST "Packages/JavaScript/JSX.sublime-syntax"
 
+// comment
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^ comment.line.double-slash.js
+
+/// comment
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^ comment.line.triple-slash.js
+
+/////////////////////////////////////////////////////////////////
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.other.js punctuation.definition.comment.js
+//                                                               ^ comment.line.other.js - punctuation
+
+/* */
+// <- comment.block.js punctuation.definition.comment.begin.js
+//^^^ comment.block.js
+//   ^ - comment
+
+    /**/ /***/
+// ^ - comment
+//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//      ^ - comment
+//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//            ^ - comment
+
+    /** @todo **/
+//  ^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^ punctuation.definition.comment.begin.js
+//      ^^^^^ entity.other.attribute-name.documentation.js
+//            ^^^ punctuation.definition.comment.end.js
+
+    /**
+// ^ - comment
+//  ^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//     ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     **/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^ comment.block.documentation.js
+//      ^ - comment
+
+    /*** @todo ***/
+//  ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^^ punctuation.definition.comment.begin.js
+//       ^^^^^ entity.other.attribute-name.documentation.js
+//             ^^^^ punctuation.definition.comment.end.js
+
+    /***
+// ^ - comment
+//  ^^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//      ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     ***/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^^ comment.block.documentation.js
+//       ^ - comment
+
+/// <foo bar="baz"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - meta.preprocessor
+
+//// <foo bar="baz"/>
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
+
     <foo />;
 //  ^^^^^^^ meta.jsx meta.tag
 //  ^ punctuation.definition.tag.begin

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -30,9 +30,9 @@
 
     /**/ /***/
 // ^ - comment
-//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//  ^^^^ comment.block.empty.js punctuation.definition.comment.js
 //      ^ - comment
-//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//       ^^^^^ comment.block.empty.js punctuation.definition.comment.js
 //            ^ - comment
 
     /** @todo **/

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -4,9 +4,19 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+// comment //
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^ comment.line.double-slash.js
+//         ^^ punctuation.definition.comment.js
+
 /// comment
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
 //^^^^^^^^^^ comment.line.triple-slash.js
+
+/// comment ///
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^ comment.line.triple-slash.js
+//          ^^^ punctuation.definition.comment.js
 
 /////////////////////////////////////////////////////////////////
 // <- comment.line.other.js punctuation.definition.comment.js

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -1,5 +1,38 @@
 // SYNTAX TEST "Packages/JavaScript/TSX.sublime-syntax"
 
+// comment
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^ comment.line.double-slash.js
+
+/* */
+// <- comment.block.js punctuation.definition.comment.begin.js
+//^^^ comment.block.js
+//   ^ - comment
+
+/// <reference no-default-lib="true"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^ comment.line.triple-slash.js - meta.preprocessor
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js meta.preprocessor.directive.js meta.tag.xml
+//                                    ^ comment.line.triple-slash.js - meta.preprocessor
+
+/// <foo bar="baz"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^ comment.line.triple-slash.js - meta.preprocessor
+//  ^^^^^^^^^^^^^^^^ comment.line.triple-slash.js meta.preprocessor.directive.js meta.tag.xml
+//                  ^ comment.line.triple-slash.js - meta.preprocessor
+
+//// <foo bar="baz"/>
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+
+import foo;
+
+/// <normal comment="after first statement"/>
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+
     <foo />;
 //  ^^^^^^^ meta.jsx meta.tag
 //  ^ punctuation.definition.tag.begin

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -30,9 +30,9 @@
 
     /**/ /***/
 // ^ - comment
-//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//  ^^^^ comment.block.empty.js punctuation.definition.comment.js
 //      ^ - comment
-//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//       ^^^^^ comment.block.empty.js punctuation.definition.comment.js
 //            ^ - comment
 
     /** @todo **/

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -30,8 +30,9 @@
 import foo;
 
 /// <normal comment="after first statement"/>
-// <- comment.line.double-slash.js punctuation.definition.comment.js
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - punctuation - meta.preprocessor
 
     <foo />;
 //  ^^^^^^^ meta.jsx meta.tag

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -4,10 +4,64 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+/// comment
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^ comment.line.triple-slash.js
+
+/////////////////////////////////////////////////////////////////
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.other.js punctuation.definition.comment.js
+//                                                               ^ comment.line.other.js - punctuation
+
 /* */
 // <- comment.block.js punctuation.definition.comment.begin.js
 //^^^ comment.block.js
 //   ^ - comment
+
+    /**/ /***/
+// ^ - comment
+//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//      ^ - comment
+//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//            ^ - comment
+
+    /** @todo **/
+//  ^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^ punctuation.definition.comment.begin.js
+//      ^^^^^ entity.other.attribute-name.documentation.js
+//            ^^^ punctuation.definition.comment.end.js
+
+    /**
+// ^ - comment
+//  ^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//     ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     **/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^ comment.block.documentation.js
+//      ^ - comment
+
+    /*** @todo ***/
+//  ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^^ punctuation.definition.comment.begin.js
+//       ^^^^^ entity.other.attribute-name.documentation.js
+//             ^^^^ punctuation.definition.comment.end.js
+
+    /***
+// ^ - comment
+//  ^^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//      ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     ***/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^^ comment.block.documentation.js
+//       ^ - comment
 
 /// <reference no-default-lib="true"/>
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
@@ -24,8 +78,8 @@
 //                  ^ comment.line.triple-slash.js - meta.preprocessor
 
 //// <foo bar="baz"/>
-// <- comment.line.double-slash.js punctuation.definition.comment.js
-//^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
 
 import foo;
 

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -4,9 +4,19 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+// comment //
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^ comment.line.double-slash.js
+//         ^^ punctuation.definition.comment.js
+
 /// comment
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
 //^^^^^^^^^^ comment.line.triple-slash.js
+
+/// comment ///
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^ comment.line.triple-slash.js
+//          ^^^ punctuation.definition.comment.js
 
 /////////////////////////////////////////////////////////////////
 // <- comment.line.other.js punctuation.definition.comment.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -30,9 +30,9 @@
 
     /**/ /***/
 // ^ - comment
-//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//  ^^^^ comment.block.empty.js punctuation.definition.comment.js
 //      ^ - comment
-//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//       ^^^^^ comment.block.empty.js punctuation.definition.comment.js
 //            ^ - comment
 
     /** @todo **/

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -4,10 +4,64 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+/// comment
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^ comment.line.triple-slash.js
+
+/////////////////////////////////////////////////////////////////
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.other.js punctuation.definition.comment.js
+//                                                               ^ comment.line.other.js - punctuation
+
 /* */
 // <- comment.block.js punctuation.definition.comment.begin.js
 //^^^ comment.block.js
 //   ^ - comment
+
+    /**/ /***/
+// ^ - comment
+//  ^^^^ comment.block.empty.java punctuation.definition.comment.java
+//      ^ - comment
+//       ^^^^^ comment.block.empty.java punctuation.definition.comment.java
+//            ^ - comment
+
+    /** @todo **/
+//  ^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^ punctuation.definition.comment.begin.js
+//      ^^^^^ entity.other.attribute-name.documentation.js
+//            ^^^ punctuation.definition.comment.end.js
+
+    /**
+// ^ - comment
+//  ^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//     ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     **/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^ comment.block.documentation.js
+//      ^ - comment
+
+    /*** @todo ***/
+//  ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//  ^^^^ punctuation.definition.comment.begin.js
+//       ^^^^^ entity.other.attribute-name.documentation.js
+//             ^^^^ punctuation.definition.comment.end.js
+
+    /***
+// ^ - comment
+//  ^^^^ comment.block.documentation.js punctuation.definition.comment.begin.js
+//      ^ comment.block.documentation.js - punctuation
+     * @todo test it
+//   ^ comment.block.documentation.js punctuation.definition.comment.js
+//    ^^^^^^^^^^^^^^^ comment.block.documentation.js
+//     ^^^^^ entity.other.attribute-name.documentation.js
+     ***/
+//^^^ comment.block.documentation.js - punctuation
+//   ^^^^ comment.block.documentation.js
+//       ^ - comment
 
 /// <reference no-default-lib="true"/>
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
@@ -24,8 +78,8 @@
 //                  ^ comment.line.triple-slash.js - meta.preprocessor
 
 //// <foo bar="baz"/>
-// <- comment.line.double-slash.js punctuation.definition.comment.js
-//^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
 
 import foo;
 

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -30,8 +30,9 @@
 import foo;
 
 /// <normal comment="after first statement"/>
-// <- comment.line.double-slash.js punctuation.definition.comment.js
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - punctuation - meta.preprocessor
 
 
 /* Import/Export */

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1,5 +1,39 @@
 // SYNTAX TEST "Packages/JavaScript/TypeScript.sublime-syntax"
 
+// comment
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^ comment.line.double-slash.js
+
+/* */
+// <- comment.block.js punctuation.definition.comment.begin.js
+//^^^ comment.block.js
+//   ^ - comment
+
+/// <reference no-default-lib="true"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^ comment.line.triple-slash.js - meta.preprocessor
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js meta.preprocessor.directive.js meta.tag.xml
+//                                    ^ comment.line.triple-slash.js - meta.preprocessor
+
+/// <foo bar="baz"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^ comment.line.triple-slash.js punctuation.definition.comment.js
+// ^ comment.line.triple-slash.js - meta.preprocessor
+//  ^^^^^^^^^^^^^^^^ comment.line.triple-slash.js meta.preprocessor.directive.js meta.tag.xml
+//                  ^ comment.line.triple-slash.js - meta.preprocessor
+
+//// <foo bar="baz"/>
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+
+import foo;
+
+/// <normal comment="after first statement"/>
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.js - meta.preprocessor
+
+
 /* Import/Export */
 
     import type T from 'somewhere';
@@ -832,7 +866,7 @@ let x: {
 //                                        ^ support.class
 //                                          ^ punctuation.section.brackets.end
 //                                            ^ punctuation.separator
-    
+
     }
 //  ^ meta.type punctuation.section.block.end
 

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -4,9 +4,19 @@
 // <- comment.line.double-slash.js punctuation.definition.comment.js
 //^^^^^^^^^ comment.line.double-slash.js
 
+// comment //
+// <- comment.line.double-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^ comment.line.double-slash.js
+//         ^^ punctuation.definition.comment.js
+
 /// comment
 // <- comment.line.triple-slash.js punctuation.definition.comment.js
 //^^^^^^^^^^ comment.line.triple-slash.js
+
+/// comment ///
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^ comment.line.triple-slash.js
+//          ^^^ punctuation.definition.comment.js
 
 /////////////////////////////////////////////////////////////////
 // <- comment.line.other.js punctuation.definition.comment.js


### PR DESCRIPTION
Fixes #2880

This PR implements  ...

1. shebang highlighting using the scheme of PHP/Java/ShellScript to ensure it being highlighted at the very first line, only.
2. xml highlighting in triple-slash comments in TS/TSX syntax according to Typescript specs, but with a more lazy/forgiving xml highlighting.
3. more forgiving comment punctuation highlighting in order to help ligatures for `//` or `///` to be displayed and to improve UX in case color schemes apply special highlighting to comment punctuation.
4. scopes trailing `//` in line comments `punctuation` for consistent highlighting.
5. adds various comment related test cases to illustrate changes and differences between syntaxes.

It feels odd to only highlight

-  `/*` and `*/` as punctuation in delimiters like `/***************************/` 
-  `//` in `/// comment` or `/////////////////////////////////////`

Note:

If `double-slash` and `triple-slash` sub-scopes are not needed, all line comment related contexts could probably be simplified/merged in some way.