### PR TITLE
[Python] Fix keyword highlighting after expressions

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -824,6 +824,8 @@ contexts:
           scope: punctuation.separator.slice.python
         - include: expression-in-a-group
     # indirect function call following attribute access
+    - match: (?={{illegal_names}})
+      pop: true
     - include: function-calls
     # arbitrary attribute access
     - match: '\s*(\.)'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -590,6 +590,15 @@ myobj.method().attribute
 #    ^ punctuation.accessor.dot
 #      ^^^^^ variable.function
 
+'foo'.and()
+#    ^^^^^^ meta.function-call
+#    ^ punctuation.accessor.dot
+#     ^^^ invalid.illegal.name.python
+
+'foo'and()
+#    ^^^ keyword.operator.logical.python
+#       ^^ meta.sequence.tuple.empty.python
+
 func()(1, 2)
 # <- meta.function-call
 #^^^^^^^^^^^ meta.function-call
@@ -1723,6 +1732,11 @@ mytuple = ("this", 'is', 4, tuple)
 also_a_tuple = ()[-1]
 #              ^^ meta.sequence.tuple.empty.python
 #                ^^^^ meta.item-access
+
+tuple_expression = ()and()
+#                  ^^ meta.sequence.tuple.empty.python
+#                    ^^^ keyword.operator.logical.python
+#                       ^^ meta.sequence.tuple.empty.python
 
 not_a_tuple = (a = 2, b += 3)
 #             ^^^^^^^^^^^^^^^ meta.sequence


### PR DESCRIPTION
Fixes #3160

This commit prevents reserved words from being highlighted as functions after expressions such as tuples, lists, ... .