### PR TITLE
[R] Fix code section comments

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -37,7 +37,7 @@ contexts:
     - include: general-variables
 
   codesection:
-    - match: ^\s*((\#+)\s*(.+?)\s*(?:-{4,}|={4,}|#{4,})[ \t]*$\n?)
+    - match: ^\s*((\#+)\s+(.+?)\s+(?:-{4,}|={4,}|#{4,})[ \t]*$\n?)
       captures:
         1: comment.line.number-sign.r
         2: punctuation.definition.comment.r

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -40,6 +40,14 @@
 #    ^^^^^^^^^^^^^ entity.name.section.r
 #                 ^^^^^^ comment.line.number-sign.r - entity
 
+######
+# ^^^^^ comment.line.number-sign.r - entity
+
+# # ####
+# <- comment.line.number-sign.r punctuation.definition.comment.r
+#^^^^^^^^ comment.line.number-sign.r
+# ^ entity.name.section.r
+
 # no section ###
 # ^^^^^^^^^^^^^^^ comment.line.number-sign.r - entity
 


### PR DESCRIPTION
Enforce whitespace around code section titles like Markdown.

fixes: https://forum.sublimetext.com/t/strange-syntax-highlighting-for-r-comments/63227

see: https://support.rstudio.com/hc/en-us/articles/200484568-Code-Folding-and-Sections-in-the-RStudio-IDE