### PR TITLE
[Python] Fix assignment expressions in sets

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1585,10 +1585,10 @@ contexts:
 
   maybe-inside-set:
     - meta_scope: meta.set.python
-    - match: ':|\*\*'
-      fail: dictionaries-and-sets
-    - match: (?=,)
+    - match: (?=,|:=)
       set: inside-set
+    - match: (?=:|\*\*)
+      fail: dictionaries-and-sets
     - include: inside-set
 
   inside-set:
@@ -1596,9 +1596,6 @@ contexts:
     - match: \}
       scope: punctuation.section.set.end.python
       set: after-expression
-    - include: illegal-assignment-expression
-    - match: ':'
-      scope: invalid.illegal.colon-inside-set.python
     - match: ','
       scope: punctuation.separator.set.python
     - match: \*
@@ -1611,6 +1608,8 @@ contexts:
         - include: expression-in-a-group
     - include: inline-for
     - include: expression-in-a-group
+    - match: ':'
+      scope: invalid.illegal.colon-inside-set.python
 
   empty-dictionaries:
     - match: (\{)\s*(\})

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1842,6 +1842,30 @@ myset = {"key", True, key2, [-1], {}:1}
 #                                   ^ invalid.illegal.colon-inside-set.python
 #                                     ^ punctuation.section.set.end.python
 
+myset = {a := 1, b := 2}
+#       ^^^^^^^^^^^^^^^^ meta.set.python
+#       ^ punctuation.section.set.begin.python
+#          ^^ keyword.operator.assignment.inline.python
+#             ^ constant.numeric.value.python
+#              ^ punctuation.separator.set.python
+#                  ^^ keyword.operator.assignment.inline.python
+#                     ^ constant.numeric.value.python
+#                      ^ punctuation.section.set.end.python
+
+{a := 1: 2}
+# <- meta.set.python punctuation.section.set.begin.python
+#^^^^^^^^^^ meta.set.python
+#  ^^ keyword.operator.assignment.inline.python
+#      ^ invalid.illegal.colon-inside-set.python
+#         ^ punctuation.section.set.end.python
+
+{1, b := 2}
+# <- meta.set.python punctuation.section.set.begin.python
+#^^^^^^^^^^ meta.set.python
+# ^ punctuation.separator.set.python
+#     ^^ keyword.operator.assignment.inline.python
+#         ^ punctuation.section.set.end.python
+
 mapping_or_set = {
 #                ^ meta.mapping.python punctuation.section.mapping.begin.python
     1: True
@@ -2411,10 +2435,6 @@ def foo(x: y:=f(x)) -> a:=None: pass
 foo(x = y := f(x), y=x:=2)
 #         ^^ invalid.illegal.not-allowed-here.python
 #                     ^^ invalid.illegal.not-allowed-here.python
-{a := 1: 2}
-#  ^^ invalid.illegal.not-allowed-here.python
-{1, b := 2}
-#     ^^ invalid.illegal.not-allowed-here.python
 [1][x:=0]
 #    ^^ invalid.illegal.not-allowed-here.python
 def foo(answer = p := 42):  pass


### PR DESCRIPTION
Fixes #3295

The original implementation of assignment expressions follows the
behavior of python 3.8, which raises syntax error on expressions like

    { a := 1, b := 2 }

Python 3.10 however accepts it and so Python.sublime-syntax needs to.