### PR TITLE
[Makefile] Let build runs for the current Makefile

### DIFF
--- a/Makefile/Make.sublime-build
+++ b/Makefile/Make.sublime-build
@@ -1,7 +1,7 @@
 {
 	"shell_cmd": "make",
 	"file_regex": "^(..[^:\n]*):([0-9]+):?([0-9]+)?:? (.*)$",
-	"working_dir": "${folder:${project_path:${file_path}}}",
+	"working_dir": "${file_path}",
 	"selector": "source.makefile",
 	"syntax": "Packages/Makefile/Make Output.sublime-syntax",
 	"keyfiles": ["Makefile", "makefile"],


### PR DESCRIPTION
The problem I encounter is that when a project is opened (that is, `$folder` is defined), the `build` command always builds `project_root/Makefile` no matter which makefile you are editing. This PR wants to let `build` command always runs the current Makefile.

---

Say I have a project directory structure like

```
project_root/
    module_1/
    module_2/
        Makefile
```

and now I am editing `project_root/module_2/Makefile` and triggering the `build` command. The current `Make.sublime-build` tries to run `project_root/Makefile`, which doesn't exist. I am wondering that do people expect it runs `project_root/Makefile` while editing/triggering `project_root/module_2/Makefile`?

---

Here's another problematic example.

```
project_root/
    Makefile
```

This time I temporary open and edit an external Makefile, say `another_project_root/module/Makefile`. Now I trigger `build` command on `another_project_root/module/Makefile`, but ST runs `project_root/Makefile`.