### PR TITLE
[Java] Improve import statement identifiers

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -546,105 +546,40 @@ contexts:
 ###[ IMPORT DECLARATIONS ]#####################################################
 
   import:
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.5
     - match: import{{break}}
       scope: keyword.declaration.import.java
-      push: import-modifier
+      push:
+        - import-meta
+        - import-modifier
+
+  import-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.import.java
+    - include: immediately-pop
 
   import-modifier:
-    - meta_scope: meta.import.java
     - match: static{{break}}
       scope: storage.modifier.java
-      set:
-        - meta_content_scope: meta.import.java
-        - match: (?=\S)
-          set: import-static-namespace
+      set: import-static
     - match: (?=\S)
-      set: import-normal-namespace
+      set: type-import
 
-  import-normal-namespace:
-    - meta_content_scope: meta.import.java meta.path.java
-    - include: import-terminator
-    - include: import-package-name
+  import-static:
     - match: (?=\S)
-      set: import-normal-class
-
-  import-normal-class:
-    - meta_content_scope: meta.import.java meta.path.java
-    - include: import-terminator
-    - include: import-class-name
-    - include: import-wildcard
-    - include: else-pop
-
-  import-static-namespace:
-    - meta_content_scope: meta.import.java meta.path.java
-    - include: import-terminator
-    - include: import-package-name
-    - match: (?=\S)
-      set: import-static-class
-
-  import-static-class:
-    - meta_content_scope: meta.import.java meta.path.java
-    - include: import-terminator
-    - include: import-constant-name
-    - include: import-class-path
-    - include: import-function-name
-    - include: import-wildcard
-    - include: else-pop
-
-  import-constant-name:
-    - match: '{{uppercase_id}}(?!\s*\.)'
-      scope:
-        meta.import.java meta.path.java
-        entity.name.constant.java
-      set: import-expect-terminator
-
-  import-package-name:
-    - match: '{{lowercase_id}}'
-      scope: variable.namespace.java
-      push: import-acessor-or-termintor
-    - include: punctuation-accessor-dot
-
-  import-class-path:
-    - match: '{{classcase_id}}'
-      scope: storage.type.class.java
-      push: import-acessor-or-termintor
-    - include: punctuation-accessor-dot
-
-  import-class-name:
-    - match: '{{classcase_id}}'
-      scope: entity.name.class.java
-      push: import-acessor-or-termintor
-    - include: punctuation-accessor-dot
-
-  import-function-name:
-    - match: '{{identifier}}'
-      scope:
-        meta.import.java meta.path.java
-        entity.name.function.java
-      set: import-expect-terminator
+      set: static-import
 
   import-wildcard:
     - match: \*
-      scope:
-        meta.import.java meta.path.java
-        variable.language.wildcard.asterisk.java
+      scope: variable.language.wildcard.asterisk.java
+      pop: 3 # skip meta-import
       set: import-expect-terminator
 
-  import-acessor-or-termintor:
-    # continue with the import context
-    - include: punctuation-accessor-dot-pop
-    # pop the import context
-    - match: (?=\s*;|\S)
-      pop: 2
-
   import-expect-terminator:
-    - include: import-terminator
-    - match: \S
-      scope: invalid.illegal.expect-semicolon.java
-
-  import-terminator:
     - match: (?=\s*;|{{reserved_words}}{{break}})
       pop: 1
+    - match: \S
+      scope: invalid.illegal.expect-semicolon.java
 
 ###[ CLASS DECLARATIONS ]######################################################
 
@@ -2589,6 +2524,119 @@ contexts:
       scope: constant.other.java
       pop: 3
     - include: annotation-else-pop3
