### PR TITLE
[C/C++/ObjC/ObjC++] Improve Indentation Rules

### DIFF
--- a/C++/Indentation Rules.tmPreferences
+++ b/C++/Indentation Rules.tmPreferences
@@ -6,26 +6,102 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>(?x)
-		^ (.*\*/)? \s* \} .* $
-		|   ^ \s* (public|private|protected): \s* $
-		|   ^ \s* @(public|private|protected) \s* $
-		</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? \s*
+			(?:
+			# dedent closing braces
+			  \}
+			# detent `case ... :`
+			| case\b
+			# detent `default:`
+			| default\b
+			# class member access attributes
+			| ( public | private | protected ):
+			# objc/objc++ attributes
+			| @( public | private | protected )\b
+			)
+		]]></string>
+
 		<key>increaseIndentPattern</key>
-		<string>(?x)
-		^ .* \{ [^}"']* $
-		|   ^ \s* (public|private|protected): \s* $
-		|   ^ \s* @(public|private|protected) \s* $
-		</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? \s*
+			(?:
+			# indent after opening braces (may be followed by whitespace or comments)
+			# but exclude lines such as `extern "C" {`
+			  (?!extern\s*\"[^\"]\") .* \{ (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
+			# indent after `case ... :`
+			| case\b
+			# indent after `default:`
+			| default\b
+			# class member access attributes
+			| ( public | private | protected ):
+			# objc/objc++ attributes
+			| @( public | private | protected )\b
+			)
+		]]></string>
 
 		<key>bracketIndentNextLinePattern</key>
-		<string>(?x)
-		^ \s* \b(if|while|else)\b [^;]* $
-		| ^ \s* \b(for)\b .* $
-		</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? (?<comment_or_whitespace> (?: \s* (?<block_comment> /\*.*\*/ ) )* \s* )
+			(?:
+			# indent after:
+			# - `do`
+			# - `else`
+			  do | else
+			# indent after:
+			# - `else if (...)`
+			# - `if (...)`
+			# - `for (...)`
+			# - `while (...)`
+			| (?: (?: else \g<comment_or_whitespace> )? if | for | while )
+			  # followed by whitespace or block comments [optional]
+			  \g<comment_or_whitespace>
+			  # top-level balanced parentheses
+			  \(
+				(?<group_body> (?:
+				# nested balanced parentheses
+				  \( \g<group_body> \)
+				# double quoted string with ignored escaped quotation marks
+				| \".*(?<![^\\]\\)(?<![\\]{3})\"
+				# single quoted character with ignored escaped quotation marks
+				| \'.*(?<![^\\]\\)\'
+				# block comment
+				| \g<block_comment>
+				# anything but closing parenthesis
+				| [^)]
+				)* )
+			  # maybe missing, balanced or stray closing parenthesis
+			  \)*
+			)
+			# followed by whitespace or block comments [optional]
+			\g<comment_or_whitespace>
+			# followed by line comment [optional]
+			(?: //.* )? $
+		]]></string>
 
 		<key>unIndentedLinePattern</key>
