### PR TITLE
[C/C++/ObjC/ObjC++] Fix loop statement indentation

### DIFF
--- a/C++/Indentation Rules.tmPreferences
+++ b/C++/Indentation Rules.tmPreferences
@@ -60,10 +60,10 @@
 			  # followed by whitespace or block comments [optional]
 			  \g<comment_or_whitespace>
 			  # top-level balanced parentheses
-			  \(
-				(?<group_body> (?:
+			  (?<group>
+			  	\( (?:
 				# nested balanced parentheses
-				  \( \g<group_body> \)
+				  \g<group>
 				# double quoted string with ignored escaped quotation marks
 				| \".*(?<![^\\]\\)(?<![\\]{3})\"
 				# single quoted character with ignored escaped quotation marks
@@ -72,9 +72,8 @@
 				| \g<block_comment>
 				# anything but closing parenthesis
 				| [^)]
-				)* )
-			  # maybe missing, balanced or stray closing parenthesis
-			  \)*
+				)* \)
+			  )
 			)
 			# followed by whitespace or block comments [optional]
 			\g<comment_or_whitespace>

--- a/C++/tests/syntax_test_indent_common.c++
+++ b/C++/tests/syntax_test_indent_common.c++
@@ -696,6 +696,23 @@ bool testForIndentation(int v) {
             System.out.println("Row " + i + " Col " + j);
         }
     }
+
+    for (
+        int i = 0;
+        i < 10;
+        i++)
+    {
+        int j = 0;
+        int k = 0;
+    }
+
+    for (
+        int i = 0;
+        i < 10;
+        i++) {
+        int j = 0;
+        int k = 0;
+    }
 }
 
 bool testWhileIndentationNoBraces(int v) {
@@ -890,6 +907,24 @@ bool testWhileIndentationWithBraces(int v) {
     {
         v++
     }
+    while (
+        v == foo( bar("") + "" )
+        )
+    {
+        v++
+        v++
+    }
+    while (
+        v == foo( bar("") + "" ) ) {
+        v++
+        v++
+    }
+    while (
+        v == foo( bar("") + "" )
+        ) {
+        v++
+        v++
+    }
 }
 
 bool testWhileIndentationWithBracesAndComments(int v) {
@@ -967,6 +1002,24 @@ bool testWhileIndentationWithBracesAndComments(int v) {
     }                                   // ;  "comments" ()
     while (v == foo( bar("") + "" ))    // ;  "comments" ()
     {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" )        // ;  "comments" ()
+        )                               // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" ) ) {    // ;  "comments" ()
+        v++                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" )        // ;  "comments" ()
+        ) {                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
         v++                             // ;  "comments" ()
     }                                   // ;  "comments" ()
 }


### PR DESCRIPTION
This commit restricts `bracketIndentNextLinePattern` to not match loops
if the loop condition expression spans multiple lines as it causes
breaks indentation of the following code block if the block's opening
brace directly follows the closing parenthesis on the same line.

The result was only the first line of the block being indented.

Fixes https://forum.sublimetext.com/t/the-indenting-of-a-c-for-loop-is-incorrect-under-certain-conditions/52634/4