### PR TITLE
[Markdown] Terminate inline formatting on paragraph boundaries

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -504,10 +504,9 @@ contexts:
             - match: \*
               scope: markup.italic.markdown punctuation.definition.italic.end.markdown
               pop: true
-            - include: inline
+            - include: format-common
             - include: bold
             - include: strikethrough
-            - include: bold-italic-trailing
         - match: \*
           scope: punctuation.definition.italic.end.markdown
           set:
@@ -520,13 +519,11 @@ contexts:
             - match: \*\*
               scope: markup.bold.markdown punctuation.definition.bold.end.markdown
               pop: true
-            - include: inline
+            - include: format-common
             - include: italic
             - include: strikethrough
-            - include: bold-italic-trailing
-        - include: inline
+        - include: format-common
         - include: strikethrough
-        - include: bold-italic-trailing
     - match: '\*\*(?=\S)(?!\*\*|\*\s)'
       scope: punctuation.definition.bold.begin.markdown
       push:
@@ -540,12 +537,12 @@ contexts:
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
-        - include: inline
+        # Consume the underscore that has no corresponding underscore before the closing bold
+        # punctuation on the same line, as it won't be treated as italic by CommonMark
         - match: \b_(?=[^\s_])(?=[^*_]*\*\*)
-          comment: eat the underscore that has no corresponding underscore before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
+        - include: format-common
         - include: italic
         - include: strikethrough
-        - include: bold-italic-trailing
     - match: '\b(__)(_)(?=\S)(?!_)'
       captures:
         1: punctuation.definition.bold.begin.markdown
@@ -575,10 +572,9 @@ contexts:
             - match: __\b
               scope: markup.bold.markdown punctuation.definition.bold.end.markdown
               pop: true
-            - include: inline
+            - include: format-common
             - include: italic
             - include: strikethrough
-            - include: bold-italic-trailing
         - match: __\b
           scope: punctuation.definition.bold.end.markdown
           set:
@@ -591,13 +587,11 @@ contexts:
             - match: _\b
               scope: markup.italic.markdown punctuation.definition.italic.end.markdown
               pop: true
-            - include: inline
+            - include: format-common
             - include: bold
             - include: strikethrough
-            - include: bold-italic-trailing
-        - include: inline
+        - include: format-common
         - include: strikethrough
-        - include: bold-italic-trailing
     - match: '\b__(?=\S)(?!_[_\s])'
       scope: punctuation.definition.bold.begin.markdown
       push:
@@ -611,12 +605,12 @@ contexts:
           captures:
             1: punctuation.definition.bold.end.markdown
           pop: true
-        - include: inline
+        # Consume the asterisk that has no corresponding asterisk before the closing bold
+        # punctuation on the same line, as it won't be treated as italic by CommonMark
         - match: \*(?=[^\s*])(?=[^*_]*__\b)
-          comment: eat the asterisk that has no corresponding asterisk before the closing bold punctuation on the same line, as it won't be treated as italic by CommonMark
+        - include: format-common
         - include: italic
         - include: strikethrough
-        - include: bold-italic-trailing
   bracket:
     - match: '<(?![A-Za-z/?!$])'
       comment: |
@@ -829,11 +823,10 @@ contexts:
         - match: \*(?!\*[^*])
           scope: punctuation.definition.italic.end.markdown
           pop: true
-        - include: inline
+        - match: \*+
+        - include: format-common
         - include: bold
-        - match: '\*+'
         - include: strikethrough
-        - include: bold-italic-trailing
     - match: '\b_(?=\S)(?!_)'
       scope: punctuation.definition.italic.begin.markdown
       push:
@@ -846,10 +839,9 @@ contexts:
         - match: _\b
           scope: punctuation.definition.italic.end.markdown
           pop: true
-        - include: inline
+        - include: format-common
         - include: bold
         - include: strikethrough
-        - include: bold-italic-trailing
     - match: '[*_]+'
   strikethrough:
     - match: '(~+)(?=\S)(?!~)'
