### PR TITLE
[C/C++/ObjC/ObjC++] Improve comments punctuation

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -278,21 +278,7 @@ contexts:
     - include: keywords-angle-brackets
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
-    # Take care of comments just before a function definition.
-    - match: /\*
-      scope: punctuation.definition.comment.c
-      push:
-        - - match: \s*(?=\w)
-            set: global-modifier
-          - match: ""
-            pop: true
-        - - meta_scope: comment.block.c
-          - match: \*/
-            scope: punctuation.definition.comment.c
-            pop: true
-          - match: ^\s*(\*)(?!/)
-            captures:
-              1: punctuation.definition.comment.c
+    - include: global-block-comments
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.c++
@@ -323,6 +309,38 @@ contexts:
     - match: ^\s*(?=\w)
       push: global-modifier
     - include: late-expressions
+
+  global-block-comments:
+    # NOTE: This context overrides `comments` context, which re-uses scopes
+    # from `source.c#comments`. So keep the trailing `c` for consistency reasons!
+    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+      scope: comment.block.banner.c
+      captures:
+        1: punctuation.definition.comment.begin.c
+        2: meta.toc-list.banner.block.c
+        3: punctuation.definition.comment.end.c
+    # empty block comments
+    - match: /\*\*+/
+      scope: comment.block.empty.c punctuation.definition.comment.c
+      push: global-block-comment-after
+    # documentation block comments
+    - match: (?:/\*!|/\*{2,})
+      scope: punctuation.definition.comment.begin.c
+      push:
+        - global-block-comment-after
+        - scope:source.c#block-comment-documentation-body
+    # normal block comments
+    - match: /\*
+      scope: punctuation.definition.comment.begin.c
+      push:
+        - global-block-comment-after
+        - scope:source.c#block-comment-body
+
+  global-block-comment-after:
+    - match: \s*(?=\w)
+      set: global-modifier
+    - match: ''
+      pop: true
 
   statements:
     - include: preprocessor-statements

--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -317,7 +317,7 @@ contexts:
   global-block-comments:
     # NOTE: This context overrides `comments` context, which re-uses scopes
     # from `source.c#comments`. So keep the trailing `c` for consistency reasons!
-    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+    - match: ^(/\*) =\s*(.*?)\s*= (\*/)$\n?
       scope: comment.block.banner.c
       captures:
         1: punctuation.definition.comment.begin.c

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -69,7 +69,7 @@ contexts:
     - include: line-comments
 
   block-comments:
-    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+    - match: ^(/\*) =\s*(.*?)\s*= (\*/)$\n?
       scope: comment.block.banner.c
       captures:
         1: punctuation.definition.comment.begin.c
@@ -108,7 +108,7 @@ contexts:
       pop: true
 
   line-comments:
