### PR TITLE
[HTML] Add 'onfocusin' and 'onfocusout' event names

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -86,7 +86,7 @@ variables:
     | oncontextmenu | oncuechange | ondblclick | ondrag | ondragend
     | ondragenter | ondragexit | ondragleave | ondragover | ondragstart | ondrop
     | ondurationchange | onemptied | onended | onerror | onfocus | onfocusin
-    | onfocusou | oninput | oninvalid | onkeydown | onkeypress | onkeyup
+    | onfocusout | oninput | oninvalid | onkeydown | onkeypress | onkeyup
     | onload | onloadeddata | onloadedmetadata | onloadstart | onmousedown
     | onmouseenter | onmouseleave | onmousemove | onmouseout | onmouseover
     | onmouseup | onmousewheel | onpause | onplay | onplaying | onprogress

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -79,6 +79,22 @@ variables:
     |   ^ (\s*) (-->) \s* $
     )
 
+  event_attribute_names: |-
+    (?xi:
+      onabort | onautocomplete | onautocompleteerror | onauxclick | onblur
+    | oncancel | oncanplay | oncanplaythrough | onchange | onclick | onclose
+    | oncontextmenu | oncuechange | ondblclick | ondrag | ondragend
+    | ondragenter | ondragexit | ondragleave | ondragover | ondragstart | ondrop
+    | ondurationchange | onemptied | onended | onerror | onfocus | onfocusin
+    | onfocusou | oninput | oninvalid | onkeydown | onkeypress | onkeyup
+    | onload | onloadeddata | onloadedmetadata | onloadstart | onmousedown
+    | onmouseenter | onmouseleave | onmousemove | onmouseout | onmouseover
+    | onmouseup | onmousewheel | onpause | onplay | onplaying | onprogress
+    | onratechange | onreset | onresize | onscroll | onseeked | onseeking
+    | onselect | onshow | onsort | onstalled | onsubmit | onsuspend
+    | ontimeupdate | ontoggle | onvolumechange | onwaiting
+    ){{attribute_name_break}}
+
 ###############################################################################
 
 contexts:
@@ -542,18 +558,7 @@ contexts:
 ###[ EVENT ATTRIBUTE ]########################################################
 
   tag-event-attribute:
-    - match: |-
-        (?ix:on(?:
-          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
-          |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
-          |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
-          |durationchange|emptied|ended|error|focus|input|invalid|keydown
-          |keypress|keyup|load|loadeddata|loadedmetadata|loadstart|mousedown
-          |mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|mousewheel
-          |pause|play|playing|progress|ratechange|reset|resize|scroll|seeked
-          |seeking|select|show|sort|stalled|submit|suspend|timeupdate|toggle
-          |volumechange|waiting
-        )){{attribute_name_break}}
+    - match: '{{event_attribute_names}}'
       scope: entity.other.attribute-name.event.html
       push:
         - tag-event-attribute-meta

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -83,15 +83,15 @@ variables:
     (?xi:
       onabort | onautocomplete | onautocompleteerror | onauxclick | onblur
     | oncancel | oncanplay | oncanplaythrough | onchange | onclick | onclose
-    | oncontextmenu | oncuechange | ondblclick | ondrag | ondragend
+    | oncontextmenu | oncopy | oncuechange | ondblclick | ondrag | ondragend
     | ondragenter | ondragexit | ondragleave | ondragover | ondragstart | ondrop
     | ondurationchange | onemptied | onended | onerror | onfocus | onfocusin
     | onfocusout | oninput | oninvalid | onkeydown | onkeypress | onkeyup
     | onload | onloadeddata | onloadedmetadata | onloadstart | onmousedown
     | onmouseenter | onmouseleave | onmousemove | onmouseout | onmouseover
-    | onmouseup | onmousewheel | onpause | onplay | onplaying | onprogress
-    | onratechange | onreset | onresize | onscroll | onseeked | onseeking
-    | onselect | onshow | onsort | onstalled | onsubmit | onsuspend
+    | onmouseup | onmousewheel | onpaste | onpause | onplay | onplaying
+    | onprogress | onratechange | onreset | onresize | onscroll | onseeked
+    | onseeking | onselect | onshow | onsort | onstalled | onsubmit | onsuspend
     | ontimeupdate | ontoggle | onvolumechange | onwaiting
     ){{attribute_name_break}}
 

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -390,15 +390,15 @@ def get_tag_attributes():
         'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick',
         'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave',
         'ondragover', 'ondragstart', 'ondrop', 'ondurationchange',
-        'onemptied', 'onended', 'onerror', 'onfocus', 'oninput', 'oninvalid',
-        'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onloadeddata',
-        'onloadedmetadata', 'onloadstart', 'onmousedown', 'onmouseenter',
-        'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover',
-        'onmouseup', 'onmousewheel', 'onpause', 'onplay', 'onplaying',
-        'onprogress', 'onratechange', 'onreset', 'onresize', 'onscroll',
-        'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort', 'onstalled',
-        'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle', 'onvolumechange',
-        'onwaiting'
+        'onemptied', 'onended', 'onerror', 'onfocus', 'onfocusin', 'onfocusout'
+        'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup', 'onload',
+        'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown',
+        'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout',
+        'onmouseover', 'onmouseup', 'onmousewheel', 'onpause', 'onplay',
+        'onplaying', 'onprogress', 'onratechange', 'onreset', 'onresize',
+        'onscroll', 'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort',
+        'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle',
+        'onvolumechange', 'onwaiting'
     )
 
     for attributes in tag_attr_dict.values():

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -385,20 +385,20 @@ def get_tag_attributes():
         'hidden', 'id', 'lang', 'style', 'tabindex', 'title', 'translate'
 
         # event handler attributes
-        'onabort', 'onautocomplete', 'onautocompleteerror', 'onauxclick',
-        'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange',
-        'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick',
+        'onabort', 'onautocomplete', 'onautocompleteerror', 'onauxclick', 'onblur',
+        'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange', 'onclick',
+        'onclose', 'oncontextmenu', 'oncopy', 'oncuechange', 'ondblclick',
         'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave',
-        'ondragover', 'ondragstart', 'ondrop', 'ondurationchange',
-        'onemptied', 'onended', 'onerror', 'onfocus', 'onfocusin', 'onfocusout'
-        'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup', 'onload',
+        'ondragover', 'ondragstart', 'ondrop', 'ondurationchange', 'onemptied',
+        'onended', 'onerror', 'onfocus', 'onfocusin', 'onfocusout', 'oninput',
+        'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup', 'onload',
         'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown',
-        'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout',
-        'onmouseover', 'onmouseup', 'onmousewheel', 'onpause', 'onplay',
-        'onplaying', 'onprogress', 'onratechange', 'onreset', 'onresize',
-        'onscroll', 'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort',
-        'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle',
-        'onvolumechange', 'onwaiting'
+        'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover',
+        'onmouseup', 'onmousewheel', 'onpaste', 'onpause', 'onplay', 'onplaying',
+        'onprogress', 'onratechange', 'onreset', 'onresize', 'onscroll',
+        'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort', 'onstalled',
+        'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle', 'onvolumechange',
+        'onwaiting'
     )
 
     for attributes in tag_attr_dict.values():


### PR DESCRIPTION
Fixes #3248

This commit...

1. adds 'onfocusin' and 'onfocusout' to completions and syntax
2. creates a variable to store the pattern of all known event names