### PR TITLE
[Haskell] Add HSX support

### DIFF
--- a/Haskell/Embeddings/HTML (for HSX).sublime-syntax
+++ b/Haskell/Embeddings/HTML (for HSX).sublime-syntax
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+scope: text.html.embedded.haskell
+version: 2
+hidden: true
+
+extends: Packages/HTML/HTML.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: haskell-interpolations
+
+  cdata-content:
+    - meta_prepend: true
+    - meta_include_prototype: false
+    - include: haskell-string-interpolations
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: haskell-string-interpolations
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: haskell-string-interpolations
+
+  haskell-string-interpolations:
+    - meta_include_prototype: false
+    - match: (?=\{)
+      push: haskell-string-interpolation-body
+
+  haskell-string-interpolation-body:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - include: haskell-interpolations
+    - include: immediately-pop
+
+  haskell-interpolations:
+    - meta_include_prototype: false
+    - match: \{
+      scope: meta.interpolation.haskell punctuation.section.interpolation.begin.haskell
+      embed: Packages/Haskell/Haskell.sublime-syntax
+      embed_scope: meta.interpolation.haskell source.haskell.embedded.html
+      escape: \}
+      escape_captures:
+        0: meta.interpolation.haskell punctuation.section.interpolation.end.haskell

--- a/Haskell/Embeddings/HTML (for HSX).sublime-syntax
+++ b/Haskell/Embeddings/HTML (for HSX).sublime-syntax
@@ -1,5 +1,11 @@
 %YAML 1.2
 ---
+# HSX (Haskell Source with XML) allows literal XML syntax in Haskell source code.
+# - https://hackage.haskell.org/package/hsx
+#
+# Note:
+# This package uses HTML instead as it is what other editors seem to use.
+# It's probably the most common use case for Haskell Web Devs.
 scope: text.html.embedded.haskell
 version: 2
 hidden: true

--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -1183,6 +1183,7 @@ contexts:
 ###[ BRACKETS ]################################################################
 
   brackets:
+    - include: hsx-quotes
     - include: typed-quotes
     - include: overloaded-quotes
     - include: empty-lists
@@ -1253,6 +1254,19 @@ contexts:
     - match: \|\]
       scope: meta.quoted.quasi.haskell punctuation.section.quoted.end.haskell
       pop: 1
+
+  hsx-quotes:
+    - match: (\[)(hsx)(\|)
+      scope: meta.quoted.quasi.haskell
+      captures:
+        1: punctuation.section.quoted.begin.haskell
+        2: variable.function.quasi-quoter.haskell
+        3: punctuation.section.quoted.haskell
+      embed: scope:text.html.embedded.haskell
+      embed_scope: meta.quoted.quasi.haskell text.html.embedded.haskell
+      escape: \|\]
+      escape_captures:
+        0: meta.quoted.quasi.haskell punctuation.section.quoted.end.haskell
 
   overloaded-quotes:
     # https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0246-overloaded-bracket.rst

--- a/Haskell/tests/syntax_test_haskell.hs
+++ b/Haskell/tests/syntax_test_haskell.hs
@@ -3097,6 +3097,87 @@ main = do
 --      ^^^ punctuation.section.quoted.begin.haskell
 --                      ^^^ punctuation.section.quoted.end.haskell
 
