### PR TITLE
[LaTeX] add TeX math symbols to be recognized by TeX and LaTeX syntax

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -427,7 +427,7 @@ contexts:
     - include: references
     - include: begin-end-commands
     # extended from tex
-    - include: scope:text.tex#greeks
+    - include: scope:text.tex#math-builtin
     - include: scope:text.tex#math-brackets
     - include: math-braces
     - include: boxes

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -171,8 +171,7 @@ contexts:
   greeks:
     - match: ((\\)({{greeks}}))(?=\b|_)
       captures:
-        # keyword.other.greek.math.tex retained for backward compatibility
-        1: keyword.other.math.greek.tex keyword.other.greek.math.tex
+        1: keyword.other.math.greek.tex
         2: punctuation.definition.backslash.tex
 
   math-functions:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -175,55 +175,55 @@ contexts:
     - include: math-delimiters
 
   math-greeks:
-    - match: (\\)({{greeks}})(?=\b|_)
+    - match: (\\){{greeks}}(?=\b|_)
       scope: keyword.other.math.greek.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-functions:
-    - match: (\\)({{mathfun}})(?=\b|_)
+    - match: (\\){{mathfun}}(?=\b|_)
       scope: keyword.other.math.function.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-relations:
-    - match: (\\)({{relations}})(?=\b|_)
+    - match: (\\){{relations}}(?=\b|_)
       scope: keyword.other.math.relation.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-largeops:
-    - match: (\\)({{largeops}})(?=\b|_)
+    - match: (\\){{largeops}}(?=\b|_)
       scope: keyword.other.math.large-operator.tex
       captures:
         1: punctuation.definition.backslash.texpunctuation.definition.backslash.tex
 
   math-binops:
-    - match: (\\)({{binops}})(?=\b|_)
+    - match: (\\){{binops}}(?=\b|_)
       scope: keyword.other.math.binary-operator.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-symbols:
-    - match: (\\)({{symbols}})(?=\b|_)
+    - match: (\\){{symbols}}(?=\b|_)
       scope: keyword.other.math.symbol.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-accents:
-    - match: (\\)({{accents}})(?=\b|_)
+    - match: (\\){{accents}}(?=\b|_)
       scope: keyword.other.math.accent.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-arrows:
-    - match: (\\)({{arrows}})(?=\b|_)
+    - match: (\\){{arrows}}(?=\b|_)
       scope: keyword.other.math.arrow.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-delimiters:
-    - match: (\\)({{delimiters}})(?=\b|_)
+    - match: (\\){{delimiters}}(?=\b|_)
       scope: keyword.other.math.delimiter.tex
       captures:
         1: punctuation.definition.backslash.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -163,7 +163,17 @@ contexts:
         - include: general-commands
         - include: macro-braces
 
-  greeks:
+  math-builtin:
+    - include: math-greeks
+    - include: math-functions
+    - include: math-relations
+    - include: math-largeops
+    - include: math-binops
+    - include: math-symbols
+    - include: math-accents
+    - include: math-arrows
+
+  math-greeks:
     - match: ((\\)({{greeks}}))(?=\b|_)
       captures:
         1: keyword.other.math.greek.tex
@@ -216,16 +226,6 @@ contexts:
       captures:
         1: keyword.other.math.delimiter.tex
         2: punctuation.definition.backslash.tex
-
-  math-builtin:
-    - include: greeks
-    - include: math-functions
-    - include: math-relations
-    - include: math-largeops
-    - include: math-binops
-    - include: math-symbols
-    - include: math-accents
-    - include: math-arrows
 
   math-commands:
     - match: '((\\)[A-Za-z@]+)'

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -172,66 +172,67 @@ contexts:
     - include: math-symbols
     - include: math-accents
     - include: math-arrows
+    - include: math-delimiters
 
   math-greeks:
-    - match: ((\\)({{greeks}}))(?=\b|_)
+    - match: (\\)({{greeks}})(?=\b|_)
+      scope: keyword.other.math.greek.tex
       captures:
