### PR TITLE
[Markdown] Add support for setext headings in list-blocks

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -259,6 +259,20 @@ variables:
        )
     )
 
+  list_paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
   # https://spec.commonmark.org/0.30/#left-flanking-delimiter-run
   bold_italic_asterisk_begin: |-
     (?x:
@@ -758,26 +772,17 @@ contexts:
   list-paragraph:
     # https://spec.commonmark.org/0.30/#paragraphs
     - meta_scope: meta.paragraph.list.markdown
-    - match: '{{list_setext_heading_escape}}'
-      fail: list-setext-headings-or-paragraphs
+    - include: list-paragraph-fail
     - include: list-paragraph-end
     - include: inlines
 
   list-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= [ \t]*
-          (?: $                           # the line is blank (or only contains whitespace)
-          |   {{block_quote}}             # a blockquote begins the line
-          |   {{atx_heading}}             # an ATX heading begins the line
-          |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-          |   {{thematic_break}}          # line is a thematic beak
-          |   {{list_item}}               # a list item begins the line
-          |   {{html_block}}              # a html block begins the line
-          )
-        )
+    - match: '{{list_paragraph_end}}'
       pop: 1
+
+  list-paragraph-fail:
+    - match: '{{list_setext_heading_escape}}'
+      fail: list-setext-headings-or-paragraphs
 
 ###[ LEAF BLOCKS: ATX HEADINGS ]##############################################
 
@@ -902,14 +907,17 @@ contexts:
   paragraph:
     # https://spec.commonmark.org/0.30/#paragraphs
     - meta_scope: meta.paragraph.markdown
-    - match: '{{setext_heading_escape}}'
-      fail: setext-headings-or-paragraphs
+    - include: paragraph-fail
     - include: paragraph-end
     - include: inlines
 
   paragraph-end:
     - match: '{{paragraph_end}}'
       pop: 1
+
+  paragraph-fail:
+    - match: '{{setext_heading_escape}}'
+      fail: setext-headings-or-paragraphs
 
 ###[ LEAF BLOCKS: INDENTED CODE BLOCKS ]######################################
 

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -25,14 +25,14 @@ variables:
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
 
   setext_heading_or_paragraph: ^[ ]{,3}(?:=+|(?=\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)    # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)    # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
   setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one hyphon (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
   list_setext_heading_or_paragraph: '[ \t]*(?:=+|(?=\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)\s*$) # two or more spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)\s*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
   list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)    # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)    # two or more spaces, followed by at least one hyphon (setext underline can be of any length)
+  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)    # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
@@ -118,7 +118,7 @@ variables:
       # at least 2 non-escaped pipe chars on the line
       (?:{{table_cell}}?\|){2}
 
-      # something other than whitespace followed by a pipe char or hyphon,
+      # something other than whitespace followed by a pipe char or hyphen,
       # followed by something other than whitespace and the end of the line
     | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
     )

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -26,11 +26,13 @@ variables:
 
   setext_heading_or_paragraph: ^[ ]{,3}(?:=+|(?=\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
   setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)    # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  setext_heading1_escape: ^(?=[ ]{,3}=+\s*$)          # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
   setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
   setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
   list_setext_heading_or_paragraph: '[ \t]*(?:=+|(?=\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
   list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)\s*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}=+\s*$)       # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
   list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)    # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
   list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)    # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
 
@@ -738,8 +740,6 @@ contexts:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
-    - match: '{{list_setext_heading_escape}}'
-      fail: list-setext-headings-or-paragraphs
     - include: setext-heading-content
 
   list-setext-heading2:
@@ -751,7 +751,7 @@ contexts:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
-    - match: '{{list_setext_heading_escape}}'
+    - match: '{{list_setext_heading1_escape}}'
       fail: list-setext-headings-or-paragraphs
     - include: setext-heading-content
 
@@ -877,8 +877,6 @@ contexts:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
-    - match: '{{setext_heading_escape}}'
-      fail: setext-headings-or-paragraphs
     - include: setext-heading-content
 
   setext-heading2:
@@ -890,7 +888,7 @@ contexts:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
-    - match: '{{setext_heading_escape}}'
+    - match: '{{setext_heading1_escape}}'
       fail: setext-headings-or-paragraphs
     - include: setext-heading-content
 

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -30,11 +30,11 @@ variables:
   setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
   setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
