### PR TITLE
[Erlang] Restrict shebang highlighting to very first line

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -126,6 +126,7 @@ variables:
 contexts:
 
   main:
+    - meta_include_prototype: false
     - match: ''
       push: [statements, shebang]
 
@@ -242,10 +243,11 @@ contexts:
           pop: 1
 
   shebang:
+    - meta_include_prototype: false
     - match: ^\#!
       scope: punctuation.definition.comment.shell
       set: shebang-body
-    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Erlang is embedded.
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if the syntax is embedded.
       pop: 1
 
   shebang-body:

--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -131,7 +131,7 @@ contexts:
       push: [statements, shebang]
 
   prototype:
-    - include: comment
+    - include: comments
 
   statements:
     - include: preproc-control
@@ -234,13 +234,16 @@ contexts:
 
 ###[ COMMENTS ]###############################################################
 
-  comment:
+  comments:
     - match: \%+
       scope: punctuation.definition.comment.percentage.erlang
-      push:
-        - meta_scope: comment.line.percentage.erlang
-        - match: \n
-          pop: 1
+      push: comment-body
+
+  comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.percentage.erlang
+    - match: \n
+      pop: 1
 
   shebang:
     - meta_include_prototype: false
@@ -674,7 +677,7 @@ contexts:
 
   preproc-spec-return:
     - match: ->
-      scope: 
+      scope:
         meta.preprocessor.spec.erlang
         punctuation.separator.parameters-return-type.erlang
       set:


### PR DESCRIPTION
This PR ...

1. adds some prototype exclusions to ensure shebang comments to be highlighted at the very first line only.
2. renames `comment` context to `comments` as it is non-popping.
3. adds a named `comment-body` context to keep in-line with the others.