### PR TITLE
[Rails] Add meta.model.rails on classes that inherit from ApplicationRecord

### DIFF
--- a/Rails/Ruby on Rails.sublime-syntax
+++ b/Rails/Ruby on Rails.sublime-syntax
@@ -159,8 +159,8 @@ contexts:
         - match: ^\1(?=end)\b
           pop: true
         - include: embedded-expressions
-    # Uses lookahead to match classes that (may) inherit from ActiveRecord::Base
-    - match: (^\s*)(?=class\s+.+ActiveRecord::Base\b)
+    # Uses lookahead to match classes that (may) inherit from ActiveRecord::Base or ApplicationRecord
+    - match: (^\s*)(?=class\s+.+(ActiveRecord::Base|ApplicationRecord)\b)
       push:
         - meta_scope: meta.model.rails
         - match: ^\1(?=end)\b

--- a/Rails/syntax_test_rails.rb
+++ b/Rails/syntax_test_rails.rb
@@ -24,7 +24,16 @@ class ApplicationController < ApplicationController
   end
 end
 
+class Product < ActiveRecord::Base
+
+# <- meta.model.rails
+
+end
+
 class PictureFile < ApplicationRecord
+
+# <- meta.model.rails
+
   after_commit :delete_picture_file_from_disk, on: :destroy
 # ^ support.function.activerecord.rails
 


### PR DESCRIPTION
ApplicationRecord was introduced some years ago with rails 5. In few words, it's the "new way" of inheriting from "ActiveRecord::Base"