-  list_setext_heading_or_paragraph: (?:[ \t]*=+|(?=[ \t]*\S)) # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)[ \t]*$)  # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  list_setext_heading1_escape: ^(?=[ \t]{2,}=+[ \t]*$)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)        # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
+  list_setext_heading_or_paragraph: (?:[ \t]*=+|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*$(\n?)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*$(\n?)        # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -24,17 +24,17 @@ variables:
   atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
 
-  setext_heading_or_paragraph: ^[ ]{,3}(?:=+|(?=\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)    # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  setext_heading1_escape: ^(?=[ ]{,3}=+\s*$)          # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
+  setext_heading_or_paragraph: ^(?:[ ]{,3}=+|(?=[ ]{,3}\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)        # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)              # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)              # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)              # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
-  list_setext_heading_or_paragraph: '[ \t]*(?:=+|(?=\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)\s*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  list_setext_heading1_escape: ^(?=[ \t]{2,}=+\s*$)       # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)    # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)    # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
+  list_setext_heading_or_paragraph: '(?:[ \t]*=+|(?=[ \t]*\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)[ \t]*$)    # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}=+[ \t]*$)          # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
+  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)          # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
+  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)          # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -23,7 +23,16 @@ variables:
   atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
   atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
-  setext_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)            # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+
+  setext_heading_or_paragraph: ^[ ]{,3}(?:=+|(?=\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)    # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)       # between 0 and 3 spaces, followed by at least one hyphon (setext underline can be of any length)
+
+  list_setext_heading_or_paragraph: '[ \t]*(?:=+|(?=\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)\s*$) # two or more spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)    # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
+  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)    # two or more spaces, followed by at least one hyphon (setext underline can be of any length)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
@@ -650,7 +659,7 @@ contexts:
     - include: reference-definitions
     - include: list-block-common
     - include: list-block-quotes
-    - include: list-paragraphs
+    - include: list-setext-headings-or-paragraphs
 
   list-block-common:
     - include: thematic-breaks
@@ -708,12 +717,49 @@ contexts:
     - include: list-block-quote-punctuations
     - include: inlines
 
-  list-paragraphs:
-    - match: '[ \t]*(?=\S)'
-      push: list-paragraph-body
+  list-setext-headings-or-paragraphs:
+    # A paragraph may start with a line of equal signs which must not be matched
+    # as heading underline. This is achieved by consuming them here, which also
+    # applies `meta.paragraph` scope as expected.
+    # A line of dashes is already matched as thematic break and thus ignored.
+    - match: '{{list_setext_heading_or_paragraph}}'
+      branch_point: list-setext-headings-or-paragraphs
+      branch:
+        - list-paragraph
+        - list-setext-heading2
+        - list-setext-heading1
 
-  list-paragraph-body:
+  list-setext-heading1:
+    # https://spec.commonmark.org/0.30/#setext-headings
+    - meta_scope: markup.heading.1.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - match: '{{list_setext_heading1_end}}'
+      captures:
+        1: punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
+      pop: 1
+    - match: '{{list_setext_heading_escape}}'
+      fail: list-setext-headings-or-paragraphs
+    - include: setext-heading-content
+
+  list-setext-heading2:
+    # https://spec.commonmark.org/0.30/#setext-headings
+    - meta_scope: markup.heading.2.markdown
+    - meta_content_scope: entity.name.section.markdown
+    - match: '{{list_setext_heading2_end}}'
+      captures:
+        1: punctuation.definition.heading.setext.markdown
+        2: meta.whitespace.newline.markdown
+      pop: 1
+    - match: '{{list_setext_heading_escape}}'
+      fail: list-setext-headings-or-paragraphs
+    - include: setext-heading-content
+
+  list-paragraph:
+    # https://spec.commonmark.org/0.30/#paragraphs
     - meta_scope: meta.paragraph.list.markdown
+    - match: '{{list_setext_heading_escape}}'
+      fail: list-setext-headings-or-paragraphs
     - include: list-paragraph-end
     - include: inlines
 
@@ -815,7 +861,7 @@ contexts:
     # as heading underline. This is achieved by consuming them here, which also
     # applies `meta.paragraph` scope as expected.
     # A line of dashes is already matched as thematic break and thus ignored.
-    - match: ^[ ]{,3}(?:=+|(?=\S))
+    - match: '{{setext_heading_or_paragraph}}'
       branch_point: setext-headings-or-paragraphs
       branch:
         - paragraph
@@ -826,27 +872,29 @@ contexts:
     # https://spec.commonmark.org/0.30/#setext-headings
     - meta_scope: markup.heading.1.markdown
     - meta_content_scope: entity.name.section.markdown
-    - match: ^[ ]{,3}(=+)[ \t]*$(\n?)
+    - match: '{{setext_heading1_end}}'
       captures:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
+    - match: '{{setext_heading_escape}}'
+      fail: setext-headings-or-paragraphs
     - include: setext-heading-content
 
   setext-heading2:
     # https://spec.commonmark.org/0.30/#setext-headings
     - meta_scope: markup.heading.2.markdown
     - meta_content_scope: entity.name.section.markdown
