### PR TITLE
[C#] Add support for the #nullable compiler directive in C# 9.

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -174,15 +174,11 @@ contexts:
         - include: comments
         - match: $
           pop: true
-    - match: '\b(nullable)\s+(enable|disable|restore)\s+(annotations|warnings)\b'
+    - match: '\b(nullable)\s+(enable|disable|restore)(?:\s+(annotations|warnings))?\b'
       captures:
         1: keyword.other.preprocessor.cs
         2: keyword.other.preprocessor.cs
         3: keyword.other.preprocessor.cs
-    - match: '\b(nullable)\s+(enable|disable|restore)\b'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
     - match: .*
       scope: invalid.illegal.cs
     - match: $

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -174,6 +174,15 @@ contexts:
         - include: comments
         - match: $
           pop: true
+    - match: '\b(nullable)\s+(enable|disable|restore)\s+(annotations|warnings)\b'
+      captures:
+        1: keyword.other.preprocessor.cs
+        2: keyword.other.preprocessor.cs
+        3: keyword.other.preprocessor.cs
+    - match: '\b(nullable)\s+(enable|disable|restore)\b'
+      captures:
+        1: keyword.other.preprocessor.cs
+        2: keyword.other.preprocessor.cs
     - match: .*
       scope: invalid.illegal.cs
     - match: $

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -68,3 +68,25 @@ public class MyClass
 //         ^^^^^ variable.other.section
 #endregion
 // ^^ storage.type.section
+
+#nullable enable
+/// ^^ meta.preprocessor keyword.other.preprocessor
+///       ^^ meta.preprocessor keyword.other.preprocessor
+
+#nullable disable
+/// ^^ meta.preprocessor keyword.other.preprocessor
+///       ^^ meta.preprocessor keyword.other.preprocessor
+
+#nullable restore
+/// ^^ meta.preprocessor keyword.other.preprocessor
+///       ^^ meta.preprocessor keyword.other.preprocessor
+
+#nullable enable annotations
+/// ^^ meta.preprocessor keyword.other.preprocessor
+///       ^^ meta.preprocessor keyword.other.preprocessor
+///              ^^ meta.preprocessor keyword.other.preprocessor
+
+#nullable disable warnings
+/// ^^ meta.preprocessor keyword.other.preprocessor
+///       ^^ meta.preprocessor keyword.other.preprocessor
+// /              ^^ meta.preprocessor keyword.other.preprocessor


### PR DESCRIPTION
Ref: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/nullable-reference-types-specification#nullable-compiler-directives