### PR TITLE
[PHP] Fix regression in PHP arrow function return type scoping

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1005,6 +1005,7 @@ contexts:
 
   arrow-function-or-fail:
     - include: comments
+    - include: function-return-type
     - match: =>
       scope: keyword.declaration.function.arrow.php
       pop: 1

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -989,6 +989,7 @@ contexts:
       set:
         - arrow-function-body
         - arrow-function-or-fail
+        - arrow-function-return-type
         - arrow-function-parameters
 
   arrow-function-parameters:
@@ -1003,9 +1004,22 @@ contexts:
     - meta_scope: meta.function.anonymous.parameters.php meta.group.php
     - include: function-parameters-body
 
+  arrow-function-return-type:
+    - match: ':'
+      scope: punctuation.separator.colon.php
+      set:
+        - arrow-function-return-type-body
+        - type-hint-simple-type
+        - type-hint-nullable
+    - include: else-pop
+
+  arrow-function-return-type-body:
+    - clear_scopes: 1
+    - meta_scope: meta.function.anonymous.return-type.php
+    - include: type-hint-body
+
   arrow-function-or-fail:
     - include: comments
-    - include: function-return-type
     - match: =>
       scope: keyword.declaration.function.arrow.php
       pop: 1

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1759,8 +1759,40 @@ $fn = fn($x) => fn($y) => $x * $y + $z;
 //                     ^^ keyword.declaration.function.arrow.php
 //                                    ^ punctuation.terminator.statement.php
 
+$fn = fn ($value): bool => true;
+//    ^^^ meta.function.anonymous.php
+//       ^^^^^^^^ meta.function.anonymous.parameters.php meta.group.php
+//               ^^^^^^^ meta.function.anonymous.return-type.php
+//                      ^^^^^^^ meta.function.anonymous.php
+//                             ^ - meta.function
+//    ^^ keyword.declaration.function.php
+//       ^ punctuation.section.group.begin.php
+//        ^^^^^^ variable.parameter.php
+//              ^ punctuation.section.group.end.php
+//               ^ punctuation.separator.colon.php
+//                 ^^^^ storage.type.primitive.php
+//                      ^^ keyword.declaration.function.arrow.php
+//                         ^^^^ constant.language.boolean.php
+//                             ^ punctuation.terminator.statement.php
+
 $fn = fn ($x): stringSpace\Test1 => null;
-//             ^^^^^^^^^^^^^^^^^ meta.function.return-type.php
+//    ^^^ meta.function.anonymous.php
+//       ^^^^ meta.function.anonymous.parameters.php meta.group.php
+//           ^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.return-type.php
+//                               ^^^^^^^ meta.function.anonymous.php
+//                                      ^ - meta.function
+//    ^^ keyword.declaration.function.php
+//       ^ punctuation.section.group.begin.php
+//        ^^ variable.parameter.php
+//          ^ punctuation.section.group.end.php
+//           ^ punctuation.separator.colon.php
+//             ^^^^^^^^^^^^^^^^^ meta.path.php
+//             ^^^^^^^^^^^ variable.namespace.php
+//                        ^ punctuation.accessor.namespace.php
+//                         ^^^^^ support.class.php
+//                               ^^ keyword.declaration.function.arrow.php
+//                                  ^^^^ constant.language.null.php
+//                                      ^ punctuation.terminator.statement.php
 
 $var = fn($x)
 //     ^^ meta.function.anonymous.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1759,6 +1759,9 @@ $fn = fn($x) => fn($y) => $x * $y + $z;
 //                     ^^ keyword.declaration.function.arrow.php
 //                                    ^ punctuation.terminator.statement.php
 
+$fn = fn ($x): stringSpace\Test1 => null;
+//             ^^^^^^^^^^^^^^^^^ meta.function.return-type.php
+
 $var = fn($x)
 //     ^^ meta.function.anonymous.php
 //       ^^^^ meta.function.anonymous.parameters.php meta.group.php


### PR DESCRIPTION
Fixes #3407 by adding back support for short arrow function return types.