### PR TITLE
[Java] Tweak JavaDoc punctuation in html tags

### DIFF
--- a/Java/JavaDoc.sublime-syntax
+++ b/Java/JavaDoc.sublime-syntax
@@ -284,3 +284,24 @@ contexts:
       push:
         - clear_scopes: 1
         - include: javadoc-asterisk
+
+  tag-generic-attribute-assignment:
+    - meta_prepend: true
+    - match: ^
+      push:
+        - clear_scopes: 2
+        - include: javadoc-asterisk
+
+  tag-generic-attribute-value:
+    - meta_prepend: true
+    - match: ^
+      push:
+        - clear_scopes: 2
+        - include: javadoc-asterisk
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - match: ^
+      push:
+        - clear_scopes: 4
+        - include: javadoc-asterisk

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -401,6 +401,48 @@
 //^^^ comment.block.documentation.java - meta.tag
 // ^ punctuation.definition.comment.java
 //   ^ meta.tag punctuation.definition.tag.end.html
+   *
+   * <tag
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^ comment.block.documentation.java meta.tag.html
+   * attrib = "
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^^^^^^^ comment.block.documentation.java meta.tag.html meta.attribute-with-value.html
+//   ^^^^^^ entity.other.attribute-name.html
+//          ^ punctuation.separator.key-value.html
+//            ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+   * string"
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^^^ comment.block.documentation.java meta.tag.html meta.attribute-with-value.html meta.string.html string.quoted.double.html
+//         ^ punctuation.definition.string.end.html
+   * >
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+   *
+   * <tag
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^ comment.block.documentation.java meta.tag.html
+   * attrib
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^^^ comment.block.documentation.java meta.tag.html meta.attribute-with-value.html
+//   ^^^^^^ entity.other.attribute-name.html
+   * =
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^ comment.block.documentation.java meta.tag.html meta.attribute-with-value.html punctuation.separator.key-value.html
+   * string
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+//   ^^^^^^ comment.block.documentation.java meta.tag.html meta.attribute-with-value.html meta.string.html string.unquoted.html
+   * >
+// ^ comment.block.documentation.java punctuation.definition.comment.java - meta.tag - meta.attribute-with-value - string
+//  ^ comment.block.documentation.java - meta.tag - meta.attribute-with-value - string - punctuation
+   *
    * <script>
 //^^^^^^^^^^^^ comment.block.documentation.java
 // ^ punctuation.definition.comment.java


### PR DESCRIPTION
This PR clears `meta.tag`, ... scopes for leading `*` punctuation in html tags and attribute values of JavaDoc comments.