### PR TITLE
[Markdown] Improve MultiMarkdown frontmatter

### DIFF
--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -13,26 +13,39 @@ variables:
 
 contexts:
   main:
-    - match: ^(?={{header}})
-      push: multimarkdown-header
+    - meta_include_prototype: false
     - match: ^
-      set: multimarkdown-content
+      set:
+        - markdown
+        - frontmatter
 
-  multimarkdown-header:
-    - match: ^$
-      pop: 1
-    - match: ^(?:{{header}}\s*)?
+  frontmatter:
+    # MultiMarkdown 6 supports frontmatter like headers for compatibility reasons
+    # Note: The content is still limited to simple key-value pairs, no YAML!
+    - match: (---)\s*\n
       captures:
-        1: keyword.other.multimarkdown
-        2: punctuation.separator.key-value.multimarkdown
-      push: multimarkdown-header-value
-
-  multimarkdown-header-value:
-    - meta_scope: meta.header.multimarkdown
-    - meta_content_scope: string.unquoted.multimarkdown
-    - match: \n
+        0: meta.frontmatter.multimarkdown
+        1: punctuation.section.block.begin.frontmatter.multimarkdown
+        2: constant.other.language-name.multimarkdown
+      embed: frontmatter-content
+      embed_scope: meta.frontmatter.multimarkdown
+      escape: ^(---|\.{3})\s*\n
+      escape_captures:
+        0: meta.frontmatter.multimarkdown
+        1: punctuation.section.block.end.frontmatter.multimarkdown
+      pop: 1
+    # Classic key-value frontmatter beginning with first key, terminated by empty line.
+    - match: (?={{header}})
+      embed: frontmatter-content
+      embed_scope: meta.frontmatter.multimarkdown
+      escape: ^$
       pop: 1
 
-  multimarkdown-content:
-    - meta_scope: meta.content.multimarkdown
-    - include: markdown
+  frontmatter-content:
+    - match: ^{{header}}
+      captures:
+        1: meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+        2: meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+      embed: html-content
+      embed_scope: meta.mapping.value.multimarkdown
+      escape: ^(?={{header}})

--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -26,7 +26,6 @@ contexts:
       captures:
         0: meta.frontmatter.multimarkdown
         1: punctuation.section.block.begin.frontmatter.multimarkdown
-        2: constant.other.language-name.multimarkdown
       embed: frontmatter-content
       embed_scope: meta.frontmatter.multimarkdown
       escape: ^(---|\.{3})\s*\n

--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -14,15 +14,13 @@ variables:
 contexts:
   main:
     - meta_include_prototype: false
-    - match: ^
-      set:
-        - markdown
-        - frontmatter
+    - match: ''
+      set: [markdown, frontmatter]
 
   frontmatter:
     # MultiMarkdown 6 supports frontmatter like headers for compatibility reasons
     # Note: The content is still limited to simple key-value pairs, no YAML!
-    - match: (---)\s*\n
+    - match: ^(---)\s*\n
       captures:
         0: meta.frontmatter.multimarkdown
         1: punctuation.section.block.begin.frontmatter.multimarkdown
@@ -34,10 +32,13 @@ contexts:
         1: punctuation.section.block.end.frontmatter.multimarkdown
       pop: 1
     # Classic key-value frontmatter beginning with first key, terminated by empty line.
-    - match: (?={{header}})
+    - match: ^(?={{header}})
       embed: frontmatter-content
       embed_scope: meta.frontmatter.multimarkdown
       escape: ^$
+      pop: 1
+    # Ensure to highlight frontmatter if the syntax is embedded, but pop as early as possible
+    - match: ^|(?=\S)
       pop: 1
 
   frontmatter-content:

--- a/Markdown/MultiMarkdown.sublime-syntax
+++ b/Markdown/MultiMarkdown.sublime-syntax
@@ -9,7 +9,7 @@ extends: Markdown.sublime-syntax
 first_line_match: (?i:^format:\s*complete\s*$)
 
 variables:
-  header: ([A-Za-z0-9][\w -]*)(:)
+  header: ([A-Za-z0-9][\w -]*)((:)\s+)
 
 contexts:
   main:
@@ -45,7 +45,8 @@ contexts:
     - match: ^{{header}}
       captures:
         1: meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-        2: meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+        2: meta.mapping.multimarkdown
+        3: punctuation.separator.key-value.multimarkdown
       embed: html-content
       embed_scope: meta.mapping.value.multimarkdown
       escape: ^(?={{header}})

--- a/Markdown/tests/syntax_test_multimarkdown.md
+++ b/Markdown/tests/syntax_test_multimarkdown.md
@@ -1,35 +1,36 @@
 T: SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
 Title:   A Sample MultiMarkdown Document
-T: ^^ meta.header.multimarkdown keyword.other.multimarkdown
-T:   ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
-T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
-T:                                      ^ meta.header.multimarkdown - string
+T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Author:  Fletcher T. Penney
-T:^^^^ meta.header.multimarkdown keyword.other.multimarkdown
-T:    ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
-T:       ^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Date:    February 9, 2011
 Comment: This is a comment intended to demonstrate
          metadata that spans multiple lines, yet
          is treated as a single value.
-T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
-T:                                    ^ meta.header.multimarkdown - string
+T:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Test:    And this is a new key-value pair
 With-Dash: Test
