### PR TITLE
[TypeScript] Support export declare enum/export abstract class.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -340,6 +340,8 @@ contexts:
     - include: variable-declaration
     - include: class
     - include: regular-function
+    - include: ts-declare-enum
+    - include: ts-abstract-class
 
     - match: 'default{{identifier_break}}'
       scope: keyword.control.import-export.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -340,8 +340,6 @@ contexts:
     - include: variable-declaration
     - include: class
     - include: regular-function
-    - include: ts-declare-enum
-    - include: ts-abstract-class
 
     - match: 'default{{identifier_break}}'
       scope: keyword.control.import-export.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -164,6 +164,20 @@ contexts:
         - ts-type-parameter-list
         - ts-type-alias-name
 
+  ts-declare-enum:
+    - match: declare{{identifier_break}}
+      scope: storage.type.js
+      set:
+        - include: ts-enum
+        - include: else-pop
+
+  ts-abstract-class:
+    - match: abstract{{identifier_break}}
+      scope: storage.modifier.js
+      set:
+        - include: class
+        - include: else-pop
+
   statement:
     - meta_prepend: true
     - include: ts-enum
@@ -181,17 +195,8 @@ contexts:
             - variable-binding-list-top
             - variable-binding-top
 
-    - match: declare{{identifier_break}}
-      scope: storage.type.js
-      set:
-        - include: ts-enum
-        - include: else-pop
-
-    - match: abstract{{identifier_break}}
-      scope: storage.modifier.js
-      set:
-        - include: class
-        - include: else-pop
+    - include: ts-declare-enum
+    - include: ts-abstract-class
 
   class:
     - match: class{{identifier_break}}

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -141,6 +141,8 @@ contexts:
     - include: ts-type-declaration
     - include: ts-interface-declaration
     - include: ts-namespace-declaration
+    - include: ts-declare-enum
+    - include: ts-abstract-class
 
   property-access:
     - meta_prepend: true

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -142,6 +142,24 @@ import foo;
 //                   ^^^ entity.name.namespace
 //                       ^^ meta.block
 
+    export abstract class C {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^^^^^ storage.modifier
+//                  ^^^^^^^^^^ meta.class
+//                  ^^^^^ keyword.declaration.class
+//                        ^ entity.name.class
+//                          ^^ punctuation.section.block
+
+    export declare enum E {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^^^^ storage.type
+//                 ^^^^^^^^^ meta.enum
+//                 ^^^^ storage.type
+//                      ^ entity.name.enum
+//                        ^^ meta.block punctuation.section.block
+
 /* Declarations */
 
     interface Foo {


### PR DESCRIPTION
Fix #3060.

The `abstract` and `declare` keywords were only handled in `statement`, not in the export stuff. This adds them to `export-extended`.

It might be a good idea to move all of the exportable declarations into a single new context in the future.

Also, the scopes on `enum` and `declare` should probably be updated in the future.