### PR TITLE
[Makefile] Fix possible stack underflow

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -133,6 +133,7 @@ contexts:
       push: expect-rule
     - include: variable-substitutions
     - include: control-flow
+    - include: line-continuation
     - match: ^\s*(endef)
       captures:
         1: invalid.illegal.stray.endef.makefile
@@ -520,12 +521,6 @@ contexts:
     - match: \s*(override)\b
       captures:
         1: keyword.control.makefile
-      set:
-        - match: \bdefine\b
-          scope: keyword.control.makefile
-          push: inside-define-directive-context
-        - include: variable-definitions
-        - include: continuation-or-pop-on-line-end
     - match: \s*(define)\b
       captures:
         1: keyword.control.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -200,6 +200,18 @@ endef
 endef
 # <- invalid.illegal.stray
 
+override \
+# <- keyword.control.makefile
+#        ^ punctuation.separator.continuation.line.makefile
+
+override \
+	define foo
+# ^^^^^ keyword.control.makefile
+#       ^^^^ variable.other.makefile
+endef
+# <- keyword.control.makefile
+
+
 ########################################
 # 6.11 target-specific variable values #
 ########################################


### PR DESCRIPTION
The `main` context directly includes `variable-definitions` context. If `override` is consumed an anonymous context is set onto stack, overriding `main`. This context is popped at eol, causing a potential context-stack underflow. Presumably only ST's safety mechanisms prevent bad things from happening here.

As the pushed context also includes `variable-definitions` things start to become even more suspicious. Hence the whole construct is removed.

The only change needed to maintain behavior is to include `line-continuation` in main.