### PR TITLE
[C/C++/Objc/ObjC++] Tweak enumeration constant assignments

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -338,6 +338,12 @@ contexts:
     - include: scope:source.c#label
     - match: '{{identifier}}'
       scope: entity.name.constant.c++
+      push: constant-value
+    - include: expressions
+
+  constant-value:
+    - match: (?=[,;}])
+      pop: true
     - include: expressions
 
   expressions:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -693,6 +693,12 @@ contexts:
       push: data-structures
     - match: '{{identifier}}'
       scope: entity.name.constant.c
+      push: constant-value
+    - include: expressions
+
+  constant-value:
+    - match: (?=[,;}])
+      pop: true
     - include: expressions
 
   block:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -30,6 +30,16 @@ enum { kFoo, kBar };
 /*     ^ entity.name.constant.c */
 /*           ^ entity.name.constant.c */
 
+enum { kFoo = FOO, kBar = BAR };
+/* <- keyword.declaration */
+/*     ^^^^ entity.name.constant.c */
+/*          ^ keyword.operator.assignment.c */
+/*            ^^^ - entity.name.constant */
+/*               ^ punctuation.separator.c */
+/*                 ^^^^ entity.name.constant.c */
+/*                      ^ keyword.operator.assignment.c */
+/*                        ^^^ - entity.name.constant */
+
 typedef enum state { DEAD, ALIVE } State;
 /* <- keyword.declaration
 /*           ^ entity.name.enum */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2016,8 +2016,14 @@ private:
 /*  ^ meta.enum punctuation.section.block.begin */
         A = 1,
 /*      ^ entity.name.constant.c++ */
-        B = 20 / 5
+/*           ^ punctuation.separator.c++ */
+        B = 20 / 5,
 /*      ^ entity.name.constant.c++ */
+/*                ^ punctuation.separator.c++ */
+        C = FOO
+/*      ^ entity.name.constant.c++ */
+/*        ^ keyword.operator.assignment.c */
+/*          ^^^^ - entity.name */
     }
 /*  ^ meta.enum punctuation.section.block.end */
 /*   ^ - meta.enum */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -122,6 +122,12 @@ contexts:
     - include: scope:source.c#label
     - match: '{{identifier}}'
       scope: entity.name.constant.objc++
+      push: constant-value
+    - include: expressions
+
+  constant-value:
+    - match: (?=[,;}])
+      pop: true
     - include: expressions
 
   expressions:

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -789,6 +789,12 @@ contexts:
       push: data-structures
     - match: '{{identifier}}'
       scope: entity.name.constant.objc
+      push: constant-value
+    - include: expressions
+
+  constant-value:
+    - match: (?=[,;}])
+      pop: true
     - include: expressions
 
   block:

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1968,8 +1968,14 @@ private:
 /*  ^ meta.enum punctuation.section.block.begin */
         A = 1,
 /*      ^ entity.name.constant.objc++ */
-        B = 20 / 5
+/*           ^ punctuation.separator.objc++ */
+        B = 20 / 5,
 /*      ^ entity.name.constant.objc++ */
+/*                ^ punctuation.separator.objc++ */
+        C = FOO
+/*      ^ entity.name.constant.objc++ */
+/*        ^ keyword.operator.assignment.c */
+/*          ^^^^ - entity.name */
     }
 /*  ^ meta.enum punctuation.section.block.end */
 /*   ^ - meta.enum */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -30,6 +30,16 @@ enum { kFoo, kBar };
 /*     ^ entity.name.constant.objc */
 /*           ^ entity.name.constant.objc */
 
+enum { kFoo = FOO, kBar = BAR };
+/* <- keyword.declaration */
+/*     ^^^^ entity.name.constant.objc */
+/*          ^ keyword.operator.assignment.c */
+/*            ^^^ - entity.name.constant */
+/*               ^ punctuation.separator.objc */
+/*                 ^^^^ entity.name.constant.objc */
+/*                      ^ keyword.operator.assignment.c */
+/*                        ^^^ - entity.name.constant */
+
 typedef enum state { DEAD, ALIVE } State;
 /* <- keyword.declaration
 /*           ^ entity.name.enum */


### PR DESCRIPTION
This commit fixes enum r-values from being scoped `entity.name.constant`.