### PR TITLE
[Python] Fix lambdas inside list comprehensions

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -673,6 +673,7 @@ contexts:
   expression-in-a-group:  # Always include this last!
     # Differs from expression-in-a-statement in that:
     # - accessor matching continues into the next line
+    - include: lambda-in-groups
     - include: expression-in-a-statement
     - match: '(\.) *(?={{identifier}})'
       captures:
@@ -1215,8 +1216,39 @@ contexts:
         - match: '{{identifier}}'
           scope: variable.parameter.python
 
+  lambda-in-groups:
+    # A lambda keyword within a group may be part of a generator expression
+    # Hence pop contexts off stack if `for` keyword is matched in order to
+    # not scope it invalid.
+    - match: \blambda(?=\s|:|$)
+      scope:
+        meta.function.inline.python
+        storage.type.function.inline.python
+        keyword.declaration.function.inline.python
+      push: [lambda-in-group-parameters, allow-unpack-operators]
+
+  lambda-in-group-parameters:
+    - meta_content_scope: meta.function.inline.parameters.python
+    - match: ':'
+      scope: punctuation.section.function.begin.python
+      set:
+        - meta_include_prototype: false
+        - match: ''
+          set: lambda-in-group-body
+    - include: lambda-in-group-end
+    - include: lambda-parameters-common
+
+  lambda-in-group-body:
+    - meta_scope: meta.function.inline.body.python
+    - include: lambda-in-group-end
+    - include: lambda-body
+
+  lambda-in-group-end:
+    - match: (?=for\b)
+      pop: true
+
   lambda:
-    - match: \b(lambda)(?=\s|:|$)
+    - match: \blambda(?=\s|:|$)
       scope:
         meta.function.inline.python
         storage.type.function.inline.python
@@ -1225,32 +1257,37 @@ contexts:
 
   lambda-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
-    - include: line-continuation-or-pop
-    - match: '\:'
+    - match: ':'
       scope: punctuation.section.function.begin.python
       set:
-        # clear meta_scope
+        - meta_include_prototype: false
         - match: ''
-          set:
-            - meta_scope: meta.function.inline.body.python
-            - include: illegal-assignment-expression
-            # We don't know whether we are within a grouped
-            # or line-statement context at this point.
-            # If we're in a group, the underlying context will take over
-            # at the end of the line.
-            - match: (?=[,:)}\]])|$
-              pop: true
-            - include: expression-in-a-statement
+          set: lambda-body
+    - include: lambda-parameters-common
+
+  lambda-parameters-common:
     - match: ','
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
+    - include: line-continuation-or-pop
     - include: keyword-arguments
     - include: function-parameters-tuple
     - include: illegal-names
     - match: '{{identifier}}'
       scope: variable.parameter.python
-    - match: '\S'
+    - match: \S
       scope: invalid.illegal.expected-parameter.python
+
+  lambda-body:
+    - meta_scope: meta.function.inline.body.python
+    - include: illegal-assignment-expression
+    # We don't know whether we are within a grouped
+    # or line-statement context at this point.
+    # If we're in a group, the underlying context will take over
+    # at the end of the line.
+    - match: (?=[,:)}\]])|$
+      pop: true
+    - include: expression-in-a-statement
 
   generators-groups-and-tuples:
     - include: empty-tuples

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -643,7 +643,6 @@ contexts:
     - include: numbers
     - include: yields
     - include: operators
-    - include: lambda
     - match: \b(await)\b
       scope: keyword.other.await.python
     - include: inline-if
@@ -658,6 +657,7 @@ contexts:
 
   # Always include these last and only one at a time!
   expression-as-a-statement:
+    - include: lambda
     - include: expressions-common
     - include: qualified-name
 
@@ -665,6 +665,7 @@ contexts:
     # Differs from expression-as-a-statement in that:
     # - invalid-name matches will pop the current context
     # - assignment expressions
+    - include: lambda
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
@@ -674,7 +675,10 @@ contexts:
     # Differs from expression-in-a-statement in that:
     # - accessor matching continues into the next line
     - include: lambda-in-groups
