### PR TITLE
[Python] Improve case statement indentation rules

### DIFF
--- a/Python/Dedentation Rules.tmPreferences
+++ b/Python/Dedentation Rules.tmPreferences
@@ -2,11 +2,11 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>source.python meta.statement.conditional.case - meta.disable-dedentation</string>
+	<string>source.python - meta.disable-dedentation</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*case\b</string>
+		<string>^\s*(case|elif|else|except|finally)\b.*:(?!=)</string>
 	</dict>
 </dict>
 </plist>

--- a/Python/Indentation Rules - Case.tmPreferences
+++ b/Python/Indentation Rules - Case.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.python meta.statement.conditional.case - meta.disable-dedentation</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*case\b</string>
+	</dict>
+</dict>
+</plist>

--- a/Python/Indentation Rules.tmPreferences
+++ b/Python/Indentation Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*(elif|else|except|finally)\b.*:</string>
+		<string>^\s*(elif|else|except|finally)\b</string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)
 			^\s*

--- a/Python/Indentation Rules.tmPreferences
+++ b/Python/Indentation Rules.tmPreferences
@@ -5,8 +5,6 @@
 	<string>source.python</string>
 	<key>settings</key>
 	<dict>
-		<key>decreaseIndentPattern</key>
-		<string>^\s*(elif|else|except|finally)\b</string>
 		<key>increaseIndentPattern</key>
 		<string><![CDATA[(?x)
 			^\s*

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -501,10 +501,11 @@ contexts:
     - include: allow-unpack-operators
 
   case-statement-end:
-    - match: ':(?!=)'
-      scope:
-        meta.statement.conditional.case.python
-        punctuation.section.block.conditional.case.python
+    # consume trailing whitespace so ST applies indentation rules reliably
+    - match: (:(?!=))\s*
+      scope: meta.statement.conditional.case.python
+      captures:
+        1: punctuation.section.block.conditional.case.python
       pop: true
 
   case-statement-fail:
@@ -725,7 +726,27 @@ contexts:
   match-statement-end:
     - match: ':(?!=)'
       scope: punctuation.section.block.conditional.match.python
-      pop: true
+      set: expect-first-case-statement
+
+  expect-first-case-statement:
+    # Disable detentation of first case statement by special indentation rule.
+    # see: https://github.com/sublimehq/Packages/issues/3456
+    - match: case\b
+      scope:
+        meta.statement.conditional.case.python
+        keyword.control.conditional.case.python
+      set:
+        - meta-disable-detention
+        - case-statement-pattern
+        - allow-unpack-operators
+    - include: comments
+    - include: else-pop
+
+  meta-disable-detention:
+    - meta_include_prototype: false
+    - meta_scope: meta.disable-dedentation.python
+    - match: ''
+      pop: 1
 
   structural-pattern-fallback:
     # Fallback context, which is used if `match` or `case` don't seem to

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -736,13 +736,13 @@ contexts:
         meta.statement.conditional.case.python
         keyword.control.conditional.case.python
       set:
-        - meta-disable-detention
+        - meta-disable-dedentation
         - case-statement-pattern
         - allow-unpack-operators
     - include: comments
     - include: else-pop
 
-  meta-disable-detention:
+  meta-disable-dedentation:
     - meta_include_prototype: false
     - meta_scope: meta.disable-dedentation.python
     - match: ''

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -501,11 +501,10 @@ contexts:
     - include: allow-unpack-operators
 
   case-statement-end:
-    # consume trailing whitespace so ST applies indentation rules reliably
-    - match: (:(?!=))\s*
-      scope: meta.statement.conditional.case.python
-      captures:
-        1: punctuation.section.block.conditional.case.python
+    - match: ':(?!=)'
+      scope:
+        meta.statement.conditional.case.python
+        punctuation.section.block.conditional.case.python
       pop: true
 
   case-statement-fail:
@@ -745,8 +744,7 @@ contexts:
   meta-disable-dedentation:
     - meta_include_prototype: false
     - meta_scope: meta.disable-dedentation.python
-    - match: ''
-      pop: 1
+    - include: else-pop
 
   structural-pattern-fallback:
     # Fallback context, which is used if `match` or `case` don't seem to

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -951,8 +951,7 @@ def _():
     case "200":
 #   ^^^^ meta.statement.conditional.case.python
 #       ^^^^^^ meta.statement.conditional.case.patterns.python
-#             ^ meta.statement.conditional.case.python
-#              ^ - meta.statement
+#             ^^ meta.statement.conditional.case.python
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^^ string.quoted.double.python
 #             ^ punctuation.section.block.conditional.case.python
@@ -977,8 +976,8 @@ def _():
     case \
         418: ; print("I'm a teapot")
 #      ^^^^ meta.statement.conditional.case.patterns.python
-#          ^ meta.statement.conditional.case.python - meta.sequence
-#           ^^^ - meta.statement
+#          ^^ meta.statement.conditional.case.python - meta.sequence
+#            ^^ - meta.statement
 #       ^^^ meta.number.integer.decimal.python constant.numeric.value.python
 #          ^ punctuation.section.block.conditional.case.python
 #            ^ punctuation.terminator.statement.python
@@ -987,8 +986,7 @@ def _():
     case -408+203:
 #   ^^^^ meta.statement.conditional.case.python
 #       ^^^^^^^^^ meta.statement.conditional.case.patterns.python
-#                ^ meta.statement.conditional.case.python - meta.sequence
-#                 ^ - meta.statement
+#                ^^ meta.statement.conditional.case.python - meta.sequence
 #   ^^^^ keyword.control.conditional.case.python
 #        ^ keyword.operator.arithmetic.python
 #         ^^^ constant.numeric.value.python
@@ -1165,8 +1163,7 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #            ^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                             ^ meta.statement.conditional.case.python - meta.function-call
-#                              ^ - meta.statement
+#                             ^^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^ storage.type.class.python
 #            ^ punctuation.section.arguments.begin.python
@@ -1183,8 +1180,7 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #            ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                           ^ meta.statement.conditional.case.python - meta.function-call
-#                            ^ - meta.statement
+#                           ^^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^ storage.type.class.python
 #            ^ punctuation.section.arguments.begin.python
@@ -1199,8 +1195,7 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #                 ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                                ^ meta.statement.conditional.case.python - meta.function-call
-#                                 ^ - meta.statement
+#                                ^^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^^^^^^ meta.qualified-name.python
 #        ^^^^ meta.generic-name.python
@@ -1244,8 +1239,7 @@ def _():
 #                                                                ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                                                                  ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #                                                                   ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.function-call
-#                                                                                 ^ meta.statement.conditional.case.python
-#                                                                                  ^ - meta.statement
+#                                                                                 ^^ meta.statement.conditional.case.python
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^ support.type.python
 #           ^ punctuation.section.arguments.begin.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -949,15 +949,18 @@ def _():
 #         ^^^^^^^^^ meta.qualified-name.python meta.generic-name.python
 #                  ^ punctuation.section.block.conditional.match.python
     case "200":
+#   ^^^^^^^^^^^^ meta.disable-dedentation.python
 #   ^^^^ meta.statement.conditional.case.python
 #       ^^^^^^ meta.statement.conditional.case.patterns.python
-#             ^^ meta.statement.conditional.case.python
+#             ^ meta.statement.conditional.case.python
+#              ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^^ string.quoted.double.python
 #             ^ punctuation.section.block.conditional.case.python
         print("OK")
 
     case ["403",
+#   ^^^^^^^^^^^^ - meta.disable-dedentation
 #   ^^^^ meta.statement.conditional.case.python
 #       ^^^^^^^^^ meta.statement.conditional.case.patterns.python
 #   ^^^^ keyword.control.conditional.case.python
@@ -976,8 +979,8 @@ def _():
     case \
         418: ; print("I'm a teapot")
 #      ^^^^ meta.statement.conditional.case.patterns.python
-#          ^^ meta.statement.conditional.case.python - meta.sequence
-#            ^^ - meta.statement
+#          ^ meta.statement.conditional.case.python - meta.sequence
+#           ^^^ - meta.statement
 #       ^^^ meta.number.integer.decimal.python constant.numeric.value.python
 #          ^ punctuation.section.block.conditional.case.python
 #            ^ punctuation.terminator.statement.python
@@ -986,7 +989,8 @@ def _():
     case -408+203:
 #   ^^^^ meta.statement.conditional.case.python
 #       ^^^^^^^^^ meta.statement.conditional.case.patterns.python
-#                ^^ meta.statement.conditional.case.python - meta.sequence
+#                ^ meta.statement.conditional.case.python - meta.sequence
+#                 ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^ keyword.operator.arithmetic.python
 #         ^^^ constant.numeric.value.python
@@ -1163,7 +1167,8 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #            ^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                             ^^ meta.statement.conditional.case.python - meta.function-call
+#                             ^ meta.statement.conditional.case.python - meta.function-call
+#                              ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^ storage.type.class.python
 #            ^ punctuation.section.arguments.begin.python
@@ -1180,7 +1185,8 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #            ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                           ^^ meta.statement.conditional.case.python - meta.function-call
+#                           ^ meta.statement.conditional.case.python - meta.function-call
+#                            ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^ storage.type.class.python
 #            ^ punctuation.section.arguments.begin.python
@@ -1195,7 +1201,8 @@ def _():
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #        ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
 #                 ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
-#                                ^^ meta.statement.conditional.case.python - meta.function-call
+#                                ^ meta.statement.conditional.case.python - meta.function-call
+#                                 ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^^^^^^^ meta.qualified-name.python
 #        ^^^^ meta.generic-name.python
@@ -1239,7 +1246,8 @@ def _():
 #                                                                ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                                                                  ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #                                                                   ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.function-call
-#                                                                                 ^^ meta.statement.conditional.case.python
+#                                                                                 ^ meta.statement.conditional.case.python
+#                                                                                  ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
 #        ^^^ support.type.python
 #           ^ punctuation.section.arguments.begin.python

--- a/Python/tests/syntax_test_indentation_case.py
+++ b/Python/tests/syntax_test_indentation_case.py
@@ -1,0 +1,17 @@
+# SYNTAX TEST reindent-unchanged "Packages/Python/Python.sublime-syntax"
+
+match var:
+    case 10:
+        case = 1
+    case 20:
+        case = 2
+    case "10":
+        case = 3
+    case 5 if True:
+        case = 4
+    case [1,2,3]:
+        case = 5
+    case (1,2,3,):
+        case = 6
+    case {"key": "value"}:
+        case = 7


### PR DESCRIPTION
Fixes #3456 

This PR...

1. adds an `expect-first-case-statement` context to scope first case
   statement `meta.disable-dedentation.python`.

   > **Note**
   >  An extra pattern is added which doesn't `fail` any branches.

2. adds `Indentation Rules - Case.tmPreferences` to decrease
   indentation level of all but the first case keywords.

   > **Note**
   >  As `case` can also be a variable, dedicated indentation rules
   >  are used to avoid decreasing indentation level in normal
   >  assignment expressions.

   > **Note**
   >  Indentation rules are not applied if a case pattern spans
   >  multiple lines, because `case` is not scoped keyword before final
   >  `:` is inserted. ST applies indentation rules per line only.

3. scopes whitespace after `:` `meta.statement.conditional.case` as it
   is required for ST to reliably apply indentation rules.