### PR TITLE
[CSS] Fix counter properties

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1570,17 +1570,16 @@ contexts:
   counter-property-value:
     - match: ':'
       scope: punctuation.separator.key-value.css
-      set:
-        - property-value-content
-        - counter-identifier
+      set: counter-property-value-content
     - include: else-pop
 
-  counter-identifier:
+  counter-property-value-content:
+    - include: global-constants
+    - match: (?i:none){{break}}
+      scope: constant.language.null.css
     - match: '{{ident}}'
       scope: entity.other.counter-name.css
-      pop: 1
-    - include: comments
-    - include: else-pop
+    - include: property-value-content
 
 ###[ COUNTER STYLE FALLBACK PROPERTY ]#########################################
 
@@ -1737,11 +1736,7 @@ contexts:
         - match: \(
           scope: punctuation.section.group.begin.css
           set:
-            - - meta_scope: meta.function-call.arguments.css meta.group.css
-              - include: function-arguments-common
-              - include: comma-delimiters
-              - include: counter-style-identifiers
-              - include: quoted-strings
+            - counter-function-arguments-body
             - counter-identifier
 
     # symbols()
@@ -1757,6 +1752,20 @@ contexts:
             - include: function-arguments-common
             - include: comma-delimiters
             - include: counter-symbol-values
+
+  counter-function-arguments-body:
+    - meta_scope: meta.function-call.arguments.css meta.group.css
+    - include: function-arguments-common
+    - include: comma-delimiters
+    - include: counter-style-identifiers
+    - include: quoted-strings
+
+  counter-identifier:
+    - match: '{{ident}}'
+      scope: entity.other.counter-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
 
   at-document-functions:
     # url-prefix()
@@ -2728,6 +2737,10 @@ contexts:
   # https://drafts.csswg.org/css-fonts-3/#family-name-value
   generic-font-names:
     - match: '{{font_family_constants}}'
+      scope: support.constant.property-value.css
+
+  global-constants:
+    - match: '{{global_property_constants}}'
       scope: support.constant.property-value.css
 
   grid-constants:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1369,6 +1369,69 @@
 }
 /* <- meta.at-rule.counter-style.css meta.property-list.css meta.block.css punctuation.section.block.end.css */
 
+.test-counter-properties {
+
+    /* Set "my-counter" to 0 */
+    counter-set: my-counter;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^^^^ entity.other.counter-name.css */
+/*                         ^ punctuation.terminator.rule.css */
+    /* Set "my-counter" to -1 */
+    counter-set: my-counter -1;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^^^^ entity.other.counter-name.css */
+/*                          ^^ meta.number.integer.decimal.css */
+/*                            ^ punctuation.terminator.rule.css */
+
+    /* Set "counter1" to 1, and "counter2" to 4 */
+    counter-set: counter1 1 counter2 4;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^^ entity.other.counter-name.css */
+/*                        ^ constant.numeric.value.css */
+/*                          ^^^^^^^^ entity.other.counter-name.css */
+/*                                   ^ constant.numeric.value.css */
+/*                                    ^ punctuation.terminator.rule.css */
+
+    /* Cancel any counter that could have been set in less specific rules */
+    counter-set: none;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^ constant.language.null.css */
+/*                   ^ punctuation.terminator.rule.css */
+
+    /* Global values */
+    counter-set: inherit;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^ support.constant.property-value.css */
+/*                      ^ punctuation.terminator.rule.css */
+
+    counter-set: initial;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^ support.constant.property-value.css */
+/*                      ^ punctuation.terminator.rule.css */
+    counter-set: revert;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^ support.constant.property-value.css */
+/*                     ^ punctuation.terminator.rule.css */
+
+    counter-set: revert-layer;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^^^^^^ support.constant.property-value.css */
+/*                           ^ punctuation.terminator.rule.css */
+    counter-set: unset;
+/*  ^^^^^^^^^^^ support.type.property-name.css */
+/*             ^ punctuation.separator.key-value.css */
+/*               ^^^^^ support.constant.property-value.css */
+/*                    ^ punctuation.terminator.rule.css */
+}
+
 .test-var-functions {
     --test-var: arial;
 /*  ^^^^^^^^^^ entity.other.custom-property.css */


### PR DESCRIPTION
This commit...

1. adds global constants to counter property values
2. fixes multiple counter values in `counter-set` properties
3. reorganizes `counter()` function accordingly as `counter-identifier`
   context is now used by this function only.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/counter-set