### PR TITLE
[Markdown] Highlight any unknown fenced language identifier

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -136,7 +136,7 @@ variables:
           \2          # the backtick/tilde combination that opened the code fence
           (?:\3|\4)*  # plus optional additional closing characters
         )
-        \s*$          # any amount of whitespace until EOL
+        \s*$\n?       # any amount of whitespace until EOL
       )
     html_tag_open_commonmark: |-
       (?xi:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -112,6 +112,13 @@ variables:
           )
           \s*          # allow for whitespace between code block start and info string
         )
+    fenced_code_block_language: |-
+      (?x:             # first word of an infostring is used as language specifier
+        (
+          [[:alpha:]]  # starts with a letter to make sure not to hit any attribute annotation
+          [^`\s]*      # optionally followed by any nonwhitespace character (except backticks)
+        )
+      )
     fenced_code_block_trailing_infostring_characters: |-
         (?x:
           (
@@ -447,7 +454,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ([\w-]*)     # any number of word characters or dashes
+          {{fenced_code_block_language}}?
           .*$\n?       # all characters until EOL
       captures:
         0: meta.code-fence.definition.begin.text.markdown-gfm
@@ -1804,7 +1811,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ([\w-]*)     # any number of word characters or dashes
+          {{fenced_code_block_language}}?
           .*$\n?       # all characters until EOL
       captures:
         0: meta.code-fence.definition.begin.text.markdown-gfm

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -789,6 +789,24 @@ paragraph
 |^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
 | ^^^^ meta.block-level.markdown markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
 | ^^^ punctuation.definition.raw.code-fence.end.markdown
+
+> Quoted fenced code block language identifier
+> ```C++
+| <- meta.block-level.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
+| ^^^^^^^ meta.block-level.markdown markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+|    ^^^ constant.other.language-name.markdown
+> ```
+
+> Quoted fenced code block language identifier
+> ```C++ info string
+| <- meta.block-level.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ meta.block-level.markdown markup.quote.markdown - meta.code-fence
+| ^^^^^^^^^^^^^^^^^^^ meta.block-level.markdown markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+|    ^^^ constant.other.language-name.markdown
+|       ^^^^^^^^^^^^^ - constant
+> ```
+
 > > 2nd level
 > > 
 > > ```
@@ -1900,6 +1918,22 @@ for (var i = 0; i < 10; i++) {
 |  ^^ constant.other.language-name
 declare type foo = 'bar'
 |       ^^^^ source.ts meta.type-alias storage.type
+```
+
+```R%&?! weired language name
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|  ^^^^^ constant.other.language-name.markdown
+|        ^^^^^^^^^^^^^^^^^^^^^ - constant
+```
+
+```{key: value}
+|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|   ^^^^^^^^^^^^ - constant
+```
+
+``` {key: value}
+|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|   ^^^^^^^^^^^^ - constant
 ```
 
 ```testing``123```

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1927,8 +1927,8 @@ declare type foo = 'bar'
 ```
 
 ```{key: value}
-|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
-|   ^^^^^^^^^^^^ - constant
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|  ^^^^^^^^^^^^ - constant
 ```
 
 ``` {key: value}


### PR DESCRIPTION
This PR implements a re-interpreted version of CommonMark's statement:

>  The first word of the info string is typically used to specify the language of the code sample...
>
>  see: https://spec.commonmark.org/0.30/#fenced-code-blocks

A word is not only `[\w-]+` but a sequence of any non-whitespace character, except backticks, in this context.

This is why `C++` is an valid fenced code language identifier.

This commit expects a language identifier to start with a letter, in order to avoid confusion with e.g. attribute annotations such as `{key=value}` which some Markdown extension support.

This enables `C++` being scoped as `constant.other.language` in block quotes, for instance.