### PR TITLE
[PHP] Fix anonymous class instantiations

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -328,7 +328,7 @@ contexts:
           pop: 1
         - include: class-name
         - include: variables
-    - include: instantiation
+    - include: instantiations
     - match: '(?i)(goto)\s+({{identifier}})'
       captures:
         1: keyword.control.goto.php
@@ -1298,6 +1298,7 @@ contexts:
         # is generated and the constant is assumed to have the value of its name.
         - match: '{{identifier}}'
           scope: constant.other.php
+
   function-call:
     # Functions in a user-defined namespace should only be highlighted as user,
     # any built-in function names should not be highlighted specially
@@ -1323,6 +1324,7 @@ contexts:
         - include: support
         - match: '{{identifier}}'
           scope: variable.function.php
+
   function-call-static:
     - match: (::)(?={{identifier}}\s*\()
       captures:
@@ -1333,18 +1335,22 @@ contexts:
           set: function-call-parameters
         - match: '{{identifier}}'
           scope: variable.function.php
+
   function-call-parameters:
     - match: \(
       scope: punctuation.section.group.begin.php
-      set:
-        - meta_scope: meta.function-call.php meta.group.php
-        - match: \)
-          scope: punctuation.section.group.end.php
-          set: after-function-call
-        - match: ','
-          scope: punctuation.separator.comma.php
-        - include: function-call-named-parameters
-        - include: nested-expressions
+      set: function-call-parameters-body
+
+  function-call-parameters-body:
+    - meta_scope: meta.function-call.arguments.php meta.group.php
+    - match: \)
+      scope: punctuation.section.group.end.php
+      set: after-function-call
+    - match: ','
+      scope: punctuation.separator.comma.php
+    - include: function-call-named-parameters
+    - include: nested-expressions
+
   function-call-named-parameters:
     # https://wiki.php.net/rfc/named_params
     - match: ({{identifier}})\s*(:)(?!:)
@@ -1355,6 +1361,7 @@ contexts:
         - include: nested-expressions
         - match: ''
           pop: 1
+
   heredoc:
     - match: (?=<<<\s*'?({{identifier}})'?\s*$)
       push:
@@ -1539,27 +1546,56 @@ contexts:
       push: scope:source.yaml
       with_prototype:
         - include: interpolation
-  instantiation:
+
+###[ INSTANTIATIONS ]#########################################################
+
+  instantiations:
+    - match: \b(?i:new)\b
+      scope: keyword.other.new.php
+      push:
+        - instantiation-meta
+        - instantiation-body
+
+  instantiation-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.instantiation.php
+    - include: immediately-pop
+
+  instantiation-body:
+    - include: attributes
+    - include: comments
     # anonymous class ( http://php.net/manual/en/language.oop5.anonymous.php )
