### PR TITLE
[Python] Scope assignments after constants illegal

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -854,16 +854,26 @@ contexts:
     - include: nones
     - match: \b(?:Ellipsis|NotImplemented|__debug__)\b
       scope: constant.language.python
+      push: illegal-assignment
     - match: \.{3}(?!\w)
       scope: constant.language.python
 
   booleans:
     - match: \b(?:True|False)\b
       scope: constant.language.boolean.python
+      push: illegal-assignment
 
   nones:
     - match: \bNone\b
       scope: constant.language.null.python
+      push: illegal-assignment
+
+  illegal-assignment:
+    - match: \:?=
+      scope: invalid.illegal.not-allowed-here.python
+      pop: true
+    - match: (?=\S)
+      pop: true
 
   numbers:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
@@ -1053,7 +1063,7 @@ contexts:
               scope: punctuation.separator.inheritance.python
             - include: illegal-name
             - include: constants
-            - match: (?:({{identifier}}) *)?(=)
+            - match: (?:({{identifier}}) *)(=)
               captures:
                 1: variable.parameter.class-inheritance.python
                 2: keyword.operator.assignment.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1625,7 +1625,7 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                                      ^^^^^ constant.language.boolean.python
 #                                           ^ punctuation.separator.inheritance.python
 #                                             ^^^^ constant.language.boolean.python
-#                                                 ^ keyword.operator.assignment.python
+#                                                 ^ invalid.illegal.not-allowed-here.python
 #                                                  ^^^^^ constant.language.boolean.python
 
 
@@ -2326,6 +2326,15 @@ class Starship:
 ##################
 # Assignment Expressions
 ##################
+
+True = False
+#    ^ invalid.illegal.not-allowed-here.python
+
+False = True
+#     ^ invalid.illegal.not-allowed-here.python
+
+None = True
+#    ^ invalid.illegal.not-allowed-here.python
 
 # Examples from https://www.python.org/dev/peps/pep-0572/
 


### PR DESCRIPTION
This commit scopes assignment operators after constants illegal.