### PR TITLE
[C#] Standardize scope name for throwaway variables

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1422,7 +1422,7 @@ contexts:
     - match: ':'
       scope: keyword.operator.assignment.cs
     - match: _\b
-      scope: variable.language.deconstruction.discard.cs
+      scope: variable.language.anonymous.cs
     - match: (?!{{reserved}})(?={{namespaced_name}}{{type_suffix}}\s+{{name}}\s*[:,])
       push: var_declaration_explicit
     - match: '({{name}})(<)'
@@ -2073,7 +2073,7 @@ contexts:
               pop: true
             - include: line_of_code_in
         - match: \b_\b
-          scope: variable.language.deconstruction.discard.cs
+          scope: variable.language.anonymous.cs
         - match: '\bwhen\b'
           scope: keyword.control.switch.case.when.cs
         - match: \(
@@ -2086,7 +2086,7 @@ contexts:
             - match: ','
               scope: punctuation.separator.sequence.cs
             - match: _\b
-              scope: variable.language.deconstruction.discard.cs
+              scope: variable.language.anonymous.cs
             - include: line_of_code_in_no_semicolon # needed for "when" syntax?
         - match: (?={{namespaced_name}}\s+(?:\{|(?!{{reserved}}|when\b){{name}}))
           push: [maybe_pattern_matching_object, var_declaration]
@@ -2151,7 +2151,7 @@ contexts:
           scope: meta.sequence.tuple.cs punctuation.section.sequence.end.cs
           pop: true
         - match: _\b
-          scope: variable.language.deconstruction.discard.cs
+          scope: variable.language.anonymous.cs
         - match: '{{name}}'
           scope: variable.other.cs
         - match: ','

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -424,7 +424,7 @@ class Foo {
 ///      ^^^^^^ storage.type
 ///             ^^^^ variable.other
 ///                 ^ punctuation.separator.sequence
-///                   ^ variable.language.deconstruction.discard
+///                   ^ variable.language.anonymous
 ///                    ^ punctuation.separator.sequence
 ///                      ^^^^^^ storage.type
 ///                             ^^^^ variable.other
@@ -436,7 +436,7 @@ class Foo {
 ///          ^ punctuation.separator.sequence
 ///            ^^^^^^^^^^ variable.other
 ///                      ^ punctuation.separator.sequence
-///                        ^ variable.language.deconstruction
+///                        ^ variable.language.anonymous
 ///                         ^ punctuation.section.sequence.end
 ///                           ^ keyword.operator.assignment
         var (_, _, _, pop1, _, pop2) = QueryCityDataForYears("New York City", 1960, 2010);

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -48,7 +48,7 @@ public static decimal CalculateToll(object vehicle) =>
 ///                     ^^ meta.method meta.block punctuation.separator.case-expression
 
         _ => throw new ArgumentException("Not a known vehicle type", nameof(vehicle))
-///     ^ variable.language.deconstruction.discard
+///     ^ variable.language.anonymous
 ///       ^^ punctuation.separator.case-expression
     };
 
@@ -239,11 +239,11 @@ static Quadrant GetQuadrant(Point point) => point switch
     var (_, _) => Quadrant.OnBorder,
 /// ^^^ storage.type.variable
 ///     ^^^^^^ meta.sequence.tuple
-///      ^ variable.language.deconstruction.discard
+///      ^ variable.language.anonymous
 ///       ^ punctuation.separator.sequence
-///         ^ variable.language.deconstruction.discard
+///         ^ variable.language.anonymous
     _ => Quadrant.Unknown
-/// ^ variable.language.deconstruction.discard
+/// ^ variable.language.anonymous
 ///   ^^ punctuation.separator.case-expression
 };
 /// <- punctuation.section.block.end

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -91,7 +91,7 @@ var message = myValue switch
 ///            ^^ constant.numeric.value
 ///               ^^ punctuation.separator.case-expression
     _ => "More than 10"
-/// ^ variable.language.deconstruction.discard
+/// ^ variable.language.anonymous
 ///   ^^ punctuation.separator.case-expression
 } + ".";
 /// <- punctuation.section.block.end
@@ -137,7 +137,7 @@ static bool CheckIfCanWalkIntoBank(Bank bank, bool isVip)
 ///                      ^ punctuation.accessor.dot
 ///                       ^^^^ variable.other
 ///                           ^ punctuation.separator.sequence
-///                             ^ variable.language.deconstruction.discard
+///                             ^ variable.language.anonymous
 ///                              ^ punctuation.section.sequence.end
 ///                                ^^ punctuation.separator.case-expression
 ///                                   ^^^^ constant.language


### PR DESCRIPTION
Attempting to standardize the scope name for throwaway variables between syntaxes.

Not sure whether it would be worth it to alternatively append another subscope like the former `discard` here?