### PR TITLE
[JSON] Add GLTF to the list of file_extensions

### DIFF
--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -20,6 +20,7 @@ file_extensions:
   - sublime-workspace
   - ipynb
   - Pipfile.lock
+  - gltf
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
GLTF is the JSON encoding of a widely used 3D scene file format. A separate extension `glb` is used for the binary format, the GLTF format is generally only useful for debugging - and is therefore opened often in my sublime.

Thought it might be helpful for others. Though I'm not sure how exhaustive these lists are intended to be.