### PR TITLE
[Git Formats] Update to sublime-syntax version 2

### DIFF
--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -7,11 +7,13 @@
 # Examples: https://github.com/alexkaratarakis/gitattributes
 
 name: Git Attributes
+scope: text.git.attributes
+version: 2
+
 file_extensions:
   - attributes                # .git/info/attributes
   - gitattributes             # *.gitattributes
   - .gitattributes            # ~/.gitattributes
-scope: text.git.attributes
 
 contexts:
 
@@ -59,7 +61,7 @@ contexts:
     - meta_scope: string.unquoted.git.attributes
     - meta_content_scope: entity.name.pattern.git.attributes
     - match: (?=\s)
-      pop: true
+      pop: 1
     - include: Git Common.sublime-syntax#fnmatch-body
 
   pattern-attributes:
@@ -74,7 +76,7 @@ contexts:
     # attriubte list ends with line
     - match: $\n?
       scope: meta.attributes-list.git.attributes
-      pop: true
+      pop: 1
     # set/unset operators
     - match: '[-!](?=\w)'
       scope: keyword.operator.logical.git.attributes
@@ -154,10 +156,10 @@ contexts:
   attribute-maybe-value-list:
     - meta_content_scope: meta.mapping.git.attributes
     - match: =(?=\S)
-      scope: punctuation.separator.mapping.key-value.git.attributes
+      scope: meta.mapping.git.attributes punctuation.separator.mapping.key-value.git.attributes
       set: [attribute-value-list, attribute-value-content]
     - match: =
-      scope: punctuation.separator.mapping.key-value.git.attributes
+      scope: meta.mapping.git.attributes punctuation.separator.mapping.key-value.git.attributes
       set: attribute-value-expected
     - include: attribute-separator
     - include: immediately-pop
@@ -169,7 +171,7 @@ contexts:
       scope: punctuation.separator.mapping.values.git.attributes
       push: attribute-value-content
     - match: ','
-      scope: punctuation.separator.mapping.values.git.attributes
+      scope: meta.mapping.git.attributes punctuation.separator.mapping.values.git.attributes
       set: attribute-value-expected
     - match: \S
       scope: invalid.illegal.value.git.attributes
@@ -183,7 +185,7 @@ contexts:
     # unquoted value is everything except , and whitespace
     - match: '[^,\s]*'
       scope: meta.string.git.attributes string.unquoted.git.attributes
-      pop: true
+      pop: 1
     - include: immediately-pop
 
   attribute-value-expected:
@@ -191,14 +193,14 @@ contexts:
     # One whitespace after each attribute/value is captured as separator
     - match: \s
       scope: meta.mapping.expect-value.git.attributes punctuation.separator.mapping.pair.git.attributes
-      pop: true
+      pop: 1
 
   attribute-separator:
     # Attributes are separated by whitespace
     # One whitespace after each attribute/value is captured as separator
     - match: \s
       scope: meta.mapping.git.attributes punctuation.separator.mapping.pair.git.attributes
-      pop: true
+      pop: 1
 
 ##[ PROTOTYPES ]#######################################################
 
@@ -212,11 +214,11 @@ contexts:
   string-end:
     - match: \"
       scope: punctuation.definition.string.end.git.attributes
-      pop: true
+      pop: 1
     - match: \n
       scope: invalid.illegal.unexpected.eol.git.attributes
-      pop: true
+      pop: 1
 
   immediately-pop:
     - match: ''
-      pop: true
+      pop: 1

--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -3,11 +3,13 @@
 # Highlight regular git commits, merge commits, and tags.
 
 name: Git Commit
+scope: text.git.commit
+version: 2
+
 file_extensions:
   - COMMIT_EDITMSG
   - MERGE_MSG
   - TAG_EDITMSG
-scope: text.git.commit
 
 variables:
   comment_char: '[#;]'