-        1: keyword.other.math.greek.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-functions:
-    - match: ((\\)({{mathfun}}))(?=\b|_)
+    - match: (\\)({{mathfun}})(?=\b|_)
+      scope: keyword.other.math.function.tex
       captures:
-        1: keyword.other.math.function.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-relations:
-    - match: ((\\)({{relations}}))(?=\b|_)
+    - match: (\\)({{relations}})(?=\b|_)
+      scope: keyword.other.math.relation.tex
       captures:
-        1: keyword.other.math.relation.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-largeops:
-    - match: ((\\)({{largeops}}))(?=\b|_)
+    - match: (\\)({{largeops}})(?=\b|_)
+      scope: keyword.other.math.large-operator.tex
       captures:
-        1: keyword.other.math.large-operator.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.texpunctuation.definition.backslash.tex
 
   math-binops:
-    - match: ((\\)({{binops}}))(?=\b|_)
+    - match: (\\)({{binops}})(?=\b|_)
+      scope: keyword.other.math.binary-operator.tex
       captures:
-        1: keyword.other.math.binary-operator.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-symbols:
-    - match: ((\\)({{symbols}}))(?=\b|_)
+    - match: (\\)({{symbols}})(?=\b|_)
+      scope: keyword.other.math.symbol.tex
       captures:
-        1: keyword.other.math.symbol.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-accents:
-    - match: ((\\)({{accents}}))(?=\b|_)
+    - match: (\\)({{accents}})(?=\b|_)
+      scope: keyword.other.math.accent.tex
       captures:
-        1: keyword.other.math.accent.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-arrows:
-    - match: ((\\)({{arrows}}))(?=\b|_)
+    - match: (\\)({{arrows}})(?=\b|_)
+      scope: keyword.other.math.arrow.tex
       captures:
-        1: keyword.other.math.arrow.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-delimiters:
-    - match: ((\\)({{delimiters}}))(?=\b|_)
+    - match: (\\)({{delimiters}})(?=\b|_)
+      scope: keyword.other.math.delimiter.tex
       captures:
-        1: keyword.other.math.delimiter.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-commands:
-    - match: '((\\)[A-Za-z@]+)'
+    - match: '(\\)[A-Za-z@]+'
+      scope: support.function.math.tex
       captures:
-        1: support.function.math.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   math-operators:
     - match: \+|\-|=|-|\*|/|\^|_|<|>

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -6,6 +6,61 @@ file_extensions:
   - sty
   - cls
 scope: text.tex
+
+variables:
+  greeks: |-
+    (?x:alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|
+        iota|kappa|lambda|mu|nu|xi|o|pi|varpi|rho|varrho|sigma|varsigma|
+        tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|
+        Sigma|Upsilon|Phi|Psi|Omega
+      )
+  mathfun: |-
+    (?x:arccos|cos|csc|exp|ker|limsup|min|sinh|
+        arcsin|cosh|deg|gcd|lg|ln|Pr|sup|
+        arctan|cot|det|hom|lim|log|sec|tan|
+        arg|coth|dim|inf|liminf|max|sin|tan|pmod|bmod
+      )
+  relations: |-
+    (?x:leq|lq|geq|ge|equiv|prec|succ|sim|
+        preceq|succeq|simeq|ll|gg|subset|supset|approx|
+        subseteq|supseteq|cong|sqsubseteq|sqsupseteq|bowtie|
+        in|notin|ne|ni|owns|vdash|dashv|models|smile|mid|
+        doteq|frown|parallel|perp|propto
+      )
+  largeops: |-
+    (?x:sum|prod|coprod|int|oint|bigcap|bigcup|bigsqcup|
+        bigvee|bigwedge|bigodot|bigotimes|bigoplus|biguplus
+    )
+  binops: |-
+    (?x:pm|mp|setminus|cdot|times|ast|star|diamond|circ|bullet|
+        div|cap|cup|uplus|sqcap|sqcup|triangleleft|triangleright|
+        wr|bigcirc|bigtriangleup|bigtriangledown|vee|lor|
+        wedge|land|oplus|ominus|otimes|oslash|odot|dagger|
+        ddagger|amalg
+    )
+  accents: |-
+    (?x:hat|widehat|check|tilde|widetilde|acute|grave|dot|
+        ddot|breve|bar|vec
+    )
+  symbols: |-
+    (?x:aleph|hbar|imath|jmath|ell|wp|Re|Im|partial|infty|
+        prime|emptyset|nabla|surd|top|bot|\||angle|triangle|
+        backslash|forall|exists|neg|lnot|flat|natural|sharp|
+        clubsuit|diamondsuit|heartsuit|spadesuit
+    )
+  arrows: |-
+    (?x:leftarrow|gets|longleftarrow|Leftarrow|Longleftarrow|
+        rightarrow|to|longrightarrow|Rightarrow|Longrightarrow|
+        leftrightarrow|longleftrightarrow|Leftrightarrow|
+        Longleftrightarrow|mapsto|longmapsto|hookleftarrow|
+        hookrightarrow|uparrow|Uparrow|downarrow|Downarrow|
+        updownarrow|Updownarrow|nearrow|searrow|nwarrow|swarrow
+    )
+  delimiters: |-
+    (?x:lbrack|lbrace|langle|rbrack|rbrace|rangle|
+        vert|lfloor|lceil|Vert|rfloor|rceil
+    )
+
 contexts:
   prototype:
     - include: comments
