### PR TITLE
[JavaScript] Move non-TS-compatible test to separate file.

### DIFF
--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -73,10 +73,6 @@
 //   ^^^^ comment.block.documentation.js
 //       ^ - comment
 
-/// <foo bar="baz"/>
-// <- comment.line.triple-slash.js punctuation.definition.comment.js
-//^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - meta.preprocessor
-
 //// <foo bar="baz"/>
 // <- comment.line.other.js punctuation.definition.comment.js
 //^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor

--- a/JavaScript/tests/syntax_test_js_not_typescript.js
+++ b/JavaScript/tests/syntax_test_js_not_typescript.js
@@ -1,0 +1,5 @@
+// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
+
+/// <foo bar="baz"/>
+// <- comment.line.triple-slash.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^ comment.line.triple-slash.js - meta.preprocessor


### PR DESCRIPTION
This is so that the TypeScript syntax will pass all of the main syntax tests. I rely on this for JS Custom, and it will be directly useful if https://github.com/sublimehq/sublime_text/issues/3998 is implemented.