### PR TITLE
[Lua] Restrict shebang highlighting to very first line

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -63,21 +63,34 @@ contexts:
       pop: 1
 
   prototype:
+    - include: comments
+
+  comments:
+    - include: block-comments
+    - include: line-comments
+
+  block-comments:
     - match: --\[(=*)\[
       scope: punctuation.definition.comment.begin.lua
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.block.lua
-        - match: \]\1\]
-          scope: punctuation.definition.comment.end.lua
-          pop: 1
+      push: block-comment-body
+
+  block-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.lua
+    - match: \]\1\]
+      scope: punctuation.definition.comment.end.lua
+      pop: 1
+
+  line-comments:
     - match: --
       scope: punctuation.definition.comment.lua
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.lua
-        - match: \n
-          pop: 1
+      push: line-comment-body
+
+  line-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.lua
+    - match: \n
+      pop: 1
 
   shebang:
     - meta_include_prototype: false

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -50,6 +50,7 @@ variables:
 
 contexts:
   main:
+    - meta_include_prototype: false
     - match: ''
       push: [statements, shebang]
 
@@ -89,6 +90,7 @@ contexts:
     - include: statements
 
   shebang:
+    - meta_include_prototype: false
     - match: ^\#!
       scope: punctuation.definition.comment.lua
       set: shebang-body
@@ -96,6 +98,7 @@ contexts:
       pop: 1
 
   shebang-body:
+    - meta_include_prototype: false
     - meta_scope: comment.line.shebang.lua
     - match: \blua\b
       scope: constant.language.shebang.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -79,16 +79,6 @@ contexts:
         - match: \n
           pop: 1
 
-  end:
-    - match: end{{identifier_break}}
-      scope: keyword.control.end.lua
-      pop: 1
-
-  block-contents:
-    - meta_scope: meta.block.lua
-    - include: end
-    - include: statements
-
   shebang:
     - meta_include_prototype: false
     - match: ^\#!
@@ -135,6 +125,16 @@ contexts:
 
     - match: (?=\S)
       push: expression
+
+  block-contents:
+    - meta_scope: meta.block.lua
+    - include: end
+    - include: statements
+
+  end:
+    - match: end{{identifier_break}}
+      scope: keyword.control.end.lua
+      pop: 1
 
   function-parameter-list:
     - match: \(


### PR DESCRIPTION
This PR ...

1. adds some prototype exclusions to ensure shebang comments to be highlighted at the very first line only.
2. creates named comment contexts to keep in-line with other syntaxes and improve inheritability.
