### PR TITLE
[Javascript] Extra space for block comments

### DIFF
--- a/JavaScript/Comments.tmPreferences
+++ b/JavaScript/Comments.tmPreferences
@@ -17,13 +17,13 @@
 				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
-				<string>/*</string>
+				<string>/* </string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END_2</string>
 				<key>value</key>
-				<string>*/</string>
+				<string> */</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
Add spaces around block comments, to match style for single-line comments. Understand this might be an individual preference, but when using for 'inline' comments such as `const { destructure, /* notUsed */ } = thing`, it's much more readable. For multi-line comments, I always use non-block (`// `) which already has a space.

Adding as an option would be ideal, but beyond me I'm afraid :), so I could define it as:
```
  { "keys": ["ctrl+f2"], "command": "toggle_comment", "args": { "block": true, "space": true } },
```

If you can point me where to look to add such an option, I'm happy to give it a go...