### PR TITLE
[PHP] Add enum constants to symbol list/index

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -711,6 +711,8 @@ contexts:
     - include: class-body
 
   constant-name:
+    - include: attributes
+    - include: comments
     - match: '{{identifier}}'
       scope: entity.name.constant.php
       pop: true

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -705,7 +705,7 @@ contexts:
 
   enum-body:
     - meta_scope: meta.enum.php meta.block.php
-    - match: \bcase\b
+    - match: \b(?i:case)\b
       scope: keyword.control.php
       push: constant-name
     - include: class-body

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -670,7 +670,7 @@ contexts:
           pop: 1
     - match: \{
       scope: meta.block.php punctuation.section.block.begin.php
-      set: class-body
+      set: enum-body
     - include: attributes
     - include: comments
     - match: (?i)(extends)\b
@@ -696,6 +696,19 @@ contexts:
           scope: punctuation.separator.comma.php
         - match: (?=\S)
           pop: 1
+
+  enum-body:
+    - match: \bcase\b
+      scope: keyword.control.php
+      push: enum-constant-name
+    - include: class-body
+
+  enum-constant-name:
+    - match: '{{identifier}}'
+      scope: entity.name.constant.php
+      pop: true
+    - match: (?=\S)
+      pop: true
 
   class:
     - match: '(?i)(\b(?:abstract|final)\s+)?\b(class)\s+({{identifier}})\s*'

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -266,9 +266,12 @@ contexts:
       scope: storage.type.php
     - match: (?i)\b(parent|self)\b
       scope: variable.language.php
+    - match: \b(?i:const)\b
+      scope: storage.modifier.php
+      push: constant-name
     - match: |-
         {{visibility_modifier}}|\b(?xi:
-          abstract | const | extends | final | global | implements | static | readonly
+          abstract | extends | final | global | implements | static | readonly
         )\b
       scope: storage.modifier.php
     - include: object
@@ -704,10 +707,10 @@ contexts:
     - meta_scope: meta.enum.php meta.block.php
     - match: \bcase\b
       scope: keyword.control.php
-      push: enum-constant-name
+      push: constant-name
     - include: class-body
 
-  enum-constant-name:
+  constant-name:
     - match: '{{identifier}}'
       scope: entity.name.constant.php
       pop: true

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -645,14 +645,17 @@ contexts:
         - include: identifier-constant-pop
     - include: use-statement-common
     - include: identifier-constant-pop
+
   enum:
     - match: (?i)\b(enum)\s+({{identifier}})\s*
+      scope: meta.enum.php
       captures:
         1: keyword.declaration.enum.php
         2: entity.name.enum.php
       push: enum-definition
 
   enum-definition:
+    - meta_content_scope: meta.enum.php
     - match: (?=;)
       pop: 1
     - match: ':'
@@ -669,7 +672,7 @@ contexts:
         - match: (?=\S)
           pop: 1
     - match: \{
-      scope: meta.block.php punctuation.section.block.begin.php
+      scope: punctuation.section.block.begin.php
       set: enum-body
     - include: attributes
     - include: comments
@@ -698,6 +701,7 @@ contexts:
           pop: 1
 
   enum-body:
+    - meta_scope: meta.enum.php meta.block.php
     - match: \bcase\b
       scope: keyword.control.php
       push: enum-constant-name

--- a/PHP/Symbol List.tmPreferences
+++ b/PHP/Symbol List.tmPreferences
@@ -6,6 +6,7 @@
 		source.php entity.name.function,
 		source.php support.function.magic,
 		source.php entity.name.class,
+		source.php entity.name.constant,
 		source.php entity.name.interface,
 		source.php entity.name.trait
 	</string>

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -817,8 +817,14 @@ $f3 = #[ExampleAttribute] fn () => 1;
 //                ^ - comment
 
 enum Suit {
-// ^ keyword.declaration.enum
+// <- meta.enum.php keyword.declaration.enum.php
+//^^^^^^^^^^ - meta.enum meta.enum, - meta.block meta.block
+//^^^^^^^^ meta.enum.php - meta.block
+//        ^^ meta.enum.php meta.block.php
+//^^ keyword.declaration.enum
+//  ^ - keyword - entity
 //   ^^^^ entity.name.enum
+//       ^ - entity - punctuation
     case Hearts;
 //  ^^^^ keyword.control
 //       ^^^^^^ entity.name.constant
@@ -828,9 +834,17 @@ enum Suit {
 }
 
 enum Suit: string extends Colorful {}
+// <- meta.enum.php keyword.declaration.enum.php
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.enum meta.enum, - meta.block meta.block
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum.php - meta.block
+//                                 ^^ meta.enum.php meta.block.php
 //                ^^^^^^^ invalid
 
 enum Suit: string implements Colorful {
+// <- meta.enum.php keyword.declaration.enum.php
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.enum meta.enum, - meta.block meta.block
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.enum.php - meta.block
+//                                    ^^ meta.enum.php meta.block.php
 // ^ keyword.declaration.enum
 //   ^^^^ entity.name.enum
 //       ^ punctuation.separator

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1340,13 +1340,19 @@ class B
     public const STR_1 = '';
 //  ^^^^^^ storage.modifier
 //         ^^^^^ storage.modifier
-//               ^^^^^ constant
+//               ^^^^^ entity.name.constant.php
 //                     ^ keyword.operator.assignment
 
     const STR_2 = '';
 //  ^^^^^ storage.modifier
-//        ^^^^^ constant
+//        ^^^^^ entity.name.constant.php
 //              ^ keyword.operator.assignment
+
+    CONST STR_3 = array();
+//  ^^^^^ storage.modifier
+//        ^^^^^ entity.name.constant.php
+//              ^ keyword.operator.assignment
+//                ^^^^^ support.function.construct.php
 
     public function abc(
 //         ^ keyword.declaration.function

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -828,7 +828,11 @@ enum Suit {
     case Hearts;
 //  ^^^^ keyword.control
 //       ^^^^^^ entity.name.constant
-    case Diamonds;
+//             ^ punctuation.terminator.expression.php
+    CASE Diamonds;
+//  ^^^^ keyword.control.php
+//       ^^^^^^^^ entity.name.constant.php
+//               ^ punctuation.terminator.expression.php
     case Clubs;
     case Spades;
 }

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1352,11 +1352,13 @@ class B
 //        ^^^^^ entity.name.constant.php
 //              ^ keyword.operator.assignment
 
-    CONST STR_3 = array();
+    CONST #[attr] /**/ STR_3 = array();
 //  ^^^^^ storage.modifier
-//        ^^^^^ entity.name.constant.php
-//              ^ keyword.operator.assignment
-//                ^^^^^ support.function.construct.php
+//        ^^^^^^^ meta.attribute.php
+//                ^^^^ comment.block.php
+//                     ^^^^^ entity.name.constant.php
+//                           ^ keyword.operator.assignment
+//                             ^^^^^ support.function.construct.php
 
     public function abc(
 //         ^ keyword.declaration.function

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -821,7 +821,7 @@ enum Suit {
 //   ^^^^ entity.name.enum
     case Hearts;
 //  ^^^^ keyword.control
-//       ^^^^^^ constant.other
+//       ^^^^^^ entity.name.constant
     case Diamonds;
     case Clubs;
     case Spades;
@@ -839,7 +839,7 @@ enum Suit: string implements Colorful {
 //                           ^^^^^^^^ entity.other.inherited-class
     case Hearts = 'H';
 //  ^^^^ keyword.control
-//       ^^^^^^ constant.other
+//       ^^^^^^ entity.name.constant
 //              ^ keyword.operator.assignment
 //                ^^^ string.quoted.single
     case Diamonds = 'D';


### PR DESCRIPTION
This commit...

1. adds some contexts/patterns to scope enumerated constants
   `entity.name.constant`.

   `entity.name.constant` vs. `constant.other` may enable
   "Goto Reference" at some point.

2. Adds `entity.name.constant` to symbol list and index.