### PR TITLE
[Markdown] Fix setext headings in symbol list

### DIFF
--- a/Markdown/Symbol List - Heading.tmPreferences
+++ b/Markdown/Symbol List - Heading.tmPreferences
@@ -9,9 +9,14 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string><![CDATA[
-		s/\s*#*\s*\z//g;         # strip trailing space and #'s
-		s/(?<=#)#/ /g;           # change all but first # to m-space
-		s/^#( *)\s+(.*)/$1$2/;   # strip first # and space before title
+			s/\[([^]]+)\]\([^)]+\)/$1/g; 		# beautify links
+			s/\[([^]]+)\](?:\[[^]]+\])?/$1/g; 	# beautify references
+			s/^\s*//g;							# strip leading whitespace
+			s/\s*#+\s*\z//g;					# strip trailing hashes
+			s/(?<=#)#/ /g;						# change all but first # to m-space
+			s/^#( *)\s+(.*)/$1$2/;				# strip first # and space before title
+			s/^(.+?)=+\s*\z/$1/g;				# indent SETEXT heading 1
+			s/^(.+?)-+\s*\z/  $1/g;				# indent SETEXT heading 2
 		]]></string>
 	</dict>
 </dict>


### PR DESCRIPTION
This PR adds symbol transformations to...

1. fix underline markers of SETEXT headings from being displayed after the heading's text.

   Before this commit they looked like:

       heading======

   With this commit:

       heading

2. strip leading whitespace before starting any further transformation.  
   This is required because headings can be indented by up to 3 chars.  
   The last pattern of the old symbol transformation didn't match for those.

3. adds some patterns from MarkdownEditing, which convert links and references to normal text.