### PR TITLE
[TypeScript] Remove non-TSX test (again)

### DIFF
--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1229,21 +1229,6 @@ const x = {
 //           ^^^ variable.other.readwrite
 };
 
-    <any>(<any>a);
-//  ^^^^^ meta.assertion
-//  ^ punctuation.definition.assertion.begin
-//   ^^^ support.type.any
-//      ^ punctuation.definition.assertion.end
-//       ^^^^^^^^ meta.group
-//       ^ punctuation.section.group.begin
-//        ^^^^^ meta.assertion
-//        ^ punctuation.definition.assertion.begin
-//         ^^^ support.type.any
-//            ^ punctuation.definition.assertion.end
-//             ^ variable.other.readwrite
-//              ^ punctuation.section.group.end
-//               ^ punctuation.terminator.statement
-
     true ? (a) : <T,foo="a">() => {} => {} : null; // </T>;
 //  ^^^^ constant.language.boolean.true
 //       ^ keyword.operator.ternary


### PR DESCRIPTION
The test was moves to the TSX test file in #3311 but accidentally re-added in #3312.