-T: ^^^^^^ meta.header.multimarkdown keyword.other.multimarkdown
-T:       ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
-T:         ^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 With Space: Test
-T: ^^^^^^^ meta.header.multimarkdown keyword.other.multimarkdown
-T:        ^ meta.header.multimarkdown punctuation.separator.key-value.multimarkdown
-T:          ^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html
 HTML Header: <style>
              body { width:100ex; margin:auto; text-align:justify; }
              /* Some more style. */
              </style>
-T:           ^^^^^^^^ meta.header.multimarkdown string.unquoted.multimarkdown
+T:           ^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown meta.tag.style.end.html
 
-T: <- meta.content.multimarkdown - meta.header.multimarkdown
+T: <- - meta.frontmatter.multimarkdown
 # Heading
-T: <- markup.heading punctuation.definition.heading
-T:^^^^^^^ markup.heading
+T: <- markup.heading punctuation.definition.heading - meta.frontmatter.multimarkdown
+T:^^^^^^^ markup.heading - meta.frontmatter.multimarkdown

--- a/Markdown/tests/syntax_test_multimarkdown.md
+++ b/Markdown/tests/syntax_test_multimarkdown.md
@@ -1,36 +1,5 @@
-T: SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
-Title:   A Sample MultiMarkdown Document
-T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Author:  Fletcher T. Penney
-T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Date:    February 9, 2011
-Comment: This is a comment intended to demonstrate
-         metadata that spans multiple lines, yet
-         is treated as a single value.
-T:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Test:    And this is a new key-value pair
-With-Dash: Test
-T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-With Space: Test
-T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-HTML Header: <style>
-             body { width:100ex; margin:auto; text-align:justify; }
-T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html
-HTML Header: <style>
-             body { width:100ex; margin:auto; text-align:justify; }
-             /* Some more style. */
-             </style>
-T:           ^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown meta.tag.style.end.html
+| SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
 
-T: <- - meta.frontmatter.multimarkdown
-# Heading
-T: <- markup.heading punctuation.definition.heading - meta.frontmatter.multimarkdown
-T:^^^^^^^ markup.heading - meta.frontmatter.multimarkdown
+# MultiMarkdown without frontmatter
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown

--- a/Markdown/tests/syntax_test_multimarkdown_frontmatter.md
+++ b/Markdown/tests/syntax_test_multimarkdown_frontmatter.md
@@ -1,12 +1,15 @@
 T: SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
+T: <- meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 Title:   A Sample MultiMarkdown Document
 T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:    ^^^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Author:  Fletcher T. Penney
 T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:     ^^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Date:    February 9, 2011
 Comment: This is a comment intended to demonstrate
          metadata that spans multiple lines, yet
@@ -16,11 +19,13 @@ Test:    And this is a new key-value pair
 With-Dash: Test
 T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:         ^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 With Space: Test
 T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:         ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:          ^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 HTML Header: <style>
              body { width:100ex; margin:auto; text-align:justify; }
 T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html

--- a/Markdown/tests/syntax_test_multimarkdown_frontmatter.md
+++ b/Markdown/tests/syntax_test_multimarkdown_frontmatter.md
@@ -1,0 +1,36 @@
+T: SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
+Title:   A Sample MultiMarkdown Document
+T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Author:  Fletcher T. Penney
+T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Date:    February 9, 2011
+Comment: This is a comment intended to demonstrate
+         metadata that spans multiple lines, yet
+         is treated as a single value.
+T:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Test:    And this is a new key-value pair
+With-Dash: Test
+T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+With Space: Test
+T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+             /* Some more style. */
+             </style>
+T:           ^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown meta.tag.style.end.html
+
+T: <- - meta.frontmatter.multimarkdown
+# Heading
+T: <- markup.heading punctuation.definition.heading - meta.frontmatter.multimarkdown
+T:^^^^^^^ markup.heading - meta.frontmatter.multimarkdown

--- a/Markdown/tests/syntax_test_multimarkdown_no_frontmatter.md
+++ b/Markdown/tests/syntax_test_multimarkdown_no_frontmatter.md
@@ -1,0 +1,2 @@
+T:SYNTAX TEST "Packages/Markdown/MultiMarkdown.sublime-syntax"
+T: <- meta.paragraph.markdown - meta.frontmatter


### PR DESCRIPTION
This PR:

1. adds support for YAML like frontmatter in MultiMarkdown

   If a document starts with `---` MultiMarkdown 6 interprets it as
   beginning of meta-data for compatibility with YAML frontmatter,
   if not run in compatibility mode (-c flag).

   It does not support YAML though! Content is limited to same simple
   key-value pairs as in classical multimarkdown header format.

2. scopes all kinds of headers `meta.frontmatter.multimarkdown`
3. scopes key-value pairs `meta.mapping`
4. supports HTML in frontmatter values. Therefore `string` scope is
   removed.

Implementation uses `embed` to ensure correct bailouts without too many context duplication.

inspired by: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/690

---

#### Classical metadata format

![grafik](https://user-images.githubusercontent.com/16542113/169771671-5fd660cc-3e28-44cb-87e2-5b571a6e6714.png)


#### YAML frontmatter like metadata format

![grafik](https://user-images.githubusercontent.com/16542113/169771776-9b436286-689c-4d82-b521-e702f85b068e.png)