@@ -859,20 +851,19 @@ contexts:
         - match: ~+
           scope: punctuation.definition.strikethrough.end.markdown
           pop: true
-        - include: inline
+        - include: format-common
         - include: bold
         - include: italic
-        - include: bold-italic-trailing
-  bold-italic-trailing:
-    - include: scope:text.html.basic
+  format-common:
     - match: '{{setext_escape}}'
       pop: true
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.bold-italic.markdown
       pop: true
-    - match: '^(?={{list_item}})'
-      pop: true
+    - include: paragraph-end
     - include: hard-line-break
+    - include: inline
+    - include: scope:text.html.basic
   hard-line-break:
     - match: '[ ]{2,}$'
       scope: meta.hard-line-break.markdown punctuation.definition.hard-line-break.markdown

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -104,6 +104,35 @@ https://spec.commonmark.org/0.30/#example-79
 | <- - markup.heading
 |^^^^^^^^^^^^ - markup.heading
 
+Headings terminate paragraphs
+# Heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold
+|^^^^^^^^ markup.heading.1.markdown
+
+Headings terminate **bold text
+# Heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold
+|^^^^^^^^ markup.heading.1.markdown
+this must not be bold**
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Headings terminate *italic text
+# Heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.italic
+|^^^^^^^^ markup.heading.1.markdown
+this must not be italic*
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
+
+Headings terminate ***bold italic text
+# Heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold - markup.italic
+|^^^^^^^^ markup.heading.1.markdown
+this must not be bold italic***
+| <- - meta.bold - markup.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - markup.italic
+
 SETEXT Heading Level 1
 | <- markup.heading.1.markdown
 =================
@@ -147,6 +176,24 @@ Foo *bar*
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 |^^^^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 |        ^ markup.heading.2.markdown meta.whitespace.newline.markdown
+
+Foo *bar
+| <- markup.heading.1.markdown
+|^^^^^^^^^ markup.heading.1.markdown
+|   ^^^^^ markup.italic.markdown
+=========
+| <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown - markup.italic
+|^^^^^^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown - markup.italic
+|        ^ markup.heading.1.markdown meta.whitespace.newline.markdown - markup.italic
+
+Foo *bar
+| <- markup.heading.2.markdown
+|^^^^^^^^^ markup.heading.2.markdown
+|   ^^^^^ markup.italic.markdown
+---------
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown - markup.italic
+|^^^^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown - markup.italic
+|        ^ markup.heading.2.markdown meta.whitespace.newline.markdown - markup.italic
 
 https://spec.commonmark.org/0.30/#example-81
 
@@ -1769,11 +1816,75 @@ new paragraph~~.
 | <- invalid.illegal.non-terminated.bold-italic
 
 # Fenced Code Block Tests
+
 Paragraph is terminated by fenced code blocks.
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+Code blocks terminate **bold text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold**
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Code blocks terminate __bold text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold__
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Code blocks terminate *italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be italic*
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
+
+Code blocks terminate _italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be italic_
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate ***bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic***
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate ___bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic___
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate **_bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic_**
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 ```js
 | <- punctuation.definition.raw.code-fence.begin


### PR DESCRIPTION
This PR...

1. includes `paragraph-end` into `bold-italic-trailing` context
2. moves the `bold-italic-trailing` includes before `inline` includes to terminate inline formatting by fenced code blocks
3. renames `bold-italic-trailing` to `bold-italic-common` and moves the `inline` include into it.

Everything, which terminates a paragraph, now also terminates inline formatting.

### Note:

A token, which starts with an inline-formatting character such as `_` or `*` but is terminated by a paragraph boundary is not rendered bold/italic/strikethrough by CommonMark.

It is still scoped/highlighted as such by this syntax. This PR only fixes paragraph boundaries which have been ignored in such situations before.

A future PR may work on fixing this by using branch points, but it requires way more considerations and a possibly larger overhaul of inline formatting contexts.