### PR TITLE
[PHP] Improve type hints

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -987,9 +987,12 @@ contexts:
 
   arrow-function-parameters:
     - meta_include_prototype: false
-    - match: \(
-      scope: punctuation.section.group.begin.php
-      set: arrow-function-parameters-body
+    - match: (?=\()
+      set:
+        - arrow-function-parameters-body
+        - function-parameter-variable
+        - expect-type-hint
+        - group-begin
     - include: else-pop
 
   arrow-function-parameters-body:
@@ -1082,47 +1085,75 @@ contexts:
       set: function-parameters
 
   constructor-parameters:
-    - match: \(
-      scope: punctuation.section.group.begin.php
-      set: constructor-parameters-body
+    - meta_include_prototype: false
+    - match: (?=\()
+      set:
+        - constructor-parameters-body
+        - function-parameter-variable
+        - constructor-type-hint
+        - group-begin
+    - include: comments
     - include: else-pop
 
   constructor-parameters-body:
     - clear_scopes: 1
     - meta_scope: meta.function.parameters.php meta.group.php
+    - match: ',|(?=[(?\\[:alpha:]])'  # handle missing comma gracefully
+      scope: punctuation.separator.sequence.php
+      push:
+        - function-parameter-variable
+        - constructor-type-hint
+    - include: function-parameter-values
+    - include: group-end
+    - include: comments
+    - include: else-pop
+
+  constructor-type-hint:
     - match: '{{constructor_modifier}}'
       scope: storage.modifier.php
     - include: access-modifiers
     - include: static-modifiers
-    - include: function-parameters-body
+    - include: expect-type-hint
 
   function-parameters:
     - meta_include_prototype: false
-    - match: \(
-      scope: punctuation.section.group.begin.php
-      set: function-parameters-body
+    - match: (?=\()
+      set:
+        - function-parameters-body
+        - function-parameter-variable
+        - expect-type-hint
+        - group-begin
+    - include: comments
     - include: else-pop
 
   function-parameters-body:
     - clear_scopes: 1
     - meta_scope: meta.function.parameters.php meta.group.php
-    - match: \)
-      scope: punctuation.section.group.end.php
-      pop: 1
-    - match: =
-      scope: keyword.operator.assignment.php
-      push: single-expression
-    - include: expression-end-pop
-    - include: attributes
+    - match: ',|(?=[(?\\[:alpha:]])'  # handle missing comma gracefully
+      scope: punctuation.separator.sequence.php
+      push:
+        - function-parameter-variable
+        - expect-type-hint
+    - include: function-parameter-values
+    - include: group-end
     - include: comments
-    - include: punctuation-separators
-    - include: reference-modifiers
-    - include: variadic-operators
-    - include: type-hints
+    - include: else-pop
+
+  function-parameter-variable:
     - match: (\$+){{identifier}}
       scope: variable.parameter.php
       captures:
         1: punctuation.definition.variable.php
+      pop: 1
+    - include: reference-modifiers
+    - include: variadic-operators
+    - include: comments
+    - include: else-pop
+
+  function-parameter-values:
+    - match: =
+      scope: keyword.operator.assignment.php
+      push: single-expression
 
   function-use:
     - match: (?i:use)\b
@@ -1136,6 +1167,7 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.php
       set: function-use-group-body
+    - include: comments
     - include: else-pop
 
   function-use-group-body:
@@ -1161,6 +1193,7 @@ contexts:
     - match: \{
       scope: punctuation.section.block.begin.php
       set: function-block-body
+    - include: comments
     - include: else-pop
 
   function-block-body:
@@ -1472,6 +1505,12 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.php
       push: group-body
+
+  group-begin:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.group.begin.php
+      pop: 1
 
   group-body:
     - meta_scope: meta.group.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -788,7 +788,6 @@ contexts:
       set:
         - type-hint-body
         - type-hint-simple-type
-        - type-hint-nullable
     - include: else-pop
 
   enum-declaration-body:
@@ -1007,7 +1006,6 @@ contexts:
       set:
         - arrow-function-return-type-body
         - type-hint-simple-type
-        - type-hint-nullable
     - include: else-pop
 
   arrow-function-return-type-body:
@@ -1154,7 +1152,6 @@ contexts:
       set:
         - function-return-type-body
         - type-hint-simple-type
-        - type-hint-nullable
     - include: else-pop
 
   function-return-type-body:
@@ -1911,7 +1908,6 @@ contexts:
       push:
         - type-hint-body
         - type-hint-simple-type
-        - type-hint-nullable
 
   type-hint:
     # https://wiki.php.net/rfc/union_types_v2
@@ -1919,38 +1915,29 @@ contexts:
       set:
         - type-hint-body
         - type-hint-simple-type
-        - type-hint-nullable
 
   type-hint-body:
     - meta_scope: meta.type.php
-    - match: \|(?!\s*\$)
-      scope: punctuation.separator.type.union.php
-      push:
-        - type-hint-simple-type
-        - type-hint-nullable
-    - match: '&(?!\s*\$)'
-      scope: punctuation.separator.type.intersection.php
-      push:
-        - type-hint-simple-type
-        - type-hint-nullable
-    - include: type-hint-groups
-    - include: else-pop
-
-  type-hint-groups:
     - match: \(
       scope: punctuation.section.group.begin.php
       push:
-        - meta_scope: meta.group.php
-        - match: \)
-          scope: punctuation.section.group.end.php
-          pop: 1
-        - include: type-hints
-
-  type-hint-nullable:
-    - match: \?
-      scope: storage.type.nullable.php
-      pop: 1
+        - type-hint-group-body
+        - type-hint-simple-type
+    - match: \|
+      scope: punctuation.separator.type.union.php
+      push: type-hint-simple-type
+    - match: \&(?!\s*\$)  # references have precedence
+      scope: punctuation.separator.type.intersection.php
+      push: type-hint-simple-type
+    - include: comments
     - include: else-pop
+
+  type-hint-group-body:
+    - meta_scope: meta.group.php
+    - match: \)
+      scope: punctuation.section.group.end.php
+      pop: 1
+    - include: type-hint-body
 
   type-hint-simple-type:
     # note that
@@ -1962,8 +1949,11 @@ contexts:
     - match: (?=(?i:extends|implements)\b)
       pop: 1
     - include: expression-end-pop
+    - match: \?
+      scope: storage.type.nullable.php
     - include: binding
     - include: class-name
+    - include: comments
     - include: else-pop
 
 ###[ CLASSES ]################################################################

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1312,21 +1312,21 @@ contexts:
     - meta_content_scope: meta.catch.php
     - match: \(
       scope: punctuation.section.group.begin.php
-      set: catch-arguments-body
+      set:
+        - catch-arguments-body
+        - expect-type-hint
     - include: comments
     - include: else-pop
 
   catch-arguments-body:
     - meta_scope: meta.catch.arguments.php meta.group.php
-    - include: group-end
-    - include: expression-end-pop
-    - include: attributes
-    - include: comments
-    - include: type-hints
     - match: (\$){{identifier}}
       scope: variable.other.php
       captures:
         1: punctuation.definition.variable.php
+    - include: group-end
+    - include: comments
+    - include: else-pop
 
 ###[ FOR STATEMENTS ]#########################################################
 
@@ -1944,13 +1944,6 @@ contexts:
     # https://wiki.php.net/rfc/union_types_v2
     - match: (?=\S)
       set:
-        - type-hint-body
-        - type-hint-simple-type
-
-  type-hints:
-    # https://wiki.php.net/rfc/union_types_v2
-    - match: (?=(?:\(\s*)?(?:\?\s*)?\\?{{identifier_start}})
-      push:
         - type-hint-body
         - type-hint-simple-type
 

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -952,16 +952,13 @@ contexts:
       push: property-type-hint
 
   property-type-hint:
-    - match: (?=(?i:const|function)\b)
+    - match: (?=\$|(?i:const|function)\b)
       pop: 1
     - match: '{{property_modifier}}'
       scope: storage.modifier.php
     - include: access-modifiers
     - include: static-modifiers
-    - include: type-hint
-    - include: attributes
-    - include: comments
-    - include: else-pop
+    - include: expect-type-hint
 
 ###[ ARROW FUNCTION DECLARATIONS ]############################################
 
@@ -1902,17 +1899,19 @@ contexts:
 
 ###[ TYPE HINTS ]#############################################################
 
+  expect-type-hint:
+    - include: attributes
+    - include: comments
+    # https://wiki.php.net/rfc/union_types_v2
+    - match: (?=\S)
+      set:
+        - type-hint-body
+        - type-hint-simple-type
+
   type-hints:
     # https://wiki.php.net/rfc/union_types_v2
     - match: (?=(?:\(\s*)?(?:\?\s*)?\\?{{identifier_start}})
       push:
-        - type-hint-body
-        - type-hint-simple-type
-
-  type-hint:
-    # https://wiki.php.net/rfc/union_types_v2
-    - match: (?=(?:\(\s*)?(?:\?\s*)?\\?{{identifier_start}})
-      set:
         - type-hint-body
         - type-hint-simple-type
 

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1552,6 +1552,71 @@ class B
 
 class TestTypedProperties {
 
+    public ;
+//  ^^^^^^ storage.modifier.access.php
+//        ^^ - meta.type
+//         ^ punctuation.terminator.statement.php
+
+    public ( ;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php meta.group.php
+//           ^ punctuation.terminator.statement.php - meta.type
+
+    public ? ;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php
+//         ^ storage.type.nullable.php
+//           ^ punctuation.terminator.statement.php - meta.type
+
+    public & ;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php
+//         ^ punctuation.separator.type.intersection.php
+//           ^ punctuation.terminator.statement.php - meta.type
+
+    public | ;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php
+//         ^ punctuation.separator.type.union.php
+//           ^ punctuation.terminator.statement.php - meta.type
+
+    public $var;
+//  ^^^^^^ storage.modifier.access.php
+//        ^^^^^ - meta.type
+//         ^^^^ variable.other.php
+//             ^ punctuation.terminator.statement.php
+
+    public ( $var;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php meta.group.php
+//           ^^^^^ - meta.type
+//           ^^^^ variable.other.php
+//               ^ punctuation.terminator.statement.php
+
+    public ? $var;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php
+//           ^^^^^ - meta.type
+//         ^ storage.type.nullable.php
+//           ^^^^ variable.other.php
+//               ^ punctuation.terminator.statement.php
+
+    public & $var;
+//  ^^^^^^ storage.modifier.access.php
+//        ^^^^^^^ - meta.type
+//         ^ - punctuation.separator.type.intersection
+//           ^^^^ variable.other.php
+//               ^ punctuation.terminator.statement.php
+
+    public | $var;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^ meta.type.php
+//           ^^^^^ - meta.type
+//         ^ punctuation.separator.type.union.php
+//           ^^^^ variable.other.php
+//               ^ punctuation.terminator.statement.php
+
+
     public static ?Foo $str = '';
 //  ^^^^^^ storage.modifier.access.php
 //         ^^^^^^ storage.modifier.namespace.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2074,6 +2074,106 @@ function foo(?stinrg ...$args) {}
 //                                                              ^ punctuation.separator.type.intersection
 //                                                                ^^^^^^^^^^ support.class
 
+    function incompleteParamTypesFunction(
+
+        $param0,
+//      ^^^^^^^ variable.parameter.php
+//             ^ punctuation.separator.sequence.php
+
+        ? $param1,
+//      ^^ meta.type.php
+//        ^^^^^^^ - meta.type
+//      ^ storage.type.nullable.php
+//        ^^^^^^^ variable.parameter.php
+//               ^ punctuation.separator.sequence.php
+
+        & $param2,
+//      ^^^^^^^^^ - meta.type
+//      ^ keyword.operator.reference.php
+//        ^^^^^^^ variable.parameter.php
+//               ^ punctuation.separator.sequence.php
+
+        | $param3,
+//      ^^ meta.type.php
+//        ^^^^^^^ - meta.type
+//      ^ punctuation.separator.type.union.php
+//        ^^^^^^^ variable.parameter.php
+//               ^ punctuation.separator.sequence.php
+
+        ( $param4,
+//      ^^ meta.type.php meta.group.php
+//        ^^^^^^^ - meta.type
+//      ^ punctuation.section.group.begin.php
+//        ^^^^^^^ variable.parameter.php
+//        ^ punctuation.definition.variable.php
+//               ^ punctuation.separator.sequence.php
+
+        () $param5,
+//      ^^ meta.type.php meta.group.php
+//        ^ meta.type.php - meta.type meta.group
+//         ^^^^^^^ - meta.type
+//      ^ punctuation.section.group.begin.php
+//       ^ punctuation.section.group.end.php
+//         ^^^^^^^ variable.parameter.php
+//                ^ punctuation.separator.sequence.php
+
+        ...$param1,
+//      ^^^ keyword.operator.variadic.php
+//         ^^^^^^^ variable.parameter.php
+//                ^ punctuation.separator.sequence.php
+
+        ? ...$param2,
+//      ^^ meta.type.php
+//        ^^^^^^^^^^^ - meta.type
+//      ^ storage.type.nullable.php
+//        ^^^ keyword.operator.variadic.php
+//           ^^^^^^^ variable.parameter.php
+//                  ^ punctuation.separator.sequence.php
+
+        & ...$param3,
+//      ^^ meta.type.php
+//        ^^^^^^^^^^^ - meta.type
+//      ^ punctuation.separator.type.intersection.php
+//        ^^^ keyword.operator.variadic.php
+//           ^^^^^^^ variable.parameter.php
+//                  ^ punctuation.separator.sequence.php
+
+        | ...$param4,
+//      ^^ meta.type.php
+//        ^^^^^^^^^^^ - meta.type
+//      ^ punctuation.separator.type.union.php
+//        ^^^ keyword.operator.variadic.php
+//           ^^^^^^^ variable.parameter.php
+//                  ^ punctuation.separator.sequence.php
+
+        ( ...$param5,
+//      ^^ meta.type.php meta.group.php
+//        ^^^^^^^^^^^ - meta.type
+//      ^ punctuation.section.group.begin.php
+//        ^^^ keyword.operator.variadic.php
+//           ^^^^^^^ variable.parameter.php
+//           ^ punctuation.definition.variable.php
+//                  ^ punctuation.separator.sequence.php
+
+        () ...$param6,
+//      ^^ meta.type.php meta.group.php
+//        ^ meta.type.php - meta.type meta.group
+//         ^^^^^^^^^^^ - meta.type
+//      ^ punctuation.section.group.begin.php
+//       ^ punctuation.section.group.end.php
+//         ^^^ keyword.operator.variadic.php
+//            ^^^^^^^ variable.parameter.php
+//                   ^ punctuation.separator.sequence.php
+
+        bool $param0 string $param2,
+//      ^^^^ storage.type.primitive.php
+//           ^^^^^^^ variable.parameter.php
+//                   ^^^^^^ storage.type.primitive.php
+//                          ^^^^^^^ variable.parameter.php
+//                                 ^ punctuation.separator.sequence.php
+
+    ): {}
+
     function unionTypeFunction(
 //  ^ keyword.declaration.function
 //           ^ entity.name.function.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1927,6 +1927,27 @@ function foo(?stinrg ...$args) {}
 //                   ^^^ keyword.operator.variadic
 //                      ^^^^^ variable.parameter
 
+    // incomplete and therefore invalid code to illustrate reference operator precedence
+    function &typedParameterReferences(int & C &$v, bool & $new, ?string | $str) {}
+//  ^ keyword.declaration.function.php
+//           ^ keyword.operator.reference.php
+//            ^ entity.name.function.php
+//                                    ^ punctuation.section.group.begin.php
+//                                     ^^^ storage.type.primitive.php
+//                                         ^ punctuation.separator.type.intersection.php
+//                                           ^ support.class.php
+//                                             ^ keyword.operator.reference.php
+//                                              ^^ variable.parameter.php
+//                                                ^ punctuation.separator.sequence.php
+//                                                  ^^^^ storage.type.primitive.php
+//                                                       ^ keyword.operator.reference.php
+//                                                         ^^^^ variable.parameter.php
+//                                                             ^ punctuation.separator.sequence.php
+//                                                               ^ storage.type.nullable.php
+//                                                                ^^^^^^ storage.type.primitive.php
+//                                                                       ^ punctuation.separator.type.union.php
+//                                                                         ^^^^ variable.parameter.php
+//                                                                             ^ punctuation.section.group.end.php
 
     function noReturnType(array $param1, int $param2) {}
 //  ^ keyword.declaration.function
@@ -2038,6 +2059,28 @@ function foo(?stinrg ...$args) {}
 //                     ^ support.class
 //                       ^ punctuation.definition.variable
 //                        ^^^^^^ variable.parameter
+
+        (?A/**/|/**/B/**/)/**/&/**/(/**/C/**/|/**/?D/**/)/**/&/**/?E $param2,
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.php
+//                                                                   ^^^^^^^^^ - meta.type
+//      ^ punctuation.section.group.begin
+//       ^ storage.type.nullable
+//        ^ support.class
+//             ^ punctuation.separator.type.union
+//                  ^ support.class
+//                       ^ punctuation.section.group.end
+//                            ^ punctuation.separator.type.intersection
+//                                 ^ punctuation.section.group.begin
+//                                      ^ support.class
+//                                           ^ punctuation.separator.type.union
+//                                                ^ storage.type.nullable
+//                                                 ^ support.class
+//                                                      ^ punctuation.section.group.end
+//                                                           ^ punctuation.separator.type.intersection
+//                                                                ^ storage.type.nullable
+//                                                                 ^ support.class
+//                                                                   ^ punctuation.definition.variable
+//                                                                    ^^^^^^ variable.parameter
         string $param3,
 //      ^^^^^^ storage.type
 //             ^ punctuation.definition.variable


### PR DESCRIPTION
This PR mainly optimizes parsing performance of type hints and makes them somewhat more robust with regards to incomplete expressions.

### Benchmarks

#### Type hints in function parameter lists

10k lines of:

```php
<?
function unionTypeFunction(int | string $param0, Foo | \Foo\Bar | ?int $param1, Foo|\Foo\Bar|?int $param2, (?A|B)&(C|?D)&?E $param2, string $param3, $param4): Foo|\Foo\Bar|?int|static {}
```

| ST4137 | this PR | delta
|--------|---------|--------
| 207ms  | 178ms   | -14%


#### Type hints in typed properties

10k lines of:

```php
<?
class Foo {
    public $var = 0; public int | string $param0; public Foo | \Foo\Bar | ?int $param1; public Foo|\Foo\Bar|?int $param2; public (?A|B)&(C|?D)&?E $param2; public string $param3; public $param4;
}
```

| ST4137 | this PR | delta
|--------|---------|--------
| 304ms  | 277ms   | -9%
