### PR TITLE
[Matlab] Improve indentation rules for switch/case statement

### DIFF
--- a/Matlab/Indentation Rules - Unindent.tmPreferences
+++ b/Matlab/Indentation Rules - Unindent.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.matlab - meta.disable-dedentation</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*\b(end\w*|catch|else|elseif|case|otherwise)\b</string>
+	</dict>
+</dict>
+</plist>

--- a/Matlab/Indentation Rules.tmPreferences
+++ b/Matlab/Indentation Rules.tmPreferences
@@ -5,8 +5,6 @@
 	<string>source.matlab</string>
 	<key>settings</key>
 	<dict>
-		<key>decreaseIndentPattern</key>
-		<string>^\s*\b(end\w*|catch|else|elseif|case|otherwise)\b</string>
 		<key>increaseIndentPattern</key>
 		<string>(?x)^\s*
 		\b(

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -438,6 +438,12 @@ contexts:
     - include: variables
     - include: invalid-variables
 
+  expect-expression:
+    - match: (?=\s*[;,])
+      pop: 1
+    - include: eol-pop
+    - include: expressions
+
   eol-pop:
     - match: '{{eol}}'
       pop: 1
@@ -977,7 +983,26 @@ contexts:
   switch-blocks:
     - match: \bswitch\b
       scope: keyword.control.conditional.switch.matlab
-      push: switch-block-content
+      push:
+        - switch-block-content
+        - expect-first-case-statement
+        - expect-expression
+
+  expect-first-case-statement:
+    # Disable dedentation of first case statement by special indentation rule.
+    - match: ^\s*(case)\b
+      captures:
+        1: keyword.control.conditional.case.matlab
+      set:
+        - meta-disable-dedentation
+        - expect-expression
+    - include: comments
+    - include: else-pop
+
+  meta-disable-dedentation:
+    - meta_include_prototype: false
+    - meta_scope: meta.disable-dedentation.matlab
+    - include: immediately-pop
 
   switch-block-content:
     - meta_scope: meta.block.switch.matlab

--- a/Matlab/syntax_test_matlab.matlab
+++ b/Matlab/syntax_test_matlab.matlab
@@ -881,10 +881,12 @@ fprintf(fileID,'%6.2f %12.8f\r\n',A);
    switch plottype
 %  ^^^^^^ meta.block.switch.matlab keyword.control.conditional.switch.matlab
       case 'bar'
+%^^^^^^^^^^^^^^^ meta.disable-dedentation.matlab
 %     ^^^^ meta.block.switch.matlab keyword.control.conditional.case.matlab
          bar(x)
          title('Bar Graph')
       case {'pie', 'pie3'}
+%^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.disable-dedentation.matlab
 %     ^^^^ meta.block.switch.matlab keyword.control.conditional.case.matlab
          pie3(x)
          title('Pie Chart')


### PR DESCRIPTION
Inspired by #3464.

There is still no test case for it in the `syntax_test_indentation.matlab` file, because the closing `end` keyword is expected to be unindented by two levels for the switch/case statement, and afaik this isn't possible to achieve with indentation rules.