### PR TITLE
[Java] Add support for Java 19

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -152,12 +152,15 @@ contexts:
     - include: labeled-statements
 
   expressions:
+    - include: instantiations
+    - include: lambdas
+    - include: constant-expressions
+
+  constant-expressions:
     - include: groups
     - include: literals
     - include: punctuations
-    - include: lambdas
     - include: operators
-    - include: instantiations
     - include: primitive-types
     - include: var-types
     - include: array-modifiers
@@ -1376,7 +1379,7 @@ contexts:
     - clear_scopes: 1
     - meta_content_scope: meta.statement.conditional.case.label.java
     - include: case-label-end
-    - include: expression
+    - include: constant-expressions
 
   case-label-end:
     - match: ','

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -1296,10 +1296,7 @@ contexts:
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-14.html#jls-14.11
     - match: case{{break}}
       scope: keyword.control.conditional.case.java
-      branch_point: case-label
-      branch:
-        - case-label-constant
-        - case-label-expression
+      push: case-label
     - match: default{{break}}
       scope: keyword.control.conditional.default.java
       push: case-default-end
@@ -1322,9 +1319,19 @@ contexts:
       pop: 1
     - include: else-pop
 
-  case-label-constant:
+  case-label:
+    - meta_include_prototype: false
     - meta_scope: meta.statement.conditional.case.java
     - match: (?=\S)
+      branch_point: case-label
+      branch:
+        - case-label-constant
+        - case-label-pattern
+        - case-label-expression
+
+  case-label-constant:
+    - meta_include_prototype: false
+    - match: ''
       set:
         - case-label-constant-end
         - case-label-constant-identifier
@@ -1336,26 +1343,50 @@ contexts:
     - include: case-label-fail
 
   case-label-constant-end:
+    - clear_scopes: 1
     - meta_content_scope: meta.statement.conditional.case.label.java
     - include: case-label-end
-    - match: (?=[;{}]|(?:{{keywords}}|{{storage_types}}|{{storage_modifiers}}){{break}})
+    - include: case-label-fail
+
+  case-label-pattern:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - case-label-pattern-end
+        - case-label-pattern-identifier
+        - type-pattern-type
+
+  case-label-pattern-identifier:
+    # prevent `when` from being scoped variable or constant
+    - match: (?=when{{break}})
       pop: 1
+    - include: variable-declaration-maybe-identifier
+
+  case-label-pattern-end:
+    - clear_scopes: 1
+    - meta_content_scope: meta.statement.conditional.case.label.java
+    - match: when{{break}}
+      scope: meta.statement.conditional.case.label.java keyword.control.conditional.when.java
+      pop: 1
+      push: case-label-expression
+    - include: case-label-end
     - include: case-label-fail
 
   case-label-expression:
-    - meta_scope: meta.statement.conditional.case.java
-    - match: (?=\S)
-      set: case-label-expression-body
-
-  case-label-expression-body:
+    - clear_scopes: 1
     - meta_content_scope: meta.statement.conditional.case.label.java
     - include: case-label-end
     - include: expression
 
   case-label-end:
+    - match: ','
+      scope: meta.statement.conditional.case.java punctuation.separator.comma.java
+      pop: 1
     - match: ':|->'
       scope: meta.statement.conditional.case.java punctuation.separator.expressions.java
-      pop: 1
+      pop: 2
+    - match: (?=[;{}]|(?:{{keywords}}|{{storage_modifiers}}){{break}})
+      pop: 2
 
   case-label-fail:
     - match: (?=\S)

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -2060,6 +2060,56 @@ contexts:
       scope: invalid.illegal.identifier.java
       set: maybe-only-array-modifiers
 
