### PR TITLE
[Clojure] Embed regexp instead of push with_prototype

### DIFF
--- a/Clojure/Clojure.sublime-syntax
+++ b/Clojure/Clojure.sublime-syntax
@@ -31,6 +31,14 @@ variables:
   rational: ({{sign}})(\d+)(/)(\d+)(?=[{{non_number_chars}}])
   float: ({{sign}})(\d+)(?:((\.)\d+{{dec_exponent}}?|{{dec_exponent}})(M)?|(M))(?=[{{non_number_chars}}])
 
+  # no odd number of backslashes behind (`\` or `\\\`)
+  # note:
+  #  1. For use in `escape` commands only !!
+  #  2. ST's Regex Compatibility Check marks it as incompatible
+  #     as the real usage of the variable is not checked.
+  #     It's a false positive as long as (1.) is respected.
+  no_escape_behind: '(?<![^\\]\\)(?<![^\\][\\]{3})'
+
 contexts:
   main:
     - include: match-expr
@@ -226,8 +234,13 @@ contexts:
       scope: keyword.operator.macro.clojure
       pop: true
     - match: '"'
-      scope: punctuation.definition.string.begin.clojure
-      set: pop-regexp-tail
+      scope: string.regexp.clojure punctuation.definition.string.begin.clojure
+      pop: 1
+      embed: scope:source.regexp
+      embed_scope: string.regexp.clojure
+      escape: '{{no_escape_behind}}"'
+      escape_captures:
+        0: string.regexp.clojure punctuation.definition.string.end.clojure
     - match: (?=[\^:])
       pop: true
     - match: (?=\S)
@@ -248,17 +261,6 @@ contexts:
       pop: true
     - match: (?=\S)
       set: pop-expr
-
-  pop-regexp-tail:
-    - meta_scope: string.regexp.clojure
-    - match: '"'
-      scope: punctuation.definition.string.end.clojure
-      pop: true
-    - match: ''
-      push: scope:source.regexp#base-literal
-      with_prototype:
-        - match: (?=")
-          pop: true
 
   pop-string-tail:
     - meta_scope: string.quoted.double.clojure

--- a/Clojure/tests/syntax_test_clojure.clj
+++ b/Clojure/tests/syntax_test_clojure.clj
@@ -925,6 +925,24 @@
   "
 ; ^ string.regexp.clojure punctuation.definition.string.end.clojure
 
+ #"\\"
+; ^^^^ string.regexp.clojure
+; ^ punctuation.definition.string.begin.clojure
+;  ^^ constant.character.escape.regexp
+;    ^ punctuation.definition.string.end.clojure
+
+ #"\\\""
+; ^^^^^^ string.regexp.clojure
+; ^ punctuation.definition.string.begin.clojure
+;  ^^^^ constant.character.escape.regexp
+;      ^ punctuation.definition.string.end.clojure
+
+ #"\\\\"
+; ^^^^^^ string.regexp.clojure
+; ^ punctuation.definition.string.begin.clojure
+;  ^^^^ constant.character.escape.regexp
+;      ^ punctuation.definition.string.end.clojure
+
 ; ## Invalid
 
   #"{1}"

--- a/Clojure/tests/syntax_test_clojure.clj
+++ b/Clojure/tests/syntax_test_clojure.clj
@@ -927,6 +927,9 @@
 
 ; ## Invalid
 
+  #"{1}"
+;   ^^^ string.regexp.clojure source.regexp invalid.illegal.unexpected-quantifier.regexp
+
   # ""
 ; ^ keyword.operator.macro.clojure
 ;  ^^^- string.regexp.clojure


### PR DESCRIPTION
This PR introduces 2 noticeable changes:

1. The current `push...with_prototype` solution is replaced by `embed...escape`
2. The main `source.regexp` syntax is embedded instead of `base-literal` in order to correctly highlight leading quantifiers illegal and to ensure to correctly apply all meta scopes of the regexp syntax.

Prepares for: #3078