### PR TITLE
[Go] preliminary support for Go 1.18

### DIFF
--- a/Go/Fold.tmPreferences
+++ b/Go/Fold.tmPreferences
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
-    <key>scope</key>
-    <string>source.go</string>
-    <key>settings</key>
-    <dict>
-        <key>foldScopes</key>
-        <array>
-            <dict>
-                <key>begin</key>
-                <string>punctuation.section.braces.begin</string>
-                <key>end</key>
-                <string>punctuation.section.braces.end</string>
-            </dict>
-        </array>
-    </dict>
+  <key>scope</key>
+  <string>source.go</string>
+  <key>settings</key>
+  <dict>
+    <key>foldScopes</key>
+    <array>
+      <dict>
+        <key>begin</key>
+        <string>punctuation.section.braces.begin</string>
+        <key>end</key>
+        <string>punctuation.section.braces.end</string>
+      </dict>
+      <dict>
+        <key>begin</key>
+        <string>punctuation.definition.comment.begin.go</string>
+        <key>end</key>
+        <string>punctuation.definition.comment.end.go</string>
+      </dict>
+    </array>
+  </dict>
 </dict>
 </plist>

--- a/Go/Go.sublime-completions
+++ b/Go/Go.sublime-completions
@@ -3,6 +3,11 @@
     "completions": [
          // https://golang.org/ref/spec#Keywords
         {
+            "trigger": "any",
+            "contents": "any",
+            "kind": "type"
+        },
+        {
             "trigger": "append",
             "contents": "append",
             "kind": "function"
@@ -41,6 +46,11 @@
             "trigger": "close",
             "contents": "close",
             "kind": "function"
+        },
+        {
+            "trigger": "comparable",
+            "contents": "comparable",
+            "kind": "type"
         },
         {
             "trigger": "complex",
@@ -195,7 +205,7 @@
         {
             "trigger": "make",
             "annotation": "make(type, 0)",
-            "contents": "make(${1:type}, 0)",
+            "contents": "make(${0:type}, 0)",
             "kind": "snippet"
         },
         {

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -238,7 +238,7 @@ contexts:
     - meta_scope: comment.block.go
     - match: \*/
       scope: punctuation.definition.comment.end.go
-      pop: true
+      pop: 1
     # Indentation, followed by exactly one space, followed by *.
     # This enables support for javadoc comments, while avoiding false
     # positives in non-javadoc comments that use "*" as simple list bullets.
@@ -365,7 +365,7 @@ contexts:
   pop-identifier-anon:
     - match: '{{ident_anon}}'
       scope: variable.language.anonymous.go
-      pop: true
+      pop: 1
 
   # https://golang.org/ref/spec#Operators_and_punctuation
   #
@@ -441,10 +441,10 @@ contexts:
   pop-selector:
     - match: '{{ident_anon}}(?!{{noise}}\()'
       scope: variable.language.anonymous.go
-      pop: true
+      pop: 1
     - match: '{{ident}}(?!{{noise}}\()'
       scope: variable.other.member.go
-      pop: true
+      pop: 1
     - match: \(
       scope: punctuation.section.parens.begin.go
       set: pop-type-assertion
@@ -474,7 +474,7 @@ contexts:
 
   pop-brackets-inner:
     - match: ''
-      pop: true
+      pop: 1
       branch_point: point-brackets-inner
       branch:
         - pop-brackets-inner-type-parameter-list
@@ -644,7 +644,7 @@ contexts:
         - meta_scope: string.quoted.other.go
         - match: '`'
           scope: punctuation.definition.string.end.go
-          pop: true
+          pop: 1
         - include: match-template-string
         - match: \%%
           scope: constant.character.escape.go
@@ -658,7 +658,7 @@ contexts:
         - meta_scope: string.quoted.double.go
         - match: '"'
           scope: punctuation.definition.string.end.go
-          pop: true
+          pop: 1
         - include: match-template-string
         - match: '{{char_escape}}'
           scope: constant.character.escape.go
@@ -674,7 +674,7 @@ contexts:
        - clear_scopes: 1
        - match: "}}"
          scope: punctuation.section.interpolation.end.go
-         pop: true
+         pop: 1
        - match: "\\s-"
          scope: keyword.operator.template.right.trim.go
        - match: "-\\s"
@@ -837,7 +837,7 @@ contexts:
   pop-package-name:
     - match: '{{ident}}'
       scope: entity.name.namespace.go
-      pop: true
+      pop: 1
     - include: pop-before-nonblank
 
   match-keyword-range:
@@ -962,11 +962,11 @@ contexts:
   pop-func-name:
     - match: '{{ident_anon}}'
       scope: variable.language.anonymous.go
-      pop: true
+      pop: 1
 
     - match: '{{ident}}'
       scope: entity.name.function.go
-      pop: true
+      pop: 1
 
     - include: pop-before-nonblank
 
@@ -1043,7 +1043,7 @@ contexts:
 
   pop-parameter-type:
     - match: (?=\)|,)
-      pop: true
+      pop: 1
     - include: match-ellipsis
     - include: pop-type
 
@@ -1114,19 +1114,19 @@ contexts:
 
   pop-now:
     - match: ''
-      pop: true
+      pop: 1
 
   pop-before-nonblank:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   pop-before-semicolon:
     - match: (?=;)
-      pop: true
+      pop: 1
 
   pop-before-newline:
     - match: (?=$)
-      pop: true
+      pop: 1
 
   pop-before-terminator:
     - include: pop-before-semicolon
@@ -1134,30 +1134,30 @@ contexts:
 
   pop-before-paren-end:
     - match: (?=\))
-      pop: true
+      pop: 1
 
   pop-on-paren-end:
     - match: \)
       scope: punctuation.section.parens.end.go
-      pop: true
+      pop: 1
 
   pop-before-bracket-end:
     - match: (?=\])
-      pop: true
+      pop: 1
 
   pop-on-bracket-end:
     - match: \]
       scope: punctuation.section.brackets.end.go
-      pop: true
+      pop: 1
 
   pop-on-brace-end:
     - match: \}
       scope: punctuation.section.braces.end.go
-      pop: true
+      pop: 1
 
   pop-before-brace-end:
     - match: (?=\})
-      pop: true
+      pop: 1
 
   match-type:
     - match: (?=\S)
@@ -1396,11 +1396,11 @@ contexts:
   pop-member:
     - match: '{{ident_anon}}'
       scope: variable.language.anonymous.go
-      pop: true
+      pop: 1
 
     - match: '{{ident}}'
       scope: variable.other.member.go
-      pop: true
+      pop: 1
 
   pop-arguments-starting-with-type:
     # Go allows functions and types to be wrapped in an arbitrary number of
@@ -1416,7 +1416,7 @@ contexts:
   # should also match \r\n due to Sublime's internal normalization.
   pop-on-eol:
     - match: $\n?