@@ -72,7 +74,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: meta.message.git.commit
         - match: ^(?=#)
-          pop: true
+          pop: 1
         - include: Git Common.sublime-syntax#references
         - include: signed-off
 
@@ -91,7 +93,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: comment.line.git.commit
         - match: $\n?
-          pop: true
+          pop: 1
         - include: branch-line
         - include: change-list
         - include: commands-line

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -3,8 +3,9 @@
 # This file is some kind of internal library which is used to store
 # common rules which are used by the visible syntax files.
 name: Git Common
-hidden: true
 scope: text.git.common
+version: 2
+hidden: true
 
 variables:
   comment_char: '[#;]'
@@ -29,18 +30,18 @@ contexts:
     # make sure to resume parsing at next line
       push:
         - match: (?=\S|^\s*$)
-          pop: true
+          pop: 1
 
   eol-pop:
     - include: line-continuation
     - match: $
-      pop: true
+      pop: 1
 
   illegal-eol-pop:
     - include: line-continuation
     - match: $\n?
       scope: invalid.illegal.unexpected.eol.git
-      pop: true
+      pop: 1
 
 ##[ COMMENTS ]#########################################################
 
@@ -97,14 +98,15 @@ contexts:
       push: [email-meta, email-name]
 
   email-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.reference.email.git
     - match: ''
-      pop: true
+      pop: 1
 
   email-name:
     - meta_content_scope: entity.name.reference.email.git
     - match: '@'
-      scope: punctuation.separator.email.git
+      scope: entity.name.reference.email.git punctuation.separator.email.git
       set: email-domain
     - include: email-end
 
@@ -117,7 +119,7 @@ contexts:
   email-end:
     - match: '>'
       scope: punctuation.definition.reference.email.end.git
-      pop: true
+      pop: 1
 
   username:
     # user reference
@@ -143,11 +145,11 @@ contexts:
     - match: '[A-Za-z](:)(?=/)'
       captures:
         1: punctuation.separator.drive.fnmatch.git
-      pop: true
+      pop: 1
     # homedir tilde operator
     - match: ~(?=/)
       scope: variable.language.environment.home.fnmatch.git
-      pop: true
+      pop: 1
     # any other directory pattern
     - include: fnmatch-dir-pattern
 
@@ -181,31 +183,31 @@ contexts:
   fnmatch-dir-pattern:
     - match: \.\.(?=/)
       scope: constant.language.path.parent.fnmatch.git
-      pop: true
+      pop: 1
     - match: \.(?=/)
       scope: constant.language.path.self.fnmatch.git
-      pop: true
+      pop: 1
     - match: ''
-      pop: true
+      pop: 1
 
   fnmatch-char-class-operator:
     - match: '[!^]?'  # optional pattern negation
       scope: keyword.operator.logical.fnmatch.git
-      pop: true
+      pop: 1
 
   fnmatch-char-class-start:
     - match: \]?  # first unescaped ']' is matched as normal char
       scope: constant.character.char-class.fnmatch.git
-      pop: true
+      pop: 1
 
   fnmatch-char-class-body:
     - meta_scope: meta.char-class.fnmatch.git
     - match: \]
       scope: keyword.control.char-class.end.fnmatch.git
-      pop: true
+      pop: 1
     - match: $\n?     # class must end before end of line
       scope: invalid.illegal.unexpected.eol.fnmatch.git
-      pop: true
+      pop: 1
     - match: '\\\]'   # backslash escapes only ']'
       scope: constant.character.escape.char-class.fnmatch.git
     - match: '[*?]'   # asterisk is ignored by fnmatch
@@ -244,7 +246,7 @@ contexts:
   include-pretty-formats:
     - meta_content_scope: meta.pretty-formats.git
     - match: (?!\S)
-      pop: true
+      pop: 1
     - match: (\')(?:(t?format)(:))?
       captures:
         1: punctuation.definition.string.begin.shell
@@ -254,7 +256,7 @@ contexts:
         - meta_scope: string.quoted.single.shell
         - match: \'
           scope: punctuation.definition.string.end.shell
-          pop: true
+          pop: 1
         - include: illegal-eol-pop
         - include: pretty-formats
     - match: \"(?:(t?format)(:))?
@@ -266,7 +268,7 @@ contexts:
         - meta_scope: string.quoted.double.shell
         - match: \"
           scope: punctuation.definition.string.end.shell
-          pop: true
+          pop: 1
         - include: illegal-eol-pop
         - include: pretty-formats
     - include: pretty-formats
@@ -301,7 +303,7 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.pretty-formats.git
         - match: '\)'
           scope: meta.function-call.arguments.pretty-formats.git punctuation.section.parens.end.pretty-formats.git
-          pop: true
+          pop: 1
         - match: \d+
           scope: meta.number.integer.decimal.git constant.numeric.value.git
         - match: ',,'
@@ -345,7 +347,7 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.pretty-formats.git
         - match: \)
           scope: meta.function-call.arguments.pretty-formats.git punctuation.section.parens.end.pretty-formats.git
-          pop: true
+          pop: 1
         - include: Git Config.sublime-syntax#color-value
         - match: reset
           scope: support.constant.color-reset.git.config
@@ -360,13 +362,13 @@ contexts:
         - include: illegal-eol-pop
         - match: \)
           scope: punctuation.section.parens.end.pretty-formats.git
-          pop: true
+          pop: 1
         - match: ':'
           scope: keyword.operator.assignment.option.pretty-formats.git
           push:
             - include: eol-pop
             - match: (?=\))
