### PR TITLE
[HTML] Prevent completions in inappropriate contexts

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -486,13 +486,16 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
 
         # Note: Exclude opening punctuation to enable appreviations
         #       if the caret is located directly in front of a html tag.
-        if match_selector("text.html meta.tag - punctuation.definition.tag.begin"):
+        if match_selector("text.html meta.tag - meta.string - punctuation.definition.tag.begin"):
             if ch in ' \f\n\t':
                 return self.attribute_completions(view, locations[0], prefix)
             return None
 
-        # Expand tag and attribute appreviations
-        return self.expand_tag_attributes(view, locations) or self.tag_abbreviations
+        if match_selector("text.html - meta.tag"):
+            # Expand tag and attribute appreviations
+            return self.expand_tag_attributes(view, locations) or self.tag_abbreviations
+
+        return None
 
     def expand_tag_attributes(self, view, locations):
         """

--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -484,7 +484,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
                 return self.tag_name_completions
             return self.tag_completions
 
-        # Note: Exclude opening punctuation to enable appreviations
+        # Note: Exclude opening punctuation to enable abbreviations
         #       if the caret is located directly in front of a html tag.
         if match_selector("text.html meta.tag - meta.string - punctuation.definition.tag.begin"):
             if ch in ' \f\n\t':
@@ -492,7 +492,7 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
             return None
 
         if match_selector("text.html - meta.tag"):
-            # Expand tag and attribute appreviations
+            # Expand tag and attribute abbreviations
             return self.expand_tag_attributes(view, locations) or self.tag_abbreviations
 
         return None


### PR DESCRIPTION
This commit...

1. prevents attribute-completions within attribute values
   (aka. strings)

       <div attrib="|">   <- don't suggest attribute names

2. prevents abbreviation expansion within tags

       <div | >  <- don't expand `tag.attrib`