+
+###[ STATIC IMPORT ]###########################################################
+
+  static-import:
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.5.3
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.5.4
+    - meta_include_prototype: false
+    - meta_content_scope: meta.path.java
+    - match: ''
+      branch_point: static-import
+      branch:
+        - static-import-package
+        - static-import-class-or-name
+
+  static-import-package:
+    - match: '{{lowercase_id}}'
+      scope: variable.namespace.java
+      set: static-import-package-accessor
+    - include: annotations
+    - match: (?=\S)
+      fail: static-import
+
+  static-import-package-accessor:
+    - include: punctuation-accessor-dot-pop
+    - match: (?=\S)
+      fail: static-import
+
+  static-import-class-or-name:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1
+      branch_point: static-import-class-or-name
+      branch:
+        - static-import-class
+        - static-import-name
+
+  static-import-class:
+    - match: '{{identifier}}'
+      scope: storage.type.class.java
+      set:
+        - static-import-class-accessor
+        - maybe-type-argument
+    - include: import-wildcard
+    - include: annotation-else-pop2
+
+  static-import-class-accessor:
+    - include: punctuation-accessor-dot-pop
+    - match: (?=\S)
+      fail: static-import-class-or-name
+
+  static-import-name:
+    - match: '{{uppercase_id}}'
+      scope: entity.name.constant.java
+      pop: 2
+    - match: '{{identifier}}'
+      scope: entity.name.import.java
+      pop: 2
+    - include: annotation-else-pop2
+
+###[ TYPE IMPORT ]#############################################################
+
+  type-import:
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.5.1
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.5.2
+    - meta_include_prototype: false
+    - meta_content_scope: meta.path.java
+    - match: ''
+      branch_point: type-import
+      branch:
+        - type-import-package
+        - type-import-class-or-name
+
+  type-import-package:
+    - match: '{{lowercase_id}}'
+      scope: variable.namespace.java
+      set: type-import-package-accessor
+    - include: annotations
+    - match: (?=\S)
+      fail: type-import
+
+  type-import-package-accessor:
+    - include: punctuation-accessor-dot-pop
+    - match: (?=\S)
+      fail: type-import
+
+  type-import-class-or-name:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1
+      branch_point: type-import-class-or-name
+      branch:
+        - type-import-class
+        - type-import-name
+
+  type-import-class:
+    - match: '{{identifier}}'
+      scope: storage.type.class.java
+      set:
+        - type-import-class-accessor
+        - maybe-type-argument
+    - include: import-wildcard
+    - include: annotation-else-pop2
+
+  type-import-class-accessor:
+    - include: punctuation-accessor-dot-pop
+    - match: (?=\S)
+      fail: type-import-class-or-name
+
+  type-import-name:
+    - match: '{{identifier}}'
+      scope: entity.name.class.java
+      pop: 2
+    - include: annotation-else-pop2
 
 ###[ ENTITY CLASS ]############################################################
 

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -572,7 +572,7 @@ contexts:
   import-wildcard:
     - match: \*
       scope: variable.language.wildcard.asterisk.java
-      pop: 3 # skip meta-import
+      pop: 2
       set: import-expect-terminator
 
   import-expect-terminator:

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -520,10 +520,11 @@ import
 import no.terminator
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
-//     ^^^^^^^^^^^^^^ meta.import.java meta.path.java
+//     ^^^^^^^^^^^^^ meta.import.java meta.path.java
+//                  ^ - meta.import - meta.path
 //     ^^ variable.namespace.java - punctuation
 //       ^ punctuation.accessor.dot.java - entity - variable
-//        ^^^^^^^^^^ variable.namespace.java - punctuation
+//        ^^^^^^^^^^ entity.name.class.java - punctuation
     variable
 //  ^^^^^^^^ variable.other - meta.import
 
@@ -534,10 +535,11 @@ import static
 import static no.terminator
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^^^^^^^^ meta.import.java - meta.path
-//            ^^^^^^^^^^^^^^ meta.import.java meta.path.java
+//            ^^^^^^^^^^^^^ meta.import.java meta.path.java
+//                         ^ - meta.import - meta.path
 //            ^^ variable.namespace.java - punctuation
 //              ^ punctuation.accessor.dot.java - entity - variable
-//               ^^^^^^^^^^ variable.namespace.java - punctuation
+//               ^^^^^^^^^^ entity.name.import.java - punctuation
     variable
 //  ^^^^^^^^ variable.other - meta.import
 
@@ -623,7 +625,7 @@ import a.b.Class.*;
 //      ^ punctuation.accessor.dot.java - entity - variable
 //       ^ variable.namespace.java
 //        ^ punctuation.accessor.dot.java - entity - variable