@@ -114,10 +169,69 @@ contexts:
         - include: macro-braces
 
   greeks:
-    - match: ((\\)(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|gamma|kappa|lambda|mu|nu|xi|pi|varpi|rho|varrho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega))(?=\b|_)
+    - match: ((\\)({{greeks}}))(?=\b|_)
       captures:
-        1: keyword.other.greek.math.tex
+        # keyword.other.greek.math.tex retained for backward compatibility
+        1: keyword.other.math.greek.tex keyword.other.greek.math.tex
         2: punctuation.definition.backslash.tex
+
+  math-functions:
+    - match: ((\\)({{mathfun}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.function.tex
+        2: punctuation.definition.backslash.tex
+
+  math-relations:
+    - match: ((\\)({{relations}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.relation.tex
+        2: punctuation.definition.backslash.tex
+
+  math-largeops:
+    - match: ((\\)({{largeops}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.large-operator.tex
+        2: punctuation.definition.backslash.tex
+
+  math-binops:
+    - match: ((\\)({{binops}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.binary-operator.tex
+        2: punctuation.definition.backslash.tex
+
+  math-symbols:
+    - match: ((\\)({{symbols}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.symbol.tex
+        2: punctuation.definition.backslash.tex
+
+  math-accents:
+    - match: ((\\)({{accents}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.accent.tex
+        2: punctuation.definition.backslash.tex
+
+  math-arrows:
+    - match: ((\\)({{arrows}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.arrow.tex
+        2: punctuation.definition.backslash.tex
+
+  math-delimiters:
+    - match: ((\\)({{delimiters}}))(?=\b|_)
+      captures:
+        1: keyword.other.math.delimiter.tex
+        2: punctuation.definition.backslash.tex
+
+  math-builtin:
+    - include: greeks
+    - include: math-functions
+    - include: math-relations
+    - include: math-largeops
+    - include: math-binops
+    - include: math-symbols
+    - include: math-accents
+    - include: math-arrows
 
   math-commands:
     - match: '((\\)[A-Za-z@]+)'
@@ -158,7 +272,7 @@ contexts:
       scope: variable.other.math.tex
 
   math-content:
-    - include: greeks
+    - include: math-builtin
     - include: math-brackets
     - include: math-braces
     - include: boxes

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -9,57 +9,49 @@ scope: text.tex
 
 variables:
   greeks: |-
-    (?x:alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|
-        iota|kappa|lambda|mu|nu|xi|o|pi|varpi|rho|varrho|sigma|varsigma|
-        tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|
-        Sigma|Upsilon|Phi|Psi|Omega
-      )
+    (?x: alpha | beta | gamma | delta | epsilon | varepsilon | zeta | eta | theta
+    | vartheta | iota | kappa | lambda | mu | nu | xi | o | pi | varpi | rho
+    | varrho | sigma | varsigma | tau | upsilon | phi | varphi | chi | psi
+    | omega | Gamma | Delta | Theta | Lambda | Xi | Pi | Sigma | Upsilon | Phi
+    | Psi | Omega )
   mathfun: |-
-    (?x:arccos|cos|csc|exp|ker|limsup|min|sinh|
-        arcsin|cosh|deg|gcd|lg|ln|Pr|sup|
-        arctan|cot|det|hom|lim|log|sec|tan|
-        arg|coth|dim|inf|liminf|max|sin|tan|pmod|bmod
-      )
+    (?x: arccos | cos | csc | exp | ker | limsup | min | sinh
+    | arcsin | cosh | deg | gcd | lg | ln | Pr | sup
+    | arctan | cot | det | hom | lim | log | sec | tan
+    | arg | coth | dim | inf | liminf | max | sin | tan | pmod | bmod)
   relations: |-
-    (?x:leq|lq|geq|ge|equiv|prec|succ|sim|
-        preceq|succeq|simeq|ll|gg|subset|supset|approx|
-        subseteq|supseteq|cong|sqsubseteq|sqsupseteq|bowtie|
-        in|notin|ne|ni|owns|vdash|dashv|models|smile|mid|
-        doteq|frown|parallel|perp|propto
-      )
+    (?x: leq | lq | geq | ge | equiv | prec | succ | sim
+    | preceq | succeq | simeq | ll | gg | subset | supset | approx
+    | subseteq | supseteq | cong | sqsubseteq | sqsupseteq | bowtie
+    | in | notin | ne | ni | owns | vdash | dashv | models | smile | mid
+    | doteq | frown | parallel | perp | propto)
   largeops: |-
-    (?x:sum|prod|coprod|int|oint|bigcap|bigcup|bigsqcup|
-        bigvee|bigwedge|bigodot|bigotimes|bigoplus|biguplus
-    )
+    (?x: sum | prod | coprod | int | oint | bigcap | bigcup | bigsqcup
+    | bigvee | bigwedge | bigodot | bigotimes | bigoplus | biguplus)
   binops: |-
-    (?x:pm|mp|setminus|cdot|times|ast|star|diamond|circ|bullet|
-        div|cap|cup|uplus|sqcap|sqcup|triangleleft|triangleright|
-        wr|bigcirc|bigtriangleup|bigtriangledown|vee|lor|
-        wedge|land|oplus|ominus|otimes|oslash|odot|dagger|
-        ddagger|amalg
-    )
+    (?x: pm | mp | setminus | cdot | times | ast | star | diamond | circ | bullet
+    | div | cap | cup | uplus | sqcap | sqcup | triangleleft | triangleright
+    | wr | bigcirc | bigtriangleup | bigtriangledown | vee | lor
+    | wedge | land | oplus | ominus | otimes | oslash | odot | dagger
+    | ddagger | amalg)
   accents: |-
-    (?x:hat|widehat|check|tilde|widetilde|acute|grave|dot|
-        ddot|breve|bar|vec
-    )
+    (?x: hat | widehat | check | tilde | widetilde | acute | grave | dot
+    | ddot | breve | bar | vec)
   symbols: |-
-    (?x:aleph|hbar|imath|jmath|ell|wp|Re|Im|partial|infty|
-        prime|emptyset|nabla|surd|top|bot|\||angle|triangle|
-        backslash|forall|exists|neg|lnot|flat|natural|sharp|
-        clubsuit|diamondsuit|heartsuit|spadesuit
-    )
+    (?x: aleph | hbar | imath | jmath | ell | wp | Re | Im | partial | infty
+    | prime | emptyset | nabla | surd | top | bot | \| | angle | triangle
+    | backslash | forall | exists | neg | lnot | flat | natural | sharp
+    | clubsuit | diamondsuit | heartsuit | spadesuit)
   arrows: |-
-    (?x:leftarrow|gets|longleftarrow|Leftarrow|Longleftarrow|
-        rightarrow|to|longrightarrow|Rightarrow|Longrightarrow|
-        leftrightarrow|longleftrightarrow|Leftrightarrow|
-        Longleftrightarrow|mapsto|longmapsto|hookleftarrow|
-        hookrightarrow|uparrow|Uparrow|downarrow|Downarrow|
-        updownarrow|Updownarrow|nearrow|searrow|nwarrow|swarrow
-    )
+    (?x: leftarrow | gets | longleftarrow | Leftarrow | Longleftarrow
+    | rightarrow | to | longrightarrow | Rightarrow | Longrightarrow
+    | leftrightarrow | longleftrightarrow | Leftrightarrow
+    | Longleftrightarrow | mapsto | longmapsto | hookleftarrow
+    | hookrightarrow | uparrow | Uparrow | downarrow | Downarrow
+    | updownarrow | Updownarrow | nearrow | searrow | nwarrow | swarrow)
   delimiters: |-
-    (?x:lbrack|lbrace|langle|rbrack|rbrace|rangle|
-        vert|lfloor|lceil|Vert|rfloor|rceil
-    )
+    (?x: lbrack | lbrace | langle | rbrack | rbrace | rangle
+    | vert | lfloor | lceil | Vert | rfloor | rceil)
 
 contexts:
   prototype:
@@ -127,6 +119,9 @@ contexts:
           pop: true
         - include: main
 
+  # within macros, it is possible that only part of some nested struture
+  # is present. To prevent this from causing problems, here we only match
+  # elements that are simple, i.e. that do not push to the stack.
   macro-braces:
     - match: '\{'
       scope: punctuation.definition.group.brace.begin.tex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -345,17 +345,17 @@ f(x) = x^2
 \end{equation}
 
 $\iota$
-% ^ keyword.other.greek.math.tex
+% ^ keyword.other.math.greek.tex
 
 $\Iota$
 % ^ support.function.math.tex
 
 $\alpha _$
-% ^ keyword.other.greek.math.tex
+% ^ keyword.other.math.greek.tex
 %       ^ keyword.operator.math.tex
 
 $\alpha_$
-% ^ keyword.other.greek.math.tex
+% ^ keyword.other.math.greek.tex
 %      ^ keyword.operator.math.tex
 
 % Boxes

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -555,6 +555,20 @@ a & b
 $f(x) = \} {} y$
 % ^^^^^^^^^^^^^ meta.environment.math.inline.dollar.latex
 
+$\alpha \cdot \beta \leq \cos( 5 )$
+%^ punctuation.definition.backslash.tex
+%^^^^^^ keyword.other.math.greek.tex
+%       ^ punctuation.definition.backslash.tex       
+%       ^^^^^ keyword.other.math.binary-operator.tex
+%                   ^^^^ keyword.other.math.relation.tex
+%                              
+$s \gets \sum_{\imath = 0}^10 \langle \hat{x}, x \rangle$ 
+%  ^^^^^ keyword.other.math.arrow.tex
+%        ^^^^ keyword.other.math.large-operator.tex
+%              ^^^^^^ keyword.other.math.symbol.tex
+%                             ^^^^^^^ keyword.other.math.delimiter.tex
+%                                     ^^^^ keyword.other.math.accent.tex
+%                                                ^^^^^^^ keyword.other.math.delimiter.tex
 
 \end{document}
 % ^ support.function.end.latex keyword.control.flow.end.latex


### PR DESCRIPTION
This adds a large number of symbols to be recognized in TeX's math mode, in addition to the greek letters.
I've based the list of added matchings on https://www.math.brown.edu/johsilve/ReferenceCards/TeXRefCard.v1.5.pdf,
it may not be exhaustive.

I've also changed the `keyword.other.greek.math.tex` to `keyword.other.math.greek.tex`, so that we can have proper scoping with other math-type keywords. For now, I've left the old scope there additionally, if you think this is fine to remove I'd agree with that, though.