### PR TITLE
[PHP] Support `readonly` with constructor property promotion

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -820,7 +820,7 @@ contexts:
                   scope: punctuation.section.group.begin.php
                   set:
                     - meta_scope: meta.function.parameters.php meta.group.php
-                    - match: '{{visibility_modifier}}'
+                    - match: '(?i){{visibility_modifier}}|\b(?:readonly)\b'
                       scope: storage.modifier.php
                     - include: function-parameters
             # Exit on unexpected content

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -820,7 +820,7 @@ contexts:
                   scope: punctuation.section.group.begin.php
                   set:
                     - meta_scope: meta.function.parameters.php meta.group.php
-                    - match: '(?i){{visibility_modifier}}|\b(?:readonly)\b'
+                    - match: '(?i){{visibility_modifier}}|\breadonly\b'
                       scope: storage.modifier.php
                     - include: function-parameters
             # Exit on unexpected content

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2151,6 +2151,14 @@ class D {
     }
 }
 
+class E {
+    public function __construct(
+        public readonly int $val = 1
+//      ^^^^^^ storage.modifier
+//             ^^^^^^^^ storage.modifier
+    ) {}
+}
+
 var_dump(new C(42));
 //           ^ meta.path support.class
 


### PR DESCRIPTION
This PR adds support for using the `readonly` keyword inside constructor-promoted properties.

This is valid PHP code:

```php
class Bar
{
    public function __construct(
        public readonly string $foo,
    ) {}
}
```

But Sublime currently doesn't scope that `readonly` correctly:

<img width="334" alt="image" src="https://user-images.githubusercontent.com/18192441/150621477-66a2b34b-df7b-4f90-9add-754f294d046d.png">