### PR TITLE
[C#] Unify namespace scopes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -236,15 +236,16 @@ contexts:
         3: meta.path.cs
       push: using_namespace
 
-  namespace_alias:
+  namespace_variables:
     - match: '(?:(global)|({{name}}))\s*(::)'
+      scope: meta.path.cs
       captures:
-        1: support.namespace.cs
-        2: variable.other.namespace.cs
+        1: support.namespace.global.cs
+        2: variable.namespace.cs
         3: punctuation.accessor.double-colon.namespace.cs
 
   using_namespace:
-    - include: namespace_alias
+    - include: namespace_variables
     - match: '{{name}}'
       scope: meta.path.cs
     - match: '='
@@ -503,17 +504,13 @@ contexts:
   type_constraint_common:
     - match: (?=\{)
       pop: true
+    - include: namespace_variables
     - match: '\b(where)\s+(?:({{base_type}})|({{name}}))\s*(:)'
       captures:
         1: storage.modifier.cs
         2: storage.type.cs
         3: support.type.cs
         4: punctuation.separator.type.cs
-    - match: '(?:(global)|({{name}}))\s*(::)'
-      captures:
-        1: support.namespace.cs
-        2: meta.path.cs
-        3: punctuation.accessor.double-colon.namespace.cs
     - match: '(class|struct|interface)'
       scope: storage.type.cs
     - match: 'new\s*\(\s*\)'
@@ -864,6 +861,7 @@ contexts:
 
   attribute_in:
     - meta_scope: meta.annotation.cs
+    - include: namespace_variables
     - match: '({{name}})\s*(\()'
       captures:
         1: variable.annotation.cs
@@ -871,13 +869,8 @@ contexts:
       set: [attribute_arguments, arguments]
     - match: '({{name}})\s*(\.)'
       captures:
-        1: variable.other.namespace.cs
+        1: variable.namespace.cs
         2: punctuation.accessor.dot.namespace.cs
-    - match: '(?:(global)|({{name}}))\s*(::)'
-      captures:
-        1: support.namespace.cs
-        2: support.namespace.cs
-        3: punctuation.accessor.double-colon.namespace.cs
     - match: '{{name}}'
       scope: variable.annotation.cs
     - match: ','
@@ -999,7 +992,7 @@ contexts:
         1: entity.name.label.cs
         2: punctuation.separator.cs
       pop: true
-    - include: namespace_alias
+    - include: namespace_variables
     - match: '({{name}})\s+({{name}})'
       captures:
         1: support.type.cs
@@ -1327,11 +1320,7 @@ contexts:
       push: switch_expression
     - match: '({{reserved}})\b'
       scope: keyword.other.cs
-    - match: '(?:(global)|({{name}}))\s*(::)'
-      captures:
-        1: support.namespace.cs
-        2: support.namespace.cs
-        3: punctuation.accessor.double-colon.namespace.cs
+    - include: namespace_variables
     - match: '{{name}}'
       scope: variable.other.cs
     - match: '@'
@@ -1543,7 +1532,7 @@ contexts:
           push: var_declaration_explicit
 
   type_common:
-    - include: namespace_alias
+    - include: namespace_variables
     - match: '(class|struct|enum)'
       scope: storage.type.other.cs
     - match: 'new\s*\(\s*\)'

--- a/C#/tests/syntax_test_Using.cs
+++ b/C#/tests/syntax_test_Using.cs
@@ -36,6 +36,14 @@ using sys = global::System;
 ///               ^^ punctuation.accessor.double-colon.namespace
 ///                 ^^^^^^ meta.path
 ///                       ^ punctuation.terminator
+using sys = custom::System;
+///^^ keyword.control.import
+///   ^^^ meta.path
+///       ^ keyword.operator.assignment
+///         ^^^^^^ variable.namespace.cs
+///               ^^ punctuation.accessor.double-colon.namespace
+///                 ^^^^^^ meta.path
+///                       ^ punctuation.terminator
 using abc = global:test;
 ///   ^^^ meta.path
 ///       ^ keyword.operator.assignment
@@ -120,9 +128,9 @@ class Foo {
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
 ///  ^ support.namespace
 ///    ^^ punctuation.accessor.double-colon
-///      ^^^^^^ variable.other.namespace
+///      ^^^^^^ variable.namespace
 ///            ^ punctuation.accessor.dot.namespace
-///             ^^^^^^^ variable.other.namespace
+///             ^^^^^^^ variable.namespace
 internal sealed partial class Test : sys::Configuration.ApplicationSettingsBase {
 ///                                  ^^^ meta.path
 ///                                     ^^ punctuation.accessor.double-colon


### PR DESCRIPTION
This commit applies same scheme of scopes to all kinds of namespaces,
so `global` is the only `support.namespace` in all contexts.

see: https://github.com/sublimehq/Packages/issues/1842#issuecomment-1100697757