### PR TITLE
[JSON] Add support for syntax based folding

### DIFF
--- a/JSON/Folding Rules.tmPreferences
+++ b/JSON/Folding Rules.tmPreferences
@@ -11,9 +11,9 @@
 		<array>
 			<dict>
 				<key>begin</key>
-				<string>meta.fold.begin</string>
+				<string>punctuation.definition.comment.begin</string>
 				<key>end</key>
-				<string>meta.fold.end</string>
+				<string>punctuation.definition.comment.end</string>
 			</dict>
 			<dict>
 				<key>begin</key>

--- a/JSON/Folding Rules.tmPreferences
+++ b/JSON/Folding Rules.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.json</string>
+	<key>settings</key>
+	<dict>
+		<key>indentationFoldingEnabled</key>
+		<false/>
+		<key>foldScopes</key>
+		<array>
+			<dict>
+				<key>begin</key>
+				<string>meta.fold.begin</string>
+				<key>end</key>
+				<string>meta.fold.end</string>
+			</dict>
+			<dict>
+				<key>begin</key>
+				<string>punctuation.section.mapping.begin</string>
+				<key>end</key>
+				<string>punctuation.section.mapping.end</string>
+			</dict>
+			<dict>
+				<key>begin</key>
+				<string>punctuation.section.sequence.begin</string>
+				<key>end</key>
+				<string>punctuation.section.sequence.end</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -67,8 +67,8 @@ contexts:
     # documentation block comments
     - match: (/\*)(\*+)
       captures:
-        1: punctuation.definition.comment.begin.json
-        2: meta.fold.begin.json punctuation.definition.comment.begin.json
+        1: meta.fold.begin.json punctuation.definition.comment.begin.json
+        2: punctuation.definition.comment.begin.json
       push: jsdoc-comment-body
     # normal block comments
     - match: /\*

--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -57,27 +57,56 @@ contexts:
           scope: invalid.illegal.expected-sequence-separator.json
 
   comments:
-    - match: /\*\*(?!/)
-      scope: punctuation.definition.comment.json
-      push:
-        - meta_scope: comment.block.documentation.json
-        - meta_include_prototype: false
-        - match: \*/
-          pop: 1
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.json
+    - include: line-comments
+    - include: block-comments
+
+  block-comments:
+    # empty block comments
+    - match: /\*\*+/
+      scope: comment.block.empty.json punctuation.definition.comment.json
+    # documentation block comments
+    - match: (/\*)(\*+)
+      captures:
+        1: punctuation.definition.comment.begin.json
+        2: meta.fold.begin.json punctuation.definition.comment.begin.json
+      push: jsdoc-comment-body
+    # normal block comments
     - match: /\*
-      scope: punctuation.definition.comment.json
-      push:
-        - meta_scope: comment.block.json
-        - meta_include_prototype: false
-        - match: \*/
-          pop: 1
-    - match: (//).*$\n?
-      scope: comment.line.double-slash.js
+      scope: meta.fold.begin.json punctuation.definition.comment.begin.json
+      push: block-comment-body
+
+  block-comment-end:
+    - match: (\**)(\*/)
+      captures:
+        1: punctuation.definition.comment.end.json
+        2: meta.fold.end.json punctuation.definition.comment.end.json
+      pop: true
+
+  block-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.json
+    - include: block-comment-end
+
+  jsdoc-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.documentation.json
+    - include: block-comment-end
+    - match: ^\s*(\*)(?!/)
       captures:
         1: punctuation.definition.comment.json
+
+  line-comments:
+    - match: //+
+      scope: punctuation.definition.comment.json
+      push: line-comment-body
+
+  line-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.double-slash.json
+    - match: (//+)?\n
+      captures:
+        1: punctuation.definition.comment.json
+      pop: 1
 
   constant:
     - match: \b(?:false|true)\b

--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -65,21 +65,21 @@ contexts:
     - match: /\*\*+/
       scope: comment.block.empty.json punctuation.definition.comment.json
     # documentation block comments
-    - match: (/\*)(\*+)
+    - match: (/\*\*)(\**)
       captures:
-        1: meta.fold.begin.json punctuation.definition.comment.begin.json
-        2: punctuation.definition.comment.begin.json
+        1: punctuation.definition.comment.begin.json
+        2: punctuation.definition.comment.json
       push: jsdoc-comment-body
     # normal block comments
     - match: /\*
-      scope: meta.fold.begin.json punctuation.definition.comment.begin.json
+      scope: punctuation.definition.comment.begin.json
       push: block-comment-body
 
   block-comment-end:
     - match: (\**)(\*/)
       captures:
-        1: punctuation.definition.comment.end.json
-        2: meta.fold.end.json punctuation.definition.comment.end.json
+        1: punctuation.definition.comment.json
+        2: punctuation.definition.comment.end.json
       pop: true
 
   block-comment-body:

--- a/JSON/syntax_test_json.json
+++ b/JSON/syntax_test_json.json
@@ -32,7 +32,7 @@
   "array": [ /**/ ],
 //         ^^^^^^^^ meta.mapping.value.json meta.sequence.json
 //         ^   punctuation.section.sequence.begin.json
-//           ^^^^ comment.block.json
+//           ^^^^ comment.block.empty.json
 //                ^ punctuation.section.sequence.end.json
 
   "dict": {"foo": },
@@ -52,7 +52,7 @@
     "foo": "bar"
     // comment
 // ^ - invalid
-//  ^^^^^^^^^^ comment.line.double-slash.js
+//  ^^^^^^^^^^ comment.line.double-slash.json
     ,
 //  ^ punctuation.separator.sequence.json
     "foo": "bar"
@@ -96,7 +96,7 @@
 // <- - string
 
 /**/: "test",
-// ^ meta.mapping.json comment.block.json
+// ^ meta.mapping.json comment.block.empty.json
 //  ^ punctuation.separator.key-value.json - comment
 //    ^^^^^^ meta.mapping.value.json string.quoted.double.json
 


### PR DESCRIPTION
Requires ST 4130

This commit ...

1. disables indentation folding
2. introduces a common `meta.fold.[begin|end]` scope
3. adds required `Folding Rules.tmPreferences`
4. reworks comments based on JavaScript.sublime-syntax to properly support highlighting and folding block comments. It keeps double slash line comments only though.

Note: 

1. The rules for `meta.fold.begin` and `meta.fold.end` should probably be added to _Default/Fold.tmPreferences_
2. _Folding Rules.tmPreferences_ is choosen to follow the scheme of _Indentation Rules.tmPreferences_