### PR TITLE
[HTML] Add meta.string to CDATA content

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -110,7 +110,7 @@ contexts:
 
   cdata-content:
     - meta_scope: meta.tag.sgml.cdata.html
-    - meta_content_scope: string.unquoted.cdata.html
+    - meta_content_scope: meta.string.html string.unquoted.cdata.html
     - match: ']]>'
       scope: punctuation.definition.tag.end.html
       pop: 1

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -237,12 +237,14 @@
         <script type="text/html">
             <![CDATA[
         ## ^ - meta.tag - punctuation - source
-        ##  ^^^^^^^^^^ meta.tag.sgml.cdata.html
+        ##  ^^^^^^^^^ meta.tag.sgml.cdata.html - meta.string
+        ##           ^ meta.tag.sgml.cdata.html meta.string.html
         ##  ^^^ punctuation.definition.tag.begin.html
         ##     ^^^^^ keyword.declaration.cdata.html
-        ##          ^ punctuation.definition.tag.begin.html
+        ##          ^ punctuation.definition.tag.begin.html - string
+        ##           ^ string.unquoted.cdata.html
                 var i = 0;
-        ##    ^^^^^^^^^^^^^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
+        ##    ^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
             ]]>
         ## ^ meta.tag.sgml.cdata.html string.unquoted.cdata.html
         ##  ^^^ meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
@@ -404,24 +406,26 @@
 ##   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata
 ##   ^^^ punctuation.definition.tag.begin
 ##      ^^^^^ keyword.declaration.cdata
-##           ^ punctuation.definition.tag.begin
-##            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
-##                                          ^ - string.unquoted.cdata
+##           ^ punctuation.definition.tag.begin - string
+##            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.cdata
+##                                          ^ - string
 ##                                          ^^^ punctuation.definition.tag.end
      <![CDATA[
-##   ^^^^^^^^^^ meta.tag.sgml.cdata
-##   ^^^ punctuation.definition.tag.begin
-##      ^^^^^ keyword.declaration.cdata
-##           ^ punctuation.definition.tag.begin
+##  ^ - meta.tag - punctuation - source
+##   ^^^^^^^^^ meta.tag.sgml.cdata.html - meta.string
+##            ^ meta.tag.sgml.cdata.html meta.string.html
+##   ^^^ punctuation.definition.tag.begin.html
+##      ^^^^^ keyword.declaration.cdata.html
+##           ^ punctuation.definition.tag.begin.html - string
+##            ^ string.unquoted.cdata.html
         <!DOCTYPE catalog plist "dtd">
-##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.cdata
     ]]>
-##  ^ - string.unquoted.cdata
-##  ^^^ punctuation.definition.tag.end
+##  ^^^ punctuation.definition.tag.end - meta.string - string
 
      <![CDATA[
         <![CDATA[ unparsed! ]]>
-##      ^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata
+##      ^^^^^^^^^^^^^^^^^^^^ meta.string.html string.unquoted.cdata
 ##      ^^^ - punctuation.definition.tag.begin
 ##         ^^^^^ - keyword.declaration.cdata
 ##              ^ - punctuation.definition.tag.begin


### PR DESCRIPTION
Fixes #3305

This commit adds `meta.string.html` to CDATA content so it uses the same scopes as CDATA in XML.