### PR TITLE
[HTML] Reorganize Tags

### DIFF
--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1,9 +1,9 @@
 ' SYNTAX TEST "Packages/ASP/HTML (ASP).sublime-syntax"
 <!DOCTYPE html>
 <html>
-'<- meta.tag.structure.any.html punctuation.definition.tag.begin.html - source.asp.embedded.html
-'^^^^ meta.tag.structure.any.html entity.name.tag.structure.any.html
-'    ^ meta.tag.structure.any.html punctuation.definition.tag.end.html
+'<- meta.tag.structure punctuation.definition.tag.begin.html - source.asp.embedded.html
+'^^^^ meta.tag.structure entity.name.tag.structure
+'    ^ meta.tag.structure punctuation.definition.tag.end.html
  <%@ TRANSACTION = Required %>
 '^^ punctuation.section.embedded.begin.asp
 '    ^^^^^^^^^^^ constant.language.processing-directive.asp
@@ -1038,7 +1038,7 @@
     %>
     
     <p>foobar</p>
-   '^^^ text.html.asp meta.tag.block.any.html - source.asp.embedded.html
+   '^^^ text.html.asp meta.tag.block - source.asp.embedded.html
     <%='test %>
    '^^^ punctuation.section.embedded.begin.asp - source.asp
    '   ^^^^^^ comment.line.apostrophe.asp
@@ -1114,12 +1114,12 @@ test = "hello%>
 '              ^ - source.asp.embedded.html
 
 <footer>
-'^^^^^^ text.html.asp meta.tag.block.any.html entity.name.tag.block.any.html
+'^^^^^^ text.html.asp meta.tag.block entity.name.tag.block
     <% With abc %>
     '  ^^^^ keyword.control.flow.asp
     '           ^^ text.html.asp punctuation.section.embedded.end.inside-block.asp
         <p>Some conditional content in the footer</p>
-        '<- text.html.asp meta.tag.block.any.html punctuation.definition.tag.begin.html
+        '<- text.html.asp meta.tag.block punctuation.definition.tag.begin.html
     <% End With %>
    '^^ punctuation.section.embedded.begin.inside-block.asp
    '   ^^^^^^^^ keyword.control.flow.asp
@@ -1128,8 +1128,8 @@ test = "hello%>
     <% If abc = "def" Then %>
     '                     ^ meta.if.block.asp - meta.if.line.asp
         <span id="span1">Text here</span>
-        '     ^^ text.html.asp meta.tag.inline.any.html meta.attribute-with-value.id.html entity.other.attribute-name.id.html
-        '                         ^^ text.html.asp meta.tag.inline.any.html punctuation.definition.tag.begin.html
+        '     ^^ text.html.asp meta.tag.inline meta.attribute-with-value.id.html entity.other.attribute-name.id.html
+        '                         ^^ text.html.asp meta.tag.inline punctuation.definition.tag.begin.html
     <% End If %>
     ' ^ meta.if.block.asp
     '  ^^^^^^ keyword.control.flow.asp
