### PR TITLE
[Markdown] Fix fenced code block syntax name for Go

### DIFF
--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -74,6 +74,12 @@
 			"details": "Specifies <code>Erlang</code> code highlighting"
 		},
 		{
+			"trigger": "go",
+			"annotation": "Go",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Go</code> code highlighting"
+		},
+		{
 			"trigger": "golang",
 			"annotation": "Go",
 			"kind": ["markup", "s", "Syntax"],

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1339,7 +1339,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:golang))
+          ((?i:go(?:lang)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.go.markdown-gfm


### PR DESCRIPTION
This PR adds `go` as valid syntax name of fenced code blocks.

see: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/650