### PR TITLE
[PHP] Fix SQL string termination

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -2014,6 +2014,7 @@ contexts:
       escape_captures:
         0: meta.string.php string.quoted.single.php punctuation.definition.string.end.php
     - include: nested-expressions
+    - include: else-pop
 
 ###[ BUILTINS ]###############################################################
 

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1944,6 +1944,10 @@ $statement = match ($this->lexer->lookahead['type']) {
     default => $this->syntaxError('UPDATE or DELETE'),
 //  ^^^^^^^ keyword.control
 //          ^^ keyword.operator.key
+//                               ^^^^^^^^^^^^^^^^^^^^ meta.group.php
+//                               ^ punctuation.section.group.begin.php
+//                                ^^^^^^^^^^^^^^^^^^ meta.string.php
+//                                                  ^ punctuation.section.group.end.php
 };
 
 $non_sql = "NO SELECT HIGHLIGHTING!";


### PR DESCRIPTION
This PR adds a bailout to continued SQL strings to ensure to pop
the expression part off stack if an unmatched token is found.

Note: Adding `else-pop` to `nested-expressions` doesn't yet work.
      Some refactorings are required before.