### PR TITLE
[PHP] Fix SQL query concatenation 

### DIFF
--- a/PHP/Embeddings/SQL (for PHP Interpolation).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP Interpolation).sublime-syntax
@@ -1,0 +1,11 @@
+%YAML 1.2
+---
+scope: source.sql.interpolated.php
+hidden: true
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: Packages/PHP/PHP Source.sublime-syntax#interpolation

--- a/PHP/Embeddings/SQL (for PHP).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP).sublime-syntax
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+scope: source.sql.embedded.php
+hidden: true
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: php-single-quoted-strings
+    - include: php-string-single-quoted-escapes
+
+  php-string-single-quoted-escapes:
+    - match: \\[\\']
+      scope: constant.character.escape.php
+
+  php-single-quoted-strings:
+    # single quoted sql strings use escaped quotes in a single quoted php string
+    - match: \\\'
+      scope: punctuation.definition.string.begin.sql constant.character.escape.php
+      push: php-string-single-quoted-content
+
+  php-string-single-quoted-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.sql string.quoted.single.sql
+    - match: \\\'
+      scope: punctuation.definition.string.begin.sql constant.character.escape.php
+      pop: true
+    - match: \\.
+      scope: constant.character.escape.sql

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1371,8 +1371,8 @@ contexts:
           captures:
             1: keyword.operator.heredoc.php
             2: meta.string.heredoc.php meta.tag.heredoc.php entity.name.tag.heredoc.php
-          embed: heredoc-sql
-          embed_scope: meta.embedded.sql
+          embed: scope:source.sql.interpolated.php
+          embed_scope: meta.embedded.sql source.sql.embedded.php
           escape: '{{heredoc_unquoted_end}}'
         - match: (<<<)\s*((')(?i:(SQL))('))\s*$\n?
           captures:
@@ -1382,7 +1382,7 @@ contexts:
             4: entity.name.tag.heredoc.php
             5: punctuation.definition.tag.end.php
           embed: scope:source.sql
-          embed_scope: meta.embedded.sql source.sql
+          embed_scope: meta.embedded.sql source.sql.embedded.php
           escape: '{{heredoc_quoted_end}}'
         - match: (<<<)\s*(?i:(JAVASCRIPT|JS))\s*$\n?
           captures:
@@ -1482,12 +1482,6 @@ contexts:
     - meta_include_prototype: false
     - match: ''
       push: scope:text.xml
-      with_prototype:
-        - include: interpolation
-  heredoc-sql:
-    - meta_include_prototype: false
-    - match: ''
-      push: scope:source.sql
       with_prototype:
         - include: interpolation
   heredoc-javascript:

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -41,6 +41,14 @@ variables:
   heredoc_quoted_end: (?=^\s*\4\b)
   heredoc_unquoted_end: (?=^\s*\2\b)
 
+  # no odd number of backslashes behind (`\` or `\\\`)
+  # note:
+  #  1. For use in `escape` commands only !!
+  #  2. ST's Regex Compatibility Check marks it as incompatible
+  #     as the real usage of the variable is not checked.
+  #     It's a false positive as long as (1.) is respected.
+  no_escape_behind: (?<![^\\]\\)(?<![^\\][\\]{3})
+
 contexts:
   main:
     - include: statements
@@ -1780,13 +1788,10 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.string.php
     - meta_content_scope: string.quoted.double.php
-    - include: string-double-quoted-end
     - match: (?={{sql_indicator}})
-      push: string-quoted-sql-content
-      with_prototype:
-        - match: (?=")
-          pop: 1
-        - include: interpolation
+      set:
+        - nested-sql-expressions
+        - string-double-quoted-sql-content
     - match: (?=\S)
       set: string-double-quoted-plain-content
 
@@ -1836,6 +1841,15 @@ contexts:
     - include: string-double-quoted-end
     - include: interpolation
 
+  string-double-quoted-sql-content:
+    - match: ''
+      pop: 1
+      embed: scope:source.sql.interpolated.php
+      embed_scope: meta.string.php meta.interpolation.php source.sql.embedded.php
+      escape: '{{no_escape_behind}}"'
+      escape_captures:
+        0: meta.string.php string.quoted.double.php punctuation.definition.string.end.php
+
 
   strings-single-quoted:
     - match: (?='/)
@@ -1858,12 +1872,9 @@ contexts:
     - meta_content_scope: string.quoted.single.php
     - include: string-single-quoted-end
     - match: (?={{sql_indicator}})
-      push: string-quoted-sql-content
-      with_prototype:
-        - match: (?=')
-          pop: 1
-        - match: '\\[\\'']'
-          scope: constant.character.escape.php
+      set:
+        - nested-sql-expressions
+        - string-single-quoted-sql-content
     - match: (?=\S)
       scope: punctuation.definition.string.begin.php
       set: string-single-quoted-plain-content
@@ -1910,12 +1921,31 @@ contexts:
     - match: \\[\\'']
       scope: constant.character.escape.php
 
-  string-quoted-sql-content:
-    - clear_scopes: 1
-    - meta_include_prototype: false
-    - meta_content_scope: meta.interpolation.php source.sql.embedded.php
-    - include: scope:source.sql
-      apply_prototype: true
+  string-single-quoted-sql-content:
+    - match: ''
+      pop: 1
+      embed: scope:source.sql.embedded.php  # no interpolation
+      embed_scope: meta.string.php meta.interpolation.php source.sql.embedded.php
+      escape: "{{no_escape_behind}}'"
+      escape_captures:
+        0: meta.string.php string.quoted.single.php punctuation.definition.string.end.php
+
+  nested-sql-expressions:
+    - match: \"
+      scope: meta.string.php string.quoted.double.php punctuation.definition.string.begin.php
+      embed: scope:source.sql.interpolated.php
+      embed_scope: meta.string.php meta.interpolation.php source.sql.embedded.php
+      escape: '{{no_escape_behind}}"'
+      escape_captures:
+        0: meta.string.php string.quoted.double.php punctuation.definition.string.end.php
+    - match: \'
+      scope: meta.string.php string.quoted.single.php punctuation.definition.string.begin.php
+      embed: scope:source.sql.embedded.php  # no interpolation
+      embed_scope: meta.string.php meta.interpolation.php source.sql.embedded.php
+      escape: "{{no_escape_behind}}'"
+      escape_captures:
+        0: meta.string.php string.quoted.single.php punctuation.definition.string.end.php
+    - include: nested-expressions
 
 ###[ BUILTINS ]###############################################################
 

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1728,6 +1728,38 @@ $sql = "
 ";
 // <- meta.string.php string.quoted.double.php punctuation.definition.string.end.php - meta.interpolation - string string
 
+$sql = "SELECT " . $col . "FROM $table WHERE ( first_name =" . $name . ")" ; . "GROUP BY" ;
+//     ^ meta.string.php - meta.interpolation
+//      ^^^^^^^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//             ^ meta.string.php - meta.interpolation
+//              ^^^^^^^^^^ - meta.string
+//                        ^ meta.string.php - meta.interpolation
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//                                                         ^ meta.string.php - meta.interpolation
+//                                                          ^^^^^^^^^^^ - meta.string
+//                                                                     ^ meta.string.php - meta.interpolation
+//                                                                      ^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//                                                                       ^ meta.string.php - meta.interpolation
+//                                                                        ^^^^^ - meta.string
+//                                                                             ^^^^^^^^^^ meta.string.php string.quoted.double.php - meta.interpolation
+//     ^ string.quoted.double.php punctuation.definition.string.begin.php
+//      ^^^^^^ keyword.other.DML.sql
+//             ^ string.quoted.double.php punctuation.definition.string.end.php
+//               ^ keyword.operator.string.php
+//                 ^^^^ variable.other.php
+//                      ^ keyword.operator.string.php
+//                        ^ string.quoted.double.php punctuation.definition.string.begin.php
+//                              ^^^^^^ variable.other.php
+//                                                         ^ string.quoted.double.php punctuation.definition.string.end.php
+//                                                           ^ keyword.operator.string.php
+//                                                             ^^^^^ variable.other.php
+//                                                                   ^ keyword.operator.string.php
+//                                                                     ^ string.quoted.double.php punctuation.definition.string.begin.php
+//                                                                       ^ string.quoted.double.php punctuation.definition.string.end.php
+//                                                                         ^ punctuation.terminator.expression.php
+//                                                                           ^ keyword.operator.string.php
+//                                                                                        ^ punctuation.terminator.expression.php
+
 $non_sql = 'NO SELECT HIGHLIGHTING!';
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation - string string
 //         ^ punctuation.definition.string.begin
@@ -1738,6 +1770,7 @@ $sql = 'SELECT * FROM users WHERE first_name = \'Eric\'';
 //     ^ meta.string.php string.quoted.single.php punctuation.definition.string.begin.php - meta.interpolation - string string
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql - string.quoted.single.php
 //      ^ keyword.other.DML
+//                                             ^^^^^^^^ meta.string.sql string.quoted.single.sql
 //                                             ^^ constant.character.escape.php
 //                                                   ^^ constant.character.escape.php
 //                                                     ^ meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation - string string
@@ -1749,6 +1782,37 @@ $sql = '
 //                                         ^^ constant.character.escape.php
 ';
 // <- meta.string.php string.quoted.single.php punctuation.definition.string.end.php - meta.interpolation - string string
+
+$sql = 'SELECT ' . $col . 'FROM table WHERE ( first_name =' . $name . ')' ; . 'GROUP BY' ;
+//     ^ meta.string.php - meta.interpolation
+//      ^^^^^^^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//             ^ meta.string.php - meta.interpolation
+//              ^^^^^^^^^^ - meta.string
+//                        ^ meta.string.php - meta.interpolation
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//                                                        ^ meta.string.php - meta.interpolation
+//                                                         ^^^^^^^^^^^ - meta.string
+//                                                                    ^ meta.string.php - meta.interpolation
+//                                                                     ^ meta.string.php meta.interpolation.php source.sql.embedded.php
+//                                                                      ^ meta.string.php - meta.interpolation
+//                                                                       ^^^^^ - meta.string
+//                                                                            ^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation
+//     ^ string.quoted.single.php punctuation.definition.string.begin.php
+//      ^^^^^^ keyword.other.DML.sql
+//             ^ string.quoted.single.php punctuation.definition.string.end.php
+//               ^ keyword.operator.string.php
+//                 ^^^^ variable.other.php
+//                      ^ keyword.operator.string.php
+//                        ^ string.quoted.single.php punctuation.definition.string.begin.php
+//                                                        ^ string.quoted.single.php punctuation.definition.string.end.php
+//                                                          ^ keyword.operator.string.php
+//                                                            ^^^^^ variable.other.php
+//                                                                  ^ keyword.operator.string.php
+//                                                                    ^ string.quoted.single.php punctuation.definition.string.begin.php
+//                                                                      ^ string.quoted.single.php punctuation.definition.string.end.php
+//                                                                        ^ punctuation.terminator.expression.php
+//                                                                          ^ keyword.operator.string.php
+//                                                                                       ^ punctuation.terminator.expression.php
 
 preg_replace('/[a-zSOME_CHAR]*+\'\n  $justTxt  \1  \\1/m');
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2021,7 +2021,7 @@ echo <<<sql
 //      ^^^ meta.string.heredoc meta.tag.heredoc
 //      ^^^ entity.name.tag.heredoc
 SELECT * FROM users WHERE first_name = 'John' LIMIT $limit
-//^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql.embedded.php
 // <- keyword.other.DML
 //     ^ variable.language.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
@@ -2038,7 +2038,7 @@ echo <<<'SQL'
 //      ^^^^^ meta.string.heredoc meta.tag.heredoc
 //       ^^^ entity.name.tag.heredoc
 SELECT * FROM users WHERE first_name = 'John'\n
-//^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql.embedded.php
 // <- keyword.other.DML
 //     ^ variable.language.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single


### PR DESCRIPTION
Fixes #572

see: https://forum.sublimetext.com/t/color-of-sql-query-change-when-add-quotes/63178/2

This commit adds support for highlighting sql queries in all parts of a chained string.

```
$sql = "SELECT " . $col . " FROM " . $table . " WHERE foo is " . $bar ;
```

![grafik](https://user-images.githubusercontent.com/16542113/156925598-d5fe73fe-167c-4974-a2cb-7c4347ed0496.png)


_Note: This PR may cause some conflicts with #3046. Depending on which one is merged first, we might need to tweak the one or the other slighly afterwards._