### PR TITLE
[Groovy] Hide non-file extensions

### DIFF
--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -8,6 +8,8 @@ file_extensions:
   - groovy
   - gvy
   - gradle
+
+hidden_file_extensions:
   - Jenkinsfile
 
 first_line_match: |-


### PR DESCRIPTION
This commit moves some those items into hidden_file_extensions, which
are unlikely to be used as normal file extensions.