### PR TITLE
[JavaScript] Improve Indentation Rules

### DIFF
--- a/JavaScript/Indentation Rules - Comments.tmPreferences
+++ b/JavaScript/Indentation Rules - Comments.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string><![CDATA[(source.js | source.ts | source.jsx | source.tsx) & comment.block]]></string>
+	<key>settings</key>
+	<dict>
+		<key>unIndentedLinePattern</key>
+		<string>.</string>
+	</dict>
+</dict>
+</plist>

--- a/JavaScript/Indentation Rules.tmPreferences
+++ b/JavaScript/Indentation Rules.tmPreferences
@@ -6,14 +6,87 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^(.*\*/)?\s*\}.*$</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? \s*
+			(?:
+			# dedent closing braces
+			  \}
+			# detent `case ... :`
+			| case\b
+			# detent `default:`
+			| default\b
+			)
+		]]></string>
+
 		<key>increaseIndentPattern</key>
-		<string>^.*\{[^}"']*$</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? \s*
+			(?:
+			# indent after opening braces (may be followed by whitespace or comments)
+			# but exclude lines such as `extern "C" {`
+			  .* \{ (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
+			# indent after `case ... :`
+			| case\b
+			# indent after `default:`
+			| default\b
+			)
+		]]></string>
+
 		<key>bracketIndentNextLinePattern</key>
-		<string>(?x)
-		^ \s* \b(if|while|else)\b [^;]* $
-		| ^ \s* \b(for)\b .* $
-		</string>
+		<string><![CDATA[(?x)
+			# line beginning with whitespace or block comments
+			^ (.*\*/)? (?<comment_or_whitespace> (?: \s* (?<block_comment> /\*.*\*/ ) )* \s* )
+			(?:
+			# indent after:
+			# - `else`
+			  else
+			# indent after:
+			# - `else if (...)`
+			# - `if (...)`
+			# - `for (...)`
+			# - `while (...)`
+			| (?: (?: else \g<comment_or_whitespace> )? if | for | while )
+			  # followed by whitespace or block comments [optional]
+			  \g<comment_or_whitespace>
+			  # top-level balanced parentheses
+			  \(
+				(?<group_body> (?:
+				# nested balanced parentheses
+				  \( \g<group_body> \)
+				# double quoted string with ignored escaped quotation marks
+				| \".*(?<![^\\]\\)(?<![\\]{3})\"
+				# single quoted character with ignored escaped quotation marks
+				| \'.*(?<![^\\]\\)\'
+				# block comment
+				| \g<block_comment>
+				# anything but closing parenthesis
+				| [^)]
+				)* )
+			  # maybe missing, balanced or stray closing parenthesis
+			  \)*
+			)
+			# followed by whitespace or block comments [optional]
+			\g<comment_or_whitespace>
+			# followed by line comment [optional]
+			(?: //.* )? $
+		]]></string>
+
+		<key>unIndentedLinePattern</key>
+		<string><![CDATA[(?x)
+			^\s*
+			(?:
+			# standalone begin or end of block comments
+			#   ST doesn't apply `Indentation Rules - Comments`, because
+			#   comment scope doesn't cover the whole line. So they need
+			#   to be excluded from indentation engine here.
+			  // | /\*(?!.*\*/) | .*\*/
+			)
+		]]></string>
+
+		<key>indentSquareBrackets</key>
+		<true/>
 	</dict>
 </dict>
 </plist>

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -1,0 +1,968 @@
+// SYNTAX TEST reindent-unchanged "Packages/JavaScript/JavaScript.sublime-syntax"
+
+/**
+ * This is my first JavaScript program.
+ * This will print 'Hello World' as the output
+ **/
+
+function testIfElseIndentationNoBraces(v)
+{
+    /**
+     * comment
+     */
+    if (v.isNull() == true) return
+
+    if (v.isNull() == true) return fun(v)
+
+    if (v.isNull() == true) return fun(v);
+
+    if (v.isNull() == true)
+        return false;
+
+    if (v.isNull() == true)
+        return false;
+    else
+    {
+        if (v.endsWith("("))
+            return false;
+        else if (v.endsWith(")"))
+            return true;
+        else if (v.endsWith("\""))
+            return true;
+        else if (v.endsWith("\\"))
+            return true;
+        else if (v.endsWith('('))
+            return false;
+        else if (v.endsWith(')'))
+            return true;
+        else if (v.endsWith('\''))
+            return true;
+        else if (v.endsWith('\\'))
+            return true;
+        else
+            return false;
+
+        if (v.endsWith("baz"))
+            return false;
+        return true;
+    }
+}
+
+function testIfElseIndentationNoBracesWithLineComments(v)
+{
+    /**
+     * comment
+     */
+
+    // line comment
+    if (v.isNull() == true) return
+
+    // line comment
+    if (v.isNull() == true) return fun(v)
+
+    // line comment
+    if (v.isNull() == true) return fun(v);
+
+    // line comment
+    if (v.isNull() == true)
+        // line comment
+        return false;
+
+    // line comment
+    if (v.isNull() == true)
+        // line comment
+        return false;
+    // line comment
+    else
+    // line comment
+    {
+        // line comment
+        if (v.endsWith("("))
+            // line comment
+            return false;
+        // line comment
+        else if (v.endsWith(")"))
+            // line comment
+            return true;
+        // line comment
+        else if (v.endsWith("\""))
+            // line comment
+            return true;
+        // line comment
+        else if (v.endsWith("\\"))
+            // line comment
+            return true;
+        // line comment
+        else if (v.endsWith('('))
+            // line comment
+            return false;
+        // line comment
+        else if (v.endsWith(')'))
+            // line comment
+            return true;
+        // line comment
+        else if (v.endsWith('\''))
+            // line comment
+            return true;
+        // line comment
+        else if (v.endsWith('\\'))
+            // line comment
+            return true;
+        // line comment
+        else
+            // line comment
+            return false;
+
+        // line comment
+        if (v.endsWith("baz"))
+            // line comment
+            return false;
+        // line comment
+        return true;
+    }
+}
+
+function testIfElseIndentationNoBracesButComments(v)
+{
+    if (v.isNull() == true) return         /**/ // ; "comment" ()
+
+    if (v.isNull() == true) return fun(v)  /**/ // ; "comment" ()
+
+    if (v.isNull() == true) return fun(v); /**/ // ; "comment" ()
+
+    if (v.isNull() == true)                /**/ // ; "comment" ()
+        return false;                      /**/ // ; "comment" ()
+
+    if (v.isNull() == true)                /**/ // ; "comment" ()
+        return false;                      /**/ // ; "comment" ()
+    else                                   /**/ // ; "comment" ()
+    {                                      /**/ // ; "comment" ()
+        if (v.endsWith("("))               /**/ // ; "comment" ()
+            return false;                  /**/ // ; "comment" ()
+        else if (v.endsWith(")"))          /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else if (v.endsWith("\""))         /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else if (v.endsWith("\\"))         /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else if (v.endsWith('('))          /**/ // ; "comment" ()
+            return false;                  /**/ // ; "comment" ()
+        else if (v.endsWith(')'))          /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else if (v.endsWith('\''))         /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else if (v.endsWith('\\'))         /**/ // ; "comment" ()
+            return true;                   /**/ // ; "comment" ()
+        else                               /**/ // ; "comment" ()
+            return false;                  /**/ // ; "comment" ()
+    }                                      /**/ // ; "comment" ()
+}
+
+function testIfElseIndentationNoBracesButBlockCommentsPart1(v)
+{
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ true /*(*/ ) /*(*/ return /*(*/ // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ true /*(*/ ) /*(*/ return /*(*/ fun /*(*/ ( /*(*/ ) /*(*/ // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ true /*(*/ ) /*(*/ return /*(*/ fun /*(*/ ( /*(*/ ) /*(*/ ; // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ true /*(*/ ) /*(*/  // ; "comment" ()
+        return false; /*(*/  // ; "comment" ()
+
+    /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ isNull( /*(*/ ) /*(*/ == /*(*/ true /*(*/ ) /*(*/ // ; "comment" ()
+        return false; /*(*/ // ; "comment" ()
+    else /*(*/ // ; "comment" ()
+    { /*(*/ // ; "comment" ()
+        /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "(") /*(*/ ) /*(*/ // ; "comment" ()
+            return false; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ ")") /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "\"") /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ "\\") /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '(') /*(*/ ) /*(*/ // ; "comment" ()
+            return false; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ ')') /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '\'') /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ if /*(*/ ( /*(*/ v /*(*/ . /*(*/ endsWith /*(*/ ( /*(*/ '\\') /*(*/ ) /*(*/ // ; "comment" ()
+            return true; /*(*/ // ; "comment" ()
+        else /*(*/ // ; "comment" ()
+            return false; /*(*/ // ; "comment" ()
+    } /*(*/ // ; "comment" ()
+}
+
+function testIfElseIndentationNoBracesButBlockCommentsPart2(v)
+{
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ true /*)*/ ) /*)*/ return /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ true /*)*/ ) /*)*/ return /*)*/ fun /*)*/ ( /*)*/ ) /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ true /*)*/ ) /*)*/ return /*)*/ fun /*)*/ ( /*)*/ ) /*)*/ ; // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ true /*)*/ ) /*)*/ // ; "comment" ()
+        return false; /*)*/ // ; "comment" ()
+
+    /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ isNull( /*)*/ ) /*)*/ == /*)*/ true /*)*/ ) /*)*/ // ; "comment" ()
+        return false; /*)*/ // ; "comment" ()
+    else /*)*/ // ; "comment" ()
+    { /*)*/ // ; "comment" ()
+        /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "(") /*)*/ ) /*)*/ // ; "comment" ()
+            return false; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ ")") /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "\"") /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ "\\") /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '(') /*)*/ ) /*)*/ // ; "comment" ()
+            return false; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ ')') /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '\'') /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ if /*)*/ ( /*)*/ v /*)*/ . /*)*/ endsWith /*)*/ ( /*)*/ '\\') /*)*/ ) /*)*/ // ; "comment" ()
+            return true; /*)*/ // ; "comment" ()
+        else /*)*/ // ; "comment" ()
+            return false; /*)*/ // ; "comment" ()
+    } /*)*/ // ; "comment" ()
+}
+
+function testIfElseIndentationWithBraces(v) {
+
+    if (v.isNull() == true) { return }
+
+    if (v.isNull() == true) { return fun(v) }
+
+    if (v.isNull() == true) { return fun(v); }
+
+    if (v.isNull() == true) {
+        return false;
+    }
+
+    if (v.isNull() == true) {
+        return false;
+    } else {
+        if (v.endsWith("(")) {
+            return false;
+        } else if (v.endsWith(")")) {
+            return true;
+        } else if (v.endsWith("\"")) {
+            return true;
+        } else if (v.endsWith("\\")) {
+            return true;
+        } else if (v.endsWith('(')) {
+            return false;
+        } else if (v.endsWith(')')) {
+            return true;
+        } else if (v.endsWith('\'')) {
+            return true;
+        } else if (v.endsWith('\\')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    if (v.isNull() == true)
+    {
+        return
+    }
+    if (v.isNull() == true)
+    {
+        return false
+    }
+    if (v.isNull() == true)
+    {
+        return false;
+    }
+
+    if (v.isNull() == true)
+    {
+        return false;
+    }
+    else
+    {
+        if (v.endsWith("("))
+        {
+            return false;
+        }
+        else if (v.endsWith(")"))
+        {
+            return true;
+        }
+        else if (v.endsWith("\""))
+        {
+            return true;
+        }
+        else if (v.endsWith("\\"))
+        {
+            return true;
+        }
+        else if (v.endsWith('('))
+        {
+            return false;
+        }
+        else if (v.endsWith(')'))
+        {
+            return true;
+        }
+        else if (v.endsWith('\''))
+        {
+            return true;
+        }
+        else if (v.endsWith('\\'))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}
+
+function testIfElseIndentationWithBracesAndLineComments(v) {
+
+    // comment
+    if (v.isNull() == true) { return }
+
+    // comment
+    if (v.isNull() == true) { return fun(v) }
+
+    // comment
+    if (v.isNull() == true) { return fun(v); }
+
+    // comment
+    if (v.isNull() == true) {
+        // comment
+        return false;
+    }
+
+    // comment
+    if (v.isNull() == true) {
+        // comment
+        return false;
+    } else {
+        // comment
+        if (v.endsWith("(")) {
+            // comment
+            return false;
+        // comment
+        } else if (v.endsWith(")")) {
+            // comment
+            return true;
+        // comment
+        } else if (v.endsWith("\"")) {
+            // comment
+            return true;
+        // comment
+        } else if (v.endsWith("\\")) {
+            // comment
+            return true;
+        // comment
+        } else if (v.endsWith('(')) {
+            // comment
+            return false;
+        // comment
+        } else if (v.endsWith(')')) {
+            // comment
+            return true;
+        // comment
+        } else if (v.endsWith('\'')) {
+            // comment
+            return true;
+        // comment
+        } else if (v.endsWith('\\')) {
+            // comment
+            return true;
+        // comment
+        } else {
+            // comment
+            return false;
+        }
+    }
+
+    // comment
+    if (v.isNull() == true)
+    {
+        // comment
+        return
+    }
+    // comment
+    if (v.isNull() == true)
+    {
+        // comment
+        return false
+    }
+    // comment
+    if (v.isNull() == true)
+    {
+        // comment
+        return false;
+    }
+
+    // comment
+    if (v.isNull() == true)
+    {
+        // comment
+        return false;
+    }
+    // comment
+    else
+    {
+        // comment
+        if (v.endsWith("("))
+        {
+            // comment
+            return false;
+        }
+        // comment
+        else if (v.endsWith(")"))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else if (v.endsWith("\""))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else if (v.endsWith("\\"))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else if (v.endsWith('('))
+        {
+            // comment
+            return false;
+        }
+        // comment
+        else if (v.endsWith(')'))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else if (v.endsWith('\''))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else if (v.endsWith('\\'))
+        {
+            // comment
+            return true;
+        }
+        // comment
+        else
+        {
+            // comment
+            return false;
+        }
+    }
+}
+
+function testIfElseIndentationWithBracesAndComment(v) {
+
+    if (v.isNull() == true) { return }            /**/ // ; "comment" ()
+
+    if (v.isNull() == true) { return fun(v) }     /**/ // ; "comment" ()
+
+    if (v.isNull() == true) { return fun(v); }    /**/ // ; "comment" ()
+
+    if (v.isNull() == true) {                     /**/ // ; "comment" ()
+        return false;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == true) {                     /**/ // ; "comment" ()
+        return false;                             /**/ // ; "comment" ()
+    } else {                                      /**/ // ; "comment" ()
+        if (v.endsWith("(")) {                    /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        } else if (v.endsWith(")")) {             /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else if (v.endsWith("\"")) {            /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else if (v.endsWith("\\")) {            /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('(')) {             /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        } else if (v.endsWith(')')) {             /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('\'')) {            /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else if (v.endsWith('\\')) {            /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        } else {                                  /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == true)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return                                    /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    if (v.isNull() == true)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return false                              /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    if (v.isNull() == true)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return false;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+
+    if (v.isNull() == true)                       /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        return false;                             /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+    else                                          /**/ // ; "comment" ()
+    {                                             /**/ // ; "comment" ()
+        if (v.endsWith("("))                      /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith(")"))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith("\""))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith("\\"))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('('))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith(')'))                 /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('\''))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else if (v.endsWith('\\'))                /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return true;                          /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+        else                                      /**/ // ; "comment" ()
+        {                                         /**/ // ; "comment" ()
+            return false;                         /**/ // ; "comment" ()
+        }                                         /**/ // ; "comment" ()
+    }                                             /**/ // ; "comment" ()
+}
+
+function testSwitchCaseIndentation(v) {
+    switch (s) {
+    case
+    case:
+    case break
+    case: break
+    case "(": break
+    case ")": break;
+    case ":": break;
+    case ";": break;
+    case
+        break;
+    case:
+        break;
+    case ":"
+        break;
+    case ':':
+        break;
+    case NestedIfStatement:
+        if (s.endsWith() = '(')
+            return;
+        break;
+    case NestedSwitchCase:
+        switch (v) {
+        case 0: break;
+        case 2:
+            break;
+        }
+        break;
+    case NestedSwitchCaseBlock:
+        {
+            switch (v) {
+            case 0: break;
+            case 2:
+                break;
+            }
+            break;
+        }
+    case NestedSwitchCaseBlock2:
+        {
+            switch (v) {
+            case 0: break;
+            case 2:
+                break;
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+function testSwitchCaseIndentationWithLineComments(v) {
+    switch (s) {                 // comments
+    case                         // comments
+    case:                        // comments
+    case break                   // comments
+    case: break                  // comments
+    case "(": break              // comments
+    case ")": break;             // comments
+    case ":": break;             // comments
+    case ";": break;             // comments
+    case                         // comments
+        break;                   // comments
+    case:                        // comments
+        break;                   // comments
+    case ":"                     // comments
+        break;                   // comments
+    case ':':                    // comments
+        break;                   // comments
+    case NestedIfStatement:      // comments
+        if (s.endsWith() = '(')  // comments
+            return;              // comments
+        break;                   // comments
+    case NestedSwitchCase:       // comments
+        switch (v) {             // comments
+        case 0: break;           // comments
+        case 2:                  // comments
+            break;               // comments
+        }                        // comments
+        break;                   // comments
+    case NestedSwitchCaseBlock:  // comments
+        {                        // comments
+            switch (v) {         // comments
+            case 0: break;       // comments
+            case 2:              // comments
+                break;           // comments
+            }                    // comments
+            break;               // comments
+        }                        // comments
+    case NestedSwitchCaseBlock2: // comments
+        {                        // comments
+            switch (v) {         // comments
+            case 0: break;       // comments
+            case 2:              // comments
+                break;           // comments
+            }                    // comments
+        }                        // comments
+        break;                   // comments
+    default:                     // comments
+        break;                   // comments
+    }                            // comments
+}                                // comments
+
+function testForIndentation(int  {
+
+    for (int i = 0; i < 10; i++)
+        System.out.println("Row " + i);
+
+    for (int i = 0; i < 10; i++) {
+        System.out.println("Row " + i);
+    }
+
+    for (int i = 0; i < 10; i++)
+    {
+        System.out.println("Row " + i);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++)
+            System.out.println("Row " + i + " Col " + j);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++) {
+            System.out.println("Row " + i + " Col " + j);
+        }
+    }
+}
+
+function testWhileIndentationNoBraces(int  {
+    while () v++
+    while () v++;
+    while (()) v++
+    while ((())) v++
+    while ((())()) v++
+    while ()
+        v++
+    while (v == '(')
+        v++
+    while (v == ')')
+        v++
+    while (v == '\'')
+        v++
+    while (v == '\\')
+        v++
+    while (v == "(")
+        v++
+    while (v == ")")
+        v++
+    while (v == "\"")
+        v++
+    while (v == "\\\"")
+        v++
+    while (v == foo( bar("") + "" ))
+        v++
+}
+
+function testWhileIndentationNoBracesButComments(int  {
+    while () v++                      // ; "comment" ()
+    while () v++;                     // ; "comment" ()
+    while (()) v++                    // ; "comment" ()
+    while ((())) v++                  // ; "comment" ()
+    while ((())()) v++                // ; "comment" ()
+    while ()                          // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '(')                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == ')')                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '\'')                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == '\\')                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "(")                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == ")")                  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "\"")                 // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == "\\\"")               // ; "comment" ()
+        v++                           // ; "comment" ()
+    while (v == foo( bar("") + "" ))  // ; "comment" ()
+        v++                           // ; "comment" ()
+    while () { } // a hack to make tests succeed
+}
+
+function testWhileIndentationNoBracesButBlockCommentsPart1(int  {
+    while /*(*/ () v++ /*(*/ // ; "comment" ()
+    while /*(*/ () v++; /*(*/ // ; "comment" ()
+    while /*(*/ (()) v++ /*(*/ // ; "comment" ()
+    while /*(*/ ((())) v++ /*(*/ // ; "comment" ()
+    while /*(*/ ((()/*(*/)/*(*/()) v++ /*(*/ // ; "comment" ()
+    while /*(*/ () /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '(' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ ')' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '\'' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ '\\' /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "(" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ ")" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "\"" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ "\\\"" /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ ( /*(*/ v /*(*/ == /*(*/ foo( /*(*/ bar( /*(*/ "/*(*/" /*(*/ ) /*(*/ + /*(*/ "" /*(*/ ) /*(*/ ) /*(*/ // ; "comment" ()
+        v++ /*(*/ // ; "comment" ()
+    while /*(*/ () { } // a hack to make tests succeed
+}
+
+function testWhileIndentationNoBracesButBlockCommentsPart2(int  {
+    while /*)*/ () v++ /*)*/ // ; "comment" ()
+    while /*)*/ () v++; /*)*/ // ; "comment" ()
+    while /*)*/ (()) v++ /*)*/ // ; "comment" ()
+    while /*)*/ ((())) v++ /*)*/ // ; "comment" ()
+    while /*)*/ ((()/*)*/)/*)*/()) v++ /*)*/ // ; "comment" ()
+    while /*)*/ () /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '(' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ ')' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '\'' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ '\\' /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "(" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ ")" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "\"" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ "\\\"" /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ ( /*)*/ v /*)*/ == /*)*/ foo( /*)*/ bar( /*)*/ "/*)*/" /*)*/ ) /*)*/ + /*)*/ "" /*)*/ ) /*)*/ ) /*)*/ // ; "comment" ()
+        v++ /*)*/ // ; "comment" ()
+    while /*)*/ () { } // a hack to make tests succeed
+}
+
+function testWhileIndentationWithBraces(int  {
+
+    while () { v++ }
+    while () { v++; }
+    while (()) { v++ }
+    while ((())) { v++ }
+    while ((())()) { v++ }
+    while () {
+        v++
+    }
+    while (v == '(') {
+        v++
+    }
+    while (v == ')') {
+        v++
+    }
+    while (v == '\'') {
+        v++
+    }
+    while (v == '\\') {
+        v++
+    }
+    while (v == "(") {
+        v++
+    }
+    while (v == ")") {
+        v++
+    }
+    while (v == "\"") {
+        v++
+    }
+    while (v == "\\\"") {
+        v++
+    }
+    while (v == foo( bar("") + "" )) {
+        v++
+    }
+    while ()
+    {
+        v++
+    }
+    while (v == '(')
+    {
+        v++
+    }
+    while (v == ')')
+    {
+        v++
+    }
+    while (v == '\'')
+    {
+        v++
+    }
+    while (v == '\\')
+    {
+        v++
+    }
+    while (v == "(")
+    {
+        v++
+    }
+    while (v == ")")
+    {
+        v++
+    }
+    while (v == "\"")
+    {
+        v++
+    }
+    while (v == "\\\"")
+    {
+        v++
+    }
+    while (v == foo( bar("") + "" ))
+    {
+        v++
+    }
+}
+
+function testWhileIndentationWithBracesAndComments(int  {
+
+    while () { v++ }                    // ;  "comments" ()
+    while () { v++; }                   // ;  "comments" ()
+    while (()) { v++ }                  // ;  "comments" ()
+    while ((())) { v++ }                // ;  "comments" ()
+    while ((())()) { v++ }              // ;  "comments" ()
+    while () {                          // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '(') {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ')') {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\'') {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\\') {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "(") {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ")") {                  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\"") {                 // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\\\"") {               // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == foo( bar("") + "" )) {  // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while ()                            // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '(')                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ')')                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\'')                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == '\\')                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "(")                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == ")")                    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\"")                   // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == "\\\"")                 // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (v == foo( bar("") + "" ))    // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+}


### PR DESCRIPTION
Fixes #3212

This commit copies indentation rules from Java (also added to C/C++ via #3148).

It improves behavior related to comments and one-liner statements such as:

    if (foo) return bar

It can't solve all problems, but may help to improve some of the known issues.