### PR TITLE
[D] Improve shebang handling

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -74,15 +74,31 @@ contexts:
     - include: comment-in
 
   main:
-    - match: '^#!'
-      scope: punctuation.definition.comment.number-sign.d
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.number-sign.d
-        - match: '$\n?'
-          pop: true
+    - meta_include_prototype: false
+    - match: ''
+      set: [d, shebang]
+
+  shebang:
+    - meta_include_prototype: false
+    - match: ^\#!
+      scope: punctuation.definition.comment.d
+      set: shebang-body
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if syntax is embedded.
+      pop: 1
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.d
+    # Note: Keep sync with first_line_match!
+    - match: \bg?dmd\b
+      scope: constant.language.shebang.d
+    - match: \n
+      pop: 1
+
+  d:
     - include: module-in
     - include: statement-list-in
+
   module-in:
     - match: \bmodule\b
       scope: keyword.declaration.namespace.d

--- a/D/tests/syntax_test_shebang.d
+++ b/D/tests/syntax_test_shebang.d
@@ -1,10 +1,14 @@
-#! SYNTAX TEST "Packages/D/D.sublime-syntax"
-#! <- comment.line.number-sign.d punctuation.definition.comment.number-sign.d
- #! <- comment.line.number-sign.d punctuation.definition.comment.number-sign.d
-#!^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.d
+#! SYNTAX TEST "Packages/D/D.sublime-syntax" dmd
+#! <- comment.line.shebang.d punctuation.definition.comment.d
+ #! <- comment.line.shebang.d punctuation.definition.comment.d
+#!^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.shebang.d
+#!                                           ^^^ constant.language.shebang.d
 ;
 // foo
 #! ^^^ comment.line.double-slash.d
 
 #! foo
-#! ^^^ comment.line.number-sign.d
+#! <- invalid.illegal.d
+ #! <- keyword.operator.logical.d dmd
+#! ^^^ meta.path.d variable.other.d
+


### PR DESCRIPTION
This commit modifies shebang handling according to Erlang/Java/Bash and other syntaxes of this repo to...

1. match shebang comments on the very first line only.
2. highlight `dmd` as constant.
3. use the same comment scope `comment.line.shebang`.