### PR TITLE
[CSS] Fix logical operator scope

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1079,7 +1079,7 @@ contexts:
     - match: '[<>]=?|='
       scope: keyword.operator.comparison.css
     - match: \b(?i:and|or|not|only){{break}}
-      scope: keyword.operator.logic.css
+      scope: keyword.operator.logical.css
 
   media-query-group-content:
     - meta_scope: meta.group.css

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -211,7 +211,7 @@
 /*               ^^^^^^^^^^^^^^^ string.quoted.single.css */
 /*                               ^ punctuation.section.group.end.css */
 /*                                 ^^^^^^ support.constant.media.css */
-/*                                        ^^^ keyword.operator.logic.css */
+/*                                        ^^^ keyword.operator.logical.css */
 /*                                            ^ punctuation.section.group.begin.css */
 /*                                             ^^^^^^^^^^^ support.type.property-name.css */
 /*                                                        ^ punctuation.separator.key-value.css */
@@ -516,7 +516,7 @@
 /*                       ^ - meta.at-rule - meta.block */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^ keyword.control.directive.css - punctuation */
-/*         ^^^^ keyword.operator.logic.css */
+/*         ^^^^ keyword.operator.logical.css */
 /*              ^^^^^^ support.constant.media.css */
 /*                     ^ punctuation.section.block.begin.css */
 /*                      ^ punctuation.section.block.end.css */
@@ -612,7 +612,7 @@
 /*                     ^^^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*                        ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 /*                          ^ punctuation.section.group.end.css */
-/*                            ^^^ keyword.operator.logic */
+/*                            ^^^ keyword.operator.logical.css */
 /*                                ^ punctuation.section.group.begin.css */
 /*                                 ^^^^^^^^^ support.type.property-name.css */
 /*                                            ^^^^ meta.number.integer.decimal.css constant.numeric.value.css */
@@ -625,9 +625,9 @@
 /*                                                                            ^^ meta.at-rule.media.css - meta.group */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^ keyword.control.directive.css - punctuation */
-/*         ^^^^ keyword.operator.logic.css */
+/*         ^^^^ keyword.operator.logical.css */
 /*              ^^^^^^ support.constant.media.css */
-/*                     ^^^ keyword.operator.logic.css */
+/*                     ^^^ keyword.operator.logical.css */
 /*                         ^ punctuation.section.group.begin.css */
 /*                          ^^^^^^^^ support.type.vendor-prefix.css */
 /*                                  ^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.css */
@@ -640,9 +640,9 @@
 /*  ^^^^^^^^^^^^^^^^ meta.at-rule.media.css - meta.group */
 /*                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css meta.group.css */
 /*                                                    ^^ meta.at-rule.media.css - meta.group */
-/*  ^^^^ keyword.operator.logic.css */
+/*  ^^^^ keyword.operator.logical.css */
 /*       ^^^^^^ support.constant.media.css */
-/*              ^^^ keyword.operator.logic.css */
+/*              ^^^ keyword.operator.logical.css */
 /*                  ^ punctuation.section.group.begin.css */
 /*                   ^^^ support.type.vendor-prefix.css */
 /*                      ^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.css */
@@ -655,9 +655,9 @@
 /*  ^^^^^^^^^^^^^^^^ meta.at-rule.media.css - meta.group */
 /*                  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css meta.group.css */
 /*                                          ^ meta.at-rule.media.css - meta.group */
-/*  ^^^^ keyword.operator.logic.css */
+/*  ^^^^ keyword.operator.logical.css */
 /*       ^^^^^^ support.constant.media.css */
-/*              ^^^ keyword.operator.logic.css */
+/*              ^^^ keyword.operator.logical.css */
 /*                  ^ punctuation.section.group.begin.css */
 /*                   ^^^^^^^^^^^^^^ support.type.property-name.css */
 /*                                 ^ punctuation.separator.key-value.css */
@@ -677,14 +677,14 @@
 /*                                                            ^ - meta.at-rule */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^ keyword.control.directive.css - punctuation */
-/*         ^^^^ keyword.operator.logic.css */
+/*         ^^^^ keyword.operator.logical.css */
 /*              ^^^^^^ support.constant.media.css */
-/*                     ^^^ keyword.operator.logic.css */
+/*                     ^^^ keyword.operator.logical.css */
 /*                         ^ punctuation.section.group.begin.css */
 /*                          ^^^^^ support.type.property-name.css */
 /*                                ^^ keyword.operator.comparison.css */
 /*                                   ^^^^^ meta.number.integer.decimal.css */
-/*                                         ^^ keyword.operator.logic.css */
+/*                                         ^^ keyword.operator.logical.css */
 /*                                            ^ punctuation.section.group.begin.css */
 /*                                             ^^^^^^ support.type.property-name.css */
 /*                                                    ^ keyword.operator.comparison.css */


### PR DESCRIPTION
This commit renames `keyword.operator.logic` to
`keyword.operator.logical` to comply with scope naming guidelines.