### PR TITLE
[Python] Adjust scope for module name in qualified base class

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1080,14 +1080,19 @@ contexts:
               captures:
                 1: variable.parameter.class-inheritance.python
                 2: keyword.operator.assignment.python
-            - match: (?={{path}})
+            - match: (?={{identifier}} *\.)
               push:
-                - meta_scope: entity.other.inherited-class.python
-                - match: '{{identifier}}(?: *(\.) *)?'
+                - meta_scope: meta.path.python
+                - match: '({{identifier}}) *(\.) *'
                   captures:
-                    1: punctuation.accessor.dot.python
+                    1: variable.namespace.python
+                    2: punctuation.accessor.dot.python
+                - match: '{{identifier}}'
+                  scope: entity.other.inherited-class.python
                 - match: ''
                   pop: true
+            - match: '{{identifier}}'
+              scope: entity.other.inherited-class.python
             - include: expression-in-a-group
 
   functions:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1089,6 +1089,7 @@ contexts:
                     2: punctuation.accessor.dot.python
                 - match: '{{identifier}}'
                   scope: entity.other.inherited-class.python
+                  pop: true
                 - match: ''
                   pop: true
             - match: '{{identifier}}'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1609,8 +1609,10 @@ class MyClass(Inherited, \
 #                      ^ punctuation.separator.inheritance
 #                        ^ punctuation.separator.continuation.line.python
               module . Inherited2, metaclass=ABCMeta):
-#             ^^^^^^^^^^^^^^^^^^^ entity.other.inherited-class
+#             ^^^^^^^^^^^^^^^^^^^ meta.path - meta.path meta.path
+#             ^^^^^^ variable.namespace - entity
 #                    ^ punctuation.accessor.dot
+#                      ^^^^^^^^^^ entity.other.inherited-class
 #                                ^ punctuation.separator.inheritance
 #                                  ^^^^^^^^^ variable.parameter.class-inheritance
 #                                           ^ keyword.operator.assignment


### PR DESCRIPTION
Inspired by the syntaxes for e.g. Java and PHP.

**Before**:
![before](https://user-images.githubusercontent.com/6579999/172019773-dc07cd94-c07f-4990-a6bb-2a502a31ad81.png)

**After**:
![after](https://user-images.githubusercontent.com/6579999/172019777-a4d668de-e19e-4d4d-82df-4c7da6d762da.png)