### PR TITLE
[Lua] Add support for EmmyLua and LDoc doc comments

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
       captures:
         1: entity.name.tag.documentation.lua
         2: entity.name.section.lua
-    - match: ^\s*(@param)(?:\[[\w=']*\])?\s+({{identifier}})\b
+    - match: ^\s*(@param)(?:\[[\w=']*\])?\s+({{identifier}})
       captures:
         1: entity.name.tag.documentation.lua
         2: variable.parameter.lua
@@ -122,7 +122,7 @@ contexts:
 
   line-comments:
     - match: -{3,}
-      scope: punctuation.definition.comment.lua
+      scope: comment.line.documentation.lua punctuation.definition.comment.lua
       push: line-doc-comment-body
     - match: --
       scope: punctuation.definition.comment.lua
@@ -130,31 +130,36 @@ contexts:
 
   line-doc-comment-body:
     - meta_include_prototype: false
-    - meta_scope: comment.line.documentation.lua
-    - match: \s*(@section)\s+(.*\S).*\n?
+    - match: \s*(@section)\s+(.*\S)\s*\n?
+      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
         2: entity.name.section.lua
       set: maybe-line-doc-comment
-    - match: \s*(@param)(?:\[[\w=']*\])?\s+({{identifier}})\b.*\n?
+    - match: \s*(@param)(?:\[[\w=']*\])?\s+({{identifier}}).*\n?
+      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
         2: variable.parameter.lua
       set: maybe-line-doc-comment
     - match: \s*({{doc_comment_tag}}).*\n?
+      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
       set: maybe-line-doc-comment
     - match: \s*({{doc_comment_custom_tag}}).*\n?
+      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.custom.lua
       set: maybe-line-doc-comment
-    - match: .*\n
+    - match: .*\n?
+      scope: comment.line.documentation.lua
       set: maybe-line-doc-comment
 
   maybe-line-doc-comment:
-    - match: ^-{2,}
-      scope: punctuation.definition.comment.lua
+    - match: ^\s*(-{2,})
+      captures:
+        1: comment.line.documentation.lua punctuation.definition.comment.lua
       set: line-doc-comment-body
     - match: ^
       pop: 1

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
       captures:
         1: entity.name.tag.documentation.lua
         2: entity.name.section.lua
-    - match: ^\s*(@param)\s+({{identifier}})\b
+    - match: ^\s*(@param)(?:\[[\w=']*\])?\s+({{identifier}})\b
       captures:
         1: entity.name.tag.documentation.lua
         2: variable.parameter.lua
@@ -136,7 +136,7 @@ contexts:
         1: entity.name.tag.documentation.lua
         2: entity.name.section.lua
       set: maybe-line-doc-comment
-    - match: \s*(@param)\s+({{identifier}})\b.*\n?
+    - match: \s*(@param)(?:\[[\w=']*\])?\s+({{identifier}})\b.*\n?
       captures:
         1: entity.name.tag.documentation.lua
         2: variable.parameter.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -130,37 +130,34 @@ contexts:
 
   line-doc-comment-body:
     - meta_include_prototype: false
+    - meta_scope: comment.line.documentation.lua
     - match: \s*(@section)\s+(.*\S)\s*\n?
-      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
         2: entity.name.section.lua
       set: maybe-line-doc-comment
     - match: \s*(@param)(?:\[[\w=']*\])?\s+({{identifier}}).*\n?
-      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
         2: variable.parameter.lua
       set: maybe-line-doc-comment
     - match: \s*({{doc_comment_tag}}).*\n?
-      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.lua
       set: maybe-line-doc-comment
     - match: \s*({{doc_comment_custom_tag}}).*\n?
-      scope: comment.line.documentation.lua
       captures:
         1: entity.name.tag.documentation.custom.lua
       set: maybe-line-doc-comment
     - match: .*\n?
-      scope: comment.line.documentation.lua
       set: maybe-line-doc-comment
 
   maybe-line-doc-comment:
-    - match: ^\s*(-{2,})
-      captures:
-        1: comment.line.documentation.lua punctuation.definition.comment.lua
-      set: line-doc-comment-body
+    - match: ^\s*(?=--(?!\[\[))
+      set:
+        - match: -{2,}
+          scope: punctuation.definition.comment.lua
+          set: line-doc-comment-body
     - match: ^
       pop: 1
 

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -54,13 +54,12 @@ variables:
   hex_exponent: (?:[Pp][-+]?\d*)
 
   doc_comment_tag: |-
-    (?x:(?:@(?:
+    (?x:@(?:
       alias|async|author|class|classmod|copyright|deprecated|diagnostic|field
       |fixme|function|generic|language|lfunction|license|local|module|nodiscard
       |overload|param|raise|release|return|script|section|see|submodule|table
       |todo|tparam|treturn|type|usage|vararg|version|warning|within
-    )\b))
-
+    )\b)
   doc_comment_custom_tag: (?:@\w+\b)
 
 contexts:

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -53,6 +53,16 @@ variables:
   dec_exponent: (?:[Ee][-+]?\d*)
   hex_exponent: (?:[Pp][-+]?\d*)
 
+  doc_comment_tag: |-
+    (?x:(?:@(?:
+      alias|async|author|class|classmod|copyright|deprecated|diagnostic|field
+      |fixme|function|generic|language|lfunction|license|local|module|nodiscard
+      |overload|param|raise|release|return|script|section|see|submodule|table
+      |todo|tparam|treturn|type|usage|vararg|version|warning|within
+    )\b))
+
+  doc_comment_custom_tag: (?:@\w+\b)
+
 contexts:
   main:
     - meta_include_prototype: false
@@ -75,9 +85,33 @@ contexts:
     - include: line-comments
 
   block-comments:
+    - match: --\[\[--
+      scope: punctuation.definition.comment.begin.lua
+      push: block-doc-comment-body
     - match: --\[(=*)\[
       scope: punctuation.definition.comment.begin.lua
       push: block-comment-body
+
+  block-doc-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.documentation.lua
+    - match: \]\]
+      scope: punctuation.definition.comment.end.lua
+      pop: 1
+    - match: ^\s*(@section)\s+(.*?\S)\s*(?=\]\]|$)
+      captures:
+        1: entity.name.tag.documentation.lua
+        2: entity.name.section.lua
+    - match: ^\s*(@param)\s+({{identifier}})\b
+      captures:
+        1: entity.name.tag.documentation.lua
+        2: variable.parameter.lua
+    - match: ^\s*({{doc_comment_tag}})
+      captures:
+        1: entity.name.tag.documentation.lua
+    - match: ^\s*({{doc_comment_custom_tag}})
+      captures:
+        1: entity.name.tag.documentation.custom.lua
 
   block-comment-body:
     - meta_include_prototype: false
@@ -87,9 +121,43 @@ contexts:
       pop: 1
 
   line-comments:
+    - match: -{3,}
+      scope: punctuation.definition.comment.lua
+      push: line-doc-comment-body
     - match: --
       scope: punctuation.definition.comment.lua
       push: line-comment-body
+
+  line-doc-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.documentation.lua
+    - match: \s*(@section)\s+(.*\S).*\n?
+      captures:
+        1: entity.name.tag.documentation.lua
+        2: entity.name.section.lua
+      set: maybe-line-doc-comment
+    - match: \s*(@param)\s+({{identifier}})\b.*\n?
+      captures:
+        1: entity.name.tag.documentation.lua
+        2: variable.parameter.lua
+      set: maybe-line-doc-comment
+    - match: \s*({{doc_comment_tag}}).*\n?
+      captures:
+        1: entity.name.tag.documentation.lua
+      set: maybe-line-doc-comment
+    - match: \s*({{doc_comment_custom_tag}}).*\n?
+      captures:
+        1: entity.name.tag.documentation.custom.lua
+      set: maybe-line-doc-comment
+    - match: .*\n
+      set: maybe-line-doc-comment
+
+  maybe-line-doc-comment:
+    - match: ^-{2,}
+      scope: punctuation.definition.comment.lua
+      set: line-doc-comment-body
+    - match: ^
+      pop: 1
 
   line-comment-body:
     - meta_include_prototype: false

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -69,6 +69,14 @@
 --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
 --  ^^^^^^ entity.name.tag.documentation.lua
 --         ^^^^^^^^^^^^^^^^^ variable.parameter.lua
+--- @param[opt] name_of_parameter the description of this parameter as verbose text
+--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^^^^^ entity.name.tag.documentation.lua
+--              ^^^^^^^^^^^^^^^^^ variable.parameter.lua
+--- @param[type=number] name_of_parameter the description of this parameter as verbose text
+--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^^^^^ entity.name.tag.documentation.lua
+--                      ^^^^^^^^^^^^^^^^^ variable.parameter.lua
 --- @return the description of the return value
 --  ^^^^^^^ entity.name.tag.documentation.lua
 --- @unknowntagname

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -38,6 +38,77 @@
 --  ^^^ comment.block punctuation.definition.comment.end
 --     ^ - comment
 
+---@param name_of_parameter Type @EmmyLua style doc comment
+-- <- comment.line.documentation.lua punctuation.definition.comment.lua
+ -- <- comment.line.documentation.lua punctuation.definition.comment.lua
+--^ comment.line.documentation.lua punctuation.definition.comment.lua
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+-- ^^^^^^ entity.name.tag.documentation.lua
+--        ^^^^^^^^^^^^^^^^^ variable.parameter.lua
+
+---@return Type|Othertype @the description of the return value
+-- ^^^^^^^ comment.line.documentation.lua entity.name.tag.documentation.lua
+
+---@unknowntagname
+-- ^^^^^^^^^^^^^^^ comment.line.documentation.lua entity.name.tag.documentation.custom.lua
+
+--- LDoc style doc comment.
+-- <- comment.line.documentation.lua punctuation.definition.comment.lua
+--^ comment.line.documentation.lua punctuation.definition.comment.lua
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+-- Description; this can extend over
+-- several lines
+-- ^^^^^^^^^^^^^^ comment.line.documentation.lua
+-- NOTE: The following comments with @tags start with a triple-dash to avoid being recognized as symbol tests by ST.
+--       The triple-dash is not required for consecutive doc comment lines by LDoc.
+--- @section section name
+--^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^^^^^^^ entity.name.tag.documentation.lua
+--           ^^^^^^^^^^^^ entity.name.section.lua
+--- @param name_of_parameter the description of this parameter as verbose text
+--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^^^^^ entity.name.tag.documentation.lua
+--         ^^^^^^^^^^^^^^^^^ variable.parameter.lua
+--- @return the description of the return value
+--  ^^^^^^^ entity.name.tag.documentation.lua
+--- @unknowntagname
+--  ^^^^^^^^^^^^^^^ entity.name.tag.documentation.custom.lua
+-- text @return text
+--      ^^^^^^^ - entity
+
+-- no more doc comment after empty line
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.documentation
+
+-----------------
+--^^^^^^^^^^^^^^^ comment.line.documentation.lua punctuation.definition.comment.lua
+-- This will also do.
+-- ^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+
+    --[[--
+--  ^^^^^^ comment.block.documentation.lua punctuation.definition.comment.begin.lua
+        Summary. A description
+        @section section name
+--      ^^^^^^^^ entity.name.tag.documentation.lua
+--               ^^^^^^^^^^^^ entity.name.section.lua
+        @param name_of_parameter the description of this parameter as verbose text
+--      ^^^^^^ entity.name.tag.documentation.lua
+--             ^^^^^^^^^^^^^^^^^ variable.parameter.lua
+        @return the description of the return value
+--      ^^^^^^^ entity.name.tag.documentation.lua
+        @unknowntagname
+--      ^^^^^^^^^^^^^^^ entity.name.tag.documentation.custom.lua
+    ]]
+--  ^^ comment.block.documentation.lua punctuation.definition.comment.end.lua
+
+    --[[--
+--  ^^^^^^ comment.block.documentation.lua punctuation.definition.comment.begin.lua
+        @section section name ]
+--               ^^^^^^^^^^^^^^ entity.name.section.lua
+        @section section name ]]
+--               ^^^^^^^^^^^^ entity.name.section.lua
+--                            ^^ punctuation.definition.comment.end.lua - entity.name.section
+--                              ^ - comment
+
 --VARIABLES
 
     foo;

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -59,7 +59,7 @@
 -- Description; this can extend over
 -- several lines
 -- ^^^^^^^^^^^^^^ comment.line.documentation.lua
--- NOTE: The following comments with @tags start with a triple-dash to avoid being recognized as symbol tests by ST.
+-- NOTE: The following comments with @tags start with a triple-dash to prevent being recognized as symbol tests by ST.
 --       The triple-dash is not required for consecutive doc comment lines by LDoc.
 --- @section section name
 --^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
@@ -91,6 +91,18 @@
 --^^^^^^^^^^^^^^^ comment.line.documentation.lua punctuation.definition.comment.lua
 -- This will also do.
 -- ^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+
+    --- LDoc style doc comment with indentation.
+    -- Description
+--^^ - comment
+--  ^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^ punctuation.definition.comment.lua
+    --- @param name_of_parameter the description of this parameter as verbose text
+--^^ - comment
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.lua
+--  ^^^ punctuation.definition.comment.lua
+--      ^^^^^^ entity.name.tag.documentation.lua
+--             ^^^^^^^^^^^^^^^^^ variable.parameter.lua
 
     --[[--
 --  ^^^^^^ comment.block.documentation.lua punctuation.definition.comment.begin.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -130,7 +130,7 @@
 --                              ^ - comment
 
     ---
-    -- line doc comment
+    -- line doc comment followed by block comment
     --[[
 --  ^^^^ comment.block.lua punctuation.definition.comment.begin.lua - comment.line
     ]]

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -129,6 +129,12 @@
 --                            ^^ punctuation.definition.comment.end.lua - entity.name.section
 --                              ^ - comment
 
+    ---
+    -- line doc comment
+    --[[
+--  ^^^^ comment.block.lua punctuation.definition.comment.begin.lua - comment.line
+    ]]
+
 --VARIABLES
 
     foo;


### PR DESCRIPTION
Resolves #3211.

This PR adds basic highlighting for [EmmyLua](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations) and [LDoc](https://stevedonovan.github.io/ldoc/manual/doc.md.html) documentation comments. They are not really part of the Lua language, so I don't know whether it is desired to be added (having the open PR for JSDoc types in mind, which seems to be stuck for some reason), but I think it would be useful to provide a PR. Also there are at least three competing standards for the scope name of `@tag` tags already used in the default syntaxes...

It is kept pretty basic with only `@tags` being highlighted, with two exceptions for `@section` and `@param`.

Ideally this should be tested by a regular Lua user, @jingyuexing maybe do you want to try it out?