### PR TITLE
[C#] Standardize some operator scope names

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1276,7 +1276,9 @@ contexts:
     - match: '->'
       scope: punctuation.accessor.arrow.cs
     - match: '{{bin_op}}='
-      scope: keyword.operator.cs
+      scope: keyword.operator.assignment.augmented.cs
+    - match: \?\?
+      scope: keyword.operator.null-coalescing.cs
     - match: '{{bin_op}}|{{unary_op}}'
       scope: keyword.operator.cs
     - match: '='

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -7,7 +7,7 @@ List<int> numbers = null;
 int? i = null;
 
 numbers ??= new List<int>();
-///     ^^^ keyword.operator
+///     ^^^ keyword.operator.assignment.augmented
 numbers.Add(i ??= 17);
 numbers.Add(i ??= 20);
 

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -21,6 +21,7 @@ public record Person
 ///     ^^^^ keyword.declaration.function.accessor.set
 ///          ^^ keyword.declaration.function.arrow
 ///             ^^^^^^^^ variable.other
+///                               ^^ keyword.operator.null-coalescing
     }
 }
 


### PR DESCRIPTION
* Standardize scope name for null coalescing operator as used in PHP syntax
* Use `keyword.operator.assignment.augmented` for augmented assignments, as already used in various other syntaxes