### PR TITLE
[TypeScript] Fix bug when arrow function return type is parenthesized

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -885,8 +885,8 @@ contexts:
       pop: 1
       branch_point: ts-function-type
       branch:
-        - ts-type-parenthesized
         - ts-type-function
+        - ts-type-parenthesized
 
     - include: literal-string
     - include: literal-number
@@ -1005,9 +1005,6 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.js
       set:
-        - - match: (?==>)
-            fail: ts-function-type
-          - include: else-pop
         - - meta_scope: meta.group.js
           - match: \)
             scope: punctuation.section.group.end.js
@@ -1032,7 +1029,8 @@ contexts:
                 - ts-type-expression-end
                 - ts-type-expression-end-no-line-terminator
                 - ts-type-expression-begin
-            - include: else-pop
+            - match: (?=\S)
+              fail: ts-function-type
         - include: comma-separator
         - match: '\.\.\.'
           scope: keyword.operator.spread.js
@@ -1041,6 +1039,8 @@ contexts:
           push:
             - ts-type-annotation
             - ts-type-annotation-optional
+        - match: (?=\S)
+          fail: ts-function-type
 
   object-literal-contents:
     - meta_prepend: true

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1265,3 +1265,43 @@ const x = {
 //                                           ^^^^ constant.language.null
 //                                               ^ punctuation.terminator.statement
 //                                                 ^^^^^^^^ comment.line.double-slash
+
+const f = (x): ((y) => any) => 42;
+//        ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//        ^^^ meta.function.parameters
+//         ^ meta.binding.name variable.parameter.function
+//           ^ punctuation.separator.type
+//            ^^^^^^^^^^^^^^ meta.type
+//             ^^^^^^^^^^^^ meta.group
+//             ^ punctuation.section.group.begin
+//              ^^^ meta.group
+//              ^ punctuation.section.group.begin
+//               ^ variable.parameter
+//                ^ punctuation.section.group.end
+//                  ^^ keyword.declaration.function
+//                     ^^^ support.type.any
+//                        ^ punctuation.section.group.end
+//                          ^^ keyword.declaration.function.arrow
+//                             ^^ meta.block meta.number.integer.decimal
+//                             ^^ constant.numeric.value
+//                               ^ punctuation.terminator.statement
+
+const f = (x): (y) => 42 => z;
+//    ^ meta.binding.name entity.name.function
+//    ^ variable.other.readwrite
+//      ^ keyword.operator.assignment
+//        ^^^^^^^^^^^^^^^^^^^ meta.function
+//        ^ punctuation.section.group.begin
+//         ^ meta.binding.name variable.parameter.function
+//          ^ punctuation.section.group.end
+//           ^ punctuation.separator.type
+//            ^^^^^^^^^^^ meta.type
+//             ^^^ meta.group
+//             ^ punctuation.section.group.begin
+//              ^ variable.parameter
+//               ^ punctuation.section.group.end
+//                 ^^ keyword.declaration.function
+//                    ^^ meta.number.integer.decimal constant.numeric.value
+//                       ^^ keyword.declaration.function.arrow
+//                          ^ meta.block variable.other.readwrite
+//                           ^ punctuation.terminator.statement


### PR DESCRIPTION
Fix #3441.

Currently, when `ts-type-expression-begin` sees an open paren, it tries to parse it as a parenthesized type, and then, if it sees `=>` after the close paren, it backtracks and tries to parse a function type instead. (This mirrors the behavior with expressions: `expression-begin` tries to parse an open paren as a parenthesized expression, then falls back to an arrow function if it sees the arrow. This makes sense because parenthesized expressions are more common, so this leads to less backtracking.)

This approach fails for arrow function return types. If an arrow function return type is a parenthesized type, then it will see the following arrow and assume that it's supposed to be a function type — but that arrow could be part of the arrow function itself, not the return type.

This PR swaps the order. In a type context, an open paren is presumed to be an arrow function. If the paren contents don't look like an arguments list, or there is no arrow after the close paren, then it will backtrack and reparse as a parenthesized expression.

If anyone was wondering about the case `(x): (y) => z;`, it turns out that's invalid (according to AST explorer). Apparently, TypeScript's parser will greedily parse `(y) => z` as a function type, and then fail; it won't parse `(y)` as a parenthesized type. So this PR shouldn't break any valid code. (I once again lament the lack of a TypeScript spec.)