### PR TITLE
[CSS] Add space after colon only via `auto_complete_trailing_spaces`

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -1,24 +1,13 @@
 [
 	// Add a colon followed by space and semicolon after a property name,
 	// if the next following token doesn't look like a value.
-	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0;"}, "context":
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.css meta.property-list - meta.selector - meta.group - comment - string", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\s*($|[^:;}]+:)", "match_all": false }
-		]
-	},
-	// Add a colon followed by space after a property name,
-	// if the next character is a semicolon or the following token looks like a value.
-	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ": $0"}, "context":
-		[
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "selector", "operator": "equal", "operand": "source.css - meta.selector.css", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": false },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^;|^[^\\s:;][^:]*($|[;}]|//|/\\*)", "match_all": true }
 		]
 	},
 	// Move the cursor to prevent adding a duplicated semicolon.

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -91,24 +91,28 @@ class CSSCompletions(sublime_plugin.EventListener):
         return None
 
     def complete_property_name(self, view, prefix, pt):
-        if match_selector(view, pt, "meta.group"):
-            # don't append semicolon in groups e.g.: `@media screen (prop: |)`
-            suffix = ": $0"
-        else:
-            suffix = ": $0;"
         text = view.substr(sublime.Region(pt, view.line(pt).end()))
         matches = self.re_value.search(text)
         if matches:
             colon, space, value, term = matches.groups()
-            if colon:
-                # don't append anything if the next character is a colon
-                suffix = ""
-            elif value:
-                # only append colon if value already exists
-                suffix = ":" if space else ": "
-            elif term == ";":
-                # ommit semicolon if rule is already terminated
+        else:
+            colon = ""
+            space = ""
+            value = ""
+            term = ""
+
+        # don't append anything if next character is a colon
+        suffix = ""
+        if not colon:
+            # add space after colon if smart typing is enabled
+            if not space and view.settings().get("auto_complete_trailing_spaces"):
                 suffix = ": $0"
+            else:
+                suffix = ":$0"
+
+            # terminate empty value if not within parentheses
+            if not value and not term and not match_selector(view, pt, "meta.group"):
+                suffix += ";"
 
         return (
             sublime.CompletionItem(
@@ -136,10 +140,7 @@ class CSSCompletions(sublime_plugin.EventListener):
             if values:
                 details = f"<code>{prop}</code> property-value"
 
-                if match_selector(view, pt, "meta.group"):
-                    # don't append semicolon in groups e.g.: `@media screen (prop: val)`
-                    suffix = ""
-                elif next_none_whitespace(view, pt) == ";":
+                if match_selector(view, pt, "meta.group") or next_none_whitespace(view, pt) == ";":
                     suffix = ""
                 else:
                     suffix = "$0;"


### PR DESCRIPTION
This commit is the 3rd alternative for #2886 and #2912.

It uses the default `auto_complete_trailing_spaces` setting to decide
whether to add a space after colons or not when completing properties.

Default behavior (`auto_complete_trailing_spaces`: true):

    font-fam|    =>   font-family: |;

Custom behavior (`auto_complete_trailing_spaces`: false):

    font-fam|    =>   font-family:|;

Default bindings no longer add space when typing `:` (colon):

    font-family|    =>   font-family:|;

inspired by: https://github.com/sublimehq/Packages/pull/2886#issuecomment-922543383