### PR TITLE
[Ruby] Add support for .arb view template files

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -28,6 +28,7 @@ name: Ruby
 scope: source.ruby
 
 file_extensions:
+  - arb
   - rb
   - rbi
   - rbx


### PR DESCRIPTION
Add support for [Arbre](https://activeadmin.github.io/arbre/) view template files with `.arb` extension.