### PR TITLE
[Markdown] Restrict image/link/reference highlighting

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -704,24 +704,23 @@ contexts:
             (\!\[)                             # Images start with ![
             (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
                   \]                           # Closing square bracket
-                  [ ]?                         # Space not allowed, but we check for it anyway to mark it as invalid
                   \(                           # Open paren
             )
          )
       captures:
         1: meta.image.inline.markdown punctuation.definition.image.begin.markdown
       push: [image-inline-attr, image-inline-after-text, image-link-text]
+
   image-link-text:
     - meta_content_scope: meta.image.inline.description.markdown
     - include: link-text
     - match: \]
       scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
       pop: true
+
   image-inline-after-text:
-    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.metadata.begin.markdown
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
       set:
         - meta_scope: meta.image.inline.markdown
         - match: \)
@@ -748,22 +747,22 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+    - include: immediately-pop
+
   image-inline-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.image.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   image-ref:
     - match: |-
         (?x:
           (\!\[)                             # Images start with ![
           (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
                 \]                           # Closing square bracket
-                [ ]?                         # Space
                 \[                           # [
                 [^\]]+                       # anything other than ]
                 \]                           # ]
@@ -772,29 +771,32 @@ contexts:
       captures:
         1: meta.image.reference.markdown punctuation.definition.image.begin.markdown
       push: [image-ref-attr, image-ref-after-text, image-ref-text]
+
   image-ref-text:
     - meta_content_scope: meta.image.reference.description.markdown
     - include: link-text
     - match: \]
       scope: meta.image.reference.markdown punctuation.definition.image.end.markdown
       pop: true
+
   image-ref-after-text:
-    - match: '[ ]?(\[)([^\]]+)(\])'
+    - match: (\[)([^\]]+)(\])
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
       scope: meta.image.reference.markdown
       pop: true
+    - include: immediately-pop
+
   image-ref-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.image.reference.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   inline:
     - include: escape
     - include: ampersand
@@ -878,6 +880,7 @@ contexts:
       scope: meta.hard-line-break.markdown
       captures:
         1: constant.character.escape.markdown
+
   autolink-email:
     - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
       scope: meta.link.email.lt-gt.markdown
@@ -887,6 +890,7 @@ contexts:
         4: punctuation.definition.link.end.markdown
     - match: '[\w.+-]+@[\w-]+(\.((?![._-][\W])[\w_-])+)+(?![_-])'
       scope: markup.underline.link.markdown
+
   autolink-inet:
     - match: (<)((?:https?|ftp)://.*?)(>)
       scope: meta.link.inet.markdown
@@ -912,6 +916,7 @@ contexts:
           pop: true
         - match: '[^?!.,:*_~\s<&()]+|\S'
           scope: markup.underline.link.markdown-gfm
+
   link-inline:
     - match: |-
         (?x:
@@ -919,17 +924,16 @@ contexts:
             (?=
                 {{balance_square_brackets}}?
                 \]
-                [ ]?\(
+                \(
             )
         )
       captures:
         1: meta.link.inline.markdown punctuation.definition.link.begin.markdown
       push: [link-inline-attr, link-inline-after-text, link-inline-link-text]
+
   link-inline-after-text:
-    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.metadata.begin.markdown
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
       set:
         - meta_scope: meta.link.inline.markdown
         - match: \)
@@ -955,28 +959,29 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+    - include: immediately-pop
+
   link-inline-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-inline-link-text:
     - meta_content_scope: meta.link.inline.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref:
     - match: |-
         (?x:
           (\[)
           (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
                 \]                           # Closing square bracket
-                [ ]?                         # Space
                 \[                           # [
                 [^\]]+                       # anything other than ]
                 \]                           # ]
@@ -995,29 +1000,32 @@ contexts:
       captures:
         1: meta.link.reference.markdown punctuation.definition.link.begin.markdown
       push: link-ref-link-text
+
   link-ref-link-text:
     - meta_content_scope: meta.link.reference.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref-after-text:
-    - match: '[ ]?(\[)([^\]]+)(\])'
+    - match: (\[)([^\]]+)(\])
+      scope: meta.link.reference.markdown
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
-      scope: meta.link.reference.markdown
       pop: true
+    - include: immediately-pop
+
   link-ref-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.reference.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-ref-literal:
     - match: |-
         (?x:
@@ -1025,7 +1033,6 @@ contexts:
           (?=
               {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
               \]                           # Closing square bracket
-              [ ]?                         # Space
               \[                           # [
               \]                           # ]
           )
@@ -1033,28 +1040,31 @@ contexts:
       captures:
         1: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
       push: [link-ref-literal-attr, link-ref-literal-after-text, link-ref-literal-link-text]
+
   link-ref-literal-link-text:
     - meta_content_scope: meta.link.reference.literal.description.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.literal.markdown punctuation.definition.link.end.markdown
       pop: true
+
   link-ref-literal-after-text:
-    - match: '[ ]?(\[)(\])'
+    - match: (\[)(\])
       scope: meta.link.reference.literal.markdown
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: punctuation.definition.constant.end.markdown
       pop: true
+    - include: immediately-pop
+
   link-ref-literal-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.reference.literal.markdown
         - include: tag-attributes
     - include: immediately-pop
+
   link-ref-footnote:
     - match: |-
         (?x:
@@ -1067,6 +1077,7 @@ contexts:
         1: punctuation.definition.link.begin.markdown
         2: meta.link.reference.literal.footnote-id.markdown
         3: punctuation.definition.link.end.markdown
+
   reference-link-definition:
     - match: |-
         (?x:
@@ -1088,6 +1099,7 @@ contexts:
         7: punctuation.definition.link.end.markdown
         8: markup.underline.link.markdown
       push: [link-ref-def-expect-end, link-title]
+
   list-paragraph:
     - match: '^(?=(?:[ ]{4}|\t){2,}(?![>+*\s-]))(?={{indented_code_block}})'
       push:

--- a/Markdown/syntax_test_markdown.md
+++ b/Markdown/syntax_test_markdown.md
@@ -1197,6 +1197,35 @@ escaped backtick \`this is not code\`
 |                                  ^^ constant.character.escape
 |                  ^^^^^^^^^^^^^^^^ - markup.raw.inline
 
+This is a [reference] ()
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^ - meta.link
+
+This is a [reference] (followed by parens)
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a [reference] []
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^ - meta.link
+|                     ^^ meta.link.reference
+
+This is a ![reference] ()
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^ - meta.link
+
+This is a ![reference] (followed by parens)
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a ![reference] []
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^ - meta.link
+|                      ^^ meta.link.reference
+
 http://spec.commonmark.org/0.28/#example-322
 *foo`*`
 |^^^^^^^ markup.italic


### PR DESCRIPTION
See: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/633

Space between description and metadata is not allowed in inline links, images or references. Markdown must therefore not claim it to be such an entity as it causes otherwise valid markdown files to get highlighted wrong.

Example:

    [description] (no more url)

This is no inline link according to CommonMark or GFM.