### PR TITLE
[HTML] Support all valid json mime-types

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,8 +43,13 @@ variables:
       | text/livescript
     )
 
+  # A JSON MIME type
+  # is any MIME type whose subtype ends in "+json"
+  # or whose essence is "application/json" or "text/json".
+  # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
-  json_mime_type: (?i:application/|text/|.+\+)json
+  json_mime_type: |-
+    (?xi: (?:[[:ascii:]]+/)?[[:ascii:]]+\+json | (?:application|text)/json )
 
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -48,8 +48,7 @@ variables:
   # or whose essence is "application/json" or "text/json".
   # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
-  json_mime_type: |-
-    (?xi: (?:[[:ascii:]]+/)?[[:ascii:]]+\+json | (?:application|text)/json )
+  json_mime_type: (?i:application/|text/|[[:ascii:]]+\+)json
 
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -152,7 +152,7 @@
             ]]>
         </script>
 
-        <script type="whatever-json">
+        <script type="application/f̱oo+json">
             { "@id": {"key": "value" } }
         ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
         </script>

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -135,6 +135,11 @@
         ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
         </script>
 
+        <script type="application/ld+json">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        </script>
+
         <script type="whatever+json">
             <![CDATA[
                 {
@@ -145,6 +150,11 @@
                 }
         ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
             ]]>
+        </script>
+
+        <script type="whatever-json">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
         </script>
 
         <script type = "text/html"> <!--


### PR DESCRIPTION
Fixes #3477

whatwg says:

1. A JSON MIME type is any MIME type whose subtype ends in "+json"
   or whose essence is "application/json" or "text/json".

2. The essence of a MIME type mimeType is mimeType’s type,
   followed by U+002F (/), followed by mimeType’s subtype.

   A MIME type’s type is a non-empty ASCII string.
   A MIME type’s subtype is a non-empty ASCII string. 

see: https://mimesniff.spec.whatwg.org/#understanding-mime-types