### PR TITLE
[JavaScript] Decorators can't have bracketed accesses.

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -926,7 +926,7 @@ contexts:
     - include: immediately-pop
 
   decorator-name:
-    - match: '{{identifier_name}}{{left_expression_end_lookahead}}'
+    - match: '{{identifier_name}}(?!\s*[.\(`])'
       scope: variable.annotation.js
       pop: true
 
@@ -937,7 +937,15 @@ contexts:
         - include: decorator-name
         - include: object-property
 
-    - include: left-expression-end
+    - include: expression-break
+
+    - match: (?=`)
+      push: literal-string-template
+
+    - match: (?=(?:{{dot_accessor}})?\()
+      push: function-call-arguments
+
+    - include: else-pop
 
   decorator-expression-begin:
     - include: decorator-name

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -723,6 +723,21 @@ class MyClass extends TheirClass {
 //   ^^^^^^^^^^ meta.group
 //              ^^^ entity.name.function
 
+    @foo`bar` bar() {}
+//  ^^^^^^^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.function.tagged-template
+//      ^^^^^ meta.string string.quoted.other
+//      ^ punctuation.definition.string.begin
+//          ^ punctuation.definition.string.end
+//            ^^^ meta.function entity.name.function
+
+    @foo['bar']() {}
+//  ^^^^ meta.annotation
+//  ^ punctuation.definition.annotation
+//   ^^^ variable.annotation
+//      ^^^^^^^^^^^^ meta.function - meta.annotation
+
     ['foo']() {}
 //  ^^^^^^^^^^^^ meta.function
 


### PR DESCRIPTION
Fix #3253.

Annotations used `left-expression-end`, but a left-expression can contain a bracketed property access while an annotation cannot.

Also slightly improve scoping for annotations with tagged templates.