### PR TITLE
[Matlab] Exclude strings from transpose operator keybinding

### DIFF
--- a/Matlab/Default.sublime-keymap
+++ b/Matlab/Default.sublime-keymap
@@ -2,7 +2,7 @@
     // Disable auto-pair for single quote when used as transpose operator
     { "keys": ["'"], "command": "insert", "args": {"characters": "'"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.matlab" },
+            { "key": "selector", "operator": "equal", "operand": "source.matlab - punctuation.definition.string.end" },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "[])}.]$", "match_all": true }
         ]


### PR DESCRIPTION
The keybinding recently added to disable auto-pairing of the single quote, when used as transpose operator (after one of the characters `])}.`) inadvertently disabled the default keybinding to step over the closing punctuation of a string, if the string ends with one of these characters.

This commit excludes the string punctuation scope from the keybinding to fix it.