### PR TITLE
[Git Formats] Add Git Commit Message

### DIFF
--- a/Git Formats/Git Commit Message.sublime-syntax
+++ b/Git Formats/Git Commit Message.sublime-syntax
@@ -1,0 +1,76 @@
+%YAML 1.2
+---
+# Highlight regular git commits, merge commits, and tags.
+
+name: Git Commit Message
+scope: text.git.commit-message
+version: 2
+
+variables:
+  comment_char: '[#;]'
+
+contexts:
+  main:
+    - include: comments
+    - match: ^\s*(?=\S)
+      set: commit-subject
+
+##[ COMMENTS ]#########################################################
+
+  comments:
+    - match: ^{{comment_char}}
+      scope: punctuation.definition.comment.git.commit
+      push: comment-content
+
+  comment-content:
+    - meta_scope: comment.line.git.commit
+    - match: $\n?
+      pop: 1
+
+  nested-comments:
+    - match: ^{{comment_char}}
+      scope: punctuation.definition.comment.git.commit
+      push: nested-comment-content
+
+  nested-comment-content:
+    - clear_scopes: 1  # remove `meta.message.git.commit`
+    - meta_scope: comment.line.git.commit
+    - include: comment-content
+
+##[ COMMIT MESSAGE ]###################################################
+
+  commit-subject:
+    # first none empty none comment line is commit subject
+    - meta_scope: meta.subject.git.commit markup.heading.subject.git.commit
+    - match: $\n?
+      set: commit-separator
+    - include: Git Common.sublime-syntax#references
+
+  commit-separator:
+    # empty line between subject and message
+    - include: comments
+    - match: \n
+      set: commit-message
+    - match: \S.*
+      scope: invalid.illegal.empty-line-expected.git.commit
+
+  commit-message:
+    - meta_scope: meta.message.git.commit
+    - include: nested-comments
+    - include: change-id
+    - include: signed-off
+    - include: Git Common.sublime-syntax#references
+
+  # for Gerrit Code Review
+  change-id:
+    - match: ^\s*(Change-Id)\s*(:)\s*(.*)
+      captures:
+        1: keyword.other.change-id.git.commit
+        2: punctuation.separator.key-value.git.commit
+        3: constant.language.change-id.git.commit
+
+  signed-off:
+    - match: ^\s*(Signed-off-by)\s*(:)
+      captures:
+        1: keyword.other.signed-off-by.git.commit
+        2: punctuation.separator.key-value.git.commit

--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -6,13 +6,14 @@ name: Git Commit
 scope: text.git.commit
 version: 2
 
+extends: Git Commit Message.sublime-syntax
+
 file_extensions:
   - COMMIT_EDITMSG
   - MERGE_MSG
   - TAG_EDITMSG
 
 variables:
-  comment_char: '[#;]'
   hash: \b\h{7,}\b
   # Rebase operations
   shortcut: '[defprsx]'
@@ -44,70 +45,16 @@ variables:
 
 contexts:
   prototype:
+    - meta_prepend: true
     - include: dropped-content
-    - include: comments
 
