### PR TITLE
[JavaScript] Standardize scope name for null-coalescing operator

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1263,8 +1263,11 @@ contexts:
         \?\?=
       scope: keyword.operator.assignment.augmented.js
       push: expression-begin
-    - match: '&&|\|\||\?\?'
+    - match: '&&|\|\|'
       scope: keyword.operator.logical.js
+      push: expression-begin
+    - match: \?\?
+      scope: keyword.operator.null-coalescing.js
       push: expression-begin
     - match: |-
         (?x)

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1612,7 +1612,7 @@ debugger
 // <- meta.sequence
 
     a ?? b;
-//    ^^ keyword.operator.logical
+//    ^^ keyword.operator.null-coalescing
 
     a &&= b;
 //    ^^^ keyword.operator.assignment.augmented


### PR DESCRIPTION
I'd like to propose a few small pull request to standardize / unify some scope names between syntaxes. They should have little or no impact for syntax highlighting, but make it is easier for color schemes to define simple rules if they want to target certain tokens in all languages.

---

This one proposes to adjust the scope for the [Nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) to `keyword.operator.null-coalescing`, which is already used in the PHP syntax. An alternative could be `keyword.operator.logical.null-coalescing`, since it is described as a special form of logical operator in the linked MDN docs, but I think the scope from the PHP syntax is better, because I would expect logical operators to return a boolean value.