-    - match: '(?i)(new)\s+(class)\b\s*'
-      captures:
-        1: keyword.other.new.php
-        2: keyword.declaration.class.php
-      push:
-        - match: (?=\()
-          push: function-call-parameters
-        - match: ''
-          set: class-definition
-    - match: (?i)(new)\s+
-      captures:
-        1: keyword.other.new.php
-      push:
-        - match: '(?=[^[:alnum:]$_\\])'
-          pop: 1
-        - match: '(parent|static|self)\b'
-          scope: variable.language.php
-        - include: class-name
-        - include: variables
+    - match: \b(?i:class)\b
+      scope: meta.class.php keyword.declaration.class.php
+      set:
+        - class-definition
+        - instantiation-arguments
+    - match: (?=\S)
+      set:
+        - instantiation-arguments
+        - instantiation-class
+
+  instantiation-class:
+    - match: (?=[^[:alnum:]$_\\])
+      pop: 1
+    - match: (parent|static|self)\b
+      scope: variable.language.php
+      pop: 1
+    - include: class-name
+    - include: variables
+
+  instantiation-arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.php
+      set: instantiation-arguments-body
+    - include: else-pop
+
+  instantiation-arguments-body:
+    - meta_scope: meta.group.php
+    - include: function-call-parameters-body
+
+###[ INTERPOLATION ]##########################################################
+
   interpolation:
     - match: '\\[0-7]{1,3}'
       scope: constant.character.escape.octal.php
@@ -1713,7 +1749,7 @@ contexts:
       scope: keyword.operator.assignment.php
     - match: '&(?=\s*\$)'
       scope: storage.modifier.reference.php
-    - include: instantiation
+    - include: instantiations
     - match: \s*(?={{path}}(::)({{identifier}})?)
       push:
         - match: '(::)({{identifier}})?'

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1299,6 +1299,8 @@ contexts:
         - match: '{{identifier}}'
           scope: constant.other.php
 
+###[ FUNCTION CALLS ]#########################################################
+
   function-call:
     # Functions in a user-defined namespace should only be highlighted as user,
     # any built-in function names should not be highlighted specially
@@ -1361,6 +1363,8 @@ contexts:
         - include: nested-expressions
         - match: ''
           pop: 1
+
+###[ HEREDOCS ]###############################################################
 
   heredoc:
     - match: (?=<<<\s*'?({{identifier}})'?\s*$)

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -347,8 +347,6 @@ contexts:
     # fallback patterns incase no other expression matches
     - match: \b(?i:class)\b
       scope: keyword.declaration.class.php
-    - match: \b(?i:enum)\b
-      scope: keyword.declaration.enum.php
     - match: \b(?i:interface)\b
       scope: keyword.declaration.interface.php
     - match: \b(?i:function)\b

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -255,13 +255,13 @@ contexts:
     - include: variables
     - include: strings
     - include: arrays
+    - include: keywords
     - match: (?i)\s*\(\s*(array|real|double|float|int(eger)?|bool(ean)?|string|object|binary|unset)\s*\)
       captures:
         1: storage.type.php
     - match: |-
         \b(?xi:
-          array | bool | boolean | class | clone | double | float | function |
-          int | integer | interface | object | real | string
+          array | bool | boolean | clone | double | float | int | integer | object | real | string
         )\b
       scope: storage.type.php
     - match: (?i)\b(parent|self)\b
@@ -342,6 +342,17 @@ contexts:
           scope: punctuation.section.group.end.php
           pop: 1
         - include: nested-expressions
+
+  keywords:
+    # fallback patterns incase no other expression matches
+    - match: \b(?i:class)\b
+      scope: keyword.declaration.class.php
+    - match: \b(?i:enum)\b
+      scope: keyword.declaration.enum.php
+    - match: \b(?i:interface)\b
+      scope: keyword.declaration.interface.php
+    - match: \b(?i:function)\b
+      scope: keyword.declaration.function.php
 
   arrays:
     - match: (array)(\()(\))

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -461,7 +461,7 @@ contexts:
               pop: 1
             - match: ','
               scope: punctuation.separator.comma.php
-            - include: function-call-named-parameters
+            - include: function-call-named-arguments
             - include: nested-expressions
         - match: \]
           scope: punctuation.definition.attribute.end.php
@@ -1308,7 +1308,7 @@ contexts:
         - include: identifier-parts
         - match: '{{identifier}}(?=\s*\()'
           scope: variable.function.php
-          set: function-call-parameters
+          set: function-call-arguments
     - match: (?i)\b(print|echo)\b
       scope: support.function.construct.php
     # Root namespace function calls may be a built-in or user