-  main:
-    - match: ^\s*(?=\S)
-      set: commit-subject
-
-##[ COMMITS ]##########################################################
-
-  commit-subject:
-    # first none empty none comment line is commit subject
-    - meta_scope: meta.subject.git.commit markup.heading.subject.git.commit
-    - match: $\n?
-      set: commit-separator
-    - include: Git Common.sublime-syntax#references
-
-  commit-separator:
-    # empty line between subject and message
-    - match: \n
-      set: commit-message
-    - match: \S.*
-      scope: invalid.illegal.empty-line-expected.git.commit
-
-  commit-message:
-    # all none comment lines after subject belong to the message
-    - match: ^
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.message.git.commit
-        - match: ^(?=#)
-          pop: 1
-        - include: Git Common.sublime-syntax#references
-        - include: change-id
-        - include: signed-off
-
-  # for Gerrit Code Review
-  change-id:
-    - match: ^\s*(Change-Id)\s*(:)\s*(.*)
-      captures:
-        1: keyword.other.change-id.git.commit
-        2: punctuation.separator.key-value.git.commit
-        3: constant.language.change-id.git.commit
-
-  signed-off:
-    - match: ^\s*(Signed-off-by)\s*(:)
-      captures:
-        1: keyword.other.signed-off-by.git.commit
-        2: punctuation.separator.key-value.git.commit
-
-##[ COMMENTS ]#########################################################
-
-  comments:
-    - match: ^{{comment_char}}
-      scope: punctuation.definition.comment.git.commit
-      push:
-        - meta_include_prototype: false
-        - meta_scope: comment.line.git.commit
-        - match: $\n?
-          pop: 1
-        - include: branch-line
-        - include: change-list
-        - include: commands-line
-        - include: date-line
-        - include: heading
+  comment-content:
+    - meta_append: true
+    - include: branch-line
+    - include: change-list
+    - include: commands-line
+    - include: date-line
+    - include: heading
 
   branch-line:
     - match: \b({{on_branch}})\s+(.*)

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -71,6 +71,7 @@ contexts:
     - include: email
     - include: username
     - include: commit
+    - include: urls
 
   issue:
     # issue reference
@@ -140,6 +141,17 @@ contexts:
       captures:
         1: punctuation.separator.reference.commit.git  # (inside repository_ref)
         2: punctuation.separator.reference.commit.git
+
+  urls:
+    - match: |-
+        (?x)
+        \b(?:
+          https?://(?:(?:[\w\d\-]+(?:\.[\w\d\-.]+)+)|localhost)  # http://
+        | www\.[\w\d\-]+(?:\.[\w\d\-.]+)+                        # www.
+        )
+        /?[\w\d\-.?,!'(){}\[\]/+&@%$#=:"|~;]*                    # url path and query string
+        [\w\d\-~:/#@$*+=]                                        # allowed end chars
+      scope: markup.underline.link.git
 
 ##[ FNMATCH ]##########################################################
 

--- a/Git Formats/Git Log.sublime-syntax
+++ b/Git Formats/Git Log.sublime-syntax
@@ -71,7 +71,7 @@ contexts:
     # using push instead of include as workaround for
     # https://github.com/SublimeTextIssues/Core/issues/2395
     - match: ^
-      push: Git Commit.sublime-syntax
+      push: Git Commit Message.sublime-syntax
 
   extended-patch-headers:
     # https://git-scm.com/docs/git-show#_generating_patch_text_with_p

--- a/Git Formats/tests/syntax_test_git_commit_message
+++ b/Git Formats/tests/syntax_test_git_commit_message
@@ -1,0 +1,133 @@
+# SYNTAX TEST "Git Commit Message.sublime-syntax"
+# <- text.git.commit-message comment.line punctuation.definition.comment
+Add git package # no comment (#403)
+# <- meta.subject.git.commit markup.heading.subject.git.commit - meta.expect-subject
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit markup.heading.subject.git.commit
+#               ^^^^^^^^^^^^^^^^^^^ - comment
+#                             ^ punctuation.definition.reference.issue.git
+#                             ^^^^ meta.reference.issue.git constant.other.reference.issue.git
+-
+# <- invalid.illegal.empty-line-expected.git.commit
+The message can contain # which is no comment start
+# <- meta.message.git.commit - meta.subject - meta.expect-subject
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line
+  @user-name
+# ^ punctuation.definition.reference.username
+# ^^^^^^^^^^ meta.reference.username entity.name.reference.username
+Thanks to @username <name@mail-host.domain>.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#         ^ punctuation.definition.reference.username.git
+#         ^^^^^^^^^ entity.name.reference.username.git
+#                  ^ - string.unquoted.reference.username.git
+#                   ^ punctuation.definition.reference.email.begin.git
+#                    ^^^^^^^^^^^^^^^^^^^^^ entity.name.reference.email.git
+#                        ^ punctuation.separator.email.git
+#                                  ^ punctuation.separator.domain.git
+#                                         ^ punctuation.definition.reference.email.end.git
+This is a <tag> name <tag.name>
+#         ^^^^^ - meta.reference - entity
+#                    ^^^^^^^^^^ - meta.reference - entity
+These are no C#, C#7, C#10 issues.
+#            ^^^^^^^^^^^^^ - constant
+This is a valid u/r#1 issue.
+#               ^^^^^ meta.reference.issue.git constant.other.reference.issue.git
+#                ^ punctuation.separator.reference.issue.git
+#                  ^ punctuation.definition.reference.issue.git
+Issue user/repo#230 is not closed yet.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#     ^^^^^^^^^^^^^ constant.other.reference.issue.git
+#         ^ punctuation.separator.reference.issue.git
+#              ^ punctuation.definition.reference.issue.git
+#                          ^^^^^^ - keyword.other.resolved-issue.git
+Issue repo-with/many-hyphen_and_underscores#1 closed yet.
+# <- meta.message.git.commit
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.reference.issue.git
+#              ^ punctuation.separator.reference.issue.git
+#                                          ^ punctuation.definition.reference.issue.git
+Issue -user-/-repo-#230 starting and ending with hyphons.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#     ^^^^^^^^^^^^^^^^^ constant.other.reference.issue.git
+#           ^ punctuation.separator.reference.issue.git
+#                  ^ punctuation.definition.reference.issue.git
+Issue user#230 is not resolved yet.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#     ^^^^^^^^ constant.other.reference.issue.git
+#         ^ punctuation.definition.reference.issue.git
+#                     ^^^^^^^^ - keyword.other.resolved-issue.git
+Issue #230 is not fixed yet.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#     ^^^^ constant.other.reference.issue.git
+#     ^ punctuation.definition.reference.issue.git
+#                 ^^^^^ - keyword.other.resolved-issue.git
+This commit closes #230 # without comment.
+# <- meta.message.git.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#           ^^^^^^^^^^^ meta.reference.issue.git
+#           ^^^^^^ keyword.other.resolved-issue.git
+#                  ^ punctuation.definition.reference.issue.git
+#                  ^^^^ constant.other.reference.issue.git
+#                       ^^^^^^^^^^^^^^^^^^^ - comment
+fix #203
+# <- meta.message.git.commit meta.reference.issue.git keyword.other.resolved-issue.git
+#^^^^^^^ meta.message.git.commit
+#^^^^^^^ meta.reference.issue.git
+#^^ keyword.other.resolved-issue.git
+#   ^ punctuation.definition.reference.issue.git
+#   ^^^^ constant.other.reference.issue.git
+fixes #203
+# <- meta.message.git.commit meta.reference.issue.git keyword.other.resolved-issue.git
+#^^^^^^^^^ meta.message.git.commit
+#^^^^^^^^^ meta.reference.issue.git
+#^^^^ keyword.other.resolved-issue.git
+#     ^ punctuation.definition.reference.issue.git
+#     ^^^^ constant.other.reference.issue.git
+fixed #203
+# <- meta.message.git.commit meta.reference.issue.git keyword.other.resolved-issue.git
+#^^^^^^^^^ meta.message.git.commit
+#^^^^^^^^^ meta.reference.issue.git
+#^^^^ keyword.other.resolved-issue.git
+#     ^ punctuation.definition.reference.issue.git
+#     ^^^^ constant.other.reference.issue.git
+Fix: #203
+# <- meta.message.git.commit meta.reference.issue.git keyword.other.resolved-issue.git
+#^^^^^^^^ meta.message.git.commit
+#^^^^^^^^ meta.reference.issue.git
+#^^ keyword.other.resolved-issue.git
+#  ^ punctuation.separator.key-value.resolved-issue.git
+#    ^ punctuation.definition.reference.issue.git
+#    ^^^^ constant.other.reference.issue.git
+#
+  Change-Id: I3b3613e336397febf02cd8e5c14c53d493343e93
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+# ^^^^^^^^^ keyword.other.change-id.git.commit
+#          ^ punctuation.separator.key-value.git.commit
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.change-id.git.commit
+  Signed-off-by: username <user.name@domain.com>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                         ^^^^^^^^^^^^^^^^^^^^^^ meta.reference.email.git
+# ^^^^^^^^^^^^^ keyword.other.signed-off-by.git.commit
+#              ^ punctuation.separator.key-value.git.commit
+#                         ^ punctuation.definition.reference.email.begin.git
+#                          ^^^^^^^^^^^^^^^^^^^^ entity.name.reference.email.git
+#                              ^ - punctuation.separator.email.git
+#                                   ^ punctuation.separator.email.git
+#                                          ^ punctuation.separator.domain.git
+#                                              ^ punctuation.definition.reference.email.end.git
+  This commit references a hash: 21dde213
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                                ^^^^^^^^ constant.other.hash.git
+  This commit does not references a hash: user@21dde213
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                                         ^^^^^^^^^^^^^ constant.other.hash.git
+#                                             ^ punctuation.separator.reference.commit.git
+  This commit references a hash on a different repo: test/repo@21dde213
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
+#                                                    ^^^^^^^^^^^^^^^^^^ constant.other.hash.git
+#                                                        ^ punctuation.separator.reference.commit.git
+#                                                             ^ punctuation.separator.reference.commit.git

--- a/Git Formats/tests/syntax_test_git_commit_message
+++ b/Git Formats/tests/syntax_test_git_commit_message
@@ -103,6 +103,9 @@ Fix: #203
 #    ^ punctuation.definition.reference.issue.git
 #    ^^^^ constant.other.reference.issue.git
 #
+  see: https://github.com/sublimehq
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit markup.underline.link.git
+
   Change-Id: I3b3613e336397febf02cd8e5c14c53d493343e93
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit
 # ^^^^^^^^^ keyword.other.change-id.git.commit


### PR DESCRIPTION
This PR adds a separate Git Commit Message syntax which defines commit message subject and body only. 

It is meant for use with Sublime Merge. _Git Log_ makes use of it already.

The goal is consistent highlighting accross sublimehq applications, which has been regressed with SM 2076.