### PR TITLE
[Markdown] Update to sublime-syntax version 2

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -11,6 +11,7 @@
 # to help make this syntax definition easier to maintain.
 name: Markdown
 scope: text.html.markdown
+version: 2
 
 file_extensions:
   - md
@@ -352,7 +353,7 @@ contexts:
 
   block-quote-end:
     - match: ^(?!(?:[ \t]*>))
-      pop: true
+      pop: 1
 
   block-quote-punctuations:
     - match: ^[ \t]{,3}(>)[ ]?
@@ -415,7 +416,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.end.text.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
-      pop: true
+      pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > REFERENCE DEFINITIONS ]#################
 
@@ -444,7 +445,7 @@ contexts:
     # A footnote definition is terminated by blocks not indented by at least 4 characters.
     # Note: The first space after a quotation punctuation is not counted for simplicity reasons.
     - match: ^(?!(?:[ \t]*>)+[ ](?:\1[ ]{4}|\s*$))
-      pop: true
+      pop: 1
 
   block-quote-footnote-paragraphs:
     - match: '[ \t]*(?=\S)'
@@ -469,7 +470,7 @@ contexts:
            |   {{html_block}}              # a html block begins the line
            )
         )
-      pop: true
+      pop: 1
 
   block-quote-link-definitions:
     # https://spec.commonmark.org/0.30/#link-reference-definition
@@ -554,7 +555,7 @@ contexts:
     #  According to CommonMark, a list block ends as soon as a new paragraph
     #  starts which is less indented than the first list item's text.
     - match: ^(?=(?:[ \t]*>)+[ ]?\S)
-      pop: true
+      pop: 1
 
   block-quote-list-paragraphs:
     # A list paragraph doesn't support indented code blocks.
@@ -580,7 +581,7 @@ contexts:
            |   {{html_block}}              # a html block begins the line
            )
         )
-      pop: true
+      pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > PARAGRAPHS ]############################
 
@@ -607,7 +608,7 @@ contexts:
            |   {{html_block}}              # a html block begins the line
            )
         )
-      pop: true
+      pop: 1
 
 ###[ CONTAINER BLOCKS: LISTS ]################################################
 
@@ -641,7 +642,7 @@ contexts:
 
   list-block-end:
     - match: ^(?=\S)
-      pop: true
+      pop: 1
 
   list-block-content:
     - include: fenced-code-blocks
@@ -730,7 +731,7 @@ contexts:
           |   {{html_block}}              # a html block begins the line
           )
         )
-      pop: true
+      pop: 1
 
 ###[ LEAF BLOCKS: ATX HEADINGS ]##############################################
 
@@ -801,7 +802,7 @@ contexts:
       captures:
         1: punctuation.definition.heading.end.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
     - include: emphasis
     - include: images
     - include: literals
@@ -829,7 +830,7 @@ contexts:
       captures:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
     - include: setext-heading-content
 
   setext-heading2:
@@ -840,7 +841,7 @@ contexts:
       captures:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
-      pop: true
+      pop: 1
     - include: setext-heading-content
 
   setext-heading-content:
@@ -862,7 +863,7 @@ contexts:
 
   paragraph-end:
     - match: '{{paragraph_end}}'
-      pop: true
+      pop: 1
 
 ###[ LEAF BLOCKS: INDENTED CODE BLOCKS ]######################################
 
@@ -880,7 +881,7 @@ contexts:
 
   fenced-code-block-content:
     - match: $
-      pop: true
+      pop: 1
     - include: fenced-syntaxes
     - include: fenced-raw
 
