### PR TITLE
[Markdown] Hide embedded syntax's symbols

### DIFF
--- a/Markdown/Symbol List - Hide.tmPreferences
+++ b/Markdown/Symbol List - Hide.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>
+		text.html.markdown markup.raw.code-fence,
+		text.html.markdown meta.toc-list.id
+	</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>0</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>0</integer>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This PR hides symbols defined in fenced-code blocks from `Goto Symbol` quick panel and avoids them being indexed.

Same applies to `<tag id="hide-symbol"`> html `id` values.

The goals are:

1. reduce noise in Goto Symbol
2. avoid code snippets from being indexed, which are used for documentation purpose only.