### PR TITLE
[JavaScript] Replace pop: true by pop: 1

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -45,7 +45,7 @@ contexts:
           captures:
             1: punctuation.definition.comment.end.js
             2: punctuation.definition.interpolation.end.js
-          pop: true
+          pop: 1
         - match: (?=\*/)
           fail: jsx-interpolation-comment
 
@@ -57,14 +57,14 @@ contexts:
           - meta_content_scope: source.js.embedded.jsx
           - match: '}'
             scope: punctuation.definition.interpolation.end.js
-            pop: true
+            pop: 1
         - expression
 
   jsx-expect-tag-end:
     - meta_content_scope: meta.tag.js
     - match: '>'
       scope: meta.tag.js punctuation.definition.tag.end.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   jsx-meta:
@@ -132,7 +132,7 @@ contexts:
         - meta_scope: string.quoted.single.js
         - match: \'
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - include: jsx-html-escapes
     - match: '"'
       scope: punctuation.definition.string.begin.js
@@ -141,7 +141,7 @@ contexts:
         - meta_scope: string.quoted.double.js
         - match: \"
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - include: jsx-html-escapes
 
     - include: else-pop
@@ -176,13 +176,13 @@ contexts:
   jsx-tag-name-component:
     - match: '{{jsx_identifier}}'
       scope: entity.name.tag.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   jsx-tag-name-component-possibly-native:
     - match: '[[:lower:]]{{jsx_identifier_part}}*{{jsx_identifier_break}}(?!{{nothing}}[.:])'
       scope: entity.name.tag.native.js
-      pop: true
+      pop: 1
     - include: jsx-tag-name-component
 
   jsx-body:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -154,7 +154,7 @@ contexts:
   block-comment-end:
     - match: \*+/
       scope: punctuation.definition.comment.end.js
-      pop: true
+      pop: 1
 
   block-comment-body:
     - meta_include_prototype: false
@@ -230,11 +230,11 @@ contexts:
 
   else-pop:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   immediately-pop:
     - match: ''
-      pop: true
+      pop: 1
 
   immediately-pop-2:
     - meta_include_prototype: false
@@ -285,10 +285,10 @@ contexts:
       set:
         - match: default{{identifier_break}}
           scope: keyword.control.import-export.js
-          pop: true
+          pop: 1
         - match: '{{identifier_name}}'
           scope: variable.other.readwrite.js
-          pop: true
+          pop: 1
         - include: else-pop
     - include: else-pop
 
@@ -321,10 +321,10 @@ contexts:
       set: import-brace
     - match: '{{non_reserved_identifier}}'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - match: '\*'
       scope: constant.other.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   import-brace:
@@ -332,7 +332,7 @@ contexts:
     - include: comma-separator
     - match: '\}'
       scope: punctuation.section.block.end.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       push: import-export-alias
@@ -386,10 +386,10 @@ contexts:
       set: export-brace
     - match: '{{non_reserved_identifier}}'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - match: '\*'
       scope: constant.other.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   export-brace:
@@ -397,7 +397,7 @@ contexts:
     - include: comma-separator
     - match: '\}'
       scope: punctuation.section.block.end.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       push: import-export-alias
@@ -409,7 +409,7 @@ contexts:
   statements:
     - match: '\)|\}|\]'
       scope: invalid.illegal.stray-bracket-end.js
-      pop: true
+      pop: 1
 
     - match: (?=\S)
       push: statement
@@ -417,7 +417,7 @@ contexts:
   statement:
     - match: \;
       scope: punctuation.terminator.statement.empty.js
-      pop: true
+      pop: 1
 
     - include: declaration
     - include: import-statement-or-import-meta
@@ -462,7 +462,7 @@ contexts:
   expect-semicolon:
     - match: \;
       scope: punctuation.terminator.statement.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   expect-label:
@@ -471,10 +471,10 @@ contexts:
       set:
         - match: '{{non_reserved_identifier}}'
           scope: variable.label.js
-          pop: true
+          pop: 1
         - match: '{{identifier_name}}'
           scope: invalid.illegal.identifier.js variable.label.js
-          pop: true
+          pop: 1
         - include: else-pop
     - include: immediately-pop
 
@@ -485,7 +485,7 @@ contexts:
         - meta_scope: meta.block.js
         - match: '\}'
           scope: punctuation.section.block.end.js
-          pop: true
+          pop: 1
         - include: statements
 
   variable-binding-pattern:
@@ -508,7 +508,7 @@ contexts:
         - meta_scope: meta.binding.destructuring.sequence.js
         - match: '\]'
           scope: punctuation.section.sequence.end.js
-          pop: true
+          pop: 1
         - include: variable-binding-spread
         - include: variable-binding-list
 
@@ -519,7 +519,7 @@ contexts:
         - meta_scope: meta.binding.destructuring.mapping.js
         - match: '\}'
           scope: punctuation.section.mapping.end.js
