### PR TITLE
[TypeScript] Allow number literals as object/interface type keys

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -394,7 +394,7 @@ contexts:
         - function-declaration-expect-parameters
         - ts-type-parameter-list
 
-    - match: (?={{identifier_start}}|['"])
+    - match: (?={{identifier_start}}|['"]|\d)
       push:
         - - match: (?=[<(])
             set:
@@ -411,6 +411,7 @@ contexts:
       scope: variable.other.readwrite.js
       pop: true
     - include: literal-string
+    - include: literal-number
 
   ts-enum:
     - match: enum{{identifier_break}}

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -226,6 +226,14 @@ import foo;
 //           ^ punctuation.separator.type
 //             ^^^ meta.type support.type.any
 //                ^ punctuation.separator
+
+        1: any,
+//      ^ meta.number.integer.decimal
+//      ^ constant.numeric.value
+//       ^ punctuation.separator.type
+//        ^^^^ meta.type
+//         ^^^ support.type.any
+//            ^ punctuation.separator
     }
 //  ^ meta.block punctuation.section.block.end
 


### PR DESCRIPTION
An old oversight I keep forgetting to fix.