@@ -938,7 +939,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.actionscript.2
-      embed_scope: markup.raw.code-fence.actionscript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.actionscript.markdown-gfm
+        source.actionscript.2
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.actionscript.markdown-gfm
@@ -955,7 +958,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.applescript
-      embed_scope: markup.raw.code-fence.applescript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.applescript.markdown-gfm
+        source.applescript
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.applescript.markdown-gfm
@@ -972,7 +977,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.clojure
-      embed_scope: markup.raw.code-fence.clojure.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.clojure.markdown-gfm
+        source.clojure
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.clojure.markdown-gfm
@@ -989,7 +996,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.c
-      embed_scope: markup.raw.code-fence.c.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.c.markdown-gfm
+        source.c
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.c.markdown-gfm
@@ -1006,7 +1015,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.c++
-      embed_scope: markup.raw.code-fence.c++.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.c++.markdown-gfm
+        source.c++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.c++.markdown-gfm
@@ -1023,7 +1034,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.cs
-      embed_scope: markup.raw.code-fence.csharp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.csharp.markdown-gfm
+        source.cs
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.csharp.markdown-gfm
@@ -1040,7 +1053,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.css
-      embed_scope: markup.raw.code-fence.css.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.css.markdown-gfm
+        source.css
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.css.markdown-gfm
@@ -1057,7 +1072,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.diff
-      embed_scope: markup.raw.code-fence.diff.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.diff.markdown-gfm
+        source.diff
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.diff.markdown-gfm
@@ -1074,7 +1091,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.dosbatch
-      embed_scope: markup.raw.code-fence.dosbatch.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.dosbatch.markdown-gfm
+        source.dosbatch
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.dosbatch.markdown-gfm
@@ -1091,7 +1110,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.erlang
-      embed_scope: markup.raw.code-fence.erlang.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.erlang.markdown-gfm
+        source.erlang
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.erlang.markdown-gfm
@@ -1108,7 +1129,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.dot
-      embed_scope: markup.raw.code-fence.graphviz.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.graphviz.markdown-gfm
+        source.dot
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.graphviz.markdown-gfm
@@ -1125,7 +1148,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.go
-      embed_scope: markup.raw.code-fence.go.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.go.markdown-gfm
+        source.go
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.go.markdown-gfm
@@ -1142,7 +1167,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.haskell
-      embed_scope: markup.raw.code-fence.haskell.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.haskell.markdown-gfm
+        source.haskell
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.haskell.markdown-gfm
@@ -1159,7 +1186,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:embedding.php
-      embed_scope: markup.raw.code-fence.html-php.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.html-php.markdown-gfm
+        embedding.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.html-php.markdown-gfm
@@ -1176,7 +1205,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:text.html.basic
-      embed_scope: markup.raw.code-fence.html.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.html.markdown-gfm
+        text.html.basic
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.html.markdown-gfm
@@ -1193,7 +1224,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.java
-      embed_scope: markup.raw.code-fence.java.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.java.markdown-gfm
+        source.java
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.java.markdown-gfm
@@ -1210,7 +1243,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.js
-      embed_scope: markup.raw.code-fence.javascript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.javascript.markdown-gfm
+        source.js
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.javascript.markdown-gfm
@@ -1227,7 +1262,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.json
-      embed_scope: markup.raw.code-fence.json.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.json.markdown-gfm
+        source.json
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.json.markdown-gfm
@@ -1244,7 +1281,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:text.html.jsp
-      embed_scope: markup.raw.code-fence.jsp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.jsp.markdown-gfm
+        text.html.jsp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.jsp.markdown-gfm
@@ -1261,7 +1300,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.jsx
-      embed_scope: markup.raw.code-fence.jsx.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.jsx.markdown-gfm
+        source.jsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.jsx.markdown-gfm
@@ -1278,7 +1319,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.lisp
-      embed_scope: markup.raw.code-fence.lisp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.lisp.markdown-gfm
+        source.lisp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.lisp.markdown-gfm
@@ -1295,7 +1338,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.lua
-      embed_scope: markup.raw.code-fence.lua.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.lua.markdown-gfm
+        source.lua
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.lua.markdown-gfm
@@ -1312,7 +1357,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.matlab
-      embed_scope: markup.raw.code-fence.matlab.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.matlab.markdown-gfm
+        source.matlab
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.matlab.markdown-gfm
@@ -1329,7 +1376,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.objc
-      embed_scope: markup.raw.code-fence.objc.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.objc.markdown-gfm
+        source.objc
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.objc.markdown-gfm
@@ -1346,7 +1395,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.objc++
-      embed_scope: markup.raw.code-fence.objc++.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.objc++.markdown-gfm
+        source.objc++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.objc++.markdown-gfm
@@ -1363,7 +1414,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.ocaml
-      embed_scope: markup.raw.code-fence.ocaml.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.ocaml.markdown-gfm
+        source.ocaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.ocaml.markdown-gfm
@@ -1380,7 +1433,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.perl
-      embed_scope: markup.raw.code-fence.perl.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.perl.markdown-gfm
+        source.perl
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.perl.markdown-gfm
@@ -1397,7 +1452,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.php
-      embed_scope: markup.raw.code-fence.php.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.php.markdown-gfm
+        source.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.php.markdown-gfm
@@ -1414,7 +1471,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.python
-      embed_scope: markup.raw.code-fence.python.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.python.markdown-gfm
+        source.python
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.python.markdown-gfm
@@ -1431,7 +1490,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.regexp
-      embed_scope: markup.raw.code-fence.regexp.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.regexp.markdown-gfm
+        source.regexp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.regexp.markdown-gfm
@@ -1448,7 +1509,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.r
-      embed_scope: markup.raw.code-fence.r.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.r.markdown-gfm
+        source.r
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.r.markdown-gfm
@@ -1465,7 +1528,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.ruby
-      embed_scope: markup.raw.code-fence.ruby.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.ruby.markdown-gfm
+        source.ruby
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.ruby.markdown-gfm
@@ -1482,7 +1547,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.rust
-      embed_scope: markup.raw.code-fence.rust.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.rust.markdown-gfm
+        source.rust
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.rust.markdown-gfm
@@ -1499,7 +1566,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.scala
-      embed_scope: markup.raw.code-fence.scala.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.scala.markdown-gfm
+        source.scala
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.scala.markdown-gfm
@@ -1516,7 +1585,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.shell.interactive.markdown
-      embed_scope: markup.raw.code-fence.shell.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.shell.markdown-gfm
+        source.shell.interactive.markdown
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.shell.markdown-gfm
@@ -1533,7 +1604,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.shell.bash
-      embed_scope: markup.raw.code-fence.shell-script.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.shell-script.markdown-gfm
+        source.shell.bash
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.shell-script.markdown-gfm
@@ -1550,7 +1623,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.sql
-      embed_scope: markup.raw.code-fence.sql.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.sql.markdown-gfm
+        source.sql
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.sql.markdown-gfm
@@ -1567,7 +1642,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.tsx
-      embed_scope: markup.raw.code-fence.tsx.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.tsx.markdown-gfm
+        source.tsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.tsx.markdown-gfm
@@ -1584,7 +1661,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.ts
-      embed_scope: markup.raw.code-fence.typescript.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.typescript.markdown-gfm
+        source.ts
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.typescript.markdown-gfm
@@ -1601,7 +1680,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:text.xml
-      embed_scope: markup.raw.code-fence.xml.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.xml.markdown-gfm
+        text.xml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.xml.markdown-gfm
@@ -1618,7 +1699,9 @@ contexts:
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
       embed: scope:source.yaml