-      pop: true
+      pop: 1
 
   pop-inside-parens:
     - include: pop-on-paren-end

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -641,7 +641,7 @@ contexts:
       scope: punctuation.definition.string.begin.go
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.other.go
+        - meta_scope: string.quoted.backtick.go
         - match: '`'
           scope: punctuation.definition.string.end.go
           pop: 1

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -802,8 +802,7 @@ contexts:
     # A proper implementation may involve complicated branching.
     - match: (?=\([^()]*\){{noise}}{{ident}}{{noise}}[\[\(])
       set: [pop-func-signature, pop-func-method-receiver]
-    - match: (?=\S)
-      set: pop-func-signature
+    - include: pop-func-signature
 
   match-keyword-go:
     - match: \bgo\b
@@ -831,7 +830,7 @@ contexts:
 
   match-keyword-package:
     - match: \bpackage\b
-      scope: storage.type.namespace.go keyword.declaration.namespace.go
+      scope: keyword.declaration.namespace.go
       push: [meta-namespace, pop-package-name]
 
   pop-package-name:
@@ -869,8 +868,7 @@ contexts:
     - match: \(
       scope: punctuation.section.parens.begin.go
       set: pop-type-declaration-list
-    - match: (?=\S)
-      set: pop-type-declaration
+    - include: pop-type-declaration
 
   pop-type-declaration-list:
     - include: pop-on-paren-end
@@ -1271,7 +1269,7 @@ contexts:
     - include: pop-before-nonblank
 
   # Ideally we would scope embedded interfaces as `entity.other.inherited-class`
-  # rather than `storage.type` Prior to Go 1.18 and type unions, it was
+  # rather than `storage.type`. Prior to Go 1.18 and type unions, it was
   # possible to detect embedding unambiguously. With the advent of unions,
   # embeddings are syntactically indistinguishable from single-element unions.
   pop-interface-inner:
@@ -1429,17 +1427,21 @@ contexts:
         2: punctuation.accessor.dot.go
 
   meta-function-declaration:
+    - meta_include_prototype: false
     - meta_scope: meta.function.declaration.go
     - include: pop-now
 
   meta-block:
+    - meta_include_prototype: false
     - meta_scope: meta.block.go
     - include: pop-now
 
   meta-type:
+    - meta_include_prototype: false
     - meta_scope: meta.type.go
     - include: pop-now
 
   meta-namespace:
+    - meta_include_prototype: false
     - meta_scope: meta.namespace.go
     - include: pop-now

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -82,7 +82,7 @@ variables:
   # Directive comment key.
   directive: \b[[:alpha:]_-][[:alnum:]_-]*\b
 
-  # Single line only
+  # Single-line general comment.
   inline_comment: /[*](?:[^*]|[*](?!/))*[*]/
 
   # Whitespace and general comments on a single line.
@@ -108,30 +108,42 @@ variables:
   bin_digits: (?:_?[01]+(?:_[01]+)*)
 
 contexts:
+  prototype:
+    - include: match-comments
+
   main:
     - include: match-any
 
   match-any:
-    - include: match-comments
     - include: match-tokens
 
   # https://golang.org/ref/spec#Comments
   match-comments:
-    # Go has magic comments in the form of:
-    #
-    # //go:some_directive arg0 arg1 ...
-    #
-    # These have been adopted outside the gc compiler for use in linting
-    # directives and pragmas for other compiler suites where they take the
-    # more generalised form of:
-    #
-    # //namespace:some_directive ...
-    #
-    # They're not part of the language spec, may not be recognized by some Go
-    # compilers, and may stop working in future releases. Therefore,
-    # highlighting them as compiler pragmas could be misleading. We scope them
-    # as plain comments by default, and add some detailed meta scopes for
-    # enterprising users wishing to add more color.
+    - include: match-comment-magic
+    - include: match-comment-line
+    - include: match-comment-general
+
+  match-comment-magic:
+    - include: match-comment-magic-general
+    - include: match-comment-magic-line-renum
+    - include: match-comment-magic-line-extern
+
+  # Go has magic comments in the form of:
+  #
+  # //go:directive arg0 arg1 ...
+  #
+  # These have been adopted outside the gc compiler for use in linting
+  # directives and pragmas for other compiler suites where they take the
+  # more generalised form of:
+  #
+  # //namespace:some_directive ...
+  #
+  # They're not part of the language spec, may not be recognized by some Go
+  # compilers, and may stop working in future releases. Therefore, highlighting
+  # them as compiler pragmas could be misleading. We scope them as plain
+  # comments by default, and add some detailed meta scopes for enterprising
+  # users wishing to add more color.
+  match-comment-magic-general:
     - match: (//)([a-z]+[a-z-]*)(:)({{directive}})([ ]?)
       scope: meta.annotation.go
       captures:
@@ -142,10 +154,11 @@ contexts:
         5: meta.punctuation.separator.space.go
       push: pop-line-annotation
 
-    # Go also has line renumbering; line directives specify the source
-    # position for the character immediately following the comment as
-    # having come from the specified file, line and column. Both single
-    # line and block comment line directives are valid.
+  # Go also has line renumbering; line directives specify the source
+  # position for the character immediately following the comment as
+  # having come from the specified file, line and column. Both single
+  # line and block comment line directives are valid.
+  match-comment-magic-line-renum:
     - match: ((//)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
       scope: comment.line.go
       captures:
@@ -165,7 +178,8 @@ contexts:
         5: meta.annotation.parameters.go
         6: meta.annotation.go punctuation.definition.comment.end.go
 
-    # Finally, Cgo and gccgo have directives for exporting functions to C.
+  # Finally, Cgo and gccgo have directives for exporting functions to C.
+  match-comment-magic-line-extern:
     - match: ((//)(export|extern)( ))({{ident}})$\n?
       scope: comment.line.go
       captures:
@@ -175,37 +189,45 @@ contexts:
         4: meta.punctuation.separator.space.go
         5: meta.annotation.parameters.go
 
-    # Line comment
-    - match: //
-      scope: punctuation.definition.comment.go
-      push: pop-line-comment
-
-    # General comment
-    - match: /\*
-      scope: punctuation.definition.comment.begin.go
-      push:
-        - meta_scope: comment.block.go
-        - match: \*/
-          scope: punctuation.definition.comment.end.go
-          pop: true
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.go
+  pop-comment-line-annotation:
+    - meta_scope: meta.annotation.go comment.line.go
+    - match: \S+
+      scope: meta.variable.parameter.go
+    # End the annotation scope at EOL, but stretch the comment scope
+    # indefinitely to the right.
+    - match: $
+      set: pop-comment-line-normal
 
   pop-line-annotation:
     - meta_scope: comment.line.go
     - meta_content_scope: meta.annotation.parameters.go
-    - match: $\n?
-      pop: true
+    - include: pop-on-eol
 
-  pop-line-comment:
+  match-comment-line:
+    - match: //
+      scope: punctuation.definition.comment.go
+      push: pop-comment-line-normal
+
+  pop-comment-line-normal:
     - meta_scope: comment.line.go
-    # Including the newline allows the scope to visually stretch to the right,
-    # and ensures that functionality that relies on comment scoping, such as
-    # contextual hotkeys, works properly at EOL while typing a comment. This
-    # should also match \r\n due to Sublime's internal normalization.
-    - match: $\n?
+    - include: pop-on-eol
+
+  match-comment-general:
+    - match: /\*
+      scope: punctuation.definition.comment.begin.go
+      push: pop-comment-general
+
+  pop-comment-general:
+    - meta_scope: comment.block.go
+    - match: \*/
+      scope: punctuation.definition.comment.end.go
       pop: true
+    # Indentation, followed by exactly one space, followed by *.
+    # This enables support for javadoc comments, while avoiding false
+    # positives in non-javadoc comments that use "*" as simple list bullets.
+    - match: ^(?:\t|[ ]{2}|[ ]{4}|[ ]{8})*[ ](\*)(?!/)
+      captures:
+        1: punctuation.definition.comment.go
 
   # https://golang.org/ref/spec#Tokens
   #
@@ -325,7 +347,6 @@ contexts:
   match-short-variable-declarations:
     - match: (?={{ident}}(?:{{noise}},{{noise}}{{ident}})*{{noise}}:=)
       push:
-        - include: match-comments
         - match: \b_\b
           scope: variable.language.anonymous.go
         - match: '{{ident}}'
@@ -389,7 +410,6 @@ contexts:
     - match: \.
       scope: punctuation.accessor.dot.go
       push:
-        - include: match-comments
         - include: pop-type-assertion
 
         # Note: we can't syntactically distinguish calls from type conversions.
@@ -422,7 +442,6 @@ contexts:
       scope: punctuation.section.brackets.end.go
       push:
         - include: pop-on-terminator
-        - include: match-comments
         - include: match-star
         - match: '{{ident}}(?={{noise}}\.)'
           scope: variable.other.go
@@ -572,6 +591,7 @@ contexts:
     - match: '`'
       scope: punctuation.definition.string.begin.go
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.other.go
         - match: '`'
           scope: punctuation.definition.string.end.go
@@ -585,6 +605,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.go
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.go
         - match: '"'
           scope: punctuation.definition.string.end.go
@@ -627,7 +648,6 @@ contexts:
          scope: keyword.control.go
        - match: \b(and|call|html|index|slice|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
          scope: variable.function.go support.function.builtin.go
-       - include: match-comments
        - include: match-strings
 
   # https://godoc.org/fmt
@@ -676,7 +696,6 @@ contexts:
 
             - include: match-any
 
-        - include: match-comments
         - include: match-comma
 
         - match: \b_\b(?={{noise}},)
@@ -721,8 +740,6 @@ contexts:
     - match: \bfunc\b
       scope: keyword.declaration.function.go
       push:
-        - include: match-comments
-
         # Method
         - match: (?=\({{noise}}[^)]+{{noise}}\){{noise}}{{ident}}{{noise}}\()
           set:
@@ -800,8 +817,6 @@ contexts:
     - match: \btype\b
       scope: keyword.declaration.type.go
       push:
-        - include: match-comments
-
         - match: \(
           scope: punctuation.section.parens.begin.go
           set:
@@ -856,7 +871,6 @@ contexts:
 
             - include: match-any
 
-        - include: match-comments
         - include: match-comma
 
         - match: \b_\b(?={{noise}},)
@@ -874,7 +888,6 @@ contexts:
         - include: pop-before-nonblank
 
   pop-func-signature:
-    - include: match-comments
     - match: \b_\b
       scope: variable.language.anonymous.go
       set: pop-func-parameter-and-return-lists
@@ -915,25 +928,21 @@ contexts:
   # multiline, and have name groups. We're still trying to cover as many edge
   # cases as possible.
   pop-func-parameter-and-return-lists:
-    - include: match-comments
     - match: (?=\()
       set: [pop-func-return-signature, pop-func-parameter-list]
     - include: pop-before-nonblank
 
   pop-func-return-signature:
     - include: pop-on-terminator
-    - include: match-comments
     - match: (?=\()
       set: pop-func-parameter-list
     - match: (?=\S)
       set: pop-type
 
   pop-func-parameter-list:
-    - include: match-comments
     - match: \(
       scope: punctuation.section.parens.begin.go
       set:
-        - include: match-comments
         - match: |
             (?x)
             (?=
@@ -949,7 +958,6 @@ contexts:
     - match: \)
       scope: punctuation.section.parens.end.go
       pop: true
-    - include: match-comments
     - include: match-keywords
     - include: match-comma
     - include: match-ellipsis
@@ -970,7 +978,6 @@ contexts:
     - match: \)
       scope: punctuation.section.parens.end.go
       pop: true
-    - include: match-comments
     - include: match-keywords
     - include: match-comma
     - include: match-ellipsis
@@ -993,7 +1000,6 @@ contexts:
 
   pop-type:
     - include: pop-on-semicolon
-    - include: match-comments
 
     # Note: Go allows wrapping types in an arbitrary number of parens.
     - match: \(
@@ -1040,7 +1046,6 @@ contexts:
     - match: \bstruct\b
       scope: keyword.declaration.struct.go
       set:
-        - include: match-comments
         - match: \{
           scope: punctuation.section.braces.begin.go
           set:
@@ -1070,7 +1075,6 @@ contexts:
                 - match: (?=\})
                   pop: true
                 - include: pop-on-terminator
-                - include: match-comments
                 - include: pop-type
                 - include: match-any
 
@@ -1082,7 +1086,6 @@ contexts:
     - match: \binterface\b
       scope: keyword.declaration.interface.go
       set:
-        - include: match-comments
         - match: \{
           scope: punctuation.section.braces.begin.go
           set:
@@ -1119,7 +1122,6 @@ contexts:
     - match: \bmap\b
       scope: keyword.declaration.map.go
       set:
-        - include: match-comments
         - include: pop-on-semicolon
         - match: \[
           scope: punctuation.section.brackets.begin.go
@@ -1129,7 +1131,6 @@ contexts:
               set:
                 - include: pop-on-terminator
                 - include: pop-type
-            - include: match-comments
             - match: (?=\S)
               push:
                 - match: (?=\])
@@ -1145,7 +1146,6 @@ contexts:
       set: pop-type
 
   pop-named-type:
-    - include: match-comments
     - match: \b_\b
       scope: variable.language.anonymous.go
       pop: true
@@ -1169,7 +1169,6 @@ contexts:
 
   pop-type-alias-or-typedef:
     - include: pop-on-terminator
-    - include: match-comments
     # Newlines after `=` are ok.
     - match: =
       scope: keyword.operator.assignment.go
@@ -1179,7 +1178,6 @@ contexts:
 
   pop-const-type-and-or-assignment:
     - include: pop-on-terminator
-    - include: match-comments
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-const-expressions
@@ -1188,7 +1186,6 @@ contexts:
 
   pop-const-assignment-or-terminate:
     - include: pop-on-terminator
-    - include: match-comments
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-const-expressions
@@ -1203,7 +1200,6 @@ contexts:
   # for the entire package.
   pop-const-expressions:
     - include: pop-on-semicolon
-    - include: match-comments
     - match: (?=\S)
       set:
         - include: pop-on-terminator
@@ -1213,7 +1209,6 @@ contexts:
 
   pop-var-type-and-or-assignment:
     - include: pop-on-terminator
-    - include: match-comments
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-var-expressions
@@ -1222,7 +1217,6 @@ contexts:
 
   pop-var-assignment-or-terminate:
     - include: pop-on-terminator
-    - include: match-comments
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-var-expressions
@@ -1231,7 +1225,6 @@ contexts:
   # Note: this doesn't support multiline expressions.
   pop-var-expressions:
     - include: pop-on-semicolon
-    - include: match-comments
     - match: (?=\S)
       set:
         - include: pop-on-terminator
@@ -1255,7 +1248,6 @@ contexts:
       pop: true
 
   pop-arguments-starting-with-type:
-    - include: match-comments
     # Go allows functions and types to be wrapped in an arbitrary number of
     # parens. These are not part of the call.
     - match: \)
@@ -1266,8 +1258,15 @@ contexts:
         - match: \)
           scope: punctuation.section.parens.end.go
           pop: true
-        - include: match-comments
         - match: (?=\S)
           set: pop-type
     - include: pop-on-terminator
     - include: pop-before-nonblank
+
+  # Including the newline allows the scope to visually stretch to the right,
+  # and ensures that functionality that relies on comment scoping, such as
+  # contextual hotkeys, works properly at EOL while typing a comment. This
+  # should also match \r\n due to Sublime's internal normalization.
+  pop-on-eol:
+    - match: $\n?
+      pop: true

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -1211,8 +1211,9 @@ contexts:
     - include: pop-before-nonblank
 
   pop-type-nested-in-parens:
-    - include: pop-on-paren-end
-    - include: pop-type
+    # The implementation is fairly similar. Parameter lists allow some
+    # additional tokens, which shouldn't occur here.
+    - include: pop-parameter-list-unnamed
 
   pop-struct:
     - match: \bstruct\b

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -55,6 +55,7 @@
 
 name: Go
 scope: source.go
+version: 2
 
 file_extensions:
   - go
@@ -70,14 +71,18 @@ variables:
   keyword: \b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b
 
   # https://golang.org/ref/spec#Predeclared_identifiers
-  predeclared_type: \b(?:bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr)\b
+  predeclared_type: \b(?:any|bool|byte|comparable|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr)\b
 
   # https://golang.org/ref/spec#Predeclared_identifiers
   predeclared_func: \b(?:append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\b
 
+  ident_anon: \b_\b
+
   # Note: this matches ALL valid identifiers, including predeclared constants,
   # functions and types.
   ident: \b(?!{{keyword}})[[:alpha:]_][[:alnum:]_]*\b
+
+  keyword_or_ident: \b[[:alpha:]_][[:alnum:]_]*\b
 
   # Directive comment key.
   directive: \b[[:alpha:]_-][[:alnum:]_-]*\b
@@ -106,6 +111,27 @@ variables:
 
   # Binary counterpart to dec_digits.
   bin_digits: (?:_?[01]+(?:_[01]+)*)
+
+  # Should be used only for lookahead. Syntactically ambiguous with many other
+  # uses of square brackets. Should be used ONLY in contexts where the use of
+  # brackets is unambiguous.
+  #
+  # Known defect: fails to recognize multiline type argument lists.
+  # We should convert from lookahead to branching.
+  type_argument_list: \[(?:{{noise}}|[^\[\]])*\]
+
+  iface_entry_delim: (?://|;|\}|$)
+  struct_entry_delim: (?:"|`|{{iface_entry_delim}})
+  struct_embed_argument_list: '{{type_argument_list}}{{noise}}{{struct_entry_delim}}'
+
+  operator_char: '[!%&*+/:<=>^|-]'
+  operator_break: (?!{{operator_char}})
+
+  # Tokens that may signify the beginning of a type. Should be used only for
+  # lookahead, and only in contexts where this is unambiguous with other
+  # expressions. Doesn't include `*` because inside brackets, it would be
+  # ambiguous with multiplication, which may be used for array size.
+  type_begin: (?:~|\[|{{keyword_or_ident}})
 
 contexts:
   prototype:
@@ -273,8 +299,7 @@ contexts:
     - include: match-predeclared-constants
     - include: match-call-or-type-conversion
     - include: match-short-variable-declarations
-    - match: \b_\b
-      scope: variable.language.anonymous.go
+    - include: match-identifier-anon
     - match: '{{ident}}'
       scope: variable.other.go
 
@@ -318,6 +343,7 @@ contexts:
   # However, we stick to `variable.function.go` to make the treatment of
   # built-ins purely additive, allowing the user to opt out.
   match-call-or-type-conversion:
+    - include: match-identifier-anon
     - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
       scope: variable.function.go support.function.builtin.go
       push: pop-arguments-starting-with-type
@@ -325,11 +351,15 @@ contexts:
       scope: variable.function.go support.type.builtin.go
     - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go support.function.builtin.go
+    - match: '{{ident}}(?=(?:{{noise}}\))*(?:{{noise}}{{type_argument_list}})?{{noise}}\()'
+      scope: variable.function.go
+      push: pop-type-argument-list
     - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go
 
   # See notes on `match-call-or-type-conversion`.
   pop-call-or-type-conversion:
+    - include: pop-identifier-anon
     - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
       scope: variable.function.go support.function.builtin.go
       set: pop-arguments-starting-with-type
@@ -339,6 +369,9 @@ contexts:
     - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go support.function.builtin.go
       pop: true
+    - match: '{{ident}}(?=(?:{{noise}}\))*(?:{{noise}}{{type_argument_list}})?{{noise}}\()'
+      scope: variable.function.go
+      set: pop-type-argument-list
     - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go
       pop: true
@@ -347,14 +380,25 @@ contexts:
   match-short-variable-declarations:
     - match: (?={{ident}}(?:{{noise}},{{noise}}{{ident}})*{{noise}}:=)
       push:
-        - match: \b_\b
-          scope: variable.language.anonymous.go
+        - include: match-identifier-anon
         - match: '{{ident}}'
           scope: variable.other.readwrite.declaration.go
         - include: match-comma
         - include: pop-before-nonblank
 
+  match-identifier-anon:
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+
+  pop-identifier-anon:
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+      pop: true
+
   # https://golang.org/ref/spec#Operators_and_punctuation
+  #
+  # Note: pipe "|" is not always bitwise. In type unions
+  # it should be scoped differently.
   match-operators:
     - match: '<<=|>>=|&\^=|&=|\^=|\|=|%=|\+=|-=|\*=|/=|\+\+|--'
       scope: keyword.operator.assignment.augmented.go
@@ -372,11 +416,22 @@ contexts:
       scope: keyword.operator.bitwise.go
     - match: '[-+/%]'
       scope: keyword.operator.arithmetic.go
-    - match: '[*&]'
+    - match: '[*&~]'
       scope: keyword.operator.go
 
+  # Special characters that in some contexts may precede a type.
+  # Not all of them are allowed in all contexts.
+  # Bundling them together simplifies our syntax implementation.
+  match-type-operators:
+    - include: match-star
+    - include: match-union-pipe
+
   match-star:
-    - match: \*
+    - match: \*{{operator_break}}
+      scope: keyword.operator.go
+
+  match-union-pipe:
+    - match: \|{{operator_break}}
       scope: keyword.operator.go
 
   # https://golang.org/ref/spec#Operators_and_punctuation
@@ -409,47 +464,71 @@ contexts:
   match-selector:
     - match: \.
       scope: punctuation.accessor.dot.go
-      push:
-        - include: pop-type-assertion
+      push: pop-selector
 
-        # Note: we can't syntactically distinguish calls from type conversions.
-        # It's also not always possible to distinguish function calls from
-        # method calls.
-        - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
-          scope: variable.function.go
-          pop: true
+  pop-selector:
+    - match: '{{ident_anon}}(?!{{noise}}\()'
+      scope: variable.language.anonymous.go
+      pop: true
+    - match: '{{ident}}(?!{{noise}}\()'
+      scope: variable.other.member.go
+      pop: true
+    - match: \(
+      scope: punctuation.section.parens.begin.go
+      set: pop-type-assertion
+    - include: pop-before-nonblank
 
-        - include: pop-member
-        # Note: newlines between dot and assertion/field are ok.
-        - include: pop-before-nonblank
+  pop-type-assertion:
+    - include: pop-on-paren-end
+    - match: (?=\S)
+      push: pop-type
 
   match-parens:
     - match: \(
       scope: punctuation.section.parens.begin.go
-      push:
-        - match: \)
-          scope: punctuation.section.parens.end.go
-          pop: true
-        - include: pop-call-or-type-conversion
-        - include: match-any
+      push: pop-parens-inner
     - match: \)
-      scope: punctuation.section.parens.end.go
+      scope: invalid.illegal.go
+
+  pop-parens-inner:
+    - include: pop-on-paren-end
+    - include: match-any
 
   match-brackets:
     - match: \[
       scope: punctuation.section.brackets.begin.go
+      push: [pop-after-brackets, pop-brackets-inner]
     - match: \]
-      scope: punctuation.section.brackets.end.go
-      push:
-        - include: pop-on-terminator
-        - include: match-star
-        - match: '{{ident}}(?={{noise}}\.)'
-          scope: variable.other.go
-        - match: \b_\b
-          scope: variable.language.anonymous.go
-          pop: true
-        - include: pop-type-identifier
-        - include: pop-before-nonblank
+      scope: invalid.illegal.go
+
+  pop-brackets-inner:
+    - match: ''
+      pop: true
+      branch_point: point-brackets-inner
+      branch:
+        - pop-brackets-inner-type-parameter-list
+        - pop-brackets-inner-any
+
+  pop-brackets-inner-type-parameter-list:
+    - match: (?={{ident}}{{noise}}(?:,|{{type_begin}}))
+      set: pop-type-parameter-list-inner
+    - match: (?=\S)
+      fail: point-brackets-inner
+
+  pop-brackets-inner-any:
+    - include: pop-on-bracket-end
+    - include: match-any
+
+  # Known bug:
+  #
+  #   _ = ident[0] * ident
+  #
+  # This currently parses as an array type of `[0]*ident`.
+  # Can we ever fix this false positive?
+  pop-after-brackets:
+    - include: pop-before-terminator
+    - include: match-type-operators
+    - include: pop-type-identifier
 
   # TODO: consider detecting composite literals. In principle, it should allow
   # us to drop the erroneous "meta.block" from composite literals, detect field
@@ -463,14 +542,13 @@ contexts:
   match-braces:
     - match: \{
       scope: punctuation.section.braces.begin.go
-      push:
-        - meta_scope: meta.block.go
-        - match: \}
-          scope: punctuation.section.braces.end.go
-          pop: true
-        - include: match-any
+      push: [meta-block, pop-braces-inner]
     - match: \}
-      scope: punctuation.section.braces.end.go
+      scope: invalid.illegal.go
+
+  pop-braces-inner:
+    - include: pop-on-brace-end
+    - include: match-any
 
   match-literals:
     - include: match-imaginary
@@ -678,18 +756,18 @@ contexts:
         - match: \(
           scope: punctuation.section.parens.begin.go
           set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
+            - include: pop-on-paren-end
 
-            - match: \b_\b(?={{noise}},)
+            - match: '{{ident_anon}}(?={{noise}},)'
               scope: variable.language.anonymous.go
+
             - match: '{{ident}}(?={{noise}},)'
               scope: variable.other.constant.declaration.go
 
-            - match: \b_\b
+            - match: '{{ident_anon}}'
               scope: variable.language.anonymous.go
               push: pop-const-type-and-or-assignment
+
             - match: '{{ident}}'
               scope: variable.other.constant.declaration.go
               push: pop-const-type-and-or-assignment
@@ -698,14 +776,16 @@ contexts:
 
         - include: match-comma
 
-        - match: \b_\b(?={{noise}},)
+        - match: '{{ident_anon}}(?={{noise}},)'
           scope: variable.language.anonymous.go
+
         - match: '{{ident}}(?={{noise}},)'
           scope: variable.other.constant.declaration.go
 
-        - match: \b_\b
+        - match: '{{ident_anon}}'
           scope: variable.language.anonymous.go
           set: pop-const-type-and-or-assignment
+
         - match: '{{ident}}'
           scope: variable.other.constant.declaration.go
           set: pop-const-type-and-or-assignment
@@ -739,25 +819,20 @@ contexts:
   match-keyword-func:
     - match: \bfunc\b
       scope: keyword.declaration.function.go
-      push:
-        # Method
-        - match: (?=\({{noise}}[^)]+{{noise}}\){{noise}}{{ident}}{{noise}}\()
-          set:
-            - meta_scope: meta.function.declaration.go
-            - match: (?=[^(])
-              set:
-                - meta_scope: meta.function.declaration.go
-                - include: pop-func-signature
-            # Receiver list
-            - match: (?=\()
-              push: pop-func-parameter-list
+      push: [meta-function-declaration, pop-func]
 
-        # Named function
-        - match: (?={{ident}}{{noise}}\()
-          set: pop-func-signature
-
-        # Anonymous function
-        - include: pop-func-parameter-and-return-lists
+  pop-func:
+    # Known false positive:
+    #
+    #   func(param Type[TypeArg]) Name[Type] {}
+    #
+    # In this example, the anonymous function is incorrectly scoped as a method,
+    # where `Name` is scoped as method name rather than type. TODO avoid.
+    # A proper implementation may involve complicated branching.
+    - match: (?=\([^()]*\){{noise}}{{ident}}{{noise}}[\[\(])
+      set: [pop-func-signature, pop-func-method-receiver]
+    - match: (?=\S)
+      set: pop-func-signature
 
   match-keyword-go:
     - match: \bgo\b
@@ -786,12 +861,13 @@ contexts:
   match-keyword-package:
     - match: \bpackage\b
       scope: storage.type.namespace.go keyword.declaration.namespace.go
-      push:
-        - meta_scope: meta.namespace.go
-        - match: '{{ident}}'
-          scope: entity.name.namespace.go
-          pop: true
-        - include: pop-before-nonblank
+      push: [meta-namespace, pop-package-name]
+
+  pop-package-name:
+    - match: '{{ident}}'
+      scope: entity.name.namespace.go
+      pop: true
+    - include: pop-before-nonblank
 
   match-keyword-range:
     - match: \brange\b
@@ -816,35 +892,31 @@ contexts:
   match-keyword-type:
     - match: \btype\b
       scope: keyword.declaration.type.go
-      push:
-        - match: \(
-          scope: punctuation.section.parens.begin.go
-          set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
-            - match: \b_\b
-              scope: variable.language.anonymous.go
-              push:
-                - match: (?=\))
-                  pop: true
-                - include: pop-type-alias-or-typedef
-            - match: '{{ident}}'
-              scope: entity.name.type.go
-              push:
-                - match: (?=\))
-                  pop: true
-                - include: pop-type-alias-or-typedef
-            - include: match-any
+      push: pop-type-declaration-or-list
 
-        - match: \b_\b
-          scope: variable.language.anonymous.go
-          set: pop-type-alias-or-typedef
-        - match: '{{ident}}'
-          scope: entity.name.type.go
-          set: pop-type-alias-or-typedef
+  pop-type-declaration-or-list:
+    - match: \(
+      scope: punctuation.section.parens.begin.go
+      set: pop-type-declaration-list
+    - match: (?=\S)
+      set: pop-type-declaration
 
-        - include: pop-before-nonblank
+  pop-type-declaration-list:
+    - include: pop-on-paren-end
+    - match: (?={{ident}})
+      push: pop-type-declaration
+    - include: match-any
+
+  pop-type-declaration:
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+      set: pop-type-spec
+
+    - match: '{{ident}}'
+      scope: entity.name.type.go
+      set: pop-type-spec
+
+    - include: pop-before-nonblank
 
   match-keyword-var:
     - match: \bvar\b
@@ -853,18 +925,18 @@ contexts:
         - match: \(
           scope: punctuation.section.parens.begin.go
           set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
+            - include: pop-on-paren-end
 
-            - match: \b_\b(?={{noise}},)
+            - match: '{{ident_anon}}(?={{noise}},)'
               scope: variable.language.anonymous.go
+
             - match: '{{ident}}(?={{noise}},)'
               scope: variable.other.readwrite.declaration.go
 
-            - match: \b_\b
+            - match: '{{ident_anon}}'
               scope: variable.language.anonymous.go
               push: pop-var-type-and-or-assignment
+
             - match: '{{ident}}'
               scope: variable.other.readwrite.declaration.go
               push: pop-var-type-and-or-assignment
@@ -873,28 +945,71 @@ contexts:
 
         - include: match-comma
 
-        - match: \b_\b(?={{noise}},)
+        - match: '{{ident_anon}}(?={{noise}},)'
           scope: variable.language.anonymous.go
+
         - match: '{{ident}}(?={{noise}},)'
           scope: variable.other.readwrite.declaration.go
 
-        - match: \b_\b
+        - match: '{{ident_anon}}'
           scope: variable.language.anonymous.go
           set: pop-var-type-and-or-assignment
+
         - match: '{{ident}}'
           scope: variable.other.readwrite.declaration.go
           set: pop-var-type-and-or-assignment
 
         - include: pop-before-nonblank
 
-  pop-func-signature:
-    - match: \b_\b
+  pop-func-method-receiver:
+    - match: \(
+      scope: punctuation.section.parens.begin.go
+      set: pop-func-method-receiver-inner
+    - include: pop-before-nonblank
+
+  pop-func-method-receiver-inner:
+    - include: pop-on-paren-end
+    - include: match-type-operators
+    - include: match-namespace
+
+    # The lookahead is too special-case. TODO improve.
+    - match: '{{ident_anon}}(?={{noise}}(?:\*|{{ident}}))'
       scope: variable.language.anonymous.go
-      set: pop-func-parameter-and-return-lists
+    - match: '{{ident}}(?={{noise}}(?:\*|{{ident}}))'
+      scope: variable.parameter.go
+
+    - match: '{{ident}}'
+      scope: storage.type.go
+      push: pop-type-parameter-list-simple
+
+    - include: match-any
+
+  pop-func-signature:
+    - match: (?=\S)
+      set: [pop-func-parameter-and-return-lists, pop-type-parameter-list, pop-func-name]
+
+  pop-func-name:
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+      pop: true
+
     - match: '{{ident}}'
       scope: entity.name.function.go
-      set: pop-func-parameter-and-return-lists
+      pop: true
+
     - include: pop-before-nonblank
+
+  pop-func-parameter-and-return-lists:
+    - match: (?=\()
+      set: [pop-func-return-signature, pop-func-parameter-list]
+    - include: pop-before-nonblank
+
+  pop-func-return-signature:
+    - include: pop-before-terminator
+    - match: (?=\()
+      set: pop-func-parameter-list
+    - match: (?=\S)
+      set: pop-type
 
   # https://golang.org/ref/spec#Function_types
   #
@@ -902,43 +1017,31 @@ contexts:
   #
   # Unnamed:
   #
-  #   (int)
-  #   (int, int)
-  #   (int, int, ...int)
+  #   (typ)
+  #   (typ, typ)
+  #   (typ, typ, ...typ)
   #
   # Named:
   #
-  #   (a int)
-  #   (a, b int)
-  #   (a, b ...int)
-  #   (a int, b int)
-  #   (a, b int, c ...int)
+  #   (a typ)
+  #   (a, b typ)
+  #   (a, b ...typ)
+  #   (a typ, b typ)
+  #   (a, b typ, c ...typ)
   #
   # The modes are distinct: either all named, or all unnamed.
   #
   # Gotchas:
   #
-  #   parameters can span multiple lines
-  #   a type can span multiple lines (anonymous struct, interface, etc.)
-  #   parameter groups AND parameter names are comma-separated
-  #   `chan type` is a type that looks like an identifier followed by a type
+  #   * Parameters can span multiple lines.
+  #   * A type can span multiple lines (anonymous struct, interface, etc.).
+  #   * Parameter groups AND parameter names are comma-separated.
+  #   * `chan type` is a type that looks like an identifier followed by a type.
   #
-  # I have an impression that with the current syntax engine, it's impossible to
-  # perfectly parse some parameter lists, particularly ones that are named,
-  # multiline, and have name groups. We're still trying to cover as many edge
-  # cases as possible.
-  pop-func-parameter-and-return-lists:
-    - match: (?=\()
-      set: [pop-func-return-signature, pop-func-parameter-list]
-    - include: pop-before-nonblank
-
-  pop-func-return-signature:
-    - include: pop-on-terminator
-    - match: (?=\()
-      set: pop-func-parameter-list
-    - match: (?=\S)
-      set: pop-type
-
+  # The current implementation is imperfect: when a group of comma-separated
+  # parameters spans multiple lines, we incorrectly assume "unnamed" mode.
+  # However, a "perfect" implementation requires multiline lookahead or
+  # branching. The current approach works for most real code.
   pop-func-parameter-list:
     - match: \(
       scope: punctuation.section.parens.begin.go
@@ -955,15 +1058,15 @@ contexts:
     - include: pop-before-nonblank
 
   pop-parameter-list-named:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
+    - include: pop-on-paren-end
     - include: match-keywords
     - include: match-comma
     - include: match-ellipsis
-    - match: \b_\b
+
+    - match: '{{ident_anon}}'
       scope: variable.language.anonymous.go
       push: pop-parameter-type
+
     - match: '{{ident}}'
       scope: variable.parameter.go
       push: pop-parameter-type
@@ -975,168 +1078,269 @@ contexts:
     - include: pop-type
 
   pop-parameter-list-unnamed:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
-    - include: match-keywords
+    - include: pop-on-paren-end
     - include: match-comma
     - include: match-ellipsis
+    - include: match-keywords
     - match: (?=\S)
       push: pop-type
+
+  # At the time of writing, this is the only part of Go that uses "untyped"
+  # syntax for parameters, similar to function definitions in dynamic languages
+  # or closure definitions in typed languages such as Java lambdas.
+  #
+  # Note: this should not be confused with `pop-type-parameter-list` that
+  # uses "typed" syntax.
+  pop-type-parameter-list-simple:
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      set: pop-type-parameter-list-simple-inner
+    - include: pop-before-nonblank
+
+  pop-type-parameter-list-simple-inner:
+    - include: pop-on-bracket-end
+    - include: match-identifier-anon
+    - match: '{{ident}}'
+      scope: variable.parameter.type.go
+    - include: match-any
+
+  # Note: this should not be confused with `pop-type-parameter-list-simple` or
+  # `pop-type-argument-list`.
+  pop-type-parameter-list:
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      set: pop-type-parameter-list-inner
+    - include: pop-before-nonblank
+
+  # Unlike value parameter lists that have both named and anonymous modes,
+  # type parameter lists have only the named mode. Parameter names must exist.
+  pop-type-parameter-list-inner:
+    - include: pop-on-bracket-end
+    - match: '{{ident_anon}}(?={{noise}},)'
+      scope: variable.language.anonymous.go
+    - match: '{{ident}}(?={{noise}},)'
+      scope: variable.parameter.type.go
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+      push: pop-type
+    - match: '{{ident}}'
+      scope: variable.parameter.type.go
+      push: pop-type
+    - include: match-any
+
+  # Note: this should not be confused with `pop-type-parameter-list`.
+  pop-type-argument-list:
+    - include: pop-before-terminator
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      set: pop-type-argument-list-inner
+    - include: pop-before-nonblank
+
+  pop-type-argument-list-inner:
+    - include: pop-on-bracket-end
+    - include: match-identifier-anon
+    - match: '{{ident}}'
+      scope: variable.other.type.go
+    - include: match-any
+
+  pop-now:
+    - match: ''
+      pop: true
 
   pop-before-nonblank:
     - match: (?=\S)
       pop: true
 
-  pop-on-semicolon:
-    - match: ;
-      scope: punctuation.terminator.go
+  pop-before-semicolon:
+    - match: (?=;)
       pop: true
 
-  pop-on-terminator:
-    - include: pop-on-semicolon
-    - match: $
+  pop-before-newline:
+    - match: (?=$)
       pop: true
+
+  pop-before-terminator:
+    - include: pop-before-semicolon
+    - include: pop-before-newline
+
+  pop-before-paren-end:
+    - match: (?=\))
+      pop: true
+
+  pop-on-paren-end:
+    - match: \)
+      scope: punctuation.section.parens.end.go
+      pop: true
+
+  pop-before-bracket-end:
+    - match: (?=\])
+      pop: true
+
+  pop-on-bracket-end:
+    - match: \]
+      scope: punctuation.section.brackets.end.go
+      pop: true
+
+  pop-on-brace-end:
+    - match: \}
+      scope: punctuation.section.braces.end.go
+      pop: true
+
+  pop-before-brace-end:
+    - match: (?=\})
+      pop: true
+
+  match-type:
+    - match: (?=\S)
+      push: pop-type
 
   pop-type:
-    - include: pop-on-semicolon
+    - match: (?=\S)
+      set: [pop-after-type, pop-type-single]
+
+  pop-type-single:
+    - include: pop-before-semicolon
 
     # Note: Go allows wrapping types in an arbitrary number of parens.
     - match: \(
       scope: punctuation.section.parens.begin.go
       push: [pop-type-nested-in-parens, pop-type]
 
-    - match: \[
-      scope: punctuation.section.brackets.begin.go
-      set:
-        - match: \]
-          scope: punctuation.section.brackets.end.go
-          # BUG:
-          #   _ = blah[0] * blah
-          # This currently parses as an array type of `[0]*blah`.
-          # Can we fix this false positive?
-          set: pop-type
-        - include: match-any
-
+    - include: match-type-operators
     - include: match-operators
 
     - match: (?=\bchan\b)
       set: pop-chan
+
     - match: (?=\binterface\b)
       set: pop-interface
+
     - match: (?=\bmap\b)
       set: pop-map
+
     - match: (?=\bstruct\b)
       set: pop-struct
+
     - match: \bfunc\b
       scope: keyword.declaration.function.go
       set: pop-func-parameter-and-return-lists
+
     - match: (?={{ident}})
-      set: pop-named-type
+      set: pop-type-identifier
+
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      set: [pop-after-brackets, pop-brackets-inner]
 
     - include: pop-before-nonblank
 
+  pop-after-type:
+    - match: \|{{operator_break}}
+      scope: keyword.operator.go
+      set: pop-type
+    - include: pop-before-newline
+    - include: pop-before-nonblank
+
   pop-type-nested-in-parens:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
+    - include: pop-on-paren-end
     - include: pop-type
 
   pop-struct:
     - match: \bstruct\b
       scope: keyword.declaration.struct.go
-      set:
-        - match: \{
-          scope: punctuation.section.braces.begin.go
-          set:
-            - meta_scope: meta.type.go
+      set: pop-struct-block
 
-            - match: \}
-              scope: punctuation.section.braces.end.go
-              pop: true
+  pop-struct-block:
+    - match: \{
+      scope: punctuation.section.braces.begin.go
+      set: [meta-type, pop-struct-block-inner]
+    - include: pop-before-nonblank
 
-            - include: match-keywords
-            - include: match-star
+  pop-struct-block-inner:
+    - include: pop-on-brace-end
+    - include: match-keywords
+    - include: match-type-operators
+    - include: match-namespace
 
-            - match: '{{ident}}(?={{noise}}\.)'
-              scope: variable.other.go
-            - match: \.
-              scope: punctuation.accessor.dot.go
-            - match: '{{predeclared_type}}(?={{noise}}(?:"|`|//|;|\}|$))'
-              scope: entity.other.inherited-class.go support.type.builtin.go
-            - match: '{{ident}}(?={{noise}}(?:"|`|//|;|\}|$))'
-              scope: entity.other.inherited-class.go
+    - match: '{{ident_anon}}(?={{noise}}{{struct_embed_argument_list}})'
+      scope: variable.language.anonymous.go
+      push: pop-type-argument-list
 
-            - match: \b_\b
-              scope: variable.language.anonymous.go
-            - match: '{{ident}}'
-              scope: variable.other.member.declaration.go
-              push:
-                - match: (?=\})
-                  pop: true
-                - include: pop-on-terminator
-                - include: pop-type
-                - include: match-any
+    - match: '{{ident}}(?={{noise}}{{struct_embed_argument_list}})'
+      scope: entity.other.inherited-class.go
+      push: pop-type-argument-list
 
-            - include: match-any
+    - match: '{{predeclared_type}}(?={{noise}}{{struct_entry_delim}})'
+      scope: entity.other.inherited-class.go support.type.builtin.go
 
-        - include: pop-before-nonblank
+    - include: match-identifier-anon
+
+    - match: '{{ident}}(?={{noise}}{{struct_entry_delim}})'
+      scope: entity.other.inherited-class.go
+
+    - match: '{{ident}}'
+      scope: variable.other.member.declaration.go
+      push: pop-struct-field-meta
+
+    - include: match-any
+
+  pop-struct-field-meta:
+    - include: pop-before-brace-end
+    - include: pop-before-terminator
+    - include: pop-type
+    - include: match-any
 
   pop-interface:
     - match: \binterface\b
       scope: keyword.declaration.interface.go
-      set:
-        - match: \{
-          scope: punctuation.section.braces.begin.go
-          set:
-            - meta_scope: meta.type.go
-            - match: \}
-              scope: punctuation.section.braces.end.go
-              pop: true
+      set: [meta-type, pop-interface-block]
 
-            - include: match-keywords
-            - include: match-star
+  pop-interface-block:
+    - match: \{
+      scope: punctuation.section.braces.begin.go
+      set: pop-interface-inner
+    - include: pop-before-nonblank
 
-            - match: '{{ident}}(?={{noise}}\.)'
-              scope: variable.other.go
-            - match: \.
-              scope: punctuation.accessor.dot.go
-            - match: '{{predeclared_type}}(?={{noise}}(?://|;|\}|$))'
-              scope: entity.other.inherited-class.go support.type.builtin.go
-            - match: '{{ident}}(?={{noise}}(?://|;|\}|$))'
-              scope: entity.other.inherited-class.go
+  # Ideally we would scope embedded interfaces as `entity.other.inherited-class`
+  # rather than `storage.type` Prior to Go 1.18 and type unions, it was
+  # possible to detect embedding unambiguously. With the advent of unions,
+  # embeddings are syntactically indistinguishable from single-element unions.
+  pop-interface-inner:
+    - include: pop-on-brace-end
+    - include: match-keywords
+    - include: match-namespace
+    - include: match-type-operators
 
-            - match: '{{ident}}(?={{noise}}\()'
-              scope: entity.name.function.go
-              push:
-                - match: (?=\})
-                  pop: true
-                - include: pop-func-parameter-and-return-lists
+    - match: '{{ident}}(?={{noise}}\()'
+      scope: entity.name.function.go
+      push: pop-func-parameter-and-return-lists
 
-            - include: match-any
-        - include: pop-before-nonblank
+    - match: '{{predeclared_type}}'
+      scope: storage.type.go support.type.builtin.go
+
+    - match: '{{ident}}'
+      scope: storage.type.go
+
+    - include: match-any
 
   pop-map:
     # Note: newlines between `map` and `[` are ok, but newlines after `]`
     # terminate the type.
     - match: \bmap\b
       scope: keyword.declaration.map.go
-      set:
-        - include: pop-on-semicolon
-        - match: \[
-          scope: punctuation.section.brackets.begin.go
-          set:
-            - match: \]
-              scope: punctuation.section.brackets.end.go
-              set:
-                - include: pop-on-terminator
-                - include: pop-type
-            - match: (?=\S)
-              push:
-                - match: (?=\])
-                  pop: true
-                - include: pop-type
-        - include: pop-type
+      set: [meta-type, pop-map-brackets]
+
+  pop-map-brackets:
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      set: pop-map-brackets-inner
+    - include: pop-before-nonblank
+
+  pop-map-brackets-inner:
+    - match: \]
+      scope: punctuation.section.brackets.end.go
+      set: pop-type
+    - include: match-type
 
   # Note: newlines between `chan`, subsequent arrow, and subsequent type, are
   # perfectly ok.
@@ -1145,30 +1349,21 @@ contexts:
       scope: keyword.declaration.chan.go
       set: pop-type
 
-  pop-named-type:
-    - match: \b_\b
-      scope: variable.language.anonymous.go
-      pop: true
-    - match: '{{ident}}(?={{noise}}\.)'
-      scope: variable.other.go
-    - match: \.
-      scope: punctuation.accessor.dot.go
-    - match: \b_\b
-      scope: variable.language.anonymous.go
-      pop: true
-    - include: pop-type-identifier
-    - include: pop-before-nonblank
-
   pop-type-identifier:
+    - include: match-namespace
+    - match: '{{ident_anon}}'
+      scope: variable.language.anonymous.go
+      set: pop-type-argument-list
     - match: '{{predeclared_type}}'
       scope: storage.type.go support.type.builtin.go
-      pop: true
+      set: pop-type-argument-list
     - match: '{{ident}}'
       scope: storage.type.go
-      pop: true
+      set: pop-type-argument-list
+    - include: pop-before-nonblank
 
-  pop-type-alias-or-typedef:
-    - include: pop-on-terminator
+  pop-type-spec:
+    - include: pop-before-terminator
     # Newlines after `=` are ok.
     - match: =
       scope: keyword.operator.assignment.go
@@ -1177,7 +1372,7 @@ contexts:
       set: pop-type
 
   pop-const-type-and-or-assignment:
-    - include: pop-on-terminator
+    - include: pop-before-terminator
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-const-expressions
@@ -1185,7 +1380,7 @@ contexts:
       set: [pop-const-assignment-or-terminate, pop-type]
 
   pop-const-assignment-or-terminate:
-    - include: pop-on-terminator
+    - include: pop-before-terminator
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-const-expressions
@@ -1199,16 +1394,16 @@ contexts:
   # redefine it. Doing so in the root scope makes the magic constant unavailable
   # for the entire package.
   pop-const-expressions:
-    - include: pop-on-semicolon
+    - include: pop-before-semicolon
     - match: (?=\S)
       set:
-        - include: pop-on-terminator
+        - include: pop-before-terminator
         - match: \biota\b
           scope: constant.language.go
         - include: match-any
 
   pop-var-type-and-or-assignment:
-    - include: pop-on-terminator
+    - include: pop-before-terminator
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-var-expressions
@@ -1216,7 +1411,7 @@ contexts:
       set: [pop-var-assignment-or-terminate, pop-type]
 
   pop-var-assignment-or-terminate:
-    - include: pop-on-terminator
+    - include: pop-before-terminator
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-var-expressions
@@ -1224,25 +1419,17 @@ contexts:
 
   # Note: this doesn't support multiline expressions.
   pop-var-expressions:
-    - include: pop-on-semicolon
+    - include: pop-before-semicolon
     - match: (?=\S)
       set:
-        - include: pop-on-terminator
+        - include: pop-before-terminator
         - include: match-any
 
-  pop-type-assertion:
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      set:
-        - match: \)
-          scope: punctuation.section.parens.end.go
-          pop: true
-        - include: pop-type
-
   pop-member:
-    - match: \b_\b
+    - match: '{{ident_anon}}'
       scope: variable.language.anonymous.go
       pop: true
+
     - match: '{{ident}}'
       scope: variable.other.member.go
       pop: true
@@ -1250,17 +1437,9 @@ contexts:
   pop-arguments-starting-with-type:
     # Go allows functions and types to be wrapped in an arbitrary number of
     # parens. These are not part of the call.
-    - match: \)
-      scope: punctuation.section.parens.end.go
     - match: \(
       scope: punctuation.section.parens.begin.go
-      set:
-        - match: \)
-          scope: punctuation.section.parens.end.go
-          pop: true
-        - match: (?=\S)
-          set: pop-type
-    - include: pop-on-terminator
+      set: [pop-inside-parens, pop-type]
     - include: pop-before-nonblank
 
   # Including the newline allows the scope to visually stretch to the right,
@@ -1270,3 +1449,29 @@ contexts:
   pop-on-eol:
     - match: $\n?
       pop: true
+
+  pop-inside-parens:
+    - include: pop-on-paren-end
+    - include: match-any
+
+  match-namespace:
+    - match: '({{ident}})\s*(\.)'
+      captures:
+        1: variable.other.go
+        2: punctuation.accessor.dot.go
+
+  meta-function-declaration:
+    - meta_scope: meta.function.declaration.go
+    - include: pop-now
+
+  meta-block:
+    - meta_scope: meta.block.go
+    - include: pop-now
+
+  meta-type:
+    - meta_scope: meta.type.go
+    - include: pop-now
+
+  meta-namespace:
+    - meta_scope: meta.namespace.go
+    - include: pop-now

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -84,6 +84,12 @@ variables:
 
   keyword_or_ident: \b[[:alpha:]_][[:alnum:]_]*\b
 
+  # Sublime normalizes newlines from `\r\n` and `\r` into `\n`. Sublime's syntax
+  # engine uses regexps line-by-line, so `$` is often equivalent to `\n`. For
+  # semantic accuracy, we should use `\n` when possible. However, the last line
+  # in a file may end with `$` INSTEAD of `\n`, so we must try both.
+  newline: (?:\n|$)
+
   # Directive comment key.
   directive: \b[[:alpha:]_-][[:alnum:]_-]*\b
 
@@ -120,7 +126,8 @@ variables:
   # We should convert from lookahead to branching.
   type_argument_list: \[(?:{{noise}}|[^\[\]])*\]
 
-  iface_entry_delim: (?://|;|\}|$)
+
+  iface_entry_delim: (?://|;|\}|{{newline}})
   struct_entry_delim: (?:"|`|{{iface_entry_delim}})
   struct_embed_argument_list: '{{type_argument_list}}{{noise}}{{struct_entry_delim}}'
 
@@ -185,7 +192,7 @@ contexts:
   # having come from the specified file, line and column. Both single
   # line and block comment line directives are valid.
   match-comment-magic-line-renum:
-    - match: ((//)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
+    - match: ((//)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2}){{newline}}?
       scope: comment.line.double-slash.go
       captures:
         1: meta.annotation.go
@@ -206,7 +213,7 @@ contexts:
 
   # Finally, Cgo and gccgo have directives for exporting functions to C.
   match-comment-magic-line-extern:
-    - match: ((//)(export|extern)( ))({{ident}})$\n?
+    - match: ((//)(export|extern)( ))({{ident}}){{newline}}?
       scope: comment.line.double-slash.go
       captures:
         1: meta.annotation.go
@@ -1123,7 +1130,7 @@ contexts:
       pop: 1
 
   pop-before-newline:
-    - match: (?=$)
+    - match: (?={{newline}})
       pop: 1
 
   pop-before-terminator:
@@ -1410,10 +1417,9 @@ contexts:
 
   # Including the newline allows the scope to visually stretch to the right,
   # and ensures that functionality that relies on comment scoping, such as
-  # contextual hotkeys, works properly at EOL while typing a comment. This
-  # should also match \r\n due to Sublime's internal normalization.
+  # contextual hotkeys, works properly at EOL while typing a comment.
   pop-on-eol:
-    - match: $\n?
+    - match: '{{newline}}'
       pop: 1
 
   pop-inside-parens:

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -80,7 +80,7 @@ variables:
 
   # Note: this matches ALL valid identifiers, including predeclared constants,
   # functions and types.
-  ident: \b(?!{{keyword}})[[:alpha:]_][[:alnum:]_]*\b
+  ident: (?!{{keyword}}){{keyword_or_ident}}
 
   keyword_or_ident: \b[[:alpha:]_][[:alnum:]_]*\b
 
@@ -348,25 +348,6 @@ contexts:
     - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
       scope: variable.function.go
 
-  # See notes on `match-call-or-type-conversion`.
-  pop-call-or-type-conversion:
-    - include: pop-identifier-anon
-    - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
-      scope: variable.function.go support.function.builtin.go
-      set: pop-arguments-starting-with-type
-    - match: '{{predeclared_type}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.type.builtin.go
-      pop: true
-    - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.function.builtin.go
-      pop: true
-    - match: '{{ident}}(?=(?:{{noise}}\))*(?:{{noise}}{{type_argument_list}})?{{noise}}\()'
-      scope: variable.function.go
-      set: pop-type-argument-list
-    - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go
-      pop: true
-
   # Note: this currently doesn't work across multiple lines.
   match-short-variable-declarations:
     - match: (?={{ident}}(?:{{noise}},{{noise}}{{ident}})*{{noise}}:=)
@@ -471,8 +452,7 @@ contexts:
 
   pop-type-assertion:
     - include: pop-on-paren-end
-    - match: (?=\S)
-      push: pop-type
+    - include: match-type
 
   match-parens:
     - match: \(
@@ -999,8 +979,7 @@ contexts:
     - include: pop-before-terminator
     - match: (?=\()
       set: pop-func-parameter-list
-    - match: (?=\S)
-      set: pop-type
+    - include: pop-type
 
   # https://golang.org/ref/spec#Function_types
   #
@@ -1073,8 +1052,7 @@ contexts:
     - include: match-comma
     - include: match-ellipsis
     - include: match-keywords
-    - match: (?=\S)
-      push: pop-type
+    - include: match-type
 
   # At the time of writing, this is the only part of Go that uses "untyped"
   # syntax for parameters, similar to function definitions in dynamic languages
@@ -1183,7 +1161,7 @@ contexts:
 
   match-type:
     - match: (?=\S)
-      push: pop-type
+      push: [pop-after-type, pop-type-single]
 
   pop-type:
     - match: (?=\S)
@@ -1279,7 +1257,6 @@ contexts:
     - include: pop-before-brace-end
     - include: pop-before-terminator
     - include: pop-type
-    - include: match-any
 
   pop-interface:
     - match: \binterface\b
@@ -1359,8 +1336,7 @@ contexts:
     - match: =
       scope: keyword.operator.assignment.go
       set: pop-type
-    - match: (?=\S)
-      set: pop-type
+    - include: pop-type
 
   pop-const-type-and-or-assignment:
     - include: pop-before-terminator

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -215,15 +215,6 @@ contexts:
         4: meta.punctuation.separator.space.go
         5: meta.annotation.parameters.go
 
-  pop-comment-line-annotation:
-    - meta_scope: meta.annotation.go comment.line.go
-    - match: \S+
-      scope: meta.variable.parameter.go
-    # End the annotation scope at EOL, but stretch the comment scope
-    # indefinitely to the right.
-    - match: $
-      set: pop-comment-line-normal
-
   pop-line-annotation:
     - meta_scope: comment.line.go
     - meta_content_scope: meta.annotation.parameters.go

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -186,7 +186,7 @@ contexts:
   # line and block comment line directives are valid.
   match-comment-magic-line-renum:
     - match: ((//)(line)( ))([a-zA-Z0-9. :]*(?::[0-9]+){1,2})$\n?
-      scope: comment.line.go
+      scope: comment.line.double-slash.go
       captures:
         1: meta.annotation.go
         2: punctuation.definition.comment.go
@@ -207,7 +207,7 @@ contexts:
   # Finally, Cgo and gccgo have directives for exporting functions to C.
   match-comment-magic-line-extern:
     - match: ((//)(export|extern)( ))({{ident}})$\n?
-      scope: comment.line.go
+      scope: comment.line.double-slash.go
       captures:
         1: meta.annotation.go
         2: punctuation.definition.comment.go
@@ -216,7 +216,7 @@ contexts:
         5: meta.annotation.parameters.go
 
   pop-line-annotation:
-    - meta_scope: comment.line.go
+    - meta_scope: comment.line.double-slash.go
     - meta_content_scope: meta.annotation.parameters.go
     - include: pop-on-eol
 
@@ -226,7 +226,7 @@ contexts:
       push: pop-comment-line-normal
 
   pop-comment-line-normal:
-    - meta_scope: comment.line.go
+    - meta_scope: comment.line.double-slash.go
     - include: pop-on-eol
 
   match-comment-general:

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -34,19 +34,23 @@ You may have to disable Go-specific linters when working on this file.
 //                            ^^^^^^^^^^^ comment.line.go
 
     /*
-//  ^^ comment.block.go punctuation.definition.comment.begin.go
 // ^ -comment
+//  ^^ comment.block.go punctuation.definition.comment.begin.go
+//    ^^ comment.block.go - punctuation
 //  ^^^^ comment.block.go
     comment
 //  ^^^^^^^^ comment.block.go
     */
+//^^ comment.block.go - punctuation
 //  ^^ comment.block.go punctuation.definition.comment.end.go
 //    ^ -comment
 
     /* * */
 // ^ -comment
-//     ^ -punctuation.definition.comment.go
 //  ^^^^^^^ comment.block.go
+//  ^^ punctuation.definition.comment.begin.go
+//    ^^^ -punctuation.definition.comment.go
+//       ^^ punctuation.definition.comment.end.go
 //         ^ -comment
 
     /*

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -10,8 +10,7 @@ This file must not be formatted with `go fmt`.
 You may have to disable Go-specific linters when working on this file.
 */
 
-
-// # Comments
+/* # Comments */
 
     //
 // ^ -comment -punctuation
@@ -35,22 +34,30 @@ You may have to disable Go-specific linters when working on this file.
 //                            ^^^^^^^^^^^ comment.line.go
 
     /*
+//  ^^ comment.block.go punctuation.definition.comment.begin.go
 // ^ -comment
 //  ^^^^ comment.block.go
     comment
 //  ^^^^^^^^ comment.block.go
     */
-//  ^^ comment.block.go
+//  ^^ comment.block.go punctuation.definition.comment.end.go
 //    ^ -comment
 
     /* * */
 // ^ -comment
+//     ^ -punctuation.definition.comment.go
 //  ^^^^^^^ comment.block.go
 //         ^ -comment
 
-    /**
+    /*
+    *
+//  ^ -punctuation.definition.comment.go
+
+        *
+//      ^ -punctuation.definition.comment.go
+
      *
-//   ^ comment.block.go punctuation.definition.comment.go
+//   ^ punctuation.definition.comment.go
     */
 
     //go
@@ -66,7 +73,7 @@ You may have to disable Go-specific linters when working on this file.
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
 //                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
@@ -75,7 +82,7 @@ You may have to disable Go-specific linters when working on this file.
     //go-sumtype:decl MySumType
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
 //                    ^^^^^^^^^ comment.line.go meta.annotation.parameters.go
@@ -84,7 +91,7 @@ You may have to disable Go-specific linters when working on this file.
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
 //                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
@@ -93,7 +100,7 @@ You may have to disable Go-specific linters when working on this file.
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
 //                     ^^^^^^^ comment.line.go meta.annotation.parameters.go
@@ -102,7 +109,7 @@ You may have to disable Go-specific linters when working on this file.
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
 //         ^^^ comment.line.go meta.annotation.parameters.go
 //            ^ comment.line.go -meta.annotation
@@ -110,7 +117,7 @@ You may have to disable Go-specific linters when working on this file.
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
 //         ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                   ^ comment.line.go -meta.annotation
@@ -118,14 +125,14 @@ You may have to disable Go-specific linters when working on this file.
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
 //         ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
 //                       ^ comment.line.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
 //         ^^^ comment.block.go meta.annotation.parameters.go
 //            ^^ comment.block.go punctuation.definition.comment.end.go
@@ -133,7 +140,7 @@ You may have to disable Go-specific linters when working on this file.
 
     /*line file.rl:10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
 //         ^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
@@ -142,7 +149,7 @@ You may have to disable Go-specific linters when working on this file.
 
     /*line file.rl:100:10*/
 // ^ -comment
-//  ^^^^^^^ comment.block.go meta.annotation.go
+//  ^^^^^^ comment.block.go meta.annotation.go
 //  ^^ punctuation.definition.comment.begin.go
 //    ^^^^ meta.variable.function.go
 //         ^^^^^^^^^^^^^^ comment.block.go meta.annotation.parameters.go
@@ -169,19 +176,19 @@ You may have to disable Go-specific linters when working on this file.
     //export myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^ comment.line.go meta.annotation.go
 //           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
     //extern myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^ comment.line.go meta.annotation.go
 //           ^^^^^^ comment.line.go meta.annotation.parameters.go
 //                 ^ comment.line.go -meta.annotation
 
 
-// # Imports
+/* # Imports */
 
     package main
 //  ^^^^^^^ storage.type.namespace.go keyword.declaration.namespace.go
@@ -218,7 +225,7 @@ You may have to disable Go-specific linters when working on this file.
     )
 
 
-// # Type Keywords and Syntax
+/* # Type Keywords and Syntax */
 
 /*
 Type keywords are tested early because they're used in many other tests.
@@ -228,7 +235,7 @@ Note: Go permits an arbitrary number of parens around a type.
 Note: built-ins are tested separately. Search for "# Built-in Types".
 */
 
-// ## chan
+/* ## chan */
 
     chan _
 //  ^^^^ keyword.declaration.chan.go
@@ -422,7 +429,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //               ^^^ storage.type.go
 
 
-// ## func
+/* ## func */
 
 // Note: a function type and the beginning of a non-method function declaration
 // are parsed EXACTLY the same. Function types may contain parameter names.
@@ -755,8 +762,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                                     ^^^ storage.type.go
 //                                                                        ^^ punctuation.section.parens.end.go
 
-
-// ## interface
+/* ## interface */
 
     interface{}
 //  ^^^^^^^^^ keyword.declaration.interface.go
@@ -853,8 +859,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                        ^ meta.type.go punctuation.terminator.go
 //                                                         ^ meta.type.go punctuation.section.braces.end.go
 
-
-// ## map
+/* ## map */
 
     map[typ]typ
 //  ^^^ keyword.declaration.map.go
@@ -1030,7 +1035,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                             ^^^ storage.type.go
 
 
-// ## struct
+/* ## struct */
 
     struct{}
 //  ^^^^^^ keyword.declaration.struct.go
@@ -1298,7 +1303,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 
 
-// ## Array / Slice
+/* ## Array / Slice */
 
     [0]typ
 //  ^ punctuation.section.brackets.begin.go
@@ -1381,7 +1386,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //        ^^^^^ variable.other.go
 
 
-// ## type
+/* ## type */
 
     type _ typ
 //  ^^^^ keyword.declaration.type.go
@@ -1547,7 +1552,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     )
 
 
-// # Constants and Vars
+/* # Constants and Vars */
 
 // Note: initialization expressions may span multiple lines, but the syntax
 // currently doesn't support this due to implementation difficulties. This may
@@ -1847,7 +1852,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     )
 //  ^ punctuation.section.parens.end.go
 
-// ## Short Variable Declaration
+/* ## Short Variable Declaration */
 
     ident := expr
 //  ^^^^^ variable.other.readwrite.declaration.go
@@ -1874,11 +1879,11 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //        ^ keyword.operator.assignment.go
 //          ^^^^ variable.other.go
 
-// # Literals
+/* # Literals */
 
-// ## Integers
+/* ## Integers */
 
-// ### Decimal
+/* ### Decimal */
 
     0; 123456789; -0; -123456789; 1777_000_000;
 //  ^ meta.number.integer.decimal.go constant.numeric.value.go
@@ -1889,7 +1894,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^^^^^^^^^ meta.number.integer.decimal.go constant.numeric.value.go
 //                                ^^^^^^^^^^^^ meta.number.integer.decimal.go constant.numeric.value.go
 
-// ### Octal
+/* ### Octal */
 
     00; 01234567; -01234567; 0_0; 012_45;
 //  ^ meta.number.integer.octal.go constant.numeric.base.go
@@ -1921,7 +1926,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                               ^^ meta.number.integer.octal.go constant.numeric.base.go
 //                                 ^^^^^ meta.number.integer.octal.go constant.numeric.value.go
 
-// ### Hex
+/* ### Hex */
 
     0x0; 0x0123456789ABCDEFabcdef; -0x0123456789ABCDEFabcdef;
 //  ^^ meta.number.integer.hexadecimal.go constant.numeric.base.go
@@ -1938,7 +1943,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //        ^^ meta.number.integer.hexadecimal.go constant.numeric.base.go
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal.go constant.numeric.value.go
 
-// ### Binary
+/* ### Binary */
 
     0b1011; 0B00001; -0b1; 0b_1; 0B1_0;
 //  ^^ meta.number.integer.binary.go constant.numeric.base.go
@@ -1953,7 +1958,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                               ^^ meta.number.integer.binary.go constant.numeric.base.go
 //                                 ^^^ meta.number.integer.binary.go constant.numeric.value.go
 
-// ## Floats
+/* ## Floats */
 
     000.000; 123.456; .0; 1.;
 //  ^^^^^^^ meta.number.float.decimal.go constant.numeric.value.go
@@ -2067,7 +2072,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                       ^^^^^ meta.number.float.hexadecimal.go constant.numeric.value.go
 //                       ^ punctuation.separator.decimal.go
 
-// ## Imaginary
+/* ## Imaginary */
 
     000i; 100i; -100i; 1_1i;
 //  ^^^^ meta.number.imaginary.decimal.go
@@ -2197,7 +2202,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                 ^ punctuation.separator.decimal.go
 //                            ^ meta.number.imaginary.hexadecimal.go constant.numeric.suffix.go
 
-// ## Runes
+/* ## Runes */
 
     ' '
 //  ^^^ meta.string.go string.quoted.single.go
@@ -2243,7 +2248,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //   ^^^^ constant.character.escape.go
 //       ^ punctuation.definition.string.end.go - constant
 
-// ## Strings
+/* ## Strings */
 
     "one two"
 //  ^ punctuation.definition.string.begin.go
@@ -2377,7 +2382,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.go -comment
 
 
-// # Operators
+/* # Operators */
 
     !=
 //  ^^ keyword.operator.comparison.go
@@ -2453,7 +2458,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^ keyword.operator.bitwise.go
 
 
-// # Punctuation
+/* # Punctuation */
 
 // Note: [] can denote array and slice types. It's covered in the type section.
 
@@ -2477,9 +2482,9 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     }
 //  ^ meta.block.go punctuation.section.braces.end.go
 
-// ## Selector
+/* ## Selector */
 
-// ### Member
+/* ### Member */
 
     ident.ident
 //  ^^^^^ variable.other.go
@@ -2506,7 +2511,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     ident
 //  ^^^^^ variable.other.member.go
 
-// ### Type Assertion
+/* ### Type Assertion */
 
     ident.(ident)
 //  ^^^^^ variable.other.go
@@ -2585,7 +2590,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                     ^ punctuation.accessor.dot.go
 //                      ^^^^^ storage.type.go
 
-// ## Parens
+/* ## Parens */
 
 // Note: we can't syntactically disambiguate calls and type conversions.
 
@@ -2702,7 +2707,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^^^^ variable.other.go
 
 
-// # Keywords
+/* # Keywords */
 
 // Some keywords are covered elsewhere in the test.
 
@@ -2737,7 +2742,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     switch
 //  ^^^^^^ keyword.control.go
 
-// ## func
+/* ## func */
 
 // Note: function signatures are thoroughly tested in the section of this test
 // file dedicated to types. The part after the function name (parameters and
@@ -2827,7 +2832,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //         ^ meta.block.go punctuation.section.braces.end.go
 
 
-// # Predeclared Constants
+/* # Predeclared Constants */
 
     true false nil
 //  ^^^^ constant.language.go
@@ -2835,7 +2840,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //             ^^^ constant.language.go
 
 
-// # Built-in Types
+/* # Built-in Types */
 
 /*
 These tests make sure that the treatment of built-ins is consistent with
@@ -2952,9 +2957,9 @@ every type individually.
 //        ^^^^^ variable.other.go
 
 
-// # Built-in Functions
+/* # Built-in Functions */
 
-// ## Special Functions
+/* ## Special Functions */
 
     make(typ)
 //  ^^^^ variable.function.go support.function.builtin.go
@@ -3042,7 +3047,7 @@ every type individually.
 //  ^^^ keyword.declaration.var.go
 //      ^^^ variable.other.readwrite.declaration.go -support
 
-// ## Other Functions
+/* ## Other Functions */
 
 /*
 These tests make sure that the treatment of built-ins is consistent with

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -319,11 +319,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 
     chan
 //  ^^^^ keyword.declaration.chan.go
-    ident /**/ . /**/
+    ident . /**/
 //  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
+//        ^ punctuation.accessor.dot.go
+//          ^^^^ comment.block.go
     typ
 //  ^^^ storage.type.go
 
@@ -331,16 +330,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^ keyword.operator.assignment.go
     chan
 //  ^^^^ keyword.declaration.chan.go
-    ident /**/ . /**/
+    ident . /**/
 //  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
+//        ^ punctuation.accessor.dot.go
+//          ^^^^ comment.block.go
+    ident . /**/
 //  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
+//        ^ punctuation.accessor.dot.go
+//          ^^^^ comment.block.go
     typ
 //  ^^^ storage.type.go
 
@@ -349,16 +346,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     <-    /**/
 //  ^^ keyword.operator.assignment.go
 //        ^^^^ comment.block.go
-    ident /**/ . /**/
+    ident . /**/
 //  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
+//        ^ punctuation.accessor.dot.go
+//          ^^^^ comment.block.go
+    ident . /**/
 //  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
+//        ^ punctuation.accessor.dot.go
+//          ^^^^ comment.block.go
     typ
 //  ^^^ storage.type.go
 
@@ -675,17 +670,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                      ^ punctuation.separator.go
         /**/
 //      ^^^^ comment.block.go
-        param /**/ * /**/ ident /**/ . /**/ Type,
+        param /**/ * /**/ ident . /**/ Type,
 //      ^^^^^ variable.parameter.go
 //            ^^^^ comment.block.go
 //                 ^ keyword.operator.go
 //                   ^^^^ comment.block.go
 //                        ^^^^^ variable.other.go
-//                              ^^^^ comment.block.go
-//                                   ^ punctuation.accessor.dot.go
-//                                     ^^^^ comment.block.go
-//                                          ^^^^ storage.type.go
-//                                              ^ punctuation.separator.go
+//                              ^ punctuation.accessor.dot.go
+//                                ^^^^ comment.block.go
+//                                     ^^^^ storage.type.go
+//                                         ^ punctuation.separator.go
     ) /**/ (
 //  ^ punctuation.section.parens.end.go
 //    ^^^^ comment.block.go
@@ -708,17 +702,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                  ^ punctuation.separator.go
         /**/
 //      ^^^^ comment.block.go
-        param /**/ * /**/ ident /**/ . /**/ Type,
+        param /**/ * /**/ ident . /**/ Type,
 //      ^^^^^ variable.parameter.go
 //            ^^^^ comment.block.go
 //                 ^ keyword.operator.go
 //                   ^^^^ comment.block.go
 //                        ^^^^^ variable.other.go
-//                              ^^^^ comment.block.go
-//                                   ^ punctuation.accessor.dot.go
-//                                     ^^^^ comment.block.go
-//                                          ^^^^ storage.type.go
-//                                              ^ punctuation.separator.go
+//                              ^ punctuation.accessor.dot.go
+//                                ^^^^ comment.block.go
+//                                     ^^^^ storage.type.go
+//                                         ^ punctuation.separator.go
     )
 //  ^ punctuation.section.parens.end.go
 
@@ -762,6 +755,428 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                                     ^^^ storage.type.go
 //                                                                        ^^ punctuation.section.parens.end.go
 
+    /*
+    Support for unions. At the time of writing, type unions are not permitted
+    in this position. The Go parser considers this a syntax error. However,
+    it's better to future-proof our syntax implementation by allowing unions
+    in any type position.
+    */
+    func /**/ (param /**/ ... /**/ typ | ~typ | *typ)
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ comment.block.go
+//       ^^ punctuation.definition.comment.begin.go
+//             ^^^^^ variable.parameter.go
+//                   ^^^^ comment.block.go
+//                        ^^^ keyword.operator.variadic.go
+//                            ^^^^ comment.block.go
+//                                 ^^^ storage.type.go
+//                                     ^ keyword.operator.go
+//                                       ^ keyword.operator.go
+//                                        ^^^ storage.type.go
+//                                            ^ keyword.operator.go
+//                                              ^ keyword.operator.go
+//                                               ^^^ storage.type.go
+//                                                  ^ punctuation.section.parens.end.go
+
+/* ### Generic functions: anonymous */
+
+/*
+At the time of writing, Go doesn't support anonymous generic functions.
+The Go parser understands them and rejects them. We may support them
+by accident, but if necessary, such support could be sacrificed.
+*/
+
+    func[TypeParam Type[TypeArg]] (param Type[TypeArg]) Type {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.brackets.begin.go
+//       ^^^^^^^^^ variable.parameter.type.go
+//                 ^^^^ storage.type.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^^^^^ variable.other.type.go
+//                             ^^ punctuation.section.brackets.end.go
+//                                ^ punctuation.section.parens.begin.go
+//                                 ^^^^^ variable.parameter.go
+//                                       ^^^^ storage.type.go
+//                                           ^ punctuation.section.brackets.begin.go
+//                                            ^^^^^^^ variable.other.type.go
+//                                                   ^ punctuation.section.brackets.end.go
+//                                                    ^ punctuation.section.parens.end.go
+//                                                      ^^^^ storage.type.go
+//                                                           ^^ meta.block.go
+//                                                           ^ punctuation.section.braces.begin.go
+//                                                            ^ punctuation.section.braces.end.go
+
+    func[TypeParam Type[TypeArg]] (param Type[TypeArg]) Type[TypeArg] {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.brackets.begin.go
+//       ^^^^^^^^^ variable.parameter.type.go
+//                 ^^^^ storage.type.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^^^^^ variable.other.type.go
+//                             ^^ punctuation.section.brackets.end.go
+//                                ^ punctuation.section.parens.begin.go
+//                                 ^^^^^ variable.parameter.go
+//                                       ^^^^ storage.type.go
+//                                           ^ punctuation.section.brackets.begin.go
+//                                            ^^^^^^^ variable.other.type.go
+//                                                   ^ punctuation.section.brackets.end.go
+//                                                    ^ punctuation.section.parens.end.go
+//                                                      ^^^^ storage.type.go
+//                                                          ^ punctuation.section.brackets.begin.go
+//                                                           ^^^^^^^ variable.other.type.go
+//                                                                  ^ punctuation.section.brackets.end.go
+//                                                                    ^^ meta.block.go
+//                                                                    ^ punctuation.section.braces.begin.go
+//                                                                     ^ punctuation.section.braces.end.go
+
+    func(param Type[TypeArg]) (param Type[TypeArg]) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.parens.begin.go
+//       ^^^^^ variable.parameter.go
+//             ^^^^ storage.type.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^^^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.section.parens.end.go
+//                            ^ punctuation.section.parens.begin.go
+//                             ^^^^^ variable.parameter.go
+//                                   ^^^^ storage.type.go
+//                                       ^ punctuation.section.brackets.begin.go
+//                                        ^^^^^^^ variable.other.type.go
+//                                               ^ punctuation.section.brackets.end.go
+//                                                ^ punctuation.section.parens.end.go
+//                                                  ^^ meta.block.go
+//                                                  ^ punctuation.section.braces.begin.go
+//                                                   ^ punctuation.section.braces.end.go
+
+    func[TypeParam Type[TypeArg]] (param Type[TypeArg]) (param Type[TypeArg]) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.brackets.begin.go
+//       ^^^^^^^^^ variable.parameter.type.go
+//                 ^^^^ storage.type.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^^^^^ variable.other.type.go
+//                             ^^ punctuation.section.brackets.end.go
+//                                ^ punctuation.section.parens.begin.go
+//                                 ^^^^^ variable.parameter.go
+//                                       ^^^^ storage.type.go
+//                                           ^ punctuation.section.brackets.begin.go
+//                                            ^^^^^^^ variable.other.type.go
+//                                                   ^ punctuation.section.brackets.end.go
+//                                                    ^ punctuation.section.parens.end.go
+//                                                      ^ punctuation.section.parens.begin.go
+//                                                       ^^^^^ variable.parameter.go
+//                                                             ^^^^ storage.type.go
+//                                                                 ^ punctuation.section.brackets.begin.go
+//                                                                  ^^^^^^^ variable.other.type.go
+//                                                                         ^ punctuation.section.brackets.end.go
+//                                                                          ^ punctuation.section.parens.end.go
+//                                                                            ^^ meta.block.go
+//                                                                            ^ punctuation.section.braces.begin.go
+//                                                                             ^ punctuation.section.braces.end.go
+
+/* ### Generic functions: named */
+
+    func Func(param Type[TypeArg]) Type
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.parens.begin.go
+//            ^^^^^ variable.parameter.go
+//                  ^^^^ storage.type.go
+//                      ^ punctuation.section.brackets.begin.go
+//                       ^^^^^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.section.parens.end.go
+//                                 ^^^^ storage.type.go
+
+    func Func[TypeParam Type[TypeArg]] (param Type[TypeArg]) Type
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^^^^^^^ variable.parameter.type.go
+//                      ^^^^ storage.type.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^^^^^ variable.other.type.go
+//                                  ^^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.section.parens.begin.go
+//                                      ^^^^^ variable.parameter.go
+//                                            ^^^^ storage.type.go
+//                                                ^ punctuation.section.brackets.begin.go
+//                                                 ^^^^^^^ variable.other.type.go
+//                                                        ^ punctuation.section.brackets.end.go
+//                                                         ^ punctuation.section.parens.end.go
+//                                                           ^^^^ storage.type.go
+
+    func Func(param Type[TypeArg]) Type[TypeArg]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.parens.begin.go
+//            ^^^^^ variable.parameter.go
+//                  ^^^^ storage.type.go
+//                      ^ punctuation.section.brackets.begin.go
+//                       ^^^^^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.section.parens.end.go
+//                                 ^^^^ storage.type.go
+//                                     ^ punctuation.section.brackets.begin.go
+//                                      ^^^^^^^ variable.other.type.go
+//                                             ^ punctuation.section.brackets.end.go
+
+    func Func[TypeParam Type[TypeArg]] (param Type[TypeArg]) Type[TypeArg]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^^^^^^^ variable.parameter.type.go
+//                      ^^^^ storage.type.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^^^^^ variable.other.type.go
+//                                  ^^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.section.parens.begin.go
+//                                      ^^^^^ variable.parameter.go
+//                                            ^^^^ storage.type.go
+//                                                ^ punctuation.section.brackets.begin.go
+//                                                 ^^^^^^^ variable.other.type.go
+//                                                        ^ punctuation.section.brackets.end.go
+//                                                         ^ punctuation.section.parens.end.go
+//                                                           ^^^^ storage.type.go
+//                                                               ^ punctuation.section.brackets.begin.go
+//                                                                ^^^^^^^ variable.other.type.go
+//                                                                       ^ punctuation.section.brackets.end.go
+
+    func Func(param Type[TypeArg]) (param Type[TypeArg])
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.parens.begin.go
+//            ^^^^^ variable.parameter.go
+//                  ^^^^ storage.type.go
+//                      ^ punctuation.section.brackets.begin.go
+//                       ^^^^^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.section.parens.end.go
+//                                 ^ punctuation.section.parens.begin.go
+//                                  ^^^^^ variable.parameter.go
+//                                        ^^^^ storage.type.go
+//                                            ^ punctuation.section.brackets.begin.go
+//                                             ^^^^^^^ variable.other.type.go
+//                                                    ^ punctuation.section.brackets.end.go
+//                                                     ^ punctuation.section.parens.end.go
+
+    func Func[TypeParam Type[TypeArg]] (param Type[TypeArg]) (param Type[TypeArg]) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^^^^^^^ variable.parameter.type.go
+//                      ^^^^ storage.type.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^^^^^ variable.other.type.go
+//                                  ^^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.section.parens.begin.go
+//                                      ^^^^^ variable.parameter.go
+//                                            ^^^^ storage.type.go
+//                                                ^ punctuation.section.brackets.begin.go
+//                                                 ^^^^^^^ variable.other.type.go
+//                                                        ^ punctuation.section.brackets.end.go
+//                                                         ^ punctuation.section.parens.end.go
+//                                                           ^ punctuation.section.parens.begin.go
+//                                                            ^^^^^ variable.parameter.go
+//                                                                  ^^^^ storage.type.go
+//                                                                      ^ punctuation.section.brackets.begin.go
+//                                                                       ^^^^^^^ variable.other.type.go
+//                                                                              ^ punctuation.section.brackets.end.go
+//                                                                               ^ punctuation.section.parens.end.go
+//                                                                                 ^^ meta.block.go
+//                                                                                 ^ punctuation.section.braces.begin.go
+//                                                                                  ^ punctuation.section.braces.end.go
+
+    func Func /**/ [
+//  ^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//       ^^^^ entity.name.function.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+    ] (
+//^^^^^ meta.function.declaration.go
+//  ^ punctuation.section.brackets.end.go
+//    ^ punctuation.section.parens.begin.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+    ) (
+//^^^^^ meta.function.declaration.go
+//  ^ punctuation.section.parens.end.go
+//    ^ punctuation.section.parens.begin.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+        ident /**/ ident . /**/ Ident [/**/ ident . /**/ Ident /**/],
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//      ^^^^^ variable.parameter.go
+//            ^^^^ comment.block.go
+//                 ^^^^^ variable.other.go
+//                       ^ punctuation.accessor.dot.go
+//                         ^^^^ comment.block.go
+//                              ^^^^^ storage.type.go
+//                                    ^ punctuation.section.brackets.begin.go
+//                                     ^^^^ comment.block.go
+//                                          ^^^^^ variable.other.type.go
+//                                                ^ punctuation.accessor.dot.go
+//                                                  ^^^^ comment.block.go
+//                                                       ^^^^^ variable.other.member.go
+//                                                             ^^^^ comment.block.go
+//                                                                 ^ punctuation.section.brackets.end.go
+//                                                                  ^ punctuation.separator.go
+    )
+//^^^ meta.function.declaration.go
+//  ^ punctuation.section.parens.end.go
+
+/* ### Generic functions: methods */
+
+    func(param Type[TypeArg]) Func(param Type[TypeArg]) Type
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.parens.begin.go
+//       ^^^^^ variable.parameter.go
+//             ^^^^ storage.type.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^^^^^ variable.parameter.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.section.parens.end.go
+//                            ^^^^ entity.name.function.go
+//                                ^ punctuation.section.parens.begin.go
+//                                 ^^^^^ variable.parameter.go
+//                                       ^^^^ storage.type.go
+//                                           ^ punctuation.section.brackets.begin.go
+//                                            ^^^^^^^ variable.other.type.go
+//                                                   ^ punctuation.section.brackets.end.go
+//                                                    ^ punctuation.section.parens.end.go
+//                                                      ^^^^ storage.type.go
+//                                                          ^ -meta.function.declaration.go
+
+    func(ident ident[ident, ident]) ident(ident ident[ident, ident]) (ident ident[ident, ident])
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.go
+//  ^^^^ keyword.declaration.function.go
+//      ^ punctuation.section.parens.begin.go
+//       ^^^^^ variable.parameter.go
+//             ^^^^^ storage.type.go
+//                  ^ punctuation.section.brackets.begin.go
+//                   ^^^^^ variable.parameter.type.go
+//                        ^ punctuation.separator.go
+//                          ^^^^^ variable.parameter.type.go
+//                               ^ punctuation.section.brackets.end.go
+//                                ^ punctuation.section.parens.end.go
+//                                  ^^^^^ entity.name.function.go
+//                                       ^ punctuation.section.parens.begin.go
+//                                        ^^^^^ variable.parameter.go
+//                                              ^^^^^ storage.type.go
+//                                                   ^ punctuation.section.brackets.begin.go
+//                                                    ^^^^^ variable.other.type.go
+//                                                         ^ punctuation.separator.go
+//                                                           ^^^^^ variable.other.type.go
+//                                                                ^ punctuation.section.brackets.end.go
+//                                                                 ^ punctuation.section.parens.end.go
+//                                                                   ^ punctuation.section.parens.begin.go
+//                                                                    ^^^^^ variable.parameter.go
+//                                                                          ^^^^^ storage.type.go
+//                                                                               ^ punctuation.section.brackets.begin.go
+//                                                                                ^^^^^ variable.other.type.go
+//                                                                                     ^ punctuation.separator.go
+//                                                                                       ^^^^^ variable.other.type.go
+//                                                                                            ^ punctuation.section.brackets.end.go
+//                                                                                             ^ punctuation.section.parens.end.go
+//                                                                                              ^ -meta.function.declaration.go
+
 /* ## interface */
 
     interface{}
@@ -793,20 +1208,20 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                  ^ meta.type.go punctuation.section.parens.end.go
 
         Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//      ^^^^^^^ meta.type.go storage.type.go
 
         *ident.Inherit
 //      ^ meta.type.go keyword.operator.go
 //       ^^^^^ meta.type.go variable.other.go
 //            ^ meta.type.go punctuation.accessor.dot.go
-//             ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//             ^^^^^^^ meta.type.go storage.type.go
 
         Inherit // comment
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//      ^^^^^^^ meta.type.go storage.type.go
 //              ^^^^^^^^^^^ meta.type.go comment.line.go
 
         Inherit /* comment */
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//      ^^^^^^^ meta.type.go storage.type.go
 //              ^^^^^^^^^^^^^ meta.type.go comment.block.go
 
         Method(
@@ -822,18 +1237,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //           ^ meta.type.go punctuation.accessor.dot.go
 //            ^^^^^ meta.type.go variable.other.go
 //                 ^ meta.type.go punctuation.accessor.dot.go
-//                  ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//                  ^^^^^^^ meta.type.go storage.type.go
 
-        ident /**/ .
+        ident .
 //      ^^^^^ meta.type.go variable.other.go
-//            ^^^^ meta.type.go comment.block.go
-//                 ^ meta.type.go punctuation.accessor.dot.go
-        ident /**/ .
+//            ^ meta.type.go punctuation.accessor.dot.go
+        ident .
 //      ^^^^^ meta.type.go variable.other.go
-//            ^^^^ meta.type.go comment.block.go
-//                 ^ meta.type.go punctuation.accessor.dot.go
+//            ^ meta.type.go punctuation.accessor.dot.go
         Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//      ^^^^^^^ meta.type.go storage.type.go
     }
 //  ^ meta.type.go punctuation.section.braces.end.go
 
@@ -848,7 +1261,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                   ^ meta.type.go punctuation.section.parens.end.go
 //                     ^^^ meta.type.go storage.type.go
 //                        ^ meta.type.go punctuation.terminator.go
-//                          ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//                          ^^^^^^^ meta.type.go storage.type.go
 //                                 ^ meta.type.go punctuation.terminator.go
 //                                   ^^^^^^ meta.type.go entity.name.function.go
 //                                         ^ meta.type.go punctuation.section.parens.begin.go
@@ -858,6 +1271,50 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                                                     ^^^ meta.type.go storage.type.go
 //                                                        ^ meta.type.go punctuation.terminator.go
 //                                                         ^ meta.type.go punctuation.section.braces.end.go
+
+    interface{~ident}
+//  ^^^^^^^^^ keyword.declaration.interface.go
+//           ^^^^^^^^ meta.type.go
+//           ^ punctuation.section.braces.begin.go
+//            ^ keyword.operator.go
+//             ^^^^^ storage.type.go
+//                  ^ punctuation.section.braces.end.go
+
+    interface{one|two|three}
+//  ^^^^^^^^^ keyword.declaration.interface.go
+//           ^^^^^^^^^^^^^^^ meta.type.go
+//           ^ punctuation.section.braces.begin.go
+//            ^^^ storage.type.go
+//               ^ keyword.operator.go
+//                ^^^ storage.type.go
+//                   ^ keyword.operator.go
+//                    ^^^^^ storage.type.go
+//                         ^ punctuation.section.braces.end.go
+
+    interface{~one|~two|~three}
+//  ^^^^^^^^^ keyword.declaration.interface.go
+//           ^^^^^^^^^^^^^^^^^^ meta.type.go
+//           ^ punctuation.section.braces.begin.go
+//            ^ keyword.operator.go
+//             ^^^ storage.type.go
+//                ^ keyword.operator.go
+//                 ^ keyword.operator.go
+//                  ^^^ storage.type.go
+//                     ^ keyword.operator.go
+//                      ^ keyword.operator.go
+//                       ^^^^^ storage.type.go
+//                            ^ punctuation.section.braces.end.go
+
+    interface{
+        one |
+//      ^^^ storage.type.go
+//          ^ keyword.operator.go
+        // comment
+//      ^^^^^^^^^^ comment.line.go
+//      ^^ punctuation.definition.comment.go
+        two
+//      ^^^ storage.type.go
+    }
 
 /* ## map */
 
@@ -876,12 +1333,6 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //          ^^^ storage.type.go
 //              ^^^^^ variable.other.go -storage
 
-    map[typ]
-//  ^^^ keyword.declaration.map.go
-//      ^^^ storage.type.go
-    ident
-//  ^^^^^ variable.other.go
-
     map /**/ [/**/ typ /**/] /**/ typ
 //  ^^^ keyword.declaration.map.go
 //      ^^^^ comment.block.go
@@ -893,20 +1344,23 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                           ^^^^ comment.block.go
 //                                ^^^ storage.type.go
 
-    map /**/
+    map
 //  ^^^ keyword.declaration.map.go
+    /**/
+//  ^^^^ comment.block.go
+    [
+//  ^ punctuation.section.brackets.begin.go
+        /**/
 //      ^^^^ comment.block.go
-    /**/ [ /**/
+        typ
+//      ^^^ storage.type.go
+        /**/
+//      ^^^^ comment.block.go
+    ]
+    /**/
 //  ^^^^ comment.block.go
-//       ^ punctuation.section.brackets.begin.go
-//         ^^^^ comment.block.go
-    /**/ typ /**/ ] /**/ typ
-//  ^^^^ comment.block.go
-//       ^^^ storage.type.go
-//           ^^^^ comment.block.go
-//                ^ punctuation.section.brackets.end.go
-//                  ^^^^ comment.block.go
-//                       ^^^ storage.type.go
+    typ
+//  ^^^ storage.type.go
 
     map[typ]map[typ]map[typ]map[typ]typ
 //  ^^^ keyword.declaration.map.go
@@ -1000,18 +1454,16 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                        ^ punctuation.accessor.dot.go
 //                         ^^^^ storage.type.go
 
-    map[typ]ident /**/ . /**/
+    map[typ]ident . /**/
 //  ^^^ keyword.declaration.map.go
 //      ^^^ storage.type.go
 //          ^^^^^ variable.other.go
-//                ^^^^ comment.block.go
-//                     ^ punctuation.accessor.dot.go
-//                       ^^^^ comment.block.go
-            ident /**/ . /**/
+//                ^ punctuation.accessor.dot.go
+//                  ^^^^ comment.block.go
+            ident . /**/
 //          ^^^^^ variable.other.go
-//                ^^^^ comment.block.go
-//                     ^ punctuation.accessor.dot.go
-//                       ^^^^ comment.block.go
+//                ^ punctuation.accessor.dot.go
+//                  ^^^^ comment.block.go
             typ
 //          ^^^ storage.type.go
 
@@ -1148,30 +1600,26 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^ meta.type.go punctuation.section.braces.end.go
 
     struct {
-        ** /**/ ident /**/ . /**/ ident /**/ . /**/ embed
+        ** /**/ ident . /**/ ident . /**/ embed
 //      ^^ meta.type.go keyword.operator.go
 //         ^^^^ meta.type.go comment.block.go
 //              ^^^^^ meta.type.go variable.other.go
-//                    ^^^^ meta.type.go comment.block.go
-//                         ^ meta.type.go punctuation.accessor.dot.go
-//                           ^^^^ meta.type.go comment.block.go
-//                                ^^^^^ meta.type.go variable.other.go
-//                                      ^^^^ meta.type.go comment.block.go
-//                                           ^ meta.type.go punctuation.accessor.dot.go
-//                                             ^^^^ meta.type.go comment.block.go
-//                                                  ^^^^^ meta.type.go entity.other.inherited-class.go
+//                    ^ meta.type.go punctuation.accessor.dot.go
+//                      ^^^^ meta.type.go comment.block.go
+//                           ^^^^^ meta.type.go variable.other.go
+//                                 ^ meta.type.go punctuation.accessor.dot.go
+//                                   ^^^^ meta.type.go comment.block.go
+//                                        ^^^^^ meta.type.go entity.other.inherited-class.go
 
-        ** ident /**/ . /**/
+        ** ident . /**/
 //      ^^ meta.type.go keyword.operator.go
 //         ^^^^^ meta.type.go variable.other.go
-//               ^^^^ meta.type.go comment.block.go
-//                    ^ meta.type.go punctuation.accessor.dot.go
-//                      ^^^^ meta.type.go comment.block.go
-           ident /**/ . /**/
+//               ^ meta.type.go punctuation.accessor.dot.go
+//                 ^^^^ meta.type.go comment.block.go
+           ident . /**/
 //         ^^^^^ meta.type.go variable.other.go
-//               ^^^^ meta.type.go comment.block.go
-//                    ^ meta.type.go punctuation.accessor.dot.go
-//                      ^^^^ meta.type.go comment.block.go
+//               ^ meta.type.go punctuation.accessor.dot.go
+//                 ^^^^ meta.type.go comment.block.go
            embed
 //         ^^^^^ meta.type.go entity.other.inherited-class.go
     }
@@ -1302,6 +1750,1337 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //               ^^^ meta.type.go storage.type.go
     }
 
+/* ### Embedded parametrized types */
+
+    struct{ embed[typ] }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ]; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                    ^ punctuation.terminator.go
+//                      ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                           ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                          ^ punctuation.terminator.go
+//                            ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ]; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                    ^ punctuation.terminator.go
+//                      ^^^^^ variable.other.member.declaration.go
+//                            ^^^ storage.type.go
+//                                ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ]; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                    ^ punctuation.terminator.go
+//                      ^^^^^ variable.other.member.declaration.go
+//                            ^^^ storage.type.go
+//                               ^ punctuation.terminator.go
+//                                ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ]; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                    ^ punctuation.terminator.go
+//                      ^^^^^ variable.other.member.declaration.go
+//                            ^^^ storage.type.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ]; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                    ^ punctuation.terminator.go
+//                      ^^^^^ variable.other.member.declaration.go
+//                            ^^^ storage.type.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag`; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag`; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                     ^ punctuation.terminator.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag`; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ embed[typ] `tag`; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ entity.other.inherited-class.go
+//               ^ punctuation.section.brackets.begin.go
+//                ^^^ variable.other.type.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^^^^^ string.quoted.other.go
+//                     ^ punctuation.definition.string.begin.go
+//                         ^ punctuation.definition.string.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ]; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.terminator.go
+//                            ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                 ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                ^ punctuation.terminator.go
+//                                  ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ]; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ]; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                     ^ punctuation.terminator.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ]; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ]; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                          ^ punctuation.terminator.go
+//                            ^^^^^ variable.other.member.declaration.go
+//                                  ^^^ storage.type.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag`; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                ^ punctuation.terminator.go
+//                                  ^^^^^ variable.other.member.declaration.go
+//                                        ^^^ storage.type.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag`; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                ^ punctuation.terminator.go
+//                                  ^^^^^ variable.other.member.declaration.go
+//                                        ^^^ storage.type.go
+//                                           ^ punctuation.terminator.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag`; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                ^ punctuation.terminator.go
+//                                  ^^^^^ variable.other.member.declaration.go
+//                                        ^^^ storage.type.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                  ^ punctuation.section.braces.end.go
+
+    struct{ ident.embed[typ] `tag`; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ entity.other.inherited-class.go
+//                     ^ punctuation.section.brackets.begin.go
+//                      ^^^ variable.other.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ string.quoted.other.go
+//                           ^ punctuation.definition.string.begin.go
+//                               ^ punctuation.definition.string.end.go
+//                                ^ punctuation.terminator.go
+//                                  ^^^^^ variable.other.member.declaration.go
+//                                        ^^^ storage.type.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ]; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.terminator.go
+//                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ]; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.terminator.go
+//                                 ^^^^^ variable.other.member.declaration.go
+//                                       ^^^ storage.type.go
+//                                           ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ]; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.terminator.go
+//                                 ^^^^^ variable.other.member.declaration.go
+//                                       ^^^ storage.type.go
+//                                          ^ punctuation.terminator.go
+//                                           ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ]; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.terminator.go
+//                                 ^^^^^ variable.other.member.declaration.go
+//                                       ^^^ storage.type.go
+//                                           ^^^^^ string.quoted.other.go
+//                                           ^ punctuation.definition.string.begin.go
+//                                               ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ]; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                               ^ punctuation.terminator.go
+//                                 ^^^^^ variable.other.member.declaration.go
+//                                       ^^^ storage.type.go
+//                                           ^^^^^ string.quoted.other.go
+//                                           ^ punctuation.definition.string.begin.go
+//                                               ^ punctuation.definition.string.end.go
+//                                                ^ punctuation.terminator.go
+//                                                  ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag`; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag`; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                ^ punctuation.terminator.go
+//                                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag`; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^ punctuation.definition.string.begin.go
+//                                                     ^ punctuation.definition.string.end.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ; embed[typ] `tag`; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                   ^ punctuation.terminator.go
+//                     ^^^^^ entity.other.inherited-class.go
+//                          ^ punctuation.section.brackets.begin.go
+//                           ^^^ variable.other.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ string.quoted.other.go
+//                                ^ punctuation.definition.string.begin.go
+//                                    ^ punctuation.definition.string.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^ punctuation.definition.string.begin.go
+//                                                     ^ punctuation.definition.string.end.go
+//                                                      ^ punctuation.terminator.go
+//                                                        ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ]; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ]; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ]; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                ^ punctuation.terminator.go
+//                                                 ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ]; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^ punctuation.definition.string.begin.go
+//                                                     ^ punctuation.definition.string.end.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ]; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                     ^ punctuation.terminator.go
+//                                       ^^^^^ variable.other.member.declaration.go
+//                                             ^^^ storage.type.go
+//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^ punctuation.definition.string.begin.go
+//                                                     ^ punctuation.definition.string.end.go
+//                                                      ^ punctuation.terminator.go
+//                                                        ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag`; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag`; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                      ^ punctuation.terminator.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag`; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^ punctuation.definition.string.begin.go
+//                                                           ^ punctuation.definition.string.end.go
+//                                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; embed[typ] `tag`; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ entity.other.inherited-class.go
+//                                ^ punctuation.section.brackets.begin.go
+//                                 ^^^ variable.other.type.go
+//                                    ^ punctuation.section.brackets.end.go
+//                                      ^^^^^ string.quoted.other.go
+//                                      ^ punctuation.definition.string.begin.go
+//                                          ^ punctuation.definition.string.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^ punctuation.definition.string.begin.go
+//                                                           ^ punctuation.definition.string.end.go
+//                                                            ^ punctuation.terminator.go
+//                                                              ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ]; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                  ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ]; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ]; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                      ^ punctuation.terminator.go
+//                                                       ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ]; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^ punctuation.definition.string.begin.go
+//                                                           ^ punctuation.definition.string.end.go
+//                                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ]; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                           ^ punctuation.terminator.go
+//                                             ^^^^^ variable.other.member.declaration.go
+//                                                   ^^^ storage.type.go
+//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^ punctuation.definition.string.begin.go
+//                                                           ^ punctuation.definition.string.end.go
+//                                                            ^ punctuation.terminator.go
+//                                                              ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag`; field typ }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^^^^^ variable.other.member.declaration.go
+//                                                         ^^^ storage.type.go
+//                                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag`; field typ;}
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^^^^^ variable.other.member.declaration.go
+//                                                         ^^^ storage.type.go
+//                                                            ^ punctuation.terminator.go
+//                                                             ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag`; field typ `tag` }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^^^^^ variable.other.member.declaration.go
+//                                                         ^^^ storage.type.go
+//                                                             ^^^^^ string.quoted.other.go
+//                                                             ^ punctuation.definition.string.begin.go
+//                                                                 ^ punctuation.definition.string.end.go
+//                                                                   ^ punctuation.section.braces.end.go
+
+    struct{ field typ `tag`; ident.embed[typ] `tag`; field typ `tag`; }
+//  ^^^^^^ keyword.declaration.struct.go
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//        ^ punctuation.section.braces.begin.go
+//          ^^^^^ variable.other.member.declaration.go
+//                ^^^ storage.type.go
+//                    ^^^^^ string.quoted.other.go
+//                    ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+//                         ^ punctuation.terminator.go
+//                           ^^^^^ variable.other.go
+//                                ^ punctuation.accessor.dot.go
+//                                 ^^^^^ entity.other.inherited-class.go
+//                                      ^ punctuation.section.brackets.begin.go
+//                                       ^^^ variable.other.type.go
+//                                          ^ punctuation.section.brackets.end.go
+//                                            ^^^^^ string.quoted.other.go
+//                                            ^ punctuation.definition.string.begin.go
+//                                                ^ punctuation.definition.string.end.go
+//                                                 ^ punctuation.terminator.go
+//                                                   ^^^^^ variable.other.member.declaration.go
+//                                                         ^^^ storage.type.go
+//                                                             ^^^^^ string.quoted.other.go
+//                                                             ^ punctuation.definition.string.begin.go
+//                                                                 ^ punctuation.definition.string.end.go
+//                                                                  ^ punctuation.terminator.go
+//                                                                    ^ punctuation.section.braces.end.go
+
+    struct {
+//  ^^^^^^ keyword.declaration.struct.go
+//         ^ meta.type.go punctuation.section.braces.begin.go
+        embed[typ]
+//^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^ variable.other.type.go
+//               ^ punctuation.section.brackets.end.go
+        embed[typ, typ]
+//^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^ variable.other.type.go
+//               ^ punctuation.separator.go
+//                 ^^^ variable.other.type.go
+//                    ^ punctuation.section.brackets.end.go
+        embed[typ] ``
+//^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^ variable.other.type.go
+//               ^ punctuation.section.brackets.end.go
+//                 ^^ string.quoted.other.go
+//                 ^ punctuation.definition.string.begin.go
+//                  ^ punctuation.definition.string.end.go
+        embed /**/ [typ]
+//^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+        embed /**/ [typ] ``
+//^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^^ string.quoted.other.go
+//                       ^ punctuation.definition.string.begin.go
+//                        ^ punctuation.definition.string.end.go
+        embed /**/ [typ] /**/
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^^^^ comment.block.go
+//                       ^^ punctuation.definition.comment.begin.go
+//                         ^^ punctuation.definition.comment.end.go
+        embed /**/ [typ] /**/ ``
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^^^^ comment.block.go
+//                       ^^ punctuation.definition.comment.begin.go
+//                         ^^ punctuation.definition.comment.end.go
+//                            ^^ string.quoted.other.go
+//                            ^ punctuation.definition.string.begin.go
+//                             ^ punctuation.definition.string.end.go
+        embed /**/ [typ] ; field typ
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^ punctuation.terminator.go
+//                         ^^^^^ variable.other.member.declaration.go
+//                               ^^^ storage.type.go
+        embed /**/ [typ] /**/; field typ
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^^^^ comment.block.go
+//                       ^^ punctuation.definition.comment.begin.go
+//                         ^^ punctuation.definition.comment.end.go
+//                           ^ punctuation.terminator.go
+//                             ^^^^^ variable.other.member.declaration.go
+//                                   ^^^ storage.type.go
+        embed /**/ [typ] /**/ ``; field typ
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ entity.other.inherited-class.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^ variable.other.type.go
+//                     ^ punctuation.section.brackets.end.go
+//                       ^^^^ comment.block.go
+//                       ^^ punctuation.definition.comment.begin.go
+//                         ^^ punctuation.definition.comment.end.go
+//                            ^^ string.quoted.other.go
+//                            ^ punctuation.definition.string.begin.go
+//                             ^ punctuation.definition.string.end.go
+//                              ^ punctuation.terminator.go
+//                                ^^^^^ variable.other.member.declaration.go
+//                                      ^^^ storage.type.go
+        field /**/ [] /**/ typ
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ variable.other.member.declaration.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^ punctuation.section.brackets.end.go
+//                    ^^^^ comment.block.go
+//                    ^^ punctuation.definition.comment.begin.go
+//                      ^^ punctuation.definition.comment.end.go
+//                         ^^^ storage.type.go
+        field /**/ [size] /**/ typ
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ variable.other.member.declaration.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^^ variable.other.go
+//                      ^ punctuation.section.brackets.end.go
+//                        ^^^^ comment.block.go
+//                        ^^ punctuation.definition.comment.begin.go
+//                          ^^ punctuation.definition.comment.end.go
+//                             ^^^ storage.type.go
+        field /**/ [size] /**/ typ `tag`
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^^^^^ variable.other.member.declaration.go
+//            ^^^^ comment.block.go
+//            ^^ punctuation.definition.comment.begin.go
+//              ^^ punctuation.definition.comment.end.go
+//                 ^ punctuation.section.brackets.begin.go
+//                  ^^^^ variable.other.go
+//                      ^ punctuation.section.brackets.end.go
+//                        ^^^^ comment.block.go
+//                        ^^ punctuation.definition.comment.begin.go
+//                          ^^ punctuation.definition.comment.end.go
+//                             ^^^ storage.type.go
+//                                 ^^^^^ string.quoted.other.go
+//                                 ^ punctuation.definition.string.begin.go
+//                                     ^ punctuation.definition.string.end.go
+    }
+//^^^ meta.type.go
+//  ^ punctuation.section.braces.end.go
+
+    struct {_}
+//  ^^^^^^ keyword.declaration.struct.go
+//         ^^^ meta.type.go
+//         ^ punctuation.section.braces.begin.go
+//          ^ variable.language.anonymous.go
+//           ^ punctuation.section.braces.end.go
+
+    struct {
+        _[typ]
+//^^^^^^^^^^^^ meta.type.go
+//      ^ variable.language.anonymous.go
+//       ^ punctuation.section.brackets.begin.go
+//        ^^^ variable.other.type.go
+//           ^ punctuation.section.brackets.end.go
+    }
+
+    struct {
+        *ident.embed[typ]
+//^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//      ^ keyword.operator.go
+//       ^^^^^ variable.other.go
+//            ^ punctuation.accessor.dot.go
+//             ^^^^^ entity.other.inherited-class.go
+//                  ^ punctuation.section.brackets.begin.go
+//                   ^^^ variable.other.type.go
+//                      ^ punctuation.section.brackets.end.go
+    }
+
+    /*
+    Known defect. This should be scoped as an embedded type.
+    The current implementation incorrectly scopes this as a field.
+    TODO improve.
+    */
+    struct {
+        embed[struct{
+        }]
+    }
 
 /* ## Array / Slice */
 
@@ -1402,7 +3181,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^^ keyword.declaration.type.go
     /**/
 //  ^^^^ comment.block.go
-    Type /**/ * /**/ * /**/ ident /**/ . /**/
+    Type /**/ * /**/ * /**/ ident . /**/
 //  ^^^^ entity.name.type.go
 //       ^^^^ comment.block.go
 //            ^ keyword.operator.go
@@ -1410,15 +3189,13 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                   ^ keyword.operator.go
 //                     ^^^^ comment.block.go
 //                          ^^^^^ variable.other.go
-//                                ^^^^ comment.block.go
-//                                     ^ punctuation.accessor.dot.go
-//                                       ^^^^ comment.block.go
-        /**/ ident /**/ . /**/
+//                                ^ punctuation.accessor.dot.go
+//                                  ^^^^ comment.block.go
+        /**/ ident . /**/
 //      ^^^^ comment.block.go
 //           ^^^^^ variable.other.go
-//                 ^^^^ comment.block.go
-//                      ^ punctuation.accessor.dot.go
-//                        ^^^^ comment.block.go
+//                 ^ punctuation.accessor.dot.go
+//                   ^^^^ comment.block.go
         /**/ Type
 //      ^^^^ comment.block.go
 //           ^^^^ storage.type.go
@@ -1490,7 +3267,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
         Method()
 //      ^^^^^^ meta.type.go entity.name.function.go
         Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
+//      ^^^^^^^ meta.type.go storage.type.go
     } ident
 //    ^^^^^ variable.other.go
 
@@ -1550,6 +3327,362 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                ^^^ meta.type.go storage.type.go
         }
     )
+
+    /*
+    Support for unions.
+
+    At the time of writing, unions are allowed only in interfaces (called
+    "general" interfaces as opposed to "basic" interfaces which contain only
+    methods), and in constraints for type parameters, where a union is
+    considered a shorthand for a general interface. Unions in RHS of type
+    definitions are not yet allowed. However, for us, it's easier to support
+    unions in all type contexts.
+    */
+    type Ident Ident | ~Ident | *Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^^^^^ storage.type.go
+//                   ^ keyword.operator.go
+//                     ^ keyword.operator.go
+//                      ^^^^^ storage.type.go
+//                            ^ keyword.operator.go
+//                              ^ keyword.operator.go
+//                               ^^^^^ storage.type.go
+
+    type Ident = Ident | ~Ident | *Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ keyword.operator.assignment.go
+//               ^^^^^ storage.type.go
+//                     ^ keyword.operator.go
+//                       ^ keyword.operator.go
+//                        ^^^^^ storage.type.go
+//                              ^ keyword.operator.go
+//                                ^ keyword.operator.go
+//                                 ^^^^^ storage.type.go
+
+    /*
+    Sanity check. This looks similar to a parametrized type, but in fact defines
+    an array type.
+    */
+    type Type[ident] ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^ entity.name.type.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^^^^^ variable.other.go
+//                 ^ punctuation.section.brackets.end.go
+//                   ^^^^^ storage.type.go
+
+    // Same as above. This is NOT a parametrized type.
+    type Type[_] ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^ entity.name.type.go
+//           ^ punctuation.section.brackets.begin.go
+//            ^ variable.language.anonymous.go
+//             ^ punctuation.section.brackets.end.go
+//               ^^^^^ storage.type.go
+
+    /*
+    Parsing ambiguity. Can be interpreted as:
+
+        * Parametrized typedef of "C" where "A" is a type parameter and "*B" is
+          a type constraint.
+
+        * Non-parametrized typedef of array of "C" where "A * B" is a constant
+          expression that defines array size.
+
+    For backwards compatibility, Go resolves such ambiguities in favor of
+    constant expressions and arrays, rather than type parameter lists.
+    We must match this behavior.
+    */
+    type Type [A * B] C
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^ entity.name.type.go
+//            ^ punctuation.section.brackets.begin.go
+//             ^ variable.other.go
+//               ^ keyword.operator.go
+//                 ^ variable.other.go
+//                  ^ punctuation.section.brackets.end.go
+//                    ^ storage.type.go
+
+    /*
+    Known issue.
+
+    This type parameter list is disambiguated from a fixed-size array definition
+    by the trailing comma. This is part of the official documentation and is
+    specifically supported by the Go parser and `gofmt`.
+
+    Our current implementation doesn't support this case.
+    TODO consider fixing.
+    */
+    type Type [A * B,] C
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^ entity.name.type.go
+//            ^ punctuation.section.brackets.begin.go
+//               ^ keyword.operator.go
+//                  ^ punctuation.separator.go
+//                   ^ punctuation.section.brackets.end.go
+//                     ^ storage.type.go
+
+    type Ident [Ident Ident] Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^^^^^ storage.type.go
+//                         ^ punctuation.section.brackets.end.go
+//                           ^^^^^ storage.type.go
+
+    type Ident [Ident, Ident Ident] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                   ^ punctuation.separator.go
+//                     ^^^^^ variable.parameter.type.go
+//                           ^^^^^ storage.type.go
+//                                ^ punctuation.section.brackets.end.go
+//                                  ^^^^^ variable.other.go
+//                                       ^ punctuation.accessor.dot.go
+//                                        ^^^^^ storage.type.go
+
+    type (
+        Ident [Ident Ident] Ident
+//      ^^^^^ entity.name.type.go
+//            ^ punctuation.section.brackets.begin.go
+//             ^^^^^ variable.parameter.type.go
+//                   ^^^^^ storage.type.go
+//                        ^ punctuation.section.brackets.end.go
+//                          ^^^^^ storage.type.go
+
+        Ident [Ident ident.Ident] ident.Ident
+//      ^^^^^ entity.name.type.go
+//            ^ punctuation.section.brackets.begin.go
+//             ^^^^^ variable.parameter.type.go
+//                   ^^^^^ variable.other.go
+//                        ^ punctuation.accessor.dot.go
+//                         ^^^^^ storage.type.go
+//                              ^ punctuation.section.brackets.end.go
+//                                ^^^^^ variable.other.go
+//                                     ^ punctuation.accessor.dot.go
+//                                      ^^^^^ storage.type.go
+    )
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident Ident,
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^^ storage.type.go
+//                 ^ punctuation.separator.go
+    ] Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^^^^^ storage.type.go
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident ident.Ident,
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^^ variable.other.go
+//                 ^ punctuation.accessor.dot.go
+//                  ^^^^^ storage.type.go
+//                       ^ punctuation.separator.go
+    ] ident.Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^^^^^ variable.other.go
+//         ^ punctuation.accessor.dot.go
+//          ^^^^^ storage.type.go
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident,
+//      ^^^^^ variable.parameter.type.go
+//           ^ punctuation.separator.go
+        Ident ident.Ident,
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^^ variable.other.go
+//                 ^ punctuation.accessor.dot.go
+//                  ^^^^^ storage.type.go
+    ] ident.Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^^^^^ variable.other.go
+//         ^ punctuation.accessor.dot.go
+//          ^^^^^ storage.type.go
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident, Ident ident.Ident,
+//      ^^^^^ variable.parameter.type.go
+//           ^ punctuation.separator.go
+//             ^^^^^ variable.parameter.type.go
+//                   ^^^^^ variable.other.go
+//                        ^ punctuation.accessor.dot.go
+//                         ^^^^^ storage.type.go
+//                              ^ punctuation.separator.go
+    ] ident.Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^^^^^ variable.other.go
+//         ^ punctuation.accessor.dot.go
+//          ^^^^^ storage.type.go
+
+    type Ident [Ident ~Ident] Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^ keyword.operator.go
+//                     ^^^^^ storage.type.go
+//                          ^ punctuation.section.brackets.end.go
+//                            ^^^^^ storage.type.go
+
+    type Ident [Ident ~ident.Ident] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^ keyword.operator.go
+//                     ^^^^^ variable.other.go
+//                          ^ punctuation.accessor.dot.go
+//                           ^^^^^ storage.type.go
+//                                ^ punctuation.section.brackets.end.go
+//                                  ^^^^^ variable.other.go
+//                                       ^ punctuation.accessor.dot.go
+//                                        ^^^^^ storage.type.go
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident ~ident.Ident,
+//      ^^^^^ variable.parameter.type.go
+//            ^ keyword.operator.go
+//             ^^^^^ variable.other.go
+//                  ^ punctuation.accessor.dot.go
+//                   ^^^^^ storage.type.go
+//                        ^ punctuation.separator.go
+    ] ident.Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^^^^^ variable.other.go
+//         ^ punctuation.accessor.dot.go
+//          ^^^^^ storage.type.go
+
+    type Ident [Ident []ident.Ident] ident.Ident
+
+    type Ident [Ident [ident.Ident] ident.Ident] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^ punctuation.section.brackets.begin.go
+//                     ^^^^^ variable.other.go
+//                          ^ punctuation.accessor.dot.go
+//                           ^^^^^ variable.other.member.go
+//                                ^ punctuation.section.brackets.end.go
+//                                  ^^^^^ variable.other.go
+//                                       ^ punctuation.accessor.dot.go
+//                                        ^^^^^ storage.type.go
+//                                             ^ punctuation.section.brackets.end.go
+//                                               ^^^^^ variable.other.go
+//                                                    ^ punctuation.accessor.dot.go
+//                                                     ^^^^^ storage.type.go
+
+    type Ident [Ident struct{}] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^^^^^^ keyword.declaration.struct.go
+//                          ^^ meta.type.go
+//                          ^ punctuation.section.braces.begin.go
+//                           ^ punctuation.section.braces.end.go
+//                            ^ punctuation.section.brackets.end.go
+//                              ^^^^^ variable.other.go
+//                                   ^ punctuation.accessor.dot.go
+//                                    ^^^^^ storage.type.go
+
+    type Ident [Ident interface{}] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^^^^^^^^^^^ meta.type.go
+//                    ^^^^^^^^^ keyword.declaration.interface.go
+//                             ^ punctuation.section.braces.begin.go
+//                              ^ punctuation.section.braces.end.go
+//                               ^ punctuation.section.brackets.end.go
+//                                 ^^^^^ variable.other.go
+//                                      ^ punctuation.accessor.dot.go
+//                                       ^^^^^ storage.type.go
+
+    type Ident [Ident map[ident.Ident]ident.Ident] ident.Ident
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+//              ^^^^^ variable.parameter.type.go
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//                    ^^^ keyword.declaration.map.go
+//                       ^ punctuation.section.brackets.begin.go
+//                        ^^^^^ variable.other.go
+//                             ^ punctuation.accessor.dot.go
+//                              ^^^^^ storage.type.go
+//                                   ^ punctuation.section.brackets.end.go
+//                                    ^^^^^ variable.other.go
+//                                         ^ punctuation.accessor.dot.go
+//                                          ^^^^^ storage.type.go
+//                                               ^ punctuation.section.brackets.end.go
+//                                                 ^^^^^ variable.other.go
+//                                                      ^ punctuation.accessor.dot.go
+//                                                       ^^^^^ storage.type.go
+
+    type Ident [
+//  ^^^^ keyword.declaration.type.go
+//       ^^^^^ entity.name.type.go
+//             ^ punctuation.section.brackets.begin.go
+        Ident ident.Ident,
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^^ variable.other.go
+//                 ^ punctuation.accessor.dot.go
+//                  ^^^^^ storage.type.go
+//                       ^ punctuation.separator.go
+        Ident interface{
+//      ^^^^^ variable.parameter.type.go
+//            ^^^^^^^^^^ meta.type.go
+//            ^^^^^^^^^ keyword.declaration.interface.go
+//                     ^ punctuation.section.braces.begin.go
+            ident.Ident
+//^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//          ^^^^^ variable.other.go
+//               ^ punctuation.accessor.dot.go
+//                ^^^^^ storage.type.go
+            Method() ident.Ident
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
+//          ^^^^^^ entity.name.function.go
+//                ^ punctuation.section.parens.begin.go
+//                 ^ punctuation.section.parens.end.go
+//                   ^^^^^ variable.other.go
+//                        ^ punctuation.accessor.dot.go
+//                         ^^^^^ storage.type.go
+        },
+//^^^^^^^ meta.type.go
+//      ^ punctuation.section.braces.end.go
+//       ^ punctuation.separator.go
+    ] [Ident * Ident] ident.Ident
+//  ^ punctuation.section.brackets.end.go
+//    ^ punctuation.section.brackets.begin.go
+//     ^^^^^ variable.other.go
+//           ^ keyword.operator.go
+//             ^^^^^ variable.other.go
+//                  ^ punctuation.section.brackets.end.go
+//                    ^^^^^ variable.other.go
+//                         ^ punctuation.accessor.dot.go
+//                          ^^^^^ storage.type.go
 
 
 /* # Constants and Vars */
@@ -2456,6 +4589,8 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^ keyword.operator.logical.go
     |
 //  ^ keyword.operator.bitwise.go
+    ~
+//  ^ keyword.operator.go
 
 
 /* # Punctuation */
@@ -2522,11 +4657,10 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //  ^^^^^ variable.other.go
     /**/./**/
 //      ^ punctuation.accessor.dot.go
-    (/* ident */ ident /* ident */ ident)
+    (/* ident */ ident /* ident */)
 //   ^^^^^^^^^^^ comment.block.go
 //               ^^^^^ storage.type.go
 //                     ^^^^^^^^^^^ comment.block.go
-//                                 ^^^^^ variable.other.go
 
     ident.(chan typ)
 //  ^^^^^ variable.other.go
@@ -2670,7 +4804,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                 ^ punctuation.accessor.dot.go
 //                   ^^^^ comment.block.go
         ident /**/ )) /**/ ((
-//      ^^^^^ variable.function.go
+//      ^^^^^ variable.other.member.go
 //            ^^^^ comment.block.go
 //                 ^^ punctuation.section.parens.end.go
 //                    ^^^^ comment.block.go
@@ -2705,6 +4839,31 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     ([]typ)(ident)
 //     ^^^ storage.type.go
 //          ^^^^^ variable.other.go
+
+    ident[]()
+//  ^^^^^ variable.function.go
+//       ^ punctuation.section.brackets.begin.go
+//        ^ punctuation.section.brackets.end.go
+//         ^ punctuation.section.parens.begin.go
+//          ^ punctuation.section.parens.end.go
+
+    ident[typ]()
+//  ^^^^^ variable.function.go
+//       ^ punctuation.section.brackets.begin.go
+//        ^^^ variable.other.type.go
+//           ^ punctuation.section.brackets.end.go
+//            ^ punctuation.section.parens.begin.go
+//             ^ punctuation.section.parens.end.go
+
+    ident[typ, typ]()
+//  ^^^^^ variable.function.go
+//       ^ punctuation.section.brackets.begin.go
+//        ^^^ variable.other.type.go
+//           ^ punctuation.separator.go
+//             ^^^ variable.other.type.go
+//                ^ punctuation.section.brackets.end.go
+//                 ^ punctuation.section.parens.begin.go
+//                  ^ punctuation.section.parens.end.go
 
 
 /* # Keywords */
@@ -2783,7 +4942,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     ) typ {}
 //    ^^^ storage.type.go
 
-// Methods
+/* ### Methods */
 
     func (self Type) Method() {}
 //       ^ meta.function.declaration.go punctuation.section.parens.begin.go
@@ -2806,7 +4965,7 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
     func /**/
 //  ^^^^ keyword.declaration.function.go
 //       ^^^^ comment.block.go
-    ( /**/ self /**/ * /**/ ident /**/ . /**/ Type /**/ ) /**/ Method /**/ (
+    ( /**/ self /**/ * /**/ ident . /**/ Type /**/ ) /**/ Method /**/ (
 //  ^ meta.function.declaration.go punctuation.section.parens.begin.go
 //    ^^^^ meta.function.declaration.go comment.block.go
 //         ^^^^ meta.function.declaration.go variable.parameter.go
@@ -2814,15 +4973,14 @@ Note: built-ins are tested separately. Search for "# Built-in Types".
 //                   ^ meta.function.declaration.go keyword.operator.go
 //                     ^^^^ meta.function.declaration.go comment.block.go
 //                          ^^^^^ meta.function.declaration.go variable.other.go
-//                                ^^^^ meta.function.declaration.go comment.block.go
-//                                     ^ meta.function.declaration.go punctuation.accessor.dot.go
-//                                       ^^^^ meta.function.declaration.go comment.block.go
-//                                            ^^^^ meta.function.declaration.go storage.type.go
-//                                                 ^^^^ meta.function.declaration.go comment.block.go
-//                                                      ^ meta.function.declaration.go punctuation.section.parens.end.go
-//                                                        ^^^^ meta.function.declaration.go comment.block.go
-//                                                             ^^^^^^ meta.function.declaration.go entity.name.function.go
-//                                                                    ^^^^ comment.block.go
+//                                ^ meta.function.declaration.go punctuation.accessor.dot.go
+//                                  ^^^^ meta.function.declaration.go comment.block.go
+//                                       ^^^^ meta.function.declaration.go storage.type.go
+//                                            ^^^^ meta.function.declaration.go comment.block.go
+//                                                 ^ meta.function.declaration.go punctuation.section.parens.end.go
+//                                                   ^^^^ meta.function.declaration.go comment.block.go
+//                                                        ^^^^^^ meta.function.declaration.go entity.name.function.go
+//                                                               ^^^^ comment.block.go
         param typ
 //      ^^^^^ variable.parameter.go
 //            ^^^ storage.type.go
@@ -2890,11 +5048,11 @@ every type individually.
 
     interface { typ }
 //  ^^^^^^^^^ keyword.declaration.interface.go
-//              ^^^ meta.type.go entity.other.inherited-class.go -support
+//              ^^^ meta.type.go storage.type.go -support
 
     interface { error }
 //  ^^^^^^^^^ keyword.declaration.interface.go
-//              ^^^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
+//              ^^^^^ meta.type.go storage.type.go support.type.builtin.go
 
     [...]typ
 //   ^^^ keyword.operator.variadic.go
@@ -2963,24 +5121,33 @@ every type individually.
 
     make(typ)
 //  ^^^^ variable.function.go support.function.builtin.go
+//      ^ punctuation.section.parens.begin.go
 //       ^^^ storage.type.go -support
+//          ^ punctuation.section.parens.end.go
 
     make(int)
 //  ^^^^ variable.function.go support.function.builtin.go
+//      ^ punctuation.section.parens.begin.go
 //       ^^^ storage.type.go support.type.builtin.go
+//          ^ punctuation.section.parens.end.go
 
     make /**/ (
 //  ^^^^ variable.function.go support.function.builtin.go
 //       ^^^^ comment.block.go
+//            ^ punctuation.section.parens.begin.go
         /**/ typ /**/,
 //      ^^^^ comment.block.go
 //           ^^^ storage.type.go -support
 //               ^^^^ comment.block.go
+//                   ^ punctuation.separator.go
         ident,
 //      ^^^^^ variable.other.go
+//           ^ punctuation.separator.go
         ident,
 //      ^^^^^ variable.other.go
+//           ^ punctuation.separator.go
     )
+//  ^ punctuation.section.parens.end.go
 
     make /**/ (
 //  ^^^^ variable.function.go support.function.builtin.go
@@ -3004,23 +5171,16 @@ every type individually.
 
     new(typ, ident)
 //  ^^^ variable.function.go support.function.builtin.go
-//      ^^^ storage.type.go -support
+//     ^ punctuation.section.parens.begin.go
+//      ^^^ storage.type.go
+//         ^ punctuation.separator.go
 //           ^^^^^ variable.other.go
+//                ^ punctuation.section.parens.end.go
 
     new(int, ident)
 //  ^^^ variable.function.go support.function.builtin.go
 //      ^^^ storage.type.go support.type.builtin.go
 //           ^^^^^ variable.other.go
-
-    ((new))(typ, ident)
-//    ^^^ variable.function.go support.function.builtin.go
-//          ^^^ storage.type.go -support
-//               ^^^^^ variable.other.go
-
-    ((new))(int, ident)
-//    ^^^ variable.function.go support.function.builtin.go
-//          ^^^ storage.type.go support.type.builtin.go
-//               ^^^^^ variable.other.go
 
     new /**/ (
 //  ^^^ variable.function.go support.function.builtin.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1542,20 +1542,20 @@ by accident, but if necessary, such support could be sacrificed.
         field typ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
-//                ^^^^^^^^^^^^^^ meta.type.go string.quoted.other.go
+//                ^^^^^^^^^^^^^^ meta.type.go string.quoted.backtick.go
         field /**/ typ /**/ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^^ meta.type.go comment.block.go
 //                 ^^^ meta.type.go storage.type.go
 //                     ^^^^ meta.type.go comment.block.go
-//                          ^^^^^^^^^^^^^^ meta.type.go string.quoted.other.go
+//                          ^^^^^^^^^^^^^^ meta.type.go string.quoted.backtick.go
         typ       `json:"-"`
 //      ^^^ meta.type.go entity.other.inherited-class.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.other.go
+//                ^^^^^^^^^^ meta.type.go string.quoted.backtick.go
         typ /**/  `json:"-"`
 //      ^^^ meta.type.go entity.other.inherited-class.go
 //          ^^^^ meta.type.go comment.block.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.other.go
+//                ^^^^^^^^^^ meta.type.go string.quoted.backtick.go
         typ
 //      ^^^ meta.type.go entity.other.inherited-class.go
 
@@ -1785,7 +1785,7 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                           ^ punctuation.section.braces.end.go
@@ -1798,7 +1798,7 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                          ^ punctuation.terminator.go
@@ -1842,7 +1842,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                    ^ punctuation.terminator.go
 //                      ^^^^^ variable.other.member.declaration.go
 //                            ^^^ storage.type.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                      ^ punctuation.section.braces.end.go
@@ -1858,7 +1858,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                    ^ punctuation.terminator.go
 //                      ^^^^^ variable.other.member.declaration.go
 //                            ^^^ storage.type.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
@@ -1872,7 +1872,7 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                          ^ punctuation.terminator.go
@@ -1888,7 +1888,7 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                          ^ punctuation.terminator.go
@@ -1905,13 +1905,13 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                            ^ punctuation.section.braces.end.go
@@ -1924,13 +1924,13 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.other.go
+//                     ^^^^^ string.quoted.backtick.go
 //                     ^ punctuation.definition.string.begin.go
 //                         ^ punctuation.definition.string.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
@@ -1971,7 +1971,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                 ^ punctuation.section.braces.end.go
@@ -1986,7 +1986,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                ^ punctuation.terminator.go
@@ -2036,7 +2036,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                            ^ punctuation.section.braces.end.go
@@ -2054,7 +2054,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
@@ -2070,7 +2070,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                ^ punctuation.terminator.go
@@ -2088,7 +2088,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                ^ punctuation.terminator.go
@@ -2107,13 +2107,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                  ^ punctuation.section.braces.end.go
@@ -2128,13 +2128,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.other.go
+//                           ^^^^^ string.quoted.backtick.go
 //                           ^ punctuation.definition.string.begin.go
 //                               ^ punctuation.definition.string.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
@@ -2178,7 +2178,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                      ^ punctuation.section.braces.end.go
@@ -2194,7 +2194,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
@@ -2247,7 +2247,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                               ^ punctuation.terminator.go
 //                                 ^^^^^ variable.other.member.declaration.go
 //                                       ^^^ storage.type.go
-//                                           ^^^^^ string.quoted.other.go
+//                                           ^^^^^ string.quoted.backtick.go
 //                                           ^ punctuation.definition.string.begin.go
 //                                               ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.section.braces.end.go
@@ -2266,7 +2266,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                               ^ punctuation.terminator.go
 //                                 ^^^^^ variable.other.member.declaration.go
 //                                       ^^^ storage.type.go
-//                                           ^^^^^ string.quoted.other.go
+//                                           ^^^^^ string.quoted.backtick.go
 //                                           ^ punctuation.definition.string.begin.go
 //                                               ^ punctuation.definition.string.end.go
 //                                                ^ punctuation.terminator.go
@@ -2283,7 +2283,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
@@ -2302,7 +2302,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
@@ -2322,13 +2322,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^^^^^ string.quoted.backtick.go
 //                                                 ^ punctuation.definition.string.begin.go
 //                                                     ^ punctuation.definition.string.end.go
 //                                                       ^ punctuation.section.braces.end.go
@@ -2344,13 +2344,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.other.go
+//                                ^^^^^ string.quoted.backtick.go
 //                                ^ punctuation.definition.string.begin.go
 //                                    ^ punctuation.definition.string.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^^^^^ string.quoted.backtick.go
 //                                                 ^ punctuation.definition.string.begin.go
 //                                                     ^ punctuation.definition.string.end.go
 //                                                      ^ punctuation.terminator.go
@@ -2362,7 +2362,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2378,7 +2378,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2395,7 +2395,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2403,7 +2403,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                            ^ punctuation.section.braces.end.go
@@ -2414,7 +2414,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2422,7 +2422,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
@@ -2434,7 +2434,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2453,7 +2453,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2473,7 +2473,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2484,7 +2484,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^^^^^ string.quoted.backtick.go
 //                                                 ^ punctuation.definition.string.begin.go
 //                                                     ^ punctuation.definition.string.end.go
 //                                                       ^ punctuation.section.braces.end.go
@@ -2495,7 +2495,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2506,7 +2506,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.other.go
+//                                                 ^^^^^ string.quoted.backtick.go
 //                                                 ^ punctuation.definition.string.begin.go
 //                                                     ^ punctuation.definition.string.end.go
 //                                                      ^ punctuation.terminator.go
@@ -2518,7 +2518,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2526,7 +2526,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
@@ -2540,7 +2540,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2548,7 +2548,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
@@ -2563,7 +2563,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2571,13 +2571,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^^^^^ string.quoted.backtick.go
 //                                                       ^ punctuation.definition.string.begin.go
 //                                                           ^ punctuation.definition.string.end.go
 //                                                             ^ punctuation.section.braces.end.go
@@ -2588,7 +2588,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2596,13 +2596,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.other.go
+//                                      ^^^^^ string.quoted.backtick.go
 //                                      ^ punctuation.definition.string.begin.go
 //                                          ^ punctuation.definition.string.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^^^^^ string.quoted.backtick.go
 //                                                       ^ punctuation.definition.string.begin.go
 //                                                           ^ punctuation.definition.string.end.go
 //                                                            ^ punctuation.terminator.go
@@ -2614,7 +2614,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2632,7 +2632,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2651,7 +2651,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2661,7 +2661,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                  ^ punctuation.section.braces.end.go
@@ -2672,7 +2672,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2682,7 +2682,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
@@ -2694,7 +2694,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2715,7 +2715,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2737,7 +2737,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2750,7 +2750,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^^^^^ string.quoted.backtick.go
 //                                                       ^ punctuation.definition.string.begin.go
 //                                                           ^ punctuation.definition.string.end.go
 //                                                             ^ punctuation.section.braces.end.go
@@ -2761,7 +2761,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2774,7 +2774,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.other.go
+//                                                       ^^^^^ string.quoted.backtick.go
 //                                                       ^ punctuation.definition.string.begin.go
 //                                                           ^ punctuation.definition.string.end.go
 //                                                            ^ punctuation.terminator.go
@@ -2786,7 +2786,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2796,7 +2796,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
@@ -2810,7 +2810,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2820,7 +2820,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
@@ -2835,7 +2835,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2845,13 +2845,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
-//                                                             ^^^^^ string.quoted.other.go
+//                                                             ^^^^^ string.quoted.backtick.go
 //                                                             ^ punctuation.definition.string.begin.go
 //                                                                 ^ punctuation.definition.string.end.go
 //                                                                   ^ punctuation.section.braces.end.go
@@ -2862,7 +2862,7 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.other.go
+//                    ^^^^^ string.quoted.backtick.go
 //                    ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
 //                         ^ punctuation.terminator.go
@@ -2872,13 +2872,13 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.other.go
+//                                            ^^^^^ string.quoted.backtick.go
 //                                            ^ punctuation.definition.string.begin.go
 //                                                ^ punctuation.definition.string.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
-//                                                             ^^^^^ string.quoted.other.go
+//                                                             ^^^^^ string.quoted.backtick.go
 //                                                             ^ punctuation.definition.string.begin.go
 //                                                                 ^ punctuation.definition.string.end.go
 //                                                                  ^ punctuation.terminator.go
@@ -2907,7 +2907,7 @@ by accident, but if necessary, such support could be sacrificed.
 //           ^ punctuation.section.brackets.begin.go
 //            ^^^ variable.other.type.go
 //               ^ punctuation.section.brackets.end.go
-//                 ^^ string.quoted.other.go
+//                 ^^ string.quoted.backtick.go
 //                 ^ punctuation.definition.string.begin.go
 //                  ^ punctuation.definition.string.end.go
         embed /**/ [typ]
@@ -2928,7 +2928,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                 ^ punctuation.section.brackets.begin.go
 //                  ^^^ variable.other.type.go
 //                     ^ punctuation.section.brackets.end.go
-//                       ^^ string.quoted.other.go
+//                       ^^ string.quoted.backtick.go
 //                       ^ punctuation.definition.string.begin.go
 //                        ^ punctuation.definition.string.end.go
         embed /**/ [typ] /**/
@@ -2955,7 +2955,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                       ^^^^ comment.block.go
 //                       ^^ punctuation.definition.comment.begin.go
 //                         ^^ punctuation.definition.comment.end.go
-//                            ^^ string.quoted.other.go
+//                            ^^ string.quoted.backtick.go
 //                            ^ punctuation.definition.string.begin.go
 //                             ^ punctuation.definition.string.end.go
         embed /**/ [typ] ; field typ
@@ -2997,7 +2997,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                       ^^^^ comment.block.go
 //                       ^^ punctuation.definition.comment.begin.go
 //                         ^^ punctuation.definition.comment.end.go
-//                            ^^ string.quoted.other.go
+//                            ^^ string.quoted.backtick.go
 //                            ^ punctuation.definition.string.begin.go
 //                             ^ punctuation.definition.string.end.go
 //                              ^ punctuation.terminator.go
@@ -3041,7 +3041,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                        ^^ punctuation.definition.comment.begin.go
 //                          ^^ punctuation.definition.comment.end.go
 //                             ^^^ storage.type.go
-//                                 ^^^^^ string.quoted.other.go
+//                                 ^^^^^ string.quoted.backtick.go
 //                                 ^ punctuation.definition.string.begin.go
 //                                     ^ punctuation.definition.string.end.go
     }
@@ -4469,54 +4469,54 @@ by accident, but if necessary, such support could be sacrificed.
 
     `one two`
 //  ^ punctuation.definition.string.begin.go
-//  ^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^ string.quoted.backtick.go
 //          ^ punctuation.definition.string.end.go
     `one \\ \n two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go -constant.character.escape
+//  ^^^^^^^^^^^^^^^ string.quoted.backtick.go -constant.character.escape
     `one %% two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^ constant.character.escape.go
     `one % two`
-//  ^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^ constant.other.placeholder.go
     `one %v two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^ constant.other.placeholder.go
     `one %+v two`
-//  ^^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^ constant.other.placeholder.go
     `one %1.2d two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^^^ constant.other.placeholder.go
     `one %[1] two`
-//  ^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^^^^ constant.other.placeholder.go
     `one %[1]v two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^^^ constant.other.placeholder.go
     `one %[1]+v two`
-//  ^^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^^^^ constant.other.placeholder.go
     `one %[1]1.2d two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go
+//  ^^^^^^^^^^^^^^^ string.quoted.backtick.go
 //       ^^^^^^^^ constant.other.placeholder.go
     `%`
-//  ^^^ string.quoted.other.go
+//  ^^^ string.quoted.backtick.go
 //   ^ -constant.other.placeholder
 
     `
-//  ^ string.quoted.other.go punctuation.definition.string.begin.go
+//  ^ string.quoted.backtick.go punctuation.definition.string.begin.go
     one
-//  ^^^ string.quoted.other.go
+//  ^^^ string.quoted.backtick.go
     two
-//  ^^^ string.quoted.other.go
+//  ^^^ string.quoted.backtick.go
     three
-//  ^^^^^ string.quoted.other.go
+//  ^^^^^ string.quoted.backtick.go
     `
-//  ^ string.quoted.other.go punctuation.definition.string.end.go
+//  ^ string.quoted.backtick.go punctuation.definition.string.end.go
 
     `one /* two */ three`
-//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.go -comment
+//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.backtick.go -comment
 
 
 /* # Operators */

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -195,7 +195,7 @@ You may have to disable Go-specific linters when working on this file.
 /* # Imports */
 
     package main
-//  ^^^^^^^ storage.type.namespace.go keyword.declaration.namespace.go
+//  ^^^^^^^ keyword.declaration.namespace.go
 //         ^ - keyword - storage
 //          ^^^^ entity.name.namespace.go
 

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -15,12 +15,12 @@ You may have to disable Go-specific linters when working on this file.
     //
 // ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^ comment.line.go
+//  ^^^ comment.line.double-slash.go
 
     // comment // comment
 // ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^ comment.line.go
+//  ^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.go
 //             ^^ -punctuation
 
     /* comment // comment */  // comment
@@ -31,7 +31,7 @@ You may have to disable Go-specific linters when working on this file.
 //                        ^^ punctuation.definition.comment.end.go
 //                          ^^ -comment -punctuation
 //                            ^^ punctuation.definition.comment.go
-//                            ^^^^^^^^^^^ comment.line.go
+//                            ^^^^^^^^^^^ comment.line.double-slash.go
 
     /*
 // ^ -comment
@@ -67,72 +67,72 @@ You may have to disable Go-specific linters when working on this file.
     //go
 // ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^ comment.line.go -meta.annotation
+//  ^^^^ comment.line.double-slash.go -meta.annotation
 
     //go:
 // ^ -comment -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^ comment.line.go -meta.annotation
+//  ^^^^^ comment.line.double-slash.go -meta.annotation
 
     //go:generate one two three
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^ meta.keyword.annotation.go
 //       ^^^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                             ^ comment.line.go -meta.annotation
+//                ^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                             ^ comment.line.double-slash.go -meta.annotation
 
     //go-sumtype:decl MySumType
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^^^^^^^ meta.keyword.annotation.go
 //               ^^^^ meta.variable.function.go
-//                    ^^^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                             ^ comment.line.go -meta.annotation
+//                    ^^^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                             ^ comment.line.double-slash.go -meta.annotation
 
     //lint:ignore U1000 Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^ meta.variable.function.go
-//                ^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                             ^ comment.line.go -meta.annotation
+//                ^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                             ^ comment.line.double-slash.go -meta.annotation
 
     //lint:file-ignore Reason.
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^ meta.keyword.annotation.go
 //         ^^^^^^^^^^^ meta.variable.function.go
-//                     ^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                            ^ comment.line.go -meta.annotation
+//                     ^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                            ^ comment.line.double-slash.go -meta.annotation
 
     //line :10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^ comment.line.go meta.annotation.parameters.go
-//            ^ comment.line.go -meta.annotation
+//         ^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//            ^ comment.line.double-slash.go -meta.annotation
 
     //line file.rl:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                   ^ comment.line.go -meta.annotation
+//         ^^^^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                   ^ comment.line.double-slash.go -meta.annotation
 
     //line file.rl:100:10
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^ comment.line.go meta.annotation.go
+//  ^^^^^^ comment.line.double-slash.go meta.annotation.go
 //    ^^^^ meta.variable.function.go
-//         ^^^^^^^^^^^^^^ comment.line.go meta.annotation.parameters.go
-//                       ^ comment.line.go -meta.annotation
+//         ^^^^^^^^^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                       ^ comment.line.double-slash.go -meta.annotation
 
     /*line :10*/
 // ^ -comment
@@ -180,16 +180,16 @@ You may have to disable Go-specific linters when working on this file.
     //export myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^ comment.line.go meta.annotation.go
-//           ^^^^^^ comment.line.go meta.annotation.parameters.go
-//                 ^ comment.line.go -meta.annotation
+//  ^^^^^^^^ comment.line.double-slash.go meta.annotation.go
+//           ^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                 ^ comment.line.double-slash.go -meta.annotation
 
     //extern myfunc
 // ^ -comment -meta -punctuation
 //  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^ comment.line.go meta.annotation.go
-//           ^^^^^^ comment.line.go meta.annotation.parameters.go
-//                 ^ comment.line.go -meta.annotation
+//  ^^^^^^^^ comment.line.double-slash.go meta.annotation.go
+//           ^^^^^^ comment.line.double-slash.go meta.annotation.parameters.go
+//                 ^ comment.line.double-slash.go -meta.annotation
 
 
 /* # Imports */
@@ -219,13 +219,13 @@ You may have to disable Go-specific linters when working on this file.
 //            ^ string.quoted.double.go punctuation.definition.string.begin.go
 //             ^^^^^^ string.quoted.double.go
 //                   ^ string.quoted.double.go punctuation.definition.string.end.go
-//                          ^^^^^^^^^^^ comment.line.go
+//                          ^^^^^^^^^^^ comment.line.double-slash.go
         ident "module"      // comment
 //      ^^^^^ variable.other.go
 //            ^ string.quoted.double.go punctuation.definition.string.begin.go
 //             ^^^^^^ string.quoted.double.go
 //                   ^ string.quoted.double.go punctuation.definition.string.end.go
-//                          ^^^^^^^^^^^ comment.line.go
+//                          ^^^^^^^^^^^ comment.line.double-slash.go
     )
 
 
@@ -1222,7 +1222,7 @@ by accident, but if necessary, such support could be sacrificed.
 
         Inherit // comment
 //      ^^^^^^^ meta.type.go storage.type.go
-//              ^^^^^^^^^^^ meta.type.go comment.line.go
+//              ^^^^^^^^^^^ meta.type.go comment.line.double-slash.go
 
         Inherit /* comment */
 //      ^^^^^^^ meta.type.go storage.type.go
@@ -1314,7 +1314,7 @@ by accident, but if necessary, such support could be sacrificed.
 //      ^^^ storage.type.go
 //          ^ keyword.operator.go
         // comment
-//      ^^^^^^^^^^ comment.line.go
+//      ^^^^^^^^^^ comment.line.double-slash.go
 //      ^^ punctuation.definition.comment.go
         two
 //      ^^^ storage.type.go
@@ -1561,7 +1561,7 @@ by accident, but if necessary, such support could be sacrificed.
 
         typ // comment
 //      ^^^ meta.type.go entity.other.inherited-class.go
-//          ^^^^^^^^^^^ meta.type.go comment.line.go
+//          ^^^^^^^^^^^ meta.type.go comment.line.double-slash.go
 
         typ /* comment */
 //      ^^^ meta.type.go entity.other.inherited-class.go


### PR DESCRIPTION
Features:

  * Support for `~`.
  * Support for `any` and `comparable`.
  * Support for type unions.
  * Support for general interfaces (with type unions).
  * Support for type parameters in generic functions.
  * Support for type parameters in method receivers of generic types.
  * Support for type arguments following type names.
  * Support for type parameters in type declarations.
  * Support for embedded parametrized types in struct definitions.
  * Support for type arguments between function name and function arguments.
  * Support for `invalid.illegal` for dangling `)]}`.
  * Slightly better meta scopes in type definitions.

Known regressions:

  * Embedded interfaces are no longer scoped as "inherited class", due to ambiguities.
  * "Namespace" idents such as `ident.` no longer support a comment between identifier and dot.
  * Last ident in parens followed by opening paren is no longer scoped as a function call, due to false positives and ambiguities.

Known issues and limitations:

  * Detection of type parameter lists and type argument lists is incomplete. In some places it relies on regex lookahead, which doesn't work across multiple lines. There are also edge case ambiguities which are supported by the Go compiler but not by our syntax.

Misc tweaks in comments:

  * Convert anon to named contexts for compatibility with overrides.
  * Avoid false positives when scoping javadoc bullets.
  * Use `prototype` to reduce repetition.

Closes #3281.