### PR TITLE
[Python] Fix implicit tuples termination

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1014,6 +1014,8 @@ contexts:
       pop: true
     - match: (?=\S)
       pop: true
+    - match: ^(?!\s*[#*])
+      pop: true
 
   classes:
     - match: '^\s*(class)\b'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2039,6 +2039,21 @@ generator = (
     range(100)
 )
 
+class Cls:
+    __slots__ = "item",
+#               ^^^^^^ meta.string.python string.quoted.double.python
+#                     ^ punctuation.separator.sequence.python
+
+    __slots__ = "item",
+
+    def method():
+# <- meta.function.python
+#^^^^^^^^^^^^^^^^ meta.function
+#   ^^^ keyword.declaration.function.python
+#       ^^^^^^ entity.name.function.python
+#             ^ punctuation.section.parameters.begin.python
+#              ^ punctuation.section.parameters.end.python
+#               ^ punctuation.section.function.begin.python
 
 ##################
 # Exception handling


### PR DESCRIPTION
Fixes #3243

Pop `allow-unpack-operators` off stack directly at the beginning of a line if it doesn't begin with optional whitespace followed by asterisk or hashtag.

This is to ensure to correctly match `def` statements whose pattern requires to be matched at bol.

The new pattern is appended to keep performance impact as low as possible. It is matched upon newlines only.