### PR TITLE
[D] Fix mixin() arguments lists

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1052,7 +1052,7 @@ contexts:
       captures:
         1: keyword.control.d
         2: punctuation.section.parens.begin.d
-      set: [first-value-parens-after, value]
+      set: [first-value-parens-after, value-list]
     # Match a regular function call so we properly highlight the name as a
     # function
     - match: '(?=[[:alpha:]0-9_\.]+\s*\()'

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -770,7 +770,7 @@ contexts:
       set:
         - match: '\('
           scope: punctuation.section.parens.begin.d
-          set: [basic-type2, basic-type2-after-parens, value]
+          set: [basic-type2, basic-type2-after-parens, value-list]
     - match: '{{name_lookahead}}'
       set: [basic-type2, type-identifier-ref]
     - match: '(?=\S)'

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1810,6 +1810,19 @@ extern(1)
 //                   ^ meta.function.d meta.block.d punctuation.section.block.begin.d
 //                    ^ meta.function.d meta.block.d punctuation.section.block.end.d
 
+  mixin("alias A", "= B;") foo() {};
+//^^^^^ keyword.control.d
+//     ^ punctuation.section.parens.begin.d
+//      ^^^^^^^^^ meta.string.d string.quoted.double.d
+//               ^ punctuation.separator.sequence.d
+//                 ^^^^^^ meta.string.d string.quoted.double.d
+//                       ^ punctuation.section.parens.end.d
+//                         ^^^ meta.function.d entity.name.function.d
+//                            ^ meta.function.parameters.d punctuation.section.group.begin.d
+//                             ^ meta.function.parameters.d punctuation.section.group.end.d
+//                               ^ meta.function.d meta.block.d punctuation.section.block.begin.d
+//                                ^ meta.function.d meta.block.d punctuation.section.block.end.d
+//                                 ^ punctuation.terminator.d
 
   foo:
 //^^^ entity.name.label.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1827,7 +1827,6 @@ extern(1)
   function mixin("alias A", "= B;") () {};
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.d
 //                                  ^^ meta.function.parameters.d
-//                                    ^ meta.function.d - meta.block
 //                                     ^^ meta.function.d meta.block.d
 //         ^^^^^ keyword.control.d
 //              ^ punctuation.section.parens.begin.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1824,6 +1824,23 @@ extern(1)
 //                                ^ meta.function.d meta.block.d punctuation.section.block.end.d
 //                                 ^ punctuation.terminator.d
 
+  function mixin("alias A", "= B;") () {};
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.d
+//                                  ^^ meta.function.parameters.d
+//                                    ^ meta.function.d - meta.block
+//                                     ^^ meta.function.d meta.block.d
+//         ^^^^^ keyword.control.d
+//              ^ punctuation.section.parens.begin.d
+//               ^^^^^^^^^ meta.string.d string.quoted.double.d
+//                        ^ punctuation.separator.sequence.d
+//                          ^^^^^^ meta.string.d string.quoted.double.d
+//                                ^ punctuation.section.parens.end.d
+//                                  ^ punctuation.section.group.begin.d
+//                                   ^ punctuation.section.group.end.d
+//                                     ^ punctuation.section.block.begin.d
+//                                      ^ punctuation.section.block.end.d
+//                                       ^ punctuation.terminator.d
+
   foo:
 //^^^ entity.name.label.d
 //   ^ punctuation.separator.d


### PR DESCRIPTION
Fixes #3390

This commit adds support for `value-list` in the first `mixin()` expression of a statement.

_Note: `mixin` in `value` context does so already._