### PR TITLE
[Haskell] Fix data definition termination

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -805,6 +805,7 @@ contexts:
       set: constructor-body
 
   constructor-body:
+    - include: declaration-end
     - include: type-lists
     - include: type-parens
     - include: ident-namespaces
@@ -817,7 +818,7 @@ contexts:
     # - constructor separator
     # - record block
     # - any (key)word
-    - match: (?=[;|{\w])
+    - match: (?=[|{\w])
       pop: 1
     - match: (?=\S)
       fail: constructor-or-type
@@ -1023,14 +1024,7 @@ contexts:
 ###[ DECLARATION TYPE EXPRESSIONS ]############################################
 
   declaration-type:
-    - match: (?=;|=(?!{{symbol}})|{{operator_double_colon}}|{{operator_left_arrow}}|{{reserved_id}})
-      pop: 1
-    # pop context if beginning of a line looks like a function declaration or assignment expression
-    - match: ^\s*(?={{var_id}})
-      branch_point: declaration-type-end
-      branch:
-        - declaration-type-variable
-        - immediately-pop2
+    - include: declaration-end
     - include: right-arrow-operators
     - include: infix-quoted-operators
     - include: infix-operators
@@ -1044,6 +1038,16 @@ contexts:
     - match: \S
       scope: invalid.illegal.haskell
 
+  declaration-end:
+    - match: (?=;|=(?!{{symbol}})|{{operator_double_colon}}|{{operator_left_arrow}}|{{reserved_id}})
+      pop: 1
+    # pop context if beginning of a line looks like a function declaration or assignment expression
+    - match: ^(?=\s*{{var_id}})
+      branch_point: declaration-type-end
+      branch:
+        - declaration-type-variable
+        - immediately-pop2
+
   declaration-type-variable:
     - match: '{{var_id}}'
       scope: variable.other.haskell
@@ -1052,8 +1056,12 @@ contexts:
       set: declaration-type-variable-after
 
   declaration-type-variable-after:
-    - match: (?==(?!{{symbol}})|{{operator_double_colon}}|{{operator_left_arrow}})
+    - match: (?=,|=(?!{{symbol}})|{{operator_double_colon}}|{{operator_left_arrow}})
       fail: declaration-type-end
+    - include: ident-anonymous
+    - include: ident-namespaces
+    - include: ident-types
+    - include: ident-variables
     - include: else-pop
 
 ###[ TYPE EXPRESSIONS ]########################################################

--- a/Haskell/tests/syntax_test_haskell.hs
+++ b/Haskell/tests/syntax_test_haskell.hs
@@ -1535,6 +1535,19 @@
 --       ^^ punctuation.separator.type.haskell
 --          ^^^^ support.type.prelude.haskell
 
+    -- make sure not to break following function definitions
+    data Type a = Type1 :$ Type2
+    foo, bar, baz :: Type
+--  ^^^^^^^^^^^^^^^^^^^^^ - meta.declaration.data
+--  ^^^^^^^^^^^^^^ meta.function.identifier.haskell
+--  ^^^ entity.name.function.haskell
+--     ^ punctuation.separator.sequence.haskell
+--       ^^^ entity.name.function.haskell
+--          ^ punctuation.separator.sequence.haskell
+--            ^^^ entity.name.function.haskell
+--                ^^ punctuation.separator.type.haskell
+--                   ^^^^ support.type.prelude.haskell
+
     -- make sure not to break assignment expression
     data Type a = Con Type1 !Type2 a
     var = Con
@@ -1561,12 +1574,75 @@
 
     -- make sure not to break assignment expression
     data Type a = Type1 :$ Type2
+    foo bar baz = Con
+--  ^^^^^^^^^^^^^^^^^ - meta.declaration.data
+--  ^^^ variable.other.haskell
+--      ^^^ variable.other.haskell
+--          ^^^ variable.other.haskell
+--              ^ keyword.operator.haskell
+--                ^^^ storage.type.haskell
+
+    -- make sure not to break assignment expression
+    data Type a = Type1 :$ Type2
     var <- True = Con
 --  ^^^^^^^^^^^^^^^^^ - meta.declaration.data
 --  ^^^ variable.other.haskell
 --      ^^ keyword.operator.arrow.haskell
 --              ^ keyword.operator.haskell
 --                ^^^ storage.type.haskell
+
+    -- make sure not to break assignment expression
+    data Type a = Type1 :$ Type2
+    foo bar baz <- True = Con
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.declaration.data
+--  ^^^ variable.other.haskell
+--      ^^^ variable.other.haskell
+--          ^^^ variable.other.haskell
+--              ^^ keyword.operator.arrow.haskell
+--                 ^^^^ support.constant.prelude.haskell
+--                      ^ keyword.operator.haskell
+--                        ^^^ storage.type.haskell
+
+    -- make sure not to break constructor by following function definition
+    data Type
+        = Foo                    -- comment
+        | Bar Bool {- comment -} -- comment
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.data.haskell
+--      ^ punctuation.separator.sequence.haskell
+--        ^^^ entity.name.constant.haskell
+--            ^^^^ support.type.prelude.haskell
+--                 ^^^^^^^^^^^^^ comment.block.haskell
+--                               ^^^^^^^^^^^ comment.line.double-dash.haskell
+    foo, bar, baz :: Mode
+--  ^^^^^^^^^^^^^^^^^^^^^ - meta.declaration.data
+--  ^^^^^^^^^^^^^^ meta.function.identifier.haskell
+--  ^^^ entity.name.function.haskell
+--     ^ punctuation.separator.sequence.haskell
+--       ^^^ entity.name.function.haskell
+--          ^ punctuation.separator.sequence.haskell
+--            ^^^ entity.name.function.haskell
+--                ^^ punctuation.separator.type.haskell
+--                   ^^^^ storage.type.haskell
+
+    -- make sure not to break constructor by following assignment expression
+    data Type
+        = Foo                    -- comment
+        | Bar Bool {- comment -} -- comment
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.data.haskell
+--      ^ punctuation.separator.sequence.haskell
+--        ^^^ entity.name.constant.haskell
+--            ^^^^ support.type.prelude.haskell
+--                 ^^^^^^^^^^^^^ comment.block.haskell
+--                               ^^^^^^^^^^^ comment.line.double-dash.haskell
+    foo bar baz <- True = Con
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.declaration.data
+--  ^^^ variable.other.haskell
+--      ^^^ variable.other.haskell
+--          ^^^ variable.other.haskell
+--              ^^ keyword.operator.arrow.haskell
+--                 ^^^^ support.constant.prelude.haskell
+--                      ^ keyword.operator.haskell
+--                        ^^^ storage.type.haskell
 
 -- [ DEFAULT DECLARATIONS ] ---------------------------------------------------
 


### PR DESCRIPTION
This commit...

1. fixes an edge case related to multiple l-values not terminating a
   type expression as expected.

   Improve "new statement begins" detection on the following line,
   beginning with lower case identifiers.

2. fixes constructor definition being broken if followed by assignment
   or function.
   
   Pop `constructor-body` off stack, gracefully if the end of the whole
   type expression is detected via `declaration-end`.

A type expression context is popped off stack if an unexpected
operator or the beginning of a new statement is detected via
`declaration-end` context.