### PR TITLE
[C/C++] Exclude macros from enumeration constants

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -334,12 +334,14 @@ contexts:
     - include: expressions
 
   statements-enum:
+    - include: comments
     - include: preprocessor-statements
     - include: scope:source.c#label
     - match: '{{identifier}}'
       scope: entity.name.constant.c++
       push: constant-value
-    - include: expressions
+    - match: ','
+      scope: punctuation.separator.c++
 
   constant-value:
     - match: (?=[,;}])

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -688,13 +688,15 @@ contexts:
     - include: expressions
 
   data-structures-body-enum:
+    - include: comments
     - include: preprocessor-data-structures
     - match: '(?={{before_tag}})'
       push: data-structures
     - match: '{{identifier}}'
       scope: entity.name.constant.c
       push: constant-value
-    - include: expressions
+    - match: ','
+      scope: punctuation.separator.c
 
   constant-value:
     - match: (?=[,;}])

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -40,6 +40,14 @@ enum { kFoo = FOO, kBar = BAR };
 /*                      ^ keyword.operator.assignment.c */
 /*                        ^^^ - entity.name.constant */
 
+enum { 
+    FOO, 
+/*  ^^^ entity.name.constant.c */
+/*     ^ punctuation.separator.c */
+    BAR 
+/*  ^^^ entity.name.constant.c */
+};
+
 typedef enum state { DEAD, ALIVE } State;
 /* <- keyword.declaration
 /*           ^ entity.name.enum */

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -2010,6 +2010,14 @@ private:
     and_now_method_name2();
 /*  ^ entity.name.function */
 
+    enum {
+        FOO,
+    /*  ^^^ entity.name.constant.c++ */
+    /*     ^ punctuation.separator.c++ */
+        BAR
+    /*  ^^^ entity.name.constant.c++ */
+    };
+
     enum
 /*  ^^^^ meta.enum keyword.declaration */
     {

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -118,12 +118,14 @@ contexts:
     - include: expressions
 
   statements-enum:
+    - include: comments
     - include: preprocessor-statements
     - include: scope:source.c#label
     - match: '{{identifier}}'
       scope: entity.name.constant.objc++
       push: constant-value
-    - include: expressions
+    - match: ','
+      scope: punctuation.separator.objc++
 
   constant-value:
     - match: (?=[,;}])

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -784,13 +784,15 @@ contexts:
     - include: expressions
 
   data-structures-body-enum:
+    - include: comments
     - include: preprocessor-data-structures
     - match: '(?={{before_tag}})'
       push: data-structures
     - match: '{{identifier}}'
       scope: entity.name.constant.objc
       push: constant-value
-    - include: expressions
+    - match: ','
+      scope: punctuation.separator.objc
 
   constant-value:
     - match: (?=[,;}])

--- a/Objective-C/syntax_test_objc++.mm
+++ b/Objective-C/syntax_test_objc++.mm
@@ -1962,6 +1962,14 @@ private:
     and_now_method_name2();
 /*  ^ entity.name.function */
 
+    enum {
+        FOO,
+    /*  ^^^ entity.name.constant.objc++ */
+    /*     ^ punctuation.separator.objc++ */
+        BAR
+    /*  ^^^ entity.name.constant.objc++ */
+    };
+
     enum
 /*  ^^^^ meta.enum keyword.declaration */
     {

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -46,6 +46,14 @@ typedef enum state { DEAD, ALIVE } State;
 /*                   ^ entity.name.constant.objc */
 /*                         ^ entity.name.constant.objc */
 
+enum {
+    FOO,
+/*  ^^^ entity.name.constant.objc */
+/*     ^ punctuation.separator.objc */
+    BAR
+/*  ^^^ entity.name.constant.objc */
+};
+
 struct __declspec(dllimport) X {};
 /*     ^ storage.modifier */
 /*                           ^ entity.name.struct */


### PR DESCRIPTION
Fixes #3369

Some enumeration constants have been detected as MACROS due to heuristics in `expressions`. This commit therefore restricts related contexts to match valid enumeration constants only.

_Note: enum constants between preprocessor directives like `#ifdef ... #endif` are still not highlighted as such, but fixing that is way too much for a quick hotfix. It would be addessed not before a rewrite._