### PR TITLE
[YAML] Fix bailout from explicit keys without value

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -732,22 +732,16 @@ contexts:
     - include: block-pair
 
   block-pair:
-    - match: \?(?=\s|$)
-      scope: meta.mapping.yaml punctuation.definition.key-value.begin.yaml
+    - match: ( *)(\?)(?=\s)
+      captures:
+        2: meta.mapping.yaml punctuation.definition.key-value.begin.yaml
       push: block-key-explicit
     # Attempt to match plain-out scalars and highlight as "meta.mapping.key",
     # if followed by a colon
     - match: '{{_flow_key_out_lookahead}}'
       push: block-key-implicit
-    - match: :(?=\s|$)
+    - match: :(?=\s)
       scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-
-  block-key-implicit:
-    - meta_content_scope: meta.mapping.key.yaml
-    - match: :(?=\s|$)
-      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
-      pop: true
-    - include: flow-scalar-out-12
 
   block-key-explicit:
     - meta_content_scope: meta.mapping.key.yaml
@@ -757,9 +751,20 @@ contexts:
       captures:
         1: punctuation.separator.key-value.mapping.yaml
       pop: true
-    - match: (?=\?(?=\s|$))  # Empty mapping keys & values are allowed
+    # multi-line keys are indented by at least one more space than `?`
+    - match: ^(?!\1 +\S|\s*$)
+      pop: true
+    # explicit key of any indentation
+    - match: ^ *(?=\?\s)
       pop: true
     - include: block-node-12
+
+  block-key-implicit:
+    - meta_content_scope: meta.mapping.key.yaml
+    - match: :(?=\s)
+      scope: meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+      pop: true
+    - include: flow-scalar-out-12
 
   comment:
     # http://www.yaml.org/spec/1.2/spec.html#comment//

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -754,9 +754,6 @@ contexts:
     # multi-line keys are indented by at least one more space than `?`
     - match: ^(?!\1 +\S|\s*$)
       pop: true
-    # explicit key of any indentation
-    - match: ^ *(?=\?\s)
-      pop: true
     - include: block-node-12
 
   block-key-implicit:

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -591,13 +591,15 @@ contexts:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain
     # ns-plain(n,c) (c=flow-out, c=block-key)
     - include: flow-scalar-plain-out-implicit-type-11
-    - match: (?={{ns_plain_first_plain_out}})
-      push: flow-scalar-plain-out-body
+    - include: flow-scalar-plain-out-common
 
   flow-scalar-plain-out-12:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain
     # ns-plain(n,c) (c=flow-out, c=block-key)
     - include: flow-scalar-plain-out-implicit-type-12
+    - include: flow-scalar-plain-out-common
+
+  flow-scalar-plain-out-common:
     - match: (?={{ns_plain_first_plain_out}})
       push: flow-scalar-plain-out-body
 

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -226,9 +226,9 @@ contexts:
     #   scope: invalid.illegal.unmatched.yaml
 
   node:
-    - include: block-node
+    - include: block-node-11
 
-  flow-node:
+  flow-node-11:
     # http://yaml.org/spec/1.2/spec.html#style/flow/
     # ns-flow-yaml-node(n,c)
     - include: flow-alias
@@ -265,12 +265,12 @@ contexts:
     - include: flow-sequence
     - include: flow-mapping
 
-  block-node:
+  block-node-11:
     # http://yaml.org/spec/1.2/spec.html#style/block/
     - include: block-scalar
     - include: block-collection
-    - include: flow-scalar-plain-out  # needs higher priority than flow-node, which includes flow-scalar-plain-in
-    - include: flow-node
+    - include: flow-scalar-plain-out-11  # needs higher priority than flow-node-11, which includes flow-scalar-plain-in
+    - include: flow-node-11
 
   block-node-12:
     # http://yaml.org/spec/1.2/spec.html#style/block/
@@ -587,7 +587,7 @@ contexts:
         7: punctuation.separator.time.yaml
         8: punctuation.separator.time.yaml
 