-      embed_scope: markup.raw.code-fence.yaml.markdown-gfm
+      embed_scope:
+        markup.raw.code-fence.yaml.markdown-gfm
+        source.yaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.yaml.markdown-gfm
@@ -1642,7 +1725,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.end.text.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
-      pop: true
+      pop: 1
 
 ###[ LEAF BLOCKS: HTML BLOCKS ]###############################################
 
@@ -1689,49 +1772,49 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
         3: punctuation.definition.tag.end.html
-      pop: true
+      pop: 1
     - include: html-content
 
   html-block-type-1b:
     - match: (?!</?\1>)
-      pop: true
+      pop: 1
     - include: html-content
 
   html-block-type-2:
     - match: (?!{{html_block_comment}})
-      pop: true
+      pop: 1
     - include: html-content
 
   html-block-type-3:
     - match: \?>
-      pop: true
+      pop: 1
 
   html-block-type-4:
     - match: (?!{{html_block_decl}})
-      pop: true
+      pop: 1
     - include: html-content
     - match: '{{html_block_decl}}'
       set: html-block-type-4-other
 
   html-block-type-4-other:
     - match: '>'
-      pop: true
+      pop: 1
 
   html-block-type-5:
     - match: (?!{{html_block_cdata}})
-      pop: true
+      pop: 1
     - include: html-content
 
   html-block-type-6:
     - meta_scope: meta.disable-markdown
     - match: ^\s*\n
