### PR TITLE
[Haskell] Enable indexing of constructors and types

### DIFF
--- a/Haskell/Indexed Reference List.tmPreferences
+++ b/Haskell/Indexed Reference List.tmPreferences
@@ -4,6 +4,7 @@
 	<key>scope</key>
 	<string>
 		source.haskell keyword.operator - meta.function.identifier,
+		source.haskell storage.type,
 		source.haskell variable.other
 	</string>
 	<key>settings</key>

--- a/Haskell/Indexed Symbol List.tmPreferences
+++ b/Haskell/Indexed Symbol List.tmPreferences
@@ -3,6 +3,7 @@
 <dict>
 	<key>scope</key>
 	<string>
+		source.haskell entity.name.constant,
 		source.haskell entity.name.type,
 		source.haskell meta.function.identifier meta.prefix keyword.operator
 	</string>


### PR DESCRIPTION
Fixes #3322

This PR...

1. adds `entity.name.constant` to indexed symbols which enables `Goto Definition` for constructors
2. adds `storage type` to indexed references to enable `Goto Reference` for data types.