@@ -1318,7 +1318,7 @@ contexts:
       push:
         - meta_scope: meta.function-call.php
         - match: (?=\s*\()
-          set: function-call-parameters
+          set: function-call-arguments
         - match: (?i)\b(isset|unset|e(val|mpty)|list)\b
           scope: support.function.construct.php
         - include: support
@@ -1332,26 +1332,26 @@ contexts:
       push:
         - meta_scope: meta.function-call.static.php
         - match: (?=\s*\()
-          set: function-call-parameters
+          set: function-call-arguments
         - match: '{{identifier}}'
           scope: variable.function.php
 
-  function-call-parameters:
+  function-call-arguments:
     - match: \(
       scope: punctuation.section.group.begin.php
-      set: function-call-parameters-body
+      set: function-call-arguments-body
 
-  function-call-parameters-body:
+  function-call-arguments-body:
     - meta_scope: meta.function-call.arguments.php meta.group.php
     - match: \)
       scope: punctuation.section.group.end.php
       set: after-function-call
     - match: ','
       scope: punctuation.separator.comma.php
-    - include: function-call-named-parameters
+    - include: function-call-named-arguments
     - include: nested-expressions
 
-  function-call-named-parameters:
+  function-call-named-arguments:
     # https://wiki.php.net/rfc/named_params
     - match: ({{identifier}})\s*(:)(?!:)
       captures:
@@ -1592,7 +1592,7 @@ contexts:
 
   instantiation-arguments-body:
     - meta_scope: meta.group.php
-    - include: function-call-parameters-body
+    - include: function-call-arguments-body
 
 ###[ INTERPOLATION ]##########################################################
 
@@ -1668,7 +1668,7 @@ contexts:
       captures:
         1: punctuation.definition.variable.php
         2: variable.other.php
-      push: function-call-parameters
+      push: function-call-arguments
   # Trailing underscores are allowed to prevent numbers from flickering while typing
   # The underscore is for PHP 7.4: https://wiki.php.net/rfc/numeric_literal_separator
   numbers:
@@ -1724,7 +1724,7 @@ contexts:
         1: punctuation.accessor.nullsafe.php
         2: punctuation.accessor.arrow.php
         3: variable.function.php
-      push: function-call-parameters
+      push: function-call-arguments
     - include: function-call-static
     - match: (\??)(->)((\$+)?{{identifier}})?
       captures:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -455,7 +455,7 @@ $object = new #[ExampleAttribute] class () { };
 //            ^^ punctuation.definition.attribute.begin
 //              ^^^^^^^^^^^^^^^^ meta.path
 //                              ^ punctuation.definition.attribute.end
-//                                ^^^^^ storage.type
+//                                ^^^^^ keyword.declaration.class.php
 
 $f2 = #[ExampleAttribute] function () { };
 //    ^^^^^^^^^^^^^^^^^^^ meta.attribute

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -451,11 +451,20 @@ class Foo
 }
 
 $object = new #[ExampleAttribute] class () { };
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.php
 //            ^^^^^^^^^^^^^^^^^^^ meta.attribute
 //            ^^ punctuation.definition.attribute.begin
 //              ^^^^^^^^^^^^^^^^ meta.path
 //                              ^ punctuation.definition.attribute.end
+//                                ^^^^^^ meta.class.php - meta.group - meta.block
+//                                      ^^ meta.class.php meta.group - meta.block
+//                                        ^ meta.class.php - meta.group - meta.block
+//                                         ^^^ meta.class.php meta.block - meta.group
 //                                ^^^^^ keyword.declaration.class.php
+//                                      ^ punctuation.section.group.begin.php
+//                                       ^ punctuation.section.group.end.php
+//                                         ^ punctuation.section.block.begin.php
+//                                           ^ punctuation.section.block.end.php
 
 $f2 = #[ExampleAttribute] function () { };
 //    ^^^^^^^^^^^^^^^^^^^ meta.attribute
@@ -1096,27 +1105,38 @@ array_slice($array, $offset, $length, preserve_keys: true);
 //                                                   ^^^^ constant.language
 
 $test = new Test1;
+//      ^^^^^^^^^ meta.instantiation.php
 //      ^ keyword.other.new.php
 //          ^^^^^ meta.path
 //          ^ support.class.php
 
 $anon = new class{};
+//      ^^^^^^^^^^^ - meta.class meta.class
+//      ^^^^ meta.instantiation.php - meta.class
+//          ^^^^^ meta.instantiation.php meta.class.php - meta.block
+//               ^^ meta.instantiation.php meta.class.php meta.block.php
+//                 ^ - meta.instantiation - meta.class - meta.block
 //      ^ keyword.other.new.php
 //          ^ keyword.declaration.class
 //               ^^ meta.class.php
 //               ^^ meta.block.php
-//               ^ punctuation.section.block.begin.php - meta.class meta.class
+//               ^ punctuation.section.block.begin.php
 //                ^ punctuation.section.block.end.php
 
 $anon = new class};
+//      ^^^^^^^^^^ - meta.class meta.class
+//      ^^^^ meta.instantiation.php - meta.class
+//          ^^^^^ meta.instantiation.php meta.class.php - meta.block
+//               ^ - meta.instantiation - meta.class - meta.block
 //      ^ keyword.other.new.php
 //          ^ keyword.declaration.class
-//               ^ punctuation.section.block.end.php - meta.class - meta.block
+//               ^ punctuation.section.block.end.php
 
 $anon = new class($param1, $param2) extends Test1 implements Countable {};
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.php meta.class.php - meta.class meta.class
 //      ^ keyword.other.new.php
 //          ^ keyword.declaration.class
-//               ^^^^^^^^^^^^^^^^^^ meta.function-call.php
+//               ^^^^^^^^^^^^^^^^^^ meta.group.php
 //               ^ punctuation.section.group.begin.php
 //                ^ variable.other.php
 //                       ^ punctuation.separator.comma
