### PR TITLE
[JSX] Make tests compatible with TSX.

### DIFF
--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -73,6 +73,10 @@
 //   ^^^^ comment.block.documentation.js
 //       ^ - comment
 
+//// <foo bar="baz"/>
+// <- comment.line.other.js punctuation.definition.comment.js
+//^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
+
     <foo />;
 //  ^^^^^^^ meta.jsx meta.tag
 //  ^ punctuation.definition.tag.begin


### PR DESCRIPTION
I missed these in #3104. These tests fail in TSX. They're duplicates of the tests for regular JS, so I don't think we need to create a separate `syntax_test_jsx_not_tsx.jsx` file for them.