### PR TITLE
[TypeScript] Fix array type modifier after generic.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -719,7 +719,7 @@ contexts:
   ts-generic-type-arguments:
     - match: \<(?!<)
       scope: punctuation.definition.generic.begin.js
-      set:
+      push:
         - meta_scope: meta.generic.js
         - match: \>
           scope: punctuation.definition.generic.end.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -656,6 +656,11 @@ let x: readonly any [];
 //              ^^^ support.type.any
 //                  ^^ storage.modifier.array
 
+let x: foo<T>[];
+//     ^^^^^^^^ meta.type
+//        ^^^ meta.type meta.generic
+//           ^^ meta.type storage.modifier.array
+
 let x: any [ "foo" | 'bar' ];
 //     ^^^^^^^^^^^^^^^^^^^^^ meta.type
 //     ^^^ support.type.any


### PR DESCRIPTION
Fix https://github.com/sublimehq/Packages/issues/3059#issuecomment-931252137.

Having `set` there instead of `push` was effectively popping `ts-type-expression-end-no-line-terminator` before it could match the array modifier. `push` works fine.

I tried various silly examples to see whether parsing multiple type argument lists in a row would break anything, but it doesn't seem to. For your amusement:

```tsx
Foo<bar><baz>();//</baz> // This still works correctly.
class C extends Foo <T> < 42 {} // This isn't valid anyway, and it doesn't break too badly.
```