-              pop: true
+              pop: 1
             - match: ',,|:'
               scope: invalid.illegal.pretty-formats.git
             - match: ','

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -4,12 +4,15 @@
 # https://git-scm.com/docs/git-config#_syntax
 
 name: Git Config
+scope: text.git.config
+version: 2
+
 file_extensions:
   - gitconfig                # /etc/gitconfig
   - .gitconfig               # ~/.gitconfig
   - .gitmodules              # ~/.gitmodules
+
 first_line_match: ^\[core\]  # .git/config files always start with [core]
-scope: text.git.config
 
 variables:
   variable_name: '[a-zA-Z][\w-]*'
@@ -44,7 +47,7 @@ contexts:
     - meta_scope: meta.brackets.git.config
     - match: \]
       scope: punctuation.definition.brackets.end.git.config
-      pop: true
+      pop: 1
     - include: illegal-line-end-pop
     - match: \S
       scope: invalid.illegal.header-end.git.config
@@ -59,7 +62,7 @@ contexts:
       scope: punctuation.accessor.dot.git.config
       set: subsection-name-unquoted
     - match: (?=\])
-      pop: true
+      pop: 1
     - include: illegal-line-end-pop
     - match: \S
       scope: invalid.illegal.section-name.git.config
@@ -70,7 +73,7 @@ contexts:
     - meta_scope: string.quoted.double.git.config
     - match: \"
       scope: punctuation.definition.string.end.git.config
-      pop: true
+      pop: 1
     - match: \\[\\"]
       scope: constant.character.escape.git.config
     # `\` is legal, but it can lead to confusion because escapes like `\t`
@@ -87,14 +90,14 @@ contexts:
     - match: \.
       scope: punctuation.accessor.dot.git.config
     - match: (?=\])
-      pop: true
+      pop: 1
     - include: illegal-line-end-pop
     - match: \S
       scope: invalid.illegal.subsection-name.git.config
 
   expect-section:
     - match: (?=^\s*\[) # start of new section
-      pop: true
+      pop: 1
     - match: \]
       scope: punctuation.definition.brackets.end.git.config invalid.illegal.stray-bracket.git.config
 
@@ -212,11 +215,11 @@ contexts:
     # make sure to resume parsing at next line
       push:
         - match: (?=\S|^\s*$)
-          pop: true
+          pop: 1
 
   line-end:
     - match: $
-      pop: true
+      pop: 1
 
   expect-line-end:
     - include: line-end
@@ -232,4 +235,4 @@ contexts:
   illegal-line-end-pop:
     - match: $\n?
       scope: invalid.illegal.unexpected.eol.git.config
-      pop: true
+      pop: 1

--- a/Git Formats/Git Ignore.sublime-syntax
+++ b/Git Formats/Git Ignore.sublime-syntax
@@ -6,12 +6,14 @@
 # Examples: https://github.com/github/gitignore
 
 name: Git Ignore
+scope: text.git.ignore
+version: 2
+
 file_extensions:
   - exclude               # .git/info/exclude
   - gitignore             # *.gitignore
   - .gitignore            # ~/.gitignore
   - sparse-checkout       # .git/info/sparse-checkout
-scope: text.git.ignore
 
 contexts:
 
@@ -24,6 +26,6 @@ contexts:
   pattern-content:
     - meta_scope: string.unquoted.git.ignore entity.name.pattern.git.ignore
     - match: $
-      pop: true
+      pop: 1
     - include: Git Common.sublime-syntax#fnmatch-body
 

--- a/Git Formats/Git Link.sublime-syntax
+++ b/Git Formats/Git Link.sublime-syntax
@@ -3,10 +3,13 @@
 # Highlight .git files.
 
 name: Git Link
+scope: text.git.link
+version: 2
+
 file_extensions:
   - .git
+
 first_line_match: '^\s*gitdir\s*:'
-scope: text.git.link
 
 contexts:
 
@@ -34,23 +37,23 @@ contexts:
       scope: punctuation.separator.mapping.key-value.git.link
       set: [mapping-value-meta, expect-path]
     - match: \n
-      pop: true
+      pop: 1
 
   expect-path:
     - match: (?=\S)   # path starts with the first non-space character
       set: [path, path-start]
     - match: \n
-      pop: true
+      pop: 1
 
   mapping-value-meta:
     - meta_content_scope: meta.mapping.value.git.link
     - match: ''
-      pop: true
+      pop: 1
 
   path:
     - meta_content_scope: meta.path.git string.unquoted.git
     - match: $
-      pop: true
+      pop: 1
     - match: '[\\/]'
       scope: punctuation.separator.path.git
       push: path-dir-pattern
