### PR TITLE
[Matlab] Add code section comments to symbol list

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -467,10 +467,11 @@ contexts:
     - include: block-comments
 
   line-comments:
-    - match: (%%(?!%)).*\n?
+    - match: ^\s*(%%(?!%))\s*(.*\S)?\s*\n?
       scope: comment.line.double-percentage.matlab
       captures:
         1: punctuation.definition.comment.matlab
+        2: entity.name.section.matlab
     - match: (%+).*\n?
       scope: comment.line.percentage.matlab
       captures:

--- a/Matlab/Symbol List.tmPreferences
+++ b/Matlab/Symbol List.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.matlab entity.name.section</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>

--- a/Matlab/syntax_test_matlab.matlab
+++ b/Matlab/syntax_test_matlab.matlab
@@ -171,7 +171,9 @@ xAprox = fMetodoDeNewton( xi )
 %% comment % comment
 %<- comment.line.double-percentage.matlab punctuation.definition.comment.matlab
 %^ comment.line.double-percentage.matlab punctuation.definition.comment.matlab
-% ^^^^^^^^^^^^^^^^^^^ comment.line.double-percentage.matlab - punctuation
+% ^ comment.line.double-percentage.matlab - punctuation - entity
+%  ^^^^^^^^^^^^^^^^^ comment.line.double-percentage.matlab entity.name.section.matlab
+%                   ^ comment.line.double-percentage.matlab - entity
 
 %%%
 %<- comment.line.percentage.matlab punctuation.definition.comment.matlab
@@ -188,8 +190,8 @@ a = b % doc
 %      ^^^^^ comment.line.percentage.matlab - punctuation
 
 a = b %% doc
-%     ^^ comment.line.double-percentage.matlab punctuation.definition.comment.matlab
-%       ^^^^^ comment.line.double-percentage.matlab - punctuation
+%     ^^ comment.line.percentage.matlab punctuation.definition.comment.matlab
+%       ^^^^^ comment.line.percentage.matlab - punctuation - entity
 
 
 %---------------------------------------------


### PR DESCRIPTION
Reference from the Matlab docs: https://www.mathworks.com/help/matlab/matlab_prog/create-and-run-sections.html

The scope `entity.name.section` is added to the section title, which is already used in R and gets a "navigation" kind icon in the Goto Symbol panel. Also the pattern was adjusted so that section comments should start on their own line.