-          pop: true
+          pop: 1
         - include: variable-binding-spread
         - match: (?={{identifier_start}}|\[|'|")
           push:
@@ -537,7 +537,7 @@ contexts:
 
   variable-binding-object-key:
     - match: '{{identifier_name}}(?=\s*:)'
-      pop: true
+      pop: 1
     - include: literal-string
     - include: computed-property-name
     - include: variable-binding-name
@@ -605,7 +605,7 @@ contexts:
         - meta_scope: meta.binding.destructuring.sequence.js
         - match: '\]'
           scope: punctuation.section.sequence.end.js
-          pop: true
+          pop: 1
         - include: function-parameter-binding-list
 
   function-parameter-binding-object-destructuring:
@@ -617,7 +617,7 @@ contexts:
           scope: punctuation.separator.parameter.function.js
         - match: '\}'
           scope: punctuation.section.mapping.end.js
-          pop: true
+          pop: 1
         - include: function-parameter-binding-spread
         - match: (?={{identifier_start}}|\[|'|")
           push:
@@ -634,7 +634,7 @@ contexts:
 
   function-parameter-binding-object-key:
     - match: '{{identifier_name}}(?=\s*:)'
-      pop: true
+      pop: 1
     - include: literal-string
     - include: computed-property-name
     - include: function-parameter-binding-name
@@ -683,14 +683,14 @@ contexts:
   restricted-production:
     - meta_include_prototype: false
     - match: '{{line_ending_ahead}}'
-      pop: true
+      pop: 1
     - match: ''
       set: expression-statement
 
   expect-case-colon:
     - match: ':'
       scope: punctuation.separator.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   conditional:
@@ -821,7 +821,7 @@ contexts:
   for-await:
     - match: await{{identifier_break}}
       scope: keyword.control.flow.await.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   for-condition:
@@ -837,7 +837,7 @@ contexts:
 
     - match: '\)'
       scope: punctuation.section.group.end.js
-      pop: true
+      pop: 1
 
   for-condition-contents:
     # This could be either type of for loop.
@@ -867,7 +867,7 @@ contexts:
 
   for-oldstyle-rest:
     - match: (?=\))
-      pop: true
+      pop: 1
     - match: ;
       scope: punctuation.separator.expression.js
     - match: (?=\S)
@@ -893,7 +893,7 @@ contexts:
 
     - match: '\}'
       scope: punctuation.section.block.end.js
-      pop: true
+      pop: 1
 
     - match: case{{identifier_break}}
       scope: keyword.control.conditional.case.js
@@ -930,7 +930,7 @@ contexts:
   decorator-name:
     - match: '{{identifier_name}}(?!\s*[.\(`])'
       scope: variable.annotation.js
-      pop: true
+      pop: 1
 
   decorator-expression-end:
     - match: '{{dot_accessor}}'
@@ -955,7 +955,7 @@ contexts:
 
   expression-break:
     - match: (?=[;})\]])
-      pop: true
+      pop: 1
 
   expression:
     - meta_include_prototype: false
@@ -995,12 +995,12 @@ contexts:
 
   expression-end-no-comma:
     - match: (?=,)
-      pop: true
+      pop: 1
     - include: expression-end
 
   expression-end-no-in:
     - match: (?=in{{identifier_break}})
-      pop: true
+      pop: 1
     - include: expression-end
 
   expression-begin:
@@ -1023,7 +1023,7 @@ contexts:
     - include: regular-function
 
     - match: (?={{reserved_word}})
-      pop: true
+      pop: 1
 
     - match: (?={{identifier_name}}{{function_assignment_lookahead}})
       set:
@@ -1034,7 +1034,7 @@ contexts:
 
     # Newline not allowed between `async` and parameters.
     - match: (?=async{{identifier_break}}{{nothing}}{{possible_arrow_function_begin}})
-      pop: true
+      pop: 1
       branch_point: async-arrow-function
       branch:
         - async-arrow-function
@@ -1043,7 +1043,7 @@ contexts:
     - include: literal-call
 
     - match: (?={{possible_arrow_function_begin}})
-      pop: true
+      pop: 1
       branch_point: arrow-function
       branch:
         - branch-possible-arrow-function
@@ -1067,7 +1067,7 @@ contexts:
   arrow-function-expect-arrow-or-fail-async:
     - match: '=>'
       scope: keyword.declaration.function.arrow.js
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: async-arrow-function
 
@@ -1101,10 +1101,10 @@ contexts:
     - meta_scope: meta.string.js string.quoted.double.js
     - match: \"
       scope: punctuation.definition.string.end.js
-      pop: true
+      pop: 1
     - match: \n
       scope: invalid.illegal.newline.js
-      pop: true
+      pop: 1
     - include: string-content
 
   literal-single-quoted-string:
@@ -1117,10 +1117,10 @@ contexts:
     - meta_scope: meta.string.js string.quoted.single.js
     - match: \'
       scope: punctuation.definition.string.end.js
-      pop: true
+      pop: 1
     - match: \n
       scope: invalid.illegal.newline.js
-      pop: true
+      pop: 1
     - include: string-content
 
   literal-string-template:
