### PR TITLE
[HTML] Fix tag name completions

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -477,10 +477,9 @@ class HtmlTagCompletions(sublime_plugin.EventListener):
             return self.entity_completions
 
         if ch == '<':
-            # If the caret is in front of `>` complete only tag names.
+            # If the caret is within tag, complete only tag names.
             # see: https://github.com/sublimehq/sublime_text/issues/3508
-            ch = view.substr(locations[0])
-            if ch == '>':
+            if match_selector("meta.tag"):
                 return self.tag_name_completions
             return self.tag_completions
 


### PR DESCRIPTION
This commit prevents full tag snippets from applying within tags.

Before:

   `<di|style></style>` expands to `<div>|</div>style></style>`

After:

   `<di|style></style>` expands to `<div|style></style>`

Notes:

1) That's possible because `<>` is scoped `meta.tag.incomplete`.
2) The result might not be syntactical correct as well, but it doesn't
   at leas cause a stray `>` to be added. In the example `style` could
   easily be modified or wanted to be turned into an attribute.