### PR TITLE
[Python] Fix default value assignment after union type annotation

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1134,6 +1134,8 @@ contexts:
             - meta_scope: meta.function.parameters.annotation.python
             - match: '(?=[,)=])'
               set: function-parameters
+            - match: \bNone\b
+              scope: constant.language.null.python
             - include: illegal-assignment-expression
             - include: expression-in-a-group
     - include: function-parameters-tuple

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1487,6 +1487,15 @@ def type_annotations_line_continuation() \
 #     ^ meta.function.python punctuation.section.function.begin.python
     pass
 
+def type_annotation_with_defaults(foo: str | None = None)
+#                                    ^^^^^^^^^^^^^ meta.function.parameters.annotation.python - meta.function.parameters.default-value
+#                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
+#                                      ^^^ support.type.python
+#                                          ^ keyword.operator.arithmetic.python
+#                                            ^^^^ constant.language.null.python
+#                                                 ^ keyword.operator.assignment.python
+#                                                   ^^^^ constant.language.null.python
+
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                  ^^^^^^^^ meta.function.parameters - meta.function meta.function


### PR DESCRIPTION
Fixes #3290

This PR provides a quick fix to avoid assignment operators after type annotations to be highlighted illegal, if the type annotation is finalized by `None` type, without implementing full fledged type hint support.