### PR TITLE
[OCaml] Fix bug when ocamlyacc file starts with comment

### DIFF
--- a/OCaml/OCamlyacc.sublime-syntax
+++ b/OCaml/OCamlyacc.sublime-syntax
@@ -35,8 +35,8 @@ contexts:
           pop: true
         - include: comments
         - include: rules
-    - include: scope:source.ocaml
     - include: comments
+    - include: scope:source.ocaml
     - match: (’|‘|“|”)
       scope: invalid.illegal.unrecognized-character.ocaml
   comments:

--- a/OCaml/syntax_test_mly.mly
+++ b/OCaml/syntax_test_mly.mly
@@ -1,0 +1,10 @@
+/* SYNTAX TEST "Packages/OCaml/OCamlyacc.sublime-syntax" */
+/*  This is a comment
+ *  at the beginning of the file
+/* ^ comment */
+ */
+
+%{
+open Support.Error
+/* ^ meta.header.ocamlyacc meta.module.open.ocaml */
+%}


### PR DESCRIPTION
If the ocamlyacc file begins with a multiline comment (`/*`), the `include: ocaml` rule gets activated, and parses it as a `/` operator followed by more pure ocaml syntax. By moving the `include: comments` rule higher up, it will be given precedence.

Before:
![before](https://user-images.githubusercontent.com/29517049/132736231-eeef54a9-7c08-4282-aa1a-b9a386d9e8f6.png)
After:
![after](https://user-images.githubusercontent.com/29517049/132736272-a619f956-2fbd-4ac5-92da-c3b41d3b0eeb.png)

Test file: https://github.com/roehst/tapl-implementations/blob/master/recon/parser.mly

(Side note: It seems even the github syntax highlighter is broken - the comments aren't getting highlighted properly)