-      pop: true
+      pop: 1
     - include: html-content
 
   html-block-pop-at-eol:
     - meta_scope: meta.disable-markdown
     - match: $\n?
-      pop: true
+      pop: 1
     - include: html-content
 
   html-content:
@@ -1765,7 +1848,7 @@ contexts:
 
   footnote-def-end:
     - match: ^(?!(?:\1[ ]{4}|\s*$))
-      pop: true
+      pop: 1
 
   footnote-paragraphs:
     - match: '[ \t]*(?=\S)'
@@ -1795,7 +1878,7 @@ contexts:
            |   {{html_block}}              # a html block begins the line
            )
         )
-      pop: true
+      pop: 1
 
   link-definitions:
     # https://spec.commonmark.org/0.30/#link-reference-definition
@@ -1817,7 +1900,7 @@ contexts:
 
   link-def-title:
     - match: ^(?!\s*["'(])
-      pop: true
+      pop: 1
     - match: (?=["'(])
       set:
         - expect-eol
@@ -1842,7 +1925,7 @@ contexts:
     # URLs are terminated by whitespace or newline in reference definitions
     # Note: \s includes \n
     - match: (?=\s)
-      pop: true
+      pop: 1
     - include: link-url-common
 
 ###[ LEAF BLOCKS: TABLES ]####################################################
@@ -1852,7 +1935,7 @@ contexts:
       push: table-header
 
   table-header:
-    - meta_content_scope: meta.table.header.markdown-gfm
+    - meta_scope: meta.table.header.markdown-gfm
     - match: \n
       set: table-header-separator-begin
     - include: table-cell-content
@@ -1861,10 +1944,10 @@ contexts:
     - match: ^(?=[-|:\s]+$)
       set: table-header-separator
     - match: ^
-      pop: true
+      pop: 1
 
   table-header-separator:
-    - meta_content_scope: meta.table.header-separator.markdown-gfm
+    - meta_scope: meta.table.header-separator.markdown-gfm
     - match: \n
       set: table-body
     - match: -+
@@ -1889,7 +1972,7 @@ contexts:
           |   {{indented_code_block}}
           |   {{thematic_break}}
           )
-      pop: true
+      pop: 1
 
   table-cell-content:
     - match: (?={{balanced_emphasis}})
@@ -1923,7 +2006,7 @@ contexts:
     - match: '[-_*]+'
       scope: punctuation.definition.thematic-break.markdown
     - match: \n
-      pop: true
+      pop: 1
 
 ###[ INLINE ]#################################################################
 
@@ -1979,11 +2062,11 @@ contexts:
     - meta_scope: markup.raw.inline.markdown
     - match: \1(?!`)
       scope: punctuation.definition.raw.end.markdown
-      pop: true
+      pop: 1
     - match: '`+'
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.raw.markdown
-      pop: true
+      pop: 1
     - include: paragraph-end
 
 ###[ INLINE: EMPHASIS ]#######################################################
@@ -2019,7 +2102,7 @@ contexts:
     - match: (?:_)?(\*\*)
       captures:
         1: punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     # Consume the underscore that has no corresponding underscore before the closing bold
     # punctuation on the same line, as it won't be treated as italic by CommonMark
     - match: \b_(?=[^\s_])(?=[^*_]*\*\*)
@@ -2035,7 +2118,7 @@ contexts:
     - match: (?:\*)?(__\b)
       captures:
         1: punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     # Consume the asterisk that has no corresponding asterisk before the closing bold
     # punctuation on the same line, as it won't be treated as italic by CommonMark
     - match: \*(?=[^\s*])(?=[^*_]*__\b)
@@ -2053,12 +2136,12 @@ contexts:
       captures:
         1: markup.italic.markdown punctuation.definition.italic.end.markdown
         2: punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     - match: \*\*
-      scope: punctuation.definition.bold.end.markdown
+      scope: markup.italic.markdown punctuation.definition.bold.end.markdown
       set: italic-after-bold-italic-asterisk
     - match: \*
-      scope: punctuation.definition.italic.end.markdown
+      scope: markup.italic.markdown punctuation.definition.italic.end.markdown
       set: bold-after-bold-italic-asterisk
     - include: emphasis-common
     - include: strikethrough
@@ -2072,7 +2155,7 @@ contexts:
         | ^\*\*           # emphasis can't be closed at the start of the line
     - match: \*\*
       scope: markup.bold.markdown punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     - include: bold-common
 
   italic-after-bold-italic-asterisk:
@@ -2084,7 +2167,7 @@ contexts:
         | ^\*\*           # emphasis can't be closed at the start of the line
     - match: \*
       scope: markup.italic.markdown punctuation.definition.italic.end.markdown
-      pop: true
+      pop: 1
     - include: italic-common
 
   bold-italic-underscore:
@@ -2099,12 +2182,12 @@ contexts:
       captures:
         1: markup.italic.markdown punctuation.definition.italic.end.markdown
         2: punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     - match: _\b
-      scope: punctuation.definition.italic.end.markdown
+      scope: markup.italic.markdown punctuation.definition.italic.end.markdown
       set: bold-after-bold-italic-underscore
     - match: __\b
-      scope: punctuation.definition.bold.end.markdown
+      scope: markup.italic.markdown punctuation.definition.bold.end.markdown
       set: italic-after-bold-italic-underscore
     - include: emphasis-common
     - include: strikethrough
@@ -2118,7 +2201,7 @@ contexts:
         | ^__             # emphasis can't be closed at the start of the line
     - match: __\b
       scope: markup.bold.markdown punctuation.definition.bold.end.markdown
-      pop: true
+      pop: 1
     - include: bold-common
 
   italic-after-bold-italic-underscore:
@@ -2130,7 +2213,7 @@ contexts:
         | ^__             # emphasis can't be closed at the start of the line
     - match: _\b
       scope: markup.italic.markdown punctuation.definition.italic.end.markdown
-      pop: true
+      pop: 1
     - include: italic-common
 
   bold-common:
@@ -2156,7 +2239,7 @@ contexts:
         | ^\*(?!\*)       # emphasis can't be closed at the start of the line
     - match: \*(?!\*[^*])
       scope: punctuation.definition.italic.end.markdown
-      pop: true
+      pop: 1
     - match: \*+
     - include: italic-common
 
@@ -2169,7 +2252,7 @@ contexts:
         | ^_(?!_)         # emphasis can't be closed at the start of the line
     - match: _\b
       scope: punctuation.definition.italic.end.markdown
-      pop: true
+      pop: 1
     - include: italic-common
 
   italic-common:
@@ -2188,7 +2271,7 @@ contexts:
     - meta_scope: markup.strikethrough.markdown-gfm
     - match: ~~(?:(?!~)|(?=~~}|~>))  # 2x ~ maybe followed by ~> or ~~}
       scope: punctuation.definition.strikethrough.end.markdown
-      pop: true
+      pop: 1
     - match: ~+(?:(?!~)|(?=~~}|~>))  # any number of ~ maybe followed by ~> or ~~}
     - include: emphasis-common
     - include: bold
@@ -2196,10 +2279,10 @@ contexts:
 
   emphasis-common:
     - match: '{{setext_escape}}'
-      pop: true
+      pop: 1
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.bold-italic.markdown
-      pop: true
+      pop: 1
     - include: paragraph-end
     - include: hard-line-breaks
     - include: images
@@ -2220,7 +2303,7 @@ contexts:
     - meta_scope: meta.image.inline.description.markdown
     - match: \]
       scope: punctuation.definition.image.end.markdown
-      pop: true
+      pop: 1
     - include: link-text
 
   image-inline-metadata:
@@ -2276,7 +2359,7 @@ contexts:
     - meta_scope: meta.image.reference.description.markdown
     - match: \]
       scope: punctuation.definition.image.end.markdown
