### PR TITLE
[Git Formats] Highlight "Change-Id:" in commit msg

### DIFF
--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -81,10 +81,11 @@ contexts:
 
   # for Gerrit Code Review
   change-id:
-    - match: ^\s*(Change-Id)\s*(:)
+    - match: ^\s*(Change-Id)\s*(:)\s*(.*)
       captures:
         1: keyword.other.change-id.git.commit
         2: punctuation.separator.key-value.git.commit
+        3: constant.language.change-id.git.commit
 
   signed-off:
     - match: ^\s*(Signed-off-by)\s*(:)

--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -76,7 +76,15 @@ contexts:
         - match: ^(?=#)
           pop: 1
         - include: Git Common.sublime-syntax#references
+        - include: change-id
         - include: signed-off
+
+  # for Gerrit Code Review
+  change-id:
+    - match: ^\s*(Change-Id)\s*(:)
+      captures:
+        1: keyword.other.change-id.git.commit
+        2: punctuation.separator.key-value.git.commit
 
   signed-off:
     - match: ^\s*(Signed-off-by)\s*(:)

--- a/Git Formats/tests/syntax_test_git_commit
+++ b/Git Formats/tests/syntax_test_git_commit
@@ -130,6 +130,11 @@ This commit applies all changes required to satisfy the JSON format unittest.
 # <- comment.line.git.commit punctuation.definition.comment.git.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.commit
 #
+  Change-Id: I3b3613e336397febf02cd8e5c14c53d493343e93
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+# ^^^^^^^^^ keyword.other.change-id.git.commit
+#          ^ punctuation.separator.key-value.git.commit
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.change-id.git.commit
   Signed-off-by: username <user.name@domain.com>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 #                         ^^^^^^^^^^^^^^^^^^^^^^ meta.reference.email.git


### PR DESCRIPTION
Not sure whether it's worth being added but anyway, a PR is here.

---

It's used in [Gerrit Code Review](https://en.wikipedia.org/wiki/Gerrit_(software)).

For people who use Gerrit Code Review, their commit messages usually look like the following.
The `Change-Id` attribute is necessary for submitting a code review.

```
This is the commit subject.

Here are the commit details line 1.
Here are the commit details line 2.
......

Change-Id: I3b3613e336397febf02cd8e5c14c53d493343e93
Signed-off-by: Foo Bar <foo.bar@example.com>
```