@@ -1133,7 +1133,7 @@ contexts:
     - meta_scope: meta.string.js string.quoted.other.js
     - match: \`
       scope: punctuation.definition.string.end.js
-      pop: true
+      pop: 1
     - include: string-interpolations
     - include: string-content
 
@@ -1154,7 +1154,7 @@ contexts:
     - meta_content_scope: source.js.embedded
     - match: \}
       scope: punctuation.section.interpolation.end.js
-      pop: true
+      pop: 1
     - match: (?=\S)
       push: expression
 
@@ -1179,7 +1179,7 @@ contexts:
         push:
           - meta_include_prototype: false
           - match: '(?=/)'
-            pop: true
+            pop: 1
           - include: scope:source.regexp.js
 
   constructor:
@@ -1214,15 +1214,15 @@ contexts:
         - include: support
         - match: '{{dollar_only_identifier}}'
           scope: variable.type.dollar.only.js punctuation.dollar.js
-          pop: true
+          pop: 1
         - match: '{{dollar_identifier}}'
           scope: variable.type.dollar.js
           captures:
             1: punctuation.dollar.js
-          pop: true
+          pop: 1
         - match: '{{identifier_name}}'
           scope: variable.type.js
-          pop: true
+          pop: 1
         - include: else-pop
 
     - include: expression-begin
@@ -1233,7 +1233,7 @@ contexts:
       set:
         - match: target{{identifier_break}}
           scope: variable.language.target.js
-          pop: true
+          pop: 1
         - include: else-pop
 
     - include: else-pop
@@ -1351,7 +1351,7 @@ contexts:
       scope: keyword.control.flow.yield.js
       set:
         - match: $
-          pop: true
+          pop: 1
         - match: \*
           scope: keyword.generator.asterisk.js
           set: expression-begin
@@ -1388,7 +1388,7 @@ contexts:
 
     - match: '\}'
       scope: punctuation.section.block.end.js
-      pop: true
+      pop: 1
 
     - match: \;
       scope: punctuation.terminator.statement.js
@@ -1448,12 +1448,12 @@ contexts:
     - meta_scope: meta.block.js
     - match: \}
       scope: punctuation.section.block.end.js
-      pop: true
+      pop: 1
     - include: statements
 
   class-element-modifiers:
     - match: ''
-      pop: true
+      pop: 1
       branch_point: class-element-modifier
       branch:
         - class-element-modifier
@@ -1464,7 +1464,7 @@ contexts:
       scope: storage.modifier.js
       set:
         - match: (?={{class_element_name}}|\*)
-          pop: true
+          pop: 1
         - match: (?=\S)
           fail: class-element-modifier
 
@@ -1479,7 +1479,7 @@ contexts:
   inherited-class-name:
     - match: '{{non_reserved_identifier}}{{left_expression_end_lookahead}}'
       scope: entity.other.inherited-class.js
-      pop: true
+      pop: 1
 
   inherited-class-expression-end:
     - match: '{{dot_accessor}}'
@@ -1497,12 +1497,12 @@ contexts:
   class-name:
     - match: '{{non_reserved_identifier}}'
       scope: entity.name.class.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   class-element:
     - match: ''
-      pop: true
+      pop: 1
       branch_point: class-field
       branch:
         - class-field
@@ -1559,19 +1559,19 @@ contexts:
   special-name:
     - match: true{{identifier_break}}
       scope: constant.language.boolean.true.js
-      pop: true
+      pop: 1
     - match: false{{identifier_break}}
       scope: constant.language.boolean.false.js
-      pop: true
+      pop: 1
     - match: null{{identifier_break}}
       scope: constant.language.null.js
-      pop: true
+      pop: 1
     - match: super{{identifier_break}}
       scope: variable.language.super.js
-      pop: true
+      pop: 1
     - match: this{{identifier_break}}
       scope: variable.language.this.js
-      pop: true
+      pop: 1
 
   function-name-meta:
     - meta_include_prototype: false
@@ -1610,25 +1610,25 @@ contexts:
   function-declaration-expect-name:
     - match: '{{non_reserved_identifier}}'
       scope: entity.name.function.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   function-declaration-expect-generator-star:
     - match: \*
       scope: keyword.declaration.generator.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   function-declaration-expect-function-keyword:
     - match: function{{identifier_break}}
       scope: keyword.declaration.function.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   function-declaration-expect-async:
     - match: 'async{{identifier_break}}'
       scope: keyword.declaration.async.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   arrow-function-declaration:
@@ -1650,7 +1650,7 @@ contexts:
   arrow-function-expect-arrow:
     - match: '=>'
       scope: keyword.declaration.function.arrow.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   arrow-function-expect-parameters:
@@ -1660,7 +1660,7 @@ contexts:
         - meta_scope: meta.function.parameters.js
         - match: '{{identifier_name}}'
           scope: variable.parameter.function.js
-          pop: true
+          pop: 1
     - include: function-declaration-parameters
     - include: else-pop
 
@@ -1671,7 +1671,7 @@ contexts:
         - meta_scope: meta.block.js
         - match: '\}'
           scope: punctuation.section.block.end.js
-          pop: true
+          pop: 1
         - include: statements
 
   function-declaration-parameters:
@@ -1682,7 +1682,7 @@ contexts:
         - meta_scope: meta.function.parameters.js
         - match: \)
           scope: punctuation.section.group.end.js
-          pop: true
+          pop: 1
         - include: function-parameter-binding-list
 
   label:
@@ -1701,7 +1701,7 @@ contexts:
 
     - match: '\}'
       scope: punctuation.section.mapping.end.js
-      pop: true
+      pop: 1
 
     - match: \.\.\.
       scope: keyword.operator.spread.js
@@ -1742,9 +1742,9 @@ contexts:
   object-literal-element:
     - match: '{{identifier_name}}(?=\s*(?:[},]|$|//|/\*))'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - match: (?=\S)
-      pop: true
+      pop: 1
       branch_point: object-literal-property
       branch:
         - object-literal-property
@@ -1763,7 +1763,7 @@ contexts:
     - include: literal-number
 
     - match: '{{identifier_name}}'
-      pop: true
+      pop: 1
 
     - include: else-pop
 
@@ -1779,7 +1779,7 @@ contexts:
         - meta_scope: meta.brackets.js
         - match: \]
           scope: punctuation.section.brackets.end.js
-          pop: true
+          pop: 1
         - match: (?=\S)
           push: expression
 
@@ -1792,15 +1792,15 @@ contexts:
       scope: meta.mapping.key.dollar.js entity.name.function.js
       captures:
         1: punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: entity.name.function.js
-      pop: true
+      pop: 1
     - match: '(#){{identifier_name}}'
       scope: entity.name.function.js
       captures:
         1: punctuation.definition.js
-      pop: true
+      pop: 1
     - match: "'"
       scope: punctuation.definition.string.begin.js
       set:
@@ -1809,10 +1809,10 @@ contexts:
         - meta_content_scope: entity.name.function.js
         - match: \'
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - match: \n
           scope: invalid.illegal.newline.js
-          pop: true
+          pop: 1
         - include: string-content
     - match: '"'
       scope: punctuation.definition.string.begin.js
@@ -1822,10 +1822,10 @@ contexts:
         - meta_content_scope: entity.name.function.js
         - match: \"
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - match: \n
           scope: invalid.illegal.newline.js
-          pop: true
+          pop: 1
         - include: string-content
 
     - include: computed-property-name
@@ -1837,15 +1837,15 @@ contexts:
       scope: meta.mapping.key.dollar.js variable.other.readwrite.js
       captures:
         1: punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - match: (#)({{identifier_name}})
       captures:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - match: "'"
       scope: punctuation.definition.string.begin.js
       set:
@@ -1854,10 +1854,10 @@ contexts:
         - meta_content_scope: variable.other.readwrite.js
         - match: \'
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - match: \n
           scope: invalid.illegal.newline.js
-          pop: true
+          pop: 1
         - include: string-content
     - match: '"'
       scope: punctuation.definition.string.begin.js
@@ -1867,10 +1867,10 @@ contexts:
         - meta_content_scope: variable.other.readwrite.js
         - match: \"
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - match: \n
           scope: invalid.illegal.newline.js
-          pop: true
+          pop: 1
         - include: string-content
 
     - include: computed-property-name
@@ -1899,7 +1899,7 @@ contexts:
         - meta_scope: meta.group.js
         - match: \)
           scope: punctuation.section.group.end.js
-          pop: true
+          pop: 1
         - match: (?=\S)
           push: expression
 
@@ -1912,7 +1912,7 @@ contexts:
         - meta_scope: meta.group.js
         - match: \)
           scope: punctuation.section.group.end.js
-          pop: true
+          pop: 1
         - include: expression-list
 
   array-literal:
@@ -1922,7 +1922,7 @@ contexts:
         - meta_scope: meta.sequence.js
         - match: '\]'
           scope: punctuation.section.sequence.end.js
-          pop: true
+          pop: 1
         - include: expression-list
 
   property-access:
@@ -1934,7 +1934,7 @@ contexts:
         - meta_scope: meta.brackets.js
         - match: '\]'
           scope: punctuation.section.brackets.end.js
-          pop: true
+          pop: 1
         - match: (?=\S)
           push: expression
 
@@ -1962,7 +1962,7 @@ contexts:
       captures:
         1: punctuation.separator.decimal.js
         2: punctuation.separator.decimal.js
-      pop: true
+      pop: 1
 
     # integers
     - match: (0)({{dec_digit}}+){{identifier_break}}
@@ -1970,7 +1970,7 @@ contexts:
       captures:
         1: constant.numeric.base.js invalid.deprecated.numeric.octal.js
         2: constant.numeric.value.js invalid.deprecated.numeric.octal.js
-      pop: true
+      pop: 1
 
     - match: (0[Xx])({{hex_digit}}*)(n)?{{identifier_break}}
       scope: meta.number.integer.hexadecimal.js
@@ -1978,7 +1978,7 @@ contexts:
         1: constant.numeric.base.js
         2: constant.numeric.value.js
         3: constant.numeric.suffix.js
-      pop: true
+      pop: 1
 
     - match: (0[Oo])({{oct_digit}}*)(n)?{{identifier_break}}
       scope: meta.number.integer.octal.js
@@ -1986,7 +1986,7 @@ contexts:
         1: constant.numeric.base.js
         2: constant.numeric.value.js
         3: constant.numeric.suffix.js
-      pop: true
+      pop: 1
 
     - match: (0[Bb])({{bin_digit}}*)(n)?{{identifier_break}}
       scope: meta.number.integer.binary.js
@@ -1994,31 +1994,31 @@ contexts:
         1: constant.numeric.base.js
         2: constant.numeric.value.js
         3: constant.numeric.suffix.js
-      pop: true
+      pop: 1
 
     - match: ({{dec_integer}})(n|(?!\.)){{identifier_break}}
       scope: meta.number.integer.decimal.js
       captures:
         1: constant.numeric.value.js
         2: constant.numeric.suffix.js
-      pop: true
+      pop: 1
 
     # illegal numbers
     - match: 0[Xx]{{identifier_part}}+
       scope: invalid.illegal.numeric.hexadecimal.js
-      pop: true
+      pop: 1
 
     - match: 0[Bb]{{identifier_part}}+
       scope: invalid.illegal.numeric.binary.js
-      pop: true
+      pop: 1
 
     - match: 0{{identifier_part}}+
       scope: invalid.illegal.numeric.octal.js
-      pop: true
+      pop: 1
 
     - match: '[1-9]{{identifier_part}}+(?:\.{{identifier_part}}*)?'
       scope: invalid.illegal.numeric.decimal.js
-      pop: true
+      pop: 1
 
   literal-call:
     - match: (?={{identifier_name}}\s*(?:{{dot_accessor}})?\()
@@ -2053,22 +2053,22 @@ contexts:
   call-function-name:
     - match: '{{dollar_only_identifier}}'
       scope: variable.function.js variable.other.dollar.only.js punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: variable.function.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   call-method-name:
     - include: support-property
     - match: '{{identifier_name}}'
       scope: variable.function.js
-      pop: true
+      pop: 1
     - match: '(#){{identifier_name}}'
       scope: variable.function.js
       captures:
         1: punctuation.definition.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   literal-variable:
@@ -2082,11 +2082,11 @@ contexts:
 
     - match: '{{identifier_name}}(?={{nothing}}`)'
       scope: variable.function.tagged-template.js