-    - match: ^[ ]{,3}(-+)[ \t]*$(\n?)
+    - match: '{{setext_heading2_end}}'
       captures:
         1: punctuation.definition.heading.setext.markdown
         2: meta.whitespace.newline.markdown
       pop: 1
+    - match: '{{setext_heading_escape}}'
+      fail: setext-headings-or-paragraphs
     - include: setext-heading-content
 
   setext-heading-content:
-    - match: '{{setext_escape}}'
-      fail: setext-headings-or-paragraphs
     - include: emphasis
     - include: images
     - include: literals
@@ -856,7 +904,7 @@ contexts:
   paragraph:
     # https://spec.commonmark.org/0.30/#paragraphs
     - meta_scope: meta.paragraph.markdown
-    - match: '{{setext_escape}}'
+    - match: '{{setext_heading_escape}}'
       fail: setext-headings-or-paragraphs
     - include: paragraph-end
     - include: inlines
@@ -2278,7 +2326,7 @@ contexts:
     - include: italic
 
   emphasis-common:
-    - match: '{{setext_escape}}'
+    - match: '{{setext_heading_escape}}'
       pop: 1
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.bold-italic.markdown

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -24,17 +24,17 @@ variables:
   atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
 
-  setext_heading_or_paragraph: ^(?:[ ]{,3}=+|(?=[ ]{,3}\S))  # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)        # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)              # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)              # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)              # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
+  setext_heading_or_paragraph: ^(?:[ ]{,3}=+|(?=[ ]{,3}\S))   # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)         # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
-  list_setext_heading_or_paragraph: '(?:[ \t]*=+|(?=[ \t]*\S))' # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)[ \t]*$)    # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  list_setext_heading1_escape: ^(?=[ \t]{2,}=+[ \t]*$)          # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)          # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
-  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)          # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
+  list_setext_heading_or_paragraph: (?:[ \t]*=+|(?=[ \t]*\S)) # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:=+|-+)[ \t]*$)  # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}=+[ \t]*$)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
+  list_setext_heading1_end: ^[ \t]{2,}(=+)[ \t]*$(\n?)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length)
+  list_setext_heading2_end: ^[ \t]{2,}(-+)[ \t]*$(\n?)        # two or more spaces, followed by at least one hyphen (setext underline can be of any length)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -4575,7 +4575,7 @@ A list item can contain a heading:
 
 - Should be a setext heading!
   ---
-| ^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+| ^^^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 
 - Bar
   ---
@@ -5113,6 +5113,40 @@ So is this, with a empty second item:
          ## list item heading 2
          | <- markup.list.numbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
          |^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.2.markdown
+
+## https://custom-tests/list-blocks/items-with-setext-headings
+
+* list item
+global heading
+===
+| <- markup.list.unnumbered.markdown meta.paragraph.list.markdown
+|^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
+
+* list item
+ global heading (matched as list item heading)
+ ===
+ | <- markup.list.unnumbered.markdown meta.paragraph.list.markdown
+ |^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
+
+* list item
+  heading
+  ===
+  | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+  |^^ markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.setext.markdown
+  
+  - list item
+
+  list item heading
+  ---
+  | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+  |^^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+  + list item
+    
+    list item heading
+    ---
+    | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+    |^^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 
 ## https://custom-tests/list-blocks/items-with-fenced-code-blocks-indented-by-tabs
 

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -5148,6 +5148,24 @@ global heading
     | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
     |^^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 
+  - heading
+    ---
+    | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+    |^^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+  - should not be a heading, but we can't handle it yet
+  --
+  | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+  |^ markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+
+  - list item
+  - 
+  | <- markup.list.unnumbered.markdown markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+  - list item
+  = 
+  | <- markup.list.unnumbered.markdown meta.paragraph.list.markdown
+
 ## https://custom-tests/list-blocks/items-with-fenced-code-blocks-indented-by-tabs
 
   * foo


### PR DESCRIPTION
This commit adds `list-setext-headings-or-paragraphs` contexts which are a modified copy of `setext-headings-or-paragraphs` to support setext headings within list items.

Note: It may also be useful if markdown is to be embedded into 3rd-party syntaxes (e.g.: Astro) with lazy indentation handling.

#### Example

![grafik](https://user-images.githubusercontent.com/16542113/169770343-be0ac4b3-bfb3-49d1-8aa4-eb45bf6cdf6e.png)


#### Rendered as 

---

1. Heading
===

1. List Item
   ===

   - nested list
     
     with heading
     ---

     and paragraph
     
