### PR TITLE
[Markdown] Fix deadlock with SETEXT headings

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -908,11 +908,23 @@ contexts:
     - include: setext-heading-content
 
   setext-heading-content:
+    - include: setext-hard-line-breaks
     - include: emphasis
     - include: images
     - include: literals
     - include: links
     - include: markups
+
+  setext-hard-line-breaks:
+    # This context consumes what 'hard-line-breaks' does for normal
+    # paragraphs to avoid deadlock of ST's syntax engine.
+    #
+    # as workaround for
+    #    https://github.com/sublimehq/sublime_text/issues/5415
+    # causing
+    #    https://github.com/sublimehq/Packages/issues/3494
+    - match: '[ ]{2,}$'
+    - match: '\\\n'
 
   paragraph:
     # https://spec.commonmark.org/0.30/#paragraphs


### PR DESCRIPTION
Fixes #3494

The hard-line-breaks context causes deadlock in setext-or-paragraph context maybe caused by in-accurate rewinding or back-and-forth of branches while typing.

Same issue was found while working on Markdonw's MathML support.

This commit implements the same workaround by just consuming some tokens in 2nd and 3rd branch to avoid ST from trying the 1st one again.