@@ -62,20 +65,20 @@ contexts:
     - match: '[A-Za-z](:)(?=[\\/])'
       captures:
         1: punctuation.separator.drive.git
-      pop: true
+      pop: 1
     # homedir tilde operator
     - match: ~(?=/)
       scope: variable.language.environment.home.git
-      pop: true
+      pop: 1
     # any other directory pattern
     - include: path-dir-pattern
 
   path-dir-pattern:
     - match: \.\.(?=[\\/])
       scope: constant.language.path.parent.git
-      pop: true
+      pop: 1
     - match: \.(?=[\\/])
       scope: constant.language.path.self.git
-      pop: true
+      pop: 1
     - match: ''
-      pop: true
+      pop: 1

--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -1,10 +1,14 @@
 %YAML 1.2
 ---
 name: Git Log
+scope: text.git.log
+version: 2
+
 file_extensions:
   - gitlog   # no real extension but why not?
+
 first_line_match: ^commit\s+\h{7,}
-scope: text.git.log
+
 variables:
   diff_begin: ^diff\s+--git\s
   commit_begin: ^(commit)\s+(\h{7,})
@@ -25,7 +29,7 @@ contexts:
         - meta_scope: meta.header.git.commit markup.raw.block.git.log
         - match: $\n?
           scope: meta.header.git.commit markup.raw.block.git.log
-          pop: true
+          pop: 1
           embed: commit-header
           escape: '{{commit_or_diff_begin}}'
         - match: (\()(HEAD)\s*(->)
@@ -36,7 +40,7 @@ contexts:
           push:
             - match: \)
               scope: punctuation.section.parens.end.git.log
-              pop: true
+              pop: 1
             - match: \b(?:master|main)\b
               scope: entity.other.branch-name.master.git.log
             - match: (\w+)(?:(/)(\w+))?
@@ -62,7 +66,7 @@ contexts:
         - meta_scope: meta.header.git.commit markup.raw.block.git.log
         - meta_content_scope: string.unquoted.log
         - match: \n
-          pop: true
+          pop: 1
         - include: Git Common.sublime-syntax#email
     # using push instead of include as workaround for
     # https://github.com/SublimeTextIssues/Core/issues/2395
@@ -90,7 +94,7 @@ contexts:
         1: keyword.context.git.log
       push: copy-or-move
     - match: ^
-      pop: true
+      pop: 1
       embed: scope:source.diff
       escape: '{{commit_or_diff_begin}}'
 

--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -4,10 +4,12 @@
 # https://www.git-scm.com/docs/git-check-mailmap#_mapping_authors
 
 name: Git Mailmap
+scope: text.git.mailmap
+version: 2
+
 file_extensions:
   - .mailmap
   - mailmap
-scope: text.git.mailmap
 
 contexts:
   main:

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -196,11 +196,13 @@ pattern attr= no_value attr=value, eol=lf,
 #                          ^ meta.mapping.git - meta.mapping.key.git - meta.mapping.value.git - meta.mapping.expect-value.git
 #                          ^ punctuation.separator.mapping.key-value.git
 #                           ^^^^^ string.unquoted.git.attributes
-#                           ^^^^^^ meta.mapping.value.git - meta.mapping.key.git - meta.mapping.git - meta.mapping.expect-value.git
+#                           ^^^^^ meta.mapping.value.git - meta.mapping.key.git - meta.mapping.git - meta.mapping.expect-value.git
+#                                ^ meta.mapping.git.attributes punctuation.separator.mapping.values.git.attributes
 #                                 ^ meta.mapping.expect-value.git - meta.mapping.key.git - meta.mapping.git
 #                                  ^^^ meta.mapping.key.git - meta.mapping.git - meta.mapping.value.git
 #                                     ^ meta.mapping.git - meta.mapping.key.git - meta.mapping.value.git - meta.mapping.expect-value.git
 #                                     ^ punctuation.separator.mapping.key-value.git
 #                                      ^^ string.unquoted.git.attributes
-#                                      ^^^ meta.mapping.value.git - meta.mapping.key.git - meta.mapping.git - meta.mapping.expect-value.git
+#                                      ^^ meta.mapping.value.git - meta.mapping.key.git - meta.mapping.git - meta.mapping.expect-value.git
+#                                        ^ meta.mapping.git.attributes punctuation.separator.mapping.values.git.attributes
 #                                         ^ meta.mapping.expect-value.git - meta.mapping.key.git - meta.mapping.git


### PR DESCRIPTION
This PR...

1. updates all syntax definitions to version 2 syntax format
2. replaces pop: true by pop: 1
3. resorts main keys according to #2430