### PR TITLE
[HTML] Add syntax highlighting support for JSON scripts

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,6 +43,9 @@ variables:
       | text/livescript
     )
 
+  # https://mimesniff.spec.whatwg.org/#json-mime-type
+  json_mime_type: (?i:application/|text/|.+\+)json
+
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining
   # correct boundaries of embedded source scopes. That's required to enable
@@ -318,7 +321,7 @@ contexts:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?=(?i:application/json{{unquoted_attribute_break}}|'application/json'|"application/json"))
+    - match: (?={{json_mime_type}}{{unquoted_attribute_break}}|'{{json_mime_type}}'|"{{json_mime_type}}")
       set:
         - script-json
         - tag-generic-attribute-meta

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -233,6 +233,40 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json:
+    - meta_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set: script-json-content
+
+  script-json-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json
+      embed_scope: meta.tag.sgml.cdata.html source.json.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   script-html:
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
@@ -282,6 +316,11 @@ contexts:
     - match: (?=>|''|"")
       set:
         - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=(?i:application/json{{unquoted_attribute_break}}|'application/json'|"application/json"))
+      set:
+        - script-json
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?=(?i:text/html{{unquoted_attribute_break}}|'text/html'|"text/html"))

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -125,6 +125,28 @@
         ##  ^^^^^^^^^^^^^^^ source.js.embedded
         </script>
 
+        <script type=application/json>
+            {
+        ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.begin.json
+                "key": "value",
+        ##      ^^^^^ source.json.embedded.html meta.mapping.key.json
+        ##             ^^^^^^^ source.json.embedded.html meta.mapping.value.json
+            }
+        ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
+        </script>
+
+        <script type="application/json">
+            <![CDATA[
+                {
+        ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.begin.json
+                    "key": "value",
+        ##          ^^^^^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.key.json
+        ##                 ^^^^^^^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.value.json
+                }
+        ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
+            ]]>
+        </script>
+
         <script type = "text/html"> <!--
         ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value
         ##      ^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -135,7 +135,7 @@
         ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
         </script>
 
-        <script type="application/json">
+        <script type="whatever+json">
             <![CDATA[
                 {
         ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.begin.json


### PR DESCRIPTION
Closes #3176

This commit adds JSON to the list of supported syntaxes between script tags.