### PR TITLE
[C#] Improve namespace declaration

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -265,28 +265,55 @@ contexts:
 
   namespace_declaration:
     # package declaration
-    - match: '\b(namespace)\b'
+    - match: \b(namespace)\b
       scope: keyword.declaration.namespace.cs
       push:
-        - meta_scope: meta.namespace.cs
-        - match: '(?={{name}})'
-          push:
-            - meta_content_scope: entity.name.namespace.cs
-            - match: '{{name}}'
-            - match: \.
-              scope: punctuation.separator.namespace.cs
-            - match: ''
-              pop: true
-        - match: \{
-          scope: punctuation.section.block.begin.cs
-          set:
-            - meta_scope: meta.namespace.cs meta.block.cs
-            - match: \}
-              scope: punctuation.section.block.end.cs
-              pop: true
-            - include: main
-        - match: (?=\S)
-          pop: true
+        - namespace_declaration_meta
+        - namespace_declaration_block
+        - namespace_declaration_name
+
+  namespace_declaration_meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.namespace.cs
+    - match: ''
+      pop: true
+
+  namespace_declaration_name:
+    - match: ({{name}})\s*(\.)
+      captures:
+        1: variable.namespace.cs
+        2: punctuation.accessor.dot.cs
+      set: qualified_namespace_declaration_name
+    - include: unqualified_namespace_declaration_name
+
+  qualified_namespace_declaration_name:
+    - meta_scope: meta.path.cs
+    - match: ({{name}})\s*(\.)
+      captures:
+        1: variable.namespace.cs
+        2: punctuation.accessor.dot.cs
+    - include: unqualified_namespace_declaration_name
+
+  unqualified_namespace_declaration_name:
+    - match: '{{name}}'
+      scope: entity.name.namespace.cs
+      pop: true
+    - match: (?=\S)
+      pop: true
+
+  namespace_declaration_block:
+    - match: \{
+      scope: punctuation.section.block.begin.cs
+      set: namespace_declaration_block_body
+    - match: (?=\S)
+      pop: true
+
+  namespace_declaration_block_body:
+    - meta_scope: meta.block.cs
+    - match: \}
+      scope: punctuation.section.block.end.cs
+      pop: true
+    - include: main
 
   class_declaration:
     - match: '\b(static|unsafe|abstract|partial|sealed)\b'

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -4,8 +4,10 @@
 using System;
 
 namespace YourNamespace
+///^^^^^^^^^^^^^^^^^^^^^ meta.namespace.cs - meta.path
 ///<- keyword.declaration.namespace
-///        ^ entity.name.namespace
+///^^^^^^ keyword.declaration.namespace.cs
+///       ^^^^^^^^^^^^^ entity.name.namespace.cs
 {
 ///<- punctuation.section.block.begin
     class YourClass
@@ -241,8 +243,18 @@ namespace YourNamespace
 ///                                                 ^^  support.type
 ///                                                   ^  punctuation.definition.generic.end
 
-namespace TestNamespace.Test
+namespace TestNamespace . Test
+///^^^^^^^ meta.namespace.cs meta.namespace.cs - meta.path
+///       ^^^^^^^^^^^^^^^^^^^^ meta.namespace.cs meta.namespace.cs meta.path.cs
+///                           ^ meta.namespace.cs meta.namespace.cs - meta.path
+///<- keyword.declaration.namespace
+///^^^^^^ keyword.declaration.namespace.cs
+///       ^^^^^^^^^^^^^ variable.namespace.cs
+///                     ^ punctuation.accessor.dot.cs
+///                       ^^^^ entity.name.namespace.cs
 {
+/// <- meta.namespace.cs meta.namespace.cs meta.block.cs punctuation.section.block.begin.cs
+
     using NodeName = SomeNamespace.SomeClass;
 
     public class Derived : Base

--- a/C#/tests/syntax_test_HelloWorld.cs
+++ b/C#/tests/syntax_test_HelloWorld.cs
@@ -8,7 +8,7 @@ using System;
 ///         ^ punctuation.terminator.cs
 
 namespace HelloWorld
-///^^^^^^^^^^^^^^^^^ meta.namespace
+///^^^^^^^^^^^^^^^^^ meta.namespace - meta.path
 ///<- keyword.declaration.namespace
 ///        ^ entity.name.namespace
 {


### PR DESCRIPTION
This commit improves qualified and unqualified identifier scopes in
namespace declaration statements.

1. Qualified identifiers are scoped `meta.path`.
2. Path elements are scoped `variable.namespace`.
3. Only the last element is scoped `entity.name.namespace.

Goal is to have same scoping as in Erlang, Java, Perl, PHP, ...

Note:

The current implementation still relies on normal push/pop patterns,
which works only for single-line identifiers. If support for multi-line
identifiers is desired, some contexts from Java might be of interest.