+###[ TYPE PATTERNS ]###########################################################
+
+  type-pattern:
+    # https://openjdk.org/jeps/405
+    - match: \(
+      scope: punctuation.section.group.begin.java
+      set:
+        - type-pattern-group-end
+        - type-pattern
+    - match: (?=\S)
+      set:
+        - variable-declaration-maybe-identifier
+        - type-pattern-type
+
+  type-pattern-group-end:
+    - meta_scope: meta.group.java
+    - match: \)
+      scope: punctuation.section.group.end.java
+      pop: 1
+    - include: else-pop
+
+  type-pattern-type:
+    - include: primitive-maybe-array-type
+    - include: var-type
+    - match: (?={{identifier}})
+      set:
+        - record-structure-pattern
+        - maybe-only-array-modifiers
+        - object-type
+    - include: annotations
+    - include: maybe-type-argument
+
+  record-structure-pattern:
+    - match: \(
+      scope: punctuation.section.group.begin.java
+      set:
+        - record-structure-pattern-body
+        - type-pattern
+    - include: else-pop
+
+  record-structure-pattern-body:
+    - meta_scope: meta.group.java
+    - match: \)
+      scope: punctuation.section.group.end.java
+      pop: 1
+    - match: ','
+      scope: punctuation.separator.comma.java
+      push: type-pattern
+    - include: expression-terminator
+
 ###[ VARIABLES ]###############################################################
 
   variables:
@@ -2398,8 +2448,12 @@ contexts:
     - match: instanceof{{break}}
       scope: keyword.other.storage.instanceof.java
       push:
-        - maybe-only-array-modifiers
-        - cast-expression-type
+        - instanceof-meta
+        - type-pattern
+
+  instanceof-meta:
+    - meta_scope: meta.instanceof.java
+    - include: immediately-pop
 
   operator-ternary-colon:
     - match: ':'
@@ -3126,12 +3180,17 @@ contexts:
   primitive-types:
     - match: '{{storage_types}}{{break}}'
       scope: storage.type.primitive.java
-      push: maybe-array-modifiers
+      push: maybe-only-array-modifiers
 
   primitive-type:
     - match: '{{storage_types}}{{break}}'
       scope: storage.type.primitive.java
       pop: 1
+
+  primitive-maybe-array-type:
+    - match: '{{storage_types}}{{break}}'
+      scope: storage.type.primitive.java
+      set: maybe-only-array-modifiers
 
   var-types:
     - match: var{{break}}

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -161,6 +161,7 @@ contexts:
     - include: literals
     - include: punctuations
     - include: operators
+    - include: type-comparisons
     - include: primitive-types
     - include: var-types
     - include: array-modifiers
@@ -2096,6 +2097,19 @@ contexts:
 
 ###[ TYPE PATTERNS ]###########################################################
 