-      pop: true
+      pop: 1
 
     - match: '{{constant_identifier}}(?=\s*(?:{{dot_accessor}}|\[))'
       scope: support.class.js
-      pop: true
+      pop: 1
 
     - match: '{{function_call_lookahead}}'
       set: call-function-name
@@ -2096,18 +2096,18 @@ contexts:
   literal-variable-base:
     - match: '{{dollar_only_identifier}}'
       scope: variable.other.dollar.only.js punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{dollar_identifier}}'
       scope: variable.other.dollar.js
       captures:
         1: punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{constant_identifier}}'
       scope: variable.other.constant.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - include: literal-private-variable
 
   literal-private-variable:
@@ -2115,25 +2115,25 @@ contexts:
       captures:
         1: punctuation.definition.variable.js
         2: variable.other.readwrite.js
-      pop: true
+      pop: 1
 
   special-identifier:
     # These are ordinary identifiers, not reserved words
     - match: arguments{{identifier_break}}
       scope: variable.language.arguments.js
-      pop: true
+      pop: 1
     - match: globalThis{{identifier_break}}
       scope: variable.language.global.js
-      pop: true
+      pop: 1
     - match: undefined{{identifier_break}}
       scope: constant.language.undefined.js
-      pop: true
+      pop: 1
     - match: NaN{{identifier_break}}
       scope: constant.language.nan.js
