### PR TITLE
[JavaScript] Highlight dollar sign in function parameters

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -578,6 +578,10 @@ contexts:
     - include: else-pop
 
   function-parameter-binding-name:
+    - match: '{{dollar_identifier}}'
+      scope: meta.binding.name.js variable.parameter.function.js
+      captures:
+        1: punctuation.dollar.js
     - match: '{{non_reserved_identifier}}'
       scope: meta.binding.name.js variable.parameter.function.js
     - match: '{{identifier_name}}'

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -102,6 +102,18 @@ function f ([ x, [a, b], z]) {}
 //                ^ meta.binding.name variable.parameter.function
 //                   ^ meta.binding.name variable.parameter.function
 
+function f ([ $x, [$a, $b], $z]) {}
+//          ^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
+//            ^ meta.binding.name variable.parameter.function punctuation.dollar
+//             ^ meta.binding.name variable.parameter.function - punctuation.dollar
+//                ^^^^^^^^ meta.binding.destructuring.sequence meta.binding.destructuring.sequence
+//                 ^ meta.binding.name variable.parameter.function punctuation.dollar
+//                  ^ meta.binding.name variable.parameter.function - punctuation.dollar
+//                     ^ meta.binding.name variable.parameter.function punctuation.dollar
+//                      ^ meta.binding.name variable.parameter.function - punctuation.dollar
+//                          ^ meta.binding.name variable.parameter.function punctuation.dollar
+//                           ^ meta.binding.name variable.parameter.function - punctuation.dollar
+
 function f ([ x = 42, y = [a, b, c] ]) {}
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.destructuring.sequence
 //              ^ keyword.operator.assignment
@@ -136,6 +148,13 @@ function f (a, ...rest) {}
 //          ^ meta.binding.name variable.parameter.function
 //             ^^^ keyword.operator.spread
 //                ^^^^ variable.parameter.function
+
+function f ($a, ...$rest) {}
+//          ^ meta.binding.name variable.parameter.function punctuation.dollar
+//           ^ meta.binding.name variable.parameter.function - punctuation.dollar
+//              ^^^ keyword.operator.spread
+//                 ^ meta.binding.name variable.parameter.function punctuation.dollar
+//                  ^^^^ meta.binding.name variable.parameter.function - punctuation.dollar
 
 function f (new) {}
 // ^^^^^^^^^^^^^^^^ meta.function


### PR DESCRIPTION
This commit adds `dollar_identifier` to function parameter names to scope the leading `$` as `punctuation` the same way as for variables.

If the dollar is scoped punctuation, it should be everywhere.