@@ -1137,7 +1137,7 @@ test = "hello%>
    
 </footer><% [%><br />
 '            ^^ punctuation.section.embedded.end.asp
-'               ^^ text.html.asp meta.tag.inline.any.html entity.name.tag.inline.any.html
+'               ^^ text.html.asp meta.tag.inline entity.name.tag.inline
 <% Sub InventiveMethodNameHere(list) %>
 '  ^^^ meta.method.identifier.asp storage.type.function.asp
 '                                   ^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp
@@ -1149,7 +1149,7 @@ test = "hello%>
        '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
             %><li><%= item %></li><%
                     '^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp
-           '  ^ meta.tag.inline.any.html punctuation.definition.tag.begin.html
+           '  ^ meta.tag.block punctuation.definition.tag.begin.html
            '      ^^^ punctuation.section.embedded.begin.inside-block.asp
            '               ^^ punctuation.section.embedded.end.inside-block.asp
         Next
@@ -1160,8 +1160,8 @@ test = "hello%>
 '  ^^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp storage.type.function.end.asp
 '         ^ - meta.method.asp
  <p class="<% If True Then %>test<% End If %>"></p>
-'^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html
-'                                         ^^^^^^^^^ meta.tag.block.any.html
+'^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block
+'                                         ^^^^^^^^^ meta.tag.block
 '   ^^^^^ meta.attribute-with-value.class.html entity.other.attribute-name.class.html
 '         ^ meta.attribute-with-value.class.html meta.string.html string.quoted.double.html - meta.interpolation
 '          ^^ meta.attribute-with-value.class.html  meta.string.html meta.interpolation.html - string
@@ -1184,24 +1184,24 @@ test = "hello%>
 '                                             ^ punctuation.definition.tag.end.html
 
  <p <%= "class=""test""" %> id="test1"></p>
-'^^^ meta.tag.block.any.html
-'                          ^^^^^^^^^^^^^^^^ meta.tag.block.any.html
+'^^^ meta.tag.block
+'                          ^^^^^^^^^^^^^^^^ meta.tag.block
 '^ punctuation.definition.tag.begin.html
-' ^ entity.name.tag.block.any.html
+' ^ entity.name.tag.block
 '   ^^^ punctuation.section.embedded.begin.asp
 '       ^^^^^^^^^^^^^^^^ string.quoted.double.asp
 '                        ^^ punctuation.section.embedded.end.asp
 '                           ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
 '                               ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                     ^ punctuation.definition.tag.end.html
-'                                          ^ - meta.tag.block.any.html
+'                                          ^ - meta.tag.block
 <% If True Then
    Do
  %>
         <span <%= "class=""test""" %> id="test2"></span>
-       '^^^^^^ meta.tag.inline.any.html
+       '^^^^^^ meta.tag.inline
        '^ punctuation.definition.tag.begin.html
-       ' ^^^^ entity.name.tag.inline.any.html
+       ' ^^^^ entity.name.tag.inline
        '      ^^^ punctuation.section.embedded.begin.inside-block.asp
        '          ^^^^^^^^^^^^^^^^ string.quoted.double.asp
        '                           ^^ punctuation.section.embedded.end.inside-block.asp
@@ -1209,19 +1209,19 @@ test = "hello%>
        '                              ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
        '                                  ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
        '                                        ^ punctuation.definition.tag.end.html
-       '                                         ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
+       '                                         ^^^^^^^ meta.tag.inline - meta.tag.after-embedded-asp
        '                                         ^^ punctuation.definition.tag.begin.html
-       '                                           ^^^^ entity.name.tag.inline.any.html
+       '                                           ^^^^ entity.name.tag.inline
        '                                               ^ punctuation.definition.tag.end.html
 <% Loop
    End If %>
   '^^^^^^ keyword.control.flow.asp
 
  <span <% If False Then %> class="test" <% End If %> id="test3"></span>
-'^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html
-'                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html
+'^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline
+'                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline
 '^ punctuation.definition.tag.begin.html
-' ^^^^ entity.name.tag.inline.any.html
+' ^^^^ entity.name.tag.inline
 '      ^^ punctuation.section.embedded.begin.asp
 '         ^^ keyword.control.flow.asp
 '            ^^^^^ meta.between-if-and-then.asp storage.type.asp
@@ -1257,15 +1257,15 @@ test = "hello%>
 '^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
 '    ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '          ^ punctuation.definition.tag.end.html
-'           ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
+'           ^^^^^^^ meta.tag.inline - meta.tag.after-embedded-asp
 '           ^^ punctuation.definition.tag.begin.html
-'             ^^^^ entity.name.tag.inline.any.html
+'             ^^^^ entity.name.tag.inline
 '                 ^ punctuation.definition.tag.end.html
  <% If True Then %>
 '^^ punctuation.section.embedded.begin.asp
 '                ^^ punctuation.section.embedded.end.inside-block.asp
  <span class="<%= "test" %>" id="test5"></span>
-'^^^^^^^^^^^^^ meta.tag.inline.any.html
+'^^^^^^^^^^^^^ meta.tag.inline
 '            ^ string.quoted.double.html punctuation.definition.string.begin.html
 '             ^^^ punctuation.section.embedded.begin.inside-block.asp
 '                        ^^ punctuation.section.embedded.end.inside-block.asp
@@ -1274,9 +1274,9 @@ test = "hello%>
 '                            ^^ meta.attribute-with-value.id.html entity.other.attribute-name.id.html
 '                                ^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html string.quoted.double.html
 '                                      ^ punctuation.definition.tag.end.html
-'                                       ^^^^^^^ meta.tag.inline.any.html - meta.tag.after-embedded-asp.any.html
+'                                       ^^^^^^^ meta.tag.inline - meta.tag.after-embedded-asp
 '                                       ^^ punctuation.definition.tag.begin.html
-'                                         ^^^^ entity.name.tag.inline.any.html
+'                                         ^^^^ entity.name.tag.inline
 '                                             ^ punctuation.definition.tag.end.html
  <% End If %>
 '^^ punctuation.section.embedded.begin.inside-block.asp
@@ -1293,7 +1293,7 @@ test = "hello%>
 
 '<- - comment - source.asp.embedded.html
  </body>
-'^^^^^^^ meta.tag.structure.any.html
+'^^^^^^^ meta.tag.structure
 <script type="text/javascript">
 <% If True Then %>var hello = "world";<% End If %>
 </script>

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -216,8 +216,10 @@ contexts:
       scope: meta.character.greater-than.html
 
   tag-end:
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.punctuation.html
+        2: punctuation.definition.tag.end.html
       pop: 1
 
   tag-end-self-closing:
@@ -228,6 +230,16 @@ contexts:
   tag-end-maybe-self-closing:
     - match: /?>
       scope: punctuation.definition.tag.end.html
+      pop: 1
+
+  tag-end-illegal-self-closing:
+    # Note: This context is used in <script> and <style> to not break existing
+    # 3rd-party packages (e.g.: Vue Syntax Highlight or Elixir) which extend
+    # ST's HTML.sublime-syntax
+    - match: (/)(>)
+      captures:
+        1: invalid.illegal.punctuation.html
+        2: punctuation.definition.tag.end.html
       pop: 1
 
 ###[ HTML TAGS ]##############################################################

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -145,16 +145,15 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: keyword.declaration.doctype.html
       push:
-        - doctype-meta
+        - doctype-end
         - doctype-content
         - doctype-content-type
         - doctype-name
 
-  doctype-meta:
+  doctype-end:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.sgml.doctype.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      pop: 1
+    - include: tag-end
 
   doctype-name:
     - match: '{{tag_name}}'
@@ -234,21 +233,31 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - match: </?(?=[A-Za-z])
+    - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-html-content
+        - tag-html-opening-content
+        - tag-html-name
+    - match: </(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-html-closing-content
         - tag-html-name
 
   tag-html-name:
-      - meta_content_scope: entity.name.tag.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
-  tag-html-content:
-      - meta_scope: meta.tag.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+  tag-html-opening-content:
+    - meta_scope: meta.tag.html.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-html-closing-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html.end.html
+    - include: tag-end
 
 ###[ ATTRIBUTES ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -240,6 +240,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.block.end.html
         - include: tag-end
 
@@ -265,6 +266,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.form.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.form.end.html
         - include: tag-end
 
@@ -290,6 +292,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.end.html
         - include: tag-end
 
@@ -307,6 +310,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.structure.end.html
         - include: tag-end
 
@@ -332,27 +336,38 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.table.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.table.end.html
         - include: tag-end
 
 ###[ OTHER TAG ]##############################################################
 
   tag-other:
-    - match: </?(?=[A-Za-z])
+    - match: <(?=[A-Za-z])
       scope: punctuation.definition.tag.begin.html
       push:
-        - tag-other-content
+        - tag-other-opening-content
+        - tag-other-name
+    - match: </(?=[A-Za-z])
+      scope: punctuation.definition.tag.begin.html
+      push:
+        - tag-other-closing-content
         - tag-other-name
 
   tag-other-name:
-      - meta_content_scope: entity.name.tag.other.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.other.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
-  tag-other-content:
-      - meta_scope: meta.tag.other.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+  tag-other-opening-content:
+    - meta_scope: meta.tag.other.begin.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  tag-other-closing-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.end.html
+    - include: tag-end
 
 ###[ SCRIPT TAG ]#############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -33,6 +33,12 @@ variables:
     | {{html_deprecated_tags}}
     )
 
+  html_block_tags_selfclosing: |-
+    (?x:
+      {{html_text_content_tags_selfclosing}}
+    | {{html_embedded_tags_selfclosing}}
+    )
+
   html_inline_tags: |-
     (?x:
       {{html_text_semantic_tags}}
@@ -42,6 +48,12 @@ variables:
     | {{html_script_tags}}
     )
 
+  html_inline_tags_selfclosing: |-
+    (?x:
+      {{html_text_semantic_tags_selfclosing}}
+    | {{html_media_tags_selfclosing}}
+    )
+
   # Aggregates structural root notes from
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
@@ -49,9 +61,13 @@ variables:
   html_structure_tags: |-
     (?xi: html | head | body ){{tag_name_break}}
 
-  # Note: <head> is moved to `html_structure_tags`
+  # Note:
+  #  <head> is moved to `html_structure_tags`
+  #  <script> and <style> are handled by dedicated matches
   html_header_tags: |-
-    (?xi: base | link | meta | script | style | title ){{tag_name_break}}
+    (?xi: (?# | script | style | ) title ){{tag_name_break}}
+  html_header_tags_selfclosing: |-
+    (?xi: base | link | meta ){{tag_name_break}}
 
   html_section_tags: |-
     (?xi:
@@ -61,39 +77,51 @@ variables:
 
   html_text_content_tags: |-
     (?xi:
-      blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+      blockquote | cite | dd | dt | dl | div | figcaption | figure | li
     | ol | p | pre | ul
     ){{tag_name_break}}
+  html_text_content_tags_selfclosing: |-
+    (?xi: hr ){{tag_name_break}}
 
   html_text_semantic_tags: |-
     (?xi:
-      a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+      a | abbr | b | bdi | bdo | code | data | time | dfn | em | i | kbd
     | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
-    | sub | sup | u | var | wbr
+    | sub | sup | u | var
     ){{tag_name_break}}
+  html_text_semantic_tags_selfclosing: |-
+    (?xi: br | wbr ){{tag_name_break}}
 
   html_media_tags: |-
-    (?xi: area | audio | img | map | track | video ){{tag_name_break}}
+    (?xi: audio | map | video ){{tag_name_break}}
+  html_media_tags_selfclosing: |-
+    (?xi: area | img | track ){{tag_name_break}}
 
   html_embedded_tags: |-
-    (?xi: embed | iframe | object | param | picture | source ){{tag_name_break}}
+    (?xi: iframe | object | picture ){{tag_name_break}}
+  html_embedded_tags_selfclosing: |-
+    (?xi: embed | param | source ){{tag_name_break}}
 
   html_script_tags: |-
-    (?xi: canvas | noscript  script ){{tag_name_break}}
+    (?xi: canvas | noscript (?# | script ) ){{tag_name_break}}
 
   html_markup_tags: |-
     (?xi: del | ins ){{tag_name_break}}
 
   html_table_tags: |-
     (?xi:
-      caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+      caption | colgroup | table | tbody | tr | td | tfoot | th | thead
     ){{tag_name_break}}
+  html_table_tags_selfclosing: |-
+    (?xi: col ){{tag_name_break}}
 
   html_forms_tags: |-
     (?xi:
-      button | datalist | option | fieldset | label | form | input | legend
+      button | datalist | option | fieldset | label | form | legend
     | meter | optgroup | select | output | progress | textarea
     ){{tag_name_break}}
+  html_forms_tags_selfclosing: |-
+    (?xi: input ){{tag_name_break}}
 
   html_interactive_tags: |-
     (?xi: details | dialog | menu | summary ){{tag_name_break}}
@@ -182,65 +210,130 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - include: style-tag
-    - include: script-tag
-    - include: block-tag
     - include: inline-tag
+    - include: block-tag
+    - include: table-tag
+    - include: script-tag
+    - include: style-tag
+    - include: form-tag
     - include: structure-tag
 
-  structure-tag:
-    - match: (</?)({{html_structure_tags}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.structure.any.html
-      push:
-        - meta_scope: meta.tag.structure.any.html
-        - include: tag-end
-        - include: tag-attributes
-
   block-tag:
-    - match: (</?)({{html_block_tags}})
+    - match: (<)({{html_block_tags_selfclosing}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.any.html
+        2: entity.name.tag.block.html
       push:
-        - meta_scope: meta.tag.block.any.html
+        - meta_scope: meta.tag.block.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:form|fieldset){{tag_name_break}})
+    - match: (<)({{html_block_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.form.html
+        2: entity.name.tag.block.html
       push:
-        - meta_scope: meta.tag.block.form.html
+        - meta_scope: meta.tag.block.begin.html
         - include: tag-end
         - include: tag-attributes
+    - match: (</)({{html_block_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.html
+      push:
+        - meta_scope: meta.tag.block.end.html
+        - include: tag-end
+
+  form-tag:
+    - match: (<)({{html_forms_tags_selfclosing}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (<)({{html_forms_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_forms_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.form.html
+      push:
+        - meta_scope: meta.tag.form.end.html
+        - include: tag-end
 
   inline-tag:
-    - match: (</?)({{html_inline_tags}})
+    - match: (<)({{html_inline_tags_selfclosing}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.any.html
+        2: entity.name.tag.inline.html
       push:
-        - meta_scope: meta.tag.inline.any.html
+        - meta_scope: meta.tag.inline.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)({{html_forms_tags}})
+    - match: (<)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.form.html
+        2: entity.name.tag.inline.html
       push:
-        - meta_scope: meta.tag.inline.form.html
-        - include: tag-end-maybe-self-closing
+        - meta_scope: meta.tag.inline.begin.html
+        - include: tag-end
         - include: tag-attributes
-    - match: (</?)({{html_table_tags}})
+    - match: (</)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.table.html
+        2: entity.name.tag.inline.html
       push:
-        - meta_scope: meta.tag.inline.table.html
+        - meta_scope: meta.tag.inline.end.html
+        - include: tag-end
+
+  structure-tag:
+    - match: (<)({{html_structure_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.structure.html
+      push:
+        - meta_scope: meta.tag.structure.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_structure_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.structure.html
+      push:
+        - meta_scope: meta.tag.structure.end.html
+        - include: tag-end
+
+  table-tag:
+    - match: (<)({{html_table_tags_selfclosing}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.table.html
+      push:
+        - meta_scope: meta.tag.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
+    - match: (<)({{html_table_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.table.html
+      push:
+        - meta_scope: meta.tag.table.begin.html
+        - include: tag-end
+        - include: tag-attributes
+    - match: (</)({{html_table_tags}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.table.html
+      push:
+        - meta_scope: meta.tag.table.end.html
+        - include: tag-end
 
 ###[ OTHER TAG ]##############################################################
 

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -396,10 +396,10 @@ contexts:
 
   script-javascript:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-javascript-content
+    - include: script-common
 
   script-javascript-content:
     - meta_include_prototype: false
@@ -430,10 +430,10 @@ contexts:
 
   script-json:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-json-content
+    - include: script-common
 
   script-json-content:
     - meta_include_prototype: false
@@ -464,20 +464,22 @@ contexts:
 
   script-html:
     - meta_scope: meta.tag.script.begin.html
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      pop: 1
     - include: script-common
-    - include: tag-end
 
   script-other:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-close-tag
+    - include: script-common
 
   script-common:
     - include: script-type-attribute
     - include: tag-attributes
-    - include: tag-end-self-closing
+    - include: tag-end-illegal-self-closing
 
   script-type-attribute:
     - match: (?i:type){{attribute_name_break}}
@@ -556,10 +558,10 @@ contexts:
 
   style-css:
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-css-content
+    - include: style-common
 
   style-css-content:
     - meta_include_prototype: false
@@ -590,15 +592,15 @@ contexts:
 
   style-other:
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-close-tag
+    - include: style-common
 
   style-common:
     - include: style-type-attribute
     - include: tag-attributes
-    - include: tag-end-self-closing
+    - include: tag-end-illegal-self-closing
 
   style-type-attribute:
     - match: (?i:type){{attribute_name_break}}

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -19,19 +19,94 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 ###############################################################################
 
 variables:
-  block_tag_name: |-
-    (?ix:
-      address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
+  # HTML tags
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  # Note: Sections are sorted by expected frequency.
+
+  html_block_tags: |-
+    (?x:
+      {{html_text_content_tags}}
+    | {{html_section_tags}}
+    | {{html_embedded_tags}}
+    | {{html_web_tags}}
+    | {{html_header_tags}}
+    | {{html_deprecated_tags}}
+    )
+
+  html_inline_tags: |-
+    (?x:
+      {{html_text_semantic_tags}}
+    | {{html_markup_tags}}
+    | {{html_media_tags}}
+    | {{html_interactive_tags}}
+    | {{html_script_tags}}
+    )
+
+  # Aggregates structural root notes from
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#sectioning_root
+  html_structure_tags: |-
+    (?xi: html | head | body ){{tag_name_break}}
+
+  # Note: <head> is moved to `html_structure_tags`
+  html_header_tags: |-
+    (?xi: base | link | meta | script | style | title ){{tag_name_break}}
+
+  html_section_tags: |-
+    (?xi:
+      address | article | aside | footer | header | h1 | h2 | h3 | h4 | h5 | h6
+    | hgroup | main | nav | section
     ){{tag_name_break}}
 
-  inline_tag_name: |-
-    (?ix:
-      abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
+  html_text_content_tags: |-
+    (?xi:
+      blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+    | ol | p | pre | ul
     ){{tag_name_break}}
 
-  form_tag_name: |-
-    (?ix:
-      button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
+  html_text_semantic_tags: |-
+    (?xi:
+      a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+    | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
+    | sub | sup | u | var | wbr
+    ){{tag_name_break}}
+
+  html_media_tags: |-
+    (?xi: area | audio | img | map | track | video ){{tag_name_break}}
+
+  html_embedded_tags: |-
+    (?xi: embed | iframe | object | param | picture | source ){{tag_name_break}}
+
+  html_script_tags: |-
+    (?xi: canvas | noscript  script ){{tag_name_break}}
+
+  html_markup_tags: |-
+    (?xi: del | ins ){{tag_name_break}}
+
+  html_table_tags: |-
+    (?xi:
+      caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+    ){{tag_name_break}}
+
+  html_forms_tags: |-
+    (?xi:
+      button | datalist | option | fieldset | label | form | input | legend
+    | meter | optgroup | select | output | progress | textarea
+    ){{tag_name_break}}
+
+  html_interactive_tags: |-
+    (?xi: details | dialog | menu | summary ){{tag_name_break}}
+
+  html_web_tags: |-
+    (?xi: slot | template ){{tag_name_break}}
+
+  html_deprecated_tags: |-
+    (?xi:
+      acronym | applet | basefont | bgsound | big | blink | center | command
+    | content | dir | element | font | frame | frameset | image | isindex
+    | keygen | listing | marquee | menuitem | multicol | nextid | nobr
+    | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
     ){{tag_name_break}}
 
   javascript_mime_type: |-
@@ -107,9 +182,14 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - include: script-tag
     - include: style-tag
-    - match: (</?)((?i:body|head|html){{tag_name_break}})
+    - include: script-tag
+    - include: block-tag
+    - include: inline-tag
+    - include: structure-tag
+
+  structure-tag:
+    - match: (</?)({{html_structure_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.any.html
@@ -117,15 +197,9 @@ contexts:
         - meta_scope: meta.tag.structure.any.html
         - include: tag-end
         - include: tag-attributes
-    - match: (</?)({{block_tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.any.html
-      push:
-        - meta_scope: meta.tag.block.any.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</?)((?i:hr){{tag_name_break}})
+
+  block-tag:
+    - match: (</?)({{html_block_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
@@ -141,7 +215,9 @@ contexts:
         - meta_scope: meta.tag.block.form.html
         - include: tag-end
         - include: tag-attributes
-    - match: (</?)({{inline_tag_name}})
+
+  inline-tag:
+    - match: (</?)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
@@ -149,7 +225,7 @@ contexts:
         - meta_scope: meta.tag.inline.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)({{form_tag_name}})
+    - match: (</?)({{html_forms_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
@@ -157,15 +233,7 @@ contexts:
         - meta_scope: meta.tag.inline.form.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
-    - match: (</?)((?i:a){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.a.html
-      push:
-        - meta_scope: meta.tag.inline.a.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr){{tag_name_break}})
+    - match: (</?)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -30,7 +30,7 @@ variables:
     | {{html_embedded_tags}}
     | {{html_web_tags}}
     | {{html_header_tags}}
-    | {{html_deprecated_tags}}
+    | {{html_deprecated_block_tags}}
     )
 
   html_block_tags_selfclosing: |-
@@ -46,6 +46,7 @@ variables:
     | {{html_media_tags}}
     | {{html_interactive_tags}}
     | {{html_script_tags}}
+    | {{html_deprecated_inline_tags}}
     )
 
   html_inline_tags_selfclosing: |-
@@ -85,9 +86,8 @@ variables:
 
   html_text_semantic_tags: |-
     (?xi:
-      a | abbr | b | bdi | bdo | code | data | time | dfn | em | i | kbd
-    | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
-    | sub | sup | u | var
+      a | abbr | b | bdi | bdo | code | data | time | dfn | em | i | kbd | mark
+    | q | ruby | rp | rt | s | samp | small | span | strong | sub | sup | u | var
     ){{tag_name_break}}
   html_text_semantic_tags_selfclosing: |-
     (?xi: br | wbr ){{tag_name_break}}
@@ -129,13 +129,15 @@ variables:
   html_web_tags: |-
     (?xi: slot | template ){{tag_name_break}}
 
-  html_deprecated_tags: |-
+  html_deprecated_block_tags: |-
     (?xi:
-      acronym | applet | basefont | bgsound | big | blink | center | command
-    | content | dir | element | font | frame | frameset | image | isindex
-    | keygen | listing | marquee | menuitem | multicol | nextid | nobr
-    | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
+      acronym | applet | bgsound | command | content | dir | element | frame
+    | frameset | isindex | keygen | listing | marquee | menuitem | multicol
+    | nextid | noembed | noframes | plaintext | shadow | spacer | xmp
     ){{tag_name_break}}
+  html_deprecated_inline_tags: |-
+    (?xi: basefont | big | blink | center | font | image | nobr | rb | rtc
+    | strike | tt ){{tag_name_break}}
 
   javascript_mime_type: |-
     (?ix:

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -157,7 +157,8 @@
             comment -->
         ##  ^^^^^^^^^^^ comment.block.html
             <div></div>
-        ##  ^^^^^^^^^^^ text.html.basic meta.tag.block.any
+        ##  ^^^^^ text.html.basic meta.tag.block.begin.html
+        ##       ^^^^^^ text.html.basic meta.tag.block.end.html
             <script type=text/javascript>
         ##  ^ text.html.basic - source.js.embedded.html
                 function test() {}
@@ -841,8 +842,8 @@ class="foo"></div>
         ##                   ^ meta.function-call.js support.function
 
         <article><span><othertag></othertag><othertag /></span></article>
-        ## ^^^^^ entity.name.tag.block.any.html
-        ##        ^^^^ entity.name.tag.inline.any.html
+        ## ^^^^^ entity.name.tag.block.html
+        ##        ^^^^ entity.name.tag.inline.html
         ##              ^^^^^^^^ entity.name.tag.other.html
         ##                                           ^ - punctuation.definition.tag.end.html
         ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
@@ -922,38 +923,38 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag
 
         <form name="formName" type="post">
-        ## ^ entity.name.tag.block.form.html
+        ## ^ entity.name.tag.form.html
         ## <- punctuation.definition.tag.begin.html
         ##                               ^ punctuation.definition.tag.end.html
             <label for="inputId">
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
             ##     ^ entity.other.attribute-name.html
             ##        ^ punctuation.separator.key-value.html
             <input id="inputId" type="text" value="value">
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
             ##                   ^ entity.other.attribute-name.html
             <textarea name="texareaName"></textarea>
-            ## ^ entity.name.tag.inline.form.html
+            ## ^ entity.name.tag.form.html
         </form>
 
         <table border="0" cellspacing="0" cellpadding="2" class="editor">
-        ## ^ entity.name.tag.inline.table.html
+        ## ^ entity.name.tag.table.html
             <thead>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.table.html
                 <tr>
-            ##   ^ entity.name.tag.inline.table.html
+            ##   ^ entity.name.tag.table.html
                     <th> </th>
                 </tr>
             </thead>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.table.html
             <tfoot>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.table.html
                 <tr>
                     <td> </td>
-                    ##^ entity.name.tag.inline.table.html
+                    ##^ entity.name.tag.table.html
                 </tr>
             </tfoot>
-            ## ^ entity.name.tag.inline.table.html
+            ## ^ entity.name.tag.table.html
             <tbody>
                 <tr>
                     <td> </td>
@@ -1004,14 +1005,14 @@ class="foo"></div>
         ##                                     ^ punctuation.separator.path.html
 
         <hr/><hr />
-        ## ^^ meta.tag.block.any punctuation.definition.tag.end
-        ##    ^^ entity.name.tag.block.any
+        ## ^^ meta.tag.block punctuation.definition.tag.end
+        ##    ^^ entity.name.tag.block
         ##       ^^ punctuation.definition.tag.end
 
         # make sure to stop tag names before the next < to prevent php
         # and other syntaxes from breaking.
         <article<?php>
-        ##^^^^^^ entity.name.tag.block.any.html
+        ##^^^^^^ entity.name.tag.block.html
         ##      ^^^^^^ - entity.name.tag
 
         <_notag>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -846,7 +846,7 @@ class="foo"></div>
         ##        ^^^^ entity.name.tag.inline.html
         ##              ^^^^^^^^ entity.name.tag.other.html
         ##                                           ^ - punctuation.definition.tag.end.html
-        ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
+        ##                                            ^^ punctuation.definition.tag.end.html
 
         <body·other attrib=1/>
         ## ^^^^^^^^ entity.name.tag.other.html
@@ -879,9 +879,9 @@ class="foo"></div>
         ##                                                                    ^^^^^^^^^^^^^^ entity.name.tag.other.html
 
         <test-custom-tag/>
-        ##^^^^^^^^^^^^^^^^ meta.tag.other.html - invalid
+        ##^^^^^^^^^^^^^^^^ meta.tag.other.begin.html - invalid
         ##              ^^ punctuation.definition.tag.end.html
-        ##                ^ - meta.tag.other.html - punctuation.definition.tag.end.html
+        ##                ^ - meta.tag - punctuation.definition.tag
 
         <body-custom·tag₡name/>
         ## ^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
@@ -904,7 +904,7 @@ class="foo"></div>
         ## ^^^^^^^^^^^^^^^^^ entity.name.tag.other.html - invalid
 
         <A{{template}} {{attr}}={{value}} />
-        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.begin.html
         ## ^^^^^^^^^^^ entity.name.tag.other.html
         ##             ^^^^^^^^ entity.other.attribute-name.html
         ##                     ^ punctuation.separator.key-value.html

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -471,7 +471,8 @@
         ##      ^^^^ entity.other.attribute-name
         ##      ^^^^^^^^^^^^^^ meta.attribute-with-value
         ##           ^^^^^^^^^ string.unquoted
-        ##                    ^^ punctuation.definition.tag.end.html
+        ##                    ^ invalid.illegal
+        ##                     ^ punctuation.definition.tag.end.html
 
         <img title/>
         ##  ^ - meta.attribute-with-value

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -205,19 +205,19 @@
 
     The map file has <font color="<%=color.blue()%>"><%= map.size() %></font> entries.
 //  ^^^^^^^^^^^^^^^^^ - meta
-//                   ^^^^^^ meta.tag.block - meta.attribute-with-value.html
-//                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block meta.attribute-with-value.html
+//                   ^^^^^^ meta.tag.inline - meta.attribute-with-value.html
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline meta.attribute-with-value.html
 //                               ^ meta.string.html - meta.interpolation
 //                                ^^^^^^^^^^^^^^^^^ meta.string.html meta.interpolation.jsp
 //                                                 ^ meta.string.html - meta.interpolation
 //                                ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
 //                                   ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.jsp - source.java source.java
 //                                               ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
-//                                                  ^ meta.tag.block - meta.attribute-with-value.html
+//                                                  ^ meta.tag.inline - meta.attribute-with-value.html
 //                                                   ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
 //                                                      ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.jsp
 //                                                                  ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
-//                                                                    ^^^^^^^ meta.tag.block
+//                                                                    ^^^^^^^ meta.tag.inline
 //                                                                           ^^^^^^^^^ - meta
 
 

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -205,19 +205,19 @@
 
     The map file has <font color="<%=color.blue()%>"><%= map.size() %></font> entries.
 //  ^^^^^^^^^^^^^^^^^ - meta
-//                   ^^^^^^ meta.tag.inline.any.html - meta.attribute-with-value.html
-//                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.html
+//                   ^^^^^^ meta.tag.block - meta.attribute-with-value.html
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block meta.attribute-with-value.html
 //                               ^ meta.string.html - meta.interpolation
 //                                ^^^^^^^^^^^^^^^^^ meta.string.html meta.interpolation.jsp
 //                                                 ^ meta.string.html - meta.interpolation
 //                                ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
 //                                   ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.jsp - source.java source.java
 //                                               ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
-//                                                  ^ meta.tag.inline.any.html - meta.attribute-with-value.html
+//                                                  ^ meta.tag.block - meta.attribute-with-value.html
 //                                                   ^^^ meta.embedded.expression.jsp punctuation.section.embedded.begin.jsp - source.java
 //                                                      ^^^^^^^^^^^^ meta.embedded.expression.jsp source.java.embedded.jsp
 //                                                                  ^^ meta.embedded.expression.jsp punctuation.section.embedded.end.jsp - source.java
-//                                                                    ^^^^^^^ meta.tag.inline.any.html
+//                                                                    ^^^^^^^ meta.tag.block
 //                                                                           ^^^^^^^^^ - meta
 
 
@@ -236,14 +236,14 @@
 //           ^^ keyword.operator.logical.java
     %><div style="width: <%=with%>"></div><%
 //  ^^ punctuation.section.embedded.end.jsp - source.java.embedded.jsp
-//    ^^^^^ meta.tag.block.any.html - meta.attribute-with-value
-//         ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
-//                ^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css - meta.expression
-//                       ^^^^^^^^^ meta.tag.block.any.html meta.attribute-with-value.style.html source.css meta.embedded.expression.jsp
-//                                ^ meta.tag.block.any.html meta.attribute-with-value.style.html - source.css
-//                                 ^^^^^^^ meta.tag.block.any.html - meta.attribute-with-value.style.html - source.css
+//    ^^^^^ meta.tag.block - meta.attribute-with-value
+//         ^^^^^^^ meta.tag.block meta.attribute-with-value.style.html - source.css
+//                ^^^^^^^ meta.tag.block meta.attribute-with-value.style.html source.css - meta.expression
+//                       ^^^^^^^^^ meta.tag.block meta.attribute-with-value.style.html source.css meta.embedded.expression.jsp
+//                                ^ meta.tag.block meta.attribute-with-value.style.html - source.css
+//                                 ^^^^^^^ meta.tag.block - meta.attribute-with-value.style.html - source.css
 //    ^ punctuation.definition.tag.begin.html
-//     ^^^ entity.name.tag.block.any.html
+//     ^^^ entity.name.tag.block
 //         ^^^^^ entity.other.attribute-name.style.html
 //              ^ punctuation.separator.key-value.html
 //               ^ string.quoted.double punctuation.definition.string.begin.html
@@ -407,7 +407,7 @@
     Good guess, but nope. Try<b><jsp:expression>numguess.getHint()</jsp:expression></b>.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag.jsp meta.tag.jsp
-//                           ^^^ meta.tag.inline.any.html
+//                           ^^^ meta.tag.inline
 //                              ^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.begin.html
 //                              ^ punctuation.definition.tag.begin.html
 //                               ^^^ entity.name.tag.namespace.html
@@ -421,12 +421,12 @@
 //                                                                     ^ entity.name.tag.html punctuation.separator.namespace.html
 //                                                                      ^^^^^^^^^^ entity.name.tag.localname.html
 //                                                                                ^ punctuation.definition.tag.end.html
-//                                                                                 ^^^^ meta.tag.inline.any.html
+//                                                                                 ^^^^ meta.tag.inline
 
     Good guess, but nope. Try<b><jsp:expression/>numguess.getHint()</jsp:expression></b>.
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.tag.jsp meta.tag.jsp
-//                           ^^^ meta.tag.inline.any.html
+//                           ^^^ meta.tag.inline
 //                              ^^^^^^^^^^^^^^^^ meta.tag.jsp.expression.begin.html
 //                              ^ punctuation.definition.tag.begin.html
 //                               ^^^ entity.name.tag.namespace.html
@@ -440,7 +440,7 @@
 //                                                                      ^ entity.name.tag.html punctuation.separator.namespace.html
 //                                                                       ^^^^^^^^^^ entity.name.tag.localname.html
 //                                                                                 ^ punctuation.definition.tag.end.html
-//                                                                                  ^^^^ meta.tag.inline.any.html
+//                                                                                  ^^^^ meta.tag.inline
 
 
     <!--
@@ -681,8 +681,8 @@
 //      ^ punctuation.separator.namespace.html
 //       ^^^^ entity.name.tag.localname.html
 //           ^^ punctuation.definition.tag.end.html
-//                  ^^^ meta.tag.inline.any.html
-//                         ^^^^ meta.tag.inline.any.html
+//                  ^^^ meta.tag.inline
+//                         ^^^^ meta.tag.inline
 //                             ^^^^^^^^^^^ meta.tag.jsp.other.end.html
 //                             ^^ punctuation.definition.tag.begin.html
 //                               ^^^ entity.name.tag.namespace.html
@@ -698,8 +698,8 @@
 //      ^ punctuation.separator.namespace.html
 //       ^^^^ entity.name.tag.localname.html
 //           ^ punctuation.definition.tag.end.html
-//                 ^^^ meta.tag.inline.any.html
-//                        ^^^^ meta.tag.inline.any.html
+//                 ^^^ meta.tag.inline
+//                        ^^^^ meta.tag.inline
 //                            ^^^^^^^^^^^ meta.tag.jsp.other.end.html
 //                            ^^ punctuation.definition.tag.begin.html
 //                              ^^^ entity.name.tag.namespace.html
@@ -717,14 +717,14 @@
 //           ^ punctuation.definition.tag.end.html
 //                 ^^^^ constant.character.entity.named.html
 //                      ^^^^ constant.character.entity.named.html
-//                              ^^^^ meta.tag.inline.any.html
+//                              ^^^^ meta.tag.inline
 //                                  ^^^^^^^^^^^^ meta.tag.jsp.other.end.html
 //                                  ^^ punctuation.definition.tag.begin.html
 //                                    ^^^ entity.name.tag.namespace.html
 //                                       ^ punctuation.separator.namespace.html
 //                                        ^^^^^ entity.name.tag.localname.html
 //                                             ^ punctuation.definition.tag.end.html
-//                                              ^^^ meta.tag.inline.any.html
+//                                              ^^^ meta.tag.inline
 
     <c:forEach var="customer" items="${customers}">
 //                                  ^ meta.tag.other.begin.html meta.attribute-with-value.html meta.string.html - meta.interpolation - meta.embedded

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -1835,7 +1835,7 @@ graph n {}
 
 ```html+php
 <div></div>
-|^^^ entity.name.tag.block.any.html
+|^^^ entity.name.tag.block
 <?php
 | <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
 var_dump(expression);
@@ -2087,7 +2087,7 @@ okay.
 | ^^^^^^^ meta.paragraph markup.italic - meta.disable-markdown
 
 </DIV>
-| ^^^ meta.disable-markdown meta.tag.block.any.html
+| ^^^ meta.disable-markdown meta.tag.block
 
 ## https://spec.commonmark.org/0.30/#example-153
 
@@ -2145,7 +2145,7 @@ int x = 33;
 | <- meta.disable-markdown - markup.italic - punctuation
 |^^^^^ meta.disable-markdown - markup.italic
 </Warning>
-| ^^^^^^^ meta.disable-markdown meta.tag.other.html entity.name.tag.other.html
+| ^^^^^^^ meta.disable-markdown meta.tag.other entity.name.tag.other.html
 
 ## https://spec.commonmark.org/0.30/#example-164
 
@@ -2204,7 +2204,7 @@ int x = 33;
 ## https://spec.commonmark.org/0.30/#example-169
 
 <pre language="haskell"><code>
-| ^^ meta.disable-markdown meta.tag.block.any.html entity.name.tag.block.any.html
+| ^^ meta.disable-markdown meta.tag.block entity.name.tag.block
 import Text.HTML.TagSoup
 
 main :: IO ()
@@ -2212,7 +2212,7 @@ main :: IO ()
 main = print $ parseTags tags
 </code></pre>
 | ^^^^^^^^^^^ meta.disable-markdown
-|        ^^^ meta.tag.block.any.html entity.name.tag.block.any.html
+|        ^^^ meta.tag.block entity.name.tag.block
 okay
 | <- - meta.disable-markdown
 
@@ -2450,7 +2450,7 @@ non-disabled markdown
 <div>this is HTML until there are two blank lines
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
 still <span>HTML</span>
-|      ^^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+|      ^^^^ meta.tag.inline entity.name.tag.inline
 </div>
 | ^^^^ meta.disable-markdown
 
@@ -2458,14 +2458,14 @@ non-disabled markdown
 | <- - meta.disable-markdown
 
 <pre>nested tags don't count <pre>test</pre>
-|                                     ^^^^^^ meta.disable-markdown meta.tag.block.any.html
+|                                     ^^^^^^ meta.disable-markdown meta.tag.block
 non-disabled markdown
 | <- - meta.disable-markdown
 
 <div>nested tags don't count <div>test
 |                                 ^^^^^ meta.disable-markdown
 </div>
-| ^^^ meta.disable-markdown entity.name.tag.block.any.html
+| ^^^ meta.disable-markdown entity.name.tag.block
 
 non-disabled markdown
 | <- - meta.disable-markdown
@@ -2480,7 +2480,7 @@ non-disabled markdown
 
 <div>another</div> <span>disable</span> test
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-|                  ^^^^^^ meta.tag.inline.any.html
+|                  ^^^^^^ meta.tag.inline
 disabled markdown
 | <- meta.disable-markdown
 
@@ -2969,7 +2969,7 @@ with a *second* line.
 | --- | --- |
 | baz | bim <kbd>Ctrl+C</kbd> |
 | <- meta.table punctuation.separator.table-cell
-|           ^^^^^ meta.tag.inline.any
+|           ^^^^^ meta.tag.inline
 |                             ^ punctuation.separator.table-cell
 
 | <- - meta.table
@@ -5644,7 +5644,7 @@ blah*
 | ^ punctuation.definition.raw.begin.markdown
 |      ^ punctuation.definition.raw.end.markdown
 |        ^ - punctuation
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html 
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline
 
 - list item
 
@@ -5905,7 +5905,7 @@ foo
 ## https://spec.commonmark.org/0.30/#example-344
 
 <a href="`">`
-| ^^^^^^^^^ meta.tag.inline.a
+| ^^^^^^^^^ meta.tag.inline
 |           ^ punctuation.definition.raw.begin
 
 | <- invalid.illegal.non-terminated.raw
@@ -6877,38 +6877,38 @@ testing__
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _italic text <SPAN>HTML element</SPAN> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 **bold text <span>HTML element</span> end of bold text**
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.inline
+|                             ^^^^^^^ meta.tag.inline
 
 __bold text <span>HTML element</span> end of bold text__
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.inline
+|                             ^^^^^^^ meta.tag.inline
 
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _italic text <span>HTML element</span> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _test <span>text_ foobar</span>
 | <- punctuation

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5066,9 +5066,9 @@ function embedHtml() {
 //                                                   ^^ punctuation.section.embedded.end
 
   <tag-<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other
 //^ punctuation.definition.tag.begin.html
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other
 //     ^^^^^ punctuation.section.embedded.begin.php
 //     ^^^^^^^^^^^^^ meta.embedded.php
 //                ^^ punctuation.section.embedded.end
@@ -5083,9 +5083,9 @@ function embedHtml() {
 //                                                              ^^ punctuation.definition.tag.end.html
 
   <tag<?php $bar ?>na<?php $baz ?>me att<?php $bar ?>rib=false />
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other
 //^ punctuation.definition.tag.begin.html
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other.html
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.other
 //    ^^^^^ punctuation.section.embedded.begin.php
 //    ^^^^^^^^^^^^^ meta.embedded.php
 //               ^^ punctuation.section.embedded.end

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -124,13 +124,13 @@
 #                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation - source
 
 <a onclick="run(<% @ruby %>, 'var<% @ruby %>e')" style="font: <% @ruby_font %>, 'font_<% @name %>';">text</a>
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html meta.attribute-with-value.event.html meta.string.html
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline meta.attribute-with-value.event.html meta.string.html
 #           ^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #               ^^^^^^^^^^^ meta.interpolation.html meta.embedded.rails
 #                          ^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #                                ^^^^^^^^^^^ meta.interpolation.html meta.string.js meta.interpolation.rails meta.embedded.rails
 #                                           ^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
-#                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html meta.attribute-with-value.style.html meta.string.html
+#                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline meta.attribute-with-value.style.html meta.string.html
 #                                                       ^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #                                                             ^^^^^^^^^^^^^^^^ meta.interpolation.html meta.embedded.rails
 #                                                                             ^^^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -162,7 +162,7 @@ puts <<-HTML; # comment
 #            ^^ punctuation.definition.variable.ruby
 #            ^^^^^ variable.other.readwrite.instance.ruby
   </body>
-# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded meta.tag.structure.any.html
+# ^^^^^^^ meta.string.heredoc.ruby text.html.embedded meta.tag.structure
   HTML
 # ^^^^ meta.string.heredoc.ruby meta.tag.heredoc.ruby entity.name.tag.ruby
 #     ^ - meta.string - string.unquoted


### PR DESCRIPTION
This PR proposes to 

1. scope html tags by semantic meaning

   syntactic:
   - maybe self closing tags (`<link ... />`)
   - opening tags `<style>`
     - which must not be self-closing
     - scoped: `meta.tag.<type>.begin`
   - closing tags `</style>`
     - which must not contain attributes nor self-closing
     - scoped: `meta.tag.<type>.end`
   
   semantic groups:
   - block
   - form
   - inline
   - script
   - style
   - structure
   - table

2. highlight invalid self-closing html tags
3. update known tag names frowm whatwg.

It is inspired by #2772 and built on lessons learned from #2781.

A requests for better semantic scoping can be found at

- https://forum.sublimetext.com/t/html-sublime-syntax-wrong-scope-name-for-tables-tags/64207/2

#### Benchmarking

1. Syntax cache increases by 30% from about 60kB to 93kB.
2. Parsing performance doesn't change.  
   _Tried with syntax_test_html.html and some real world sources._