### PR TITLE
Add .mdwn as a markdown extension

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -16,6 +16,7 @@ version: 2
 file_extensions:
   - md
   - mdown
+  - mdwn
   - markdown
   - markdn
 


### PR DESCRIPTION
That extension is used by [Ikiwiki](https://ikiwiki.info/) and [other applications](https://superuser.com/a/285878), and it's recognized by GitHub as Markdown.