### PR TITLE
[TypeScript] Move some syntax tests to the non-TSX file.

### DIFF
--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1219,18 +1219,3 @@ const x = {
 //  ^^^^^^^^ storage.modifier
 //           ^^^ variable.other.readwrite
 };
-
-    <any>(<any>a);
-//  ^^^^^ meta.assertion
-//  ^ punctuation.definition.assertion.begin
-//   ^^^ support.type.any
-//      ^ punctuation.definition.assertion.end
-//       ^^^^^^^^ meta.group
-//       ^ punctuation.section.group.begin
-//        ^^^^^ meta.assertion
-//        ^ punctuation.definition.assertion.begin
-//         ^^^ support.type.any
-//            ^ punctuation.definition.assertion.end
-//             ^ variable.other.readwrite
-//              ^ punctuation.section.group.end
-//               ^ punctuation.terminator.statement

--- a/JavaScript/tests/syntax_test_typescript_not_tsx.ts
+++ b/JavaScript/tests/syntax_test_typescript_not_tsx.ts
@@ -34,3 +34,18 @@ let strLength: number = (<string>someValue).length; // </string>
 //    ^ punctuation.definition.generic.end
 //     ^^ meta.function.parameters
 //        ^^ keyword.declaration.function.arrow
+
+    <any>(<any>a);
+//  ^^^^^ meta.assertion
+//  ^ punctuation.definition.assertion.begin
+//   ^^^ support.type.any
+//      ^ punctuation.definition.assertion.end
+//       ^^^^^^^^ meta.group
+//       ^ punctuation.section.group.begin
+//        ^^^^^ meta.assertion
+//        ^ punctuation.definition.assertion.begin
+//         ^^^ support.type.any
+//            ^ punctuation.definition.assertion.end
+//             ^ variable.other.readwrite
+//              ^ punctuation.section.group.end
+//               ^ punctuation.terminator.statement


### PR DESCRIPTION
Since these tests use the old-style assertion syntax, which doesn't work in TSX, these tests are causing test failures in JS Custom, which runs the TSX syntax against `syntax_test_typescript.ts`, but not `syntax_test_typescript_not_tsx.ts`.

See also https://github.com/sublimehq/sublime_text/issues/3998.