### PR TITLE
[Go] Fix compiler directive syntax patterns

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -82,9 +82,6 @@ variables:
   # Directive comment key.
   directive: \b[[:alpha:]_][[:alnum:]_]*\b
 
-  # Line directive comment key.
-  line_directive: (line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})
-
   # Cgo export and gccgo extern directive.
   export_directive: (export|extern) ({{ident}})
 
@@ -157,7 +154,7 @@ contexts:
     # position for the character immediately following the comment as
     # having come from the specified file, line and column. Both single
     # line and block comment line directives are valid.
-    - match: (//){{line_directive}}$
+    - match: (//)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
@@ -171,7 +168,7 @@ contexts:
         - match: $
           set: pop-line-comment
 
-    - match: (/\*){{line_directive}}(\*/)
+    - match: (/\*)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -80,7 +80,7 @@ variables:
   ident: \b(?!{{keyword}})[[:alpha:]_][[:alnum:]_]*\b
 
   # Directive comment key.
-  directive: \b[[:alpha:]_][[:alnum:]_]*\b
+  directive: \b[[:alpha:]_-][[:alnum:]_-]*\b
 
   # Single line only
   inline_comment: /[*](?:[^*]|[*](?!/))*[*]/
@@ -117,7 +117,7 @@ contexts:
 
   # https://golang.org/ref/spec#Comments
   match-comments:
-    # Go has magic comments in the form of:
+   # Go has magic comments in the form of:
     #
     # //go:some_directive arg0 arg1 ...
     #
@@ -132,7 +132,7 @@ contexts:
     # highlighting them as compiler pragmas could be misleading. We scope them
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
-    - match: (//)([a-z]+)(:)({{directive}}.*)
+    - match: (//)([a-z]+)(:)({{directive}})[ ]?
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
@@ -140,7 +140,7 @@ contexts:
         4: meta.variable.function.go
       push:
         - meta_scope: meta.annotation.go comment.line.go
-        - match: \S+
+        - match: .+
           scope: meta.variable.parameter.go
         # End the annotation scope at EOL, but stretch the comment scope
         # indefinitely to the right.
@@ -154,22 +154,18 @@ contexts:
     - match: (//)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$
       captures:
         1: punctuation.definition.comment.go
-        2: meta.keyword.annotation.go
-        3: meta.variable.function.go
+        2: meta.variable.function.go
+        3: meta.variable.parameter.go
       push:
         - meta_scope: meta.annotation.go comment.line.go
-        - match: \S+
-          scope: meta.variable.parameter.go
-        # End the annotation scope at EOL, but stretch the comment scope
-        # indefinitely to the right.
         - match: $
           set: pop-line-comment
 
     - match: (/\*)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
       captures:
         1: punctuation.definition.comment.go
-        2: meta.keyword.annotation.go
-        3: meta.variable.function.go
+        2: meta.variable.function.go
+        3: meta.variable.parameter.go
         4: punctuation.definition.comment.go
       push:
         - meta_scope: meta.annotation.go comment.block.go
@@ -184,14 +180,10 @@ contexts:
     - match: (//)(export|extern) ({{ident}})$
       captures:
         1: punctuation.definition.comment.go
-        2: meta.keyword.annotation.go
-        3: meta.variable.function.go
+        2: meta.variable.function.go
+        3: meta.variable.parameter.go
       push:
         - meta_scope: meta.annotation.go comment.line.go
-        - match: \S+
-          scope: meta.variable.parameter.go
-        # End the annotation scope at EOL, but stretch the comment scope
-        # indefinitely to the right.
         - match: $
           set: pop-line-comment
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -132,7 +132,7 @@ contexts:
     # highlighting them as compiler pragmas could be misleading. We scope them
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
-    - match: (//)([a-z]+)(:)({{directive}})[ ]?
+    - match: (//)([a-z]+[a-z-]*)(:)({{directive}})[ ]?
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -133,52 +133,43 @@ contexts:
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
     - match: (//)([a-z]+[a-z-]*)(:)({{directive}})[ ]?
+      scope: meta.annotation.go
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
-        3: meta.punctuation.accessor.colon.go
+        3: punctuation.accessor.colon.go
         4: meta.variable.function.go
-      push:
-        - meta_scope: meta.annotation.go comment.line.go
-        - match: .+
-          scope: meta.annotation.parameters.go
-        # End the annotation scope at EOL, but stretch the comment scope
-        # indefinitely to the right.
-        - match: $
-          set: pop-line-comment
+      push: pop-line-annotation
 
     # Go also has line renumbering; line directives specify the source
     # position for the character immediately following the comment as
     # having come from the specified file, line and column. Both single
     # line and block comment line directives are valid.
-    - match: (//)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$
+    - match: ((//)(line) )([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
+      scope: comment.line.go
       captures:
-        1: punctuation.definition.comment.go
-        2: meta.variable.function.go
-        3: meta.variable.parameter.go
-      push:
-        - meta_scope: meta.annotation.go comment.line.go
-        - match: $
-          set: pop-line-comment
+        1: meta.annotation.go
+        2: punctuation.definition.comment.go
+        3: meta.variable.function.go
+        4: meta.annotation.parameters.go
 
-    - match: (/\*)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
-      scope: meta.annotation.go comment.block.go
+    - match: ((/\*)(line) )([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
+      scope: comment.block.go
       captures:
-        1: punctuation.definition.comment.begin.go
-        2: meta.variable.function.go
-        3: meta.variable.parameter.go
-        4: punctuation.definition.comment.end.go
+        1: meta.annotation.go
+        2: punctuation.definition.comment.begin.go
+        3: meta.variable.function.go
+        4: meta.annotation.parameters.go
+        5: meta.annotation.go punctuation.definition.comment.end.go
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
-    - match: (//)(export|extern) ({{ident}})$
+    - match: ((//)(export|extern) )({{ident}})$\n?
+      scope: comment.line.go
       captures:
-        1: punctuation.definition.comment.go
-        2: meta.variable.function.go
-        3: meta.variable.parameter.go
-      push:
-        - meta_scope: meta.annotation.go comment.line.go
-        - match: $
-          set: pop-line-comment
+        1: meta.annotation.go
+        2: punctuation.definition.comment.go
+        3: meta.variable.function.go
+        4: meta.annotation.parameters.go
 
     # Line comment
     - match: //
@@ -196,6 +187,12 @@ contexts:
         - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.go
+
+  pop-line-annotation:
+    - meta_scope: comment.line.go
+    - meta_content_scope: meta.annotation.parameters.go
+    - match: $\n?
+      pop: true
 
   pop-line-comment:
     - meta_scope: comment.line.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -162,15 +162,12 @@ contexts:
           set: pop-line-comment
 
     - match: (/\*)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
+      scope: meta.annotation.go comment.block.go
       captures:
         1: punctuation.definition.comment.begin.go
         2: meta.variable.function.go
         3: meta.variable.parameter.go
         4: punctuation.definition.comment.end.go
-      push:
-        - meta_scope: meta.annotation.go comment.block.go
-        - match: $
-          pop: true
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
     - match: (//)(export|extern) ({{ident}})$

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -137,7 +137,7 @@ contexts:
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
-        3: punctuation.accessor.colon.go
+        3: meta.punctuation.accessor.colon.go
         4: meta.variable.function.go
       push: pop-line-annotation
 

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -82,9 +82,6 @@ variables:
   # Directive comment key.
   directive: \b[[:alpha:]_][[:alnum:]_]*\b
 
-  # Cgo export and gccgo extern directive.
-  export_directive: (export|extern) ({{ident}})
-
   # Single line only
   inline_comment: /[*](?:[^*]|[*](?!/))*[*]/
 
@@ -184,7 +181,7 @@ contexts:
           set: pop-line-comment
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
-    - match: (//){{export_directive}}$
+    - match: (//)(export|extern) ({{ident}})$
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -79,6 +79,15 @@ variables:
   # functions and types.
   ident: \b(?!{{keyword}})[[:alpha:]_][[:alnum:]_]*\b
 
+  # Directive comment key.
+  directive: \b[[:alpha:]_][[:alnum:]_]*\b
+
+  # Line directive comment key.
+  line_directive: (line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})
+
+  # Cgo export and gccgo extern directive.
+  export_directive: (export|extern) ({{ident}})
+
   # Single line only
   inline_comment: /[*](?:[^*]|[*](?!/))*[*]/
 
@@ -118,17 +127,71 @@ contexts:
     #
     # //go:some_directive arg0 arg1 ...
     #
+    # These have been adopted outside the gc compiler for use in linting
+    # directives and pragmas for other compiler suites where they take the
+    # more generalised form of:
+    #
+    # //namespace:some_directive ...
+    #
     # They're not part of the language spec, may not be recognized by some Go
     # compilers, and may stop working in future releases. Therefore,
     # highlighting them as compiler pragmas could be misleading. We scope them
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
-    - match: (//)(go)(:)({{ident}})?
+    - match: (//)([a-z]+)(:)({{directive}}.*)
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
         3: meta.punctuation.accessor.colon.go
         4: meta.variable.function.go
+      push:
+        - meta_scope: meta.annotation.go comment.line.go
+        - match: \S+
+          scope: meta.variable.parameter.go
+        # End the annotation scope at EOL, but stretch the comment scope
+        # indefinitely to the right.
+        - match: $
+          set: pop-line-comment
+
+    # Go also has line renumbering; line directives specify the source
+    # position for the character immediately following the comment as
+    # having come from the specified file, line and column. Both single
+    # line and block comment line directives are valid.
+    - match: (//){{line_directive}}$
+      captures:
+        1: punctuation.definition.comment.go
+        2: meta.keyword.annotation.go
+        3: meta.variable.function.go
+      push:
+        - meta_scope: meta.annotation.go comment.line.go
+        - match: \S+
+          scope: meta.variable.parameter.go
+        # End the annotation scope at EOL, but stretch the comment scope
+        # indefinitely to the right.
+        - match: $
+          set: pop-line-comment
+
+    - match: (/\*){{line_directive}}(\*/)
+      captures:
+        1: punctuation.definition.comment.go
+        2: meta.keyword.annotation.go
+        3: meta.variable.function.go
+        4: punctuation.definition.comment.go
+      push:
+        - meta_scope: meta.annotation.go comment.block.go
+        - match: \S+
+          scope: meta.variable.parameter.go
+        # End the annotation scope at EOL, but stretch the comment scope
+        # indefinitely to the right.
+        - match: $
+          set: pop-line-comment
+
+    # Finally, Cgo and gccgo have directives for exporting functions to C.
+    - match: (//){{export_directive}}$
+      captures:
+        1: punctuation.definition.comment.go
+        2: meta.keyword.annotation.go
+        3: meta.variable.function.go
       push:
         - meta_scope: meta.annotation.go comment.line.go
         - match: \S+

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -132,7 +132,7 @@ contexts:
     # highlighting them as compiler pragmas could be misleading. We scope them
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
-    - match: (//)([a-z]+[a-z-]*)(:)({{directive}})[ ]?
+    - match: (//)([a-z]+[a-z-]*)(:)({{directive}})
       scope: meta.annotation.go
       captures:
         1: punctuation.definition.comment.go
@@ -145,7 +145,7 @@ contexts:
     # position for the character immediately following the comment as
     # having come from the specified file, line and column. Both single
     # line and block comment line directives are valid.
-    - match: ((//)(line) )([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
+    - match: ((//)(line))( [a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
       scope: comment.line.go
       captures:
         1: meta.annotation.go
@@ -153,7 +153,7 @@ contexts:
         3: meta.variable.function.go
         4: meta.annotation.parameters.go
 
-    - match: ((/\*)(line) )([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
+    - match: ((/\*)(line))( [a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
       scope: comment.block.go
       captures:
         1: meta.annotation.go
@@ -163,7 +163,7 @@ contexts:
         5: meta.annotation.go punctuation.definition.comment.end.go
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
-    - match: ((//)(export|extern) )({{ident}})$\n?
+    - match: ((//)(export|extern))( {{ident}})$\n?
       scope: comment.line.go
       captures:
         1: meta.annotation.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -117,7 +117,7 @@ contexts:
 
   # https://golang.org/ref/spec#Comments
   match-comments:
-   # Go has magic comments in the form of:
+    # Go has magic comments in the form of:
     #
     # //go:some_directive arg0 arg1 ...
     #

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -141,7 +141,7 @@ contexts:
       push:
         - meta_scope: meta.annotation.go comment.line.go
         - match: .+
-          scope: meta.variable.parameter.go
+          scope: meta.annotation.parameters.go
         # End the annotation scope at EOL, but stretch the comment scope
         # indefinitely to the right.
         - match: $

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -163,18 +163,14 @@ contexts:
 
     - match: (/\*)(line) ([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
       captures:
-        1: punctuation.definition.comment.go
+        1: punctuation.definition.comment.begin.go
         2: meta.variable.function.go
         3: meta.variable.parameter.go
-        4: punctuation.definition.comment.go
+        4: punctuation.definition.comment.end.go
       push:
         - meta_scope: meta.annotation.go comment.block.go
-        - match: \S+
-          scope: meta.variable.parameter.go
-        # End the annotation scope at EOL, but stretch the comment scope
-        # indefinitely to the right.
         - match: $
-          set: pop-line-comment
+          pop: true
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
     - match: (//)(export|extern) ({{ident}})$

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -132,44 +132,48 @@ contexts:
     # highlighting them as compiler pragmas could be misleading. We scope them
     # as plain comments by default, and add some detailed meta scopes for
     # enterprising users wishing to add more color.
-    - match: (//)([a-z]+[a-z-]*)(:)({{directive}})
+    - match: (//)([a-z]+[a-z-]*)(:)({{directive}})([ ]?)
       scope: meta.annotation.go
       captures:
         1: punctuation.definition.comment.go
         2: meta.keyword.annotation.go
         3: meta.punctuation.accessor.colon.go
         4: meta.variable.function.go
+        5: meta.punctuation.separator.space.go
       push: pop-line-annotation
 
     # Go also has line renumbering; line directives specify the source
     # position for the character immediately following the comment as
     # having come from the specified file, line and column. Both single
     # line and block comment line directives are valid.
-    - match: ((//)(line))( [a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
+    - match: ((//)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
       scope: comment.line.go
       captures:
         1: meta.annotation.go
         2: punctuation.definition.comment.go
         3: meta.variable.function.go
-        4: meta.annotation.parameters.go
+        4: meta.punctuation.separator.space.go
+        5: meta.annotation.parameters.go
 
-    - match: ((/\*)(line))( [a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
+    - match: ((/\*)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2})(\*/)
       scope: comment.block.go
       captures:
         1: meta.annotation.go
         2: punctuation.definition.comment.begin.go
         3: meta.variable.function.go
-        4: meta.annotation.parameters.go
-        5: meta.annotation.go punctuation.definition.comment.end.go
+        4: meta.punctuation.separator.space.go
+        5: meta.annotation.parameters.go
+        6: meta.annotation.go punctuation.definition.comment.end.go
 
     # Finally, Cgo and gccgo have directives for exporting functions to C.
-    - match: ((//)(export|extern))( {{ident}})$\n?
+    - match: ((//)(export|extern)( ))({{ident}})$\n?
       scope: comment.line.go
       captures:
         1: meta.annotation.go
         2: punctuation.definition.comment.go
         3: meta.variable.function.go
-        4: meta.annotation.parameters.go
+        4: meta.punctuation.separator.space.go
+        5: meta.annotation.parameters.go
 
     # Line comment
     - match: //

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -69,7 +69,7 @@ You may have to disable Go-specific linters when working on this file.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ meta.variable.parameter.go
+//                ^^^^^^^^^^^^^ meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //go-sumtype:decl MySumType
@@ -78,7 +78,7 @@ You may have to disable Go-specific linters when working on this file.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
-//                    ^^^^^^^^^ meta.variable.parameter.go
+//                    ^^^^^^^^^ meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:ignore U1000 Reason.
@@ -87,7 +87,7 @@ You may have to disable Go-specific linters when working on this file.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ meta.variable.parameter.go
+//                ^^^^^^^^^^^^^ meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:file-ignore Reason.
@@ -96,7 +96,7 @@ You may have to disable Go-specific linters when working on this file.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
-//                     ^^^^^^^ meta.variable.parameter.go
+//                     ^^^^^^^ meta.annotation.parameters.go
 //                            ^ comment.line.go -meta.annotation
 
     //line :10

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -56,19 +56,90 @@ You may have to disable Go-specific linters when working on this file.
     //go
 // ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^ comment.line.go -meta.annotation
+//  ^^^^ comment.line.go -meta.annotation
 
     //go:
-// ^ -comment -meta -punctuation
+// ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^ meta.annotation.go comment.line.go
-//       ^ comment.line.go -meta.annotation
+//  ^^^^^ comment.line.go -meta.annotation
 
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
 //                             ^ comment.line.go -meta.annotation
+
+    //lint:ignore U1000 Reason.
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                             ^ comment.line.go -meta.annotation
+
+    //lint:file-ignore Reason.
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                            ^ comment.line.go -meta.annotation
+
+    //line :10
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^ meta.annotation.go comment.line.go
+//            ^ comment.line.go -meta.annotation
+
+    //line file.rl:10
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                   ^ comment.line.go -meta.annotation
+
+    //line file.rl:100:10
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                       ^ comment.line.go -meta.annotation
+
+    /*line :10*/
+// ^ -comment
+//  ^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//              ^ -comment.block.go -meta.annotation
+
+    /*line file.rl:10*/
+// ^ -comment
+//  ^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//                     ^ -comment.block.go -meta.annotation
+
+    /*line file.rl:100:10*/
+// ^ -comment
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//                         ^ -comment.block.go -meta.annotation
+
+    /*line :10 */
+// ^ -comment
+//  ^^^^^^^^^^^^^ comment.block.go -meta.annotation
+//               ^ -comment
+
+    /*line file.rl:10 */
+// ^ -comment
+//  ^^^^^^^^^^^^^^^^^^^^ comment.block.go -meta.annotation
+//                      ^ -comment
+
+    /*line file.rl:100:10 */
+// ^ -comment
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.go -meta.annotation
+//                          ^ -comment
+
+    //export myfunc
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                 ^ comment.line.go -meta.annotation
+
+    //extern myfunc
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//                 ^ comment.line.go -meta.annotation
 
 
 // # Imports

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -66,86 +66,86 @@ You may have to disable Go-specific linters when working on this file.
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
-//               ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //go-sumtype:decl MySumType
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
-//                   ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                    ^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
-//               ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
-//                    ^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                     ^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                            ^ comment.line.go -meta.annotation
 
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^ comment.line.go meta.annotation.parameters.go
+//         ^^^ comment.line.go meta.annotation.parameters.go
 //            ^ comment.line.go -meta.annotation
 
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//         ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                   ^ comment.line.go -meta.annotation
 
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//         ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                       ^ comment.line.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
-//  ^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^ comment.block.go meta.annotation.parameters.go
+//         ^^^ comment.block.go meta.annotation.parameters.go
 //            ^^ comment.block.go punctuation.definition.comment.end.go
 //              ^ -comment.block.go -meta.annotation
 
     /*line file.rl:10*/
 // ^ -comment
-//  ^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//         ^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
 //                   ^^ comment.block.go punctuation.definition.comment.end.go
 //                     ^ -comment.block.go -meta.annotation
 
     /*line file.rl:100:10*/
 // ^ -comment
-//  ^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//        ^^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//         ^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
 //                       ^^ comment.block.go punctuation.definition.comment.end.go
 //                         ^ -comment.block.go -meta.annotation
 
@@ -169,15 +169,15 @@ You may have to disable Go-specific linters when working on this file.
     //export myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^ comment.line.go meta.annotation.go
-//          ^^^^^^^ comment.line.go meta.annotation.parameters.go
+//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
     //extern myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^ comment.line.go meta.annotation.go
-//          ^^^^^^^ comment.line.go meta.annotation.parameters.go
+//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -67,51 +67,72 @@ You may have to disable Go-specific linters when working on this file.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^ meta.keyword.annotation.go
+//       ^^^^^^^^ meta.variable.function.go
+//                ^^^^^^^^^^^^^ meta.variable.parameter.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^ meta.keyword.annotation.go
+//         ^^^^^^ meta.variable.function.go
+//                ^^^^^^^^^^^^^ meta.variable.parameter.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^ meta.keyword.annotation.go
+//         ^^^^^^^^^^^ meta.variable.function.go
+//                     ^^^^^^^ meta.variable.parameter.go
 //                            ^ comment.line.go -meta.annotation
 
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^ meta.variable.function.go
+//         ^^^ meta.variable.parameter.go
 //            ^ comment.line.go -meta.annotation
 
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^ meta.variable.function.go
+//         ^^^^^^^^^^ meta.variable.parameter.go
 //                   ^ comment.line.go -meta.annotation
 
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^ meta.variable.function.go
+//         ^^^^^^^^^^^^^^ meta.variable.parameter.go
 //                       ^ comment.line.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
 //  ^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//    ^^^^ meta.variable.function.go
+//         ^^^ meta.variable.parameter.go
 //              ^ -comment.block.go -meta.annotation
 
     /*line file.rl:10*/
 // ^ -comment
 //  ^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//    ^^^^ meta.variable.function.go
+//         ^^^^^^^^^^ meta.variable.parameter.go
 //                     ^ -comment.block.go -meta.annotation
 
     /*line file.rl:100:10*/
 // ^ -comment
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//    ^^^^ meta.variable.function.go
+//         ^^^^^^^^^^^^^^ meta.variable.parameter.go
 //                         ^ -comment.block.go -meta.annotation
 
     /*line :10 */

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -140,13 +140,17 @@ You may have to disable Go-specific linters when working on this file.
     /*line file.rl:100:10*/
 // ^ -comment
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
 //         ^^^^^^^^^^^^^^ meta.variable.parameter.go
+//                       ^^ punctuation.definition.comment.end.go
 //                         ^ -comment.block.go -meta.annotation
 
     /*line :10 */
 // ^ -comment
 //  ^^^^^^^^^^^^^ comment.block.go -meta.annotation
+//  ^^ punctuation.definition.comment.begin.go
+//             ^^ punctuation.definition.comment.end.go
 //               ^ -comment
 
     /*line file.rl:10 */

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -66,84 +66,87 @@ You may have to disable Go-specific linters when working on this file.
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ meta.annotation.parameters.go
+//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //go-sumtype:decl MySumType
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
-//                    ^^^^^^^^^ meta.annotation.parameters.go
+//                    ^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ meta.annotation.parameters.go
+//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
-//                     ^^^^^^^ meta.annotation.parameters.go
+//                     ^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                            ^ comment.line.go -meta.annotation
 
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^ meta.variable.parameter.go
+//         ^^^ comment.line.go meta.annotation.parameters.go
 //            ^ comment.line.go -meta.annotation
 
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^ meta.variable.parameter.go
+//         ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                   ^ comment.line.go -meta.annotation
 
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^^^^^ meta.variable.parameter.go
+//         ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                       ^ comment.line.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
-//  ^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^ meta.variable.parameter.go
+//         ^^^ comment.block.go meta.annotation.parameters.go
+//            ^^ comment.block.go punctuation.definition.comment.end.go
 //              ^ -comment.block.go -meta.annotation
 
     /*line file.rl:10*/
 // ^ -comment
-//  ^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^ meta.variable.parameter.go
+//         ^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//                   ^^ comment.block.go punctuation.definition.comment.end.go
 //                     ^ -comment.block.go -meta.annotation
 
     /*line file.rl:100:10*/
 // ^ -comment
-//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.block.go
+//  ^^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^^^^^ meta.variable.parameter.go
-//                       ^^ punctuation.definition.comment.end.go
+//         ^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//                       ^^ comment.block.go punctuation.definition.comment.end.go
 //                         ^ -comment.block.go -meta.annotation
 
     /*line :10 */
@@ -166,13 +169,15 @@ You may have to disable Go-specific linters when working on this file.
     //export myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
     //extern myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -66,86 +66,86 @@ You may have to disable Go-specific linters when working on this file.
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//               ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //go-sumtype:decl MySumType
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
-//                    ^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                   ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//               ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                             ^ comment.line.go -meta.annotation
 
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
-//                     ^^^^^^^ comment.line.go meta.annotation.parameters.go
+//                    ^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                            ^ comment.line.go -meta.annotation
 
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^ comment.line.go meta.annotation.parameters.go
+//        ^^^^ comment.line.go meta.annotation.parameters.go
 //            ^ comment.line.go -meta.annotation
 
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//        ^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                   ^ comment.line.go -meta.annotation
 
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
+//        ^^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                       ^ comment.line.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^ comment.block.go meta.annotation.parameters.go
+//        ^^^^ comment.block.go meta.annotation.parameters.go
 //            ^^ comment.block.go punctuation.definition.comment.end.go
 //              ^ -comment.block.go -meta.annotation
 
     /*line file.rl:10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//        ^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
 //                   ^^ comment.block.go punctuation.definition.comment.end.go
 //                     ^ -comment.block.go -meta.annotation
 
     /*line file.rl:100:10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
+//        ^^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
 //                       ^^ comment.block.go punctuation.definition.comment.end.go
 //                         ^ -comment.block.go -meta.annotation
 
@@ -169,15 +169,15 @@ You may have to disable Go-specific linters when working on this file.
     //export myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^ comment.line.go meta.annotation.go
-//           ^^^^^^ comment.line.go meta.annotation.parameters.go
+//  ^^^^^^^^ comment.line.go meta.annotation.go
+//          ^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
     //extern myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^ comment.line.go meta.annotation.go
-//           ^^^^^^ comment.line.go meta.annotation.parameters.go
+//  ^^^^^^^^ comment.line.go meta.annotation.go
+//          ^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -72,6 +72,15 @@ You may have to disable Go-specific linters when working on this file.
 //                ^^^^^^^^^^^^^ meta.variable.parameter.go
 //                             ^ comment.line.go -meta.annotation
 
+    //go-sumtype:decl MySumType
+// ^ -comment -meta -punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.go comment.line.go
+//    ^^^^^^^^^^ meta.keyword.annotation.go
+//               ^^^^ meta.variable.function.go
+//                    ^^^^^^^^^ meta.variable.parameter.go
+//                             ^ comment.line.go -meta.annotation
+
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go


### PR DESCRIPTION
This adds line and export directive syntax patterns and generalises the `//go:name` pattern for use in other contexts such as linter directives. It also fixes `//go:name` matching to avoid matching invalid directive comments.

~~It's not completely clear to me how to express the expectation in the tests (and some current tests expectation are incorrect; `//go` and `//go:` are invalid directives — so I expect tests to fail), so please let me know what I should add.~~

These should be marked as valid directives:
```
//go:linkname
//go:cgo_import_dynamic
//lint:ignore U1000 This is here for user documentation.
//lint:ignore-file Autogenerated.
//line file.rl:3732:45
//line :3732:45:45
//line :3732 :45:45
/*line file.rl:3732:45*/
/*line :3732:45:45*/
/*line :3732 :45:45*/
//export myfunc
//extern myfunc
```

These should not be marked:
```
/*line file.rl:3732:45 */
/*line :3732:45:45 */
/*line :3732 :45:45 */
//go:
//go
```

Please take a look.