### PR TITLE
[ShellScript] Fix toggle comments on function definitions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -191,14 +191,11 @@ contexts:
 ###[ FUNCTION DEFINITIONS ]####################################################
 
   def-anonymous:
-    - match: (\()\s*(\))
-      scope: meta.function.parameters.shell
-      captures:
-        1: punctuation.section.parameters.begin.shell
-        2: punctuation.section.parameters.end.shell
+    - match: (?=\(\s*\))
       push:
         - def-functions-redirection
         - def-anonymous-body
+        - def-functions-params
 
   def-anonymous-body:
     - include: def-function-body-braces
@@ -277,7 +274,7 @@ contexts:
         - include: statements
 
   def-functions-redirection:
-    - meta_content_scope: meta.function.shell
+    - meta_scope: meta.function.shell
     - include: redirections
     - include: else-pop
     - include: eol-pop

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -893,8 +893,8 @@ coproc foobar {
 #   ^ punctuation.section.compound.end.shell
 
    () { [[ $# == 2 ]] && tput setaf $2 || tput setaf 3; echo -e "$1"; tput setaf 15; }
-#^^ - meta.function
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+#^^ source.shell - meta.function
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.shell - meta.function meta.function
 #  ^ meta.function.parameters.shell
 #   ^ meta.function.parameters.shell
 #    ^ meta.function.shell - meta.function.identifier - meta.compound
@@ -911,8 +911,8 @@ coproc foobar {
 #                     ^^ keyword.operator.logical
 
    logC () { [[ $# == 2 ]] && tput setaf $2 || tput setaf 3; echo -e "$1"; tput setaf 15; }
-#^^ - meta.function
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+#^^ source.shell - meta.function
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.shell - meta.function meta.function
 #  ^^^^ meta.function.identifier.shell
 #      ^ meta.function.identifier.shell
 #       ^ meta.function.parameters.shell
@@ -934,7 +934,8 @@ coproc foobar {
 #                          ^^ keyword.operator.logical.shell
 
 logExit ( ) {
-# <- meta.function.identifier.shell entity.name.function.shell
+# <- source.shell meta.function.identifier.shell entity.name.function.shell
+#^^^^^^^^^^^^^ source.shell - meta.function meta.function
 #^^^^^^ meta.function.identifier.shell entity.name.function.shell
 #      ^ meta.function.identifier.shell
 #       ^^^ meta.function.parameters.shell
@@ -981,8 +982,8 @@ logExit $? $WEIRD
 #                ^ - meta.function-call - meta.interpolation - variable
 
 function foo
-#^^^^^^^^^^^^ - meta.function meta.function
-# <- meta.function.shell keyword.declaration.function.shell
+#^^^^^^^^^^^^ source.shell - meta.function meta.function
+# <- source.shell meta.function.shell keyword.declaration.function.shell
 #^^^^^^^ meta.function.shell
 #       ^^^^^ meta.function.identifier.shell
 #^^^^^^^ keyword.declaration.function.shell
@@ -1007,11 +1008,11 @@ function foo
 
 function func\
 name
-# <- meta.function.identifier.shell entity.name.function.shell
+# <- source.shell meta.function.identifier.shell entity.name.function.shell
 
 function foo (     ) {
-#^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
-# <- meta.function.shell keyword.declaration.function.shell
+#^^^^^^^^^^^^^^^^^^^^^^ source.shell - meta.function meta.function
+# <- source.shell meta.function.shell keyword.declaration.function.shell
 #^^^^^^^ meta.function.shell
 #       ^^^^^ meta.function.identifier.shell
 #            ^^^^^^^ meta.function.parameters.shell


### PR DESCRIPTION
Fixes #3108

This PR fixes an issue which caused `source.shell` to be cleared from `function` keywords, which caused the toggle comments function to not detect those lines as shell script.