### PR TITLE
[Git Formats] Add update-ref command to interactive rebase

### DIFF
--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -97,6 +97,12 @@ contexts:
         2: punctuation.separator.sequence.git.rebase
         3: keyword.operator.commit.label.git.rebase
       set: help-cmd-args
+    - match: \b(u)(,) (update-ref)\b
+      captures:
+        1: keyword.operator.commit.update-ref.git.rebase
+        2: punctuation.separator.sequence.git.rebase
+        3: keyword.operator.commit.update-ref.git.rebase
+      set: help-cmd-args
     - match: \b(m)(,) (merge)\b
       captures:
         1: keyword.operator.commit.merge.git.rebase
@@ -211,6 +217,11 @@ contexts:
         0: meta.branch.label.git.rebase
         1: keyword.other.label.git.rebase
         2: constant.language.branch-name.git.commit
+    - match: ^\s*(u|update-ref)\s+(\S+)
+      captures:
+        0: meta.branch.update-ref.git.rebase
+        1: keyword.operator.update-ref.git.rebase
+        2: constant.language.ref.git.commit
     - match: ^\s*(m|merge)\s+({{option}})\s+({{hash}})\s+(\S+)
       captures:
         0: meta.branch.merge.git.rebase

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -85,6 +85,16 @@ label feature/branch-name
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.label.git.rebase
 #^^^^ keyword.other.label.git.rebase
 #     ^^^^^^^^^^^^^^^^^^^ constant.language.branch-name.git.commit
+update-ref refs/heads/feature-branch
+# <- meta.branch.update-ref.git.rebase keyword.operator.update-ref.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.update-ref.git.rebase
+#^^^^^^^^^ keyword.operator.update-ref.git.rebase
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.ref.git.commit
+u refs/heads/feature-branch
+# <- meta.branch.update-ref.git.rebase keyword.operator.update-ref.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.update-ref.git.rebase
+# <- keyword.operator.update-ref.git.rebase
+#          ^^^^^^^^^^^^^^^^ constant.language.ref.git.commit
 t onto
 # <- meta.branch.reset.git.rebase keyword.operator.branch.reset.git.rebase
 #^^^^^ meta.branch.reset.git.rebase
@@ -373,6 +383,18 @@ merge -C c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 #                                                 ^ punctuation.definition.variable.begin.git.rebase
 #                                                         ^ punctuation.definition.variable.end.git.rebase
 #                                                          ^ punctuation.section.brackets.end.git.rebase
+#
+# u, update-ref <ref> = track a placeholder for the <ref> to be updated
+# <- comment.line.git.rebase punctuation.definition.comment.git.rebase
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commands-help.git.rebase
+# ^ keyword.operator.commit.update-ref.git.rebase
+#  ^ punctuation.separator.sequence.git.rebase
+#    ^^^^^ keyword.operator.commit.update-ref.git.rebase
+#               ^^^^^ variable.parameter.git.rebase
+#               ^ punctuation.definition.variable.begin.git.rebase
+#                   ^ punctuation.definition.variable.end.git.rebase
+#                     ^ punctuation.separator.key-value.git.rebase
+#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.rebase
 #
 # m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
 # .       create a merge commit using the original merge commit's


### PR DESCRIPTION
git v2.38.0 adds the new branch command "update-ref". The format is

```
update-ref refs/heads/feature-branch
```