### PR TITLE
[CSS] Add layer support and update @import

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -688,6 +688,7 @@ contexts:
     - include: at-font-face
     - include: at-import
     - include: at-keyframes
+    - include: at-layer
     - include: at-media
     - include: at-namespace
     - include: at-page
@@ -886,6 +887,42 @@ contexts:
     - match: \b(?i:from|to){{break}}
       scope: keyword.other.selector.css
     - include: selector-end
+
+  # @layer
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
+  at-layer:
+    - match: (@)(?i:layer){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-layer-content
+
+  at-layer-content:
+    - meta_scope: meta.at-rule.layer.css
+    - include: comma-delimiters
+    - include: at-layer-names
+    - include: at-rule-block
+    - include: at-rule-end
+
+  at-layer-names:
+    - match: ({{ident}})(\.)
+      captures:
+        1: entity.other.layer.css
+        2: punctuation.accessor.dot.css
+      push: at-layer-qualified-name
+    - match: '{{ident}}'
+      scope: entity.other.layer.css
+
+  at-layer-qualified-name:
+    - meta_scope: meta.path.css
+    - match: ({{ident}})(\.)
+      captures:
+        1: entity.other.layer.css
+        2: punctuation.accessor.dot.css
+    - match: '{{ident}}'
+      scope: entity.other.layer.css
+      pop: 1
+    - include: immediately-pop
 
   # @media
   # https://drafts.csswg.org/css-conditional-3/#at-ruledef-media
@@ -1887,6 +1924,20 @@ contexts:
             - include: font-family-names
 
   at-import-functions:
+    # layer()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/@import
+    - match: \b(?i:layer){{break}}
+      scope: meta.function-call.identifier.css support.function.layer.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: group-end
+            - include: at-rule-end
+            - include: at-layer-names
+        - include: immediately-pop
     # supports()
     # https://developer.mozilla.org/en-US/docs/Web/CSS/@import
     - match: \b(?i:supports)(?=\()

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -824,6 +824,7 @@ contexts:
 
   # @import
   # https://www.w3.org/TR/css-cascade-4/#at-ruledef-import
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@import
   at-import:
     - match: (@)(?i:import){{break}}
       captures:
@@ -836,6 +837,7 @@ contexts:
     - include: quoted-strings
     - include: url-functions
     - include: media-queries
+    - include: at-import-functions
     - include: at-rule-end
 
   # @keyframes
@@ -1883,6 +1885,19 @@ contexts:
             - include: quoted-strings
             - include: generic-font-names
             - include: font-family-names
+
+  at-import-functions:
+    # supports()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/@import
+    - match: \b(?i:supports)(?=\()
+      scope: meta.function-call.identifier.css support.function.supports.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: at-supports-group-content
 
   at-supports-functions:
     # selector()

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1010,6 +1010,7 @@ contexts:
   at-supports-content:
     - meta_scope: meta.at-rule.supports.css
     - include: at-supports-groups
+    - include: at-supports-functions
     - include: at-supports-operators
     - include: at-rule-block
     - include: at-rule-end
@@ -1028,6 +1029,7 @@ contexts:
     - include: group-end
     - include: at-rule-end
     - include: at-supports-groups
+    - include: at-supports-functions
     - include: at-supports-operators
     - include: rule-list-body
 
@@ -1881,6 +1883,22 @@ contexts:
             - include: quoted-strings
             - include: generic-font-names
             - include: font-family-names
+
+  at-supports-functions:
+    # selector()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/@supports
+    - match: \b(?i:selector)(?=\()
+      scope: meta.function-call.identifier.css support.function.selector.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - meta_content_scope: meta.selector.css
+            - include: group-end
+            - include: at-rule-end
+            - include: selector-content
 
 ###[ BUILTIN COLOR FUNCTIONS ]#################################################
 

--- a/CSS/Reference Index.tmPreferences
+++ b/CSS/Reference Index.tmPreferences
@@ -3,6 +3,7 @@
 <dict>
 	<key>scope</key>
 	<string>
+		source.css meta.at-rule.import meta.function-call.arguments entity.other.layer,
 		source.css variable.other.custom-property
 	</string>
 	<key>settings</key>

--- a/CSS/Symbol List - Layers.tmPreferences
+++ b/CSS/Symbol List - Layers.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.css meta.at-rule.layer entity.other.layer - source.css meta.at-rule.import meta.function-call.arguments</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
+	</dict>
+</dict>
+</plist>

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1088,6 +1088,25 @@
 /*                                                    ^ meta.at-rule.supports.css meta.block.css - meta.property-list - meta.block meta.block */
 /*                                                     ^ - meta.at-rule - meta.block */
 
+    @supports selector(A > B);
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css */
+/*            ^^^^^^^^ meta.function-call.identifier.css */
+/*                    ^ meta.function-call.arguments.css meta.group.css - meta.selector */
+/*                     ^^^^^ meta.function-call.arguments.css meta.group.css meta.selector.css */
+/*                          ^ meta.function-call.arguments.css meta.group.css - meta.selector */
+/*            ^^^^^^^^ support.function.selector.css */
+/*                    ^ punctuation.section.group.begin.css */
+/*                     ^ entity.name.tag.html.css */
+/*                       ^ keyword.operator.combinator.css */
+/*                         ^ entity.name.tag.html.css */
+/*                          ^ punctuation.section.group.end.css */
+
+    @supports selector( ;
+/*            ^^^^^^^^ meta.function-call.identifier.css */
+/*                    ^ meta.function-call.arguments.css meta.group.css - meta.selector */
+/*                     ^ meta.at-rule.supports.css - meta.function-call */
+/*                      ^ - meta.at-rule - meta.function-call */
+
     @counter-style {}
 /*  ^^^^^^^^^^^^^^^ meta.at-rule.counter-style.css - meta.block */
 /*                 ^^ meta.at-rule.counter-style.css meta.property-list.css meta.block.css */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -198,6 +198,40 @@
 /*              ^^^^^ support.constant.media.css */
 /*                   ^ punctuation.terminator.rule.css */
 
+    @import "foo" supports(selector(.bar > a[class="bar"]) and (scale: 20%)) screen;
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
+/*                ^^^^^^^^ meta.function-call.identifier.css */
+/*                        ^ meta.function-call.arguments.css meta.group.css */
+/*                         ^^^^^^^^ meta.function-call.arguments.css meta.group.css meta.function-call.identifier.css */
+/*                                 ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css meta.function-call.arguments.css meta.group.css */
+/*                                          ^^^^^^^^^^^^^ meta.attribute-selector.css meta.brackets.css */
+/*                                                        ^^^^^ meta.function-call.arguments.css meta.group.css - meta.group meta.group */
+/*                                                             ^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css meta.group.css */
+/*                                                                         ^ meta.function-call.arguments.css meta.group.css - meta.group meta.group */
+/*                                                                          ^^^^^^^ - meta.function-call - meta.group */
+/*                                                                                 ^ - meta.at-rule */
+/*                ^^^^^^^^ support.function.supports.css */
+/*                        ^ punctuation.section.group.begin.css */
+/*                         ^^^^^^^^ support.function.selector.css */
+/*                                 ^ punctuation.section.group.begin.css */
+/*                                  ^^^^ entity.other.attribute-name.class.css */
+/*                                       ^ keyword.operator.combinator.css */
+/*                                         ^ entity.name.tag.html.css */
+/*                                          ^ punctuation.section.brackets.begin.css */
+/*                                           ^^^^^ entity.other.attribute-name.css */
+/*                                                ^ keyword.operator.logical.css */
+/*                                                 ^^^^^ string.quoted.double.css */
+/*                                                      ^ punctuation.section.brackets.end.css */
+/*                                                       ^ punctuation.section.group.end.css */
+/*                                                         ^^^ keyword.operator.logical.css */
+/*                                                             ^ punctuation.section.group.begin.css */
+/*                                                              ^^^^^ support.type.property-name.css */
+/*                                                                   ^ punctuation.separator.key-value.css */
+/*                                                                     ^^^ meta.number.integer.decimal.css */
+/*                                                                        ^^ punctuation.section.group.end.css */
+/*                                                                           ^^^^^^ support.constant.media.css */
+/*                                                                                 ^ punctuation.terminator.rule.css */
+
     @import url( 'landscape.css' ) screen and (orientation:landscape);
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
 /*                                                                   ^ - meta.at-rule */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -198,6 +198,24 @@
 /*              ^^^^^ support.constant.media.css */
 /*                   ^ punctuation.terminator.rule.css */
 
+
+    @import "utilities.css" layer;
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
+/*                          ^^^^^ meta.function-call.identifier.css support.function.layer.css */
+
+    @import 'utilities.css' layer(framework.layout);
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
+/*                          ^^^^^ meta.function-call.identifier.css support.function.layer.css */
+/*                               ^ meta.function-call.arguments.css meta.group.css - meta.path */
+/*                                ^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css meta.path.css */
+/*                                                ^ meta.function-call.arguments.css meta.group.css - meta.path */
+/*                               ^ punctuation.section.group.begin.css */
+/*                                ^^^^^^^^^ entity.other.layer.css */
+/*                                         ^ punctuation.accessor.dot.css */
+/*                                          ^^^^^^ entity.other.layer.css */
+/*                                                ^ punctuation.section.group.end.css */
+/*                                                 ^ punctuation.terminator.rule.css */
+
     @import "foo" supports(selector(.bar > a[class="bar"]) and (scale: 20%)) screen;
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
 /*                ^^^^^^^^ meta.function-call.identifier.css */
@@ -1058,6 +1076,68 @@
 /*                           ^ punctuation.terminator.rule.css */
 }
 /* <- meta.at-rule.font-face.css meta.property-list.css meta.block.css punctuation.section.block.end.css */
+
+    @layer ;
+/*  ^^^^^^^ meta.at-rule.layer.css */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^ keyword.control.directive.css - punctuation */
+/*        ^ - keyword */
+
+    @layer utilities ;
+/*  ^^^^^^^^^^^^ meta.at-rule.layer.css */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^ keyword.control.directive.css - punctuation */
+/*        ^ - keyword */
+/*         ^^^^^^^^^ entity.other.layer.css */
+
+    @layer utilities, framework.layout, { .foo { font-family: serif } };
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css - meta.block */
+/*                                      ^^ meta.at-rule.layer.css meta.block.css - meta.property-list */
+/*                                        ^^^^ meta.at-rule.layer.css meta.block.css meta.selector.css */
+/*                                            ^ meta.at-rule.layer.css meta.block.css - meta.selector - meta.property-list */
+/*                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                   ^^ meta.at-rule.layer.css meta.block.css - meta.property-list.css */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^ keyword.control.directive.css - punctuation */
+/*        ^ - keyword */
+/*         ^^^^^^^^^ entity.other.layer.css - meta.path */
+/*                  ^ punctuation.separator.sequence.css */
+/*                    ^^^^^^^^^^^^^^^^ meta.path.css */
+/*                    ^^^^^^^^^ entity.other.layer.css */
+/*                             ^ punctuation.accessor.dot.css */
+/*                              ^^^^^^ entity.other.layer.css */
+/*                                    ^ punctuation.separator.sequence.css */
+/*                                      ^ punctuation.section.block.begin.css */
+/*                                        ^^^^ entity.other.attribute-name.class.css */
+/*                                             ^ punctuation.section.block.begin.css */
+/*                                               ^^^^^^^^^^^ support.type.property-name.css */
+/*                                                          ^ punctuation.separator.key-value.css */
+/*                                                            ^^^^^ support.constant.property-value.css */
+/*                                                                  ^ punctuation.section.block.end.css */
+/*                                                                    ^ punctuation.section.block.end.css */
+/*                                                                     ^ punctuation.terminator.rule.css */
+
+    @layer framework {
+      @layer layout {
+/*    ^^^^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css - meta.block meta.block */
+/*                  ^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css */
+/*    ^^^^^^ keyword.control.directive.css */
+/*           ^^^^^^ entity.other.layer.css */
+/*                  ^ punctuation.section.block.begin.css */
+        .foo {
+            font: status-bar;
+/*         ^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css */
+/*          ^^^^ support.type.property-name.css */
+/*              ^ punctuation.separator.key-value.css */
+/*                ^^^^^^^^^^ support.constant.property-value.css */
+/*                          ^ punctuation.terminator.rule.css */
+        }
+      }
+/*  ^^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css */
+/*    ^ punctuation.section.block.end.css */
+    }
+/* ^^ meta.at-rule.layer.css meta.block.css */
+/*  ^ punctuation.section.block.end.css */
 
     @supports not ( and ( top: 2px ) ) { }
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css - meta.block */


### PR DESCRIPTION
Fixes #3363 
Fixes #3364 

This PR adds support for...

1. `@layer`
2. `selector()` function in `@support` rules
3. `supports()` and `layer()` functions in in `@import` rules.

see:
- https://developer.mozilla.org/en-US/docs/Web/CSS/@import
- https://developer.mozilla.org/en-US/docs/Web/CSS/@layer