### PR TITLE
[Java] Improve JSTL interpolation in Java Server Pages

### DIFF
--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -13,6 +13,24 @@ file_extensions:
   - jspf
   - jspx
 
+variables:
+  # Identifiers
+  break: (?!{{id_char}})
+
+  id: (?:{{id_first_char}}{{id_char}}*)
+  id_first_char: '[\p{L}_$]'
+  id_char: '[\p{L}\p{N}_$]'
+
+  implicit_objects: |-
+    (?x:
+      param | paramValues | header | headerValues | initParam | cookie
+    | pageScope | requestScope | sessionScope | applicationScope | pageContext
+    ){{break}}
+
+  # digits
+  dec_digit: '\d'
+  dec_exponent: '[eE][-+]?{{dec_digit}}*'
+
 contexts:
 
   prototype:
@@ -374,13 +392,6 @@ contexts:
     - clear_scopes: 1
     - meta_include_prototype: false
     - meta_scope: meta.interpolation.jsp
-    - match: \$\{
-      scope: punctuation.section.interpolation.begin.jsp
-      embed: scope:source.java.embedded.html#expressions
-      embed_scope: source.java.embedded.jsp
-      escape: \}
-      escape_captures:
-        0: punctuation.section.interpolation.end.jsp
     - include: jsp-embedded
     - include: immediately-pop
 
@@ -390,6 +401,7 @@ contexts:
     - include: jsp-embedded-directives
     - include: jsp-embedded-expressions
     - include: jsp-embedded-scriptlets
+    - include: jstl-embedded
 
   jsp-embedded-comments:
     - match: <%--
@@ -501,3 +513,144 @@ contexts:
   jsp-string-escapes:
     - match: \\.
       scope: constant.character.escape.jsp
