### PR TITLE
[C#] Fix generic punctuation scopes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -664,7 +664,7 @@ contexts:
       scope: meta.method.cs
       captures:
         1: entity.other.inherited-class.cs
-        2: meta.generic.cs punctuation.section.generic.begin.cs
+        2: meta.generic.cs punctuation.definition.generic.begin.cs
       push:
         - meta_content_scope: meta.method.cs meta.generic.cs
         - match: '(>)\s*(\.)'


### PR DESCRIPTION
This commit fixes a scope name for generic punctuation.
All other patterns already use punctuation.definition.generic.