### PR TITLE
[CSS] Add global property names

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -438,12 +438,16 @@ variables:
 
   property_value_constants: |-
     (?x:
-      {{font_display_constants}}
+      {{global_property_constants}}
+    | {{font_display_constants}}
     | {{font_property_constants}}
     | {{font_size_constants}}
     | {{font_style_constants}}
     | {{unsorted_property_constants}}
     )
+
+  global_property_constants:  |-
+    \b(?xi: inherit | initial | revert | revert-layer | unset ){{break}}
 
   unsorted_property_constants: |-
     \b(?xi:
@@ -508,7 +512,7 @@ variables:
     | horizontal(-tb)?
     | hue
     | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
-    | inactive|include-ruby|infinite|inherit|initial
+    | inactive|include-ruby|infinite
     | inline(-block|-box|-flex(box)?|-line-height|-table)?
     | inset|inside
     | inter(-ideograph|-word|sect)
@@ -589,7 +593,7 @@ variables:
     | touch|traditional
     | transform(-origin)?
     | under(-edge|line)?
-    | unicase|unsafe|unset|uppercase|upright
+    | unicase|unsafe|uppercase|upright
     | use-(glyph-orientation|script)
     | verso
     | vertical(-align|-ideographic|-lr|-rl|-text)?

--- a/CSS/completions/properties.py
+++ b/CSS/completions/properties.py
@@ -34,7 +34,7 @@ def get_properties():
             "stretch",
         ],
         "align-tracks": ["normal"],
-        "all": ["revert"],
+        "all": [],
         "alt": [],
         "animation": [
             "<animation-direction>",
@@ -336,7 +336,6 @@ def get_properties():
             "flow",
             "flow-root",
             "grid",
-            "revert",
             "ruby",
             "ruby-base",
             "ruby-text",
@@ -1150,7 +1149,7 @@ def get_properties():
 
     for names, values in properties_dict.items():
         # Values that are allowed for all properties
-        allowed_values = ["inherit", "initial", "unset", ["var()", "var($1)"]]
+        allowed_values = ["inherit", "initial", "revert", "revert-layer", "unset", ["var()", "var($1)"]]
 
         # Determine which values are available for the current property name
         for value in values:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2070,6 +2070,12 @@
     font: initial;
 /*        ^^^^^^^ support - string */
 
+    font: revert;
+/*        ^^^^^^ support - string */
+
+    font: revert-layer;
+/*        ^^^^^^^^^^^^ support - string */
+
     font: unset;
 /*        ^^^^^ support - string */
 


### PR DESCRIPTION
This commit adds `revert` and `revert-layer` to the list of global
property values. ... those which are valid in every property.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/revert