### PR TITLE
[TypeScript] Support generic methods in object literals

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1047,6 +1047,11 @@ contexts:
         - ts-object-literal-element-modifier
         - object-literal-element
 
+  object-literal-property-check:
+    - meta_prepend: true
+    - match: (?=<)
+      fail: object-literal-property
+
   ts-object-literal-element-modifier:
     - match: '{{modifier}}'
       scope: storage.modifier.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1227,6 +1227,11 @@ const x = {
     readonly get,
 //  ^^^^^^^^ storage.modifier
 //           ^^^ variable.other.readwrite
+
+    f<T>() {},
+//  ^^^^^^^^^ meta.function
+//  ^ entity.name.function
+//   ^^^ meta.generic
 };
 
     true ? (a) : <T,foo="a">() => {} => {} : null; // </T>;


### PR DESCRIPTION
Fix #3384.

Object literals are implemented to assume that an identifier is a regular key first. If it sees an open paren after the identifier, that means that it's a method and it should backtrack. However, in TypeScript, it might also be followed by type parameters. This PR makes it backtrack if it sees a less-than.