### PR TITLE
[PHP] Improve heredoc matching and add support for highlighting Yaml in heredocs

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1407,6 +1407,23 @@ contexts:
           embed: scope:source.css
           embed_scope: meta.embedded.css source.css
           escape: (?=^\s*\4\b)
+        - match: (<<<)\s*(?i:(YA?ML))\s*$\n?
+          captures:
+            1: keyword.operator.heredoc.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
+          embed: heredoc-yaml
+          embed_scope: meta.embedded.yaml
+          escape: (?=^\s*\2\b)
+        - match: (<<<)\s*((')(?i:(YA?ML))('))\s*$\n?
+          captures:
+            1: keyword.operator.heredoc.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php
+            3: punctuation.definition.tag.begin.php
+            4: entity.name.tag.heredoc.php
+            5: punctuation.definition.tag.end.php
+          embed: scope:source.yaml
+          embed_scope: meta.embedded.yaml source.yaml
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*({{identifier}})\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1461,6 +1478,12 @@ contexts:
     - meta_include_prototype: false
     - match: ''
       push: scope:source.css
+      with_prototype:
+        - include: interpolation
+  heredoc-yaml:
+    - meta_include_prototype: false
+    - match: ''
+      push: scope:source.yaml
       with_prototype:
         - include: interpolation
   instantiation:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1305,13 +1305,10 @@ contexts:
             2: punctuation.terminator.expression.php
             3: meta.heredoc-end.php
           pop: 1
-        - match: (<<<)\s*(()(HTML)())\s*$\n?
+        - match: (<<<)\s*(HTML)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-html
           embed_scope: meta.embedded.html
           escape: (?=^\s*HTML\b)
@@ -1325,13 +1322,10 @@ contexts:
           embed: scope:text.html.basic
           embed_scope: meta.embedded.html text.html
           escape: (?=^\s*HTML\b)
-        - match: (<<<)\s*(()(XML)())\s*$\n?
+        - match: (<<<)\s*(XML)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-xml
           embed_scope: meta.embedded.xml
           escape: (?=^\s*XML\b)
@@ -1345,13 +1339,10 @@ contexts:
           embed: scope:text.xml
           embed_scope: meta.embedded.xml text.xml
           escape: (?=^\s*XML\b)
-        - match: (<<<)\s*(()(SQL)())\s*$\n?
+        - match: (<<<)\s*(SQL)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-sql
           embed_scope: meta.embedded.sql
           escape: (?=^\s*SQL\b)
@@ -1365,13 +1356,10 @@ contexts:
           embed: scope:source.sql
           embed_scope: meta.embedded.sql source.sql
           escape: (?=^\s*SQL\b)
-        - match: (<<<)\s*(()(JAVASCRIPT)())\s*$\n?
+        - match: (<<<)\s*(JAVASCRIPT)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-javascript
           embed_scope: meta.embedded.js
           escape: (?=^\s*JAVASCRIPT\b)
@@ -1385,13 +1373,10 @@ contexts:
           embed: scope:source.js
           embed_scope: meta.embedded.js source.js
           escape: (?=^\s*JAVASCRIPT\b)
-        - match: (<<<)\s*(()(JSON)())\s*$\n?
+        - match: (<<<)\s*(JSON)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-json
           embed_scope: meta.embedded.json
           escape: (?=^\s*JSON\b)
@@ -1405,13 +1390,10 @@ contexts:
           embed: scope:source.json
           embed_scope: meta.embedded.json source.json
           escape: (?=^\s*JSON\b)
-        - match: (<<<)\s*(()(CSS)())\s*$\n?
+        - match: (<<<)\s*(CSS)\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-css
           embed_scope: meta.embedded.css
           escape: (?=^\s*CSS\b)
@@ -1425,16 +1407,13 @@ contexts:
           embed: scope:source.css
           embed_scope: meta.embedded.css source.css
           escape: (?=^\s*CSS\b)
