### PR TITLE
[HTML] Make matching of doctype for indentation case-insensitive

### DIFF
--- a/HTML/Indentation Rules.tmPreferences
+++ b/HTML/Indentation Rules.tmPreferences
@@ -26,9 +26,9 @@
 			^.* (
 				# a valid non-self-closing HTML tag that doesn't close itself on the same line
 				<(?!
-					  !--      # no comment
-					| [?%]     # no preprocessor section like PHP/ASP
-					| !DOCTYPE # no document type
+					  !--           # no comment
+					| [?%]          # no preprocessor section like PHP/ASP
+					| (?i:!doctype) # no document type
 					| (?i:area|base|br|col|frame|hr|html|img|input|link|meta|param)[\t\n\f /<>]
 				)(?:
 					# tag name
@@ -49,7 +49,7 @@
 			)
 		]]></string>
 		<key>bracketIndentNextLinePattern</key>
-		<string><![CDATA[<!DOCTYPE(?!.*>)]]></string>
+		<string><![CDATA[<(?i:!doctype)(?!.*>)]]></string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
If the `!doctype` tag isn't upper-case, it isn't recognised, and the following lines are indented. My changes make matching of doctype case-insensitive so it shall be recognised even if it isn't upper-case.