### PR TITLE
[Python] Fix shebang highlighting for python 3.10+

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -29,8 +29,8 @@ file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \#! .* \bpython(?:\d(?:\.\d)?)?\b                        # shebang
-  | ^ \s* \# .*? -\*- .*? \bpython(?:\d(?:\.\d)?)?\b .*? -\*-  # editorconfig
+    ^ \#! .* \bpython(?:\d(?:\.\d+)?)?\b                        # shebang
+  | ^ \s* \# .*? -\*- .*? \bpython(?:\d(?:\.\d+)?)?\b .*? -\*-  # editorconfig
   )
 
 variables:
@@ -171,7 +171,7 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: comment.line.shebang.python
     # Note: Keep sync with first_line_match!
-    - match: \bpython(?:\d(?:\.\d)?)?\b
+    - match: \bpython(?:\d(?:\.\d+)?)?\b
       scope: constant.language.shebang.python
     - match: \n
       pop: true


### PR DESCRIPTION
Fixes #3172

This commit matches python minor version parts of two digits of length.