### PR TITLE
[ShellScript] Fix quoted exec commands

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -527,7 +527,6 @@ contexts:
 
   cmd-exec-args:
     - meta_content_scope: meta.function-call.arguments.shell
-    - include: cmd-args-boilerplate
     - match: ([-+])[cl]*[a]{{opt_break}}
       scope: meta.parameter.option.shell variable.parameter.option.shell
       captures:
@@ -543,6 +542,8 @@ contexts:
         1: keyword.operator.end-of-options.shell
       pop: 1
     - include: cmd-args-illegal-options
+    - include: redirections
+    - include: eoc-pop
     - include: else-pop
 
 ###[ EXPORT BUILTINS ]#########################################################

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1631,6 +1631,56 @@ exec git diff-index --check --cached $against --
 #                           ^^^^^^^^ variable.parameter.option.shell
 #                                             ^^ keyword.operator.end-of-options.shell
 
+exec "$cmd" \
+#^^^ meta.function-call.identifier.shell
+#   ^ meta.function-call.arguments.shell
+#    ^^^^^^ meta.function-call.identifier.shell meta.string.shell
+#          ^^^ meta.function-call.arguments.shell
+#           ^^ punctuation.separator.continuation.line.shell
+
+exec "$cmd" \
+  $opts \
+#^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^^ punctuation.separator.continuation.line.shell
+
+exec "$cmd" \
+  $opts \
+  --cmd-flag
+#^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^ meta.parameter.option.shell variable.parameter.option.shell
+
+exec \
+  -la name \
+#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^ meta.parameter.option.shell variable.parameter.option.shell
+#     ^^^^ meta.string.shell string.unquoted.shell
+#          ^^ punctuation.separator.continuation.line.shell
+
+exec \
+  -la name \
+  "$cmd" \
+#^ meta.function-call.arguments.shell
+# ^^^^^^ meta.function-call.identifier.shell meta.string.shell
+#       ^^^ meta.function-call.arguments.shell
+#        ^^ punctuation.separator.continuation.line.shell
+
+exec \
+  -la name \
+  "$cmd" \
+  $opts \
+#^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^^ punctuation.separator.continuation.line.shell
+
+exec \
+  -la name \
+  "$cmd" \
+  $opts \
+  --cmd-flag
+#^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^ meta.parameter.option.shell variable.parameter.option.shell
+
 
 ####################################################################
 # export builtin                                                   #


### PR DESCRIPTION
This PR restricts arguments allowed for `exec` command in order to prevent a quoted command from being scoped as argument by accident.

A real-world example for the current syntax failing can be found at https://github.com/eclipse/lemminx/blob/acbc29b71260eddc40a201f4b17bc2ec396f14f9/mvnw#L306-L310