-      pop: true
+      pop: 1
     - include: link-text
 
   image-ref-metadata:
@@ -2286,7 +2369,7 @@ contexts:
         1: punctuation.definition.metadata.begin.markdown
         2: markup.underline.link.markdown
         3: punctuation.definition.metadata.end.markdown
-      pop: true
+      pop: 1
     - include: immediately-pop
 
   image-ref-attr:
@@ -2312,7 +2395,7 @@ contexts:
     - meta_scope: meta.link.inline.description.markdown
     - match: \]
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     - include: link-text-allow-image
 
   link-inline-metadata:
@@ -2371,7 +2454,7 @@ contexts:
     - meta_scope: meta.link.reference.description.markdown
     - match: \]
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     - include: link-text-allow-image
 
   link-ref-metadata:
@@ -2381,7 +2464,7 @@ contexts:
         1: punctuation.definition.metadata.begin.markdown
         2: markup.underline.link.markdown
         3: punctuation.definition.metadata.end.markdown
-      pop: true
+      pop: 1
     - include: immediately-pop
 
   link-ref-attr:
@@ -2406,7 +2489,7 @@ contexts:
     - meta_scope: meta.link.reference.literal.description.markdown
     - match: \]
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     - include: link-text-allow-image
 
   link-ref-literal-metadata:
