### PR TITLE
[Binary] Add Syntax

### DIFF
--- a/Binary/Binary.sublime-settings
+++ b/Binary/Binary.sublime-settings
@@ -1,0 +1,7 @@
+{
+	"auto_complete": false,
+	"auto_indent": false,
+	"spell_check": false,
+	"trim_trailing_white_space_on_save": "none",
+	"word_wrap": false,
+}

--- a/Binary/Binary.sublime-syntax
+++ b/Binary/Binary.sublime-syntax
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+name: Binary
+scope: binary.plain
+version: 2
+
+first_line_match: ^(?:\h{4} )+\h{4}$
+
+contexts:
+  main: []


### PR DESCRIPTION
This PR adds an empty Binary.sublime-syntax which is meant to be used for hexadecimal encoded binary files.

Its only purpose is to prevent confusion.

Current representation of hex groups is a clear indicator of binary content already, but the "Plain Text" syntax name in status bar may cause confusing in case file encoding is not displayed.

see: https://github.com/sublimehq/sublime_text/issues/4948