-      pop: true
+      pop: 1
     - match: Infinity{{identifier_break}}
       scope: constant.language.infinity.js
-      pop: true
+      pop: 1
 
   support:
     - include: support-variable-ecma
@@ -2320,98 +2320,98 @@ contexts:
     # Classes with no constructor properties
     - match: (?:Boolean|DataView|Function|Map|RegExp|Set|WeakMap|WeakSet){{identifier_break}}
       scope: support.class.builtin.js
-      pop: true
+      pop: 1
     - match: (?:Eval|Range|Reference|Syntax|Type|URI)?Error{{identifier_break}}
       scope: support.class.builtin.js
-      pop: true
+      pop: 1
 
     - match: (?:eval|isFinite|isNaN|parseFloat|parseInt|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent){{identifier_break}}
       scope: support.function.js
-      pop: true
+      pop: 1
 
   support-property-ecma-array:
     - match: (?:from|isArray|of){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-arraybuffer:
     - match: isView{{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-atomics:
     - match: (?:and|add|compareExchange|exchange|isLockFree|load|or|store|sub|wait|wake|xor){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-bigint:
     - match: (?:asUintN|asIntN){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-date:
     - match: (?:now|parse|UTC){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-json:
     - match: (?:parse|stringify){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-math:
     - match: (?:E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2){{identifier_break}}
       scope: support.constant.builtin.js
-      pop: true
+      pop: 1
     - match: (?:abs|acos|acosh|asin|asin|atan|atanh|atan2|cbrt|ceil|clz32|cos|cosh|exp|expm1|floor|fround|hypot|imul|log|log1p|log10|log2|max|min|pow|random|round|sign|sin|sinh|sqrt|tan|tanh|trunc){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-number:
     - match: (?:EPSILON|MAX_SAFE_INTEGER|MAX_VALUE|MIN_SAFE_INTEGER|MIN_VALUE|NEGATIVE_INFINITY|POSITIVE_INFINITY){{identifier_break}}
       scope: support.constant.builtin.js
-      pop: true
+      pop: 1
     - match: (?:isFinite|isInteger|isNaN|isSafeInteger|NaN|parseFloat|parseInt){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-object:
     - match: (?:assign|create|defineProperties|defineProperty|entries|freeze|fromEntries|getOwnPropertyDescriptors?|getOwnPropertyNames|getOwnPropertySymbols|getPrototypeOf|is|isExtensible|isFrozen|isSealed|keys|preventExtensions|seal|setPrototypeOf|values){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-promise:
     - match: (?:all|race|reject|resolve|allSettled|any){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-proxy:
     - match: revocable{{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-reflect:
     - match: (?:apply|construct|defineProperty|deleteProperty|get|getOwnPropertyDescriptor|getPrototypeOf|has|isExtensible|ownKeys|preventExtensions|set|setPrototypeOf){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-string:
     - match: (?:fromCharCode|fromCodePoint|raw){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-symbol:
     - match: (?:asyncIterator|hasInstance|isConcatSpreadable|iterator|match|replace|search|species|split|toPrimitive|toStringTag|unscopeables){{identifier_break}}
       scope: support.constant.builtin.js
-      pop: true
+      pop: 1
     - match: (?:for|keyFor){{identifier_break}}
       scope: support.function.builtin.js
-      pop: true
+      pop: 1
 
   support-property-ecma-typedarray:
     - match: (?:BYTES_PER_ELEMENT){{identifier_break}}
       scope: support.constant.builtin.js
-      pop: true
+      pop: 1
 
   support-variable-console:
     # https://console.spec.whatwg.org/
@@ -2426,22 +2426,22 @@ contexts:
   support-variable-dom:
     - match: XMLHttpRequest{{identifier_break}}
       scope: support.class.dom.js
-      pop: true
+      pop: 1
     - match: (?:document|window|navigator){{identifier_break}}
       scope: support.type.object.dom.js
-      pop: true
+      pop: 1
     - match: (?:clearTimeout|clearInterval|setTimeout|setInterval){{identifier_break}}
       scope: support.function.dom.js
-      pop: true
+      pop: 1
 
   support-variable-node:
     - match: global{{identifier_break}}
       scope: support.type.object.node.js
-      pop: true
+      pop: 1
 
     - match: Buffer{{identifier_break}}
       scope: support.class.node.js
-      pop: true
+      pop: 1
 
     - match: process{{identifier_break}}
       scope: support.constant.node.js
@@ -2457,7 +2457,7 @@ contexts:
     # Module-level variables
     - match: (?:__dirname|__filename|exports){{identifier_break}}
       scope: support.constant.node.js
-      pop: true
+      pop: 1
     - match: module{{identifier_break}}
       scope: support.constant.node.js
       set:
@@ -2470,28 +2470,28 @@ contexts:
         - include: else-pop
     - match: require{{identifier_break}}
       scope: support.function.node.js
-      pop: true
+      pop: 1
 
   support-property-node-process:
     - match: (?:arch|argv|argv0|channel|config|connected|debugPort|env|execArgv|execPath|exitCode|mainModule|noDeprecation|pid|platform|ppid|release|stderr|stdin|stdout|throwDeprecation|title|traceDeprecation|version|versions){{identifier_break}}
       scope: support.constant.node.js
-      pop: true
+      pop: 1
     - match: (?:abort|chdir|cpuUsage|cwd|disconnect|dlopen|emitWarning|exit|getegid|geteuid|getgit|getgroups|getuid|hasUncaughtExceptionCaptureCallback|hrtime|initGroups|kill|memoryUsage|nextTick|send|setegid|seteuid|setgid|setgroups|setuid|hasUncaughtExceptionCaptureCallback|umask|uptime){{identifier_break}}
       scope: support.function.node.js
-      pop: true
+      pop: 1
 
   support-property-node-module:
     - match: (?:children|exports|filename|id|loaded|parent|paths){{identifier_break}}
       scope: support.constant.node.js
-      pop: true
+      pop: 1
     - match: require{{identifier_break}}
       scope: support.function.node.js
-      pop: true
+      pop: 1
 
   builtin-console-properties:
     - match: (?:warn|info|log|error|time|timeEnd|assert|count|dir|group|groupCollapsed|groupEnd|profile|profileEnd|table|trace|timeStamp){{identifier_break}}
       scope: support.function.console.js
-      pop: true
+      pop: 1
     - include: object-property
 
   object-property:
@@ -2507,7 +2507,7 @@ contexts:
 
     - match: '{{identifier_name}}(?={{nothing}}`)'
       scope: variable.function.tagged-template.js
-      pop: true
+      pop: 1
 
     - include: object-property-base
     - include: else-pop
@@ -2515,23 +2515,23 @@ contexts:
   object-property-base:
     - match: '{{dollar_only_identifier}}'
       scope: meta.property.object.dollar.only.js punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{dollar_identifier}}'
       scope: meta.property.object.dollar.js
       captures:
         1: punctuation.dollar.js
-      pop: true
+      pop: 1
     - match: '{{identifier_name}}'
       scope: meta.property.object.js
-      pop: true
+      pop: 1
     - match: '{{identifier_part}}+{{identifier_break}}'
       scope: invalid.illegal.illegal-identifier.js
-      pop: true
+      pop: 1
     - match: (#)({{identifier_name}})
       captures:
         1: punctuation.definition.variable.js
         2: meta.property.object.js
-      pop: true
+      pop: 1
 
   support-property:
     - include: support-property-ecma
@@ -2539,22 +2539,22 @@ contexts:
   support-property-ecma:
     - match: constructor{{identifier_break}}
       scope: variable.language.constructor.js
-      pop: true
+      pop: 1
     - match: prototype{{identifier_break}}
       scope: support.constant.prototype.js
-      pop: true
+      pop: 1
 
     - match: (?:hasOwnProperty|isPrototypeOf|propertyIsEnumerable|toLocaleString|toString|valueOf){{identifier_break}}
       scope: support.function.js
-      pop: true
+      pop: 1
 
     # Annex B
     - match: __proto__{{identifier_break}}
       scope: invalid.deprecated.js variable.language.prototype.js
-      pop: true
+      pop: 1
     - match: (?:__defineGetter__|__defineSetter__|__lookupGetter__){{identifier_break}}
       scope: invalid.deprecated.js support.function.js
-      pop: true
+      pop: 1
 
   import-meta-expression:
     - match: import{{identifier_break}}
@@ -2569,6 +2569,6 @@ contexts:
       set:
         - match: meta{{identifier_break}}
           scope: variable.language.import.js
-          pop: true
+          pop: 1
         - include: object-property
     - include: else-pop

--- a/JavaScript/Regular Expressions (JavaScript).sublime-syntax
+++ b/JavaScript/Regular Expressions (JavaScript).sublime-syntax
@@ -54,7 +54,7 @@ contexts:
         - meta_scope: constant.other.character-class.set.regexp
         - match: '\]'
           scope: punctuation.definition.character-class.end.regexp
-          pop: true
+          pop: 1
         - match: |-
             (?x)
             (?:
@@ -90,7 +90,7 @@ contexts:
         - meta_scope: meta.group.assertion.regexp
         - match: \)
           scope: punctuation.definition.group.end.regexp
-          pop: true
+          pop: 1
         - include: main
 
   group-definition:
@@ -106,7 +106,7 @@ contexts:
         - meta_scope: meta.group.regexp
         - match: \)
           scope: punctuation.definition.group.end.regexp
-          pop: true
+          pop: 1
         - include: main
 
   operator:

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -58,11 +58,11 @@ contexts:
       scope: entity.other.attribute-name.js
       set:
         - match: (?=[>=])
-          pop: true
+          pop: 1
         - match: (?=\S)
           fail: arrow-function
 
     - match: (?=[/>{]|{{identifier_start}})
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: arrow-function

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -105,7 +105,7 @@ contexts:
 
   ts-detect-parenthesized-arrow-return-type:
     - match: (?=:)
-      pop: true
+      pop: 1
       branch_point: ts-arrow-function-return-type
       branch:
         - ts-detect-arrow-function-return-type
@@ -228,7 +228,7 @@ contexts:
         - literal-string
     - include: declaration
     - match: (?={{identifier_start}})
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: ts-declare
 
@@ -253,21 +253,21 @@ contexts:
     - include: ts-namespace-declaration
 
     - match: (?=const{{identifier_break}})
-      pop: true
+      pop: 1
       branch_point: ts-const-enum
       branch:
         - ts-const-declaration
         - ts-const-enum
 
     - match: (?=declare{{identifier_break}})
-      pop: true
+      pop: 1
       branch_point: ts-declare
       branch:
         - ts-declare
         - expression-statement
 
     - match: (?=abstract{{identifier_break}})
-      pop: true
+      pop: 1
       branch_point: ts-abstract-class
       branch:
         - ts-abstract-class
@@ -336,7 +336,7 @@ contexts:
   ts-interface-name:
     - match: '{{identifier_name}}'
       scope: entity.name.interface.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   ts-interface-body:
@@ -346,7 +346,7 @@ contexts:
         - meta_scope: meta.block.js
         - match: \}
           scope: punctuation.section.block.end.js
-          pop: true
+          pop: 1
         - include: ts-type-members
 
   ts-type-members:
@@ -373,12 +373,12 @@ contexts:
         -  ts-type-annotation-optional
         - - match: '\+|-'
             scope: storage.modifier.js
-            pop: true
+            pop: 1
           - include: else-pop
         - - meta_scope: meta.brackets.js
           - match: \]
             scope: punctuation.section.brackets.end.js
-            pop: true
+            pop: 1
           - match: '{{identifier_name}}'
             scope: variable.other.readwrite.js
             push:
@@ -412,7 +412,7 @@ contexts:
   ts-type-member-name:
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
-      pop: true
+      pop: 1
     - include: literal-string
     - include: literal-number
 
@@ -432,7 +432,7 @@ contexts:
   ts-enum-name:
     - match: '{{identifier_name}}'
       scope: entity.name.enum.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   ts-enum-body:
@@ -442,7 +442,7 @@ contexts:
         - meta_scope: meta.block.js
         - match: \}
           scope: punctuation.section.block.end.js
-          pop: true
+          pop: 1
         - include: comma-separator
         - match: (?=['"])
           push: literal-string
@@ -458,7 +458,7 @@ contexts:
   ts-type-alias-name:
     - match: '{{identifier_name}}'
       scope: entity.name.type.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   ts-type-alias-body:
@@ -493,7 +493,7 @@ contexts:
   ts-namespace-name:
     - match: '{{identifier_name}}'
       scope: entity.name.namespace.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   variable-binding-pattern:
@@ -542,7 +542,7 @@ contexts:
     - meta_scope: meta.generic.js
     - match: \>
       scope: punctuation.definition.generic.end.js
-      pop: true
+      pop: 1
 
     - match: ','
       scope: punctuation.separator.comma
@@ -607,7 +607,7 @@ contexts:
       scope: storage.modifier.js
       set:
         - match: (?={{binding_pattern_lookahead}}|\.\.\.)
-          pop: true
+          pop: 1
         - match: (?=\S)
           fail: function-parameter-modifier
 
@@ -660,13 +660,13 @@ contexts:
       scope: punctuation.definition.generic.begin.js
       set:
         - - match: (?=[\]()};,`])
-            pop: true
+            pop: 1
           - match: (?=\S)
             fail: ts-function-type-arguments
         - - meta_scope: meta.generic.js
           - match: \>
             scope: punctuation.definition.generic.end.js
-            pop: true
+            pop: 1
           - match: ','
             scope: punctuation.separator.comma.js
             push:
@@ -688,7 +688,7 @@ contexts:
     - meta_scope: meta.assertion.js
     - match: \>
       scope: punctuation.definition.assertion.end.js
-      pop: true
+      pop: 1
 
   ts-old-type-assertion-check:
     - match: (?=\()
@@ -707,7 +707,7 @@ contexts:
       push:
         - match: const{{identifier_break}}
           scope: storage.modifier.const.js
-          pop: true
+          pop: 1
         - match: (?=\S)
           set:
             - ts-type-meta
@@ -728,13 +728,13 @@ contexts:
   ts-type-annotation-optional:
     - match: \?
       scope: storage.modifier.optional.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   ts-type-annotation-definite:
     - match: \!
       scope: storage.modifier.definite.js
-      pop: true
+      pop: 1
     - include: else-pop
 
   ts-type-meta:
@@ -793,7 +793,7 @@ contexts:
   ts-type-expression-end-no-line-terminator:
     - meta_include_prototype: false
     - match: '{{line_ending_ahead}}'
-      pop: true
+      pop: 1
     - include: prototype
 
     - match: \[(?={{nothing}}\])
@@ -801,7 +801,7 @@ contexts:
       push:
         - match: \]
           scope: storage.modifier.array.js
-          pop: true
+          pop: 1
         - include: else-pop
 
     - match: \[
@@ -810,7 +810,7 @@ contexts:
         - meta_scope: meta.brackets.js
         - match: \]
           scope: punctuation.section.brackets.end.js
-          pop: true
+          pop: 1
         - match: (?=\S)
           push:
             - ts-type-expression-end
@@ -828,7 +828,7 @@ contexts:
         - meta_scope: meta.generic.js
         - match: \>
           scope: punctuation.definition.generic.end.js
-          pop: true
+          pop: 1
         - include: comma-separator
         - match: (?=\S)
           push:
@@ -864,7 +864,7 @@ contexts:
             - meta_scope: meta.group.js
             - match: \)
               scope: punctuation.section.group.end.js
-              pop: true
+              pop: 1
             - match: (?=['"])
               push: literal-string
         - include: else-pop
@@ -882,7 +882,7 @@ contexts:
         - ts-type-parameter-list
 
     - match: (?=\()
-      pop: true
+      pop: 1
       branch_point: ts-function-type
       branch:
         - ts-type-parenthesized
@@ -899,7 +899,7 @@ contexts:
 
   ts-generic-function-type-check:
     - match: (?=\()
-      pop: true
+      pop: 1
     - match: (?=\S)
       pop: 2
 
@@ -910,7 +910,7 @@ contexts:
         - meta_scope: meta.sequence.js
         - match: \]
           scope: punctuation.section.sequence.end.js
-          pop: true
+          pop: 1
         - include: comma-separator
         - match: \.\.\.
           scope: keyword.operator.spread.js
@@ -928,53 +928,53 @@ contexts:
         - meta_scope: meta.mapping.js
         - match: \}
           scope: punctuation.section.mapping.end.js
-          pop: true
+          pop: 1
         - include: ts-type-members
 
   ts-type-special:
     - match: 'any{{identifier_break}}'
       scope: 'support.type.any.js'
-      pop: true
+      pop: 1
     - match: 'void{{identifier_break}}'
       scope: 'support.type.void.js'
-      pop: true
+      pop: 1
     - match: 'never{{identifier_break}}'
       scope: 'support.type.never.js'
-      pop: true
+      pop: 1
     - match: 'unknown{{identifier_break}}'
       scope: 'support.type.unknown.js'
-      pop: true
+      pop: 1
 
   ts-type-primitive:
     - match: 'boolean{{identifier_break}}'
       scope: 'support.type.primitive.boolean.js'
-      pop: true
+      pop: 1
     - match: 'number{{identifier_break}}'
       scope: 'support.type.primitive.number.js'
-      pop: true
+      pop: 1
     - match: 'string{{identifier_break}}'
       scope: 'support.type.primitive.string.js'
-      pop: true
+      pop: 1
     - match: 'null{{identifier_break}}'
       scope: 'support.type.primitive.null.js'
-      pop: true
+      pop: 1
     - match: 'undefined{{identifier_break}}'
       scope: 'support.type.primitive.undefined.js'
-      pop: true
+      pop: 1
     - match: 'object{{identifier_break}}'
       scope: 'support.type.primitive.object.js'
-      pop: true
+      pop: 1
     - match: 'symbol{{identifier_break}}'
       scope: 'support.type.primitive.symbol.js'
-      pop: true
+      pop: 1
     - match: 'bigint{{identifier_break}}'
       scope: 'support.type.primitive.bigint.js'
-      pop: true
+      pop: 1
 
   ts-type-basic:
     - match: '{{identifier_name}}'
       scope: support.class.js
-      pop: true
+      pop: 1
 
   ts-type-template-string:
     - match: '`'
@@ -984,7 +984,7 @@ contexts:
         - meta_scope: meta.string.js string.quoted.other.js
         - match: "`"
           scope: punctuation.definition.string.end.js
-          pop: true
+          pop: 1
         - match: '\$\{'
           scope: punctuation.section.interpolation.begin.js
           push:
@@ -993,7 +993,7 @@ contexts:
             - meta_content_scope: source.js.embedded
             - match: '\}'
               scope: punctuation.section.interpolation.end.js
-              pop: true
+              pop: 1
             - match: (?=\S)
               push:
               - ts-type-expression-end
@@ -1011,7 +1011,7 @@ contexts:
         - - meta_scope: meta.group.js
           - match: \)
             scope: punctuation.section.group.end.js
-            pop: true
+            pop: 1
           - match: (?=\S)
             fail: ts-function-type
         - ts-type-expression-end
@@ -1061,6 +1061,6 @@ contexts:
       scope: storage.modifier.js
       set:
         - match: (?={{property_name}})
-          pop: true
+          pop: 1
         - match: (?=\S)
           fail: ts-object-literal-element-modifier


### PR DESCRIPTION
JavaScript uses sublime-syntax `version: 2` and makes use of `pop: 2` in 2 contexts. Thus it might be consistent to use explicit `pop: 1` instead of legacy `pop: true`.

This commit doesn't change behavior.