### PR TITLE
[C#] Fix nested record definitions

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -256,7 +256,7 @@ contexts:
       scope: meta.generic.cs punctuation.definition.generic.begin.cs
       push: type_argument
     - match: ';'
-      scope: punctuation.terminator.cs
+      scope: punctuation.terminator.statement.cs
       pop: true
     - match: '[^\s;]+'
       scope: invalid.illegal.expected-namespace.cs
@@ -427,10 +427,11 @@ contexts:
       push: [method_param, method_param_type]
 
   delegate_end:
-    - match: ';'
-      scope: punctuation.terminator.cs
+    - match: \s*(;)
+      captures:
+        1: punctuation.terminator.statement.cs
       pop: true
-    - match: (\s+(?=\S)|\S)
+    - match: \s*(?=\S)
       scope: invalid.illegal.expected.colon
       pop: true
 
@@ -832,7 +833,7 @@ contexts:
             - include: stray_close_bracket
             - include: code_block_in
     - match: ;
-      scope: punctuation.terminator.cs
+      scope: punctuation.terminator.statement.cs
       pop: true
     - match: \S+
       scope: invalid.illegal.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -331,7 +331,7 @@ contexts:
         2: keyword.declaration.class.record.cs
         3: keyword.declaration.struct.record.cs
         4: entity.name.class.cs
-      push: [record_signature, data_type_signature, record_parameters, data_type_signature]
+      push: [record_signature, data_type_constraint, record_parameters, data_type_signature]
     - match: '(?:\b(readonly)\s+)?(?:\b(ref)\s+)?\b(struct)\s+({{name}})'
       captures:
         1: storage.modifier.cs
@@ -514,6 +514,9 @@ contexts:
       push:
         - meta_content_scope: meta.generic.cs
         - include: type_parameter
+    - include: data_type_constraint
+
+  data_type_constraint:
     - match: ':'
       scope: punctuation.separator.type.cs
       set: type_constraint

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -331,7 +331,7 @@ contexts:
         2: keyword.declaration.class.record.cs
         3: keyword.declaration.struct.record.cs
         4: entity.name.class.cs
-      push: [record_signature, data_type_signature]
+      push: [record_signature, data_type_signature, record_parameters, data_type_signature]
     - match: '(?:\b(readonly)\s+)?(?:\b(ref)\s+)?\b(struct)\s+({{name}})'
       captures:
         1: storage.modifier.cs
@@ -435,49 +435,69 @@ contexts:
       scope: invalid.illegal.expected.colon
       pop: true
 
-  struct_signature:
-    - meta_scope: meta.struct.cs
-    - match: ''
-      set: [struct_body, data_type_body]
+  record_parameters:
+    - match: \(
+      scope: punctuation.section.parameters.begin.cs
+      push: record_params
+    - match: (?=\S)
+      pop: true
+
+  record_params:
+    - clear_scopes: 1
+    - meta_scope: meta.class.record.parameters.cs
+    - match: \)
+      scope: punctuation.section.parameters.end.cs
+      pop: 2
+    - match: (?=\S)
+      push: [method_param, method_param_type]
 
   class_signature:
     - meta_scope: meta.class.cs
-    - match: ''
-      set: [class_body, data_type_body]
-
-  record_signature:
-    - meta_scope: meta.class.record.cs
-    - match: ''
-      set: [class_body, record_type_body]
-
-  interface_signature:
-    - meta_scope: meta.interface.cs
-    - match: ''
-      set: [interface_body, data_type_body]
-
-  struct_body:
-    - meta_content_scope: meta.struct.body.cs
-    - match: ''
-      pop: true
+    - match: (?=\S)
+      set: class_body
 
   class_body:
     - meta_content_scope: meta.class.body.cs
-    - match: ''
-      pop: true
+    - include: data_type_expect_block
+
+  interface_signature:
+    - meta_scope: meta.interface.cs
+    - match: (?=\S)
+      set: interface_body
 
   interface_body:
     - meta_content_scope: meta.interface.body.cs
-    - match: ''
-      pop: true
+    - include: data_type_expect_block
 
-  data_type_body:
+  record_signature:
+    - meta_scope: meta.class.record.cs
+    - match: (?=\S)
+      set: record_body
+
+  record_body:
+    - meta_content_scope: meta.class.record.body.cs
+    - match: ';'
+      scope: punctuation.terminator.statement.cs
+      pop: true
+    - include: data_type_expect_block
+
+  struct_signature:
+    - meta_scope: meta.struct.cs
+    - match: (?=\S)
+      set: struct_body
+
+  struct_body:
+    - meta_content_scope: meta.struct.body.cs
+    - include: data_type_expect_block
+
+  data_type_expect_block:
     - match: \{
       scope: punctuation.section.block.begin.cs
       push:
         - meta_scope: meta.block.cs
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 2
         - include: attribute
         - include: class_declaration
         - include: interface_declaration
@@ -485,28 +505,7 @@ contexts:
         - include: method_declaration
         - include: stray_close_bracket
     - match: \S*
-      scope: invalid.illegal
-      pop: true
-
-  record_type_body:
-    - match: \{
-      scope: punctuation.section.block.begin.cs
-      set:
-        - meta_scope: meta.block.cs
-        - match: \}
-          scope: punctuation.section.block.end.cs
-          pop: true
-        - include: attribute
-        - include: class_declaration
-        - include: interface_declaration
-        - include: delegate_declaration
-        - include: method_declaration
-        - include: stray_close_bracket
-    - match: \(
-      scope: punctuation.section.parameters.begin.cs
-      set: [data_type_signature, method_params]
-    - match: ';'
-      scope: punctuation.terminator.cs
+      scope: invalid.illegal.cs
       pop: true
 
   data_type_signature:

--- a/C#/tests/syntax_test_C#10.cs
+++ b/C#/tests/syntax_test_C#10.cs
@@ -21,12 +21,12 @@ namespace Example;
 
 public record struct Person(string Name);
 /// ^^ storage.modifier.access
-///    ^^^^^^^^^^^^^^^^^^^^ meta.class.record
+///    ^^^^^^^^^^^^^^^^^^^^ meta.class.record - meta.class.record.parameters
+///                        ^^^^^^^^^^^^^ meta.class.record.parameters
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^^^^^^ keyword.declaration.struct.record
 ///                  ^^^^^^ entity.name.class
 ///                        ^ punctuation.section.parameters.begin
-///                         ^^^^^^^^^^^^ meta.class.body meta.method.parameters
 ///                         ^^^^^^ storage.type
 ///                                ^^^^ variable.parameter
 ///                                    ^ punctuation.section.parameters.end
@@ -34,7 +34,8 @@ public record struct Person(string Name);
 
 public readonly record struct Person(string Name);
 ///^^^ storage.modifier.access
-///    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.record
+///    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.record - meta.class.record meta.class.record
+///                                 ^^^^^^^^^^^^^ meta.class.record.parameters - meta.class.record meta.class.record
 ///    ^^^^^^^^ storage.modifier
 ///             ^^^^^^ keyword.declaration.class.record
 ///                    ^^^^^^ keyword.declaration.struct.record

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -729,7 +729,7 @@ public readonly ref struct Span<T>
     private readonly int _length;
 }
 
-public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
+public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg) ;
 ///    ^^^^^^^^ storage.type.delegate
 ///             ^^^^ storage.type
 ///                  ^^^^^^^^^^ variable.other.member.delegate
@@ -738,6 +738,7 @@ public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
 ///                              ^ punctuation.separator.type
 ///                                ^^ storage.modifier
 ///                                   ^^^^ support.type
+///                                                                 ^ punctuation.terminator.statement.cs
 
 void Test ()
 {

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -301,16 +301,20 @@ if (e is not Customer) { }
 ///          ^^^^^^^^ support.type
 
 public record A(int Num);
-///    ^^^^^^^^^^^^^^^^^ meta.class
-///                     ^ punctuation.terminator.statement
-///           ^ meta.class.record entity.name.class
+///    ^^^^^^^^ meta.class.record
+///            ^^^^^^^^^ meta.class.record.parameters
+///                     ^ - meta.class
+///    ^^^^^^ keyword.declaration.class.record
+///           ^ entity.name.class
 ///            ^ punctuation.section.parameters.begin
-///             ^^^^^^^^ meta.method.parameters
 ///             ^^^ storage.type
 ///                 ^^^ variable.parameter
 ///                    ^ punctuation.section.parameters.end
+///                     ^ punctuation.terminator.statement
 public record B<T>(T Num);
 ///    ^^^^^^^^^^^ meta.class.record
+///               ^^^^^^^ meta.class.record.parameters
+///                      ^ - meta.class
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^^^ meta.generic
@@ -318,10 +322,13 @@ public record B<T>(T Num);
 ///             ^ support.type
 ///              ^ punctuation.definition.generic.end
 ///               ^ punctuation.section.parameters.begin
-///                ^^^^^ meta.method.parameters
 ///                     ^ punctuation.section.parameters.end
 ///                      ^ punctuation.terminator.statement
 public record C<TNum> (TNum Num) where TNum : class;
+///    ^^^^^^^^^^^^^^^ meta.class.record.cs
+///                   ^^^^^^^^^^ meta.class.record.parameters.cs
+///                             ^^^^^^^^^^^^^^^^^^^ meta.class.record.cs
+///                                                ^ - meta.class
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
@@ -337,6 +344,10 @@ public record C<TNum> (TNum Num) where TNum : class;
 ///                                           ^^^^^ storage.type
 ///                                                ^ punctuation.terminator.statement
 public record D<TNum> (TNum Num) where TNum : class { public const int TEST = 4; }
+///    ^^^^^^^^^^^^^^^ meta.class.record.cs
+///                   ^^^^^^^^^^ meta.class.record.parameters.cs
+///                             ^^^^^^^^^^^^^^^^^^^^ meta.class.record.cs
+///                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.record.body.cs meta.block.cs
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
@@ -373,8 +384,40 @@ public record Person(
 ///                                                          ^ punctuation.separator.parameter.function
     [property: JsonPropertyName("lastName")]string LastName);
 /// ^ punctuation.definition.annotation.begin
-/// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.body meta.method.parameters meta.annotation
+/// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.record.parameters meta.annotation
 ///                                         ^^^^^^ storage.type
 ///                                                ^^^^^^^^ variable.parameter
 ///                                                        ^ punctuation.section.parameters.end
 ///                                                         ^ punctuation.terminator.statement
+
+public class MyClass { public record MyRecord <T> (int nums) { public const int TEST = 4; } }
+///^^^^ - meta.class
+///    ^^^^^^^^^^^^^^ meta.class - meta.class.body
+///                  ^^^^^^^^^ meta.class.body meta.block
+///                           ^^^^^^^^^^^^^^^^^^^^ meta.class.body meta.block meta.class.record - meta.class.record.parameters
+///                                               ^^^^^^^^^^ meta.class.body meta.block meta.class.record.parameters
+///                                                         ^ meta.class.body meta.block meta.class.record - meta.class.record.parameters
+///                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.body meta.block meta.class.record.body meta.block
+///                                                                                        ^^ meta.class.body meta.block - meta.class meta.class
+///                                                                                          ^ - meta.class
+///^^^ storage.modifier.access
+///    ^^^^^ keyword.declaration.class
+///          ^^^^^^^ entity.name.class
+///                  ^ punctuation.section.block.begin
+///                    ^^^^^^ storage.modifier.access
+///                           ^^^^^^ keyword.declaration.class.record
+///                                  ^^^^^^^^ entity.name.class
+///                                           ^ punctuation.definition.generic.begin
+///                                            ^ support.type
+///                                             ^ punctuation.definition.generic.end
+///                                               ^ meta.class.record.parameters punctuation.section.parameters.begin
+///                                                ^^^ storage.type
+///                                                    ^^^^ variable.parameter
+///                                                        ^ punctuation.section.parameters.end
+///                                                          ^ punctuation.section.block.begin
+///                                                            ^^^^^^ storage.modifier.access
+///                                                                   ^^^^^ storage.modifier
+///                                                                         ^^^ storage.type
+///                                                                             ^^^^ variable.other.member
+///                                                                                       ^ punctuation.section.block.end
+///                                                                                         ^ punctuation.section.block.end

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -311,10 +311,11 @@ public record A(int Num);
 ///                 ^^^ variable.parameter
 ///                    ^ punctuation.section.parameters.end
 ///                     ^ punctuation.terminator.statement
-public record B<T>(T Num);
+public record B<T>(T Num)<NoGeneric>;
 ///    ^^^^^^^^^^^ meta.class.record
 ///               ^^^^^^^ meta.class.record.parameters
-///                      ^ - meta.class
+///                      ^^^^^^^^^^^ meta.class.record - meta.generic
+///                                 ^ - meta.class
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^^^ meta.generic
@@ -323,7 +324,7 @@ public record B<T>(T Num);
 ///              ^ punctuation.definition.generic.end
 ///               ^ punctuation.section.parameters.begin
 ///                     ^ punctuation.section.parameters.end
-///                      ^ punctuation.terminator.statement
+///                                 ^ punctuation.terminator.statement
 public record C<TNum> (TNum Num) where TNum : class;
 ///    ^^^^^^^^^^^^^^^ meta.class.record.cs
 ///                   ^^^^^^^^^^ meta.class.record.parameters.cs

--- a/C#/tests/syntax_test_HelloWorld.cs
+++ b/C#/tests/syntax_test_HelloWorld.cs
@@ -5,7 +5,7 @@
 using System;
 ///<- keyword.control.import
 ///    ^ meta.path
-///         ^ punctuation.terminator.cs
+///         ^ punctuation.terminator.statement.cs
 
 namespace HelloWorld
 ///^^^^^^^^^^^^^^^^^ meta.namespace - meta.path


### PR DESCRIPTION
Fixes https://github.com/sublimehq/Packages/issues/3489

This commit ...

1. fixes `data_type_body` (now `data_type_expect_block`) to be popped off stack too early.
2. fixes meta scopes of record parameter lists, which used to be `meta.method.parameters`. Now using `meta.class.record.parameters`.
3. improves overall meta scope boundaries for record definitions.