### PR TITLE
[Markdown] Add public context for embedding by 3rd-party syntaxes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -317,6 +317,13 @@ contexts:
     - include: atx-headings
     - include: setext-headings-or-paragraphs
 
+  indented-markdown:
+    # This is a public context which can be embedded by 3rd-party syntaxes
+    # to support Markdown highlighting in locations of arbitrary indentation,
+    # but without reference to list blocks as this is an implementation detail.
+    # The content may diverge from list block content in future.
+    - include: list-block-content
+
 ###[ CONTAINER BLOCKS: BLOCK QUOTES ]#########################################
 
   block-quotes:


### PR DESCRIPTION
This commit adds an alias context meant for use by external syntaxes, which want to embed Markdown.

The motivation is to avoid using `list-block-content` as it leaks too many implementation details.

_Note: This commit doesn't change behavior of Markdown syntax._