### PR TITLE
[Java] Add support for syntax based folding of groups/parentheses

### DIFF
--- a/Java/Fold.tmPreferences
+++ b/Java/Fold.tmPreferences
@@ -25,6 +25,12 @@
                 <key>end</key>
                 <string>punctuation.section.brackets.end</string>
             </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.section.group.begin</string>
+                <key>end</key>
+                <string>punctuation.section.group.end</string>
+            </dict>
         </array>
     </dict>
 </dict>


### PR DESCRIPTION
Despite syntax tests containing incomplete statements, which cause
syntax based folding to fail, the overall syntax carefully tracks
parentheses. So its safe to enable syntax based folding for groups.

Note:

Syntax based folding might fail in JSP syntax in situations of heavy
inline mixture between html and java code. That's the case for all
sorts of brackets however.