### PR TITLE
[Ruby] Use Ruby syntax for RBI files

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -29,6 +29,7 @@ scope: source.ruby
 
 file_extensions:
   - rb
+  - rbi
   - Appfile
   - Appraisals
   - Berksfile


### PR DESCRIPTION
RBI files are used by Sorbet: https://sorbet.org/docs/rbi. They use the same exact syntax as Ruby.

The only concern I have is that if we apply Ruby syntax to RBI files, RBI files will be linted by plugins like https://github.com/SublimeLinter/SublimeLinter-rubocop, which isn't necessary IMO.