-  flow-scalar-plain-out:
+  flow-scalar-plain-out-11:
     # http://yaml.org/spec/1.2/spec.html#style/flow/plain
     # ns-plain(n,c) (c=flow-out, c=block-key)
     - include: flow-scalar-plain-out-implicit-type-11
@@ -624,7 +624,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.sequence.yaml
     - include: flow-pair-no-clear
-    - include: flow-node
+    - include: flow-node-11
 
   flow-mapping:
     - match: \{
@@ -639,7 +639,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.sequence.yaml
     - include: flow-pair
-    - include: flow-node  # for sets
+    - include: flow-node-11  # for sets
 
   flow-pair:
     - match: \?
@@ -680,7 +680,7 @@ contexts:
   flow-pair-value:
     - meta_content_scope: meta.mapping.value.yaml
     - include: flow-pair-end
-    - include: flow-node
+    - include: flow-node-11
 
   flow-pair-clear-1:
     - meta_include_prototype: false

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -170,13 +170,28 @@ key: !!set
 # ^ meta.mapping.yaml punctuation.definition.key-value.begin.yaml
 #  ^^^^^^^^ meta.mapping.key.yaml
 #   ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
-
     continued set value
 #  ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml
 #   ^^^^^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
 
-  not a set value
-# ^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml - meta.mapping
+    ? value3
+#   ^ meta.mapping.yaml punctuation.definition.key-value.begin.yaml
+#    ^^^^^^^^ meta.mapping.key.yaml
+#     ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+      continued set value
+#    ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml
+#     ^^^^^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+
+ ? value3
+#^ meta.mapping.yaml punctuation.definition.key-value.begin.yaml
+# ^^^^^^^^ meta.mapping.key.yaml
+#  ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+      continued set value
+#    ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml
+#     ^^^^^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+
+ not a set value
+#^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml - meta.mapping
 
 key: !!set
   ? value1

--- a/YAML/tests/syntax_test_block.yaml
+++ b/YAML/tests/syntax_test_block.yaml
@@ -140,7 +140,51 @@ scalar
  ?not a key
 #^^^^^^^^^^ - meta.mapping
 
+# the entire first line is the key (as a mapping with one entry)
+? a key : not a value
+# ^^^^^^^^^^^^^^^^^^^ meta.mapping.key
+#       ^ meta.mapping.key meta.mapping punctuation.separator.key-value.mapping
+  still explicit key
+# ^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml meta.string.yaml string.unquoted.plain.out.yaml
+
+- scalar
+# <- punctuation.definition.block.sequence.item.yaml
+# ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
 
 x:
   - #1
 #   ^^ comment.line
+
+##############################################################################
+## Sets
+# https://yaml.org/type/set.html
+
+key: !!set
+#    ^^^^^ meta.property.yaml storage.type.tag-handle.yaml
+  ? value1
+# ^ meta.mapping.yaml punctuation.definition.key-value.begin.yaml
+#  ^^^^^^^^ meta.mapping.key.yaml
+#   ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+
+  ? value2
+# ^ meta.mapping.yaml punctuation.definition.key-value.begin.yaml
+#  ^^^^^^^^ meta.mapping.key.yaml
+#   ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+
+    continued set value
+#  ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml
+#   ^^^^^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+
+  not a set value
+# ^^^^^^^^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml - meta.mapping
+
+key: !!set
+  ? value1
+mapping-after-set:
+# <- meta.mapping.key.yaml meta.string.yaml string.unquoted.plain.out.yaml
+  - item1
+# ^ punctuation.definition.block.sequence.item.yaml
+#   ^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+  - item2
+# ^ punctuation.definition.block.sequence.item.yaml
+#   ^^^^^ meta.string.yaml string.unquoted.plain.out.yaml


### PR DESCRIPTION
This commit addresses #3395 by terminating explicit mapping keys by lines which

1. start with `:` or 
2. are indented less or equal to the opeing `?`

It doesn't introduce special handling of `!!set` values so far. Those are still scoped explicit key without value as it is what spec calls them, too.

_Note: Appends `-11` to contexts which have `-12` counter parts._