### PR TITLE
[C#] Add enum constants to symbol list/index

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -336,7 +336,7 @@ contexts:
                     pop: true
               - include: attribute
               - match: '{{name}}'
-                scope: constant.other.enum.cs
+                scope: entity.name.constant.cs
               - match: '='
                 scope: keyword.operator.assignment.cs
                 push: line_of_code_in

--- a/C#/Symbol List - Constants.tmPreferences
+++ b/C#/Symbol List - Constants.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.cs entity.name.constant</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<string>1</string>
+	</dict>
+</dict>
+</plist>

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -177,7 +177,7 @@ namespace YourNamespace
 /// ^ meta.block punctuation.section.block.begin
 /// ^ - meta.enum meta.enum
         A, B
-///     ^ constant.other.enum
+///     ^ entity.name.constant
     };
 ///^^ meta.enum meta.block
 /// ^ punctuation.section.block.end
@@ -188,7 +188,7 @@ namespace YourNamespace
         [Stuff("1")]
 ///     ^^^^^^^^^^^^ meta.annotation
         Item1,
-///     ^ constant.other.enum
+///     ^ entity.name.constant
         Item2,
         [Stuff]
 ///     ^^^^^^^ meta.annotation
@@ -1360,7 +1360,7 @@ public class AfterTopLevelMethod {
     {
         return new AfterTopLevelMethod(some_ints);
     }
-    
+
     Action<float> actionDelegate = delegate { };
 ///                              ^ keyword.operator.assignment.variable
 ///                                ^^^^^^^^ keyword.other


### PR DESCRIPTION
This commit...

1. rescopes enumerated constants from `constant.other.enum` to
   `entity.name.constant` as the latter one is what scope naming
   guidelines suggest for constant definitions.

   `entity.name.constant` vs. `constant.other` may enable
   "Goto Reference" at some point.

2. Adds `entity.name.constant` to symbol list and index.