### PR TITLE
[JavaScript] Fix loop statement indentation

### DIFF
--- a/JavaScript/Indentation Rules.tmPreferences
+++ b/JavaScript/Indentation Rules.tmPreferences
@@ -51,10 +51,10 @@
 			  # followed by whitespace or block comments [optional]
 			  \g<comment_or_whitespace>
 			  # top-level balanced parentheses
-			  \(
-				(?<group_body> (?:
+			  (?<group>
+			  	\( (?:
 				# nested balanced parentheses
-				  \( \g<group_body> \)
+				  \g<group>
 				# double quoted string with ignored escaped quotation marks
 				| \".*(?<![^\\]\\)(?<![\\]{3})\"
 				# single quoted character with ignored escaped quotation marks
@@ -63,9 +63,8 @@
 				| \g<block_comment>
 				# anything but closing parenthesis
 				| [^)]
-				)* )
-			  # maybe missing, balanced or stray closing parenthesis
-			  \)*
+				)* \)
+			  )
 			)
 			# followed by whitespace or block comments [optional]
 			\g<comment_or_whitespace>

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -692,6 +692,23 @@ function testForIndentation(v)  {
             System.out.println("Row " + i + " Col " + j);
         }
     }
+
+    for (
+        let i = 0;
+        i < 10;
+        i++)
+    {
+        let j = 0;
+        let k = 0;
+    }
+
+    for (
+        let i = 0;
+        i < 10;
+        i++) {
+        let j = 0;
+        let k = 0;
+    }
 }
 
 function testWhileIndentationNoBraces(v)  {
@@ -886,6 +903,24 @@ function testWhileIndentationWithBraces(v)  {
     {
         v++
     }
+    while (
+        v == foo( bar("") + "" )
+        )
+    {
+        v++
+        v++
+    }
+    while (
+        v == foo( bar("") + "" ) ) {
+        v++
+        v++
+    }
+    while (
+        v == foo( bar("") + "" )
+        ) {
+        v++
+        v++
+    }
 }
 
 function testWhileIndentationWithBracesAndComments(v)  {
@@ -963,6 +998,24 @@ function testWhileIndentationWithBracesAndComments(v)  {
     }                                   // ;  "comments" ()
     while (v == foo( bar("") + "" ))    // ;  "comments" ()
     {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" )        // ;  "comments" ()
+        )                               // ;  "comments" ()
+    {                                   // ;  "comments" ()
+        v++                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" ) ) {    // ;  "comments" ()
+        v++                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
+    }                                   // ;  "comments" ()
+    while (                             // ;  "comments" ()
+        v == foo( bar("") + "" )        // ;  "comments" ()
+        ) {                             // ;  "comments" ()
+        v++                             // ;  "comments" ()
         v++                             // ;  "comments" ()
     }                                   // ;  "comments" ()
 }

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -668,33 +668,33 @@ function testSwitchCaseIndentationWithLineComments(v) {
     }                            // comments
 }                                // comments
 
-function testForIndentation(int  {
+function testForIndentation(v)  {
 
-    for (int i = 0; i < 10; i++)
+    for (let i = 0; i < 10; i++)
         System.out.println("Row " + i);
 
-    for (int i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i++) {
         System.out.println("Row " + i);
     }
 
-    for (int i = 0; i < 10; i++)
+    for (let i = 0; i < 10; i++)
     {
         System.out.println("Row " + i);
     }
 
-    for (int i = 0; i < 10; i++) {
-        for (int j = 0; j < 10; j++)
+    for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 10; j++)
             System.out.println("Row " + i + " Col " + j);
     }
 
-    for (int i = 0; i < 10; i++) {
-        for (int j = 0; j < 10; j++) {
+    for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 10; j++) {
             System.out.println("Row " + i + " Col " + j);
         }
     }
 }
 
-function testWhileIndentationNoBraces(int  {
+function testWhileIndentationNoBraces(v)  {
     while () v++
     while () v++;
     while (()) v++
@@ -722,7 +722,7 @@ function testWhileIndentationNoBraces(int  {
         v++
 }
 
-function testWhileIndentationNoBracesButComments(int  {
+function testWhileIndentationNoBracesButComments(v)  {
     while () v++                      // ; "comment" ()
     while () v++;                     // ; "comment" ()
     while (()) v++                    // ; "comment" ()
@@ -751,7 +751,7 @@ function testWhileIndentationNoBracesButComments(int  {
     while () { } // a hack to make tests succeed
 }
 
-function testWhileIndentationNoBracesButBlockCommentsPart1(int  {
+function testWhileIndentationNoBracesButBlockCommentsPart1(v)  {
     while /*(*/ () v++ /*(*/ // ; "comment" ()
     while /*(*/ () v++; /*(*/ // ; "comment" ()
     while /*(*/ (()) v++ /*(*/ // ; "comment" ()
@@ -780,7 +780,7 @@ function testWhileIndentationNoBracesButBlockCommentsPart1(int  {
     while /*(*/ () { } // a hack to make tests succeed
 }
 
-function testWhileIndentationNoBracesButBlockCommentsPart2(int  {
+function testWhileIndentationNoBracesButBlockCommentsPart2(v)  {
     while /*)*/ () v++ /*)*/ // ; "comment" ()
     while /*)*/ () v++; /*)*/ // ; "comment" ()
     while /*)*/ (()) v++ /*)*/ // ; "comment" ()
@@ -809,7 +809,7 @@ function testWhileIndentationNoBracesButBlockCommentsPart2(int  {
     while /*)*/ () { } // a hack to make tests succeed
 }
 
-function testWhileIndentationWithBraces(int  {
+function testWhileIndentationWithBraces(v)  {
 
     while () { v++ }
     while () { v++; }
@@ -888,7 +888,7 @@ function testWhileIndentationWithBraces(int  {
     }
 }
 
-function testWhileIndentationWithBracesAndComments(int  {
+function testWhileIndentationWithBracesAndComments(v)  {
 
     while () { v++ }                    // ;  "comments" ()
     while () { v++; }                   // ;  "comments" ()


### PR DESCRIPTION
This commit restricts `bracketIndentNextLinePattern` to not match loops
if the loop condition expression spans multiple lines as it causes
breaks indentation of the following code block if the block's opening
brace directly follows the closing parenthesis on the same line.

The result was only the first line of the block being indented.

Fixes https://forum.sublimetext.com/t/the-indenting-of-a-c-for-loop-is-incorrect-under-certain-conditions/52634/4