### PR TITLE
[TypeScript] Implement generic function types

### DIFF
--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -57,7 +57,7 @@ contexts:
     - match: 'extends{{jsx_identifier_break}}'
       scope: entity.other.attribute-name.js
       set:
-        - match: (?=>)
+        - match: (?=[>=])
           pop: true
         - match: (?=\S)
           fail: arrow-function

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -822,8 +822,6 @@ contexts:
             - ts-type-expression-begin
 
   ts-type-expression-begin:
-    - match: (?=<)
-      pop: 3
     - match: keyof{{identifier_break}}
       scope: keyword.operator.type.js
     - match: typeof{{identifier_break}}
@@ -861,6 +859,11 @@ contexts:
     - include: ts-type-special
     - include: ts-type-primitive
     - include: ts-type-basic
+
+    - match: (?=\<)
+      set:
+        - ts-type-function
+        - ts-type-parameter-list
 
     - match: (?=\()
       pop: true

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -540,6 +540,7 @@ contexts:
             - ts-type-parameter-default
             - ts-type-parameter-constraint
         - include: comma-separator
+        - include: else-pop
     - include: else-pop
 
   ts-type-parameter-constraint:
@@ -863,6 +864,7 @@ contexts:
     - match: (?=\<)
       set:
         - ts-type-function
+        - ts-generic-function-type-check
         - ts-type-parameter-list
 
     - match: (?=\()
@@ -880,6 +882,12 @@ contexts:
       scope: keyword.operator.arithmetic.js
 
     - include: else-pop
+
+  ts-generic-function-type-check:
+    - match: (?=\()
+      pop: true
+    - match: (?=\S)
+      pop: 2
 
   ts-type-tuple:
     - match: \[

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -530,17 +530,24 @@ contexts:
     - match: \<(?!<)
       scope: punctuation.definition.generic.begin.js
       set:
-        - meta_scope: meta.generic.js
-        - match: \>
-          scope: punctuation.definition.generic.end.js
-          pop: true
-        - match: '{{identifier_name}}'
-          scope: variable.parameter.generic.js
-          push:
-            - ts-type-parameter-default
-            - ts-type-parameter-constraint
-        - include: comma-separator
-        - include: else-pop
+        - - meta_scope: meta.generic.js
+          - match: \>
+            scope: punctuation.definition.generic.end.js
+            pop: true
+
+          - match: ','
+            scope: punctuation.separator.comma
+            push: ts-type-parameter-list-item
+          - include: else-pop
+        - ts-type-parameter-list-item
+    - include: else-pop
+
+  ts-type-parameter-list-item:
+    - match: '{{identifier_name}}'
+      scope: variable.parameter.generic.js
+      set:
+        - ts-type-parameter-default
+        - ts-type-parameter-constraint
     - include: else-pop
 
   ts-type-parameter-constraint:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -530,19 +530,22 @@ contexts:
     - match: \<(?!<)
       scope: punctuation.definition.generic.begin.js
       set:
-        - - meta_scope: meta.generic.js
-          - match: \>
-            scope: punctuation.definition.generic.end.js
-            pop: true
-
-          - match: ','
-            scope: punctuation.separator.comma
-            push: ts-type-parameter-list-item
-          - include: else-pop
-        - ts-type-parameter-list-item
+        - ts-type-parameter-list-tail
+        - ts-type-parameter-list-head
     - include: else-pop
 
-  ts-type-parameter-list-item:
+  ts-type-parameter-list-tail:
+    - meta_scope: meta.generic.js
+    - match: \>
+      scope: punctuation.definition.generic.end.js
+      pop: true
+
+    - match: ','
+      scope: punctuation.separator.comma
+      push: ts-type-parameter-list-head
+    - include: else-pop
+
+  ts-type-parameter-list-head:
     - match: '{{identifier_name}}'
       scope: variable.parameter.generic.js
       set:

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -234,3 +234,14 @@ if (a < b || c <= d) {}
 //                ^ punctuation.definition.tag.end
 //                 ^ meta.tag punctuation.definition.tag.end
 //                  ^ punctuation.terminator.statement
+
+    true ? (a) : <foo />;
+//  ^^^^ constant.language.boolean.true
+//       ^ keyword.operator.ternary
+//         ^^^ meta.group
+//             ^ keyword.operator.ternary
+//               ^^^^^^^ meta.jsx meta.tag
+//               ^ punctuation.definition.tag.begin
+//                ^^^ meta.tag.name entity.name.tag
+//                    ^^ punctuation.definition.tag.end
+//                      ^ punctuation.terminator.statement

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -217,6 +217,7 @@ if (a < b || c <= d) {}
 //     ^^^^^^^ entity.other.attribute-name
 //            ^ punctuation.separator.key-value
 //             ^^^ string.quoted.double
+//                 ^^^^^^^^^ - meta.function
 //                       ^^^ meta.interpolation
 //                               ^^^^ meta.tag
 //                                 ^ meta.tag.name entity.name.tag

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -257,3 +257,20 @@ if (a < b || c <= d) {}
 //                ^^^ meta.tag.name entity.name.tag
 //                    ^^ punctuation.definition.tag.end
 //                      ^ punctuation.terminator.statement
+
+    true ? (a) : <T foo="a">() => {} => {} : null; // </T>;
+//  ^^^^ constant.language.boolean.true
+//       ^ keyword.operator.ternary
+//         ^^^ meta.group
+//          ^ variable.other.readwrite
+//             ^ keyword.operator.ternary
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
+//                ^ meta.tag.name entity.name.tag
+//                  ^^^ entity.other.attribute-name
+//                     ^ punctuation.separator.key-value
+//                      ^^^ string.quoted.double
+//                                ^^ meta.interpolation
+//                                      ^^ meta.interpolation
+//                                                    ^^^^ meta.tag
+//                                                      ^ meta.tag.name entity.name.tag
+//                                                        ^ punctuation.terminator.statement

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -203,12 +203,24 @@ if (a < b || c <= d) {}
 //     ^^^^^^^ meta.tag.attributes entity.other.attribute-name
 //            ^ punctuation.definition.tag.end
 
-    <T extends {}>() => {}; // </T>;
-//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//  ^^^^^^^^^^^^^^ meta.function meta.generic
+    <T extends "s">() => {x}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^^^ meta.function meta.generic
 //   ^ variable.parameter.generic
 //     ^^^^^^^ storage.modifier.extends
-//             ^^ meta.function meta.generic meta.mapping
+//             ^^^ meta.function meta.generic
+
+    <T extends="s">() => {x}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
+//  ^^^^^^^^^^^^^^^ meta.tag
+//   ^ meta.tag.name entity.name.tag
+//     ^^^^^^^ entity.other.attribute-name
+//            ^ punctuation.separator.key-value
+//             ^^^ string.quoted.double
+//                       ^^^ meta.interpolation
+//                               ^^^^ meta.tag
+//                                 ^ meta.tag.name entity.name.tag
+//                                   ^ punctuation.terminator.statement
 
     <T {...}>() => {};</T>;
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.jsx

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1244,21 +1244,26 @@ const x = {
 //              ^ punctuation.section.group.end
 //               ^ punctuation.terminator.statement
 
-    true ? (a) : <T>() => T => {} : null;
+    true ? (a) : <T,foo="a">() => {} => {} : null; // </T>;
 //  ^^^^ constant.language.boolean.true
 //       ^ keyword.operator.ternary
-//         ^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 //         ^^^ meta.function.parameters
 //          ^ meta.binding.name variable.parameter.function
 //             ^ punctuation.separator.type
-//               ^^^^^^^^^^  meta.type
-//               ^^^ meta.generic
+//              ^^^^^^^^^^^^^^^^^^^^^ meta.type
+//               ^^^^^^^^^^^ meta.generic
 //                ^ variable.parameter.generic
-//                  ^^ meta.group
-//                     ^^ keyword.declaration.function
-//                        ^ support.class
-//                          ^^ keyword.declaration.function.arrow
-//                             ^^ meta.block
-//                                ^ keyword.operator.ternary
-//                                  ^^^^ constant.language.null
-//                                      ^ punctuation.terminator.statement
+//                 ^ punctuation.separator.comma
+//                  ^^^ variable.parameter.generic
+//                     ^ keyword.operator.assignment
+//                      ^^^ meta.string string.quoted.double
+//                          ^^ meta.group
+//                             ^^ keyword.declaration.function
+//                                ^^ meta.mapping
+//                                   ^^ keyword.declaration.function.arrow
+//                                      ^^ meta.block
+//                                         ^ keyword.operator.ternary
+//                                           ^^^^ constant.language.null
+//                                               ^ punctuation.terminator.statement
+//                                                 ^^^^^^^^ comment.line.double-slash

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1063,6 +1063,15 @@ let x: ( ... foo : any ) => any;
 //               ^ punctuation.separator.type
 //                 ^^^ support.type.any
 
+let x: < T > ( ... foo : any ) => any;
+//     ^^^^^ meta.generic
+//       ^ variable.parameter.generic
+//           ^^^^^^^^^^^^^^^^^ meta.group
+//             ^^^ keyword.operator.spread
+//                 ^^^ variable.parameter
+//                     ^ punctuation.separator.type
+//                       ^^^ support.type.any
+
 let x: () => T
     U
 //  ^ variable.other.constant - meta.type

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1243,3 +1243,22 @@ const x = {
 //             ^ variable.other.readwrite
 //              ^ punctuation.section.group.end
 //               ^ punctuation.terminator.statement
+
+    true ? (a) : <T>() => T => {} : null;
+//  ^^^^ constant.language.boolean.true
+//       ^ keyword.operator.ternary
+//         ^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//         ^^^ meta.function.parameters
+//          ^ meta.binding.name variable.parameter.function
+//             ^ punctuation.separator.type
+//               ^^^^^^^^^^  meta.type
+//               ^^^ meta.generic
+//                ^ variable.parameter.generic
+//                  ^^ meta.group
+//                     ^^ keyword.declaration.function
+//                        ^ support.class
+//                          ^^ keyword.declaration.function.arrow
+//                             ^^ meta.block
+//                                ^ keyword.operator.ternary
+//                                  ^^^^ constant.language.null
+//                                      ^ punctuation.terminator.statement


### PR DESCRIPTION
There were no tests for the `match: (?=<)` /  `pop: 3` rule. I *think* it was there for cases like `true ? (a) : <foo />`. I've added a test for that, and a new fix compatible with generic function types, and then a new fix for that fix.