### PR TITLE
[Java] Fix loop statement indentation

### DIFF
--- a/Java/Java - Indentation Rules.tmPreferences
+++ b/Java/Java - Indentation Rules.tmPreferences
@@ -48,10 +48,10 @@
 			  # followed by whitespace or block comments [optional]
 			  \g<comment_or_whitespace>
 			  # top-level balanced parentheses
-			  \(
-				(?<group_body> (?:
+			  (?<group>
+			  	\( (?:
 				# nested balanced parentheses
-				  \( \g<group_body> \)
+				  \g<group>
 				# double quoted string with ignored escaped quotation marks
 				| \".*(?<![^\\]\\)(?<![\\]{3})\"
 				# single quoted character with ignored escaped quotation marks
@@ -60,9 +60,8 @@
 				| \g<block_comment>
 				# anything but closing parenthesis
 				| [^)]
-				)* )
-			  # maybe missing, balanced or stray closing parenthesis
-			  \)*
+				)* \)
+			  )
 			)
 			# followed by whitespace or block comments [optional]
 			\g<comment_or_whitespace>

--- a/Java/tests/syntax_test_java_indentation.java
+++ b/Java/tests/syntax_test_java_indentation.java
@@ -703,6 +703,23 @@ public class HelloWorld {
                 System.out.println("Row " + i + " Col " + j);
             }
         }
+
+        for (
+            int i = 0;
+            i < 10;
+            i++)
+        {
+            int j = 0;
+            int k = 0;
+        }
+
+        for (
+            int i = 0;
+            i < 10;
+            i++) {
+            int j = 0;
+            int k = 0;
+        }
     }
 
     public boolean testWhileIndentationNoBraces(int v) {
@@ -897,6 +914,24 @@ public class HelloWorld {
         {
             v++
         }
+        while (
+            v == foo( bar("") + "" )
+            )
+        {
+            v++
+            v++
+        }
+        while (
+            v == foo( bar("") + "" ) ) {
+            v++
+            v++
+        }
+        while (
+            v == foo( bar("") + "" )
+            ) {
+            v++
+            v++
+        }
     }
 
     public boolean testWhileIndentationWithBracesAndComments(int v) {
@@ -974,6 +1009,24 @@ public class HelloWorld {
         }                                   // ;  "comments" ()
         while (v == foo( bar("") + "" ))    // ;  "comments" ()
         {                                   // ;  "comments" ()
+            v++                             // ;  "comments" ()
+        }                                   // ;  "comments" ()
+        while (                             // ;  "comments" ()
+            v == foo( bar("") + "" )        // ;  "comments" ()
+            )                               // ;  "comments" ()
+        {                                   // ;  "comments" ()
+            v++                             // ;  "comments" ()
+            v++                             // ;  "comments" ()
+        }                                   // ;  "comments" ()
+        while (                             // ;  "comments" ()
+            v == foo( bar("") + "" ) ) {    // ;  "comments" ()
+            v++                             // ;  "comments" ()
+            v++                             // ;  "comments" ()
+        }                                   // ;  "comments" ()
+        while (                             // ;  "comments" ()
+            v == foo( bar("") + "" )        // ;  "comments" ()
+            ) {                             // ;  "comments" ()
+            v++                             // ;  "comments" ()
             v++                             // ;  "comments" ()
         }                                   // ;  "comments" ()
     }


### PR DESCRIPTION
This commit restricts `bracketIndentNextLinePattern` to not match loops
if the loop condition expression spans multiple lines as it causes
breaks indentation of the following code block if the block's opening
brace directly follows the closing parenthesis on the same line.

The result was only the first line of the block being indented.

Fixes https://forum.sublimetext.com/t/the-indenting-of-a-c-for-loop-is-incorrect-under-certain-conditions/52634/4