### PR TITLE
[TypeScript] Fix a bug in function type parsing.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -897,6 +897,8 @@ contexts:
           - match: \)
             scope: punctuation.section.group.end.js
             pop: true
+          - match: (?=\S)
+            fail: ts-function-type
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -986,6 +986,24 @@ let x: abstract new () => T;
 //                     ^^ keyword.declaration.function
 //                        ^ support.class
 
+let x: (n: number | { valueOf(): number }) => string;
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//      ^ variable.parameter
+//       ^ punctuation.separator.type
+//         ^^^^^^ support.type.primitive.number
+//                ^ keyword.operator.type.union
+//                  ^^^^^^^^^^^^^^^^^^^^^ meta.type meta.group meta.type
+//                  ^ punctuation.section.mapping.begin
+//                    ^^^^^^^ variable.other.readwrite
+//                           ^^ meta.function.parameters punctuation.section.group
+//                             ^ punctuation.separator.type
+//                               ^^^^^^ support.type.primitive.number
+//                                      ^ punctuation.section.mapping.end
+//                                         ^^ keyword.declaration.function
+//                                            ^^^^^^ support.type.primitive.string
+
 let x: ( foo );
 //     ^^^^^^^ meta.type meta.group
 //     ^ punctuation.section.group.begin


### PR DESCRIPTION
Fix https://github.com/sublimehq/Packages/issues/3059#issue-1011995899.

Function types are parsed similarly to arrow functions — the content of the parentheses is parsed as a parenthesized type, and then if an arrow is found after the close paren, the parser backtracks and re-parses as a function type. But if parsing goes far wrong within the parens, then it can't find the arrow. This can happen because function type parameter lists are not necessarily valid parenthesized types. For arrow function literals, we account for this by making sure that the expression grammar “covers” the parameter list grammar. That doesn't work here because we need to be very strict with bailing out of invalid types. Instead, when we see that a parenthesized type has gone wrong, we immediately backtrack and try to reparse as a function type.

This shouldn't affect any previously-valid syntax, but it might result in different behavior for invalid syntax. Probably it should result in better behavior, since it's more likely that a function type will be identified early while typing the argument list.