### PR TITLE
[JavaScript] Fix syntax error after img/br/... tags

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -19,6 +19,9 @@ variables:
   jsx_identifier_break: (?!{{jsx_identifier_part}})
   jsx_identifier: '{{identifier_start}}{{jsx_identifier_part}}*{{jsx_identifier_break}}'
 
+  # implicitly self-closing html tags
+  html_tag_name_selfclosing: (?:base|hr|img|link|meta|w?br){{jsx_identifier_break}}
+
 contexts:
   expression-begin:
     - meta_prepend: true
@@ -91,9 +94,13 @@ contexts:
         - jsx-expect-tag-end
         - jsx-tag-name
 
+    - match: '{{html_tag_name_selfclosing}}'
+      scope: entity.name.tag.native.js
+      set: jsx-tag-self-closing
+
     - match: (?=\S)
       set:
-        - jsx-tag-attributes
+        - jsx-tag-maybe-self-closing
         - jsx-tag-name
 
   jsx-meta-unmatched-tag:
@@ -101,16 +108,24 @@ contexts:
     - meta_scope: invalid.illegal.unmatched-tag.js
     - include: immediately-pop
 
-  jsx-tag-attributes:
+  jsx-tag-maybe-self-closing:
     - meta_scope: meta.tag.attributes.js
-
     - match: '>'
       scope: punctuation.definition.tag.end.js
       set: jsx-body
+    - include: jsx-tag-attributes
 
-    - match: '/'
+  jsx-tag-self-closing:
+    - meta_scope: meta.tag.attributes.js
+    - match: '>'
       scope: punctuation.definition.tag.end.js
-      set: jsx-expect-tag-end
+      pop: 1
+    - include: jsx-tag-attributes
+
+  jsx-tag-attributes:
+    - match: '/>'
+      scope: punctuation.definition.tag.end.js
+      pop: 1
 
     - include: jsx-interpolation
 
@@ -199,10 +214,16 @@ contexts:
             - jsx-expect-tag-end
             - jsx-tag-name
 
+        - match: '{{html_tag_name_selfclosing}}'
+          scope: entity.name.tag.native.js
+          set:
+            - jsx-body
+            - jsx-tag-self-closing
+
         - match: (?=\S)
           set:
             - jsx-body
-            - jsx-tag-attributes
+            - jsx-tag-maybe-self-closing
             - jsx-tag-name
 
     - include: jsx-html-escapes

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -47,9 +47,15 @@ contexts:
         - jsx-expect-tag-end
         - jsx-tag-name
 
+    - match: '{{html_tag_name_selfclosing}}'
+      scope: entity.name.tag.native.js
+      set:
+        - jsx-tag-self-closing
+        - tsx-tag-check
+
     - match: (?=\S)
       set:
-        - jsx-tag-attributes
+        - jsx-tag-maybe-self-closing
         - tsx-tag-check
         - jsx-tag-name
 

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -280,3 +280,13 @@
 
     <Class />;
 //   ^^^^^ entity.name.tag - entity.name.tag.native
+
+
+// https://github.com/sublimehq/Packages/issues/3473
+data.slice(data.length - 1).map((review) => (
+  <div class="review grid-sm">
+    <img src={review.avatar} alt={review.name} class="review-avatar">
+  </div>
+))
+// <- meta.group.js punctuation.section.group.end.js - meta.jsx
+ // <- meta.group.js punctuation.section.group.end.js - meta.jsx

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -275,3 +275,12 @@ if (a < b || c <= d) {}
 //                                                    ^^^^ meta.tag
 //                                                      ^ meta.tag.name entity.name.tag
 //                                                        ^ punctuation.terminator.statement
+
+// https://github.com/sublimehq/Packages/issues/3473
+data.slice(data.length - 1).map((review) => (
+  <div class="review grid-sm">
+    <img src={review.avatar} alt={review.name} class="review-avatar">
+  </div>
+))
+// <- meta.group.js punctuation.section.group.end.js - meta.jsx
+ // <- meta.group.js punctuation.section.group.end.js - meta.jsx


### PR DESCRIPTION
Fixes #3473 

This commit fixes syntax highlighting after implicitly self-closing html tags such as `<img ...>` by adding special treatment for well known tags.

> Note: Any more generic approach would be appriciated.

I guess the current solution would fail if someone wants to add `<script src="foo.js">` into its JSX code.