### PR TITLE
[C++] Add support for Qt-specific visibility modifiers Q_SIGNALS & Q_SLOTS

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -67,7 +67,7 @@ variables:
   type_qualifier: 'const|mutable|typename|volatile'
   constant_expression_specifiers: 'consteval|constexpr|constinit'
   compiler_directive: 'inline|restrict|__restrict__|__restrict'
-  visibility_modifiers: 'private|protected|public'
+  visibility_modifiers: '(?:(?:public|private|protected|Q_SIGNALS|Q_SLOTS)\s*){1,2}'
   other_keywords: 'typedef|nullptr|{{visibility_modifiers}}|static_assert|sizeof|using|typeid|alignof|alignas|namespace|template'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}|{{constant_expression_specifiers}}'
   non_angle_brackets: '(?=<<|<=)'

--- a/C++/Indentation Rules.tmPreferences
+++ b/C++/Indentation Rules.tmPreferences
@@ -17,7 +17,7 @@
 			# detent `default:`
 			| default\b
 			# class member access attributes
-			| ( public | private | protected ):
+			| (?:(?:public|private|protected|Q_SIGNALS|Q_SLOTS)\s*){1,2}:
 			# objc/objc++ attributes
 			| @( public | private | protected )\b
 			)
@@ -36,7 +36,7 @@
 			# indent after `default:`
 			| default\b
 			# class member access attributes
-			| ( public | private | protected ):
+			| (?:(?:public|private|protected|Q_SIGNALS|Q_SLOTS)\s*){1,2}:
 			# objc/objc++ attributes
 			| @( public | private | protected )\b
 			)


### PR DESCRIPTION
In addition to widely used in Qt code `Q_SIGNALS:`, `Q_SLOTS:` and
`public Q_SLOTS:` visibility modifiers, this patch makes syntax
definition also accept potentially illegal code like

    public private:

or even

    Q_SIGNALS Q_SLOTS:

But that's a compromise I'm willing to take, in order to not
over-complicate things. At the very least, there's an "only one or two
items" restriction on quantifiers.

Closes #3091