### PR TITLE
[CSS] Fix syntax tests

### DIFF
--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -1087,8 +1087,7 @@
     @layer utilities, framework.layout, { .foo { font-family: serif } };
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css - meta.block */
 /*                                      ^^ meta.at-rule.layer.css meta.block.css - meta.property-list */
-/*                                        ^^^^ meta.at-rule.layer.css meta.block.css meta.selector.css */
-/*                                            ^ meta.at-rule.layer.css meta.block.css - meta.selector - meta.property-list */
+/*                                        ^^^^^ meta.at-rule.layer.css meta.block.css meta.selector.css - meta.property-list */
 /*                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css */
 /*                                                                   ^^ meta.at-rule.layer.css meta.block.css - meta.property-list.css */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
@@ -1208,9 +1207,10 @@
 /*                          ^ punctuation.section.group.end.css */
 
     @supports selector( ;
+/*  ^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css */
 /*            ^^^^^^^^ meta.function-call.identifier.css */
 /*                    ^ meta.function-call.arguments.css meta.group.css - meta.selector */
-/*                     ^ meta.at-rule.supports.css - meta.function-call */
+/*                     ^ meta.function-call.arguments.css meta.group.css meta.selector */
 /*                      ^ - meta.at-rule - meta.function-call */
 
     @counter-style {}


### PR DESCRIPTION
Commit 727a8a198d0d6970e468aee8639752dc0ceca52c changed boundaries of `meta.selector` and was merged before #3366 which contains detailed (but outdated) checks for that scope.

This commit fixes syntax tests to comply with new `meta.selector` boundaries.