### PR TITLE
[TypeScript] Support quoted member names in object types.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -222,7 +222,7 @@ contexts:
       scope: keyword.declaration.js
       set:
         - ts-interface-meta
-        - ts-type-body
+        - ts-interface-body
         - ts-interface-extends
         - ts-type-parameter-list
         - ts-interface-name
@@ -238,7 +238,7 @@ contexts:
       pop: true
     - include: else-pop
 
-  ts-type-body:
+  ts-interface-body:
     - match: \{
       scope: punctuation.section.block.begin.js
       set:
@@ -246,11 +246,12 @@ contexts:
         - match: \}
           scope: punctuation.section.block.end.js
           pop: true
-        - match: '[,;]'
-          scope: punctuation.separator.js
-        - include: ts-type-member
+        - include: ts-type-members
 
-  ts-type-member:
+  ts-type-members:
+    - match: '[,;]'
+      scope: punctuation.separator.js
+
     - match: '\+|-'
       scope: storage.modifier.js
 
@@ -295,8 +296,7 @@ contexts:
         - function-declaration-expect-parameters
         - ts-type-parameter-list
 
-    - match: '{{identifier_name}}'
-      scope: variable.other.readwrite.js
+    - match: (?={{identifier_start}}|['"])
       push:
         - - match: (?=[<(])
             set:
@@ -306,6 +306,13 @@ contexts:
           - match: (?=\S)
             set: ts-type-annotation
         - ts-type-annotation-optional
+        - ts-type-member-name
+
+  ts-type-member-name:
+    - match: '{{identifier_name}}'
+      scope: variable.other.readwrite.js
+      pop: true
+    - include: literal-string
 
   ts-enum:
     - match: enum{{identifier_break}}
@@ -739,7 +746,7 @@ contexts:
         - include: else-pop
 
     - include: ts-type-tuple
-    - include: ts-type-body
+    - include: ts-type-object
     - include: ts-type-special
     - include: ts-type-primitive
     - include: ts-type-basic
@@ -780,20 +787,13 @@ contexts:
 
   ts-type-object:
     - match: \{
-      scope: punctuation.section.braces.begin.js
+      scope: punctuation.section.mapping.begin.js
       set:
         - meta_scope: meta.mapping.js
         - match: \}
-          scope: punctuation.section.braces.end.js
+          scope: punctuation.section.mapping.end.js
           pop: true
-        - include: comma-separator
-        - match: ;
-          scope: punctuation.separator.semicolon.js
-        - match: '{{identifier_name}}'
-          scope: variable.other.readwrite.js
-          push:
-            - ts-type-annotation
-            - ts-type-annotation-optional
+        - include: ts-type-members
 
   ts-type-special:
     - match: 'any{{identifier_break}}'

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -110,7 +110,7 @@ if (a < b || c <= d) {}
 //  ^^^^^^^^^^^^^^ meta.function meta.generic
 //   ^ variable.parameter.generic
 //     ^^^^^^^ storage.modifier.extends
-//             ^^ meta.function meta.generic meta.block
+//             ^^ meta.function meta.generic meta.mapping
 
     <T {...}>() => {};</T>;
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.jsx

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -63,6 +63,18 @@
 //          ^ punctuation.separator.type
 //            ^^^ meta.type support.type.any
 //               ^ punctuation.separator
+
+        "baz": any,
+//      ^^^^^ meta.string string.quoted.double
+//           ^ punctuation.separator.type
+//             ^^^ meta.type support.type.any
+//                ^ punctuation.separator
+
+        'baz': any,
+//      ^^^^^ meta.string string.quoted.single
+//           ^ punctuation.separator.type
+//             ^^^ meta.type support.type.any
+//                ^ punctuation.separator
     }
 //  ^ meta.block punctuation.section.block.end
 
@@ -666,7 +678,7 @@ let x: Foo.bar;
 //         ^^^ support.class
 
 let x: {
-//     ^ meta.type punctuation.section.block.begin
+//     ^ meta.type punctuation.section.mapping.begin
 
     a : any ,
 //  ^ variable.other.readwrite
@@ -834,7 +846,7 @@ let x: {
 //                                            ^ punctuation.separator
     
     }
-//  ^ meta.type punctuation.section.block.end
+//  ^ meta.type punctuation.section.mapping.end
 
 let x: ( foo ? : any ) => bar;
 //     ^^^^^^^^^^^^^^^^^^^^^^ meta.type


### PR DESCRIPTION
Fix #3019.

Also scope the braces surrounding an object type as `punctuation.section.mapping` instead of `punctuation.section.block`. The braces around interfaces are unchanged.

N.B. The `ts-type-object` context was inadvertently unused. This PR fixes it up and uses it for object types.