-    - match: ^(//) =(\s*.*?)\s*=\s*$\n?
+    - match: ^(//) =\s*(.*?)\s*=\s*$\n?
       scope: comment.line.banner.c
       captures:
         1: punctuation.definition.comment.c

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -65,35 +65,76 @@ contexts:
   #############################################################################
 
   comments:
-    - match: ^/\* =(\s*.*?)\s*= \*/$\n?
-      scope: comment.block.c
+    - include: block-comments
+    - include: line-comments
+
+  block-comments:
+    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+      scope: comment.block.banner.c
       captures:
-        1: meta.toc-list.banner.block.c
-    - match: /\*
-      scope: punctuation.definition.comment.c
-      push:
-        - meta_scope: comment.block.c
-        - match: \*/
-          scope: punctuation.definition.comment.c
-          pop: true
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.c
+        1: punctuation.definition.comment.begin.c
+        2: meta.toc-list.banner.block.c
+        3: punctuation.definition.comment.end.c
+    # empty block comments
+    - match: /\*\*+/
+      scope: comment.block.empty.c punctuation.definition.comment.c
+    # normal block comments
+    - match: /\*+
+      scope: punctuation.definition.comment.begin.c
+      push: block-comment-body
+    # stray block comment end
     - match: \*/(?!\*)
       scope: invalid.illegal.stray-comment-end.c
-    - match: ^// =(\s*.*?)\s*=\s*$\n?
+
+  block-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.c
+    - match: \*+/
+      scope: punctuation.definition.comment.end.c
+      pop: true
+    - match: ^\s*(\*)(?!/)
+      captures:
+        1: punctuation.definition.comment.c
+
+  line-comments:
+    - match: ^(//) =(\s*.*?)\s*=\s*$\n?
       scope: comment.line.banner.c
       captures:
-        1: meta.toc-list.banner.line.c
-    - match: //
+        1: punctuation.definition.comment.c
+        2: meta.toc-list.banner.line.c
+    - match: (?:/{2}!|/{4,})
       scope: punctuation.definition.comment.c
-      push:
-        - meta_scope: comment.line.double-slash.c
-        - match: '(\\)$\n'
-          captures:
-            1: punctuation.separator.continuation.c
-        - match: \n
-          pop: true
+      push: line-comment-other-body
+    - match: /{3}
+      scope: punctuation.definition.comment.c
+      push: line-comment-triple-slash-body
+    - match: /{2}
+      scope: punctuation.definition.comment.c
+      push: line-comment-double-slash-body
+
+  line-comment-end:
+    - match: (//+)?\n
+      captures:
+        1: punctuation.definition.comment.c
+      pop: 1
+    - match: (\\)\n
+      captures:
+        1: punctuation.separator.continuation.c
+
+  line-comment-double-slash-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.double-slash.c
+    - include: line-comment-end
+
+  line-comment-triple-slash-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.triple-slash.c
+    - include: line-comment-end
+
+  line-comment-other-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.other.c
+    - include: line-comment-end
 
   strings:
     - match: '(L|u8|u|U)?(")'

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -113,39 +113,31 @@ contexts:
       captures:
         1: punctuation.definition.comment.c
         2: meta.toc-list.banner.line.c
-    - match: (?:/{2}!|/{4,})
+    - match: //[/!]
       scope: punctuation.definition.comment.c
-      push: line-comment-other-body
-    - match: /{3}
+      push: line-comment-documentation-body
+    - match: /{2,}
       scope: punctuation.definition.comment.c
-      push: line-comment-triple-slash-body
-    - match: /{2}
-      scope: punctuation.definition.comment.c
-      push: line-comment-double-slash-body
+      push: line-comment-body
+
+  line-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.double-slash.c
+    - include: line-comment-end
+
+  line-comment-documentation-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.documentation.c
+    - include: line-comment-end
 
   line-comment-end:
     - match: (//+)?\n
       captures:
         1: punctuation.definition.comment.c
       pop: 1
-    - match: (\\)\n
+    - match: (\\)$\n?
       captures:
         1: punctuation.separator.continuation.c
-
-  line-comment-double-slash-body:
-    - meta_include_prototype: false
-    - meta_scope: comment.line.double-slash.c
-    - include: line-comment-end
-
-  line-comment-triple-slash-body:
-    - meta_include_prototype: false
-    - meta_scope: comment.line.triple-slash.c
-    - include: line-comment-end
-
-  line-comment-other-body:
-    - meta_include_prototype: false
-    - meta_scope: comment.line.other.c
-    - include: line-comment-end
 
   strings:
     - match: '(L|u8|u|U)?(")'

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -113,10 +113,10 @@ contexts:
       captures:
         1: punctuation.definition.comment.c
         2: meta.toc-list.banner.line.c
-    - match: //[/!]
+    - match: //(?:!|/(?!/))
       scope: punctuation.definition.comment.c
       push: line-comment-documentation-body
-    - match: /{2,}
+    - match: //+
       scope: punctuation.definition.comment.c
       push: line-comment-body
 
@@ -131,7 +131,7 @@ contexts:
     - include: line-comment-end
 
   line-comment-end:
-    - match: (//+)?\n
+    - match: (?:(//+)\s*)?$\n?
       captures:
         1: punctuation.definition.comment.c
       pop: 1

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -78,23 +78,34 @@ contexts:
     # empty block comments
     - match: /\*\*+/
       scope: comment.block.empty.c punctuation.definition.comment.c
+    # documentation block comments
+    - match: (?:/\*!|/\*{2,})
+      scope: punctuation.definition.comment.begin.c
+      push: block-comment-documentation-body
     # normal block comments
-    - match: /\*+
+    - match: /\*
       scope: punctuation.definition.comment.begin.c
       push: block-comment-body
     # stray block comment end
-    - match: \*/(?!\*)
+    - match: \*+/(?!\*)
       scope: invalid.illegal.stray-comment-end.c
+
+  block-comment-documentation-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.documentation.c
+    - match: \*+/
+      scope: punctuation.definition.comment.end.c
+      pop: true
+    - match: ^\s*(\*)(?!\**/)
+      captures:
+        1: punctuation.definition.comment.c
 
   block-comment-body:
     - meta_include_prototype: false
     - meta_scope: comment.block.c
-    - match: \*+/
+    - match: \*/
       scope: punctuation.definition.comment.end.c
       pop: true
-    - match: ^\s*(\*)(?!/)
-      captures:
-        1: punctuation.definition.comment.c
 
   line-comments:
     - match: ^(//) =(\s*.*?)\s*=\s*$\n?

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -3,12 +3,6 @@
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
-/* =Banner= */
-/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
-/*^^^^^^^^^^ comment.block.banner.c - punctuation */
-/*  ^^^^^^ meta.toc-list.banner.block.c  */
-/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
-
 //! Comment
 /* <- comment.line.other.c punctuation.definition.comment.c */
  /* <- comment.line.other.c punctuation.definition.comment.c */
@@ -21,6 +15,44 @@
   /* <- comment.line.triple-slash.c punctuation.definition.comment.c */
  /*^^^^^^^^^ comment.line.triple-slash.c - punctuation */
  /*         ^^^ comment.line.triple-slash.c punctuation.definition.comment.c */
+
+
+/* =Banner= */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*  ^^^^^^ meta.toc-list.banner.block.c  */
+/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+   /*****/
+/* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */
+
+   /**
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /***
+/* ^^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!****
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c - punctuation */
+
+   /*!****/
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c punctuation.definition.comment.end.c */
+
+   /*!
+    * docstring
+    **/
+/*  ^^^ comment.block.documentation.c */
+
+    */
+/*  ^^ invalid.illegal.stray-comment-end.c */
+
+    **/
+/*  ^^^ invalid.illegal.stray-comment-end.c */
 
 int main(){
     int a=5,b=0;
@@ -295,7 +327,11 @@ struct X
 
 /**
     *
-/*  ^ comment.block.c punctuation.definition.comment.c */
+/*  ^ comment.block.documentation.c punctuation.definition.comment.c */
+
+/*
+    *
+/*  ^ comment.block.c - punctuation */
 
 /////////////////////////////////////////////
 // Preprocessor branches starting blocks

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -1,5 +1,27 @@
 /* SYNTAX TEST "Packages/C++/C.sublime-syntax" */
 
+// =Banner=
+/*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
+
+/* =Banner= */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*  ^^^^^^ meta.toc-list.banner.block.c  */
+/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+//! Comment
+/* <- comment.line.other.c punctuation.definition.comment.c */
+ /* <- comment.line.other.c punctuation.definition.comment.c */
+  /* <- comment.line.other.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.other.c - punctuation */
+
+/// Comment ///
+/* <- comment.line.triple-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.triple-slash.c punctuation.definition.comment.c */
+  /* <- comment.line.triple-slash.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.triple-slash.c - punctuation */
+ /*         ^^^ comment.line.triple-slash.c punctuation.definition.comment.c */
+
 int main(){
     int a=5,b=0;
     while(a-->0)++b;

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -16,7 +16,6 @@
  /*^^^^^^^^^ comment.line.documentation.c - punctuation */
  /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
 
-
 /* =Banner= */
 /* <- comment.block.banner.c punctuation.definition.comment.begin.c */
 /*^^^^^^^^^^ comment.block.banner.c - punctuation */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -3,6 +3,12 @@
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
+// = Banner =
+/* ^^^^^^^^^^^ comment.line.banner.c */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.line.c */
+/*         ^^^ - meta.toc-list  */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
 /*^^^^^^^^^^ comment.block.banner.c - punctuation */
 /*  ^^^^^^ meta.toc-list.banner.block.c  */
 /*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+/* = Banner = */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.block.c  */
+/*         ^^^^^ - meta.toc-list  */
+/*            ^^ comment.block.banner.c punctuation.definition.comment.end.c */
 
    /*****/
 /* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -9,6 +9,12 @@
 /*   ^^^^^^ meta.toc-list.banner.line.c */
 /*         ^^^ - meta.toc-list  */
 
+// Comment //
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*        ^^ comment.line.double-slash.c punctuation.definition.comment.c */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
   /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /*^^^^^^^^^ comment.line.documentation.c - punctuation */
  /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+//// Comment ////  
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*  ^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*          ^^^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*               ^^ comment.line.double-slash.c - punctuation */
 
 /* =Banner= */
 /* <- comment.block.banner.c punctuation.definition.comment.begin.c */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -4,17 +4,17 @@
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
 //! Comment
-/* <- comment.line.other.c punctuation.definition.comment.c */
- /* <- comment.line.other.c punctuation.definition.comment.c */
-  /* <- comment.line.other.c punctuation.definition.comment.c */
- /*^^^^^^^^^ comment.line.other.c - punctuation */
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
 
 /// Comment ///
-/* <- comment.line.triple-slash.c punctuation.definition.comment.c */
- /* <- comment.line.triple-slash.c punctuation.definition.comment.c */
-  /* <- comment.line.triple-slash.c punctuation.definition.comment.c */
- /*^^^^^^^^^ comment.line.triple-slash.c - punctuation */
- /*         ^^^ comment.line.triple-slash.c punctuation.definition.comment.c */
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+ /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
 
 
 /* =Banner= */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -1,5 +1,58 @@
 /* SYNTAX TEST "Packages/C++/C++.sublime-syntax" */
 
+// =Banner=
+/*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
+
+//! Comment
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+
+/// Comment ///
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+ /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+/* =Banner= */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*  ^^^^^^ meta.toc-list.banner.block.c  */
+/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+   /*****/
+/* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */
+
+   /**
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /***
+/* ^^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!****
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c - punctuation */
+
+   /*!****/
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c punctuation.definition.comment.end.c */
+
+   /*!
+    * docstring
+    **/
+/*  ^^^ comment.block.documentation.c */
+
+    */
+/*  ^^ invalid.illegal.stray-comment-end.c */
+
+    **/
+/*  ^^^ invalid.illegal.stray-comment-end.c */
+
 Task<int> natural_numbers()
 {
   int n = 0;
@@ -2772,4 +2825,4 @@ void sayHi()
 
 /**
       *
-/*    ^ comment.block.c punctuation.definition.comment.c */
+/*    ^ comment.block.documentation.c punctuation.definition.comment.c */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -3,6 +3,12 @@
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
+// = Banner =
+/* ^^^^^^^^^^^ comment.line.banner.c */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.line.c */
+/*         ^^^ - meta.toc-list  */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
 /*^^^^^^^^^^ comment.block.banner.c - punctuation */
 /*  ^^^^^^ meta.toc-list.banner.block.c  */
 /*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+/* = Banner = */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.block.c  */
+/*         ^^^^^ - meta.toc-list  */
+/*            ^^ comment.block.banner.c punctuation.definition.comment.end.c */
 
    /*****/
 /* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -9,6 +9,12 @@
 /*   ^^^^^^ meta.toc-list.banner.line.c */
 /*         ^^^ - meta.toc-list  */
 
+// Comment //
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*        ^^ comment.line.double-slash.c punctuation.definition.comment.c */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
   /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /*^^^^^^^^^ comment.line.documentation.c - punctuation */
  /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+//// Comment ////  
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*  ^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*          ^^^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*               ^^ comment.line.double-slash.c - punctuation */
 
 /* =Banner= */
 /* <- comment.block.banner.c punctuation.definition.comment.begin.c */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -68,18 +68,7 @@ contexts:
     - match: '(?={{path_lookahead}}\s*<)'
       push: global-modifier
     - include: objc-structures
-    # Take care of comments just before a function definition.
-    - match: /\*
-      scope: punctuation.definition.comment.objc++
-      push:
-        - - match: \s*(?=\w)
-            set: global-modifier
-          - match: ""
-            pop: true
-        - - meta_scope: comment.block.objc++
-          - match: \*/
-            scope: punctuation.definition.comment.objc++
-            pop: true
+    - include: global-block-comments
     - include: early-expressions
     - match: ^\s*\b(extern)(?=\s+"C(\+\+)?")
       scope: storage.modifier.objc++
@@ -110,6 +99,38 @@ contexts:
     - match: ^\s*(?=\w)
       push: global-modifier
     - include: late-expressions
+
+  global-block-comments:
+    # NOTE: This context overrides `comments` context, which re-uses scopes
+    # from `source.c#comments`. So keep the trailing `c` for consistency reasons!
+    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+      scope: comment.block.banner.c
+      captures:
+        1: punctuation.definition.comment.begin.c
+        2: meta.toc-list.banner.block.c
+        3: punctuation.definition.comment.end.c
+    # empty block comments
+    - match: /\*\*+/
+      scope: comment.block.empty.c punctuation.definition.comment.c
+      push: global-block-comment-after
+    # documentation block comments
+    - match: (?:/\*!|/\*{2,})
+      scope: punctuation.definition.comment.begin.c
+      push:
+        - global-block-comment-after
+        - scope:source.c#block-comment-documentation-body
+    # normal block comments
+    - match: /\*
+      scope: punctuation.definition.comment.begin.c
+      push:
+        - global-block-comment-after
+        - scope:source.c#block-comment-body
+
+  global-block-comment-after:
+    - match: \s*(?=\w)
+      set: global-modifier
+    - match: ''
+      pop: true
 
   statements:
     - include: preprocessor-statements

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -103,7 +103,7 @@ contexts:
   global-block-comments:
     # NOTE: This context overrides `comments` context, which re-uses scopes
     # from `source.c#comments`. So keep the trailing `c` for consistency reasons!
-    - match: ^(/\*) =(\s*.*?)\s*= (\*/)$\n?
+    - match: ^(/\*) =\s*(.*?)\s*= (\*/)$\n?
       scope: comment.block.banner.c
       captures:
         1: punctuation.definition.comment.begin.c

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1,5 +1,6 @@
 /* SYNTAX TEST "Packages/Objective-C/Objective-C++.sublime-syntax" */
 
+
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
@@ -8,6 +9,12 @@
 /*^^^ - meta.toc-list  */
 /*   ^^^^^^ meta.toc-list.banner.line.c */
 /*         ^^^ - meta.toc-list  */
+
+// Comment //
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*        ^^ comment.line.double-slash.c punctuation.definition.comment.c */
 
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +28,14 @@
   /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /*^^^^^^^^^ comment.line.documentation.c - punctuation */
  /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+//// Comment ////  
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*  ^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*          ^^^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*               ^^ comment.line.double-slash.c - punctuation */
 
 /* =Banner= */
 /* <- comment.block.banner.c punctuation.definition.comment.begin.c */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -3,6 +3,12 @@
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
+// = Banner =
+/* ^^^^^^^^^^^ comment.line.banner.c */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.line.c */
+/*         ^^^ - meta.toc-list  */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
 /*^^^^^^^^^^ comment.block.banner.c - punctuation */
 /*  ^^^^^^ meta.toc-list.banner.block.c  */
 /*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+/* = Banner = */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.block.c  */
+/*         ^^^^^ - meta.toc-list  */
+/*            ^^ comment.block.banner.c punctuation.definition.comment.end.c */
 
    /*****/
 /* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1,5 +1,58 @@
 /* SYNTAX TEST "Packages/Objective-C/Objective-C++.sublime-syntax" */
 
+// =Banner=
+/*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
+
+//! Comment
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+
+/// Comment ///
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+ /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+/* =Banner= */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*  ^^^^^^ meta.toc-list.banner.block.c  */
+/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+   /*****/
+/* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */
+
+   /**
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /***
+/* ^^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!****
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c - punctuation */
+
+   /*!****/
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c punctuation.definition.comment.end.c */
+
+   /*!
+    * docstring
+    **/
+/*  ^^^ comment.block.documentation.c */
+
+    */
+/*  ^^ invalid.illegal.stray-comment-end.c */
+
+    **/
+/*  ^^^ invalid.illegal.stray-comment-end.c */
+
 Task<int> natural_numbers()
 {
   int n = 0;

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -3,6 +3,12 @@
 // =Banner=
 /*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
 
+// = Banner =
+/* ^^^^^^^^^^^ comment.line.banner.c */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.line.c */
+/*         ^^^ - meta.toc-list  */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
 /*^^^^^^^^^^ comment.block.banner.c - punctuation */
 /*  ^^^^^^ meta.toc-list.banner.block.c  */
 /*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+/* = Banner = */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*^^^ - meta.toc-list  */
+/*   ^^^^^^ meta.toc-list.banner.block.c  */
+/*         ^^^^^ - meta.toc-list  */
+/*            ^^ comment.block.banner.c punctuation.definition.comment.end.c */
 
    /*****/
 /* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -9,6 +9,12 @@
 /*   ^^^^^^ meta.toc-list.banner.line.c */
 /*         ^^^ - meta.toc-list  */
 
+// Comment //
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*        ^^ comment.line.double-slash.c punctuation.definition.comment.c */
+
 //! Comment
 /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /* <- comment.line.documentation.c punctuation.definition.comment.c */
@@ -21,6 +27,14 @@
   /* <- comment.line.documentation.c punctuation.definition.comment.c */
  /*^^^^^^^^^ comment.line.documentation.c - punctuation */
  /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+//// Comment ////  
+/* <- comment.line.double-slash.c punctuation.definition.comment.c */
+ /* <- comment.line.double-slash.c punctuation.definition.comment.c */
+/*^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*  ^^^^^^^^^ comment.line.double-slash.c - punctuation */
+ /*          ^^^^ comment.line.double-slash.c punctuation.definition.comment.c */
+/*               ^^ comment.line.double-slash.c - punctuation */
 
 /* =Banner= */
 /* <- comment.block.banner.c punctuation.definition.comment.begin.c */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -1,5 +1,58 @@
 /* SYNTAX TEST "Packages/Objective-C/Objective-C.sublime-syntax" */
 
+// =Banner=
+/*  ^^^^^^ comment.line.banner.c meta.toc-list.banner.line.c */
+
+//! Comment
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+
+/// Comment ///
+/* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /* <- comment.line.documentation.c punctuation.definition.comment.c */
+  /* <- comment.line.documentation.c punctuation.definition.comment.c */
+ /*^^^^^^^^^ comment.line.documentation.c - punctuation */
+ /*         ^^^ comment.line.documentation.c punctuation.definition.comment.c */
+
+/* =Banner= */
+/* <- comment.block.banner.c punctuation.definition.comment.begin.c */
+/*^^^^^^^^^^ comment.block.banner.c - punctuation */
+/*  ^^^^^^ meta.toc-list.banner.block.c  */
+/*          ^^ comment.block.banner.c punctuation.definition.comment.end.c */
+
+   /*****/
+/* ^^^^^^^ comment.block.empty.c punctuation.definition.comment.c */
+
+   /**
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /***
+/* ^^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+
+   /*!****
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c - punctuation */
+
+   /*!****/
+/* ^^^ comment.block.documentation.c punctuation.definition.comment.begin.c */
+/*    ^^^^^ comment.block.documentation.c punctuation.definition.comment.end.c */
+
+   /*!
+    * docstring
+    **/
+/*  ^^^ comment.block.documentation.c */
+
+    */
+/*  ^^ invalid.illegal.stray-comment-end.c */
+
+    **/
+/*  ^^^ invalid.illegal.stray-comment-end.c */
+
 int main(){
     int a=5,b=0;
     while(a-->0)++b;


### PR DESCRIPTION
Fixes #3215

This PR improves comment punctuation highlighting to support arbitrary number of opening and closing punctuation chars.

This helps to keep line comment punctuation consistent when performing hard line wrapping.

The new contexts are copied from JavaScript (see #3018) and adjusted to match C's scopes and maintain the existing "banner comments".