### PR TITLE
[meta] Fix issue template title

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-syntax-highlighting.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-syntax-highlighting.yml
@@ -1,6 +1,6 @@
 name: Syntax Highlighting problem
 description: Create a bug report for mis-highlighted code in one of the default languages.
-title: '[PackageName]: Title'
+title: '[PackageName] Title'
 labels: ['bug']
 body:
 

--- a/.github/ISSUE_TEMPLATE/02-bug-file-indexing.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-file-indexing.yml
@@ -1,6 +1,6 @@
 name: Go to Symbol problem
 description: Create a bug report for file indexing in one of the default languages.
-title: '[PackageName]: Title'
+title: '[PackageName] Title'
 body:
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/03-supporting-files.yml
+++ b/.github/ISSUE_TEMPLATE/03-supporting-files.yml
@@ -1,6 +1,6 @@
 name: Snippet, Completion, Indentation, or Build problem
 description: Suggest improvements for one of the default language support files.
-title: '[PackageName]: Title'
+title: '[PackageName] Title'
 body:
 
   - type: markdown


### PR DESCRIPTION
This PR removes colons from issue titles as those are not required due to package name being wrapped into brackets.