+    {- HSX Tests -}
+    html = [hsx|
+--         ^^^^^^ meta.quoted.quasi.haskell
+--         ^ punctuation.section.quoted.begin.haskell
+--          ^^^ variable.function.quasi-quoter.haskell
+--             ^ punctuation.section.quoted.haskell
+--              ^ text.html.embedded.haskell
+        <html>
+        <head>
+        <style data-id={
+--      ^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell
+--      ^^^^^^^ meta.tag - meta.attribute-with-value
+--             ^^^^^^^^ meta.tag meta.attribute-with-value.html - meta.string - meta.interpolation
+--                     ^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.haskell
+--      ^ punctuation.definition.tag.begin.html
+--       ^^^^^ entity.name.tag.style.html
+--             ^^^^^^^ entity.other.attribute-name.html
+--                    ^ punctuation.separator.key-value.html
+--                     ^ punctuation.section.interpolation.begin.haskell
+            -- This is Haskell
+            show "my-id"
+--      ^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.haskell source.haskell.embedded.html
+--          ^^^^ support.function.prelude.haskell
+--               ^^^^^^^ meta.string.haskell string.quoted.double.haskell
+        }>
+--     ^^^ meta.quoted.quasi.haskell text.html.embedded.haskell meta.tag
+--        ^ meta.quoted.quasi.haskell text.html.embedded.haskell - meta.tag
+--     ^^ meta.attribute-with-value.html meta.string.html meta.interpolation.haskell
+--      ^ punctuation.section.interpolation.end.haskell
+--       ^ punctuation.definition.tag.end.html
+
+            p {
+--            ^^ source.css.embedded.html meta.property-list.css meta.block.css
+--            ^ punctuation.section.block.begin.css
+                font-family: Helvetica;
+--              ^^^^^^^^^^^ meta.property-name.css support.type.property-name.css
+            }
+--          ^ source.css.embedded.html meta.property-list.css meta.block.css punctuation.section.block.end.css
+        </style>
+--      ^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell meta.tag
+
+        <script data-id={
+--      ^^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell
+--      ^^^^^^^^ meta.tag - meta.attribute-with-value
+--              ^^^^^^^^ meta.tag meta.attribute-with-value.html - meta.string - meta.interpolation
+--                      ^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.haskell
+--      ^ punctuation.definition.tag.begin.html
+--       ^^^^^^ entity.name.tag.script.html
+--              ^^^^^^^ entity.other.attribute-name.html
+--                     ^ punctuation.separator.key-value.html
+--                      ^ punctuation.section.interpolation.begin.haskell
+            -- This is Haskell
+            show "my-id"
+--      ^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.haskell source.haskell.embedded.html
+--          ^^^^ support.function.prelude.haskell
+--               ^^^^^^^ meta.string.haskell string.quoted.double.haskell
+        }>
+            function test() { console.log("js"); }
+--         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell source.js.embedded.html
+--          ^^^^^^^^ keyword.declaration.function.js
+--                   ^^^^ entity.name.function.js
+--                          ^^^^^^^^^^^^^^^^^^^^^^ meta.function.js meta.block.js
+--                          ^ punctuation.section.block.begin.js
+--                                               ^ punctuation.section.block.end.js
+        </script>
+--      ^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell meta.tag
+
+        <p><a href="{pathTo NewPostAction}">title</a></p>
+--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.quoted.quasi.haskell text.html.embedded.haskell
+--                 ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline meta.attribute-with-value.href.html meta.string.html
+--                 ^ string.quoted.double.html punctuation.definition.string.begin.html
+--                  ^ meta.interpolation.haskell punctuation.section.interpolation.begin.haskell
+--                   ^^^^^^^^^^^^^^^^^^^^ meta.interpolation.haskell source.haskell.embedded.html
+--                                       ^ meta.interpolation.haskell punctuation.section.interpolation.end.haskell
+--                                        ^ string.quoted.double.html punctuation.definition.string.end.html
+    |]
+-- ^ meta.quoted.quasi.haskell text.html.embedded.haskell
+--  ^^ meta.quoted.quasi.haskell punctuation.section.quoted.end.haskell - text.html
+--    ^ - meta.quote
+
+
 -- [ IDENTS ] -----------------------------------------------------------------
 
     _


### PR DESCRIPTION
This PR proposes to add support for `[hsx|...|]` quasi-quotes in Haskell.

HSX supports XML content, but this commit embedds HTML instead as it is
what other editors seem to use. It's probably the most common use case
for Haskell Web Devs.

see: https://hackage.haskell.org/package/hsx