### PR TITLE
[Python] Add support for `ModuleNotFoundError`

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1506,7 +1506,7 @@ contexts:
             Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe|Buffer|ChildProcess|
             Connection(?:Aborted|Refused|Reset)?|EOF|Environment|FileExists|
             FileNotFound|FloatingPoint|Interrupted|IO|IsADirectoryError|
-            Import|Indentation|Index|Key|Lookup|Memory|Name|NotADirectory|
+            Import|Indentation|Index|Key|Lookup|Memory|ModuleNotFound|Name|NotADirectory|
             NotImplemented|OS|Overflow|Permission|ProcessLookup|Reference|
             Runtime|Standard|Syntax|System|Tab|Timeout|Type|UnboundLocal|
             Unicode(?:Encode|Decode|Translate)?|Value|VMS|Windows|ZeroDivision


### PR DESCRIPTION
Built-in exception added in Python 3.6

> See : <https://docs.python.org/3.9/library/exceptions.html#ModuleNotFoundError>

---

Thanks, bye 👋