### PR TITLE
[ShellScript] fix conditional expressions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -679,12 +679,12 @@ contexts:
 
   cmd-test:
     - match: \[\[(?=\s)
-      scope: support.function.double-brace.begin.shell
+      scope: support.function.test.begin.shell
       push:
         - meta_scope: meta.conditional.shell
         - match: \s+(\]\])
           captures:
-            1: support.function.double-brace.end.shell
+            1: support.function.test.end.shell
           pop: 1
         - include: test-expression-body
     - match: \[(?=\s)

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -69,7 +69,7 @@ variables:
   cmd_char: '[^{{metachar}}]'
 
   # Command options are identifiers, which may start with interpolation.
-  opt_punctuation: (?:\s+|^)(--|[-+]){{nonposix_begin}}
+  opt_punctuation: '{{wspace}}(--|[-+]){{nonposix_begin}}'
   opt_literal_char: '[^{{metachar}}=%$\\""''`]'
   opt_break: '{{nonposix_break}}'
 
@@ -84,6 +84,7 @@ variables:
 
   nbc: '[^{}()=\s]*' # non bracket characters (and also non-whitespace, parens)
   varassign: '[-+]?='
+  wspace: (?:\s+|^)
 
   no_escape_behind: (?<![^\\]\\)(?<![\\]{3})
 
@@ -537,7 +538,7 @@ contexts:
       scope: meta.parameter.option.shell variable.parameter.option.shell
       captures:
         1: punctuation.definition.parameter.shell
-    - match: (?:\s+|^)(--){{cmd_break}}
+    - match: '{{wspace}}(--){{cmd_break}}'
       captures:
         0: meta.function-call.arguments.shell
         1: keyword.operator.end-of-options.shell
@@ -682,7 +683,7 @@ contexts:
       scope: support.function.test.begin.shell
       push:
         - meta_scope: meta.conditional.shell
-        - match: \s+(\]\])
+        - match: '{{wspace}}(\]\])'
           captures:
             1: support.function.test.end.shell
           pop: 1
@@ -691,7 +692,7 @@ contexts:
       scope: support.function.test.begin.shell
       push:
         - meta_scope: meta.conditional.shell
-        - match: \s+(\])
+        - match: '{{wspace}}(\])'
           captures:
             1: support.function.test.end.shell
           pop: 1
@@ -938,7 +939,7 @@ contexts:
 
   cmd-args-option-maybe-value:
     # NOTE: this context is used in commands-builtin-shell-bash.sublime-syntax
-    - match: \s+(?=[^-\]}{{metachar}}]|\\\n)
+    - match: '{{wspace}}(?=[^-\]}{{metachar}}]|\\\n)'
       set: variable-value
     - include: number
     - include: line-continuations
@@ -957,7 +958,7 @@ contexts:
     - include: cmd-args-end-of-options-then-ambigious
 
   cmd-args-end-of-options-then-ambigious:
-    - match: (?:\s+|^)(--){{cmd_break}}
+    - match: '{{wspace}}(--){{cmd_break}}'
       captures:
         1: keyword.operator.end-of-options.shell
       push: cmd-args-ambigious

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -907,11 +907,11 @@ coproc foobar {
 #   ^ punctuation.section.parameters.end.shell
 #    ^ - punctuation
 #     ^ punctuation.section.compound.begin.shell
-#       ^^ support.function.double-brace.begin
+#       ^^ support.function.test.begin
 #          ^ punctuation.definition.variable
 #           ^ variable.language
 #             ^^ keyword.operator.comparison
-#                  ^^ support.function.double-brace.end
+#                  ^^ support.function.test.end
 #                     ^^ keyword.operator.logical
 
    logC () { [[ $# == 2 ]] && tput setaf $2 || tput setaf 3; echo -e "$1"; tput setaf 15; }
@@ -930,11 +930,11 @@ coproc foobar {
 #        ^ punctuation.section.parameters.end.shell
 #         ^ - punctuation
 #          ^ punctuation.section.compound.begin.shell
-#            ^^ support.function.double-brace.begin.shell
+#            ^^ support.function.test.begin.shell
 #               ^ punctuation.definition.variable.shell
 #               ^^ variable.language.shell
 #                  ^^ keyword.operator.comparison.shell
-#                       ^^ support.function.double-brace.end.shell
+#                       ^^ support.function.test.end.shell
 #                          ^^ keyword.operator.logical.shell
 
 logExit ( ) {
@@ -951,22 +951,22 @@ logExit ( ) {
 #         ^ punctuation.section.parameters.end.shell
 #           ^ punctuation.section.compound.begin.shell
   [[ $1 == '0' ]] && tput setaf 2  || tput setaf 1;
-  #<- meta.conditional.shell support.function.double-brace.begin.shell
-  #^ meta.conditional.shell support.function.double-brace.begin.shell
-  #            ^^ meta.conditional.shell support.function.double-brace.end.shell
+  #<- meta.conditional.shell support.function.test.begin.shell
+  #^ meta.conditional.shell support.function.test.begin.shell
+  #            ^^ meta.conditional.shell support.function.test.end.shell
   [[ $1 == '0' ]] && echo -e "$2 PASSED" || echo -e "$2 FAILED";
-  #<- meta.conditional.shell support.function.double-brace.begin.shell
-  #^ meta.conditional.shell support.function.double-brace.begin.shell
-  #            ^^ meta.conditional.shell support.function.double-brace.end.shell
+  #<- meta.conditional.shell support.function.test.begin.shell
+  #^ meta.conditional.shell support.function.test.begin.shell
+  #            ^^ meta.conditional.shell support.function.test.end.shell
   #               ^^ keyword.operator.logical.shell
   #                  ^^^^ meta.function-call.identifier.shell support.function.echo.shell
   tput setaf 15;
   # <- meta.function meta.function-call variable.function
   #            ^ meta.function punctuation.terminator.statement
   [[ $1 == '0' ]] || exit -1
-  #<- meta.conditional.shell support.function.double-brace.begin.shell
-  #^ meta.conditional.shell support.function.double-brace.begin.shell
-  #            ^^ meta.conditional.shell support.function.double-brace.end.shell
+  #<- meta.conditional.shell support.function.test.begin.shell
+  #^ meta.conditional.shell support.function.test.begin.shell
+  #            ^^ meta.conditional.shell support.function.test.end.shell
   #               ^^ keyword.operator.logical.shell
   #                  ^^^^  keyword.control.flow.exit.shell
   #                       ^ keyword.operator.arithmetic.shell
@@ -3825,8 +3825,8 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                          ^ meta.conditional.shell meta.group.shell - meta.pattern
 #                           ^^^ meta.conditional.shell - meta.group
 #                              ^ - meta.conditional - meta.group
-# <- support.function.double-brace.begin.shell
-#^ support.function.double-brace.begin.shell
+# <- support.function.test.begin.shell
+#^ support.function.test.begin.shell
 #  ^ keyword.operator.logical.shell
 #    ^ punctuation.section.group.begin.shell
 #     ^^^^^ variable.other.readwrite.shell
@@ -3840,7 +3840,7 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                       ^ keyword.operator.quantifier.regexp.shell
 #                        ^ punctuation.definition.group.end.regexp.shell
 #                          ^ punctuation.section.group.end.shell
-#                            ^^ support.function.double-brace.end.shell
+#                            ^^ support.function.test.end.shell
 
 [[ ' foobar' == [\ ]foo* ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
@@ -4396,52 +4396,52 @@ if !cmd
 #  ^ support.function.test.end.shell
 
 [[ ]]
-# <- support.function.double-brace.begin.shell
-#^ support.function.double-brace.begin.shell
-#  ^^ support.function.double-brace.end.shell
+# <- support.function.test.begin.shell
+#^ support.function.test.begin.shell
+#  ^^ support.function.test.end.shell
 
 ! [[ ]]
 # <- keyword.operator.logical.shell
-# ^^ support.function.double-brace.begin.shell
-#    ^^ support.function.double-brace.end.shell
+# ^^ support.function.test.begin.shell
+#    ^^ support.function.test.end.shell
 
 ![[ ]]
 # <- punctuation.definition.history.shell
 #^^^^^ meta.conditional.shell
-#^^ support.function.double-brace.begin.shell
-#   ^^ support.function.double-brace.end.shell
+#^^ support.function.test.begin.shell
+#   ^^ support.function.test.end.shell
 
 if [[ expr ]] && [[ expr ]] || [[ expr ]] ; then cmd ; fi
 #  ^^^^^^^^^^ meta.conditional.shell
-#  ^^ support.function.double-brace.begin.shell
-#          ^^ support.function.double-brace.end.shell
+#  ^^ support.function.test.begin.shell
+#          ^^ support.function.test.end.shell
 #             ^^ keyword.operator.logical.shell
 #                ^^^^^^^^^^ meta.conditional.shell
-#                ^^ support.function.double-brace.begin.shell
-#                        ^^ support.function.double-brace.end.shell
+#                ^^ support.function.test.begin.shell
+#                        ^^ support.function.test.end.shell
 #                           ^^ keyword.operator.logical.shell
 #                              ^^^^^^^^^^ meta.conditional.shell
-#                              ^^ support.function.double-brace.begin.shell
-#                                      ^^ support.function.double-brace.end.shell
+#                              ^^ support.function.test.begin.shell
+#                                      ^^ support.function.test.end.shell
 #                                         ^ punctuation.terminator.statement.shell
 
 if [[ expr && expr || expr ]] ; then cmd ; fi
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
-#  ^^ support.function.double-brace.begin.shell
+#  ^^ support.function.test.begin.shell
 #          ^^ keyword.operator.logical.shell
 #                  ^^ keyword.operator.logical.shell
-#                          ^^ support.function.double-brace.end.shell
+#                          ^^ support.function.test.end.shell
 #                             ^ punctuation.terminator.statement.shell
 
 if [[ expr && ( expr || expr ) ]] ; then cmd ; fi
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
 #             ^^^^^^^^^^^^^^^^ meta.group.shell
-#  ^^ support.function.double-brace.begin.shell
+#  ^^ support.function.test.begin.shell
 #          ^^ keyword.operator.logical.shell
 #             ^ punctuation.section.group.begin.shell
 #                    ^^ keyword.operator.logical.shell
 #                            ^ punctuation.section.group.end.shell
-#                              ^^ support.function.double-brace.end.shell
+#                              ^^ support.function.test.end.shell
 #                                 ^ punctuation.terminator.statement.shell
 
 if [[ $- != *i* ]] ; then echo shell is not interactive; fi
@@ -4452,13 +4452,13 @@ if [[ $- != *i* ]] ; then echo shell is not interactive; fi
 #              ^^^ - meta.pattern
 #                         ^^^^ meta.function-call.identifier.shell
 #                              ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#  ^^ support.function.double-brace.begin.shell
+#  ^^ support.function.test.begin.shell
 #     ^^ meta.interpolation.parameter.shell variable.language.shell
 #     ^ punctuation.definition.variable.shell
 #        ^^ keyword.operator.comparison.shell
 #           ^ keyword.operator.quantifier.regexp.shell
 #             ^ keyword.operator.quantifier.regexp.shell
-#               ^^ support.function.double-brace.end.shell
+#               ^^ support.function.test.end.shell
 #                  ^ punctuation.terminator.statement.shell
 #                    ^^^^ keyword.control.conditional.then.shell
 #                         ^^^^ support.function.echo.shell
@@ -4975,9 +4975,9 @@ while ! { [[ true ]]; }; do echo bar; done
 # <- keyword.control.loop.while.shell
 #     ^ keyword.operator.logical.shell
 #       ^ punctuation.section.compound.begin.shell
-#         ^^ support.function.double-brace.begin.shell
+#         ^^ support.function.test.begin.shell
 #            ^^^^ constant.language.boolean.shell
-#                 ^^ support.function.double-brace.end.shell
+#                 ^^ support.function.test.end.shell
 #                   ^ punctuation.terminator.statement.shell
 #                     ^ punctuation.section.compound.end.shell
 #                      ^ punctuation.terminator.statement.shell
@@ -4988,9 +4988,9 @@ while ! ( [[ true ]] ); do echo bar; done
 # <- keyword.control.loop.while.shell
 #     ^ keyword.operator.logical.shell
 #       ^ punctuation.section.compound.begin.shell
-#         ^^ support.function.double-brace.begin.shell
+#         ^^ support.function.test.begin.shell
 #            ^^^^ constant.language.boolean.shell
-#                 ^^ support.function.double-brace.end.shell
+#                 ^^ support.function.test.end.shell
 #                    ^ punctuation.section.compound.end.shell
 #                     ^ punctuation.terminator.statement.shell
 #                       ^^ keyword.control.loop.do.shell
@@ -5030,9 +5030,9 @@ do echo bar; until ! { [[ true ]]; }
 #            ^^^^^ keyword.control.loop.until.shell
 #                  ^ keyword.operator.logical.shell
 #                    ^ punctuation.section.compound.begin.shell
-#                      ^^ support.function.double-brace.begin.shell
+#                      ^^ support.function.test.begin.shell
 #                         ^^^^ constant.language.boolean.shell
-#                              ^^ support.function.double-brace.end.shell
+#                              ^^ support.function.test.end.shell
 #                                ^ punctuation.terminator.statement.shell
 #                                  ^ punctuation.section.compound.end.shell
 
@@ -5502,8 +5502,8 @@ function clk {
     #           ^ keyword.operator.assignment.shell
     #            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.shell string.unquoted.shell
     [[ -r ${base}/hwmon/hwmon0/temp1_input && -r ${base}/power_profile ]] || return 1
-    # <- support.function.double-brace.begin.shell
-    #                                                                  ^^ support.function.double-brace.end.shell
+    # <- support.function.test.begin.shell
+    #                                                                  ^^ support.function.test.end.shell
     case $1 in
         low|high|default)
             printf '%s\n' "temp: $(<${base}/hwmon/hwmon0/temp1_input)C" "old profile: $(<${base}/power_profile)"

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -4385,6 +4385,10 @@ if !cmd
 # <- support.function.test.begin.shell
 # ^ support.function.test.end.shell
 
+[
+]
+# <- meta.conditional.shell support.function.test.end.shell
+
 ! [ ]
 # <- keyword.operator.logical.shell
 # ^ support.function.test.begin.shell
@@ -4399,6 +4403,11 @@ if !cmd
 # <- support.function.test.begin.shell
 #^ support.function.test.begin.shell
 #  ^^ support.function.test.end.shell
+
+[[
+]]
+# <- meta.conditional.shell support.function.test.end.shell
+#^ meta.conditional.shell support.function.test.end.shell
 
 ! [[ ]]
 # <- keyword.operator.logical.shell

--- a/ShellScript/test/syntax_test_shell_unix_generic.sh
+++ b/ShellScript/test/syntax_test_shell_unix_generic.sh
@@ -1,9 +1,9 @@
 # SYNTAX TEST "Packages/ShellScript/Shell-Unix-Generic.sublime-syntax"
 
 [[ ]]
-# <- support.function.double-brace.begin
- # <- support.function.double-brace.begin
- # ^^ support.function.double-brace.end
+# <- support.function.test.begin
+ # <- support.function.test.begin
+ # ^^ support.function.test.end
 
  # make sure the prototype is included
  # <- comment.line.number-sign punctuation.definition.comment


### PR DESCRIPTION
This PR ...

1. scopes both `[` and `[[` `support.function.test.begin`.
2. ensures to scobe both `]` and `]]` `support.function.test.end` even if they are located directly at the beginning of a line.