### PR TITLE
[Python] Standardize scope name for throwaway variables

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1766,11 +1766,11 @@ contexts:
 
   wildcard-variables:
     - match: _(?!{{identifier_continue}})
-      scope: variable.language.python
+      scope: variable.language.anonymous.python
 
   wildcard-variable:
     - match: _(?!{{identifier_continue}})
-      scope: variable.language.python
+      scope: variable.language.anonymous.python
       pop: true
 
   line-continuation:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -353,7 +353,7 @@ NO_SWEAT NO AA1
 #           ^^^ variable.other.constant
 
 _ self
-# <- variable.language.python
+# <- variable.language.anonymous.python
 # ^^^^ variable.language.python
 
 
@@ -1001,7 +1001,7 @@ def _():
 #       ^^ meta.statement.conditional.case.patterns.python
 #         ^ meta.statement.conditional.case.python
 #   ^^^^ keyword.control.conditional.case.python
-#        ^ variable.language.python
+#        ^ variable.language.anonymous.python
 #         ^ punctuation.section.block.conditional.case.python
 #           ^^^^^^^^^^ comment.line.number-sign.python
         print("Code not found")
@@ -1280,7 +1280,7 @@ def _():
 
     case *expr as _:
 #              ^^ keyword.control.conditional.case.as.python
-#                 ^ variable.language.python
+#                 ^ variable.language.anonymous.python
 
     case *expr as isinstance:
 #              ^^ keyword.control.conditional.case.as.python


### PR DESCRIPTION
Attempting to standardize the scope name for throwaway variables (usually underscore).

See also: https://github.com/SublimeText/ScopeNamingGuidelines/issues/5

I've chosen the scope name `variable.language.anonymous`, because this scope is already used in Erlang, Haskell, Matlab & Java.

This allows to highlight `_` differently from for example `self`.

