### PR TITLE
[Rails] Set default_extension in sublime-settings

### DIFF
--- a/Rails/Ruby (Rails).sublime-settings
+++ b/Rails/Ruby (Rails).sublime-settings
@@ -1,0 +1,5 @@
+{
+  // This gives precedence over the first file_extensions entry in the
+  // "Ruby (Rails).sublime-syntax" file.
+  "default_extension": "rb"
+}


### PR DESCRIPTION
Set the default file extension to "rb" for new "Ruby (Rails)" files.

See https://github.com/sublimehq/sublime_text/issues/5373 for details.

The idea comes from @Ultra-Instinct-05 and @jfcherng .

Thanks for any feedback.