### PR TITLE
[HTML] Fix scopes of stray script and style tags

### DIFF
--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -47,9 +47,7 @@ contexts:
     - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - script-close-tag
-        - script-vbscript-content
+      set: script-vbscript-content
 
   script-vbscript-content:
     - meta_include_prototype: false

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -88,16 +88,8 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - match: (<)((?i:style)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push: style-css
-    - match: (<)((?i:script)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push: script-javascript
+    - include: script-tag
+    - include: style-tag
     - match: (</?)((?i:body|head|html){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
@@ -184,14 +176,35 @@ contexts:
 
 ###[ SCRIPT TAG ]#############################################################
 
+  script-tag:
+    - match: (<)((?i:script)){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
+      push: script-javascript
+    - match: (</)((?i:script){{tag_name_break}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
+      push: script-close-tag-content
+
+  script-close-tag:
+    - match: (</)((?i:script){{tag_name_break}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
+      set: script-close-tag-content
+
+  script-close-tag-content:
+    - meta_scope: meta.tag.script.end.html
+    - include: tag-end
+
   script-javascript:
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - script-close-tag
-        - script-javascript-content
+      set: script-javascript-content
 
   script-javascript-content:
     - meta_include_prototype: false
@@ -211,12 +224,7 @@ contexts:
   script-html:
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set:
-        - meta_content_scope: text.html.embedded.html
-        - include: script-close-tag
-        - include: main
+    - include: tag-end
 
   script-other:
     - meta_scope: meta.tag.script.begin.html
@@ -224,16 +232,6 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-close-tag
-
-  script-close-tag:
-    - match: (</)((?i:script){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      set:
-        - meta_scope: meta.tag.script.end.html
-        - include: tag-end
-        - include: tag-attributes
 
   script-common:
     - include: script-type-attribute
@@ -287,14 +285,35 @@ contexts:
 
 ###[ STYLE TAG ]##############################################################
 
+  style-tag:
+    - match: (<)((?i:style)){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+      push: style-css
+    - match: (</)((?i:style){{tag_name_break}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+      push: style-close-tag-content
+
+  style-close-tag:
+    - match: (</)((?i:style){{tag_name_break}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+      set: style-close-tag-content
+
+  style-close-tag-content:
+    - meta_scope: meta.tag.style.end.html
+    - include: tag-end
+
   style-css:
     - meta_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - style-close-tag
-        - style-css-content
+      set: style-css-content
 
   style-css-content:
     - meta_include_prototype: false
@@ -317,16 +336,6 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-close-tag
-
-  style-close-tag:
-    - match: (</)((?i:style){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      set:
-        - meta_scope: meta.tag.style.end.html
-        - include: tag-end
-        - include: tag-attributes
 
   style-common:
     - include: style-type-attribute

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -133,19 +133,24 @@
         ##             ^ string.quoted.double.html - text.html.embedded.html
         ##                          ^^^^ comment.block.html punctuation
             comment -->
-        ##  ^^^^^^^^^^^ text.html.embedded.html comment.block.html
+        ##  ^^^^^^^^^^^ comment.block.html
             <div></div>
-        ##  ^^^^^^^^^^^ text.html.basic text.html.embedded meta.tag.block.any
+        ##  ^^^^^^^^^^^ text.html.basic meta.tag.block.any
             <script type=text/javascript>
-        ##  ^ text.html.basic text.html.embedded.html - source.js.embedded.html
+        ##  ^ text.html.basic - source.js.embedded.html
                 function test() {}
-        ##  ^ text.html.basic text.html.embedded.html source.js.embedded.html - source.js source.js
+        ##  ^ text.html.basic source.js.embedded.html - source.js source.js
             </script>
-        ##  ^^^^^^^^^ text.html.basic text.html.embedded.html meta.tag.script.end
+        ##  ^^^^^^^^^ text.html.basic meta.tag.script.end
         </script>
-##     ^ text.html.basic text.html.embedded.html
-##      ^^^^^^^^^ text.html.basic - text.html.embedded.html meta.tag.script.end
-##               ^ text.html.basic - text.html.embedded.html
+##     ^ text.html.basic - meta.tag
+##      ^^^^^^^^^ text.html.basic meta.tag.script.end
+##               ^ text.html.basic - meta.tag
+
+        </script>
+##     ^ text.html.basic - meta.tag
+##      ^^^^^^^^^ text.html.basic meta.tag.script.end
+##               ^ text.html.basic - meta.tag
 
         <script>
             <!-- i = 0;
@@ -286,6 +291,12 @@
         ##^^^^^ meta.tag.style.end.html entity.name.tag.style.html
         >
         ## <- meta.tag.style.end.html punctuation.definition.tag.end.html
+
+        </style>
+        ##^^^^^^ meta.tag.style.end.html
+        ##^^^^^ entity.name.tag.style.html
+        ##     ^ punctuation.definition.tag.end.html
+
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.style entity.name.tag.style


### PR DESCRIPTION
This PR...

1. fixes scopes of stray script and style tags, which didn't match those from tag pairs.

2. avoids multi-pushing into embedded script/style syntaxes to simplify the language a bit and improve parsing performance. Closing tags are consumed within `main` context now.

3. removes pushing `text.html.embedded.html` onto stack.

   a) As `main` context is pushed, it is not required for highlighting.
   b) The only thing we loose is the mentioned scope, which seems to be of little value.
   c) It is required as change (2) would break boundaries of `text.html.embedded` otherwise.
   d) The less contexts HTML pushes onto stack the better it is for most possible flexibility with regards to inheritance or re-use in
      heavily context aware templating syntaxes such as JSP or PHP.
   e) It slightly improves parsing performance.

4. New `script-tag` and `style-tag` contexts are introduced to form a kind of template which can be used by inheriting syntaxes for other custom tags.

Notes: 

1. `script-close-tag` still exists, so existing syntaxes shouldn't break by this change.

2.  ASP syntax is adjusted to use the same strategy, but that's just to keep inline. It would have worked without that change, too.


This PR is inspired by https://github.com/vuejs/vue-syntax-highlight/pull/216