### PR TITLE
[Perl] Fix shebang highlighting and restructure comment contexts

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -105,6 +105,7 @@ variables:
 
 contexts:
   main:
+    - meta_include_prototype: false
     - match: ''
       push: [statements, shebang]
 
@@ -169,6 +170,7 @@ contexts:
 ###[ COMMENTS ]###############################################################
 
   shebang:
+    - meta_include_prototype: false
     - match: ^\#!
       scope: punctuation.definition.comment.perl
       set:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -173,15 +173,17 @@ contexts:
     - meta_include_prototype: false
     - match: ^\#!
       scope: punctuation.definition.comment.perl
-      set:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.shebang.perl
-        # Note: Keep sync with first_line_match!
-        - match: \bperl\b
-          scope: constant.language.shebang.perl
-        - match: \n
-          pop: true
+      set: shebang-body
     - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Perl is embedded.
+      pop: true
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.perl
+    # Note: Keep sync with first_line_match!
+    - match: \bperl\b
+      scope: constant.language.shebang.perl
+    - match: \n
       pop: true
 
   comment-line:

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -189,10 +189,12 @@ contexts:
   comment-line:
     - match: \#+
       scope: punctuation.definition.comment.perl
-      push:
-        - meta_scope: meta.comment.perl comment.line.number-sign.perl
-        - match: \n
-          pop: true
+      push: comment-line-body
+
+  comment-line-body:
+    - meta_scope: meta.comment.perl comment.line.number-sign.perl
+    - match: \n
+      pop: true
 
   comment-pod:
     # SEE: https://perldoc.perl.org/perlpod.html

--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -201,16 +201,19 @@ contexts:
     - match: ^{{pod}}
       scope: entity.name.tag.pod.perl
       push:
-        - meta_scope: meta.comment.perl comment.block.documentation.perl
-        - meta_content_scope: meta.string.perl string.unquoted.perl
-        - match: \n
-          set: comment-pod-body
-        - include: comment-pod-formatting
+        - comment-pod-body
+        - comment-pod-begin
+
+  comment-pod-begin:
+    - meta_content_scope: meta.string.perl string.unquoted.perl
+    - match: \n
+      pop: true
+    - include: comment-pod-formatting
 
   comment-pod-body:
-    - meta_content_scope: meta.comment.perl comment.block.documentation.perl
+    - meta_scope: meta.comment.perl comment.block.documentation.perl
     - match: ^=cut\b
-      scope: meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
+      scope: entity.name.tag.pod.perl
       pop: true
     - include: comment-pod-embedded
     - include: comment-pod-keyword
@@ -219,62 +222,66 @@ contexts:
   comment-pod-embedded:
     - match: ^=begin\b
       scope: entity.name.tag.pod.perl
-      push:
-        - clear_scopes: 1 # remove `comment`
-        - meta_scope: meta.interpolation.perl
-        # end embedded section
-        - match: ^=end\b
-          scope: entity.name.tag.pod.perl
-          pop: true
-        # embedded css
-        - match: \bcss\b
-          scope: constant.other.language-name.css.perl
-          embed: scope:source.css
-          embed_scope: source.css.embedded.perl
-          escape: (?=^{{pod}})
-        # embedded html
-        - match: \bhtml\b
-          scope: constant.other.language-name.html.perl
-          embed: scope:text.html.basic
-          embed_scope: text.html.embedded.perl
-          escape: (?=^{{pod}})
-        # embedded javascript
-        - match: \b(?:js|javascript)\b
-          scope: constant.other.language-name.js.perl
-          embed: scope:source.js
-          embed_scope: source.js.embedded.perl
-          escape: (?=^{{pod}})
-        # embedded json
-        - match: \bjson\b
-          scope: constant.other.language-name.json.perl
-          embed: scope:source.json
-          embed_scope: source.json.embedded.perl
-          escape: (?=^{{pod}})
-        # embedded sql
-        - match: \bsql\b
-          scope: constant.other.language-name.sql.perl
-          embed: scope:source.sql
-          embed_scope: source.sql.embedded.perl
-          escape: (?=^{{pod}})
-        # embedded xml
-        - match: \bxml\b
-          scope: constant.other.language-name.xml.perl
-          embed: scope:text.xml
-          embed_scope: text.xml.embedded.perl
-          escape: (?=^{{pod}})
-        # unexpected pod command
-        - match: ^{{pod}}
-          scope: invalid.illegal.end-expected.perl
-          pop: true
-        - include: else-pop
+      push: comment-pod-embedded-body
+
+  comment-pod-embedded-body:
+    - clear_scopes: 1 # remove `comment`
+    - meta_scope: meta.interpolation.perl
+    # end embedded section
+    - match: ^=end\b
+      scope: entity.name.tag.pod.perl
+      pop: true
+    # embedded css
+    - match: \bcss\b
+      scope: constant.other.language-name.css.perl
+      embed: scope:source.css
+      embed_scope: source.css.embedded.perl
+      escape: (?=^{{pod}})
+    # embedded html
+    - match: \bhtml\b
+      scope: constant.other.language-name.html.perl
+      embed: scope:text.html.basic
+      embed_scope: text.html.embedded.perl
+      escape: (?=^{{pod}})
+    # embedded javascript
+    - match: \b(?:js|javascript)\b
+      scope: constant.other.language-name.js.perl
+      embed: scope:source.js
+      embed_scope: source.js.embedded.perl
+      escape: (?=^{{pod}})
+    # embedded json
+    - match: \bjson\b
+      scope: constant.other.language-name.json.perl
+      embed: scope:source.json
+      embed_scope: source.json.embedded.perl
+      escape: (?=^{{pod}})
+    # embedded sql
+    - match: \bsql\b
+      scope: constant.other.language-name.sql.perl
+      embed: scope:source.sql
+      embed_scope: source.sql.embedded.perl
+      escape: (?=^{{pod}})
+    # embedded xml
+    - match: \bxml\b
+      scope: constant.other.language-name.xml.perl
+      embed: scope:text.xml
+      embed_scope: text.xml.embedded.perl
+      escape: (?=^{{pod}})
+    # unexpected pod command
+    - match: ^{{pod}}
+      scope: invalid.illegal.end-expected.perl
+      pop: true
+    - include: else-pop
 
   comment-pod-keyword:
     - match: ^{{pod}}
       scope: entity.name.tag.pod.perl
-      push:
-        - meta_content_scope: markup.heading.perl
-        - include: eol-pop
-        - include: comment-pod-formatting
+      push: comment-pod-keyword-body
+
+  comment-pod-keyword-body:
+    - meta_content_scope: markup.heading.perl
+    - include: eol-pop
+    - include: comment-pod-formatting
 
   comment-pod-formatting:
     # bold text : B<content>
@@ -680,7 +687,7 @@ contexts:
         6: punctuation.definition.string.end.perl
     - match:  |-
         (?ix:
-          (') ( [-+]? ) ( 
+          (') ( [-+]? ) (
           (\.)[\d_]+ (?: e[-+]?[\d_]+ )?  |  # .1 .1e1 .1e-1 .1e+1
               [\d_]+ (?: (\.) (?:
               [\d_]+ (?: e[-+]?[\d_]+ )?  |  # 1.1 1.1e1 1.1e-1 1.1e+1

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -1,4 +1,4 @@
-# SYNTAX TEST "Perl.sublime-syntax"
+# SYNTAX TEST "Packages/Perl/Perl.sublime-syntax"
 
 # comment ; still in here
 # ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.perl


### PR DESCRIPTION
This PR...

1. restricts shebang highlighting to the very first line
2. adds some named contexts for comments (doesn't change behavior).