### PR TITLE
[Rails] Add `validates_with` pre-defined helper

### DIFF
--- a/Rails/Ruby (Rails).sublime-syntax
+++ b/Rails/Ruby (Rails).sublime-syntax
@@ -99,6 +99,7 @@ contexts:
         | validates_associated
         | validates_confirmation_of
         | validates_each
+        | validates_with
         | validates_format_of
         | validates_inclusion_of
         | validates_exclusion_of


### PR DESCRIPTION
Add the `validates_with` pre-defined validation helper to `support.function.activerecord.rails` scope.