### PR TITLE
[Java/JSPX] Add support for script/style wrapped in CDATA

### DIFF
--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -32,6 +32,18 @@ contexts:
 
   script-javascript-content:
     - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.embedded.jsp
+      embed_scope: meta.tag.sgml.cdata.html source.js.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
     - match: '{{script_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
@@ -47,6 +59,18 @@ contexts:
 
   style-css-content:
     - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.jsp
+      embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
     - match: '{{style_content_begin}}'
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -83,6 +83,78 @@
 
     </script>
 //  ^^^^^^^^^ meta.tag.script.end.html
+
+    <!-- XHTML/JSPX: wrap scripts in CDATA -->
+    <script><![CDATA[var i = 0;]]></script>
+    // ^^^^^ meta.tag.script.begin.html - source
+    //      ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html
+    //                            ^^^^^^^^^ meta.tag.script.end.html
+    //      ^^^ punctuation.definition.tag.begin.html
+    //         ^^^^^ keyword.declaration.cdata.html
+    //              ^ punctuation.definition.tag.begin.html
+    //               ^^^^^^^^^^ source.js.embedded.html
+    //                         ^^^ punctuation.definition.tag.end.html
+
+    <script>
+        <![CDATA[
+    // ^ - meta.tag - punctuation - source
+    //  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+    //  ^^^ punctuation.definition.tag.begin.html
+    //     ^^^^^ keyword.declaration.cdata.html
+    //          ^ punctuation.definition.tag.begin.html
+            var i = <% initialValue() %>;
+    //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html source.js.embedded.html
+    //              ^^^^^^^^^^^^^^^^^^^^ meta.embedded.scriptlet.jsp
+        ]]>
+    // ^ meta.tag.sgml.cdata.html source.js.embedded.html
+    //  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    //     ^ - meta.tag - punctuation - source
+    </script>
+
+    <script type="text/html">
+        <![CDATA[
+    // ^ - meta.tag - punctuation - source
+    //  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+    //  ^^^ punctuation.definition.tag.begin.html
+    //     ^^^^^ keyword.declaration.cdata.html
+    //          ^ punctuation.definition.tag.begin.html
+            var i = 0;
+    //    ^^^^^^^^^^^^^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
+        ]]>
+    // ^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
+    //  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    //     ^ - meta.tag - punctuation - source
+    </script>
+
+    <!-- XHTML: wrap style in CDATA -->
+    <style><![CDATA[h1 {}]]></style>
+    // ^^^^ meta.tag.style.begin.html - source
+    //     ^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html
+    //                      ^^^^^^^^ meta.tag.style.end.html
+    //     ^^^ punctuation.definition.tag.begin.html
+    //        ^^^^^ keyword.declaration.cdata.html
+    //             ^ punctuation.definition.tag.begin.html
+    //              ^^^^^ source.css.embedded.html
+    //                   ^^^ punctuation.definition.tag.end.html
+    //                      ^^ punctuation.definition.tag.begin.html
+    //                        ^^^^^ entity.name.tag.style.html
+    //                             ^ punctuation.definition.tag.end.html
+
+    <style>
+        <![CDATA[
+    // ^ - meta.tag - punctuation - source
+    //  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+    //  ^^^ punctuation.definition.tag.begin.html
+    //     ^^^^^ keyword.declaration.cdata.html
+    //          ^ punctuation.definition.tag.begin.html
+            h1 {}
+    //     ^^^^^^^ meta.tag.sgml.cdata.html source.css.embedded.html
+        ]]>
+    // ^ meta.tag.sgml.cdata.html source.css.embedded.html
+    //  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    //     ^ - meta.tag - punctuation - source
+    </style>
+
 </head>
 <body>
 


### PR DESCRIPTION
XHTML supports wrapping script and style content into `<![CDATA[ ... ]]>` tags.

Found at https://github.com/liuchuo/JSP/blob/master/apache-tomcat-8.5.14/webapps/examples/websocket/echo.xhtml