### PR TITLE
[Erlang] Fix hidden file extensions key

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -11,7 +11,7 @@ file_extensions:
   - hrl
   - escript
 
-hidden_extensions:
+hidden_file_extensions:
   - Emakefile
 
 first_line_match: |-


### PR DESCRIPTION
This PR renames syntax's `hidden_extensions` key to `hidden_file_extensions` as the latter one is the one which is found in documentation.