### PR TITLE
[Python] Fix constants highlighting in class declaration parameters

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1056,7 +1056,7 @@ contexts:
               captures:
                 1: variable.parameter.class-inheritance.python
                 2: keyword.operator.assignment.python
-            - match: (?={{path}})
+            - match: (?=(?!None|False|True|Ellipsis|NotImplemented|__debug__){{path}})
               push:
                 - meta_scope: entity.other.inherited-class.python
                 - match: '{{identifier}}(?: *(\.) *)?'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1052,11 +1052,12 @@ contexts:
             - match: ','
               scope: punctuation.separator.inheritance.python
             - include: illegal-name
-            - match: ({{identifier}}) *(=)
+            - include: constants
+            - match: (?:({{identifier}}) *)?(=)
               captures:
                 1: variable.parameter.class-inheritance.python
                 2: keyword.operator.assignment.python
-            - match: (?=(?!None|False|True|Ellipsis|NotImplemented|__debug__){{path}})
+            - match: (?={{path}})
               push:
                 - meta_scope: entity.other.inherited-class.python
                 - match: '{{identifier}}(?: *(\.) *)?'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1605,12 +1605,24 @@ class MyClass(Inherited, \
 #                                ^ punctuation.separator.inheritance
 #                                  ^^^^^^^^^ variable.parameter.class-inheritance
 #                                           ^ keyword.operator.assignment
+#                                            ^^^^^^^ entity.other.inherited-class.python
     ur'''
 #   ^^ storage.type.string
     This is a test of docstrings
     '''
 #   ^^^ comment.block.documentation.python
     pass
+
+
+class DataClass(TypedDict, None, total=False):
+#     ^^^^^^^^^ entity.name.class.python
+#               ^^^^^^^^^ entity.other.inherited-class.python
+#                        ^ punctuation.separator.inheritance.python
+#                          ^^^^ constant.language.null.python
+#                              ^ punctuation.separator.inheritance.python
+#                                ^^^^^ variable.parameter.class-inheritance.python
+#                                     ^ keyword.operator.assignment.python
+#                                      ^^^^^ constant.language.boolean.python
 
 
 class Unterminated(Inherited:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1614,7 +1614,7 @@ class MyClass(Inherited, \
     pass
 
 
-class DataClass(TypedDict, None, total=False):
+class DataClass(TypedDict, None, total=False, True=False):
 #     ^^^^^^^^^ entity.name.class.python
 #               ^^^^^^^^^ entity.other.inherited-class.python
 #                        ^ punctuation.separator.inheritance.python
@@ -1623,6 +1623,10 @@ class DataClass(TypedDict, None, total=False):
 #                                ^^^^^ variable.parameter.class-inheritance.python
 #                                     ^ keyword.operator.assignment.python
 #                                      ^^^^^ constant.language.boolean.python
+#                                           ^ punctuation.separator.inheritance.python
+#                                             ^^^^ constant.language.boolean.python
+#                                                 ^ keyword.operator.assignment.python
+#                                                  ^^^^^ constant.language.boolean.python
 
 
 class Unterminated(Inherited:


### PR DESCRIPTION
Fixes #3252

A simple approach to fix highlighting of constants in class declarations.