### PR TITLE
[Python] Add shebang

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -29,8 +29,8 @@ file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \#! .* \bpython(\d(\.\d)?)?\b                        # shebang
-  | ^ \s* \# .*? -\*- .*? \bpython(\d(\.\d)?)?\b .*? -\*-  # editorconfig
+    ^ \#! .* \bpython(?:\d(?:\.\d)?)?\b                        # shebang
+  | ^ \s* \# .*? -\*- .*? \bpython(?:\d(?:\.\d)?)?\b .*? -\*-  # editorconfig
   )
 
 variables:
@@ -155,7 +155,26 @@ variables:
 
 contexts:
   main:
-    - include: statements
+    - meta_include_prototype: false
+    - match: ''
+      push: [statements, shebang]
+
+  shebang:
+    - meta_include_prototype: false
+    - match: ^\#!
+      scope: punctuation.definition.comment.python
+      set: shebang-body
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Python is embedded.
+      pop: true
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.python
+    # Note: Keep sync with first_line_match!
+    - match: \bpython(?:\d(?:\.\d)?)?\b
+      scope: constant.language.shebang.python
+    - match: \n
+      pop: true
 
   statements:
     - include: docstrings


### PR DESCRIPTION
This commit adds a dedicated context to scope the shebang line.

Some fonts like provide ligatures for the `#!` sign, thus need to ensure it is tokenized correctly.

The statements context is set onto stack if shebang matches but not after the next start of line or non-whitespace character. This is to make sure, the shebang is highlighted within fenced code blocks of Markdown.