### PR TITLE
[Python] Hide non-file extensions

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -16,16 +16,18 @@ file_extensions:
   - pxi.in
   - rpy
   - cpy
-  - SConstruct
-  - SConscript
   - gyp
   - gypi
-  - Snakefile
-  - smk
   - vpy
+  - smk
   - wscript
   - bazel
   - bzl
+
+hidden_file_extensions:
+  - SConstruct
+  - SConscript
+  - Snakefile
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
This commit moves some those items into hidden_file_extensions, which
are unlikely to be used as normal file extensions.