### PR TITLE
[LaTeX] extend syntax to recognize \providecommand as a variant of \newcommand

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -114,7 +114,7 @@ contexts:
         (?x)
         (
           (\\)
-          (?:(?:re)?newcommand\*?)
+          (?:(?:new|renew|provide)command\*?)
         )
         (?:
           (\{)(\\[A-Za-z@]+)(\})

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -42,6 +42,18 @@
 %             ^support.function.latex entity.name.newcommand.latex
 %                               ^ support.function.general.latex
 
+
+\renewcommand{\foo}[1]{\bar #1}
+%   ^ meta.function.newcommand.latex
+%               ^support.function.latex entity.name.newcommand.latex
+%                        ^ support.function.general.latex
+
+\providecommand{\foo}[2][default]{\bar #1 #2}
+%   ^ meta.function.newcommand.latex
+%                 ^support.function.latex entity.name.newcommand.latex
+%                                  ^ support.function.general.latex
+
+
 \newcolumntype{x}{>{$}c<{$}}
 % ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.newcolumntype.latex
 % ^ support.function.newcolumntype.latex


### PR DESCRIPTION
In addition to `\newcommand` and `\renewcommand`, LaTeX offers also a `\providecommand` primitive that allows to define new commands. Its syntax is the same as the other two, it only differs in how it handles the case if the same command already exists.

https://latexref.xyz/_005cprovidecommand.html