@@ -1131,8 +1151,73 @@ $anon = new class($param1, $param2) extends Test1 implements Countable {};
 //                                                                     ^^ meta.class.php
 //                                                                     ^^ meta.block.php
 
+$anon = new /* comment */ #[anno] class($param1, $param2) extends Test1 implements Countable {};
+//      ^^^ keyword.other.new.php
+//          ^^^^^^^^^^^^^ comment.block.php
+//                        ^^^^^^^ meta.attribute.php
+//                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.php meta.class.php - meta.class meta.class
+//                                ^^^^^ keyword.declaration.class
+//                                     ^^^^^^^^^^^^^^^^^^ meta.group.php
+//                                     ^ punctuation.section.group.begin.php
+//                                      ^ variable.other.php
+//                                             ^ punctuation.separator.comma
+//                                               ^ variable.other.php
+//                                                      ^ punctuation.section.group.end.php
+//                                                        ^ storage.modifier.extends.php
+//                                                                ^^^^^ meta.path
+//                                                                 ^ entity.other.inherited-class.php
+//                                                                      ^ storage.modifier.implements.php
+//                                                                                 ^^^^^^^^^ meta.path
+//                                                                                 ^ entity.other.inherited-class.php
+//                                                                                           ^^ meta.class.php
+//                                                                                           ^^ meta.block.php
+
 $user_1 = new User("John", "a@b.com");
+//        ^^^^^^^^ meta.instantiation.php - meta.group
+//                ^^^^^^^^^^^^^^^^^^^ meta.instantiation.php meta.group.php
+//                                   ^ - meta.instantiation - meta.group
+//        ^^^ keyword.other.new.php
+//            ^^^^ support.class.php
+//                ^ punctuation.section.group.begin.php
+//                 ^^^^^^ meta.string.php string.quoted.double.php
 //                       ^ punctuation.separator.comma
+//                         ^^^^^^^^^ meta.string.php string.quoted.double.php
+//                                  ^ punctuation.section.group.end.php
+//                                   ^ punctuation.terminator.expression.php
+
+$user_1 = new /* comment */ #[anno] User("John", "a@b.com");
+//        ^^^^^^^^^^^^^^^^^^ meta.instantiation.php - meta.attribute
+//                          ^^^^^^^ meta.instantiation.php meta.attribute.php
+//                                 ^^^^^  meta.instantiation.php - meta.attribute - meta.group
+//                                      ^^^^^^^^^^^^^^^^^^^ meta.instantiation.php meta.group.php
+//                                                         ^ - meta.instantiation - meta.group
+//        ^^^ keyword.other.new.php
+//            ^^^^^^^^^^^^^ comment.block.php
+//                          ^^^^^^^ meta.attribute.php
+//                                  ^^^^ support.class.php
+//                                      ^ punctuation.section.group.begin.php
+//                                       ^^^^^^ meta.string.php string.quoted.double.php
+//                                             ^ punctuation.separator.comma
+//                                               ^^^^^^^^^ meta.string.php string.quoted.double.php
+//                                                        ^ punctuation.section.group.end.php
+//                                                         ^ punctuation.terminator.expression.php
+
+$user_1 = new /* comment */ #[anno] $cls("John", "a@b.com");
+//        ^^^^^^^^^^^^^^^^^^ meta.instantiation.php - meta.attribute
+//                          ^^^^^^^ meta.instantiation.php meta.attribute.php
+//                                 ^^^^^  meta.instantiation.php - meta.attribute - meta.group
+//                                      ^^^^^^^^^^^^^^^^^^^ meta.instantiation.php meta.group.php
+//                                                         ^ - meta.instantiation - meta.group
+//        ^^^ keyword.other.new.php
+//            ^^^^^^^^^^^^^ comment.block.php
+//                          ^^^^^^^ meta.attribute.php
+//                                  ^^^^ variable.other.php
+//                                      ^ punctuation.section.group.begin.php
+//                                       ^^^^^^ meta.string.php string.quoted.double.php
+//                                             ^ punctuation.separator.comma
+//                                               ^^^^^^^^^ meta.string.php string.quoted.double.php
+//                                                        ^ punctuation.section.group.end.php
+//                                                         ^ punctuation.terminator.expression.php
 
     function noReturnType(array $param1, int $param2) {}
 //  ^ keyword.declaration.function


### PR DESCRIPTION
This PR fixes an issue with class declarations in anonymous class instantiation statements not receiving proper scopes if `class` keyword is preceeded by a block comment or attribute.