### PR TITLE
[TypeScript] Adjust shebang

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -12,11 +12,13 @@ file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \#! .* \b(node|js)\b                              # shebang
-  | ^ \s* // .*? -\*- .*? \b(js|javascript)\b .*? -\*-  # editorconfig
+    ^ \#! .* \b(?:node|js)\b                              # shebang
+  | ^ \s* // .*? -\*- .*? \b(?:js|javascript)\b .*? -\*-  # editorconfig
   )
 
 variables:
+  shebang_lang: \b(?:node|js)\b
+
   bin_digit: '[01_]'
   oct_digit: '[0-7_]'
   dec_digit: '[0-9_]'
@@ -221,7 +223,7 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: comment.line.shebang.js
     # Note: Keep sync with first_line_match!
-    - match: \b(node|js)\b
+    - match: '{{shebang_lang}}'
       scope: constant.language.shebang.js
     - match: \n
       pop: 1

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -11,10 +11,13 @@ file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \s* // .*? -\*- .*? \b(ts|typescript)\b .*? -\*-  # editorconfig
+    ^ \#! .* \bts-node(?:-script)?\b                    # shebang
+  | ^ \s* // .*? -\*- .*? \b(ts|typescript)\b .*? -\*-  # editorconfig
   )
 
 variables:
+  shebang_lang: \bts-node(?:-script)?\b
+
   dot_accessor: (?:[?!]?\.)
   possible_arrow_function_begin: (?:\(|{{identifier_start}}|<)
 

--- a/JavaScript/tests/syntax_test_shebang.js
+++ b/JavaScript/tests/syntax_test_shebang.js
@@ -1,0 +1,4 @@
+#!node SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
+#!node <- comment.line.shebang.js punctuation.definition.comment.js
+   #!node <- comment.line.shebang.js constant.language.shebang.js
+         #!node <- comment.line.shebang.js - constant.language

--- a/JavaScript/tests/syntax_test_shebang.ts
+++ b/JavaScript/tests/syntax_test_shebang.ts
@@ -1,0 +1,4 @@
+#!ts-node SYNTAX TEST "Packages/JavaScript/TypeScript.sublime-syntax"
+#!ts-node <- comment.line.shebang.js punctuation.definition.comment.js
+   #!ts-node <- comment.line.shebang.js constant.language.shebang.js
+         #!ts-node <- comment.line.shebang.js - constant.language


### PR DESCRIPTION
This commit adds `ts-node` and `ts-node-script` to `first_line_match`
and highlights it via shebang-body context.

References

`ts-node`: https://www.npmjs.com/package/ts-node#shebang
`ts-node-script`: https://deepkit.io/documentation/framework