### PR TITLE
[C#] Rename declaration keywords scopes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -294,27 +294,27 @@ contexts:
       scope: storage.modifier.access.cs
     - match: \b(class)\s+({{name}})
       captures:
-        1: storage.type.class.cs
+        1: keyword.declaration.class.cs
         2: entity.name.class.cs
       push: [class_signature, data_type_signature]
     - match: (?:\b(readonly)\s+)?\b(record)\s+(?:(struct)\s+)?({{name}})
       captures:
         1: storage.modifier.cs
-        2: storage.type.class.record.cs
-        3: storage.type.struct.record.cs
+        2: keyword.declaration.class.record.cs
+        3: keyword.declaration.struct.record.cs
         4: entity.name.class.cs
       push: [record_signature, data_type_signature]
     - match: '(?:\b(readonly)\s+)?(?:\b(ref)\s+)?\b(struct)\s+({{name}})'
       captures:
         1: storage.modifier.cs
         2: storage.modifier.cs
-        3: storage.type.struct.cs
+        3: keyword.declaration.struct.cs
         4: entity.name.struct.cs
       push: [struct_signature, data_type_signature]
     - match: '\b(enum)\s+({{name}})\s*(?:(:)\s*(byte|sbyte|short|ushort|int|uint|long|ulong))?'
       scope: meta.enum.cs
       captures:
-        1: storage.type.enum.cs
+        1: keyword.declaration.enum.cs
         2: entity.name.enum.cs
         3: punctuation.separator.key-value.type.cs
         4: storage.type.cs
@@ -346,7 +346,7 @@ contexts:
   interface_declaration:
     - match: '(interface)\s+({{name}})'
       captures:
-        1: storage.type.interface.cs
+        1: keyword.declaration.interface.cs
         2: entity.name.interface.cs
       push: [interface_signature, data_type_signature]
 

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -265,7 +265,7 @@ contexts:
   namespace_declaration:
     # package declaration
     - match: '\b(namespace)\b'
-      scope: storage.type.namespace.cs
+      scope: keyword.declaration.namespace.cs
       push:
         - meta_scope: meta.namespace.cs
         - match: '(?={{name}})'

--- a/C#/tests/syntax_test_C#10.cs
+++ b/C#/tests/syntax_test_C#10.cs
@@ -15,7 +15,7 @@ global using static Console.WriteLine;
 ///                                  ^ punctuation.terminator
 
 namespace Example;
-///^^^^^^ meta.namespace storage.type.namespace
+///^^^^^^ meta.namespace keyword.declaration.namespace
 ///       ^^^^^^^ meta.namespace entity.name.namespace
 ///              ^ punctuation.terminator.statement
 

--- a/C#/tests/syntax_test_C#10.cs
+++ b/C#/tests/syntax_test_C#10.cs
@@ -22,8 +22,8 @@ namespace Example;
 public record struct Person(string Name);
 /// ^^ storage.modifier.access
 ///    ^^^^^^^^^^^^^^^^^^^^ meta.class.record
-///    ^^^^^^ storage.type.class.record
-///           ^^^^^^ storage.type.struct.record
+///    ^^^^^^ keyword.declaration.class.record
+///           ^^^^^^ keyword.declaration.struct.record
 ///                  ^^^^^^ entity.name.class
 ///                        ^ punctuation.section.parameters.begin
 ///                         ^^^^^^^^^^^^ meta.class.body meta.method.parameters
@@ -36,8 +36,8 @@ public readonly record struct Person(string Name);
 ///^^^ storage.modifier.access
 ///    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.record
 ///    ^^^^^^^^ storage.modifier
-///             ^^^^^^ storage.type.class.record
-///                    ^^^^^^ storage.type.struct.record
+///             ^^^^^^ keyword.declaration.class.record
+///                    ^^^^^^ keyword.declaration.struct.record
 ///                           ^^^^^^ entity.name.class
 ///                                 ^ punctuation.section.parameters.begin
 ///                                  ^^^^^^ storage.type

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -1,7 +1,7 @@
 /// SYNTAX TEST "Packages/C#/C#.sublime-syntax"
 
 class Foo {
-/// <- meta.class storage.type.class
+/// <- meta.class keyword.declaration.class
  /// <- meta.class
   /// <- meta.class
 ///^^^^^^^^ meta.class
@@ -640,7 +640,7 @@ class Foo {
 public readonly struct S
 /// ^^ storage.modifier.access
 ///    ^^^^^^^^ storage.modifier
-///             ^^^^^^ storage.type.struct
+///             ^^^^^^ keyword.declaration.struct
 ///                    ^ entity.name.struct
 {
 /// <- meta.struct.body meta.block punctuation.section.block.begin
@@ -717,7 +717,7 @@ public readonly ref struct Span<T>
 ///  ^ storage.modifier.access
 ///    ^^^^^^^^ storage.modifier
 ///             ^^^ storage.modifier
-///                 ^^^^^^ storage.type.struct
+///                 ^^^^^^ keyword.declaration.struct
 ///                        ^^^^ entity.name.struct
 {
     private readonly ref T _pointer;

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -5,7 +5,7 @@
 
 public record Person
 /// ^^ storage.modifier.access
-///    ^^^^^^ storage.type.class
+///    ^^^^^^ keyword.declaration.class
 ///           ^^^^^^ entity.name.class
 {
     private readonly string lastName;
@@ -310,7 +310,7 @@ public record A(int Num);
 ///                    ^ punctuation.section.parameters.end
 public record B<T>(T Num);
 ///    ^^^^^^^^^^^ meta.class.record
-///    ^^^^^^ storage.type.class.record
+///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^^^ meta.generic
 ///            ^ punctuation.definition.generic.begin
@@ -321,7 +321,7 @@ public record B<T>(T Num);
 ///                     ^ punctuation.section.parameters.end
 ///                      ^ punctuation.terminator.statement
 public record C<TNum> (TNum Num) where TNum : class;
-///    ^^^^^^ storage.type.class.record
+///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
 ///             ^^^^ support.type
@@ -336,7 +336,7 @@ public record C<TNum> (TNum Num) where TNum : class;
 ///                                           ^^^^^ storage.type
 ///                                                ^ punctuation.terminator.statement
 public record D<TNum> (TNum Num) where TNum : class { public const int TEST = 4; }
-///    ^^^^^^ storage.type.class.record
+///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
 ///             ^^^^ support.type
@@ -361,7 +361,7 @@ public record D<TNum> (TNum Num) where TNum : class { public const int TEST = 4;
 ///                                                                              ^ punctuation.section.block.end
 public record Person(
 ///^^^ storage.modifier.access
-///    ^^^^^^ meta.class.record storage.type.class.record
+///    ^^^^^^ meta.class.record keyword.declaration.class.record
 ///           ^^^^^^ meta.class.record entity.name.class
 ///                 ^ punctuation.section.parameters.begin
     [property: JsonPropertyName("firstName")]string FirstName,

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -9,7 +9,7 @@ namespace YourNamespace
 {
 ///<- punctuation.section.block.begin
     class YourClass
-/// ^ storage.type.class
+/// ^ keyword.declaration.class
 ///        ^ entity.name.class
     {
         Int x;
@@ -126,7 +126,7 @@ namespace YourNamespace
 
     struct YourStruct
 /// ^^^^^^^^^^^^^^^^^ meta.struct
-/// ^ storage.type.struct
+/// ^ keyword.declaration.struct
 ///         ^ entity.name.struct
     {
 ///^^ meta.struct
@@ -137,7 +137,7 @@ namespace YourNamespace
 
     interface IYourInterface
 /// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.interface
-/// ^ storage.type.interface
+/// ^ keyword.declaration.interface
 ///           ^ entity.name.interface
     {
 ///^^ meta.interface
@@ -170,7 +170,7 @@ namespace YourNamespace
 
     enum YourEnum
 /// ^^^^^^^^^^^^^ meta.enum
-/// ^ storage.type.enum
+/// ^ keyword.declaration.enum
 ///        ^ entity.name.enum
     {
 ///^^ meta.enum
@@ -205,7 +205,7 @@ namespace YourNamespace
         struct YourStruct
 /// ^^^^^^^^^^^^^^^^^^^^^ meta.namespace
 ///     ^^^^^^^^^^^^^^^^^ meta.struct
-///      ^ storage.type.struct
+///      ^ keyword.declaration.struct
 ///              ^ entity.name.struct
         {
 ///     ^ meta.struct meta.block punctuation.section.block.begin
@@ -216,7 +216,7 @@ namespace YourNamespace
 
     class InheritingSomething: IYourInterface
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class
-/// ^ storage.type.class
+/// ^ keyword.declaration.class
 ///       ^ entity.name.class
 ///                          ^ punctuation.separator
 ///                            ^ entity.other.inherited-class
@@ -547,7 +547,7 @@ namespace TestNamespace.Test
 
     class YourMainClass
 /// ^^^^^^^^^^^^^^^^^^^ meta.class
-///   ^ storage.type.class
+///   ^ keyword.declaration.class
 ///          ^ entity.name.class
     {
 /// ^ meta.class meta.block punctuation.section.block.begin
@@ -1307,7 +1307,7 @@ void Main () { // method outside a class, i.e. a LINQPad script
 
 public class AfterTopLevelMethod {
 ///^^^ storage.modifier.access
-///    ^^^^^ storage.type.class
+///    ^^^^^ keyword.declaration.class
 ///          ^^^^^^^^^^^^^^^^^^^ entity.name.class
 
     // https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/events/how-to-implement-custom-event-accessors

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -4,7 +4,7 @@
 using System;
 
 namespace YourNamespace
-///<- storage.type.namespace
+///<- keyword.declaration.namespace
 ///        ^ entity.name.namespace
 {
 ///<- punctuation.section.block.begin
@@ -197,7 +197,7 @@ namespace YourNamespace
 
     namespace YourNestedNamespace
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.namespace meta.namespace
-///     ^ storage.type.namespace
+///     ^ keyword.declaration.namespace
 ///             ^ entity.name.namespace
     {
 ///^^ meta.namespace

--- a/C#/tests/syntax_test_HelloWorld.cs
+++ b/C#/tests/syntax_test_HelloWorld.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace HelloWorld
 ///^^^^^^^^^^^^^^^^^ meta.namespace
-///<- storage.type.namespace
+///<- keyword.declaration.namespace
 ///        ^ entity.name.namespace
 {
 ///<- meta.namespace meta.block punctuation.section.block.begin

--- a/C#/tests/syntax_test_HelloWorld.cs
+++ b/C#/tests/syntax_test_HelloWorld.cs
@@ -14,7 +14,7 @@ namespace HelloWorld
 {
 ///<- meta.namespace meta.block punctuation.section.block.begin
     class Hello
-/// ^ storage.type.class
+/// ^ keyword.declaration.class
 ///       ^ entity.name.class
     {
 /// ^ punctuation.section.block.begin

--- a/C#/tests/syntax_test_c#.cs
+++ b/C#/tests/syntax_test_c#.cs
@@ -1,7 +1,7 @@
 // SYNTAX TEST "Packages/C#/C#.sublime-syntax"
 
 class X
-// ^ storage.type.class
+// ^ keyword.declaration.class
 {
     X () {
 //  ^ entity.name.function.constructor


### PR DESCRIPTION
This PR suggests to rename scope of special declaration keywords from `storage.type` to  `keyword.declaration`.

_This change has been made to several syntaxes in the past. C# is one of the remaining syntaxes, which have not been updated._

Note: Maybe scopes of more keywords such as `var` or `dynamic` should be renamed as well.