### PR TITLE
[SQL] Many fixes and improvements overall

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -283,8 +283,7 @@ contexts:
       set: identifier-create
   drop-condition:
     - include: dml-condition
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   dml-condition:
     - match: (?i:if)\b
       scope: keyword.control.flow.sql
@@ -296,26 +295,22 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.sql
       set: [like-escape-fail, inside-like-single-quoted-string]
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-string-followed-by-escape-slash:
     - match: \'
       scope: punctuation.definition.string.begin.sql
       set: [like-escape-character-slash, like-escape-pop, inside-like-single-quoted-string-slash-escape]
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-string-followed-by-escape-caret:
     - match: \'
       scope: punctuation.definition.string.begin.sql
       set: [like-escape-character-caret, like-escape-pop, inside-like-single-quoted-string-caret-escape]
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-string-followed-by-unknown-escape:
     - match: \'
       scope: punctuation.definition.string.begin.sql
       set: [like-escape-character-any, like-escape-pop, inside-like-single-quoted-string]
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   inside-like-single-quoted-string-slash-escape:
     - meta_include_prototype: false
     - meta_scope: meta.string.like.sql string.quoted.single.sql
@@ -351,14 +346,12 @@ contexts:
   like-escape-fail:
     - match: (?i:escape)\b
       fail: like-strings-branch
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-escape-pop:
     - match: (?i:escape)\b
       scope: keyword.operator.word.sql
       pop: true
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-escape-character-any:
     - match: (\')([^'])(\')
       captures:
@@ -367,8 +360,7 @@ contexts:
         2: constant.character.escape.sql
         3: punctuation.definition.string.end.sql
       pop: true
-    - match: (?=\S)
-      pop: true
+    - include: if-non-space-pop
   like-escape-character-caret:
     - match: (\')(\^)(\')
       captures:
@@ -389,3 +381,6 @@ contexts:
       pop: true
     - match: (?=\S)
       fail: like-strings-branch
+  if-non-space-pop:
+    - match: (?=\S)
+      pop: true

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -172,18 +172,18 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: comment.line.double-dash.sql
     - match: \n
-      pop: true
+      pop: 1
   inside-number-sign-comment:
     - meta_include_prototype: false
     - meta_scope: comment.line.number-sign.sql
     - match: \n
-      pop: true
+      pop: 1
   inside-comment-block:
     - meta_include_prototype: false
     - meta_scope: comment.block.sql
     - match: \*/
       scope: punctuation.definition.comment.end.sql
-      pop: true
+      pop: 1
     - match: ^\s*(\*)(?!/)
       captures:
         1: punctuation.definition.comment.sql
@@ -195,7 +195,7 @@ contexts:
         - meta_scope: string.regexp.sql
         - match: /
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-interpolation
         - match: \\/
           scope: constant.character.escape.slash.sql
@@ -207,7 +207,7 @@ contexts:
         - meta_scope: string.regexp.modr.sql
         - match: '\}'
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-interpolation
   string-escape:
     - meta_include_prototype: false
@@ -230,7 +230,7 @@ contexts:
           scope: constant.character.escape.sql
         - match: "'"
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-escape
     - match: "`"
       scope: punctuation.definition.string.begin.sql
@@ -239,7 +239,7 @@ contexts:
         - meta_scope: string.quoted.other.backtick.sql
         - match: "`"
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-escape
     - match: '"'
       scope: punctuation.definition.string.begin.sql
@@ -250,7 +250,7 @@ contexts:
           scope: constant.character.escape.sql
         - match: '"'
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-interpolation
     - match: '%\{'
       scope: punctuation.definition.string.begin.sql
@@ -259,7 +259,7 @@ contexts:
         - meta_scope: string.other.quoted.brackets.sql
         - match: '\}'
           scope: punctuation.definition.string.end.sql
-          pop: true
+          pop: 1
         - include: string-interpolation
   identifier-create:
     - meta_content_scope: meta.toc-list.full-identifier.sql
@@ -270,7 +270,7 @@ contexts:
         2: entity.name.function.sql
         3: entity.name.function.sql
         4: entity.name.function.sql
-      pop: true
+      pop: 1
       # Schema identifiers
     - match: (?x)((?!\d)\w+ | '[^']+' | "[^"]+" | `[^`]+`) \s* (\.)
       captures:
@@ -278,7 +278,7 @@ contexts:
         2: punctuation.accessor.dot.sql
       # Handle situations where the schema and .
     - match: '{{end_identifier}}'
-      pop: true
+      pop: 1
   create-condition:
     - include: dml-condition
     - match: (?=\S)
@@ -330,7 +330,7 @@ contexts:
     - meta_scope: meta.string.like.sql string.quoted.single.sql
     - match: \'
       scope: punctuation.definition.string.end.sql
-      pop: true
+      pop: 1
     - match: |-
         (?x)
         (\[)(\^)?
@@ -352,7 +352,7 @@ contexts:
   like-escape-pop:
     - match: (?i:escape)\b
       scope: keyword.operator.word.sql
-      pop: true
+      pop: 1
     - include: if-non-space-pop
   like-escape-character-any:
     - match: (\')([^'])(\')
@@ -361,7 +361,7 @@ contexts:
         1: punctuation.definition.string.begin.sql
         2: constant.character.escape.sql
         3: punctuation.definition.string.end.sql
-      pop: true
+      pop: 1
     - include: if-non-space-pop
   like-escape-character-caret:
     - match: (\')(\^)(\')
@@ -370,7 +370,7 @@ contexts:
         1: punctuation.definition.string.begin.sql
         2: constant.character.escape.sql
         3: punctuation.definition.string.end.sql
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: like-strings-branch
   like-escape-character-slash:
@@ -380,9 +380,9 @@ contexts:
         1: punctuation.definition.string.begin.sql
         2: constant.character.escape.sql
         3: punctuation.definition.string.end.sql
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: like-strings-branch
   if-non-space-pop:
     - match: (?=\S)
-      pop: true
+      pop: 1

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -22,15 +22,24 @@ contexts:
   main:
     - match: |-
         (?xi)
-        (create(?:\s+or\s+replace)?)\s+
-        (aggregate|conversion|database|domain|function|group|((?:fulltext|spatial|unique)\s+)?index|language|operator\s+class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
-        \b
+        (create (?:\s+ or \s+ replace)?) \s+ (
+          aggregate | conversion | database | domain | function | group
+        | ((?:fulltext | spatial | unique) \s+)? index | language
+        | operator \s+ class | operator | procedure | rule | schema | sequence
+        | table(?:space)? | trigger | type | user | view
+        )\b
       scope: meta.create.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: create-condition
-    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
+    - match: |-
+        (?xi)
+        (drop) \s+ (
+          aggregate | conversion | database | domain | function | group | index
+        | language | operator \s+ class | operator | procedure | rule | schema
+        | sequence | table| tablespace | trigger | type | user | view
+        )\b
       scope: meta.drop.sql
       captures:
         1: keyword.other.drop.sql
@@ -43,38 +52,50 @@ contexts:
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
-    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
+    - match: |-
+        (?xi)
+        (alter) \s+ (
+          aggregate | conversion | database | domain | function | group | index
+        | language | operator \s+ class | operator | procedure | rule | schema
+        | sequence | table | tablespace | trigger | type | user | view
+        )\b
       scope: meta.alter.sql
       captures:
         1: keyword.other.alter.sql
         2: keyword.other.table.sql
-    - match: (?i:(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))\b
+    - match: |-
+        (?xi)
+        (add) \s+ (
+          column | constraint | fulltext \s+ (index | key) | index
+        | spatial \s+ (index | key)
+        )\b
       scope: meta.add.sql
       captures:
         1: keyword.other.add.sql
         2: keyword.other.sql
     - match: |-
-        (?xi)
-
-                # normal stuff, capture 1
-                (bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\s+precision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
-
-                # numeric suffix, capture 2 + 3i
-                |(bit\s+varying|character(?:\s+varying)?|tinyint|var\s+char|float|interval)\((\d+)\)
-
-                # optional numeric suffix, capture 4 + 5i
-                |(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
-
-                # special case, capture 6 + 7i + 8i
-                |(numeric|decimal)\b(?:\((\d+),(\d+)\))?
-
-                # special case, captures 9, 10i, 11
-                |(times?)\b(?:\((\d+)\))?(\s+with(?:out)?\s+time\s+zone\b)?
-
-                # special case, captures 12, 13, 14i, 15
-                |(timestamp(?:s|tz)?)\b(?:\((\d+)\))?(?:\s+(with|without)\s+(time)\s+(zone)\b)?
-
-
+        (?xi)(
+        # normal stuff, capture 1
+          bigint | bigserial | bit | bool | boolean | box | bytea | cidr
+        | circle | date | datetime | double \s+ precision | enum | inet | int
+        | integer | line | longtext | lseg | macaddr | money | ntext | oid
+        | path | point | polygon | real | serial | smallint | sysdate | sysname
+        | text | tinytext
+        )\b
+        # numeric suffix, capture 2 + 3i
+        | (
+          bit \s+ varying | character (?:\s+ varying)? | tinyint | var \s+ char
+        | float | interval
+        ) \( (\d+) \)
+        # optional numeric suffix, capture 4 + 5i
+        | (char | number | nvarchar | varbinary | varchar\d?)\b (?:\( (\d+) \))?
+        # special case, capture 6 + 7i + 8i
+        | (numeric | decimal)\b (?:\( (\d+) , (\d+) \))?
+        # special case, captures 9, 10i, 11
+        | (times?)\b (?:\( (\d+) \))? (\s+ with(?:out)? \s+ time \s+ zone\b)?
+        # special case, captures 12, 13, 14i, 15
+        | (timestamp(?:s|tz)?)\b (?:\( (\d+) \))?
+          (?:\s+(with | without) \s+ (time) \s+ (zone)\b)?
       captures:
         1: storage.type.sql
         2: storage.type.sql
@@ -92,7 +113,12 @@ contexts:
         14: storage.type.sql
         15: storage.type.sql
         16: storage.type.sql
-    - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\s+delete(\s+cascade)?|on\s+update(\s+cascade)?|check|constraint|default)\b
+    - match: |-
+        (?xi)(
+          ((?:foreign | fulltext | primary | unique)\s+)? key | references
+        | on \s+ delete (\s+ cascade)? | on \s+ update (\s+ cascade)?
+        | check | constraint | default
+        )\b
       scope: storage.modifier.sql
     - match:
         (?x)
@@ -107,7 +133,16 @@ contexts:
       scope: constant.language.boolean.sql
     - match: (?i:null)\b
       scope: constant.language.null.sql
-    - match: (?i:select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b
+    - match: |-
+        (?xi)(
+          select (\s+ (distinct | top))?
+        | insert (\s+ (ignore \s+)? into)?
+        | update | delete | truncate | from | set | where | group \s+ by | with
+        | case | when | then | else | end | union (\s+ all)? | using | order \s+ by
+        | limit | (inner | cross) \s+ join | join | straight_join
+        | (left | right) (\s+ outer)? \s+ join
+        | natural (\s+ (left | right) (\s+ outer)?)? \s+ join
+        )\b
       scope: keyword.other.DML.sql
     - include: logical-operators
     - match: (?i:like)\b
@@ -124,7 +159,13 @@ contexts:
       scope: keyword.other.LUW.sql
     - match: (?i:grant(\s+with\s+grant\s+option)?|revoke)\b
       scope: keyword.other.authorization.sql
-    - match: (?i:comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\b
+    - match: |-
+        (?xi)
+        comment \s+ on \s+ (
+          table | column | aggregate | constraint | database | domain
+        | function | index | operator | rule | schema | sequence | trigger
+        | type | view
+        )\b
       scope: keyword.other.object-comments.sql
     - match: (?i:as)\b
       scope: keyword.operator.assignment.alias.sql
@@ -178,16 +219,16 @@ contexts:
         2: punctuation.section.scope.end.sql
     - match: (?i:on)\b
       scope: keyword.operator.word.sql
-    - match: ','
+    - match: \,
       scope: punctuation.separator.sequence.sql
-    - match: ';'
+    - match: ;
       scope: punctuation.terminator.statement.sql
   comments:
     - meta_include_prototype: false
-    - match: '--'
+    - match: --
       scope: punctuation.definition.comment.sql
       push: inside-double-dash-comment
-    - match: '#'
+    - match: \#
       scope: punctuation.definition.comment.sql
       push: inside-number-sign-comment
     - match: /\*
@@ -224,13 +265,13 @@ contexts:
         - include: string-interpolation
         - match: \\/
           scope: constant.character.escape.slash.sql
-    - match: '%r\{'
+    - match: \%r{
       comment: We should probably handle nested bracket pairs!?! -- Allan
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_include_prototype: false
         - meta_scope: string.regexp.modr.sql
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.string.end.sql
           pop: 1
         - include: string-interpolation
@@ -240,55 +281,55 @@ contexts:
       scope: constant.character.escape.sql
   string-interpolation:
     - meta_include_prototype: false
-    - match: '(#\{)([^\}]*)(\})'
+    - match: (#{)([^}]*)(})
       scope: string.interpolated.sql
       captures:
         1: punctuation.definition.string.begin.sql
         3: punctuation.definition.string.end.sql
   strings:
-    - match: "'"
+    - match: \'
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.single.sql
         - match: "''"
           scope: constant.character.escape.sql
-        - match: "'"
+        - match: \'
           scope: punctuation.definition.string.end.sql
           pop: 1
         - include: string-escape
-    - match: "`"
+    - match: \`
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.other.backtick.sql
-        - match: "`"
+        - match: \`
           scope: punctuation.definition.string.end.sql
           pop: 1
         - include: string-escape
-    - match: '"'
+    - match: \"
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.sql
         - match: '""'
           scope: constant.character.escape.sql
-        - match: '"'
+        - match: \"
           scope: punctuation.definition.string.end.sql
           pop: 1
         - include: string-interpolation
-    - match: '%\{'
+    - match: \%{
       scope: punctuation.definition.string.begin.sql
       push:
         - meta_include_prototype: false
         - meta_scope: string.other.quoted.brackets.sql
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.string.end.sql
           pop: 1
         - include: string-interpolation
   identifier-create:
     - meta_content_scope: meta.toc-list.full-identifier.sql
-    - match: '(?:((?!\d)\w+)|''([^'']+)''|"([^"]+)"|`([^`]+)`){{end_identifier}}'
+    - match: (?:((?!\d)\w+)|''([^'']+)''|"([^"]+)"|`([^`]+)`){{end_identifier}}
       scope: meta.toc-list.full-identifier.sql
       captures:
         1: entity.name.function.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -132,9 +132,9 @@ contexts:
       scope: keyword.other.order.sql
     - match: \*
       scope: variable.language.wildcard.asterisk.sql
-    - match: "<=>|[!<>]?=|<>|<|>"
+    - match: <=?>|[!<>]?=|[<>]
       scope: keyword.operator.comparison.sql
-    - match: '-|\+|/'
+    - match: '[-+/]'
       scope: keyword.operator.arithmetic.sql
     - match: \|\|
       scope: keyword.operator.concatenation.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -60,7 +60,7 @@ contexts:
                 (bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\s+precision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
 
                 # numeric suffix, capture 2 + 3i
-                |(bit\s+varying|character\s+(?:varying)?|tinyint|var\s+char|float|interval)\((\d+)\)
+                |(bit\s+varying|character(?:\s+varying)?|tinyint|var\s+char|float|interval)\((\d+)\)
 
                 # optional numeric suffix, capture 4 + 5i
                 |(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
@@ -72,7 +72,7 @@ contexts:
                 |(times?)\b(?:\((\d+)\))?(\s+with(?:out)?\s+time\s+zone\b)?
 
                 # special case, captures 12, 13, 14i, 15
-                |(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s+(with|without)\s+time\s+zone\b)?
+                |(timestamp(?:s|tz)?)\b(?:\((\d+)\))?(?:\s+(with|without)\s+(time)\s+(zone)\b)?
 
 
       captures:
@@ -88,9 +88,10 @@ contexts:
         10: constant.numeric.sql
         11: storage.type.sql
         12: storage.type.sql
-        13: storage.type.sql
-        14: constant.numeric.sql
+        13: constant.numeric.sql
+        14: storage.type.sql
         15: storage.type.sql
+        16: storage.type.sql
     - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\s+delete(\s+cascade)?|on\s+update(\s+cascade)?|check|constraint|default)\b
       scope: storage.modifier.sql
     - match: \d+

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -36,7 +36,7 @@ contexts:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: drop-condition
-    - match: (?i:(drop)\s+(table)\s+(\w+)(\s+cascade)?)\b
+    - match: (?i:(drop)\s+(table)\s+((?!\d)\w+)(\s+cascade)?)\b
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
@@ -138,7 +138,7 @@ contexts:
       scope: support.function.aggregate.sql
     - match: (?i:CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
-    - match: (\w+?)\.(\w+)\b
+    - match: ((?!\d)\w+?)\s*\.\s*((?!\d)\w+)\b
       captures:
         1: constant.other.database-name.sql
         2: constant.other.table-name.sql
@@ -262,7 +262,7 @@ contexts:
         - include: string-interpolation
   identifier-create:
     - meta_content_scope: meta.toc-list.full-identifier.sql
-    - match: '(?:(\w+)|''([^'']+)''|"([^"]+)"|`([^`]+)`){{end_identifier}}'
+    - match: '(?:((?!\d)\w+)|''([^'']+)''|"([^"]+)"|`([^`]+)`){{end_identifier}}'
       scope: meta.toc-list.full-identifier.sql
       captures:
         1: entity.name.function.sql
@@ -271,7 +271,7 @@ contexts:
         4: entity.name.function.sql
       pop: true
       # Schema identifiers
-    - match: (?:\w+|'[^']+'|"[^"]+"|`[^`]+`)\s*(\.)
+    - match: (?:(?!\d)\w+|'[^']+'|"[^"]+"|`[^`]+`)\s*(\.)
       captures:
         1: punctuation.accessor.dot.sql
       # Handle situations where the schema and .

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -33,20 +33,20 @@ contexts:
     - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.drop.sql
       captures:
-        1: keyword.other.create.sql
+        1: keyword.other.drop.sql
         2: keyword.other.sql
       push: drop-condition
     - match: (?i:(drop)\s+(table)\s+((?!\d)\w+)(\s+cascade)?)\b
       scope: meta.drop.sql
       captures:
-        1: keyword.other.create.sql
+        1: keyword.other.drop.sql
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
     - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.alter.sql
       captures:
-        1: keyword.other.create.sql
+        1: keyword.other.alter.sql
         2: keyword.other.table.sql
     - match: (?i:(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))\b
       scope: meta.add.sql
@@ -271,9 +271,10 @@ contexts:
         4: entity.name.function.sql
       pop: true
       # Schema identifiers
-    - match: (?:(?!\d)\w+|'[^']+'|"[^"]+"|`[^`]+`)\s*(\.)
+    - match: (?x)((?!\d)\w+ | '[^']+' | "[^"]+" | `[^`]+`) \s* (\.)
       captures:
-        1: punctuation.accessor.dot.sql
+        1: variable.other.schema.sql
+        2: punctuation.accessor.dot.sql
       # Handle situations where the schema and .
     - match: '{{end_identifier}}'
       pop: true

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -122,11 +122,11 @@ contexts:
       scope: storage.modifier.sql
     - match:
         (?x)
-        (\d+ (\.)? (?:\d* (?:[eE][-+]? \d+)?)? | (\.) \d+ (?:[eE][-+]? \d+)?)
+        (?:\d+ (\.)? \d* (?:[eE] [-+]? \d+)? | (\.) \d+ (?:[eE] [-+]? \d+)?)
       captures:
-        1: constant.numeric.sql
+        0: constant.numeric.sql
+        1: punctuation.separator.decimal.sql
         2: punctuation.separator.decimal.sql
-        3: punctuation.separator.decimal.sql
     - match: \d+
       scope: constant.numeric.sql
     - match: (?i:true|false)\b

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -24,31 +24,31 @@ contexts:
         (?xi)
         (create(?:\s+or\s+replace)?)\s+
         (aggregate|conversion|database|domain|function|group|((?:fulltext|spatial|unique)\s+)?index|language|operator class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
-        \b\s*
+        \b
       scope: meta.create.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: create-condition
-    - match: (?i:\s*(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))
+    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\b)
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: drop-condition
-    - match: (?i:\s*(drop)\s+(table)\s+(\w+)(\s+cascade)?\b)
+    - match: (?i:(drop)\s+(table)\s+(\w+)(\s+cascade)?\b)
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
-    - match: (?i:\s*(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\s+)
+    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\b)
       scope: meta.alter.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.table.sql
-    - match: (?i:\s*(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))
+    - match: (?i:(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key))\b)
       scope: meta.add.sql
       captures:
         1: keyword.other.add.sql
@@ -116,7 +116,7 @@ contexts:
       scope: keyword.other.LUW.sql
     - match: (?i:(grant(\swith\sgrant\soption)?|revoke)\b)
       scope: keyword.other.authorization.sql
-    - match: (?i:\s*(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\s+)
+    - match: (?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\b)
       scope: keyword.other.object-comments.sql
     - match: (?i)as\b
       scope: keyword.operator.assignment.alias.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
   main:
     - match: |-
         (?xi)
-        \b(create(?:\s+or\s+replace)?)\s+
+        (create(?:\s+or\s+replace)?)\s+
         (aggregate|conversion|database|domain|function|group|((?:fulltext|spatial|unique)\s+)?index|language|operator class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
         \b\s*
       scope: meta.create.sql
@@ -30,7 +30,7 @@ contexts:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: create-condition
-    - match: (?i:\s*\b(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))
+    - match: (?i:\s*(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
@@ -43,12 +43,12 @@ contexts:
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
-    - match: (?i:\s*\b(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\s+)
+    - match: (?i:\s*(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\s+)
       scope: meta.alter.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.table.sql
-    - match: (?i:\s*\b(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))
+    - match: (?i:\s*(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))
       scope: meta.add.sql
       captures:
         1: keyword.other.add.sql
@@ -57,22 +57,22 @@ contexts:
         (?xi)
 
                 # normal stuff, capture 1
-                \b(bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\s+precision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
+                (bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\s+precision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
 
                 # numeric suffix, capture 2 + 3i
-                |\b(bit\svarying|character\s+(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)
+                |(bit\svarying|character\s+(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)
 
                 # optional numeric suffix, capture 4 + 5i
-                |\b(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
+                |(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
 
                 # special case, capture 6 + 7i + 8i
-                |\b(numeric|decimal)\b(?:\((\d+),(\d+)\))?
+                |(numeric|decimal)\b(?:\((\d+),(\d+)\))?
 
                 # special case, captures 9, 10i, 11
-                |\b(times?)\b(?:\((\d+)\))?(\swith(?:out)?\s+time\s+zone\b)?
+                |(times?)\b(?:\((\d+)\))?(\swith(?:out)?\s+time\s+zone\b)?
 
                 # special case, captures 12, 13, 14i, 15
-                |\b(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\s+time\s+zone\b)?
+                |(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\s+time\s+zone\b)?
 
 
       captures:
@@ -91,18 +91,18 @@ contexts:
         13: storage.type.sql
         14: constant.numeric.sql
         15: storage.type.sql
-    - match: (?i:\b(((?:foreign|fulltext|primary|unique)\s+)?key|references|on\sdelete(\s+cascade)?|on\supdate(\s+cascade)?|check|constraint|default)\b)
+    - match: (?i:(((?:foreign|fulltext|primary|unique)\s+)?key|references|on\sdelete(\s+cascade)?|on\supdate(\s+cascade)?|check|constraint|default)\b)
       scope: storage.modifier.sql
-    - match: \b\d+\b
+    - match: \d+
       scope: constant.numeric.sql
-    - match: (?i:\b(true|false)\b)
+    - match: (?i:(true|false)\b)
       scope: constant.language.boolean.sql
-    - match: (?i:\b(null)\b)
+    - match: (?i:(null)\b)
       scope: constant.language.null.sql
-    - match: (?i:\b(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)
+    - match: (?i:(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)
       scope: keyword.other.DML.sql
     - include: logical-operators
-    - match: (?i:\blike\b)
+    - match: (?i:like\b)
       scope: keyword.operator.logical.sql
       branch_point: like-strings-branch
       branch:
@@ -110,17 +110,17 @@ contexts:
         - like-string-followed-by-escape-slash
         - like-string-followed-by-escape-caret
         - like-string-followed-by-unknown-escape
-    - match: (?i:\bvalues\b)
+    - match: (?i:values\b)
       scope: keyword.other.DML.II.sql
-    - match: (?i:\b(begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b)
+    - match: (?i:(begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b)
       scope: keyword.other.LUW.sql
-    - match: (?i:\b(grant(\swith\sgrant\soption)?|revoke)\b)
+    - match: (?i:(grant(\swith\sgrant\soption)?|revoke)\b)
       scope: keyword.other.authorization.sql
-    - match: (?i:\s*\b(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\s+)
+    - match: (?i:\s*(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\s+)
       scope: keyword.other.object-comments.sql
-    - match: (?i)\bas\b
+    - match: (?i)as\b
       scope: keyword.operator.assignment.alias.sql
-    - match: (?i)\b(asc|desc)\b
+    - match: (?i)(asc|desc)\b
       scope: keyword.other.order.sql
     - match: \*
       scope: variable.language.wildcard.asterisk.sql
@@ -130,15 +130,15 @@ contexts:
       scope: keyword.operator.arithmetic.sql
     - match: \|\|
       scope: keyword.operator.concatenation.sql
-    - match: (?i)\b(CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
+    - match: (?i)(CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
       comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.scalar.sql
-    - match: (?i)\b(AVG|COUNT|MIN|MAX|SUM)(?=\s*\()
+    - match: (?i)(AVG|COUNT|MIN|MAX|SUM)(?=\s*\()
       comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.aggregate.sql
-    - match: (?i)\b(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
+    - match: (?i)(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
-    - match: \b(\w+?)\.(\w+)\b
+    - match: (\w+?)\.(\w+)\b
       captures:
         1: constant.other.database-name.sql
         2: constant.other.table-name.sql
@@ -150,7 +150,7 @@ contexts:
       captures:
         1: punctuation.section.scope.begin.sql
         2: punctuation.section.scope.end.sql
-    - match: (?i)\bon\b
+    - match: (?i)on\b
       scope: keyword.operator.word.sql
     - match: ','
       scope: punctuation.separator.sequence.sql
@@ -286,11 +286,11 @@ contexts:
     - match: (?=\S)
       pop: true
   dml-condition:
-    - match: (?i:\b(if)\b)
+    - match: (?i:(if)\b)
       scope: keyword.control.flow.sql
     - include: logical-operators
   logical-operators:
-    - match: (?i:\b(and|or|having|exists|between|in|not|is)\b)
+    - match: (?i:(and|or|having|exists|between|in|not|is)\b)
       scope: keyword.operator.logical.sql
   like-string-not-followed-by-escape:
     - match: \'
@@ -349,12 +349,12 @@ contexts:
     - match: '[%_]'
       scope: keyword.operator.wildcard.sql
   like-escape-fail:
-    - match: (?i:\bescape\b)
+    - match: (?i:escape\b)
       fail: like-strings-branch
     - match: (?=\S)
       pop: true
   like-escape-pop:
-    - match: (?i:\bescape\b)
+    - match: (?i:escape\b)
       scope: keyword.operator.word.sql
       pop: true
     - match: (?=\S)

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -23,14 +23,14 @@ contexts:
     - match: |-
         (?xi)
         (create(?:\s+or\s+replace)?)\s+
-        (aggregate|conversion|database|domain|function|group|((?:fulltext|spatial|unique)\s+)?index|language|operator class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
+        (aggregate|conversion|database|domain|function|group|((?:fulltext|spatial|unique)\s+)?index|language|operator\s+class|operator|procedure|rule|schema|sequence|table(?:space)?|trigger|type|user|view)
         \b
       scope: meta.create.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: create-condition
-    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
+    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
@@ -43,7 +43,7 @@ contexts:
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
-    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
+    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator\s+class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.alter.sql
       captures:
         1: keyword.other.create.sql
@@ -60,7 +60,7 @@ contexts:
                 (bigint|bigserial|bit|bool|boolean|box|bytea|cidr|circle|date|datetime|double\s+precision|enum|inet|int|integer|line|longtext|lseg|macaddr|money|ntext|oid|path|point|polygon|real|serial|smallint|sysdate|sysname|text|tinytext)\b
 
                 # numeric suffix, capture 2 + 3i
-                |(bit\svarying|character\s+(?:varying)?|tinyint|var\schar|float|interval)\((\d+)\)
+                |(bit\s+varying|character\s+(?:varying)?|tinyint|var\s+char|float|interval)\((\d+)\)
 
                 # optional numeric suffix, capture 4 + 5i
                 |(char|number|nvarchar|varbinary|varchar\d?)\b(?:\((\d+)\))?
@@ -69,10 +69,10 @@ contexts:
                 |(numeric|decimal)\b(?:\((\d+),(\d+)\))?
 
                 # special case, captures 9, 10i, 11
-                |(times?)\b(?:\((\d+)\))?(\swith(?:out)?\s+time\s+zone\b)?
+                |(times?)\b(?:\((\d+)\))?(\s+with(?:out)?\s+time\s+zone\b)?
 
                 # special case, captures 12, 13, 14i, 15
-                |(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\s+time\s+zone\b)?
+                |(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s+(with|without)\s+time\s+zone\b)?
 
 
       captures:
@@ -91,7 +91,7 @@ contexts:
         13: storage.type.sql
         14: constant.numeric.sql
         15: storage.type.sql
-    - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\sdelete(\s+cascade)?|on\supdate(\s+cascade)?|check|constraint|default)\b
+    - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\s+delete(\s+cascade)?|on\s+update(\s+cascade)?|check|constraint|default)\b
       scope: storage.modifier.sql
     - match: \d+
       scope: constant.numeric.sql
@@ -114,7 +114,7 @@ contexts:
       scope: keyword.other.DML.II.sql
     - match: (?i:begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b
       scope: keyword.other.LUW.sql
-    - match: (?i:grant(\swith\sgrant\soption)?|revoke)\b
+    - match: (?i:grant(\s+with\s+grant\s+option)?|revoke)\b
       scope: keyword.other.authorization.sql
     - match: (?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is))\b
       scope: keyword.other.object-comments.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -94,6 +94,13 @@ contexts:
         16: storage.type.sql
     - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\s+delete(\s+cascade)?|on\s+update(\s+cascade)?|check|constraint|default)\b
       scope: storage.modifier.sql
+    - match:
+        (?x)
+        (\d+ (\.)? (?:\d* (?:[eE][-+]? \d+)?)? | (\.) \d+ (?:[eE][-+]? \d+)?)
+      captures:
+        1: constant.numeric.sql
+        2: punctuation.separator.decimal.sql
+        3: punctuation.separator.decimal.sql
     - match: \d+
       scope: constant.numeric.sql
     - match: (?i:true|false)\b
@@ -139,10 +146,28 @@ contexts:
       scope: support.function.aggregate.sql
     - match: (?i:CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
-    - match: ((?!\d)\w+?)\s*\.\s*((?!\d)\w+)\b
+    - match: \$\d+
+      comment: Prepared statement parameter
+      scope: constant.other.parameter.sql
+    - match: (?!\d)\w+(?=\()
+      scope: variable.function.sql
+    - match: |-
+        (?x)
+        # database identifier
+          ((?!\d)\w+) (?=(?:\s*\.\s*(?!\d)\w+){2})
+        # table and member identifier
+        | ((?!\d)\w+) (\s*\.\s*) (\s*(?!\d)\w+ | (?=\s*"))
+        # normal variable
+        | ((?!\d)\w+)
+        # accessor punctuation
+        | (\.(?!\d))
       captures:
         1: constant.other.database-name.sql
         2: constant.other.table-name.sql
+        3: punctuation.accessor.dot.sql
+        4: variable.other.member.sql
+        5: variable.other.sql
+        6: punctuation.accessor.dot.sql
     - include: strings
     - include: regexps
     - match: (\()(\))

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -116,7 +116,7 @@ contexts:
       scope: keyword.other.LUW.sql
     - match: (?i:grant(\s+with\s+grant\s+option)?|revoke)\b
       scope: keyword.other.authorization.sql
-    - match: (?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is))\b
+    - match: (?i:comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\b
       scope: keyword.other.object-comments.sql
     - match: (?i:as)\b
       scope: keyword.operator.assignment.alias.sql

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -30,25 +30,25 @@ contexts:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: create-condition
-    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\b)
+    - match: (?i:(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.sql
       push: drop-condition
-    - match: (?i:(drop)\s+(table)\s+(\w+)(\s+cascade)?\b)
+    - match: (?i:(drop)\s+(table)\s+(\w+)(\s+cascade)?)\b
       scope: meta.drop.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.table.sql
         3: entity.name.function.sql
         4: keyword.other.cascade.sql
-    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view)\b)
+    - match: (?i:(alter)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|procedure|rule|schema|sequence|table|tablespace|trigger|type|user|view))\b
       scope: meta.alter.sql
       captures:
         1: keyword.other.create.sql
         2: keyword.other.table.sql
-    - match: (?i:(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key))\b)
+    - match: (?i:(add)\s+(column|constraint|fulltext\s+(index|key)|index|spatial\s+(index|key)))\b
       scope: meta.add.sql
       captures:
         1: keyword.other.add.sql
@@ -91,18 +91,18 @@ contexts:
         13: storage.type.sql
         14: constant.numeric.sql
         15: storage.type.sql
-    - match: (?i:(((?:foreign|fulltext|primary|unique)\s+)?key|references|on\sdelete(\s+cascade)?|on\supdate(\s+cascade)?|check|constraint|default)\b)
+    - match: (?i:((?:foreign|fulltext|primary|unique)\s+)?key|references|on\sdelete(\s+cascade)?|on\supdate(\s+cascade)?|check|constraint|default)\b
       scope: storage.modifier.sql
     - match: \d+
       scope: constant.numeric.sql
-    - match: (?i:(true|false)\b)
+    - match: (?i:true|false)\b
       scope: constant.language.boolean.sql
-    - match: (?i:(null)\b)
+    - match: (?i:null)\b
       scope: constant.language.null.sql
-    - match: (?i:(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)
+    - match: (?i:select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b
       scope: keyword.other.DML.sql
     - include: logical-operators
-    - match: (?i:like\b)
+    - match: (?i:like)\b
       scope: keyword.operator.logical.sql
       branch_point: like-strings-branch
       branch:
@@ -110,17 +110,17 @@ contexts:
         - like-string-followed-by-escape-slash
         - like-string-followed-by-escape-caret
         - like-string-followed-by-unknown-escape
-    - match: (?i:values\b)
+    - match: (?i:values)\b
       scope: keyword.other.DML.II.sql
-    - match: (?i:(begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b)
+    - match: (?i:begin(\s+work)?|start\s+transaction|commit(\s+work)?|rollback(\s+work)?)\b
       scope: keyword.other.LUW.sql
-    - match: (?i:(grant(\swith\sgrant\soption)?|revoke)\b)
+    - match: (?i:grant(\swith\sgrant\soption)?|revoke)\b
       scope: keyword.other.authorization.sql
-    - match: (?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\b)
+    - match: (?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is))\b
       scope: keyword.other.object-comments.sql
-    - match: (?i)as\b
+    - match: (?i:as)\b
       scope: keyword.operator.assignment.alias.sql
-    - match: (?i)(asc|desc)\b
+    - match: (?i:asc|desc)\b
       scope: keyword.other.order.sql
     - match: \*
       scope: variable.language.wildcard.asterisk.sql
@@ -130,13 +130,13 @@ contexts:
       scope: keyword.operator.arithmetic.sql
     - match: \|\|
       scope: keyword.operator.concatenation.sql
-    - match: (?i)(CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
+    - match: (?i:CURRENT_(DATE|TIME(STAMP)?|USER)|(SESSION|SYSTEM)_USER)\b
       comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.scalar.sql
-    - match: (?i)(AVG|COUNT|MIN|MAX|SUM)(?=\s*\()
+    - match: (?i:AVG|COUNT|MIN|MAX|SUM)(?=\s*\()
       comment: List of SQL99 built-in functions from http://www.oreilly.com/catalog/sqlnut/chapter/ch04.html
       scope: support.function.aggregate.sql
-    - match: (?i)(CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
+    - match: (?i:CONCATENATE|CONVERT|LOWER|SUBSTRING|TRANSLATE|TRIM|UPPER)\b
       scope: support.function.string.sql
     - match: (\w+?)\.(\w+)\b
       captures:
@@ -150,7 +150,7 @@ contexts:
       captures:
         1: punctuation.section.scope.begin.sql
         2: punctuation.section.scope.end.sql
-    - match: (?i)on\b
+    - match: (?i:on)\b
       scope: keyword.operator.word.sql
     - match: ','
       scope: punctuation.separator.sequence.sql
@@ -286,11 +286,11 @@ contexts:
     - match: (?=\S)
       pop: true
   dml-condition:
-    - match: (?i:(if)\b)
+    - match: (?i:if)\b
       scope: keyword.control.flow.sql
     - include: logical-operators
   logical-operators:
-    - match: (?i:(and|or|having|exists|between|in|not|is)\b)
+    - match: (?i:and|or|having|exists|between|in|not|is)\b
       scope: keyword.operator.logical.sql
   like-string-not-followed-by-escape:
     - match: \'
@@ -349,12 +349,12 @@ contexts:
     - match: '[%_]'
       scope: keyword.operator.wildcard.sql
   like-escape-fail:
-    - match: (?i:escape\b)
+    - match: (?i:escape)\b
       fail: like-strings-branch
     - match: (?=\S)
       pop: true
   like-escape-pop:
-    - match: (?i:escape\b)
+    - match: (?i:escape)\b
       scope: keyword.operator.word.sql
       pop: true
     - match: (?=\S)

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -136,7 +136,7 @@ ALTER TABLE testing123 CHANGE COLUMN mycolumn mycolumn ENUM('foo', 'bar');
 --                                                     ^^^^ storage.type.sql
 
 DROP TABLE IF EXISTS testing123;
--- <- meta.drop.sql keyword.other.create.sql
+-- <- meta.drop.sql keyword.other.drop.sql
 --            ^^^^^^ keyword.operator.logical.sql
 
 select *

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -96,9 +96,13 @@ create table fancy_table (
     fancy_column character  varying(42) DEFAULT 'nice'::character varying,
 --               ^^^^^^^^^^^^^^^^^^ storage.type.sql
     mytime timestamp(3) without time zone DEFAULT now(),
---                      ^^^^^^^^^^^^^^^^^ storage.type.sql
+--                      ^^^^^^^ storage.type.sql
+--                              ^^^^ storage.type.sql
+--                                   ^^^^ storage.type.sql
     mytime2 timestamp(3) without  time  zone DEFAULT '2008-01-18 00:00:00'::timestamp(3) without time zone,
---                       ^^^^^^^^^^^^^^^^^^^ storage.type.sql
+--                       ^^^^^^^ storage.type.sql
+--                                ^^^^ storage.type.sql
+--                                      ^^^^ storage.type.sql
     primary key (id),
 --  ^^^^^^^^^^^ storage.modifier.sql
     UNIQUE (foreign_id),


### PR DESCRIPTION
Hey!

My main goal was to fix the way the word-boundary escape `\b` is used throughout the syntax file. I did much more besides that.
So I wanted, for example, `1IN` to be two tokens, and I assumed that every engine recognizes them as such, but I just tested with PSQL and MySQL and it looks like it's 2 tokens for PSQL and 1 for MySQL.

```sql
-- This is valid in PSQL and returns `true`. MySQL thinks it's an undefined function called "1IN".
SELECT 1IN(1,2,3);
```

I haven't looked at what the standard says yet. Regardless, I think my changes are pretty useful as they are and the thing above can be reverted by adding a `\b` back to the `match: \d+` context. My last commit is solely for formatting. Hope you like it! :+1: