### PR TITLE
[CSS] Fix indentation performance issue

### DIFF
--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -16,11 +16,11 @@
 			# optionally followed by...
 			(?<balanced>
 			# balanced parentheses
-			  \( (?: \g<balanced> | [^)] )* \)
+			  \( \g<balanced>* \)
 			# balanced brackets
-		  	| \[ (?: \g<balanced> | [^]] )* \]
+		  	| \[ \g<balanced>* \]
 			# balanced braces
-			| \{ (?: \g<balanced> | [^}] )* \}
+			| \{ \g<balanced>* \}
 			# double quoted string with ignored escaped quotation marks
 			| \" .*? (?<![^\\]\\)(?<![\\]{3})\"
 			# single quoted string with ignored escaped quotation marks


### PR DESCRIPTION
`[^)]` is already matched inside `balanced` on line `31`. The duplication causes performance to tank with the oniguruma regex engine.

Fixes https://github.com/sublimehq/sublime_text/issues/5576