### PR TITLE
[HTML] Add support for script/style wrapped in CDATA

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -208,6 +208,18 @@ contexts:
 
   script-javascript-content:
     - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js
+      embed_scope: meta.tag.sgml.cdata.html source.js.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
     - match: '{{script_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
@@ -317,6 +329,18 @@ contexts:
 
   style-css-content:
     - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css
+      embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
     - match: '{{style_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -186,6 +186,51 @@
         >
         ## <- meta.tag.script.end.html punctuation.definition.tag.end.html
 
+        <!-- XHTML: wrap scripts in CDATA -->
+        <script><![CDATA[var i = 0;]]></script>
+        ## ^^^^^ meta.tag.script.begin.html - source
+        ##      ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##                            ^^^^^^^^^ meta.tag.script.end.html
+        ##      ^^^ punctuation.definition.tag.begin.html
+        ##         ^^^^^ keyword.declaration.cdata.html
+        ##              ^ punctuation.definition.tag.begin.html
+        ##               ^^^^^^^^^^ source.js.embedded.html
+        ##                         ^^^ punctuation.definition.tag.end.html
+
+        <script>
+            <![CDATA[
+        ## ^ - meta.tag - punctuation - source
+        ##  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##  ^^^ punctuation.definition.tag.begin.html
+        ##     ^^^^^ keyword.declaration.cdata.html
+        ##          ^ punctuation.definition.tag.begin.html
+                var i = 0;
+        ##      ^^^^^^^^^^ meta.tag.sgml.cdata.html source.js.embedded.html
+            ]]>
+        ## ^ meta.tag.sgml.cdata.html source.js.embedded.html
+        ##  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+        ##     ^ - meta.tag - punctuation - source
+        </script>
+
+        <script type="text/html">
+            <![CDATA[
+        ## ^ - meta.tag - punctuation - source
+        ##  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##  ^^^ punctuation.definition.tag.begin.html
+        ##     ^^^^^ keyword.declaration.cdata.html
+        ##          ^ punctuation.definition.tag.begin.html
+                var i = 0;
+        ##    ^^^^^^^^^^^^^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
+            ]]>
+        ## ^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
+        ##  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+        ##     ^ - meta.tag - punctuation - source
+        </script>
+
+        <script />
+        ##        ^ - source.js.embedded.html
+        ## ^ meta.tag.script entity.name.tag.script
+
         <style type="text/css"> h1 {} </style>
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag - comment - source
         ##                     ^^^^^^^ source.css.embedded.html - meta.tag - comment
@@ -292,6 +337,35 @@
         >
         ## <- meta.tag.style.end.html punctuation.definition.tag.end.html
 
+        <!-- XHTML: wrap scripts in CDATA -->
+        <style><![CDATA[h1 {}]]></style>
+        ## ^^^^ meta.tag.style.begin.html - source
+        ##     ^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##                      ^^^^^^^^ meta.tag.style.end.html
+        ##     ^^^ punctuation.definition.tag.begin.html
+        ##        ^^^^^ keyword.declaration.cdata.html
+        ##             ^ punctuation.definition.tag.begin.html
+        ##              ^^^^^ source.css.embedded.html
+        ##                   ^^^ punctuation.definition.tag.end.html
+        ##                      ^^ punctuation.definition.tag.begin.html
+        ##                        ^^^^^ entity.name.tag.style.html
+        ##                             ^ punctuation.definition.tag.end.html
+
+        <style>
+            <![CDATA[
+        ## ^ - meta.tag - punctuation - source
+        ##  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##  ^^^ punctuation.definition.tag.begin.html
+        ##     ^^^^^ keyword.declaration.cdata.html
+        ##          ^ punctuation.definition.tag.begin.html
+                h1 {}
+        ##     ^^^^^^^ meta.tag.sgml.cdata.html source.css.embedded.html
+            ]]>
+        ## ^ meta.tag.sgml.cdata.html source.css.embedded.html
+        ##  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+        ##     ^ - meta.tag - punctuation - source
+        </style>
+
         </style>
         ##^^^^^^ meta.tag.style.end.html
         ##^^^^^ entity.name.tag.style.html
@@ -300,9 +374,7 @@
         <style />
         ##       ^ - source.css.embedded.html
         ## ^ meta.tag.style entity.name.tag.style
-        <script />
-        ##        ^ - source.js.embedded.html
-        ## ^ meta.tag.script entity.name.tag.script
+
     </head>
     <body>
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -337,7 +337,7 @@
         >
         ## <- meta.tag.style.end.html punctuation.definition.tag.end.html
 
-        <!-- XHTML: wrap scripts in CDATA -->
+        <!-- XHTML: wrap style in CDATA -->
         <style><![CDATA[h1 {}]]></style>
         ## ^^^^ meta.tag.style.begin.html - source
         ##     ^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html


### PR DESCRIPTION
XHTML supports wrapping script and style content into `<![CDATA[ ... ]]>` tags.

Found at https://github.com/liuchuo/JSP/blob/master/apache-tomcat-8.5.14/webapps/examples/websocket/echo.xhtml