### PR TITLE
[Python] Fix highlighting of match with type annotation

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -457,7 +457,9 @@ contexts:
         - case-statement-begin
 
   case-statement-begin:
-    - include: case-statement-fail
+    # fail if match is directly followed by `:` or end of statement
+    - match: (?=$|#|;|:)
+      fail: case-statements
     - include: allow-unpack-operators
 
   case-statement-end:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1296,6 +1296,22 @@ def _():
         case()
 #       ^^^^ variable.function.python - keyword
 
+    case: int = 0
+#   ^^^^ meta.generic-name.python - keyword
+#       ^ punctuation.separator.annotation.variable.python
+#         ^^^ meta.qualified-name.python support.type.python
+#             ^ keyword.operator.assignment.python
+#               ^ meta.number.integer.decimal.python constant.numeric.value.python
+
+    case \
+#   ^^^^ meta.generic-name.python - keyword
+#        ^ punctuation.separator.continuation.line.python
+    : int = 0
+#   ^ punctuation.separator.annotation.variable.python
+#     ^^^ meta.qualified-name.python support.type.python
+#         ^ keyword.operator.assignment.python
+#           ^ meta.number.integer.decimal.python constant.numeric.value.python
+
     match = re.match(r"^.*$")
 #   ^^^^^ meta.generic-name.python - keyword
 #              ^^^^^ meta.function-call.python variable.function.python


### PR DESCRIPTION
This PR fixes an issue which caused a variable named `match` being scoped as keyword if it is followed by an annotation.

This is achieved by failing the match-statement branch if the `match` token is directly followed by a colon.

_Note: The `match` token may be scoped keyword only if a valid match statement is identified. Absence of a variable to match invalidates it._