### PR TITLE
[PHP] Suppress method completions when typing php tags

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -120,7 +120,7 @@ contexts:
       push:
         - meta_scope: embedding.php text.html.basic
         - clear_scopes: true
-        - match: <\?(?i:php)?
+        - match: <\?(?i:p(?:hp?)?)?
           scope: meta.embedded.block.php punctuation.section.embedded.begin.php
           pop: 1
         - match: ''
@@ -131,7 +131,7 @@ contexts:
           push: scope:text.html.basic
 
   single-line-php-tag:
-    - match: (?:<\?=|<\?(?i:php)?(?=.*\?>))
+    - match: (?:<\?=|<\?(?i:p(?:hp?)?)?(?=.*\?>))
       scope: punctuation.section.embedded.begin.php
       push:
         - meta_scope: meta.embedded.line.nested.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -120,7 +120,9 @@ contexts:
       push:
         - meta_scope: embedding.php text.html.basic
         - clear_scopes: true
-        - match: <\?(?i:p(?:hp?)?)?
+        - match: <\?(?i:(?!php)ph?)
+          scope: meta.embedded.block.php punctuation.section.embedded.begin.php
+        - match: <\?(?i:php)?
           scope: meta.embedded.block.php punctuation.section.embedded.begin.php
           pop: 1
         - match: ''
@@ -131,7 +133,9 @@ contexts:
           push: scope:text.html.basic
 
   single-line-php-tag:
-    - match: (?:<\?=|<\?(?i:p(?:hp?)?)?(?=.*\?>))
+    - match: <\?(?i:(?!php)ph?)
+      scope: meta.embedded.block.php punctuation.section.embedded.begin.php
+    - match: (?:<\?=|<\?(?i:php)?(?=.*\?>))
       scope: punctuation.section.embedded.begin.php
       push:
         - meta_scope: meta.embedded.line.nested.php

--- a/PHP/PHP.sublime-completions
+++ b/PHP/PHP.sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "source.php - string - comment - variable.other.php - meta.embedded.html",
+	"scope": "source.php - string - comment - variable.other.php - meta.embedded.html - punctuation.section.embedded.begin.php",
 	"completions":
 	[
 		"php",

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -32,14 +32,14 @@ contexts:
     - match: ''
       set: scope:text.html.basic
       with_prototype:
-        - match: <\?(?i:php|=)?(?![^?]*\?>)
+        - match: <\?(?i:p(?:hp?)?|=)?(?![^?]*\?>)
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.block.php
             - meta_content_scope: source.php
             - include: php-end-tag-pop
             - include: scope:source.php
-        - match: <\?(?i:php|=)?
+        - match: <\?(?i:p(?:hp?)?|=)?
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.line.php

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -32,14 +32,16 @@ contexts:
     - match: ''
       set: scope:text.html.basic
       with_prototype:
-        - match: <\?(?i:p(?:hp?)?|=)?(?![^?]*\?>)
+        - match: <\?(?i:(?!php)ph?)
+          scope: meta.embedded.block.php punctuation.section.embedded.begin.php
+        - match: <\?(?i:php|=)?(?![^?]*\?>)
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.block.php
             - meta_content_scope: source.php
             - include: php-end-tag-pop
             - include: scope:source.php
-        - match: <\?(?i:p(?:hp?)?|=)?
+        - match: <\?(?i:php|=)?
           scope: punctuation.section.embedded.begin.php
           push:
             - meta_scope: meta.embedded.line.php

--- a/PHP/Snippets/php (begin tag).sublime-snippet
+++ b/PHP/Snippets/php (begin tag).sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[${TM_PHP_OPEN_TAG:php} $0 ?>]]></content>
+	<tabTrigger>php</tabTrigger>
+	<scope>embedding.php text.html punctuation.section.embedded.begin.php</scope>
+	<description>&lt;?php … ?&gt;</description>
+</snippet>

--- a/PHP/Snippets/php.sublime-snippet
+++ b/PHP/Snippets/php.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG:php} $0 ?>]]></content>
 	<tabTrigger>php</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>embedding.php text.html - source.php - punctuation.section.embedded.begin.php</scope>
 	<description>&lt;?php … ?&gt;</description>
 </snippet>


### PR DESCRIPTION
Resolves https://github.com/sublimehq/sublime_text/issues/5256

The fix consists of two parts:

1. Extending the completion's selector by 

       - punctuation.section.embedded.begin

2. Making sure to highlight incomplete <?php tags

       punctuation.section.embedded.begin
    
   Note: If this isn't acceptable we might want to scope incomplete
   tags using a `meta` scope and add this to the selector (1.) as well.

   We just need to ensure ST sees the correct scope while typing the
   opening php tag in order to not add those methods to the list of
   available completions.