### PR TITLE
[Rust] Add enum constants to symbol list/index

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -835,7 +835,7 @@ contexts:
       scope: punctuation.section.block.end.rust
       pop: true
     - match: '\b[[:upper:]_][[:upper:][:digit:]_]*\b'
-      scope: constant.other.rust
+      scope: entity.name.constant.rust
       push: enum-variant-type
     - match: '{{camel_ident}}'
       scope: storage.type.source.rust

--- a/Rust/tests/syntax_test_enum.rs
+++ b/Rust/tests/syntax_test_enum.rs
@@ -37,18 +37,18 @@ let m = Message::Move { x: 50, y: 200 };
 
 enum Discriminant {
     A = 1,
-//  ^ meta.enum constant.other
+//  ^ meta.enum entity.name.constant
 //      ^ meta.enum constant.numeric.integer.decimal
     V1 = 0xABC,
-//  ^^ meta.enum constant.other
+//  ^^ meta.enum entity.name.constant
 //       ^^^^^ meta.enum constant.numeric.integer.hexadecimal
     V2,
-//  ^^ meta.enum constant.other
+//  ^^ meta.enum entity.name.constant
     SomeValue = 123,
 //  ^^^^^^^^^ meta.enum storage.type.source
 //              ^^^ meta.enum constant.numeric.integer.decimal
     V3 = (1<<4),
-//  ^^ meta.enum constant.other
+//  ^^ meta.enum entity.name.constant
 //       ^^^^^^ meta.enum meta.group
 //        ^ constant.numeric.integer.decimal
 //         ^^ keyword.operator.bitwise


### PR DESCRIPTION
This commit rescopes enumerated constants from `constant.other` to
`entity.name.constant` as the latter one is what scope naming
guidelines suggest for constant definitions.

`entity.name.constant` vs. `constant.other` may enable
"Goto Reference" at some point.