### PR TITLE
[Java] Fix qualified constants highlighting

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -2570,7 +2570,6 @@ contexts:
         - qualified-constant-name
 
   qualified-constant-class:
-    - meta_include_prototype: false
     - match: '{{identifier}}'
       scope: storage.type.class.java
       set:
@@ -2584,7 +2583,6 @@ contexts:
       fail: qualified-constant-class-or-name
 
   qualified-constant-name:
-    - meta_include_prototype: false
     - match: '{{identifier}}'
       scope: constant.other.java
       pop: 3

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -5736,6 +5736,29 @@ class SwitchStatementTests {
 //                                                       ^^^^^^^^^ constant.other.java
 //                                                                ^ punctuation.separator.expressions.java
 
+      case /**/ @anno /**/ mod /**/ . /**/ @anno /**/ sub /**/ . /**/ @anno /**/ MyClass /**/ . /**/ @anno /**/ EnumConst:
+//    ^^^^^^^^^^ meta.statement.conditional.case.java - meta.path
+//              ^^^^^^^^^^^  meta.statement.conditional.case.label.java - meta.path
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.statement.conditional.case.label.java meta.path.java
+//                                                                                                                       ^ meta.statement.conditional.case.java - meta.path
+//    ^^^^ keyword.control.conditional.case.java
+//              ^ punctuation.definition.annotation.java
+//               ^^^^ variable.annotation.java
+//                         ^^^ variable.namespace.java
+//                                  ^ punctuation.accessor.dot.java
+//                                         ^ punctuation.definition.annotation.java
+//                                          ^^^^ variable.annotation.java
+//                                                    ^^^ variable.namespace.java
+//                                                             ^ punctuation.accessor.dot.java
+//                                                                    ^ punctuation.definition.annotation.java
+//                                                                     ^^^^ variable.annotation.java
+//                                                                               ^^^^^^^ storage.type.class.java
+//                                                                                            ^ punctuation.accessor.dot.java
+//                                                                                                   ^ punctuation.definition.annotation.java
+//                                                                                                    ^^^^ variable.annotation.java
+//                                                                                                              ^^^^^^^^^ constant.other.java
+//                                                                                                                       ^ punctuation.separator.expressions.java
+
       case mod.sub.myclass.enumconst
 //   ^ meta.statement.conditional.switch.java meta.block.java - meta.statement.conditional.case
 //    ^^^^^ meta.statement.conditional.case.java - meta.path


### PR DESCRIPTION
This commit removes some prototype-excludes to enable proper highlighting of qualified constants if block comments appear within the path.