### PR TITLE
[C#] Scope try/catch/finally keyword.control.exception

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -916,7 +916,7 @@ contexts:
         2: meta.group.cs punctuation.section.group.begin.cs
       set: [for_block, foreach_var_assignment, var_declaration_including_tuple]
     - match: \b(try)\b
-      scope: keyword.control.trycatch.try.cs
+      scope: keyword.control.exception.try.cs
       set: [finally_block, catch_expr, try_block]
     - match: \b(using)\s*(\()
       captures:
@@ -954,7 +954,7 @@ contexts:
         2: punctuation.terminator.statement.cs
       pop: true
     - match: \b(throw)\b
-      scope: keyword.control.trycatch.throw.cs
+      scope: keyword.control.flow.throw.cs
       set: line_of_code_in
     - match: \b(goto)\s+(case)\b
       captures:
@@ -1861,11 +1861,11 @@ contexts:
   catch_expr:
     - match: '(catch)\s*(\()'
       captures:
-        1: keyword.control.trycatch.catch.cs
+        1: keyword.control.exception.catch.cs
         2: meta.group.cs punctuation.section.group.begin.cs
       push: [catch_block, var_declaration_explicit]
     - match: 'catch'
-      scope: keyword.control.trycatch.catch.cs
+      scope: keyword.control.exception.catch.cs
       push: trycatch_block
     - match: (?=\S)
       pop: true
@@ -1878,7 +1878,7 @@ contexts:
 
   catch_when:
     - match: \bwhen\b
-      scope: keyword.control.trycatch.when.cs
+      scope: keyword.control.exception.when.cs
       set:
         - match: \(
           scope: punctuation.section.group.begin.cs
@@ -1896,7 +1896,7 @@ contexts:
   finally_block:
     - meta_scope: meta.block.trycatch.cs
     - match: finally\b
-      scope: keyword.control.trycatch.finally.cs
+      scope: keyword.control.exception.finally.cs
       set: trycatch_block
     - match: (?=\S)
       pop: true

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -435,7 +435,7 @@ namespace TestNamespace.Test
             }
 ///         ^ meta.method meta.block meta.block punctuation.section.block.end
             catch (FaultException<ServiceFault>)
-///         ^^^^^ keyword.control.trycatch.catch
+///         ^^^^^ keyword.control.exception.catch
 ///               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 ///               ^ punctuation.section.group.begin
 ///                ^^^^^^^^^^^^^^ support.type
@@ -446,11 +446,11 @@ namespace TestNamespace.Test
             {
 ///         ^ punctuation.section.block.begin
                 throw;
-///             ^^^^^ keyword.control.trycatch.throw
+///             ^^^^^ keyword.control.flow.throw
 ///                  ^ punctuation
             }
             catch (FaultException<ServiceFault> e)
-///         ^^^^^ keyword.control.trycatch.catch
+///         ^^^^^ keyword.control.exception.catch
 ///               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 ///               ^ punctuation.section.group.begin
 ///                ^^^^^^^^^^^^^^ support.type
@@ -463,7 +463,7 @@ namespace TestNamespace.Test
             {
 ///         ^ punctuation.section.block.begin
                 throw;
-///             ^^^^^ keyword.control.trycatch.throw
+///             ^^^^^ keyword.control.flow.throw
 ///                  ^ punctuation
             }
 ///         ^ punctuation.section.block.end
@@ -1030,17 +1030,17 @@ namespace TestNamespace.Test
 ///                   ^ punctuation.terminator.statement - meta.function.anonymous
 
         try
-///     ^^^ keyword.control.trycatch.try
+///     ^^^ keyword.control.exception.try
         {
 
         }
         catch (InvalidOperationException ex)
-///     ^^^^^ keyword.control.trycatch.catch
+///     ^^^^^ keyword.control.exception.catch
         {
 
         }
         finally
-///     ^^^^^^^ keyword.control.trycatch.finally
+///     ^^^^^^^ keyword.control.exception.finally
         {
 
         }
@@ -1052,17 +1052,17 @@ namespace TestNamespace.Test
 ///                               ^ punctuation.terminator.statement - meta.function.anonymous
 
         try
-///     ^^^ keyword.control.trycatch.try
+///     ^^^ keyword.control.exception.try
         {
 
         }
         catch (InvalidOperationException ex)
-///     ^^^^^ keyword.control.trycatch.catch
+///     ^^^^^ keyword.control.exception.catch
         {
 
         }
         finally
-///     ^^^^^^^ keyword.control.trycatch.finally
+///     ^^^^^^^ keyword.control.exception.finally
         {
         }
 
@@ -1076,18 +1076,18 @@ namespace TestNamespace.Test
 ///                                    ^ punctuation.terminator.statement - meta.function.anonymous
 
         try
-///     ^^^ keyword.control.trycatch.try
+///     ^^^ keyword.control.exception.try
         {
 
         }
         catch (InvalidOperationException)
-///     ^^^^^ keyword.control.trycatch.catch
+///     ^^^^^ keyword.control.exception.catch
 ///            ^^^^^^^^^^^^^^^^^^^^^^^^^ support.type
         {
 
         }
         finally
-///     ^^^^^^^ keyword.control.trycatch.finally
+///     ^^^^^^^ keyword.control.exception.finally
         {
         }
 


### PR DESCRIPTION
This commit applies scope names to exception related keywords, which
have been applied in most other recently updated syntaxes.