### PR TITLE
[JavaScript] [TypeScript] Improve highlighting of declarations.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -337,15 +337,12 @@ contexts:
     - include: immediately-pop
 
   export-extended:
-    - include: variable-declaration
-    - include: class
-    - include: regular-function
+    - include: declaration
 
     - match: 'default{{identifier_break}}'
       scope: keyword.control.import-export.js
       set:
-        - include: class
-        - include: regular-function
+        - include: declaration
         - match: (?=\S)
           set: expression-statement
 
@@ -404,12 +401,12 @@ contexts:
       scope: punctuation.terminator.statement.empty.js
       pop: true
 
+    - include: declaration
     - include: import-statement-or-import-meta
     - include: export-statement
     - include: conditional
     - include: block
     - include: label
-    - include: variable-declaration
 
     - match: break{{identifier_break}}
       scope: keyword.control.flow.break.js
@@ -435,12 +432,14 @@ contexts:
       scope: keyword.control.flow.throw.js
       set: restricted-production
 
-    - include: class
-    - include: regular-function
-
     - include: decorator
 
     - include: expression-statement
+
+  declaration:
+    - include: variable-declaration
+    - include: class
+    - include: regular-function
 
   expect-semicolon:
     - match: \;

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -136,14 +136,6 @@ contexts:
         - ts-import-type
         - import-check-branch
 
-  export-extended:
-    - meta_prepend: true
-    - include: ts-type-declaration
-    - include: ts-interface-declaration
-    - include: ts-namespace-declaration
-    - include: ts-declare-enum
-    - include: ts-abstract-class
-
   property-access:
     - meta_prepend: true
     - match: \!\.
@@ -159,46 +151,73 @@ contexts:
 
   ts-type-declaration:
     - match: type{{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.type.js
       set:
         - ts-type-alias-meta
         - ts-type-alias-body
         - ts-type-parameter-list
         - ts-type-alias-name
 
+  ts-const-declaration:
+    - match: const{{identifier_break}}
+      scope: keyword.declaration.js
+      set:
+        - expect-semicolon
+        - variable-binding-list-top
+        - variable-binding-top
+        - ts-check-not-enum
+
+  ts-check-not-enum:
+    - match: (?=enum{{identifier_break}})
+      fail: ts-const-enum
+    - include: else-pop
+
+  ts-const-enum:
+    - match: const{{identifier_break}}
+      scope: storage.modifier.js
+      set: ts-enum
+
   ts-declare-enum:
     - match: declare{{identifier_break}}
-      scope: storage.type.js
+      scope: storage.modifier.js
       set:
+        - include: ts-const-enum
         - include: ts-enum
-        - include: else-pop
+        - match: (?=\S)
+          fail: ts-declare-enum
 
   ts-abstract-class:
     - match: abstract{{identifier_break}}
       scope: storage.modifier.js
       set:
         - include: class
-        - include: else-pop
+        - match: (?=\S)
+          fail: ts-abstract-class
 
-  statement:
+  declaration:
     - meta_prepend: true
     - include: ts-enum
     - include: ts-type-declaration
     - include: ts-interface-declaration
     - include: ts-namespace-declaration
 
-    - match: const{{identifier_break}}
-      scope: keyword.declaration.js
-      set:
-        - include: ts-enum
-        - match: (?=\S)
-          set:
-            - expect-semicolon
-            - variable-binding-list-top
-            - variable-binding-top
+    - match: (?=const{{identifier_break}})
+      branch:
+        - ts-const-declaration
+        - ts-const-enum
+      branch_point: ts-const-enum
 
-    - include: ts-declare-enum
-    - include: ts-abstract-class
+    - match: (?=declare{{identifier_break}})
+      branch:
+        - ts-declare-enum
+        - expression-statement
+      branch_point: ts-declare-enum
+
+    - match: (?=abstract{{identifier_break}})
+      branch:
+        - ts-abstract-class
+        - expression-statement
+      branch_point: ts-abstract-class
 
   class:
     - match: class{{identifier_break}}
@@ -344,7 +363,7 @@ contexts:
 
   ts-enum:
     - match: enum{{identifier_break}}
-      scope: storage.type.js
+      scope: keyword.declaration.enum.js
       set:
         - ts-enum-meta
         - ts-enum-body

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -154,11 +154,19 @@ import foo;
     export declare enum E {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //  ^^^^^^ keyword.control.import-export
-//         ^^^^^^^ storage.type
+//         ^^^^^^^ storage.modifier
 //                 ^^^^^^^^^ meta.enum
-//                 ^^^^ storage.type
+//                 ^^^^ keyword.declaration.enum
 //                      ^ entity.name.enum
 //                        ^^ meta.block punctuation.section.block
+
+    export default interface Foo {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^^^^ keyword.control.import-export
+//                 ^^^^^^^^^^^^^^^^ meta.interface
+//                 ^^^^^^^^^ keyword.declaration
+//                           ^^^  entity.name.interface
 
 /* Declarations */
 
@@ -219,7 +227,7 @@ import foo;
 
     enum Foo {
 //  ^^^^^^^^^^^ meta.enum
-//  ^^^^ storage.type
+//  ^^^^ keyword.declaration.enum
 //       ^^^ entity.name.enum
 //           ^ punctuation.section.block.begin
         x,
@@ -239,20 +247,37 @@ import foo;
 //  ^ meta.enum meta.block punctuation.section.block.end
 
     const enum Foo {}
-//  ^^^^^ keyword.declaration
+//  ^^^^^ storage.modifier
 //        ^^^^^^^^^^^ meta.enum
-//        ^^^^ storage.type
+//        ^^^^ keyword.declaration.enum
 //             ^^^ entity.name.enum
 
     declare enum Foo {}
-//  ^^^^^^^ storage.type
+//  ^^^^^^^ storage.modifier
 //          ^^^^^^^^^^^ meta.enum
-//          ^^^^ storage.type
+//          ^^^^ keyword.declaration.enum
 //               ^^^ entity.name.enum
+
+    declare const enum Foo {}
+//  ^^^^^^^ storage.modifier
+//          ^^^^^ storage.modifier
+//                ^^^^^^^^^^^ meta.enum
+//                ^^^^ keyword.declaration.enum
+//                     ^^^ entity.name.enum
+
+    const; // While typing
+//  ^^^^^ keyword.declaration
+
+    declare();
+//  ^^^^^^^ meta.function-call variable.function
+
+    const declare;
+//  ^^^^^ keyword.declaration
+//        ^^^^^^^ meta.binding.name variable.other.readwrite
 
     type x < T > = any;
 //  ^^^^^^^^^^^^^^^^^^ meta.type-alias
-//  ^^^^ storage.type
+//  ^^^^ keyword.declaration.type
 //       ^ entity.name.type
 //         ^^^^^ meta.generic
 //         ^ punctuation.definition.generic.begin
@@ -263,7 +288,7 @@ import foo;
 
     type x < T = Foo > = any;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.type-alias
-//  ^^^^ storage.type
+//  ^^^^ keyword.declaration.type
 //       ^ entity.name.type
 //         ^^^^^^^^^^^ meta.generic
 //         ^ punctuation.definition.generic.begin
@@ -410,6 +435,9 @@ import foo;
 //               ^^^ entity.name.function
 
     }
+
+    abstract();
+//  ^^^^^^^^ meta.function-call variable.function
 
     class Foo < T > extends Bar implements Baz, Xyzzy { }
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class


### PR DESCRIPTION
Cleanup after fixes in #3061. Overall, simplify how declarations are handled, update scopes, and fix some corner cases.

- Add a new `declarations` context for class and function declarations in JavaScript, and all of TypeScript's new declarations. Use it in `statements` and in the export contexts instead of manually including the individual contexts.
- Use the proper `keyword.declaration` scopes for `type` and `enum`, and `storage.modifier` for `const` and `declare`.
- Use branching to correctly handle code like `declare()` and `abstract()`, and make sure that `declare const enum` works.

Un-special-casing `export default` means that e.g. `export default const foo = 42` is highlighted differently, but that's invalid code anyway so I don't think we care.