### PR TITLE
[C++] Detect forwarding headers without extension with nothing but a single #include

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -24,6 +24,7 @@ file_extensions:
 first_line_match: |-
   (?xi:
     ^ \s* // .*? -\*- .*? \b(c\+\+|cpp\b) .*? -\*-  # editorconfig
+  | ^ \s* \# \s* include \s* [<"]
   )
 
 variables:


### PR DESCRIPTION
Tried in safe mode, works for me.

Can be checked with files like `/usr/include/qt/QtCore/QSet`:

```c++
#include "qset.h"
```

This patch is important to keep LSP GoTo flow non-disruptive. Sending to C++ syntax, because plain C usually doesn't use forwarding headers like this.