### PR TITLE
[R] Reorganize file extensions

### DIFF
--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -6,7 +6,12 @@ scope: source.r
 
 file_extensions:
   - R
-  - Rprofile
+
+hidden_file_extensions:
+  - .Renviron
+  - .Rprofile
+  - Renviron.site
+  - Rprofile.site
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
This commit moves some those items into hidden_file_extensions, which
are unlikely to be used as normal file extensions.

RProfile is prefixed with a dot so .Rprofile files are assigned
correctly.

Some more environment related files are added from:

https://support.rstudio.com/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf