### PR TITLE
[LaTeX] Improve support for string variables in BibTeX files

### DIFF
--- a/LaTeX/Bibtex.sublime-syntax
+++ b/LaTeX/Bibtex.sublime-syntax
@@ -16,6 +16,9 @@ first_line_match: |-
     ^ \s* \%+ .*? -\*- .*? \bbibtex\b .*? -\*-  # editorconfig
   )
 
+variables:
+  var: '\b[a-zA-Z]\w*'
+
 contexts:
   main:
     - match: "@Comment"
@@ -25,12 +28,12 @@ contexts:
         - meta_scope: comment.line.at-sign.bibtex
         - match: $\n?
           pop: true
-    - match: '((@)String)\s*(\{)\s*([a-zA-Z]*)'
+    - match: '((@)[Ss]tring)\s*(\{)\s*({{var}})'
       captures:
         1: keyword.other.string-constant.bibtex
         2: punctuation.definition.keyword.bibtex
         3: punctuation.section.string-constant.begin.bibtex
-        4: variable.other.bibtex
+        4: entity.name.constant.bibtex
       push:
         - meta_scope: meta.string-constant.braces.bibtex
         - match: '\}'
@@ -38,12 +41,14 @@ contexts:
             0: punctuation.section.string-constant.end.bibtex
           pop: true
         - include: string_content
-    - match: '((@)String)\s*(\()\s*([a-zA-Z]*)'
+        - include: variables
+        - include: operators
+    - match: '((@)[Ss]tring)\s*(\()\s*({{var}})'
       captures:
         1: keyword.other.string-constant.bibtex
         2: punctuation.definition.keyword.bibtex
         3: punctuation.section.string-constant.begin.bibtex
-        4: variable.other.bibtex
+        4: entity.name.constant.bibtex
       push:
         - meta_scope: meta.string-constant.parenthesis.bibtex
         - match: \)
@@ -51,6 +56,8 @@ contexts:
             0: punctuation.section.string-constant.end.bibtex
           pop: true
         - include: string_content
+        - include: variables
+        - include: operators
     - match: '((@)[a-zA-Z]+)\s*(\{)\s*([^\s,]*)'
       captures:
         1: keyword.other.entry-type.bibtex
@@ -76,6 +83,8 @@ contexts:
               pop: true
             - include: string_content
             - include: integer
+            - include: variables
+            - include: operators
         - match: \,
           scope: punctuation.separator.sequence.bibtex
     - match: '((@)[a-zA-Z]+)\s*(\()\s*([^\s,]*)'
@@ -103,6 +112,8 @@ contexts:
               pop: true
             - include: string_content
             - include: integer
+            - include: variables
+            - include: operators
         - match: \,
           scope: punctuation.separator.sequence.bibtex
     - match: '[^@\n]'
@@ -112,7 +123,13 @@ contexts:
           pop: true
   integer:
     - match: \d+
-      scope: constant.numeric.bibtex
+      scope: meta.number.integer.decimal.bibtex constant.numeric.value.bibtex
+  variables:
+    - match: '{{var}}'
+      scope: variable.other.constant.bibtex
+  operators:
+    - match: \#
+      scope: keyword.operator.concatenation.bibtex
   nested_braces:
     - match: '\{'
       captures:

--- a/LaTeX/syntax_test_bibtex.bib
+++ b/LaTeX/syntax_test_bibtex.bib
@@ -1,5 +1,11 @@
 % SYNTAX TEST "Packages/LaTeX/Bibtex.sublime-syntax"
 
+@string(mar = "march")
+@string(aw = "Addison-Wesley")
+%<- keyword.other.string-constant.bibtex punctuation.definition.keyword.bibtex
+%^^^^^^ keyword.other.string-constant.bibtex
+%       ^^ entity.name.constant.bibtex
+
 @book{knuth97,
 %<- keyword.other.entry-type.bibtex punctuation.definition.keyword.bibtex
 %^^^^ keyword.other.entry-type.bibtex
@@ -14,7 +20,11 @@
 %                                ^ punctuation.separator.sequence.bibtex
     title     = {The Art of Computer Programming, Vol. 1: Fundamental Algorithms},
     edition   = {3},
-    publisher = {Addison-Wesley},
-    date      = {1997},
+    publisher = aw,
+%               ^^ variable.other.constant.bibtex
+    date      = 1997,
+%               ^^^^ meta.number.integer.decimal.bibtex constant.numeric.value.bibtex
+    month     = "1~" # mar,
+%                    ^ keyword.operator.concatenation.bibtex
     isbn      = {978-0-201-89683-1}
 }


### PR DESCRIPTION
* Add support for variables and concatenation operator in BibTeX entries
* Adjust scope name for variable definition to `entity.name.constant`
* Allow lowercased `@string` keyword
* Update scope name for integer numbers to latest convention