@@ -2415,7 +2498,7 @@ contexts:
       captures:
         1: punctuation.definition.metadata.begin.markdown
         2: punctuation.definition.metadata.end.markdown
-      pop: true
+      pop: 1
     - include: immediately-pop
 
   link-ref-literal-attr:
@@ -2445,7 +2528,7 @@ contexts:
     - meta_scope: meta.link.reference.wiki.description.markdown
     - match: \]\]
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     - include: link-text-allow-image
 
 ###[ INLINE: LINK/IMAGE PROTOTYPES ]##########################################
@@ -2462,7 +2545,7 @@ contexts:
   link-text-nested:
     - include: link-text
     - match: \]
-      pop: true
+      pop: 1
 
   link-text-allow-image:
     - include: link-text
@@ -2488,46 +2571,46 @@ contexts:
     - meta_scope: meta.string.title.markdown string.quoted.double.markdown
     - match: \"
       scope: punctuation.definition.string.end.markdown
-      pop: true
+      pop: 1
     - include: link-title-common
 
   link-title-single-quoted-content:
     - meta_scope: meta.string.title.markdown string.quoted.single.markdown
     - match: \'
       scope: punctuation.definition.string.end.markdown
-      pop: true
+      pop: 1
     - include: link-title-common
 
   link-title-other-quoted-content:
     - meta_scope: meta.string.title.markdown string.quoted.other.markdown
     - match: \)
       scope: punctuation.definition.string.end.markdown
-      pop: true
+      pop: 1
     - include: link-title-common
 
   link-title-common:
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.link-title.markdown
-      pop: true
+      pop: 1
     - include: escapes
     - include: html-entities
 
   link-url-angled:
     - match: \>
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     - include: link-url-common
 
   link-url-unquoted:
     - match: (?=[ \t)])
-      pop: true
+      pop: 1
     - match: \(
       push: link-url-unquoted-parens
     - include: link-url-common
 
   link-url-unquoted-parens:
     - match: \)
-      pop: true
+      pop: 1
     - include: link-url-unquoted
 
   link-url-common:
@@ -2555,7 +2638,7 @@ contexts:
   link-url-scheme-separator:
     - match: ':/{,2}'
       scope: punctuation.separator.path.markdown
-      pop: true
+      pop: 1
 
 ###[ INLINE: LINK/IMAGE/REFERENCE ATTRIBUTES ]################################
 
@@ -2565,7 +2648,7 @@ contexts:
     # https://pandoc.org/MANUAL.html#extension-link_attributes
     - match: \}
       scope: punctuation.definition.attributes.end.markdown
-      pop: true
+      pop: 1
     - match: \,
       scope: punctuation.separator.sequence.markdown
     - match: '{{tag_attribute_name_start}}'
@@ -2574,7 +2657,7 @@ contexts:
   tag-attr-name:
     - meta_scope: entity.other.attribute-name.markdown
     - match: '{{tag_attribute_name_break}}'
-      pop: true
+      pop: 1
     - match: '["''`<]'
       scope: invalid.illegal.attribute-name.markdown
 
@@ -2603,18 +2686,18 @@ contexts:
     - meta_scope: string.quoted.double.markdown
     - match: \"
       scope: punctuation.definition.string.end.markdown
