### PR TITLE
[JavaScript] Fix bracket indentation

### DIFF
--- a/JavaScript/Indentation Rules.tmPreferences
+++ b/JavaScript/Indentation Rules.tmPreferences
@@ -10,8 +10,8 @@
 			# line beginning with whitespace or block comments
 			^ (.*\*/)? \s*
 			(?:
-			# dedent closing braces
-			  \}
+			# dedent closing brackets
+			  [])}]
 			# detent `case ... :`
 			| case\b
 			# detent `default:`
@@ -24,9 +24,9 @@
 			# line beginning with whitespace or block comments
 			^ (.*\*/)? \s*
 			(?:
-			# indent after opening braces (may be followed by whitespace or comments)
+			# indent after opening brackets (may be followed by whitespace or comments)
 			# but exclude lines such as `extern "C" {`
-			  .* \{ (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
+			  .* [\[({] (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
 			# indent after `case ... :`
 			| case\b
 			# indent after `default:`
@@ -84,8 +84,6 @@
 			)
 		]]></string>
 
-		<key>indentSquareBrackets</key>
-		<true/>
 	</dict>
 </dict>
 </plist>

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -5,6 +5,33 @@
  * This will print 'Hello World' as the output
  **/
 
+function testIndentBrackets()
+{
+    let foo = [
+        [
+            [
+                0, 1,
+                2, 3
+            ],
+            [0, 1, 2, 3],
+            [
+                0, 1,
+                2, 3
+            ]
+        ]
+    ];
+
+    let foo = {
+        {
+            "key": "value"
+        },
+        { "key": "value" },
+        {
+            "key": "value"
+        }
+    }
+}
+
 function testIfElseIndentationNoBraces(v)
 {
     /**
@@ -696,6 +723,14 @@ function testForIndentation(v)  {
     for (
         let i = 0;
         i < 10;
+        i++) {
+        let j = 0;
+        let k = 0;
+    }
+
+    for (
+        let i = 0;
+        i < 10;
         i++)
     {
         let j = 0;
@@ -705,7 +740,8 @@ function testForIndentation(v)  {
     for (
         let i = 0;
         i < 10;
-        i++) {
+        i++
+    ) {
         let j = 0;
         let k = 0;
     }
@@ -905,7 +941,13 @@ function testWhileIndentationWithBraces(v)  {
     }
     while (
         v == foo( bar("") + "" )
-        )
+    )
+    {
+        v++
+        v++
+    }
+    while (
+        v == foo( bar("") + "" ) )
     {
         v++
         v++
@@ -917,7 +959,7 @@ function testWhileIndentationWithBraces(v)  {
     }
     while (
         v == foo( bar("") + "" )
-        ) {
+    ) {
         v++
         v++
     }


### PR DESCRIPTION
Fixes #3276

The culprit was `indentSquareBrackets` which works different than
expected.

This commit replaces that setting by explicit increase/decrease indent
patterns, which even fixes some edge cases left by eaeb678 and 937b646.