### PR TITLE
[Git Formats] Fix issue references

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -10,7 +10,11 @@ hidden: true
 variables:
   comment_char: '[#;]'
   hash: \b\h{7,}\b
-  repository_ref: '(?x: \b(?: [\w-]+ (/) )? [\w-]+)'  # user (optional) / repo
+  repository_ref: |-
+    (?x:
+      [\w-]+ (/) [\w-]+   # user / repo
+    | [\w-]{2,}           # user with a heuristic to exclude C#7, F#7, ...
+    )
   pretty_formats_builtins: oneline|short|medium|fuller|full|email|raw|reference
   pretty_formats_empty_value_modifiers: '[-+ ]?'
 
@@ -80,7 +84,7 @@ contexts:
           )?                         # keyword is optional
           # user/repo#issue
           (
-            {{repository_ref}}?
+            (?: {{repository_ref}} | \B )
             (\#)[0-9]+               # issue number
           )\b
       scope: meta.reference.issue.git

--- a/Git Formats/tests/syntax_test_git_commit
+++ b/Git Formats/tests/syntax_test_git_commit
@@ -35,6 +35,12 @@ Thanks to @username <name@mail-host.domain>.
 This is a <tag> name <tag.name>
 #         ^^^^^ - meta.reference - entity
 #                    ^^^^^^^^^^ - meta.reference - entity
+These are no C#, C#7, C#10 issues.
+#            ^^^^^^^^^^^^^ - constant
+This is a valid u/r#1 issue.
+#               ^^^^^ meta.reference.issue.git constant.other.reference.issue.git
+#                ^ punctuation.separator.reference.issue.git
+#                  ^ punctuation.definition.reference.issue.git
 Issue user/repo#230 is not closed yet.
 # <- meta.message.git.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
@@ -47,7 +53,13 @@ Issue repo-with/many-hyphen_and_underscores#1 closed yet.
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.reference.issue.git
 #              ^ punctuation.separator.reference.issue.git
 #                                          ^ punctuation.definition.reference.issue.git
-Issue repo#230 is not resolved yet.
+Issue -user-/-repo-#230 starting and ending with hyphons.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#     ^^^^^^^^^^^^^^^^^ constant.other.reference.issue.git
+#           ^ punctuation.separator.reference.issue.git
+#                  ^ punctuation.definition.reference.issue.git
+Issue user#230 is not resolved yet.
 # <- meta.message.git.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 #     ^^^^^^^^ constant.other.reference.issue.git
@@ -132,6 +144,10 @@ This commit applies all changes required to satisfy the JSON format unittest.
   This commit references a hash: 21dde213
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 #                                ^^^^^^^^ constant.other.hash.git
+  This commit does not references a hash: user@21dde213
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                                         ^^^^^^^^^^^^^ constant.other.hash.git
+#                                             ^ punctuation.separator.reference.commit.git
   This commit references a hash on a different repo: test/repo@21dde213
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 #                                                    ^^^^^^^^^^^^^^^^^^ constant.other.hash.git


### PR DESCRIPTION
Fixes #3123

This commit enforces user name of at least 2 chars in auto-links of the form `user#issue` or `user@hash` to make sure not to highlight `C#7` or `F#7` etc.