### PR TITLE
[HTML] Add dedicated html context

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -91,6 +91,9 @@ variables:
 contexts:
 
   main:
+    - include: html
+
+  html:
     - include: preprocessor
     - include: doctype
     - include: comment


### PR DESCRIPTION
This commit introduces a dedicated `html` context, which can easily be
re-used by any inheriting syntax definition.

This may be required if an inheriting syntax wants to treat `main`
context special (e.g. by pre-pending shebang, frontmatter, ...) but
still needs easy access to plain `html` context with prototype from
inheriting syntax being applied to them.

Example:

```yml
scope: text.html.foo
contexts:
   prototype:
     - include: foo-embedded

   main:
     - match: ''
       set: [html, shebang]

   shebang:
     ...

   foo-embedded:
     ...
```

Without this commit each inheriting syntax needs to copy content from
HTML (PLain).sublime-syntax's `main` context like so:

```yml
  html:
    - include: preprocessor
    - include: doctype
    - include: comment
    - include: cdata
    - include: tag
    - include: entities
```

With this commmit, such copy and paste duplication can be avoided.