### PR TITLE
[Bash] Add .bash_history extension

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -19,6 +19,7 @@ hidden_file_extensions:
   - .bash_aliases
   - .bash_completions
   - .bash_functions
+  - .bash_hisotry
   - .bash_login
   - .bash_logout
   - .bash_profile


### PR DESCRIPTION
Every line in `.bash_history` is a bash command which was executed. It basically constains commands which shows when you press `↑` in a terminal.