### PR TITLE
[Python] Mark variable annotation with a `meta.` block

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1018,15 +1018,17 @@ contexts:
     - include: illegal-assignment-expression
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
-      push:
-        - meta_scope: meta.variable.annotation.python
-        - match: (?=$|=|#|;)
-          pop: 1
-        - include: expression-in-a-group
+      push: variable-annotation
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
     - match: '=(?!=)'
       scope: keyword.operator.assignment.python
+
+  variable-annotation:
+    - meta_scope: meta.variable.annotation.python
+    - match: (?=$|=|#|;)
+      pop: 1
+    - include: expression-in-a-group
 
   operators:
     - match: <>

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1019,7 +1019,7 @@ contexts:
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
       push:
-        - meta_scope: meta.variable.parameters.annotation.python
+        - meta_scope: meta.variable.annotation.python
         - match: '(?==|$|#)'
           pop: 1
         - include: expression-in-a-group

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1020,7 +1020,7 @@ contexts:
       scope: punctuation.separator.annotation.variable.python
       push:
         - meta_scope: meta.variable.annotation.python
-        - match: '(?==|$|#)'
+        - match: (?=$|=|#|;)
           pop: 1
         - include: expression-in-a-group
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1016,8 +1016,15 @@ contexts:
 
   assignments:
     - include: illegal-assignment-expression
-    - match: ':'
-      scope: punctuation.separator.annotation.variable.python
+    - match: '(?=:)'
+      set:
+        - match: ':'
+          scope: punctuation.separator.annotation.variable.python
+          set:
+            - meta_scope: meta.variable.parameters.annotation.python
+            - match: '(?==|$|#)'
+              pop: 1
+            - include: expression-in-a-group
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
     - match: '=(?!=)'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1016,15 +1016,13 @@ contexts:
 
   assignments:
     - include: illegal-assignment-expression
-    - match: '(?=:)'
-      set:
-        - match: ':'
-          scope: punctuation.separator.annotation.variable.python
-          set:
-            - meta_scope: meta.variable.parameters.annotation.python
-            - match: '(?==|$|#)'
-              pop: 1
-            - include: expression-in-a-group
+    - match: ':'
+      scope: punctuation.separator.annotation.variable.python
+      push:
+        - meta_scope: meta.variable.parameters.annotation.python
+        - match: '(?==|$|#)'
+          pop: 1
+        - include: expression-in-a-group
     - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
       scope: keyword.operator.assignment.augmented.python
     - match: '=(?!=)'

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2392,6 +2392,10 @@ zoo: \
 #^^^ meta.variable.annotation.python
 #   ^ keyword.operator.assignment
 
+foo: int; print("foo")
+#       ^ punctuation.terminator.statement.python
+#       ^^^^^^^^^^^^^^ - meta.variable.annotation.python
+
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2361,14 +2361,20 @@ foo.bar(baz., True)
 
 primes: List[int] = []
 #     ^ punctuation.separator.annotation.variable.python
+#     ^^^^^^^^^^^^ meta.variable.parameters.annotation.python
+#       ^^^^ meta.qualified-name.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.variable.python
+#      ^^^^^^^ meta.variable.parameters.annotation.python
+#             ^^^^^^^ comment
+#        ^^^ meta.qualified-name.python
 
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.variable.parameters.annotation.python
 #                                   ^ keyword.operator.assignment
 
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2371,6 +2371,27 @@ captain: str  # Note: no initial value!
 #             ^^^^^^^ comment
 #        ^^^ meta.qualified-name.python
 
+foo: \
+#  ^^^ meta.variable.parameters.annotation.python
+foo: \
+    bar = zoo
+# <- meta.variable.parameters.annotation.python
+#^^^^^^^ meta.variable.parameters.annotation.python
+#       ^ keyword.operator.assignment
+
+zoo: \
+#  ^^^ meta.variable.parameters.annotation.python
+zoo: \
+    loo \
+# <- meta.variable.parameters.annotation.python
+#^^^^^^^^^ meta.variable.parameters.annotation.python
+zoo: \
+    loo \
+    = too
+# <- meta.variable.parameters.annotation.python
+#^^^ meta.variable.parameters.annotation.python
+#   ^ keyword.operator.assignment
+
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2361,41 +2361,41 @@ foo.bar(baz., True)
 
 primes: List[int] = []
 #     ^ punctuation.separator.annotation.variable.python
-#     ^^^^^^^^^^^^ meta.variable.parameters.annotation.python
+#     ^^^^^^^^^^^^ meta.variable.annotation.python
 #       ^^^^ meta.qualified-name.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.variable.python
-#      ^^^^^^^ meta.variable.parameters.annotation.python
+#      ^^^^^^^ meta.variable.annotation.python
 #             ^^^^^^^ comment
 #        ^^^ meta.qualified-name.python
 
 foo: \
-#  ^^^ meta.variable.parameters.annotation.python
+#  ^^^ meta.variable.annotation.python
 foo: \
     bar = zoo
-# <- meta.variable.parameters.annotation.python
-#^^^^^^^ meta.variable.parameters.annotation.python
+# <- meta.variable.annotation.python
+#^^^^^^^ meta.variable.annotation.python
 #       ^ keyword.operator.assignment
 
 zoo: \
-#  ^^^ meta.variable.parameters.annotation.python
+#  ^^^ meta.variable.annotation.python
 zoo: \
     loo \
-# <- meta.variable.parameters.annotation.python
-#^^^^^^^^^ meta.variable.parameters.annotation.python
+# <- meta.variable.annotation.python
+#^^^^^^^^^ meta.variable.annotation.python
 zoo: \
     loo \
     = too
-# <- meta.variable.parameters.annotation.python
-#^^^ meta.variable.parameters.annotation.python
+# <- meta.variable.annotation.python
+#^^^ meta.variable.annotation.python
 #   ^ keyword.operator.assignment
 
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.variable.parameters.annotation.python
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.variable.annotation.python
 #                                   ^ keyword.operator.assignment
 
 


### PR DESCRIPTION
Use ~`meta.variable.parameters.annotation.python`~ `meta.variable.annotation.python` to mark annotation blocks when assigning.

This closely follows the `meta.function.parameters.annotation.python` we have in the function signatures.