-      pop: true
+      pop: 1
 
   tag-attr-value-single-quoted:
     - meta_scope: string.quoted.single.markdown
     - match: \'
       scope: punctuation.definition.string.end.markdown
-      pop: true
+      pop: 1
 
   tag-attr-value-unquoted:
     - meta_scope: string.unquoted.markdown
     - match: '{{tag_unquoted_attribute_break}}'
-      pop: true
+      pop: 1
     - match: '["''`<]'
       scope: invalid.illegal.attribute-value.markdown
 
@@ -2666,10 +2749,10 @@ contexts:
     - meta_content_scope: markup.underline.link.markdown
     - match: \>
       scope: punctuation.definition.link.end.markdown
-      pop: true
+      pop: 1
     # Spaces are not allowed in autolinks
     - match: (?=\s)
-      pop: true
+      pop: 1
     - include: autolink-inet-common
 
   autolink-inet-unquoted-content:
@@ -2685,14 +2768,14 @@ contexts:
     #    be considered part of the autolink, though they may be included in the
     #    interior # of the link
     - match: (?=(?:\)|(?:{{html_entity}})*)[?!.,:*_~]*[\s<])
-      pop: true
+      pop: 1
     - include: autolink-inet-common
 
   autolink-inet-group:
     - match: \)
-      pop: true
+      pop: 1
     - match: (?=(?:{{html_entity}})*[?!.,:*_~]*[\s<])
-      pop: true
+      pop: 1
     - include: autolink-inet-common
 
   autolink-inet-common:
@@ -2738,7 +2821,7 @@ contexts:
     - meta_content_scope: markup.inserted.critic.markdown
     - match: \+\+\}
       scope: punctuation.definition.critic.end.markdown
-      pop: true
+      pop: 1
     - include: critics-common
 
   critics-comments:
@@ -2751,7 +2834,7 @@ contexts:
     - meta_content_scope: comment.critic.markdown
     - match: '<<}'
       scope: punctuation.definition.critic.end.markdown
-      pop: true
+      pop: 1
     - include: critics-common
 
   critics-deletions:
@@ -2764,7 +2847,7 @@ contexts:
     - meta_content_scope: markup.deleted.critic.markdown
     - match: '--}'
       scope: punctuation.definition.critic.end.markdown
-      pop: true
+      pop: 1
     - include: critics-common
 
   critics-highlights:
@@ -2777,7 +2860,7 @@ contexts:
     - meta_content_scope: markup.info.critic.markdown
     - match: '==}'
       scope: punctuation.definition.critic.end.markdown
-      pop: true
+      pop: 1
     - include: critics-common
 
   critics-substitutions:
@@ -2801,12 +2884,12 @@ contexts:
     - meta_content_scope: markup.inserted.critic.markdown
     - match: '~~}'
       scope: punctuation.definition.critic.end.markdown
-      pop: true
+      pop: 1
     - include: critics-common
 
   critics-common:
     - match: ^(?=\s*$)
-      pop: true
+      pop: 1
     - include: emphasis
     - include: images
     - include: literals
@@ -2816,11 +2899,11 @@ contexts:
 
   else-pop:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   eol-pop:
     - match: $
-      pop: true
+      pop: 1
 
   expect-eol:
     - include: eol-pop
@@ -2829,5 +2912,5 @@ contexts:
 
   immediately-pop:
     - match: ''
-      pop: true
+      pop: 1
 

--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -2,8 +2,9 @@
 ---
 name: MultiMarkdown
 scope: text.html.markdown.multimarkdown
+version: 2
 
-extends: Packages/Markdown/Markdown.sublime-syntax
+extends: Markdown.sublime-syntax
 
 first_line_match: (?i:^format:\s*complete\s*$)
 


### PR DESCRIPTION
This commit...

1. sets `version: 2` tag in both, Markdown and MultiMarkdown
2. tweaks required scope rules to fix backward incompatible changes
   - tables: replace `meta_content_scope` by `meta_scope`
   - fenced-code-blocks: add embedded syntaxes' main scopes to
     `embed_scope`
   - bold-italics: add `meta.italic` to some `set` statements
3. replaces `pop: true` by `pop: 1`