### PR TITLE
[CSS] Fix backward compatibility issue

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1517,8 +1517,7 @@ contexts:
     - include: terminator-pop
     - include: comments
     - include: comma-delimiters
-    - include: important-operators
-    - include: arithmetic-operators
+    - include: common-operators
     - include: builtin-values
     - include: other-functions
     - include: other-constants
@@ -3134,6 +3133,10 @@ contexts:
       scope: punctuation.separator.path.css
 
 ###[ OPERATORS ]###############################################################
+
+  common-operators:
+    - include: arithmetic-operators
+    - include: important-operators
 
   arithmetic-operators:
     - match: /


### PR DESCRIPTION
This commit restores `common-operators` context as it is used by `Tailwind CSS` package.

https://github.com/SublimeText/TailwindCSS/blob/5d6b4297bb90b5d18903576814be660281b3fa75/Tailwind%20CSS.sublime-syntax#L41