### PR TITLE
[ShellScript] Apply to .env

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -14,6 +14,7 @@ file_extensions:
   - bashrc    # e.g.: /etc/bash.bashrc
   - ash
   - zsh
+  - env
 
 hidden_file_extensions:
   - .bash_aliases
@@ -24,6 +25,7 @@ hidden_file_extensions:
   - .bash_profile
   - .bash_variables
   - .bashrc
+  - .env
   - .profile
   - .textmate_init
   - .zlogin


### PR DESCRIPTION
This commit makes us apply shell script syntax to `*.env` and `.env` files. These files are commonly used to store environment variables to be sourced or loaded otherwise, in shell syntax, often a simple subset of it.