### PR TITLE
[Ruby] Fix HEREDOCs

### DIFF
--- a/Ruby/Embeddings/CSS (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/CSS (for Ruby).sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+scope: source.css.embedded.ruby
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby
+
+  string-content:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#interpolated-ruby

--- a/Ruby/Embeddings/HTML (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/HTML (for Ruby).sublime-syntax
@@ -1,0 +1,108 @@
+%YAML 1.2
+---
+scope: text.html.embedded.ruby
+version: 2
+hidden: true
+
+extends: Packages/HTML/HTML.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby
+
+  script-javascript-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.embedded.ruby
+      embed_scope: source.js.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.js.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.js.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.ruby
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  tag-event-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.embedded.ruby
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.js.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.embedded.ruby
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.js.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-style-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.ruby#rule-list-body
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.css.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.ruby#rule-list-body
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.css.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#interpolated-ruby
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#interpolated-ruby

--- a/Ruby/Embeddings/JavaScript (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/JavaScript (for Ruby).sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+scope: source.js.embedded.ruby
+version: 2
+hidden: true
+
+extends: Packages/JavaScript/JavaScript.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby
+
+  string-content:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#interpolated-ruby

--- a/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+scope: source.sql.embedded.ruby
+# version: 2
+hidden: true
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby

--- a/Ruby/Embeddings/ShellScript (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/ShellScript (for Ruby).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+scope: source.shell.embedded.ruby
+version: 2
+hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -1677,7 +1677,7 @@ contexts:
         - meta_scope: meta.interpolation.ruby
         - include: interpolated-ruby-variables
 
-  interpolated-heredoc-ruby:
+  embedded-ruby:
     - match: '#\{'
       scope: punctuation.section.interpolation.begin.ruby
       push:
@@ -1810,230 +1810,310 @@ contexts:
   heredoc-css:
     - match: (<<[-~])(["`]?)({{heredoc_type_css}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-css-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-css-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_css}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-css-indented-literal, trailing-heredoc-start]
+      push: heredoc-css-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_css}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-css-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-css-unindented-interpolated
     - match: (<<)(')({{heredoc_type_css}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-css-unindented-literal, trailing-heredoc-start]
+      push: heredoc-css-unindented-literal
 
   heredoc-css-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.css.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: scope:source.css
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.css.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_css}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-css-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.css.embedded.ruby
-    - include: indented-heredoc-end
-    - include: scope:source.css
+    - match: ^
+      pop: 1
+      embed: scope:source.css
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_css}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-css-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.css.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.css
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.css.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_css}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-css-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.css.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.css
+    - match: ^
+      pop: 1
+      embed: scope:source.css
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_css}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-js:
     - match: (<<[-~])(["`]?)({{heredoc_type_js}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-js-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-js-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_js}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-js-indented-literal, trailing-heredoc-start]
+      push: heredoc-js-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_js}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-js-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-js-unindented-interpolated
     - match: (<<)(')({{heredoc_type_js}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-js-unindented-literal, trailing-heredoc-start]
+      push: heredoc-js-unindented-literal
 
   heredoc-js-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.js.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: scope:source.js
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.js.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_js}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-js-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.js.embedded.ruby
-    - include: indented-heredoc-end
-    - include: scope:source.js
+    - match: ^
+      pop: 1
+      embed: scope:source.js
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_js}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-js-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.js.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.js
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.js.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_js}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-js-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.js.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.js
+    - match: ^
+      pop: 1
+      embed: scope:source.js
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_js}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-html:
     - match: (<<[-~])(["`]?)({{heredoc_type_html}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-html-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-html-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_html}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-html-indented-literal, trailing-heredoc-start]
+      push: heredoc-html-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_html}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-html-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-html-unindented-interpolated
     - match: (<<)(')({{heredoc_type_html}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-html-unindented-literal, trailing-heredoc-start]
+      push: heredoc-html-unindented-literal
 
   heredoc-html-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: text.html.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: scope:text.html.basic
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:text.html.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_html}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-html-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: text.html.embedded.ruby
-    - include: indented-heredoc-end
-    - include: scope:text.html.basic
+    - match: ^
+      pop: 1
+      embed: scope:text.html
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_html}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-html-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: text.html.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:text.html.basic
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:text.html.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_html}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-html-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: text.html.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:text.html.basic
+    - match: ^
+      pop: 1
+      embed: scope:text.html
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_html}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-ruby:
     - match: (<<[-~])(["`]?)({{heredoc_type_ruby}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-ruby-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-ruby-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_ruby}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-ruby-indented-literal, trailing-heredoc-start]
+      push: heredoc-ruby-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_ruby}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-ruby-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-ruby-unindented-interpolated
     - match: (<<)(')({{heredoc_type_ruby}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-ruby-unindented-literal, trailing-heredoc-start]
+      push: heredoc-ruby-unindented-literal
 
   heredoc-ruby-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.ruby.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: heredoc-ruby-interpolated
+      embed_scope: meta.string.heredoc.ruby source.ruby.embedded.ruby
+      escape: ^\s*({{heredoc_type_ruby}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
     - include: expressions
 
   heredoc-ruby-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.ruby.embedded.ruby
-    - include: indented-heredoc-end
+    - match: ^
+      pop: 1
+      embed: expressions
+      embed_scope: meta.string.heredoc.ruby source.ruby.embedded.ruby
+      escape: ^\s*({{heredoc_type_ruby}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
     - include: expressions
 
   heredoc-ruby-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.ruby.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: heredoc-ruby-interpolated
+      embed_scope: meta.string.heredoc.ruby source.ruby.embedded.ruby
+      escape: ^{{heredoc_type_ruby}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
     - include: expressions
 
   heredoc-ruby-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.ruby.embedded.ruby
-    - include: unindented-heredoc-end
+    - match: ^
+      pop: 1
+      embed: expressions
+      embed_scope: meta.string.heredoc.ruby source.ruby.embedded.ruby
+      escape: ^{{heredoc_type_ruby}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
+
+  heredoc-ruby-interpolated:
+    - include: escaped-char
+    - include: embedded-ruby
     - include: expressions
 
   heredoc-plain:
@@ -2093,116 +2173,154 @@ contexts:
   heredoc-shell:
     - match: (<<[-~])(["`]?)({{heredoc_type_shell}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-shell-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-shell-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_shell}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-shell-indented-literal, trailing-heredoc-start]
+      push: heredoc-shell-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_shell}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-shell-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-shell-unindented-interpolated
     - match: (<<)(')({{heredoc_type_shell}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-shell-unindented-literal, trailing-heredoc-start]
+      push: heredoc-shell-unindented-literal
 
   heredoc-shell-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.shell.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: scope:source.shell
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.shell.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_shell}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-shell-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.shell.embedded.ruby
-    - include: indented-heredoc-end
-    - include: scope:source.shell
+    - match: ^
+      pop: 1
+      embed: scope:source.shell
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_shell}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-shell-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.shell.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.shell
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.shell.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_shell}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-shell-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.shell.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.shell
+    - match: ^
+      pop: 1
+      embed: scope:source.shell
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_shell}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-sql:
     - match: (<<[-~])(["`]?)({{heredoc_type_sql}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-sql-indented-interpolated, trailing-heredoc-start]
+      push: heredoc-sql-indented-interpolated
     - match: (<<[-~])(')({{heredoc_type_sql}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-sql-indented-literal, trailing-heredoc-start]
+      push: heredoc-sql-indented-literal
     - match: (<<)(["`]?)({{heredoc_type_sql}})(["`]?)
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-sql-unindented-interpolated, trailing-heredoc-start]
+      push: heredoc-sql-unindented-interpolated
     - match: (<<)(')({{heredoc_type_sql}})(')
       captures:
+        0: meta.string.heredoc.ruby
         1: punctuation.definition.heredoc.ruby
         2: meta.tag.heredoc.ruby punctuation.definition.tag.begin.ruby
         3: meta.tag.heredoc.ruby entity.name.tag.ruby
         4: meta.tag.heredoc.ruby punctuation.definition.tag.end.ruby
-      push: [heredoc-sql-unindented-literal, trailing-heredoc-start]
+      push: heredoc-sql-unindented-literal
 
   heredoc-sql-indented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.sql.embedded.ruby
-    - include: indented-heredoc-end
-    - include: interpolated-heredoc-ruby
-    - include: scope:source.sql
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.sql.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_sql}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-sql-indented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.sql.embedded.ruby
-    - include: indented-heredoc-end
-    - include: scope:source.sql
+    - match: ^
+      pop: 1
+      embed: scope:source.sql
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^\s*({{heredoc_type_sql}})$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby
+        1: entity.name.tag.ruby
+    - include: expressions
 
   heredoc-sql-unindented-interpolated:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.sql.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.sql
-    - include: escaped-char
+    - match: ^
+      pop: 1
+      embed: scope:source.sql.embedded.ruby
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_sql}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   heredoc-sql-unindented-literal:
-    - meta_scope: meta.string.heredoc.ruby
-    - meta_content_scope: source.sql.embedded.ruby
-    - include: unindented-heredoc-end
-    - include: scope:source.sql
+    - match: ^
+      pop: 1
+      embed: scope:source.sql
+      embed_scope: meta.string.heredoc.ruby
+      escape: ^{{heredoc_type_sql}}$
+      escape_captures:
+        0: meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+    - include: expressions
 
   indented-heredoc-end:
     - match: ^\s*(\3)$ # HEREDOC delimiter

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -133,24 +133,69 @@ puts <<-HTML; # comment
 #       ^^^^ entity.name.tag.ruby
 #           ^ punctuation.terminator.statement.ruby - meta.string
 #             ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
-  <body>
-# ^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag.structure
+  <script>
+    let me = #{@ruby_null};
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby source.js.embedded.html
+#            ^^^^^^^^^^^^^ meta.interpolation.ruby
+  </script>
+  <style>
+  .class[att=#{@ruby_sel}] {
+#            ^^^^^^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby source.css.embedded.html meta.selector.css meta.interpolation.ruby
+    font-family: #{@ruby_font};
+#                ^^^^^^^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby source.css.embedded.html meta.property-list.css meta.property-value.css meta.interpolation.ruby
+  }
+  </style>
+  <body class="#@var" style="color: #@color" onclick="run(#@what)">
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby text.html.embedded meta.tag.structure
+#              ^^^^^ meta.string.html meta.interpolation.ruby variable.other.readwrite.instance.ruby - string
+#                                   ^^^^^^^ meta.string.html meta.interpolation.ruby variable.other.readwrite.instance.ruby - string
+#                                                         ^^^^^^ meta.string.html meta.interpolation.ruby variable.other.readwrite.instance.ruby - string
     #{ sym } #@var
-#  ^ meta.string.heredoc.ruby text.html.embedded.ruby - meta.interpolation
+#  ^ meta.string.heredoc.ruby text.html.embedded - meta.interpolation
 #   ^^^^^^^^ meta.string.heredoc.ruby meta.interpolation.ruby
-#           ^ meta.string.heredoc.ruby text.html.embedded.ruby - meta.interpolation
+#           ^ meta.string.heredoc.ruby text.html.embedded - meta.interpolation
 #            ^^^^^ meta.string.heredoc.ruby meta.interpolation.ruby variable.other.readwrite.instance.ruby
-#                 ^ meta.string.heredoc.ruby text.html.embedded.ruby - meta.interpolation
+#                 ^ meta.string.heredoc.ruby text.html.embedded - meta.interpolation
 #   ^^ punctuation.section.interpolation.begin.ruby
 #     ^^^^^ source.ruby.embedded.ruby
 #          ^ punctuation.section.interpolation.end.ruby
 #            ^^ punctuation.definition.variable.ruby
 #            ^^^^^ variable.other.readwrite.instance.ruby
   </body>
-# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded.ruby meta.tag.structure.any.html
+# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded meta.tag.structure.any.html
   HTML
 # ^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #     ^ - meta.string - string.unquoted
+
+def CssHeredoc()
+  css = <<-CSS
+#       ^^^ meta.string.heredoc.ruby punctuation.definition.heredoc.ruby
+#          ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+
+  .class[att=#{@ruby_sel}] {
+#            ^^^^^^^^^^^^ meta.string.heredoc.ruby source.css.embedded.ruby meta.selector.css meta.interpolation.ruby
+
+    font-family: #{@ruby_font};
+#                ^^^^^^^^^^^^^ meta.string.heredoc.ruby source.css.embedded.ruby meta.property-list.css meta.property-value.css meta.interpolation.ruby
+  }
+  CSS
+# ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+end
+
+def JavaScriptHeredoc()
+  js = <<-JS
+#      ^^^ meta.string.heredoc.ruby punctuation.definition.heredoc.ruby
+#         ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+
+    let me = #{@ruby_null};
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.js.embedded
+#            ^^^^^^^^^^^^^ meta.interpolation.ruby
+    function test() { var local = #{@ruby_init}; }
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.js.embedded
+#                                 ^^^^^^^^^^^^^ meta.interpolation.ruby
+  JS
+# ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+end
 
 class_eval <<-RUBY, __FILE__, __LINE__ + 1
   def #{sym}(*args, &block)
@@ -171,8 +216,9 @@ puts <<-SH; # comment
 #       ^^ entity.name.tag.ruby
 #         ^ punctuation.terminator.statement.ruby - meta.string - string
 #           ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby - meta.string - string
-  git log
-# ^^^^^^^ meta.string.heredoc.ruby source.shell.embedded.ruby
+  $( git log #@var )
+# ^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.shell.embedded meta.function-call meta.interpolation.command.shell
+#            ^^^^^ meta.interpolation.ruby variable.other.readwrite.instance.ruby
   SH
 # ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #   ^ - meta.string - string.unquoted

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -182,7 +182,7 @@ def CssHeredoc()
 # ^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 end
 
-def JavaScriptHeredoc()
+def InterpolatedJavaScriptHeredoc()
   js = <<-JS
 #      ^^^ meta.string.heredoc.ruby punctuation.definition.heredoc.ruby
 #         ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
@@ -193,6 +193,21 @@ def JavaScriptHeredoc()
     function test() { var local = #{@ruby_init}; }
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.js.embedded
 #                                 ^^^^^^^^^^^^^ meta.interpolation.ruby
+  JS
+# ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+end
+
+def LiteralJavaScriptHeredoc()
+  js = <<-'JS'
+#      ^^^ meta.string.heredoc.ruby punctuation.definition.heredoc.ruby
+#          ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
+
+    let me = #{@ruby_null};
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.js
+#            ^^^^^^^^^^^^^ - meta.interpolation
+    function test() { var local = #{@ruby_init}; }
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.ruby source.js
+#                                 ^^^^^^^^^^^^^ - meta.interpolation
   JS
 # ^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 end


### PR DESCRIPTION
Fixes #3124

This commit...

1. embeds external syntaxes in HEREDOCs to reduce Ruby's size and to ensure terminating HEREDOC tags are matched under all circumstances.
2. improves ruby interpolation in embedded syntaxes using inheritance.