### PR TITLE
[Python] Fix PEP-604 union type hints

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1028,6 +1028,9 @@ contexts:
     - meta_scope: meta.variable.annotation.python
     - match: (?=$|=|#|;)
       pop: 1
+    - match: \bNone\b
+      scope: constant.language.null.python
+    - include: illegal-assignment-expression
     - include: expression-in-a-group
 
   operators:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2371,6 +2371,26 @@ captain: str  # Note: no initial value!
 #             ^^^^^^^ comment
 #        ^^^ meta.qualified-name.python
 
+foo: str | None = None
+#  ^^^^^^^^^^^^^ meta.variable.annotation.python
+#               ^^^^^^^ - meta.variable
+#  ^ punctuation.separator.annotation.variable.python
+#    ^^^ support.type.python
+#        ^ keyword.operator.arithmetic.python
+#          ^^^^ constant.language.null.python
+#               ^ keyword.operator.assignment.python
+#                 ^^^^ constant.language.null.python
+
+bar: str | None = 'b'
+#  ^^^^^^^^^^^^^ meta.variable.annotation.python
+#               ^^^^^^ - meta.variable
+#  ^ punctuation.separator.annotation.variable.python
+#    ^^^ support.type.python
+#        ^ keyword.operator.arithmetic.python
+#          ^^^^ constant.language.null.python
+#               ^ keyword.operator.assignment.python
+#                 ^^^ string.quoted.single.python
+
 foo: \
 #  ^^^ meta.variable.annotation.python
 foo: \


### PR DESCRIPTION
Fixes #3486

This commit copies some lines from function parameter lists' contexts to fix the PEP 604 highlighting issues.