### PR TITLE
[Markdown] Fix inline raw code spans

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -2152,20 +2152,29 @@ contexts:
 
   code-spans:
     # https://spec.commonmark.org/0.30/#code-spans
-    - match: (`+)(?!`)
+    - match: (?=`+)
+      branch_point: code-spans
+      branch:
+        - code-span
+        - no-code-span
+
+  code-span:
+    - match: (`+)
       scope: punctuation.definition.raw.begin.markdown
-      push: code-span-body
+      set: code-span-body
 
   code-span-body:
     - meta_scope: markup.raw.inline.markdown
     - match: \1(?!`)
       scope: punctuation.definition.raw.end.markdown
       pop: 1
-    - match: '`+'
-    - match: ^\s*$\n?
-      scope: invalid.illegal.non-terminated.raw.markdown
+    - match: \`+
+    - match: '{{list_paragraph_end}}'
+      fail: code-spans
+
+  no-code-span:
+    - match: \`+
       pop: 1
-    - include: paragraph-end
 
 ###[ INLINE: EMPHASIS ]#######################################################
 

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -5665,6 +5665,16 @@ paragraph
        | ^ punctuation.definition.heading.begin.markdown
        |   ^^^^^^^ entity.name.section.markdown
 
+       > - list item <code>```math</code> equation
+       >   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+       > 
+       >   - list item <code>```math</code> equation
+       >     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+       >   - list item <code>```math</code>``` equation
+       >     | ^^^^^^^^^^^^^^ markup.quote.markdown  markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+       >     |               ^^^^^^^^^^^^^^^^^ markup.quote.markdown  markup.list.unnumbered.markdown meta.paragraph.list.markdown markup.raw.inline.markdown
+       >     |                                ^^^^^^^^^^ markup.quote.markdown  markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+
 ## https://custom-tests/list-blocks/items-with-code-spans
 
 - `<foo>` | `<bar>` (foo/bar.baz)
@@ -5722,6 +5732,16 @@ blah*
       <span>*no-markdown*</span>
       |^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
       |                  ^^^^^^^ meta.tag
+
+- list item <code>```math</code> equation
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+
+  - list item <code>```math</code> equation
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+  - list item <code>```math</code>``` equation
+    | ^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
+    |               ^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown markup.raw.inline.markdown
+    |                                ^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown - markup.raw
 
 ## https://custom-tests/list-blocks/items-with-links-and-references
 
@@ -5814,8 +5834,9 @@ more text``
 |        ^^ punctuation.definition.raw.end
 
 ``text
+| <- meta.paragraph.markdown - markup.raw
+|^^^^^^ meta.paragraph.markdown - markup.raw
 
-| <- invalid.illegal.non-terminated.raw
 text
 | <- - markup.raw
 
@@ -5957,33 +5978,25 @@ foo
 
 `<a href="`">`
 |^^^^^^^^^^ markup.raw.inline.markdown
-|          ^^ - markup.raw
-
-| <- invalid.illegal.non-terminated.raw
+|          ^^^^ - markup.raw - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-344
 
 <a href="`">`
-| ^^^^^^^^^ meta.tag.inline.a
-|           ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
+| ^^^^^^^^^^ meta.tag.inline.a
+|           ^^ - meta.tag - markup.raw - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-345
 
 `<http://foo.bar.`baz>`
 |^^^^^^^^^^^^^^^^^ markup.raw.inline
-|                     ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
+|                 ^^^^^^ - meta.tag - markup.raw - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-346
 
 <http://foo.bar.`baz>`
 |^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                    ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
+|                    ^ - markup.raw - punctuation
 
 
 # TEST: EMPHASIS ##############################################################


### PR DESCRIPTION
Fixes #3513

This commit uses branching to render inline code spans only if they are properly closed.