### PR TITLE
[HTML] Add support for mime type parameters

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -43,8 +43,12 @@ variables:
       | text/livescript
     )
 
+  # A JSON MIME type
+  # is any MIME type whose subtype ends in "+json"
+  # or whose essence is "application/json" or "text/json".
+  # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
-  json_mime_type: (?i:application/|text/|.+\+)json
+  json_mime_type: (?i:application/|text/|[[:ascii:]]+\+)json
 
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -34,13 +34,19 @@ variables:
       button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
     ){{tag_name_break}}
 
+  html_mime_type: |-
+    (?xi: text/html {{mime_type_parameters}}? )
+
   javascript_mime_type: |-
-    (?ix:
+    (?xi:
+      (?:
       # https://mimesniff.spec.whatwg.org/#javascript-mime-type
-      (?:application|text)/(?:x-)?(?:java|ecma)script
+        (?:application|text)/(?:x-)?(?:java|ecma)script
       | text/javascript1\.[0-5]
       | text/jscript
       | text/livescript
+      )
+      {{mime_type_parameters}}?
     )
 
   # A JSON MIME type
@@ -48,7 +54,12 @@ variables:
   # or whose essence is "application/json" or "text/json".
   # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
-  json_mime_type: (?i:application/|text/|[[:ascii:]]+\+)json
+  json_mime_type: |-
+     (?xi: (?i:application/|text/|[[:ascii:]]+\+)json {{mime_type_parameters}}? )
+
+  # A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings
+  # limited to HTTP quoted-string token code points. It is initially empty.
+  mime_type_parameters: (?:;.*?)
 
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining
@@ -346,7 +357,7 @@ contexts:
         - script-json
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?=(?i:text/html{{unquoted_attribute_break}}|'text/html'|"text/html"))
+    - match: (?=(?i:{{html_mime_type}}{{unquoted_attribute_break}}|'{{html_mime_type}}'|"{{html_mime_type}}"))
       set:
         - script-html
         - tag-generic-attribute-meta

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -140,6 +140,16 @@
         ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
         </script>
 
+        <script type="application/f̱oo+json">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
+        </script>
+
+        <script type="application/ld+json;charset=utf-8">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        </script>
+
         <script type="whatever+json">
             <![CDATA[
                 {
@@ -150,11 +160,6 @@
                 }
         ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
             ]]>
-        </script>
-
-        <script type="application/f̱oo+json">
-            { "@id": {"key": "value" } }
-        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
         </script>
 
         <script type = "text/html"> <!--
@@ -183,6 +188,11 @@
 ##     ^ text.html.basic - meta.tag
 ##      ^^^^^^^^^ text.html.basic meta.tag.script.end
 ##               ^ text.html.basic - meta.tag
+
+        <script type = "text/html;charset=utf-8,foo=bar">
+            <div></div>
+        ##  ^^^^^^^^^^^ text.html.basic meta.tag.block.any
+        </script>
 
         <script>
             <!-- i = 0;

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -135,6 +135,11 @@
         ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
         </script>
 
+        <script type="application/ld+json">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        </script>
+
         <script type="whatever+json">
             <![CDATA[
                 {
@@ -145,6 +150,11 @@
                 }
         ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
             ]]>
+        </script>
+
+        <script type="application/f̱oo+json">
+            { "@id": {"key": "value" } }
+        ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
         </script>
 
         <script type = "text/html"> <!--


### PR DESCRIPTION
This commit...

1. restricts MIME type chars to ascii (from #3478)
2. adds support for MIME type parameters
   _Found in the specs while looking into #3477._

   It is to ensure to apply nested syntax also, if mime type parameters are present.

   MIME type parameters are ordered maps started with `;` separated by `,`

   e.g.: `application/json;charset=utf-8`