### PR TITLE
[Haskell] Fix qualified import alias scope name

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -506,29 +506,37 @@ contexts:
       scope: meta.import.haskell keyword.declaration.import.haskell
       push:
         - import-filter
-        - import-module
+        - import-hiding
+        - import-alias
+        - import-name
+        - import-modifier
+        - import-modifier
 
-  import-module:
-    - meta_content_scope: meta.import.module.haskell
-    - match: as{{break}}
-      scope: keyword.declaration.import.as.haskell
-      set: import-alias
-    - match: (?:qualified|hiding|safe){{break}}
+  import-modifier:
+    - match: (?:qualified|safe){{break}}
       scope: storage.modifier.import.haskell
-    - match: ({{con_id}})(\.)?
-      captures:
-        1: variable.namespace.haskell
-        2: storage.modifier.haskell
-        3: punctuation.accessor.dot.haskell
+      pop: 1
+    - include: else-pop
+
+  import-name:
+    - include: ident-namespaces
+    - include: ident-import
     - include: else-pop
 
   import-alias:
+    - meta_content_scope: meta.import.module.haskell
+    - match: as{{break}}
+      scope: keyword.declaration.import.as.haskell
+      set: import-alias-name
+    - include: else-pop
+
+  import-alias-name:
     - meta_scope: meta.import.alias.haskell
-    - include: ident-namespaces
-    - match: '{{con_id}}'
-      scope: entity.name.import.namespace.haskell
-      captures:
-        1: storage.modifier.unboxed.haskell
+    - include: import-name
+
+  import-hiding:
+    - match: hiding{{break}}
+      scope: storage.modifier.import.haskell
       pop: 1
     - include: else-pop
 
@@ -1281,6 +1289,13 @@ contexts:
   ident-module:
     - match: '{{con_id}}'
       scope: entity.name.namespace.haskell
+      captures:
+        1: storage.modifier.unboxed.haskell
+      pop: 1
+
+  ident-import:
+    - match: '{{con_id}}'
+      scope: variable.namespace.haskell
       captures:
         1: storage.modifier.unboxed.haskell
       pop: 1

--- a/Haskell/tests/syntax_test_haskell.hs
+++ b/Haskell/tests/syntax_test_haskell.hs
@@ -552,10 +552,10 @@
 --         ^ punctuation.terminator.statement.haskell
 --           ^^^^^^ meta.import.haskell keyword.declaration.import.haskell
 
-    import safe qualified Data.Vector.Mutable as MutableVector
+    import safe qualified Data.Vector.Mutable as My.MutableVector
 --  ^^^^^^ meta.import.haskell
 --        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.module.haskell
---                                            ^^^^^^^^^^^^^^^^ meta.import.alias.haskell
+--                                            ^^^^^^^^^^^^^^^^^^^ meta.import.alias.haskell
 --  ^^^^^^ keyword.declaration.import.haskell
 --         ^^^^ storage.modifier.import.haskell
 --              ^^^^^^^^^ storage.modifier.import.haskell
@@ -565,7 +565,9 @@
 --                                   ^ punctuation.accessor.dot.haskell - variable
 --                                    ^^^^^^^ variable.namespace.haskell - punctuation
 --                                            ^^ keyword.declaration.import.as.haskell
---                                               ^^^^^^^^^^^^^ entity.name.import.namespace.haskell
+--                                               ^^ variable.namespace.haskell
+--                                                 ^ punctuation.accessor.dot.haskell
+--                                                  ^^^^^^^^^^^^^ variable.namespace.haskell
 
     import
 --  ^^^^^^ meta.import.haskell keyword.declaration.import.haskell
@@ -584,8 +586,22 @@
 --  ^^^ meta.import.alias.haskell
 --  ^^ keyword.declaration.import.as.haskell
     MutableVector
---  ^^^^^^^^^^^^^ meta.import.alias.haskell entity.name.import.namespace.haskell
---               ^ - meta.import - entity
+--  ^^^^^^^^^^^^^ meta.import.alias.haskell variable.namespace.haskell
+
+--  escape from imports as early as possible
+    import Data.Vector.Mutable My.MutableVector
+--  ^^^^^^ meta.import.haskell
+--        ^^^^^^^^^^^^^^^^^^^^^ meta.import.module.haskell
+--                             ^^^^^^^^^^^^^^^^^^ - meta.import
+--  ^^^^^^ keyword.declaration.import.haskell
+--         ^^^^ variable.namespace.haskell - punctuation
+--             ^ punctuation.accessor.dot.haskell - variable
+--              ^^^^^^ variable.namespace.haskell - punctuation
+--                    ^ punctuation.accessor.dot.haskell - variable
+--                     ^^^^^^^ variable.namespace.haskell - punctuation
+--                             ^^ variable.namespace.haskell
+--                               ^ punctuation.accessor.dot.haskell
+--                                ^^^^^^^^^^^^^ storage.type.haskell
 
     import Mod1.Mod2.Module (funcName, unboxed#, Type#)
 --  ^^^^^^ meta.import.haskell - meta.sequence


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/issues/3227#issuecomment-1030044243

This commit ...

1. scopes an imported namespace's alias name `variable.namespace` as
   it doesn't introduce/declare anything new but another name for the
   imported module.
2. escapes from `import` context as early as possible by using more
   strictly sub-contexts which enforce certain order of terms to reduce
   risk of failing to highlight following expressions correctly.