-    - include: expression-in-a-statement
+    - include: expressions-common
+    - include: illegal-name
+    - include: qualified-name
+    - include: assignment-expression
     - match: '(\.) *(?={{identifier}})'
       captures:
         1: punctuation.accessor.dot.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1849,6 +1849,69 @@ dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
 #                                    ^ punctuation.section.target-list.end.python
 #                                           ^ punctuation.section.mapping.end.python
 
+list_ = [lambda: 1 for i in range(10)]
+#       ^ meta.sequence.list.python - meta.function
+#        ^^^^^^ meta.sequence.list.python meta.function.inline.python
+#              ^ meta.sequence.list.python meta.function.inline.parameters.python
+#               ^^^ meta.sequence.list.python meta.function.inline.body.python
+#                  ^^^^^^^^^^^^^^^^^^^ meta.sequence.list.python - meta.function
+#                                     ^ - meta.sequence
+#       ^ punctuation.section.sequence.begin.python
+#        ^^^^^^ keyword.declaration.function.inline.python
+#              ^ punctuation.section.function.begin.python
+#                ^ constant.numeric.value.python
+#                  ^^^ keyword.control.loop.for.generator.python
+#                      ^ meta.generic-name.python
+#                        ^^ keyword.control.loop.for.in.python
+#                           ^^^^^ support.function.builtin.python
+#                                ^ punctuation.section.arguments.begin.python
+#                                 ^^ constant.numeric.value.python
+#                                   ^ punctuation.section.arguments.end.python
+#                                    ^ punctuation.section.sequence.end.python
+
+generator_ = (lambda: 1 for i in range(10))
+#            ^ meta.sequence.generator.python - meta.function
+#             ^^^^^^ meta.sequence.generator.python meta.function.inline.python
+#                   ^ meta.sequence.generator.python meta.function.inline.parameters.python
+#                    ^^^ meta.sequence.generator.python meta.function.inline.body.python
+#                       ^^^^^^^^^^^^^^^^^^^ meta.sequence.generator.python - meta.function
+#                                          ^ - meta.sequence
+#            ^ punctuation.section.sequence.begin.python
+#             ^^^^^^ keyword.declaration.function.inline.python
+#                   ^ punctuation.section.function.begin.python
+#                     ^ constant.numeric.value.python
+#                       ^^^ keyword.control.loop.for.generator.python
+#                           ^ meta.generic-name.python
+#                             ^^ keyword.control.loop.for.in.python
+#                                ^^^^^ support.function.builtin.python
+#                                     ^ punctuation.section.arguments.begin.python
+#                                      ^^ constant.numeric.value.python
+#                                        ^ punctuation.section.arguments.end.python
+#                                         ^ punctuation.section.sequence.end.python
+
+set_ = {lambda: 1 for i in range(10)}
+#      ^ meta.set.python - meta.function
+#       ^^^^^^ meta.set.python meta.function.inline.python
+#             ^ meta.set.python meta.function.inline.parameters.python
+#              ^^^ meta.set.python meta.function.inline.body.python
+#                 ^^^^^^^^^^^^^^^^^^^ meta.set.python - meta.function
+#                                    ^ - meta.set
+#      ^ punctuation.section.set.begin.python
+#       ^^^^^^ keyword.declaration.function.inline.python
+#             ^ punctuation.section.function.begin.python
+#               ^ constant.numeric.value.python
+#                 ^^^ keyword.control.loop.for.generator.python
+#                     ^ meta.generic-name.python
+#                       ^^ keyword.control.loop.for.in.python
+#                          ^^^^^ support.function.builtin.python
+#                               ^ punctuation.section.arguments.begin.python
+#                                ^^ constant.numeric.value.python
+#                                  ^ punctuation.section.arguments.end.python
+#                                   ^ punctuation.section.set.end.python
+
+invalid_ = lambda: 1 for i in range(10)
+#                    ^^^ invalid.illegal.name.python
+
 list(i for i in generator)
 #      ^^^^^^^^ meta.expression.generator
 list((i for i in generator), 123)


### PR DESCRIPTION
Fixes #3049

This PR adds a dedicated `lambda-in-groups` context, which differs from normal `lambda` only by an additional bailout to pop contexts off stack in case of `for` keyword being matched.

Let the including context handle/consume it.

Duplication of contexts is required to maintain illegal highlighting of `for` keyword in top-level statements, if not surrounded by brackets.