### PR TITLE
[TypeScript] Fix bug in old-style type assertion parsing.

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -679,7 +679,7 @@ contexts:
     - match: (?=\()
       set:
         - detect-arrow
-        - ts-detect-arrow-function-return-type
+        - ts-detect-parenthesized-arrow-return-type
         - parenthesized-expression
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1218,4 +1218,19 @@ const x = {
     readonly get,
 //  ^^^^^^^^ storage.modifier
 //           ^^^ variable.other.readwrite
-}
+};
+
+    <any>(<any>a);
+//  ^^^^^ meta.assertion
+//  ^ punctuation.definition.assertion.begin
+//   ^^^ support.type.any
+//      ^ punctuation.definition.assertion.end
+//       ^^^^^^^^ meta.group
+//       ^ punctuation.section.group.begin
+//        ^^^^^ meta.assertion
+//        ^ punctuation.definition.assertion.begin
+//         ^^^ support.type.any
+//            ^ punctuation.definition.assertion.end
+//             ^ variable.other.readwrite
+//              ^ punctuation.section.group.end
+//               ^ punctuation.terminator.statement


### PR DESCRIPTION
Fix #3283.

It was pushing the inner context with the `fail` rather than the outer context with the `branch_point`, so when it tried to `fail`, nothing happened (and it got stuck there for the rest of the file).