### PR TITLE
[Rails] Add HAML Markdown Filter highlighting

### DIFF
--- a/Rails/HAML.sublime-syntax
+++ b/Rails/HAML.sublime-syntax
@@ -162,15 +162,14 @@ contexts:
 
   filters:
     # Notes:
-    # 1. Markdown is not implemented as it fails to render due to
-    #    indentation and because it embedds many syntaxes itself.
-    # 2. Syntaxes not part of this repo (LESS, SCSS, SASS, CoffeeScript)
-    #    are not implemented as those would cause issues when not present.
+    #   Syntaxes not part of this repo (LESS, SCSS, SASS, CoffeeScript)
+    #   are not implemented as those would cause issues when not present.
     # source:
     #   https://github.com/haml/haml/blob/main/lib/haml/filters.rb
     - include: filters-css
     - include: filters-erb
     - include: filters-javascript
+    - include: filters-markdown
     - include: filters-ruby
     - include: filters-plain
 
@@ -208,6 +207,18 @@ contexts:
       embed_scope:
         meta.filter.haml meta.embedded.haml
         source.js.embedded.haml
+      escape: '{{filter_escapes}}'
+
+  filters-markdown:
+    - match: ^(\s*)((:)(markdown)$\n?)
+      captures:
+        2: meta.filter.definition.haml
+        3: punctuation.definition.filter.haml
+        4: constant.other.language-name.markdown.haml
+      embed: scope:text.html.markdown.embedded.haml
+      embed_scope:
+        meta.filter.haml meta.embedded.haml
+        text.html.markdown.embedded.haml
       escape: '{{filter_escapes}}'
 
   filters-plain:

--- a/Rails/HTML (for HAML).sublime-syntax
+++ b/Rails/HTML (for HAML).sublime-syntax
@@ -8,15 +8,43 @@ hidden: true
 extends: Packages/HTML/HTML.sublime-syntax
 
 contexts:
-  main: []
+  prototype:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#interpolations
 
-  strings-common-content:
+  cdata-content:
     - meta_prepend: true
     - include: HAML.sublime-syntax#string-interpolations
 
-  tag-attribute-value-content:
-    - meta_prepend: true
-    - include: HAML.sublime-syntax#string-interpolations
+  script-javascript-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.embedded.haml
+      embed_scope: source.js.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.js.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.js.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.haml
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
 
   tag-event-attribute-value:
     - match: \"
@@ -71,3 +99,11 @@ contexts:
         0: meta.string.html string.quoted.single.html
            punctuation.definition.string.end.html
     - include: else-pop
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#string-interpolations
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#string-interpolations

--- a/Rails/HTML (for HAML).sublime-syntax
+++ b/Rails/HTML (for HAML).sublime-syntax
@@ -12,10 +12,6 @@ contexts:
     - meta_prepend: true
     - include: HAML.sublime-syntax#interpolations
 
-  cdata-content:
-    - meta_prepend: true
-    - include: HAML.sublime-syntax#string-interpolations
-
   script-javascript-content:
     - meta_include_prototype: false
     - match: '{{script_content_begin}}'

--- a/Rails/Markdown (for HAML).sublime-syntax
+++ b/Rails/Markdown (for HAML).sublime-syntax
@@ -1,0 +1,18 @@
+%YAML 1.2
+---
+scope: text.html.markdown.embedded.haml
+version: 2
+hidden: true
+
+extends: Packages/Markdown/Markdown.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#interpolations
+
+  main:
+    - include: indented-markdown
+
+  html-content:
+    - include: HTML (for HAML).sublime-syntax#html

--- a/Rails/tests/syntax_test_rails.haml
+++ b/Rails/tests/syntax_test_rails.haml
@@ -428,14 +428,34 @@
 
 :markdown
 / <- meta.filter.definition.haml punctuation.definition.filter.haml
-/^^^^^^^^ meta.filter.definition.haml constant.other.language-name.plain.haml
+/^^^^^^^^ meta.filter.definition.haml constant.other.language-name.markdown.haml
 /        ^ meta.filter.definition.haml - constant
 
 :markdown
-  # Title
-  / <- meta.filter.haml text.plain.embedded.haml
+  # Title #{ @name }
+  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+  /       ^^^^^^^^^^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml markup.heading.1.markdown meta.interpolation.haml
   Context
-  / <- meta.filter.haml text.plain.embedded.haml
+  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.paragraph
+
+  ```c
+  void foo() {}
+  ```
+  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.c.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  /^^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.c.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+  - list #{@item}
+  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+  /^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml markup.list.unnumbered.markdown
+  / ^^^^^^^^^^^^^^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.paragraph.list.markdown
+  /      ^^^^^^^^ meta.interpolation.haml
+  /      ^^ punctuation.section.interpolation.begin.haml
+  /        ^^^^^ source.ruby.rails.embedded.haml variable.other.readwrite.instance.ruby
+  /             ^ punctuation.section.interpolation.end.haml
+
+  <style  lang="#{@style_type}"> p { font-family: #{@font_name}; }
+/               ^^^^^^^^^^^^^^ meta.string.html meta.interpolation.haml
+/                                                 ^^^^^^^^^^^^^ meta.property-value.css meta.interpolation.haml
 
 :plain
 / <- meta.filter.definition.haml punctuation.definition.filter.haml


### PR DESCRIPTION
This PR adds support for markdown highlighting within HAML filters.

~~~haml
:markdown
  # Title #{ @name }

  ```c
  void foo() {}
  ```

  - list #{@item}

  <style  lang="#{@style_type}"> p { font-family: #{@font_name}; } </style>
~~~

![grafik](https://user-images.githubusercontent.com/16542113/177606723-5183ca7d-64dc-41d4-86dc-deba7e3f1ea9.png)