-		<string><![CDATA[^\s*((/\*|.*\*/|//|#|template\b.*?>(?!\(.*\))|@protocol|@interface(?!.*\{)|@implementation|@end).*)?$]]></string>
+		<string><![CDATA[(?x)
+			^\s*
+			(?:
+			# standalone begin or end of block comments
+			#   ST doesn't apply `Indentation Rules - Comments`, because
+			#   comment scope doesn't cover the whole line. So they need
+			#   to be excluded from indentation engine here.
+			  // | /\*(?!.*\*/) | .*\*/
+			# preprocessor directive
+			| \#
+			# templates
+			| template\b .*? > (?!\(.*\))
+			# objc/objc++ attributes
+			| @protocol
+			| @interface(?!.*\{)
+			| @implementation
+			| @end
+			)
+		]]></string>
 
 		<key>indentSquareBrackets</key>
 		<true/>

--- a/C++/tests/syntax_test_indent_classes.c++
+++ b/C++/tests/syntax_test_indent_classes.c++
@@ -1,0 +1,84 @@
+// SYNTAX TEST reindent-unchanged "Packages/C++/C++.sublime-syntax"
+
+class HelloWorld;
+class HelloWorldA : HelloWorld {
+
+public:
+
+protected:
+
+private:
+}
+
+class HelloWorldB : HelloWorld {
+
+    int m_attr1;
+    int m_attr2;
+
+public:
+    HelloWorldB();
+    ~HelloWorldB();
+
+protected:
+    int getAttr1() { return this->m_attr1; }
+    int getAttr2() {
+        return this->m_attr1;
+    }
+
+    void setAttr1(int val) { this->m_attr1 = val; }
+    void setAttr2(int val)
+    {
+        this->m_attr2 = val;
+    }
+
+private:
+    bool m_flag;
+}
+
+/**
+ * @brief      This class describes a hello world b.
+ */
+
+class HelloWorldC : HelloWorld {
+
+    int m_attr1;    // comment
+    int m_attr2;    // comment
+
+public:
+    /**
+     * @brief      Constructs a new instance.
+     */
+    HelloWorldC();
+    /**
+     * @brief      Destroys the object.
+     */
+    ~HelloWorldC();
+
+protected: // not for everybody
+
+    /**
+     * @brief      Gets the attribute 1.
+     *
+     * @return     The attribute 1.
+     */
+    int getAttr1() /**/ { /**/ return /**/ this->m_attr1; /**/ } /**/ // comment
+    /**
+     * @brief      Gets the attribute 2.
+     *
+     * @return     The attribute 2.
+     */
+    int getAttr2() /**/ { /**/ // comment
+        // comment
+        return this->m_attr1; // comment
+    }
+
+    void setAttr1(int val) { this->m_attr1 = val; }
+    void setAttr2(int val)
+    {
+        this->m_attr2 = val;
+    }
+
+private: // my private stuff
+    // comment
+    bool m_flag;
+}

--- a/C++/tests/syntax_test_indent_common.c++
+++ b/C++/tests/syntax_test_indent_common.c++
@@ -1,0 +1,972 @@
+// SYNTAX TEST reindent-unchanged "Packages/C++/C++.sublime-syntax"
+
+/**
+ * This is my first c++ program.
+ * This will print 'Hello World' as the output
+ **/
+
+static void main(void *argp, int argc) {
+    printf("Hello World"); // ; "comment" ()
+}
+
+bool testIfElseIndentationNoBraces(CString v)
+{
+    /**
+     * comment
+     */
+    if (v.isNull() == TRUE) return
+
+    if (v.isNull() == TRUE) return fun(v)
+
+    if (v.isNull() == TRUE) return fun(v);
+
+    if (v.isNull() == TRUE)
+        return FALSE;
+
+    if (v.isNull() == TRUE)
+        return FALSE;
+    else
+    {
+        if (v.endsWith("("))
+            return FALSE;
+        else if (v.endsWith(")"))
+            return TRUE;
+        else if (v.endsWith("\""))
+            return TRUE;
+        else if (v.endsWith("\\"))
+            return TRUE;
+        else if (v.endsWith('('))
+            return FALSE;
+        else if (v.endsWith(')'))
+            return TRUE;
+        else if (v.endsWith('\''))
+            return TRUE;
+        else if (v.endsWith('\\'))
+            return TRUE;
+        else
+            return FALSE;
+
+        if (v.endsWith("baz"))
+            return FALSE;
+        return TRUE;
+    }
+}
+
+bool testIfElseIndentationNoBracesWithLineComments(CString v)
+{
+    /**
+     * comment
+     */
+
+    // line comment
+    if (v.isNull() == TRUE) return
+
+    // line comment
+    if (v.isNull() == TRUE) return fun(v)
+
+    // line comment
+    if (v.isNull() == TRUE) return fun(v);
+
+    // line comment
+    if (v.isNull() == TRUE)
+        // line comment
+        return FALSE;
+
+    // line comment
+    if (v.isNull() == TRUE)
+        // line comment
+        return FALSE;
+    // line comment
+    else
+    // line comment
+    {
+        // line comment
+        if (v.endsWith("("))
+            // line comment
+            return FALSE;
+        // line comment
+        else if (v.endsWith(")"))
+            // line comment
+            return TRUE;
+        // line comment
+        else if (v.endsWith("\""))
+            // line comment
+            return TRUE;
+        // line comment
+        else if (v.endsWith("\\"))
+            // line comment
+            return TRUE;
+        // line comment
+        else if (v.endsWith('('))
+            // line comment
+            return FALSE;
+        // line comment
+        else if (v.endsWith(')'))
+            // line comment
+            return TRUE;
+        // line comment
+        else if (v.endsWith('\''))
+            // line comment
+            return TRUE;
+        // line comment
+        else if (v.endsWith('\\'))
+            // line comment
+            return TRUE;
+        // line comment
+        else
+            // line comment
+            return FALSE;
+
+        // line comment
+        if (v.endsWith("baz"))
+            // line comment
+            return FALSE;
+        // line comment
+        return TRUE;
+    }
+}
+
+bool testIfElseIndentationNoBracesButComments(CString v)
+{
+    if (v.isNull() == TRUE) return         /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) return fun(v)  /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) return fun(v); /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE)                /**/ // ; "comment" ()
+        return FALSE;                      /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE)                /**/ // ; "comment" ()
+        return FALSE;                      /**/ // ; "comment" ()
+    else                                   /**/ // ; "comment" ()
+    {                                      /**/ // ; "comment" ()
+        if (v.endsWith("("))               /**/ // ; "comment" ()
+            return FALSE;                  /**/ // ; "comment" ()
+        else if (v.endsWith(")"))          /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else if (v.endsWith("\""))         /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else if (v.endsWith("\\"))         /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else if (v.endsWith('('))          /**/ // ; "comment" ()
+            return FALSE;                  /**/ // ; "comment" ()
+        else if (v.endsWith(')'))          /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else if (v.endsWith('\''))         /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else if (v.endsWith('\\'))         /**/ // ; "comment" ()
+            return TRUE;                   /**/ // ; "comment" ()
+        else                               /**/ // ; "comment" ()
+            return FALSE;                  /**/ // ; "comment" ()
+    }                                      /**/ // ; "comment" ()
+}
+
+bool testIfElseIndentationNoBracesButBlockCommentsPart1(CString v)
+{
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ TRUE /*(*/ ) /*(*/ return /*(*/ // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ TRUE /*(*/ ) /*(*/ return /*(*/ fun /*(*/ ( /*(*/ ) /*(*/ // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ TRUE /*(*/ ) /*(*/ return /*(*/ fun /*(*/ ( /*(*/ ) /*(*/ ; // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ TRUE /*(*/ ) /*(*/  // ; "comment" ()
+        return FALSE; /*(*/  // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ TRUE /*(*/ ) /*(*/ // ; "comment" ()
+        return FALSE; /*(*/ // ; "comment" ()
+    else /*(*/ // ; "comment" ()
+    { /*(*/ // ; "comment" ()
+        /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "(") /*(*/ ) /*(*/ // ; "comment" ()
+            return FALSE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ ")") /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "\"") /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "\\") /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '(') /*(*/ ) /*(*/ // ; "comment" ()
+            return FALSE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ ')') /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '\'') /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '\\') /*(*/ ) /*(*/ // ; "comment" ()
+            return TRUE; /*(*/ // ; "comment" ()
+        else /*(*/ // ; "comment" ()
+            return FALSE; /*(*/ // ; "comment" ()
+    } /*(*/ // ; "comment" ()
+}
+
+bool testIfElseIndentationNoBracesButBlockCommentsPart2(CString v)
+{
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ TRUE /*)*/ ) /*)*/ return /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ TRUE /*)*/ ) /*)*/ return /*)*/ fun /*)*/ ( /*)*/ ) /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ TRUE /*)*/ ) /*)*/ return /*)*/ fun /*)*/ ( /*)*/ ) /*)*/ ; // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ TRUE /*)*/ ) /*)*/ // ; "comment" ()
+        return FALSE; /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ TRUE /*)*/ ) /*)*/ // ; "comment" ()
+        return FALSE; /*)*/ // ; "comment" ()
+    else /*)*/ // ; "comment" ()
+    { /*)*/ // ; "comment" ()
+        /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "(") /*)*/ ) /*)*/ // ; "comment" ()
+            return FALSE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ ")") /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "\"") /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "\\") /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '(') /*)*/ ) /*)*/ // ; "comment" ()
+            return FALSE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ ')') /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '\'') /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '\\') /*)*/ ) /*)*/ // ; "comment" ()
+            return TRUE; /*)*/ // ; "comment" ()
+        else /*)*/ // ; "comment" ()
+            return FALSE; /*)*/ // ; "comment" ()
+    } /*)*/ // ; "comment" ()
+}
+
+bool testIfElseIndentationWithBraces(CString v) {
+
+    if (v.isNull() == TRUE) { return }
+
+    if (v.isNull() == TRUE) { return fun(v) }
+
+    if (v.isNull() == TRUE) { return fun(v); }
+
+    if (v.isNull() == TRUE) {
+        return FALSE;
+    }
+
+    if (v.isNull() == TRUE) {
+        return FALSE;
+    } else {
+        if (v.endsWith("(")) {
+            return FALSE;
+        } else if (v.endsWith(")")) {
+            return TRUE;
+        } else if (v.endsWith("\"")) {
+            return TRUE;
+        } else if (v.endsWith("\\")) {
+            return TRUE;
+        } else if (v.endsWith('(')) {
+            return FALSE;
+        } else if (v.endsWith(')')) {
+            return TRUE;
+        } else if (v.endsWith('\'')) {
+            return TRUE;
+        } else if (v.endsWith('\\')) {
+            return TRUE;
+        } else {
+            return FALSE;
+        }
+    }
+
+    if (v.isNull() == TRUE)
+    {
+        return
+    }
+    if (v.isNull() == TRUE)
+    {
+        return FALSE
+    }
+    if (v.isNull() == TRUE)
+    {
+        return FALSE;
+    }
+
+    if (v.isNull() == TRUE)
+    {
+        return FALSE;
+    }
+    else
+    {
+        if (v.endsWith("("))
+        {
+            return FALSE;
+        }
+        else if (v.endsWith(")"))
+        {
+            return TRUE;
+        }
+        else if (v.endsWith("\""))
+        {
+            return TRUE;
+        }
+        else if (v.endsWith("\\"))
+        {
+            return TRUE;
+        }
+        else if (v.endsWith('('))
+        {
+            return FALSE;
+        }
+        else if (v.endsWith(')'))
+        {
+            return TRUE;
+        }
+        else if (v.endsWith('\''))
+        {
+            return TRUE;
+        }
+        else if (v.endsWith('\\'))
+        {
+            return TRUE;
+        }
+        else
+        {
+            return FALSE;
+        }
+    }
+}
+
+bool testIfElseIndentationWithBracesAndLineComments(CString v) {
+
+    // comment
+    if (v.isNull() == TRUE) { return }
+
+    // comment
+    if (v.isNull() == TRUE) { return fun(v) }
+
+    // comment
+    if (v.isNull() == TRUE) { return fun(v); }
+
+    // comment
+    if (v.isNull() == TRUE) {
+        // comment
+        return FALSE;
+    }
+
+    // comment
+    if (v.isNull() == TRUE) {
+        // comment
+        return FALSE;
+    } else {
+        // comment
+        if (v.endsWith("(")) {
+            // comment
+            return FALSE;
+        // comment
+        } else if (v.endsWith(")")) {
+            // comment
+            return TRUE;
+        // comment
+        } else if (v.endsWith("\"")) {
+            // comment
+            return TRUE;
+        // comment
+        } else if (v.endsWith("\\")) {
+            // comment
+            return TRUE;
+        // comment
+        } else if (v.endsWith('(')) {
+            // comment
+            return FALSE;
+        // comment
+        } else if (v.endsWith(')')) {
+            // comment
+            return TRUE;
+        // comment
+        } else if (v.endsWith('\'')) {
+            // comment
+            return TRUE;
+        // comment
+        } else if (v.endsWith('\\')) {
+            // comment
+            return TRUE;
+        // comment
+        } else {
+            // comment
+            return FALSE;
+        }
+    }
+
+    // comment
+    if (v.isNull() == TRUE)
+    {
+        // comment
+        return
+    }
+    // comment
+    if (v.isNull() == TRUE)
+    {
+        // comment
+        return FALSE
+    }
+    // comment
+    if (v.isNull() == TRUE)
+    {
+        // comment
+        return FALSE;
+    }
+
+    // comment
+    if (v.isNull() == TRUE)
+    {
+        // comment
+        return FALSE;
+    }
+    // comment
+    else
+    {
+        // comment
+        if (v.endsWith("("))
+        {
+            // comment
+            return FALSE;
+        }
+        // comment
+        else if (v.endsWith(")"))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else if (v.endsWith("\""))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else if (v.endsWith("\\"))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else if (v.endsWith('('))
+        {
+            // comment
+            return FALSE;
+        }
+        // comment
+        else if (v.endsWith(')'))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else if (v.endsWith('\''))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else if (v.endsWith('\\'))
+        {
+            // comment
+            return TRUE;
+        }
+        // comment
+        else
+        {
+            // comment
+            return FALSE;
+        }
+    }
+}
+
+bool testIfElseIndentationWithBracesAndComment(CString v) {
+
+    if (v.isNull() == TRUE) { return }            /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) { return fun(v) }     /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) { return fun(v); }    /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) {                     /**/ // ; "comment" ()
+        return FALSE;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE) {                     /**/ // ; "comment" ()
+        return FALSE;                             /**/ // ; "comment" ()
+    } else {                                      /**/ // ; "comment" ()
+        if (v.endsWith("(")) {                    /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        } else if (v.endsWith(")")) {             /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else if (v.endsWith("\"")) {            /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else if (v.endsWith("\\")) {            /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('(')) {             /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        } else if (v.endsWith(')')) {             /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('\'')) {            /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('\\')) {            /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        } else {                                  /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return                                    /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    if (v.isNull() == TRUE)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return FALSE                              /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    if (v.isNull() == TRUE)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return FALSE;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == TRUE)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return FALSE;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    else                                          /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        if (v.endsWith("("))                      /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith(")"))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith("\""))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith("\\"))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('('))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith(')'))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('\''))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('\\'))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return TRUE;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else                                      /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return FALSE;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+}
+
+bool testSwitchCaseIndentation(CString s) {
+    switch (s) {
+    case
+    case:
+    case break
+    case: break
+    case "(": break
+    case ")": break;
+    case ":": break;
+    case ";": break;
+    case
+        break;
+    case:
+        break;
+    case ":"
+        break;
+    case ':':
+        break;
+    case NestedIfStatement:
+        if (s.endsWith() = '(')
+            return;
+        break;
+    case NestedSwitchCase:
+        switch (v) {
+        case 0: break;
+        case 2:
+            break;
+        }
+        break;
+    case NestedSwitchCaseBlock:
+        {
+            switch (v) {
+            case 0: break;
+            case 2:
+                break;
+            }
+            break;
+        }
+    case NestedSwitchCaseBlock2:
+        {
+            switch (v) {
+            case 0: break;
+            case 2:
+                break;
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+bool testSwitchCaseIndentationWithLineComments(CString s) {
+    switch (s) {                 // comments
+    case                         // comments
+    case:                        // comments
+    case break                   // comments
+    case: break                  // comments
+    case "(": break              // comments
+    case ")": break;             // comments
+    case ":": break;             // comments
+    case ";": break;             // comments
+    case                         // comments
+        break;                   // comments
+    case:                        // comments
+        break;                   // comments
+    case ":"                     // comments
+        break;                   // comments
+    case ':':                    // comments
+        break;                   // comments
+    case NestedIfStatement:      // comments
+        if (s.endsWith() = '(')  // comments
+            return;              // comments
+        break;                   // comments
+    case NestedSwitchCase:       // comments
+        switch (v) {             // comments
+        case 0: break;           // comments
+        case 2:                  // comments
+            break;               // comments
+        }                        // comments
+        break;                   // comments
+    case NestedSwitchCaseBlock:  // comments
+        {                        // comments
+            switch (v) {         // comments
+            case 0: break;       // comments
+            case 2:              // comments
+                break;           // comments
+            }                    // comments
+            break;               // comments
+        }                        // comments
+    case NestedSwitchCaseBlock2: // comments
+        {                        // comments
+            switch (v) {         // comments
+            case 0: break;       // comments
+            case 2:              // comments
+                break;           // comments
+            }                    // comments
+        }                        // comments
+        break;                   // comments
+    default:                     // comments
+        break;                   // comments
+    }                            // comments
+}                                // comments
+
+bool testForIndentation(int v) {
+
+    for (int i = 0; i < 10; i++)
+        System.out.println("Row " + i);
+
+    for (int i = 0; i < 10; i++) {
+        System.out.println("Row " + i);
+    }
+
+    for (int i = 0; i < 10; i++)
+    {
+        System.out.println("Row " + i);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++)
+            System.out.println("Row " + i + " Col " + j);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++) {
+            System.out.println("Row " + i + " Col " + j);
+        }
+    }
+}
+
+bool testWhileIndentationNoBraces(int v) {
+    while () v++
+    while () v++;
+    while (()) v++
+    while ((())) v++
+    while ((())()) v++
+    while ()
+        v++
+    while (v == '(')
+        v++
+    while (v == ')')
+        v++
+    while (v == '\'')
+        v++
+    while (v == '\\')
+        v++
+    while (v == "(")
+        v++
+    while (v == ")")
+        v++
+    while (v == "\"")
+        v++
+    while (v == "\\\"")
+        v++
+    while (v == foo( bar("") + "" ))
+        v++
+}
+
+bool testWhileIndentationNoBracesButComments(int v) {
+    while () v++                      // ; "comment" ()
+    while () v++;                     // ; "comment" ()
+    while (()) v++                    // ; "comment" ()
+    while ((())) v++                  // ; "comment" ()
+    while ((())()) v++                // ; "comment" ()
+    while ()                          // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '(')                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == ')')                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '\'')                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '\\')                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "(")                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == ")")                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "\"")                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "\\\"")               // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == foo( bar("") + "" ))  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while () { } // a hack to make tests succeed
+}
+
+bool testWhileIndentationNoBracesButBlockCommentsPart1(int v) {
+    while /*(*/ () v++ /*(*/ // ; "comment" ()
+    while /*(*/ () v++; /*(*/ // ; "comment" ()
+    while /*(*/ (()) v++ /*(*/ // ; "comment" ()
+    while /*(*/ ((())) v++ /*(*/ // ; "comment" ()
+    while /*(*/ ((()/*(*/)/*(*/()) v++ /*(*/ // ; "comment" ()
+    while /*(*/ () /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '(' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ ')' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '\'' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '\\' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "(" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ ")" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "\"" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "\\\"" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ foo( /*(*/ bar( /*(*/ "/*(*/" /*(*/ ) /*(*/ + /*(*/ "" /*(*/ ) /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ () { } // a hack to make tests succeed
+}
+
+bool testWhileIndentationNoBracesButBlockCommentsPart2(int v) {
+    while /*)*/ () v++ /*)*/ // ; "comment" ()
+    while /*)*/ () v++; /*)*/ // ; "comment" ()
+    while /*)*/ (()) v++ /*)*/ // ; "comment" ()
+    while /*)*/ ((())) v++ /*)*/ // ; "comment" ()
+    while /*)*/ ((()/*)*/)/*)*/()) v++ /*)*/ // ; "comment" ()
+    while /*)*/ () /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '(' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ ')' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '\'' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '\\' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "(" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ ")" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "\"" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "\\\"" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ foo( /*)*/ bar( /*)*/ "/*)*/" /*)*/ ) /*)*/ + /*)*/ "" /*)*/ ) /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ () { } // a hack to make tests succeed
+}
+
+bool testWhileIndentationWithBraces(int v) {
+
+    while () { v++ }
+    while () { v++; }
+    while (()) { v++ }
+    while ((())) { v++ }
+    while ((())()) { v++ }
+    while () {
+        v++
+    }
+    while (v == '(') {
+        v++
+    }
+    while (v == ')') {
+        v++
+    }
+    while (v == '\'') {
+        v++
+    }
+    while (v == '\\') {
+        v++
+    }
+    while (v == "(") {
+        v++
+    }
+    while (v == ")") {
+        v++
+    }
+    while (v == "\"") {
+        v++
+    }
+    while (v == "\\\"") {
+        v++
+    }
+    while (v == foo( bar("") + "" )) {
+        v++
+    }
+    while ()
+    {
+        v++
+    }
+    while (v == '(')
+    {
+        v++
+    }
+    while (v == ')')
+    {
+        v++
+    }
+    while (v == '\'')
+    {
+        v++
+    }
+    while (v == '\\')
+    {
+        v++
+    }
+    while (v == "(")
+    {
+        v++
+    }
+    while (v == ")")
+    {
+        v++
+    }
+    while (v == "\"")
+    {
+        v++
+    }
+    while (v == "\\\"")
+    {
+        v++
+    }
+    while (v == foo( bar("") + "" ))
+    {
+        v++
+    }
+}
+
+bool testWhileIndentationWithBracesAndComments(int v) {
+
+    while () { v++ }                    // ;  "comments" ()
+    while () { v++; }                   // ;  "comments" ()
+    while (()) { v++ }                  // ;  "comments" ()
+    while ((())) { v++ }                // ;  "comments" ()
+    while ((())()) { v++ }              // ;  "comments" ()
+    while () {                          // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '(') {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ')') {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\'') {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\\') {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "(") {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ")") {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\"") {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\\\"") {               // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == foo( bar("") + "" )) {  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while ()                            // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '(')                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ')')                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\'')                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\\')                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "(")                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ")")                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\"")                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\\\"")                 // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == foo( bar("") + "" ))    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+}

--- a/C++/tests/syntax_test_indent_extern.hpp
+++ b/C++/tests/syntax_test_indent_extern.hpp
@@ -1,0 +1,24 @@
+// SYNTAX TEST reindent-unchanged "Packages/C++/C++.sublime-syntax"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+struct HelloWorld;
+
+struct HelloWorldA {
+    int var1;
+    int var2;
+};
+
+struct HelloWorldB
+{
+    int var1;
+    int var2;
+};
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Fixes #868
Fixes #3145

This commit copies indentation rules from Java and adds C/C++ specific rules/keywords as well as some indentation tests.

It can't solve all problems, but may help to improve some of the known issues.