+
+###[ JSTL EXPRESSIONS ]#######################################################
+
+  jstl-embedded:
+    - match: \$\{
+      scope: punctuation.section.embedded.begin.jsp
+      push: jstl-embedded-body
+
+  jstl-embedded-body:
+    - meta_scope: meta.embedded.jsp
+    - match: \}
+      scope: punctuation.section.embedded.end.jsp
+      pop: 1
+    - include: jstl-expressions
+
+  jstl-expressions:
+    - include: jsp-strings-double-quoted
+    - include: jsp-strings-single-quoted
+    - include: jstl-groups
+    - include: jstl-item-access
+    - include: jstl-operators
+    - include: jstl-numbers
+    - include: jstl-constants
+    - include: jstl-function-calls
+    - include: jstl-variables
+
+  jstl-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.jsp
+      push: jstl-group-body
+
+  jstl-group-body:
+    - meta_scope: meta.group.jsp
+    - match: \)
+      scope: punctuation.section.group.end.jsp
+      pop: 1
+    - include: jstl-expressions
+
+  jstl-item-access:
+    - match: \[
+      scope: punctuation.section.brackets.begin.jsp
+      push: jstl-item-access-body
+
+  jstl-item-access-body:
+    - meta_scope: meta.brackets.jsp
+    - match: \]
+      scope: punctuation.section.brackets.end.jsp
+      pop: 1
+    - include: jstl-expressions
+
+  jstl-constants:
+    - match: (?:false|true){{break}}
+      scope: constant.language.boolean.jsp
+    - match: null{{break}}
+      scope: constant.language.null.jsp
+
+  jstl-constant:
+    - match: (?:false|true){{break}}
+      scope: constant.language.boolean.jsp
+      pop: 1
+    - match: null{{break}}
+      scope: constant.language.null.jsp
+      pop: 1
+
+  jstl-numbers:
+    # decimal floats
+    - match: |-
+        (?x)
+        [0-9]{{dec_digit}}*
+        (?:
+          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1
+            (\.) {{dec_digit}}* (?:{{dec_exponent}})?
+          # 1e1
+          | {{dec_exponent}}
+        )
+        | (\.) {{dec_digit}}+ (?:{{dec_exponent}})?
+      scope: meta.number.float.decimal.java
+      captures:
+        0: constant.numeric.value.java
+        1: punctuation.separator.decimal.java
+        2: punctuation.separator.decimal.java
+    # decimal integers
+    - match: '{{dec_digit}}+'
+      scope: meta.number.integer.decimal.java constant.numeric.value.java
+
+  jstl-function-calls:
+    - match: ({{id}})(:)({{id}}?)(?=\()
+      captures:
+        0: meta.function-call.identifier.jsp meta.path.jsp
+        1: variable.namespace.jsp
+        2: punctuation.accessor.namespace.jsp
+        3: variable.function.jsp
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.jsp
+          set: jstl-function-call-arguments
+
+  jstl-function-call-arguments:
+    - meta_scope: meta.function-call.arguments.jsp meta.group.jsp
+    - include: jstl-group-body
+
+  jstl-variables:
+    - match: '{{implicit_objects}}'
+      scope: support.variable.jsp
+    - match: ({{id}}?)(\.)
+      captures:
+        1: variable.namespace.jsp
+        2: punctuation.accessor.namespace.jsp
+      push: jstl-qualified-variable
+    - match: '{{id}}'
+      scope: variable.other.jsp
+
+  jstl-qualified-variable:
+    - meta_scope: meta.path.jsp
+    - include: jstl-constant
+    - match: ({{id}}?)(\.)
+      captures:
+        1: variable.namespace.jsp
+        2: punctuation.accessor.namespace.jsp
+    - match: '{{id}}'
+      scope: variable.other.jsp
+      pop: 1
+
+  jstl-operators:
+    - match: (?:div|mod){{break}}
+      scope: keyword.operator.arithmetic.jsp
+    - match: (?:lt|gt|le|ge|eq|ne){{break}}
+      scope: keyword.operator.comparison.jsp
+    - match: (?:and|or|not|empty){{break}}
+      scope: keyword.operator.logical.jsp
+    - match: '[-+*/%]'
+      scope: keyword.operator.arithmetic.jsp
+    - match: '==|!=|<=|>=|<|>'
+      scope: keyword.operator.comparison.jsp
+    - match: '!|&&|\|\|'
+      scope: keyword.operator.logical.jsp
+    - match: '[?:]'
+      scope: keyword.operator.ternary.jsp
+    - match: ','
+      scope: punctuation.separator.comma.jsp

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -12,6 +12,7 @@ file_extensions:
   - jsp
   - jspf
   - jspx
+  - jstl
 
 variables:
   # Identifiers

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -541,6 +541,23 @@ contexts:
     - include: jstl-function-calls
     - include: jstl-variables
 
+  jstl-function-calls:
+    - match: ({{id}})(:)({{id}}?)(?=\()
+      captures:
+        0: meta.function-call.identifier.jstl meta.path.jstl
+        1: variable.namespace.jstl
+        2: punctuation.accessor.namespace.jstl
+        3: variable.function.jstl
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.jstl
+          set: jstl-function-call-arguments
+
+  jstl-function-call-arguments:
+    - meta_scope: meta.function-call.arguments.jstl meta.group.jstl
+    - include: jstl-group-body
+
   jstl-groups:
     - match: \(
       scope: punctuation.section.group.begin.jstl
@@ -629,23 +646,6 @@ contexts:
   jstl-string-escapes:
     - match: \\.
       scope: constant.character.escape.jstl
-
-  jstl-function-calls:
-    - match: ({{id}})(:)({{id}}?)(?=\()
-      captures:
-        0: meta.function-call.identifier.jstl meta.path.jstl
-        1: variable.namespace.jstl
-        2: punctuation.accessor.namespace.jstl
-        3: variable.function.jstl
-      push:
-        - meta_include_prototype: false
-        - match: \(
-          scope: punctuation.section.group.begin.jstl
-          set: jstl-function-call-arguments
-
-  jstl-function-call-arguments:
-    - meta_scope: meta.function-call.arguments.jstl meta.group.jstl
-    - include: jstl-group-body
 
   jstl-variables:
     - match: '{{implicit_objects}}'

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -519,19 +519,20 @@ contexts:
 
   jstl-embedded:
     - match: \$\{
-      scope: punctuation.section.embedded.begin.jsp
+      scope: punctuation.section.embedded.begin.jstl
       push: jstl-embedded-body
 
   jstl-embedded-body:
-    - meta_scope: meta.embedded.jsp
+    - meta_scope: meta.embedded.expression.jstl
+    - meta_content_scope: source.jstl.embedded.jsp
     - match: \}
-      scope: punctuation.section.embedded.end.jsp
+      scope: punctuation.section.embedded.end.jstl
       pop: 1
     - include: jstl-expressions
 
   jstl-expressions:
-    - include: jsp-strings-double-quoted
-    - include: jsp-strings-single-quoted
+    - include: jstl-strings-double-quoted
+    - include: jstl-strings-single-quoted
     - include: jstl-groups
     - include: jstl-item-access
     - include: jstl-operators
@@ -542,40 +543,40 @@ contexts:
 
   jstl-groups:
     - match: \(
-      scope: punctuation.section.group.begin.jsp
+      scope: punctuation.section.group.begin.jstl
       push: jstl-group-body
 
   jstl-group-body:
-    - meta_scope: meta.group.jsp
+    - meta_scope: meta.group.jstl
     - match: \)
-      scope: punctuation.section.group.end.jsp
+      scope: punctuation.section.group.end.jstl
       pop: 1
     - include: jstl-expressions
 
   jstl-item-access:
     - match: \[
-      scope: punctuation.section.brackets.begin.jsp
+      scope: punctuation.section.brackets.begin.jstl
       push: jstl-item-access-body
 
   jstl-item-access-body:
-    - meta_scope: meta.brackets.jsp
+    - meta_scope: meta.brackets.jstl
     - match: \]
-      scope: punctuation.section.brackets.end.jsp
+      scope: punctuation.section.brackets.end.jstl
       pop: 1
     - include: jstl-expressions
 
   jstl-constants:
     - match: (?:false|true){{break}}
-      scope: constant.language.boolean.jsp
+      scope: constant.language.boolean.jstl
     - match: null{{break}}
-      scope: constant.language.null.jsp
+      scope: constant.language.null.jstl
 
   jstl-constant:
     - match: (?:false|true){{break}}
-      scope: constant.language.boolean.jsp
+      scope: constant.language.boolean.jstl
       pop: 1
     - match: null{{break}}
-      scope: constant.language.null.jsp
+      scope: constant.language.null.jstl
       pop: 1
 
   jstl-numbers:
@@ -590,68 +591,98 @@ contexts:
           | {{dec_exponent}}
         )
         | (\.) {{dec_digit}}+ (?:{{dec_exponent}})?
-      scope: meta.number.float.decimal.java
+      scope: meta.number.float.decimal.jstl
       captures:
-        0: constant.numeric.value.java
-        1: punctuation.separator.decimal.java
-        2: punctuation.separator.decimal.java
+        0: constant.numeric.value.jstl
+        1: punctuation.separator.decimal.jstl
+        2: punctuation.separator.decimal.jstl
     # decimal integers
     - match: '{{dec_digit}}+'
-      scope: meta.number.integer.decimal.java constant.numeric.value.java
+      scope: meta.number.integer.decimal.jstl constant.numeric.value.jstl
+
+  jstl-strings-double-quoted:
+    - match: \"
+      scope: punctuation.definition.string.begin.jstl
+      push: jstl-strings-double-quoted-content
+
+  jstl-strings-double-quoted-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.jstl string.quoted.double.jstl
+    - match: \"
+      scope: punctuation.definition.string.end.jstl
+      pop: 1
+    - include: jstl-string-escapes
+
+  jstl-strings-single-quoted:
+    - match: \'
+      scope: punctuation.definition.string.begin.jstl
+      push: jstl-strings-single-quoted-content
+
+  jstl-strings-single-quoted-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.jstl string.quoted.single.jstl
+    - match: \'
+      scope: punctuation.definition.string.end.jstl
+      pop: 1
+    - include: jstl-string-escapes
+
+  jstl-string-escapes:
+    - match: \\.
+      scope: constant.character.escape.jstl
 
   jstl-function-calls:
     - match: ({{id}})(:)({{id}}?)(?=\()
       captures:
-        0: meta.function-call.identifier.jsp meta.path.jsp
-        1: variable.namespace.jsp
-        2: punctuation.accessor.namespace.jsp
-        3: variable.function.jsp
+        0: meta.function-call.identifier.jstl meta.path.jstl
+        1: variable.namespace.jstl
+        2: punctuation.accessor.namespace.jstl
+        3: variable.function.jstl
       push:
         - meta_include_prototype: false
         - match: \(
-          scope: punctuation.section.group.begin.jsp
+          scope: punctuation.section.group.begin.jstl
           set: jstl-function-call-arguments
 
   jstl-function-call-arguments:
-    - meta_scope: meta.function-call.arguments.jsp meta.group.jsp
+    - meta_scope: meta.function-call.arguments.jstl meta.group.jstl
     - include: jstl-group-body
 
   jstl-variables:
     - match: '{{implicit_objects}}'
-      scope: support.variable.jsp
+      scope: support.variable.jstl
     - match: ({{id}}?)(\.)
       captures:
-        1: variable.namespace.jsp
-        2: punctuation.accessor.namespace.jsp
+        1: variable.namespace.jstl
+        2: punctuation.accessor.namespace.jstl
       push: jstl-qualified-variable
     - match: '{{id}}'
-      scope: variable.other.jsp
+      scope: variable.other.jstl
 
   jstl-qualified-variable:
-    - meta_scope: meta.path.jsp
+    - meta_scope: meta.path.jstl
     - include: jstl-constant
     - match: ({{id}}?)(\.)
       captures:
-        1: variable.namespace.jsp
-        2: punctuation.accessor.namespace.jsp
+        1: variable.namespace.jstl
+        2: punctuation.accessor.namespace.jstl
     - match: '{{id}}'
-      scope: variable.other.jsp
+      scope: variable.other.jstl
       pop: 1
 
   jstl-operators:
     - match: (?:div|mod){{break}}
-      scope: keyword.operator.arithmetic.jsp
+      scope: keyword.operator.arithmetic.jstl
     - match: (?:lt|gt|le|ge|eq|ne){{break}}
-      scope: keyword.operator.comparison.jsp
+      scope: keyword.operator.comparison.jstl
     - match: (?:and|or|not|empty){{break}}
-      scope: keyword.operator.logical.jsp
+      scope: keyword.operator.logical.jstl
     - match: '[-+*/%]'
-      scope: keyword.operator.arithmetic.jsp
+      scope: keyword.operator.arithmetic.jstl
     - match: '==|!=|<=|>=|<|>'
-      scope: keyword.operator.comparison.jsp
+      scope: keyword.operator.comparison.jstl
     - match: '!|&&|\|\|'
-      scope: keyword.operator.logical.jsp
+      scope: keyword.operator.logical.jstl
     - match: '[?:]'
-      scope: keyword.operator.ternary.jsp
+      scope: keyword.operator.ternary.jstl
     - match: ','
-      scope: punctuation.separator.comma.jsp
+      scope: punctuation.separator.comma.jstl

--- a/Java/JSTL Expression Language.sublime-completions
+++ b/Java/JSTL Expression Language.sublime-completions
@@ -1,0 +1,144 @@
+{
+	"scope": "meta.embedded.expression.jstl",
+	"completions": [
+
+		// Operators
+
+		{
+			"trigger": "and",
+			"annotation": "logical",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "empty",
+			"annotation": "logical",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "not",
+			"annotation": "logical",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "or",
+			"annotation": "logical",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "eq",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "le",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "lt",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "ge",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "gt",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "ne",
+			"annotation": "comparison",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "div",
+			"annotation": "arithmetic",
+			"kind": ["keyword","k", "Operator"],
+		},
+		{
+			"trigger": "mod",
+			"annotation": "arithmetic",
+			"kind": ["keyword","k", "Operator"],
+		},
+
+		// Built-In Constants
+
+		{
+			"trigger": "false",
+			"annotation": "built-in",
+			"kind": ["variable", "c", "Constant"]
+		},
+		{
+			"trigger": "null",
+			"annotation": "built-in",
+			"kind": ["variable", "c", "Constant"]
+		},
+		{
+			"trigger": "true",
+			"annotation": "built-in",
+			"kind": ["variable", "c", "Constant"]
+		},
+
+		// Built-in Objects
+
+		{
+			"trigger": "cookie",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "header",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "headerValues",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "initParam",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "param",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "paramValues",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "pageContext",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "applicationScope",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "pageScope",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "requestScope",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+		{
+			"trigger": "sessionScope",
+			"annotation": "built-in",
+			"kind": ["variable", "o", "Object"]
+		},
+	]
+}

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -656,13 +656,13 @@
 
     <c:forEach var="customer" items="${customers}">
 //                                  ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation - meta.embedded
-//                                   ^^^^^^^^^^^^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html meta.interpolation.jsp meta.embedded.jsp
+//                                   ^^^^^^^^^^^^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html meta.interpolation.jsp meta.embedded.expression.jstl
 //                                               ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation - meta.embedded
 //                                                ^ meta.tag.other.begin.html - meta.string - meta.interpolation
 //                                  ^ string.quoted.double.html punctuation.definition.string.begin.html
-//                                   ^^ punctuation.section.embedded.begin.jsp
-//                                     ^^^^^^^^^ variable.other.jsp
-//                                              ^ punctuation.section.embedded.end.jsp
+//                                   ^^ punctuation.section.embedded.begin.jstl
+//                                     ^^^^^^^^^ variable.other.jstl
+//                                              ^ punctuation.section.embedded.end.jstl
 //                                               ^ string.quoted.double.html punctuation.definition.string.end.html
 
     </c:forEach>
@@ -680,99 +680,100 @@
     -->
 
     ${fn:substringAfter(string, "Nakul")}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//    ^^^^^^^^^^^^^^^^^ meta.function-call.identifier.jsp meta.path.jsp
-//                     ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.jsp meta.group.jsp
-//  ^^ punctuation.section.embedded.begin.jsp - source.java
-//    ^^ variable.namespace.jsp
-//      ^ punctuation.accessor.namespace.jsp
-//       ^^^^^^^^^^^^^^ variable.function.jsp
-//                     ^ punctuation.section.group.begin.jsp
-//                      ^^^^^^ variable.other.jsp
-//                            ^ punctuation.separator.comma.jsp
-//                              ^^^^^^^ string.quoted.double.jsp
-//                                     ^ punctuation.section.group.end.jsp
-//                                      ^ punctuation.section.embedded.end.jsp - source.java
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//    ^^^^^^^^^^^^^^^^^ meta.function-call.identifier.jstl meta.path.jstl
+//                     ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.jstl meta.group.jstl
+//  ^^ punctuation.section.embedded.begin.jstl - source.java
+//    ^^ variable.namespace.jstl
+//      ^ punctuation.accessor.namespace.jstl
+//       ^^^^^^^^^^^^^^ variable.function.jstl
+//                     ^ punctuation.section.group.begin.jstl
+//                      ^^^^^^ variable.other.jstl
+//                            ^ punctuation.separator.comma.jstl
+//                              ^^^^^^^ string.quoted.double.jstl
+//                                     ^ punctuation.section.group.end.jstl
+//                                      ^ punctuation.section.embedded.end.jstl - source.java
 
     ${empty varname}
-//  ^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//  ^^ punctuation.section.embedded.begin.jsp
-//    ^^^^^ keyword.operator.logical.jsp
-//          ^^^^^^^ variable.other.jsp - meta.path
-//                 ^ punctuation.section.embedded.end.jsp
+//  ^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//  ^^ punctuation.section.embedded.begin.jstl
+//    ^^^^^ keyword.operator.logical.jstl
+//          ^^^^^^^ variable.other.jstl - meta.path
+//                 ^ punctuation.section.embedded.end.jstl
 
     ${!empty foo.bar.varname}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//           ^^^^^^^^^^^^^^^ meta.path.jsp
-//  ^^ punctuation.section.embedded.begin.jsp
-//    ^^^^^^ keyword.operator.logical.jsp
-//           ^^^ variable.namespace.jsp
-//              ^ punctuation.accessor.namespace.jsp
-//               ^^^ variable.namespace.jsp
-//                  ^ punctuation.accessor.namespace.jsp
-//                   ^^^^^^^ variable.other.jsp
-//                          ^ punctuation.section.embedded.end.jsp
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//           ^^^^^^^^^^^^^^^ meta.path.jstl
+//  ^^ punctuation.section.embedded.begin.jstl
+//    ^^^^^^ keyword.operator.logical.jstl
+//           ^^^ variable.namespace.jstl
+//              ^ punctuation.accessor.namespace.jstl
+//               ^^^ variable.namespace.jstl
+//                  ^ punctuation.accessor.namespace.jstl
+//                   ^^^^^^^ variable.other.jstl
+//                          ^ punctuation.section.embedded.end.jstl
 
     ${not header[key]}
-//  ^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//  ^^ punctuation.section.embedded.begin.jsp
-//    ^^^ keyword.operator.logical.jsp
-//        ^^^^^^ support.variable.jsp
-//              ^^^^^ meta.brackets.jsp
-//              ^ punctuation.section.brackets.begin.jsp
-//               ^^^ variable.other.jsp
-//                  ^ punctuation.section.brackets.end.jsp
-//                   ^ punctuation.section.embedded.end.jsp
+//  ^^^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//  ^^ punctuation.section.embedded.begin.jstl
+//    ^^^ keyword.operator.logical.jstl
+//        ^^^^^^ support.variable.jstl
+//              ^^^^^ meta.brackets.jstl
+//              ^ punctuation.section.brackets.begin.jstl
+//               ^^^ variable.other.jstl
+//                  ^ punctuation.section.brackets.end.jstl
+//                   ^ punctuation.section.embedded.end.jstl
 
     ${test ? ns:foo() : Boolean.false}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//    ^^^^ variable.other.jsp
-//         ^ keyword.operator.ternary.jsp
-//           ^^^^^^ meta.function-call.identifier.jsp meta.path.jsp
-//           ^^ variable.namespace.jsp
-//             ^ punctuation.accessor.namespace.jsp
-//              ^^^ variable.function.jsp
-//                 ^^ meta.function-call.arguments.jsp meta.group.jsp
-//                 ^ punctuation.section.group.begin.jsp
-//                  ^ punctuation.section.group.end.jsp
-//                    ^ keyword.operator.ternary.jsp
-//                      ^^^^^^^^^^^^^ meta.path.jsp
-//                      ^^^^^^^ variable.namespace.jsp
-//                             ^ punctuation.accessor.namespace.jsp
-//                              ^^^^^ constant.language.boolean.jsp
-//                                   ^ punctuation.section.embedded.end.jsp
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//    ^^^^ variable.other.jstl
+//         ^ keyword.operator.ternary.jstl
+//           ^^^^^^ meta.function-call.identifier.jstl meta.path.jstl
+//           ^^ variable.namespace.jstl
+//             ^ punctuation.accessor.namespace.jstl
+//              ^^^ variable.function.jstl
+//                 ^^ meta.function-call.arguments.jstl meta.group.jstl
+//                 ^ punctuation.section.group.begin.jstl
+//                  ^ punctuation.section.group.end.jstl
+//                    ^ keyword.operator.ternary.jstl
+//                      ^^^^^^^^^^^^^ meta.path.jstl
+//                      ^^^^^^^ variable.namespace.jstl
+//                             ^ punctuation.accessor.namespace.jstl
+//                              ^^^^^ constant.language.boolean.jstl
+//                                   ^ punctuation.section.embedded.end.jstl
 
     ${obj1 != null &&
       obj2 != null}
-//    ^^^^^^^^^^^^^ meta.embedded.jsp
-//    ^^^^ variable.other.jsp
-//         ^^ keyword.operator.comparison.jsp
-//            ^^^^ constant.language.null.jsp
-//                ^ punctuation.section.embedded.end.jsp
+//    ^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//    ^^^^ variable.other.jstl
+//         ^^ keyword.operator.comparison.jstl
+//            ^^^^ constant.language.null.jstl
+//                ^ punctuation.section.embedded.end.jstl
 
     ${!(2 == 3)}
-//  ^^^ meta.embedded.jsp - meta.group
-//     ^^^^^^^^ meta.embedded.jsp meta.group.jsp
-//             ^ meta.embedded.jsp - meta.group
-//  ^^ punctuation.section.embedded.begin.jsp
-//    ^ keyword.operator.logical.jsp
-//     ^ punctuation.section.group.begin.jsp
-//      ^ meta.number.integer.decimal.java constant.numeric.value.java
-//        ^^ keyword.operator.comparison.jsp
-//           ^ meta.number.integer.decimal.java constant.numeric.value.java
-//            ^ punctuation.section.group.end.jsp
-//             ^ punctuation.section.embedded.end.jsp
+//  ^^^ meta.embedded.expression.jstl - meta.group
+//     ^^^^^^^^ meta.embedded.expression.jstl meta.group.jstl
+//             ^ meta.embedded.expression.jstl - meta.group
+//  ^^ punctuation.section.embedded.begin.jstl
+//    ^ keyword.operator.logical.jstl
+//     ^ punctuation.section.group.begin.jstl
+//      ^ meta.number.integer.decimal.jstl constant.numeric.value.jstl
+//        ^^ keyword.operator.comparison.jstl
+//           ^ meta.number.integer.decimal.jstl constant.numeric.value.jstl
+//            ^ punctuation.section.group.end.jstl
+//             ^ punctuation.section.embedded.end.jstl
 
     ${1.43 -2.35 2.34E9}
-//  ^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
-//  ^^ punctuation.section.embedded.begin.jsp
-//    ^^^^ meta.number.float.decimal.java constant.numeric.value.java
-//     ^ punctuation.separator.decimal.java
-//         ^ keyword.operator.arithmetic.jsp
-//          ^^^^ meta.number.float.decimal.java constant.numeric.value.java
-//           ^ punctuation.separator.decimal.java
-//               ^^^^^^ meta.number.float.decimal.java constant.numeric.value.java
-//                ^ punctuation.separator.decimal.java
+//  ^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.jstl
+//  ^^ punctuation.section.embedded.begin.jstl
+//    ^^^^ meta.number.float.decimal.jstl constant.numeric.value.jstl
+//     ^ punctuation.separator.decimal.jstl
+//         ^ keyword.operator.arithmetic.jstl
+//          ^^^^ meta.number.float.decimal.jstl constant.numeric.value.jstl
+//           ^ punctuation.separator.decimal.jstl
+//               ^^^^^^ meta.number.float.decimal.jstl constant.numeric.value.jstl
+//                ^ punctuation.separator.decimal.jstl
 
+    ${}
 </body>
 </html>

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -655,14 +655,14 @@
 //                                              ^^^ meta.tag.inline.any.html
 
     <c:forEach var="customer" items="${customers}">
-//                                  ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation
-//                                   ^^^^^^^^^^^^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html meta.interpolation.jsp
-//                                               ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation
+//                                  ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation - meta.embedded
+//                                   ^^^^^^^^^^^^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html meta.interpolation.jsp meta.embedded.jsp
+//                                               ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation - meta.embedded
 //                                                ^ meta.tag.other.begin.html - meta.string - meta.interpolation
 //                                  ^ string.quoted.double.html punctuation.definition.string.begin.html
-//                                   ^^ punctuation.section.interpolation.begin.jsp
-//                                     ^^^^^^^^^ source.java.embedded.jsp meta.variable.identifier.java variable.other.java
-//                                              ^ punctuation.section.interpolation.end.jsp
+//                                   ^^ punctuation.section.embedded.begin.jsp
+//                                     ^^^^^^^^^ variable.other.jsp
+//                                              ^ punctuation.section.embedded.end.jsp
 //                                               ^ string.quoted.double.html punctuation.definition.string.end.html
 
     </c:forEach>
@@ -672,6 +672,107 @@
 //     ^ entity.name.tag.html punctuation.separator.namespace.html
 //      ^^^^^^^ entity.name.tag.localname.html
 //             ^ punctuation.definition.tag.end.html
+
+    <!--
+    ---------------------------------------------------------------------------
+    -- JSTL VARIABLES AND EXPRESSION LANGUAGE
+    ---------------------------------------------------------------------------
+    -->
+
+    ${fn:substringAfter(string, "Nakul")}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//    ^^^^^^^^^^^^^^^^^ meta.function-call.identifier.jsp meta.path.jsp
+//                     ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.jsp meta.group.jsp
+//  ^^ punctuation.section.embedded.begin.jsp - source.java
+//    ^^ variable.namespace.jsp
+//      ^ punctuation.accessor.namespace.jsp
+//       ^^^^^^^^^^^^^^ variable.function.jsp
+//                     ^ punctuation.section.group.begin.jsp
+//                      ^^^^^^ variable.other.jsp
+//                            ^ punctuation.separator.comma.jsp
+//                              ^^^^^^^ string.quoted.double.jsp
+//                                     ^ punctuation.section.group.end.jsp
+//                                      ^ punctuation.section.embedded.end.jsp - source.java
+
+    ${empty varname}
+//  ^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//  ^^ punctuation.section.embedded.begin.jsp
+//    ^^^^^ keyword.operator.logical.jsp
+//          ^^^^^^^ variable.other.jsp - meta.path
+//                 ^ punctuation.section.embedded.end.jsp
+
+    ${!empty foo.bar.varname}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//           ^^^^^^^^^^^^^^^ meta.path.jsp
+//  ^^ punctuation.section.embedded.begin.jsp
+//    ^^^^^^ keyword.operator.logical.jsp
+//           ^^^ variable.namespace.jsp
+//              ^ punctuation.accessor.namespace.jsp
+//               ^^^ variable.namespace.jsp
+//                  ^ punctuation.accessor.namespace.jsp
+//                   ^^^^^^^ variable.other.jsp
+//                          ^ punctuation.section.embedded.end.jsp
+
+    ${not header[key]}
+//  ^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//  ^^ punctuation.section.embedded.begin.jsp
+//    ^^^ keyword.operator.logical.jsp
+//        ^^^^^^ support.variable.jsp
+//              ^^^^^ meta.brackets.jsp
+//              ^ punctuation.section.brackets.begin.jsp
+//               ^^^ variable.other.jsp
+//                  ^ punctuation.section.brackets.end.jsp
+//                   ^ punctuation.section.embedded.end.jsp
+
+    ${test ? ns:foo() : Boolean.false}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//    ^^^^ variable.other.jsp
+//         ^ keyword.operator.ternary.jsp
+//           ^^^^^^ meta.function-call.identifier.jsp meta.path.jsp
+//           ^^ variable.namespace.jsp
+//             ^ punctuation.accessor.namespace.jsp
+//              ^^^ variable.function.jsp
+//                 ^^ meta.function-call.arguments.jsp meta.group.jsp
+//                 ^ punctuation.section.group.begin.jsp
+//                  ^ punctuation.section.group.end.jsp
+//                    ^ keyword.operator.ternary.jsp
+//                      ^^^^^^^^^^^^^ meta.path.jsp
+//                      ^^^^^^^ variable.namespace.jsp
+//                             ^ punctuation.accessor.namespace.jsp
+//                              ^^^^^ constant.language.boolean.jsp
+//                                   ^ punctuation.section.embedded.end.jsp
+
+    ${obj1 != null &&
+      obj2 != null}
+//    ^^^^^^^^^^^^^ meta.embedded.jsp
+//    ^^^^ variable.other.jsp
+//         ^^ keyword.operator.comparison.jsp
+//            ^^^^ constant.language.null.jsp
+//                ^ punctuation.section.embedded.end.jsp
+
+    ${!(2 == 3)}
+//  ^^^ meta.embedded.jsp - meta.group
+//     ^^^^^^^^ meta.embedded.jsp meta.group.jsp
+//             ^ meta.embedded.jsp - meta.group
+//  ^^ punctuation.section.embedded.begin.jsp
+//    ^ keyword.operator.logical.jsp
+//     ^ punctuation.section.group.begin.jsp
+//      ^ meta.number.integer.decimal.java constant.numeric.value.java
+//        ^^ keyword.operator.comparison.jsp
+//           ^ meta.number.integer.decimal.java constant.numeric.value.java
+//            ^ punctuation.section.group.end.jsp
+//             ^ punctuation.section.embedded.end.jsp
+
+    ${1.43 -2.35 2.34E9}
+//  ^^^^^^^^^^^^^^^^^^^^ meta.embedded.jsp
+//  ^^ punctuation.section.embedded.begin.jsp
+//    ^^^^ meta.number.float.decimal.java constant.numeric.value.java
+//     ^ punctuation.separator.decimal.java
+//         ^ keyword.operator.arithmetic.jsp
+//          ^^^^ meta.number.float.decimal.java constant.numeric.value.java
+//           ^ punctuation.separator.decimal.java
+//               ^^^^^^ meta.number.float.decimal.java constant.numeric.value.java
+//                ^ punctuation.separator.decimal.java
 
 </body>
 </html>

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -773,7 +773,5 @@
 //           ^ punctuation.separator.decimal.jstl
 //               ^^^^^^ meta.number.float.decimal.jstl constant.numeric.value.jstl
 //                ^ punctuation.separator.decimal.jstl
-
-    ${}
 </body>
 </html>


### PR DESCRIPTION
This commit...

1. highlights ${expr} variable expansions everywhere in a document, not just in tag attribute values.
2. replaces the embedded Java syntax by a dedicated and more simple "EL" syntax, which is more or less a subset of Java. 

   EL means "expression language"

   Syntax is described in 

     Book:     "Core JSTL: Mastering the JSP Standard Tag Library"
     Chapter:  "The JSTL Expression Language"
 
     see: https://www.informit.com/store/core-jstl-mastering-the-jsp-standard-tag-library-9780131001534?w_ptgrevartcl=The+JSTL+Expression+Language_30946

Implementation follows https://www.informit.com/articles/article.aspx?p=30946

Inspired by https://forum.sublimetext.com/t/import-in-custom-syntax-default-ones/61716/2 and the linked repo.