-//         ^^^^^ entity.name.class.java
+//         ^^^^^ storage.type.class.java
 //              ^ punctuation.accessor.dot.java - entity - variable
 //               ^ variable.language.wildcard.asterisk.java
 
@@ -634,7 +636,7 @@ import a.b.Class.SubClass;
 //      ^ punctuation.accessor.dot.java - entity - variable
 //       ^ variable.namespace.java
 //        ^ punctuation.accessor.dot.java - entity - variable
-//         ^^^^^ entity.name.class.java
+//         ^^^^^ storage.type.class.java
 //              ^ punctuation.accessor.dot.java - entity
 //               ^^^^^^^^ entity.name.class.java
 
@@ -653,7 +655,7 @@ import
     .Class
 //^^^^^^^^^^^ meta.import.java meta.path.java
 //  ^ punctuation.accessor.dot.java - entity - variable
-//   ^^^^^ entity.name.class.java
+//   ^^^^^ storage.type.class.java
     .
 //^^^^ meta.import.java meta.path.java
 //  ^ punctuation.accessor.dot.java - entity
@@ -686,7 +688,7 @@ import static a.b.Class.fooMethod;
 //               ^ punctuation.accessor.dot.java
 //                ^^^^^ storage.type.class.java
 //                     ^ punctuation.accessor.dot.java
-//                      ^^^^^^^^^ meta.import.java entity.name.function.java
+//                      ^^^^^^^^^ entity.name.import.java
 //                               ^ punctuation.terminator.java
 
 import static a.b.Class.CONSTANT ;
@@ -780,6 +782,17 @@ import static a.b.Class.*;
 //                     ^ punctuation.accessor.dot.java
 //                      ^ variable.language.wildcard.asterisk.java
 
+import static C.d.ced
+//^^^^^^^^^^^^ meta.import.java
+//            ^^^^^^^ meta.import.java meta.path.java
+//                   ^ - meta.import - meta.path
+//^^^^ keyword.declaration.import.java
+//     ^^^^^^ storage.modifier.java
+//            ^ storage.type.class.java
+//             ^ punctuation.accessor.dot.java
+//              ^ variable.namespace.java
+//               ^ punctuation.accessor.dot.java
+//                ^^^ entity.name.import.java
 
 /******************************************************************************
  * Class Declaration Tests

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -554,7 +554,8 @@ import *. ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
 //     ^ meta.import.java meta.path.java
-//      ^^^ - meta.import - meta.path
+//      ^ meta.import - meta.path
+//       ^^ - meta.import - meta.path
 //     ^ variable.language.wildcard.asterisk.java
 //      ^ invalid.illegal.expect-semicolon.java
 //        ^ punctuation.terminator.java
@@ -563,7 +564,8 @@ import *.* ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
 //     ^ meta.import.java meta.path.java
-//      ^^^^ - meta.import - meta.path
+//      ^^ meta.import - meta.path
+//        ^^ - meta.import - meta.path
 //     ^ variable.language.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
@@ -572,7 +574,8 @@ import *.a ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
 //     ^ meta.import.java meta.path.java
-//      ^^^^ - meta.import - meta.path
+//      ^^ meta.import - meta.path
+//        ^^ - meta.import - meta.path
 //     ^ variable.language.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
@@ -581,7 +584,8 @@ import a . * . b ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
 //     ^^^^^ meta.import.java meta.path.java
-//          ^^^^^^ - meta.import - meta.path
+//          ^^^^ meta.import - meta.path
+//              ^^ - meta.import - meta.path
 //     ^ variable.namespace.java
 //      ^^^ - variable
 //       ^ punctuation.accessor.dot.java


### PR DESCRIPTION
Fixes #3161

This commit reworks import identifiers using branching in order to properly highlight all kinds of type and static imports in case insensitive manner.

The new sections `TYPE IMPORT` and `STATIC IMPORT` are copied from `CONSTANTS` section and simplified by removing the `unqualified-...` part.

_Note: The current implementation in master dates back to 2019 when branching was not yet available._