### PR TITLE
[Python] Fix class/def declarations after constants

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -872,8 +872,8 @@ contexts:
     - match: \:?=
       scope: invalid.illegal.not-allowed-here.python
       pop: true
-    - match: (?=\S)
-      pop: true
+    - include: line-continuation-or-pop
+    - include: else-pop
 
   numbers:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
@@ -1774,6 +1774,10 @@ contexts:
   line-continuation-or-pop:
     - include: line-continuation
     - match: (?=\s*($|;|#))
+      pop: true
+
+  else-pop:
+    - match: (?=\S)
       pop: true
 
   magic-function-names:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1629,7 +1629,19 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                                                  ^^^^^ constant.language.boolean.python
 
 
+
+class MyClass:
+    def foo():
+        return None
+
+    def bar():
+#   ^^^^^^^^^^ meta.function
+#   ^^^ keyword.declaration.function.python
+        return True
+
+
 class Unterminated(Inherited:
+# <- meta.class.python keyword.declaration.class.python
 #                           ^ invalid.illegal
 
 


### PR DESCRIPTION
This commit is a follow up or fix for e103d07, which prevents class or
function definitions directly following a constant from being scoped
illegal.