### PR TITLE
[D] Fix template constraints after class inherits

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1057,6 +1057,12 @@ contexts:
     # function
     - match: '(?=[[:alpha:]0-9_\.]+\s*\()'
       set: value-array-list
+    - match: '\b({{language_constant}})\b'
+      scope: constant.language.d
+      set: first-value-after
+    - match: '\b({{language_variable}})\b'
+      scope: variable.language.d
+      set: first-value-after
     - match: '{{name_lookahead}}'
       scope: variable.other.d
       set: [first-value-after, value-identifier]
@@ -1589,9 +1595,8 @@ contexts:
     - match: ','
       scope: punctuation.separator.sequence.d
       set: base-class-list
-    - match: '(?={)'
+    - match: '(?=\S)'
       pop: true
-    - include: not-whitespace-illegal-pop
 
   interface-in:
     - match: '\b(interface)\b'
@@ -2173,6 +2178,7 @@ contexts:
       set: [condition-after, first-value]
     - include: not-whitespace-illegal-pop
   condition-after:
+    - meta_scope: meta.parens.d
     - match: '\)'
       scope: punctuation.section.parens.end.d
       pop: true

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -776,6 +776,20 @@ extern(1)
   }
 //^ meta.class.d punctuation.section.block.end.d
 
+  class Foo : Bar
+  if (true) {}
+//^^^ meta.class.d - meta.parens
+//   ^^^^^^ meta.class.d meta.parens.d
+//         ^ meta.class.d - meta.parens - meta.block
+//          ^^ meta.class.d meta.block.d
+//            ^ - meta.class
+//^^ keyword.control.conditional.d
+//   ^ punctuation.section.parens.begin.d
+//    ^^^^ constant.language.d
+//        ^ punctuation.section.parens.end.d
+//          ^ punctuation.section.block.begin.d
+//           ^ punctuation.section.block.end.d
+
   interface S;
 //^^^^^^^^^^^^ meta.interface.d
 //^^^^^^^^^ keyword.declaration.interface.d


### PR DESCRIPTION
Fixes #3389

This commit:

1. pops `base-class-list-after` without illegal highlighting to leave that decision up to the next context on stack as that's what happening if no base classes are present.

2. makes sure language constants and variables are matched when being the first value in a group (e.g.: `condition`).

   This change is made, because after fixing 1.) `true` wasn't highlighted as `constant` in the provided example from #3389.

3. adds `meta.parens` to `condition` context as a starting point to fix various syntax based folding issues D suffers from due to lack of those meta scopes.