-        - match: (<<<)\s*(()({{identifier}})())\s*$\n?
+        - match: (<<<)\s*({{identifier}})\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
-            2: meta.string.heredoc.php meta.tag.heredoc.php
-            3: punctuation.definition.tag.begin.php
-            4: entity.name.tag.heredoc.php
-            5: punctuation.definition.tag.end.php
+            2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           push:
             - meta_scope: string.unquoted.heredoc.php
-            - match: (?=^\s*\4\b)
+            - match: (?=^\s*\2\b)
               pop: 1
             - include: interpolation
         - match: (<<<)\s*((')({{identifier}})('))

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1305,14 +1305,14 @@ contexts:
             2: punctuation.terminator.expression.php
             3: meta.heredoc-end.php
           pop: 1
-        - match: (<<<)\s*(HTML)\s*$\n?
+        - match: (<<<)\s*(?i:(HTML))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-html
           embed_scope: meta.embedded.html
           escape: (?=^\s*HTML\b)
-        - match: (<<<)\s*((')(HTML)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(HTML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php
@@ -1322,14 +1322,14 @@ contexts:
           embed: scope:text.html.basic
           embed_scope: meta.embedded.html text.html
           escape: (?=^\s*HTML\b)
-        - match: (<<<)\s*(XML)\s*$\n?
+        - match: (<<<)\s*(?i:(XML))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-xml
           embed_scope: meta.embedded.xml
           escape: (?=^\s*XML\b)
-        - match: (<<<)\s*((')(XML)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(XML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php
@@ -1339,14 +1339,14 @@ contexts:
           embed: scope:text.xml
           embed_scope: meta.embedded.xml text.xml
           escape: (?=^\s*XML\b)
-        - match: (<<<)\s*(SQL)\s*$\n?
+        - match: (<<<)\s*(?i:(SQL))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-sql
           embed_scope: meta.embedded.sql
           escape: (?=^\s*SQL\b)
-        - match: (<<<)\s*((')(SQL)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(SQL))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php
@@ -1356,14 +1356,14 @@ contexts:
           embed: scope:source.sql
           embed_scope: meta.embedded.sql source.sql
           escape: (?=^\s*SQL\b)
-        - match: (<<<)\s*(JAVASCRIPT)\s*$\n?
+        - match: (<<<)\s*(?i:(JAVASCRIPT))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-javascript
           embed_scope: meta.embedded.js
           escape: (?=^\s*JAVASCRIPT\b)
-        - match: (<<<)\s*((')(JAVASCRIPT)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(JAVASCRIPT))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php
@@ -1373,14 +1373,14 @@ contexts:
           embed: scope:source.js
           embed_scope: meta.embedded.js source.js
           escape: (?=^\s*JAVASCRIPT\b)
-        - match: (<<<)\s*(JSON)\s*$\n?
+        - match: (<<<)\s*(?i:(JSON))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-json
           embed_scope: meta.embedded.json
           escape: (?=^\s*JSON\b)
-        - match: (<<<)\s*((')(JSON)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(JSON))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php
@@ -1390,14 +1390,14 @@ contexts:
           embed: scope:source.json
           embed_scope: meta.embedded.json source.json
           escape: (?=^\s*JSON\b)
-        - match: (<<<)\s*(CSS)\s*$\n?
+        - match: (<<<)\s*(?i:(CSS))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-css
           embed_scope: meta.embedded.css
           escape: (?=^\s*CSS\b)
-        - match: (<<<)\s*((')(CSS)('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(CSS))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1311,7 +1311,7 @@ contexts:
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-html
           embed_scope: meta.embedded.html
-          escape: (?=^\s*HTML\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(HTML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1321,14 +1321,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:text.html.basic
           embed_scope: meta.embedded.html text.html
-          escape: (?=^\s*HTML\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*(?i:(XML))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-xml
           embed_scope: meta.embedded.xml
-          escape: (?=^\s*XML\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(XML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1338,14 +1338,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:text.xml
           embed_scope: meta.embedded.xml text.xml
-          escape: (?=^\s*XML\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*(?i:(SQL))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-sql
           embed_scope: meta.embedded.sql
-          escape: (?=^\s*SQL\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(SQL))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1355,14 +1355,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.sql
           embed_scope: meta.embedded.sql source.sql
-          escape: (?=^\s*SQL\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*(?i:(JAVASCRIPT))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-javascript
           embed_scope: meta.embedded.js
-          escape: (?=^\s*JAVASCRIPT\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(JAVASCRIPT))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1372,14 +1372,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.js
           embed_scope: meta.embedded.js source.js
-          escape: (?=^\s*JAVASCRIPT\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*(?i:(JSON))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-json
           embed_scope: meta.embedded.json
-          escape: (?=^\s*JSON\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(JSON))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1389,14 +1389,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.json
           embed_scope: meta.embedded.json source.json
-          escape: (?=^\s*JSON\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*(?i:(CSS))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-css
           embed_scope: meta.embedded.css
-          escape: (?=^\s*CSS\b)
+          escape: (?=^\s*\2\b)
         - match: (<<<)\s*((')(?i:(CSS))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1406,7 +1406,7 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.css
           embed_scope: meta.embedded.css source.css
-          escape: (?=^\s*CSS\b)
+          escape: (?=^\s*\4\b)
         - match: (<<<)\s*({{identifier}})\s*$\n?
           captures:
             1: keyword.operator.heredoc.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -38,6 +38,8 @@ variables:
   keywords_flow: |-
     (?x: break | continue | exit | finally | return | throw | yield )\b
 
+  heredoc_quoted_end: (?=^\s*\4\b)
+  heredoc_unquoted_end: (?=^\s*\2\b)
 
 contexts:
   main:
@@ -1311,7 +1313,7 @@ contexts:
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-html
           embed_scope: meta.embedded.html
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(HTML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1321,14 +1323,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:text.html.basic
           embed_scope: meta.embedded.html text.html
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(XML))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-xml
           embed_scope: meta.embedded.xml
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(XML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1338,14 +1340,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:text.xml
           embed_scope: meta.embedded.xml text.xml
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(SQL))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-sql
           embed_scope: meta.embedded.sql
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(SQL))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1355,14 +1357,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.sql
           embed_scope: meta.embedded.sql source.sql
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(JAVASCRIPT|JS))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-javascript
           embed_scope: meta.embedded.js
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(JAVASCRIPT|JS))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1372,14 +1374,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.js
           embed_scope: meta.embedded.js source.js
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(JSON))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-json
           embed_scope: meta.embedded.json
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(JSON))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1389,14 +1391,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.json
           embed_scope: meta.embedded.json source.json
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(CSS))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-css
           embed_scope: meta.embedded.css
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(CSS))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1406,14 +1408,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.css
           embed_scope: meta.embedded.css source.css
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(YA?ML))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-yaml
           embed_scope: meta.embedded.yaml
-          escape: (?=^\s*\2\b)
+          escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(YA?ML))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
@@ -1423,14 +1425,14 @@ contexts:
             5: punctuation.definition.tag.end.php
           embed: scope:source.yaml
           embed_scope: meta.embedded.yaml source.yaml
-          escape: (?=^\s*\4\b)
+          escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*({{identifier}})\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           push:
             - meta_scope: string.unquoted.heredoc.php
-            - match: (?=^\s*\2\b)
+            - match: '{{heredoc_unquoted_end}}'
               pop: 1
             - include: interpolation
         - match: (<<<)\s*((')({{identifier}})('))
@@ -1442,7 +1444,7 @@ contexts:
             5: punctuation.definition.tag.end.php
           push:
             - meta_scope: string.unquoted.heredoc.php
-            - match: (?=^\s*\4\b)
+            - match: '{{heredoc_quoted_end}}'
               pop: 1
   heredoc-html:
     - meta_include_prototype: false

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1356,14 +1356,14 @@ contexts:
           embed: scope:source.sql
           embed_scope: meta.embedded.sql source.sql
           escape: (?=^\s*\4\b)
-        - match: (<<<)\s*(?i:(JAVASCRIPT))\s*$\n?
+        - match: (<<<)\s*(?i:(JAVASCRIPT|JS))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
           embed: heredoc-javascript
           embed_scope: meta.embedded.js
           escape: (?=^\s*\2\b)
-        - match: (<<<)\s*((')(?i:(JAVASCRIPT))('))\s*$\n?
+        - match: (<<<)\s*((')(?i:(JAVASCRIPT|JS))('))\s*$\n?
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1925,6 +1925,9 @@ three: "$four"
 //   ^       punctuation.separator.key-value.mapping
 //     ^^^^^^^ string.quoted.double
 //      ^^^^^ variable.other.php
+Yml;
+// <- meta.embedded.yaml source.yaml string.unquoted.plain.out.yaml
+//^^ meta.embedded.yaml source.yaml string.unquoted.plain.out.yaml
 yml;
 // <- entity.name.tag.heredoc
 // ^ punctuation.terminator.expression

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1910,7 +1910,7 @@ CSS;
 // ^ punctuation.terminator.expression
 //  ^ meta.heredoc-end
 
-echo <<<SQL
+echo <<<sql
 //   ^^^ keyword.operator.heredoc
 //      ^^^ meta.string.heredoc meta.tag.heredoc
 //      ^^^ entity.name.tag.heredoc
@@ -1920,7 +1920,7 @@ SELECT * FROM users WHERE first_name = 'John' LIMIT $limit
 //     ^ variable.language.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
 //                                                  ^^^^^^ variable.other.php
-SQL;
+sql;
 // <- entity.name.tag.heredoc
 // ^ punctuation.terminator.expression
 //  ^ meta.heredoc-end

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1910,6 +1910,26 @@ CSS;
 // ^ punctuation.terminator.expression
 //  ^ meta.heredoc-end
 
+echo <<< yml
+//   ^^^ keyword.operator.heredoc
+//       ^^^ meta.string.heredoc meta.tag.heredoc
+//       ^^^ entity.name.tag.heredoc
+one: two
+//^^^^^^ meta.embedded.yaml source.yaml
+//^ string.unquoted.plain.out entity.name.tag
+// ^       punctuation.separator.key-value.mapping
+//   ^^^ string.unquoted.plain.out
+three: "$four"
+//^^^^^^^^^^^^ meta.embedded.yaml source.yaml
+//^^^ string.unquoted.plain.out entity.name.tag
+//   ^       punctuation.separator.key-value.mapping
+//     ^^^^^^^ string.quoted.double
+//      ^^^^^ variable.other.php
+yml;
+// <- entity.name.tag.heredoc
+// ^ punctuation.terminator.expression
+//  ^ meta.heredoc-end
+
 echo <<<sql
 //   ^^^ keyword.operator.heredoc
 //      ^^^ meta.string.heredoc meta.tag.heredoc


### PR DESCRIPTION
This PR simplifies and improves some of the matching of heredoc tokens in PHP:

- Removes empty captures, like the two occurrences of `()` in `(()HTML())`. This has no effect on any tests or scoping, since these captures are always empty.
- Matches all heredoc tokens case-insensitively, since these are also valid PHP syntax. I updated one existing test to use `sql` instead of `SQL` to verify that this works as expected.
- Refer to the matched heredoc token using a numbered reference in the `escape` pattern, instead of repeating the token (e.g. `(?=^\s*\2\b)` instead of `(?=^\s*HTML\b)`). This is a bit less repetitive and makes it easier to update the token pattern itself if it changes.
- Add `JS` as a 'recognized' heredoc token (in addition to `JAVASCRIPT`) and apply JavaScript syntax highlighting to the embedded heredoc text.

This PR also adds support for embedded Yaml syntax highlighting inside heredocs using the tokens `YAML` and `YML`. I implemented this in exactly the same way as the other embedded syntaxes, and added a similar test.