### PR TITLE
[JavaScript] Fix bug when some class field names are not followed by a semicolon or initializer

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1834,9 +1834,9 @@ contexts:
       captures:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
-
+      pop: true
     - match: (?=\[)
-      push: computed-property-name
+      set: computed-property-name
 
     - include: else-pop
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1719,9 +1719,7 @@ contexts:
         - object-property-name
 
   object-property-name:
-    - match: (?=\[)
-      set: computed-property-name
-
+    - include: computed-property-name
     - include: literal-string
     - include: literal-number
 
@@ -1790,8 +1788,7 @@ contexts:
           pop: true
         - include: string-content
 
-    - match: (?=\[)
-      push: computed-property-name
+    - include: computed-property-name
 
     - include: else-pop
 
@@ -1803,6 +1800,11 @@ contexts:
       pop: true
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
+      pop: true
+    - match: (#)({{identifier_name}})
+      captures:
+        1: punctuation.definition.variable.js
+        2: variable.other.readwrite.js
       pop: true
     - match: "'"
       scope: punctuation.definition.string.begin.js
@@ -1830,13 +1832,8 @@ contexts:
           scope: invalid.illegal.newline.js
           pop: true
         - include: string-content
-    - match: (#)({{identifier_name}})
-      captures:
-        1: punctuation.definition.variable.js
-        2: variable.other.readwrite.js
-      pop: true
-    - match: (?=\[)
-      set: computed-property-name
+
+    - include: computed-property-name
 
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_js_class.js
+++ b/JavaScript/tests/syntax_test_js_class.js
@@ -31,11 +31,19 @@ class MyClass extends TheirClass {
 //      ^ keyword.operator.assignment
 //        ^^ constant.numeric
 
+    [w]
+    get other() {}
+//  ^^^ storage.type.accessor.js
+
     #v = 42;
 //  ^ punctuation.definition.variable
 //   ^ variable.other.readwrite
 //     ^ keyword.operator.assignment
 //       ^^ constant.numeric
+
+    #u
+    get other() {}
+//  ^^^ storage.type.accessor.js
 
     f = a => b;
 //  ^ entity.name.function variable.other.readwrite


### PR DESCRIPTION
Reported by Mitranim on Discord.

Private and computed field names were not popping the `field-name` context, so if the next token were an identifier, it would highlight wrong. (Class fields are usually followed by initializers, type annotations, or semicolons, but they don't have to be.)