### PR TITLE
[Makefile] Hide non-file extensions

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -12,14 +12,16 @@ name: Makefile
 scope: source.makefile
 
 file_extensions:
+  - mk
+  - mak
   - make
+
+hidden_file_extensions:
   - GNUmakefile
   - Makefile
   - Makefile.am
   - Makefile.in
   - OCamlMakefile
-  - mak
-  - mk
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
This commit moves some those items into hidden_file_extensions, which
are unlikely to be used as normal file extensions.

Note: Moves `*.mk` to the beginning so it is the default extension being used.