+  type-comparisons:
+    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-15.html#jls-15.20.2
+    - match: instanceof{{break}}
+      scope: keyword.other.storage.instanceof.java
+      push:
+        - type-comparison-meta
+        - type-pattern
+
+  type-comparison-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.instanceof.java
+    - include: immediately-pop
+
   type-pattern:
     # https://openjdk.org/jeps/405
     - match: \(
@@ -2478,16 +2492,6 @@ contexts:
     - match: '\?'
       scope: keyword.operator.ternary.java
       push: ternary-expression
-    # https://docs.oracle.com/javase/specs/jls/se13/html/jls-15.html#jls-15.20.2
-    - match: instanceof{{break}}
-      scope: keyword.other.storage.instanceof.java
-      push:
-        - instanceof-meta
-        - type-pattern
-
-  instanceof-meta:
-    - meta_scope: meta.instanceof.java
-    - include: immediately-pop
 
   operator-ternary-colon:
     - match: ':'

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -5553,7 +5553,8 @@ class SwitchStatementTests {
 //    ^^^^ keyword.control.conditional.case.java
 
       case :
-//   ^^^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
+//   ^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.label.java
+//    ^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
 //          ^ meta.statement.conditional.switch.java meta.block.java - meta.statement.conditional.case
 //    ^^^^ keyword.control.conditional.case.java
 //         ^ punctuation.separator.expressions.java
@@ -5703,6 +5704,20 @@ class SwitchStatementTests {
 //         ^^^^^^^^ constant.other.java
 //                 ^ punctuation.separator.expressions.java
 
+      case CONSTANT, constant:
+//   ^ meta.statement.conditional.switch.java meta.block.java - meta.statement.conditional.case
+//    ^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
+//         ^^^^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.label.java - meta.path
+//                 ^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
+//                   ^^^^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.label.java - meta.path
+//                           ^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
+//                            ^ meta.statement.conditional.switch.java meta.block.java - meta.statement.conditional.case
+//    ^^^^ keyword.control.conditional.case.java
+//         ^^^^^^^^ constant.other.java
+//                 ^ punctuation.separator.comma.java
+//                   ^^^^^^^^ constant.other.java
+//                           ^ punctuation.separator.expressions.java
+
       case constant
 //   ^ meta.statement.conditional.switch.java meta.block.java - meta.statement.conditional.case
 //    ^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.conditional.case.java
@@ -5828,8 +5843,8 @@ class SwitchStatementTests {
 //                                                                ^ punctuation.separator.expressions.java
 
       case /**/ @anno /**/ mod /**/ . /**/ @anno /**/ sub /**/ . /**/ @anno /**/ MyClass /**/ . /**/ @anno /**/ EnumConst:
-//    ^^^^^^^^^^ meta.statement.conditional.case.java - meta.path
-//              ^^^^^^^^^^^  meta.statement.conditional.case.label.java - meta.path
+//    ^^^^^ meta.statement.conditional.case.java - meta.path
+//         ^^^^^^^^^^^^^^^^  meta.statement.conditional.case.label.java - meta.path
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.statement.conditional.case.label.java meta.path.java
 //                                                                                                                       ^ meta.statement.conditional.case.java - meta.path
 //    ^^^^ keyword.control.conditional.case.java
@@ -5961,7 +5976,11 @@ class SwitchExpressionsTests {
           case MONDAY, FRIDAY, SUNDAY -> 6;
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
 //        ^^^^^ meta.statement.conditional.case.java
-//             ^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//             ^^^^^^ meta.statement.conditional.case.label.java
+//                   ^^ meta.statement.conditional.case.java
+//                     ^^^^^^ meta.statement.conditional.case.label.java
+//                           ^^ meta.statement.conditional.case.java
+//                             ^^^^^^ meta.statement.conditional.case.label.java
 //                                    ^^ meta.statement.conditional.case.java
 //                                      ^^^^ - meta.statement.conditional.case
 //        ^^^^ keyword.control.conditional.case.java
@@ -6049,7 +6068,204 @@ class SwitchExpressionsTests {
 //     ^ punctuation.terminator.java - meta.statement.conditional.switch
    }
 // ^ punctuation.section.block.end.java
+
+   String testPatternCaseLabels(Object o) {
+     return switch (o) {
+       case Integer i -> String.format("int %d", i);
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                    ^^ meta.statement.conditional.case.java
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^ storage.type.class.java
+//                  ^ variable.other.java
+//                    ^^ punctuation.separator.expressions.java
+//                       ^^^^^^ storage.type.class.java
+//                             ^ punctuation.accessor.dot.java
+//                              ^^^^^^ variable.function.java
+
+       case Long l    -> String.format("long %d", l);
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                    ^^ meta.statement.conditional.case.java
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^ storage.type.class.java
+//               ^ variable.other.java
+//                    ^^ punctuation.separator.expressions.java
+//                       ^^^^^^ storage.type.class.java
+//                             ^ punctuation.accessor.dot.java
+//                              ^^^^^^ variable.function.java
+
+       case null, String s -> "String, including null";
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^ meta.statement.conditional.case.label.java
+//              ^^ meta.statement.conditional.case.java
+//                ^^^^^^^^^ meta.statement.conditional.case.label.java
+//                         ^^ meta.statement.conditional.case.java
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
+//          ^^^^ constant.language.null.java
+//              ^ punctuation.separator.comma.java
+//                ^^^^^^ storage.type.class.java
+//                       ^ variable.other.java
+//                         ^^ punctuation.separator.expressions.java
+//                            ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.java
+//                                                    ^ punctuation.terminator.java
+
+       default        -> o.toString();
+//     ^^^^^^^^^^^^^^^^^ meta.statement.conditional.default.java
+//                      ^^^^^^^^^^^^^^^ - meta.statement.conditional.default
+//     ^^^^^^^ keyword.control.conditional.default.java
+//                    ^^ punctuation.separator.expressions.java
+//                       ^ variable.other.java
+//                        ^ punctuation.accessor.dot.java
+//                         ^^^^^^^^ variable.function.java
+     };
+//   ^ punctuation.section.block.end.java
+//    ^ punctuation.terminator.java
+   }
+// ^ punctuation.section.block.end.java
+
+  void testPatternCaseLabelsWithGuards(Object o) {
+    return switch (o) {
+       case DayType when -> "incomplete";
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                       ^^ meta.statement.conditional.case.java
+//                         ^^^^^^^^^^^^^^^ - meta.statement.conditional.case
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^ storage.type.class.java
+//                  ^^^^ keyword.control.conditional.when.java
+//                       ^^  punctuation.separator.expressions.java
+//                          ^^^^^^^^^^^^ string.quoted.double.java
+//                                      ^ punctuation.terminator.java
+
+       case DayType t when t.isType() == WEEKDAY -> "complete";
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                                               ^^ meta.statement.conditional.case.java
+//                                                 ^^^^^^^^^^^^ - meta.statement.conditional.case
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^ storage.type.class.java
+//                  ^ variable.other.java
+//                    ^^^^ keyword.control.conditional.when.java
+//                         ^ meta.variable.identifier.java variable.other.java
+//                          ^ punctuation.accessor.dot.java
+//                           ^^^^^^ variable.function.java
+//                                    ^^ keyword.operator.comparison.java
+//                                       ^^^^^^^ constant.other.java
+//                                               ^^  punctuation.separator.expressions.java
+//                                                  ^^^^^^^^^^ string.quoted.double.java
+//                                                            ^ punctuation.terminator.java
+
+       case DayType t
+//    ^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^ meta.statement.conditional.case.label.java
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^ storage.type.class.java
+//                  ^ variable.other.java
+          when t.isType() > WEEKEND ->
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                                  ^^ meta.statement.conditional.case.java
+//                                    ^ - meta.statement.conditional.case
+//        ^^^^ keyword.control.conditional.when.java
+//             ^ variable.other.java
+//              ^ punctuation.accessor.dot.java
+//               ^^^^^^ variable.function.java
+//                        ^ keyword.operator.comparison.java
+//                          ^^^^^^^ constant.other.java
+//                                  ^^ punctuation.separator.expressions.java
+             System.out.println("weekend");
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//           ^^^^^^ storage.type.class.java
+//                 ^ punctuation.accessor.dot.java
+//                  ^^^ meta.variable.identifier.java variable.other.java
+//                     ^ punctuation.accessor.dot.java
+//                      ^^^^^^^ meta.function-call.identifier.java variable.function.java
+//                             ^^^^^^^^^^^ meta.function-call.arguments.java meta.group.java
+//                                        ^ punctuation.terminator.java
+
+       case DayType t when t == HOLIDAY, Date d when d == Date.MONDAY -> "ok";
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                                                                    ^^ meta.statement.conditional.case.java
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^ storage.type.class.java
+//                  ^ variable.other.java
+//                    ^^^^ keyword.control.conditional.when.java
+//                         ^ variable.other.java
+//                           ^^ keyword.operator.comparison.java
+//                              ^^^^^^^ constant.other.java
+//                                     ^ punctuation.separator.comma.java
+//                                       ^^^^ storage.type.class.java
+//                                            ^ variable.other.java
+//                                              ^^^^ keyword.control.conditional.when.java
+//                                                   ^ variable.other.java
+//                                                     ^^ keyword.operator.comparison.java
+//                                                        ^^^^ storage.type.class.java
+//                                                            ^ punctuation.accessor.dot.java
+//                                                             ^^^^^^ constant.other.java
+//                                                                    ^^ punctuation.separator.expressions.java
+//                                                                       ^^^^ meta.string.java string.quoted.double.java
+
+       case DateTime(Date(int y, int m, int d), Time(int h, int m, int s)) when y == 2000 -> y + m + d;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
+//     ^^^^^ meta.statement.conditional.case.java
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
+//                                                                                        ^^ meta.statement.conditional.case.java
+//                                                                                          ^ - meta.statement.conditional.case
+//     ^^^^ keyword.control.conditional.case.java
+//          ^^^^^^^^ storage.type.class.java
+//                  ^ punctuation.section.group.begin.java
+//                   ^^^^ storage.type.class.java
+//                       ^ punctuation.section.group.begin.java
+//                        ^^^ storage.type.primitive.java
+//                            ^ variable.other.java
+//                             ^ punctuation.separator.comma.java
+//                               ^^^ storage.type.primitive.java
+//                                   ^ variable.other.java
+//                                    ^ punctuation.separator.comma.java
+//                                      ^^^ storage.type.primitive.java
+//                                          ^ variable.other.java
+//                                           ^ punctuation.section.group.end.java
+//                                            ^ punctuation.separator.comma.java
+//                                              ^^^^ storage.type.class.java
+//                                                  ^ punctuation.section.group.begin.java
+//                                                   ^^^ storage.type.primitive.java
+//                                                       ^ variable.other.java
+//                                                        ^ punctuation.separator.comma.java
+//                                                          ^^^ storage.type.primitive.java
+//                                                              ^ variable.other.java
+//                                                               ^ punctuation.separator.comma.java
+//                                                                 ^^^ storage.type.primitive.java
+//                                                                     ^ variable.other.java
+//                                                                      ^^ punctuation.section.group.end.java
+//                                                                         ^^^^ keyword.control.conditional.when.java
+//                                                                              ^ meta.variable.identifier.java variable.other.java
+//                                                                                ^^ keyword.operator.comparison.java
+//                                                                                   ^^^^ meta.number.integer.decimal.java constant.numeric.value.java
+//                                                                                        ^^ punctuation.separator.expressions.java
+//                                                                                           ^ meta.variable.identifier.java variable.other.java
+//                                                                                             ^ keyword.operator.arithmetic.java
+//                                                                                               ^ meta.variable.identifier.java variable.other.java
+//                                                                                                 ^ keyword.operator.arithmetic.java
+//                                                                                                   ^ meta.variable.identifier.java variable.other.java
+//                                                                                                    ^ punctuation.terminator.java
+    };
+// ^^ meta.statement.conditional.switch.java meta.block.java
+//   ^ - meta.statement.conditional.switch
+//  ^ punctuation.section.block.end.java
+//   ^ punctuation.terminator.java
+  }
+//^ punctuation.section.block.end.java
 }
+// <- meta.class.java meta.block.java punctuation.section.block.end.java
 
 
 /******************************************************************************

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -8880,26 +8880,52 @@ class CastExpressionsTests {
 
 class TypeComparisonExpressionsTests {
 
- void instanceofPrimitiveTests {
+  void instanceofPrimitiveTests {
 
     instanceof
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 
     instanceof boolean
+//  ^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //             ^^^^^^^ storage.type.primitive.java
 
     instanceof boolean[]
+//  ^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //             ^^^^^^^ storage.type.primitive.java
 //                    ^^ storage.modifier.array.java
 
     instanceof boolean@anno[]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //             ^^^^^^^ storage.type.primitive.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
 //                         ^^ storage.modifier.array.java
+
+    instanceof ( boolean@anno[] )
+//  ^^^^^^^^^^^ meta.instanceof.java - meta.group
+//             ^^^^^^^^^^^^^^^^^^ meta.instanceof.java meta.group.java
+//                               ^ - meta.instanceof
+//  ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//               ^^^^^^^ storage.type.primitive.java
+//                      ^ punctuation.definition.annotation.java
+//                       ^^^^ variable.annotation.java
+//                           ^^ storage.modifier.array.java
+//                              ^ punctuation.section.group.end.java
+
+    instanceof ( boolean@anno[] foo )
+//  ^^^^^^^^^^^ meta.instanceof.java - meta.group
+//             ^^^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java meta.group.java
+//                                   ^ - meta.instanceof
+//  ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//               ^^^^^^^ storage.type.primitive.java
+//                      ^ punctuation.definition.annotation.java
+//                       ^^^^ variable.annotation.java
+//                           ^^ storage.modifier.array.java
+//                              ^^^ variable.other.java
+//                                  ^ punctuation.section.group.end.java
 
     instanceof char
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
@@ -8942,21 +8968,25 @@ class TypeComparisonExpressionsTests {
 //   ^^^^ variable.annotation.java
     []
 //  ^^ storage.modifier.array.java
-}
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 
- void instanceofClassTests {
+  void instanceofClassTests {
 
     a instanceof b
+//    ^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //               ^ storage.type.class.java
 
     a instanceof b.c
+//    ^^^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //               ^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
 //                 ^ storage.type.class.java
 
     a instanceof b.c.d
+//    ^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //               ^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
@@ -8964,23 +8994,53 @@ class TypeComparisonExpressionsTests {
 //                  ^ punctuation.accessor.dot.java
 //                   ^ storage.type.class.java
 
+    a instanceof b.c.d e f
+//    ^^^^^^^^^^^^^^^^^^ meta.instanceof.java
+//                      ^^^ - meta.instanceof
+//    ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//               ^ variable.namespace.java
+//                ^ punctuation.accessor.dot.java
+//                 ^ variable.namespace.java
+//                  ^ punctuation.accessor.dot.java
+//                   ^ storage.type.class.java
+//                     ^ variable.other.java
+//                       ^ variable.other.java
+
     a instanceof Object
+//    ^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //               ^^^^^^ storage.type.class.java
-}
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 
- void instanceofGenericsTests {
+  void instanceofGenericsTests {
 
     instanceof <T>
+//  ^^^^^^^^^^^ meta.instanceof.java - meta.generic
+//             ^^^ meta.instanceof.java meta.generic.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 
     instanceof X<?>.Y<?>
+//  ^^^^^^^^^^^ meta.instanceof.java - meta.path
+//             ^^^^^^^^^ meta.instanceof.java meta.path.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
- }
+//             ^ storage.type.class.java
+//              ^ punctuation.definition.generic.begin.java
+//               ^ variable.language.wildcard.java
+//                ^ punctuation.definition.generic.end.java
+//                 ^ punctuation.accessor.dot.java
+//                  ^ storage.type.class.java
+//                   ^ punctuation.definition.generic.begin.java
+//                    ^ variable.language.wildcard.java
+//                     ^ punctuation.definition.generic.end.java
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 
- void instanceofAmbigultyTests {
+  void instanceofAmbigultyTests {
 
     a = b instanceof c?1__1:0b11110101;
+//        ^^^^^^^^^^^^ meta.instanceof.java
+//                    ^^^^^^^^^^^^^^^^^^ - meta.instanceof
 //  ^ variable.other.java
 //    ^ keyword.operator.assignment.java
 //      ^ variable.other.java
@@ -8992,24 +9052,163 @@ class TypeComparisonExpressionsTests {
 //                          ^^ constant.numeric.base.java
 //                            ^^^^^^^^ constant.numeric.value.java
 //                                    ^ punctuation.terminator.java
- }
- // <- meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 
   void instanceofPatternsTests () {
 
-      obj instanceof String s && s.length() > 5
-//    ^^^ variable.other.java
-//        ^^^^^^^^^^ keyword.other.storage.instanceof.java
+    obj instanceof String s && s.length() > 5
+//      ^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
+//                         ^^^^^^^^^^^^^^^^^^^ - meta.instanceof
+//  ^^^ variable.other.java
+//      ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                 ^^^^^^ storage.type.class.java
+//                        ^ variable.other.java
+//                          ^^ keyword.operator.logical.java
+//                             ^ variable.other.java
+//                              ^ punctuation.accessor.dot.java
+//                               ^^^^^^ variable.function.java
+//                                     ^^ meta.group.java
+//                                        ^ keyword.operator.comparison.java
+//                                          ^ constant.numeric.value.java
+
+    obj instanceof ( String[] s ) s == 5
+//      ^^^^^^^^^^^ meta.instanceof.java - meta.group
+//                 ^^^^^^^^^^^^^^ meta.instanceof.java meta.group.java
+//                               ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.instanceof
+//  ^^^ variable.other.java
+//      ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                 ^ punctuation.section.group.begin.java
 //                   ^^^^^^ storage.type.class.java
-//                          ^ variable.other.java
-//                            ^^ keyword.operator.logical.java
-//                               ^ variable.other.java
-//                                ^ punctuation.accessor.dot.java
-//                                 ^^^^^^ variable.function.java
-//                                       ^^ meta.group.java
-//                                          ^ keyword.operator.comparison.java
-//                                            ^ constant.numeric.value.java
+//                         ^^ storage.modifier.array.java
+//                            ^ variable.other.java
+//                              ^ punctuation.section.group.end.java
+//                                ^ variable.other.java
+//                                  ^^ keyword.operator.comparison.java
+//                                     ^ constant.numeric.value.java
   }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
+
+  static void instanceofStructuredRecordTests(Rectangle r) {
+    if (r instanceof Rectangle(ColoredPoint(Point p, Color c),
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
+//      ^ variable.other.java
+//        ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                   ^^^^^^^^^ storage.type.class.java
+//                            ^ punctuation.section.group.begin.java
+//                             ^^^^^^^^^^^^ storage.type.class.java
+//                                         ^ punctuation.section.group.begin.java
+//                                          ^^^^^ storage.type.class.java
+//                                                ^ variable.other.java
+//                                                 ^ punctuation.separator.comma.java
+//                                                   ^^^^^ storage.type.class.java
+//                                                         ^ variable.other.java
+//                                                          ^ punctuation.section.group.end.java
+//                                                           ^ punctuation.separator.comma.java
+                               coloredpoint lr)) {
+//                            ^^^^^^^^^^^^^^^^^ meta.instanceof.java
+//                                             ^ - meta.instanceof
+//                             ^^^^^^^^^^^^ storage.type.class.java
+//                                          ^^ variable.other.java
+//                                            ^^ punctuation.section.group.end.java
+//                                               ^ punctuation.section.block.begin.java
+      System.out.println(c);
+//               ^^^^^^^ variable.function.java
+    }
+//  ^ punctuation.section.block.end.java
+
+    obj instanceof (Record(boolean a, (var b), Foo(int c) d) e) f && s.length() > 5
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
+//                                                             ^^^^^^^^^^^^^^^^^^^^^ - meta.instanceof
+//                 ^^^^^^^ meta.group.java - meta.group meta.group
+//                        ^^^^^^^^^^^^ meta.group.java meta.group.java - meta.group meta.group meta.group
+//                                    ^^^^^^^ meta.group.java meta.group.java meta.group.java
+//                                           ^^^^^ meta.group.java meta.group.java - meta.group meta.group meta.group
+//                                                ^^^^^^^ meta.group.java meta.group.java meta.group.java
+//                                                       ^^^ meta.group.java meta.group.java - meta.group meta.group meta.group
+//                                                          ^^^ meta.group.java - meta.group meta.group
+//                                                             ^ - meta.group
+//  ^^^ variable.other.java
+//      ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                 ^ punctuation.section.group.begin.java
+//                  ^^^^^^ storage.type.class.java
+//                        ^ punctuation.section.group.begin.java
+//                         ^^^^^^^ storage.type.primitive.java
+//                                 ^ variable.other.java
+//                                  ^ punctuation.separator.comma.java
+//                                    ^ punctuation.section.group.begin.java
+//                                     ^^^ storage.type.variant.java
+//                                         ^ variable.other.java
+//                                          ^ punctuation.section.group.end.java
+//                                           ^ punctuation.separator.comma.java
+//                                             ^^^ storage.type.class.java
+//                                                ^ punctuation.section.group.begin.java
+//                                                 ^^^ storage.type.primitive.java
+//                                                     ^ variable.other.java
+//                                                      ^ punctuation.section.group.end.java
+//                                                        ^ variable.other.java
+//                                                         ^ punctuation.section.group.end.java
+//                                                            ^ punctuation.section.group.end.java
+//                                                              ^ variable.other.java
+//                                                                ^^ keyword.operator.logical.java
+//                                                                   ^ variable.other.java
+//                                                                    ^ punctuation.accessor.dot.java
+//                                                                     ^^^^^^ variable.function.java
+//                                                                           ^^ meta.group.java
+//                                                                              ^ keyword.operator.comparison.java
+//                                                                                ^ constant.numeric.value.java
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
+
+  static void instanceofGenericTest1(Box<Object> bo) {
+    if (bo instanceof Box<Object>(String s)) {
+//     ^^^^ meta.group.java - meta.instanceof
+//         ^^^^^^^^^^^^^^ meta.group.java meta.instanceof.java - meta.generic
+//                       ^^^^^^^^ meta.group.java meta.instanceof.java meta.generic.java
+//                               ^^^^^^^^^^ meta.group.java meta.instanceof.java meta.group.java
+//                                         ^ meta.group.java - meta.instanceof
+//      ^^ variable.other.java
+//         ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                    ^^^ storage.type.class.java
+//                       ^ punctuation.definition.generic.begin.java
+//                        ^^^^^^ storage.type.class.java
+//                              ^ punctuation.definition.generic.end.java
+//                               ^ punctuation.section.group.begin.java
+//                                ^^^^^^ storage.type.class.java
+//                                       ^ variable.other.java
+//                                        ^ punctuation.section.group.end.java
+
+      System.out.println("String " + s);
+//               ^^^^^^^ variable.function.java
+    }
+//  ^ punctuation.section.block.end.java
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
+
+  static void instanceofGenericTest2(Box<Object> bo) {
+    if (bo instanceof box<string>(var s)) {
+//     ^^^^ meta.group.java - meta.instanceof
+//         ^^^^^^^^^^^^^^ meta.group.java meta.instanceof.java - meta.generic
+//                       ^^^^^^^^ meta.group.java meta.instanceof.java meta.generic.java
+//                               ^^^^^^^ meta.group.java meta.instanceof.java meta.group.java
+//                                      ^ meta.group.java - meta.instanceof
+//      ^^ variable.other.java
+//         ^^^^^^^^^^ keyword.other.storage.instanceof.java
+//                    ^^^ storage.type.class.java
+//                       ^ punctuation.definition.generic.begin.java
+//                        ^^^^^^ storage.type.class.java
+//                              ^ punctuation.definition.generic.end.java
+//                               ^ punctuation.section.group.begin.java
+//                                ^^^ storage.type.variant.java
+//                                    ^ variable.other.java
+//                                     ^^ punctuation.section.group.end.java
+//                                        ^ punctuation.section.block.begin.java
+      System.out.println("String " + s);
+//               ^^^^^^^ variable.function.java
+    }
+//  ^ punctuation.section.block.end.java
+  }
+//^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 }
 // <- meta.class.java meta.block.java punctuation.section.block.end.java
 


### PR DESCRIPTION
Closes #3483

This PR adds support for

1. JEP 394: Pattern Matching for instanceof
2. JEP 405: Record Patterns (Preview)
3. JEP 427: Pattern Matching for switch (preview 3)

JEP 394 has already been added in Java 16, but highlighting hasn't failed badly, so has not been handled in this syntax definition.

With support for JEP 405 type patterns however need a special treatment to correctly handle nested record structure patterns.

JEP 427 builds on top of JEP 394/405 and implements pattern matching for swich-case statements/expressions.
