### PR TITLE
[LaTeX] removed superfluous quotation marks in syntax definition

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -52,22 +52,22 @@ contexts:
     - include: scope:text.tex#comments
 
   global-braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.group.brace.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
 
   # these are used to identify arguments in commands
   general-optional-arguments:
-    - match: '\['
+    - match: \[
       scope: punctuation.definition.group.bracket.begin.latex
       push:
         - meta_scope: meta.group.bracket.latex
-        - match: '\]'
+        - match: \]
           scope: punctuation.definition.group.bracket.end.latex
           pop: true
         - include: general-constants
@@ -78,30 +78,30 @@ contexts:
 
   argument-brace:
     - meta_scope: meta.group.brace.latex
-    - match: '\}'
+    - match: \}
       scope: punctuation.definition.group.brace.end.latex
       pop: true
     - include: main
 
   argument:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       set: argument-brace
-    - match: '(?=\S)'
+    - match: (?=\S)
       pop: true
 
   optional-arguments:
     - include: general-optional-arguments
-    - match: '(?=\S)'
+    - match: (?=\S)
       pop: true
 
   # used in macros to prevent matching of \begin{env}...\end{env}
   macro-braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.group.brace.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
@@ -134,7 +134,7 @@ contexts:
         9: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.newcommand.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
@@ -164,7 +164,7 @@ contexts:
         9: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.declare-math-operator.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
@@ -172,7 +172,7 @@ contexts:
         - include: macro-braces
 
   general-constants:
-    - match: '(\\\\)(?:(\[)\s*-?((?:[[:digit:]]|\.)*)\s*(\w*)\s*(\]))?'
+    - match: (\\\\)(?:(\[)\s*-?((?:[[:digit:]]|\.)*)\s*(\w*)\s*(\]))?
       captures:
         1: constant.character.newline.latex
         2: punctuation.definition.group.bracket.begin.newline.latex
@@ -182,24 +182,24 @@ contexts:
     - include: scope:text.tex#general-constants
 
   general-commands:
-    - match: '(\\)[A-Za-z@]+'
+    - match: (\\)[A-Za-z@]+
       scope: support.function.general.latex
       captures:
         1: punctuation.definition.backslash.latex
 
   boxes:
-    - match: '((\\)[hvmf]box)\s*(\{)'
+    - match: ((\\)[hvmf]box)\s*(\{)
       captures:
         1: support.function.box.latex
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.box.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)(?:framebox|makebox))\b'
+    - match: ((\\)(?:framebox|makebox))\b
       captures:
         1: support.function.box.latex
         2: punctuation.definition.backslash.latex
@@ -207,7 +207,7 @@ contexts:
         - [{meta_scope: meta.function.box.latex}, {match: '', pop: true}]
         - argument
         - optional-arguments
-    - match: '((\\)parbox)\b'
+    - match: ((\\)parbox)\b
       captures:
         1: support.function.box.latex
         2: punctuation.definition.backslash.latex
@@ -216,7 +216,7 @@ contexts:
         - argument
         - argument
         - optional-arguments
-    - match: '((\\)raisebox)\b'
+    - match: ((\\)raisebox)\b
       captures:
         1: support.function.box.latex
         2: punctuation.definition.backslash.latex
@@ -226,37 +226,37 @@ contexts:
         - optional-arguments
 
   preamble:
-    - match: '(\\)documentclass\b'
+    - match: (\\)documentclass\b
       captures:
         0: keyword.control.preamble.latex
         1: punctuation.definition.backslash.latex
       push:
         - meta_scope: meta.preamble.documentclass.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           set:
             - meta_scope: meta.preamble.documentclass.latex meta.group.brace.latex
             - match: '[A-Za-z[:digit:]-]'
               scope: support.class.latex
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               pop: true
         - match: ''
           pop: true
 
-    - match: '(\\)usepackage\b'
+    - match: (\\)usepackage\b
       captures:
         0: keyword.control.preamble.latex
         1: punctuation.definition.backslash.latex
       push:
         - meta_scope: meta.preamble.usepackage.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           set:
             - meta_scope: meta.preamble.usepackage.latex meta.group.brace.latex
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               pop: true
             - match: '[A-Za-z[:digit:]-]*'
@@ -265,7 +265,7 @@ contexts:
           pop: true
 
   includes:
-    - match: '((\\)(?:include|includeonly))(\{)'
+    - match: ((\\)(?:include|includeonly))(\{)
       scope: meta.function.include.latex
       captures:
         1: keyword.control.include.latex
@@ -273,7 +273,7 @@ contexts:
         3: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.include.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
 
@@ -304,7 +304,7 @@ contexts:
       push:
         - meta_scope: meta.section.latex
         - meta_content_scope: entity.name.section.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
@@ -316,7 +316,7 @@ contexts:
         2: punctuation.definition.backslash.latex
 
   verbatim:
-    - match: '((\\)begin)(\{)\s*((?:[vV]erbatim|alltt)\*?)\s*(\})'
+    - match: ((\\)begin)(\{)\s*((?:[vV]erbatim|alltt)\*?)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -327,7 +327,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.verbatim.latex
         - meta_content_scope: markup.raw.verbatim.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -337,7 +337,7 @@ contexts:
           pop: true
 
   lists:
-    - match: '((\\)begin)(\{)\s*(itemize\*?)\s*(\})'
+    - match: ((\\)begin)(\{)\s*(itemize\*?)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -346,7 +346,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_scope: meta.environment.list.itemize.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -355,7 +355,7 @@ contexts:
             5: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)begin)(\{)\s*(enumerate\*?)\s*(\})'
+    - match: ((\\)begin)(\{)\s*(enumerate\*?)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -364,7 +364,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_scope: meta.environment.list.enumerate.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -373,7 +373,7 @@ contexts:
             5: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)begin)(\{)\s*(list\*?)\s*(\})'
+    - match: ((\\)begin)(\{)\s*(list\*?)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -382,7 +382,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_scope: meta.environment.list.list.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -391,7 +391,7 @@ contexts:
             5: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)begin)(\{)\s*(description\*?)\s*(\})'
+    - match: ((\\)begin)(\{)\s*(description\*?)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -400,7 +400,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_scope: meta.environment.list.description.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -411,11 +411,11 @@ contexts:
         - include: main
 
   math-braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.group.brace.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: math-content
@@ -448,7 +448,7 @@ contexts:
           scope: string.other.math.latex punctuation.definition.string.end.latex
           pop: true
         - include: math-content
-    - match: '((\\)ensuremath)(\{)'
+    - match: ((\\)ensuremath)(\{)
       captures:
         1: support.function.ensuremath.latex
         2: punctuation.definition.backslash.latex
@@ -456,7 +456,7 @@ contexts:
       push:
         - meta_scope: meta.function.ensuremath.latex
         - meta_content_scope: meta.environment.math.inline.ensuremath.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: math-content
@@ -482,11 +482,11 @@ contexts:
           pop: true
         - include: math-content
 
-    - match: '(\\\[)'
+    - match: (\\\[)
       scope: string.other.math.latex punctuation.definition.string.begin.latex
       push:
         - meta_scope: meta.environment.math.block.bracket.latex
-        - match: '(\\\])'
+        - match: (\\\])
           scope: string.other.math.latex punctuation.definition.string.end.latex
           pop: true
         - include: math-content
@@ -507,7 +507,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_content_scope: meta.environment.math.block.be.latex
-        - match: '((\\)end)(\{)\s*(\4)\s*(\})'
+        - match: ((\\)end)(\{)\s*(\4)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.begin.latex
             2: punctuation.definition.backslash.latex
@@ -518,7 +518,7 @@ contexts:
         - include: math-content
 
   graphics:
-    - match: '((\\)includegraphics)\b'
+    - match: ((\\)includegraphics)\b
       captures:
         1: support.function.includegraphics.latex
         2: punctuation.definition.backslash.latex
@@ -528,7 +528,7 @@ contexts:
         - optional-arguments
 
   url:
-    - match: '((\\)(?:url|href|path))(\{)([^}]*)(\})'
+    - match: ((\\)(?:url|href|path))(\{)([^}]*)(\})
       scope: meta.function.link.url.latex
       captures:
         1: support.function.url.latex
@@ -547,13 +547,13 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.verb.latex
         - meta_content_scope: markup.raw.verb.latex
-        - match: '\3'
+        - match: \3
           scope: punctuation.definition.verb.latex
           pop: true
 
 
   text-decorators:
-    - match: '((\\)emph)(\{)'
+    - match: ((\\)emph)(\{)
       captures:
         1: support.function.emph.latex
         2: punctuation.definition.backslash.latex
@@ -561,11 +561,11 @@ contexts:
       push:
         - meta_scope: meta.function.emph.latex
         - meta_content_scope: markup.italic.emph.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)textit)(\{)'
+    - match: ((\\)textit)(\{)
       captures:
         1: support.function.textit.latex
         2: punctuation.definition.backslash.latex
@@ -573,11 +573,11 @@ contexts:
       push:
         - meta_scope: meta.function.textit.latex
         - meta_content_scope: markup.italic.textit.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)textbf)(\{)'
+    - match: ((\\)textbf)(\{)
       captures:
         1: support.function.textbf.latex
         2: punctuation.definition.backslash.latex
@@ -585,11 +585,11 @@ contexts:
       push:
         - meta_scope: meta.function.textbf.latex
         - meta_content_scope: markup.bold.textbf.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)texttt)(\{)'
+    - match: ((\\)texttt)(\{)
       captures:
         1: support.function.texttt.latex
         2: punctuation.definition.backslash.latex
@@ -597,11 +597,11 @@ contexts:
       push:
         - meta_scope: meta.function.texttt.latex
         - meta_content_scope: markup.raw.texttt.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)textsl)(\{)'
+    - match: ((\\)textsl)(\{)
       captures:
         1: support.function.textsl.latex
         2: punctuation.definition.backslash.latex
@@ -609,21 +609,21 @@ contexts:
       push:
         - meta_scope: meta.function.textsl.latex
         - meta_content_scope: markup.italic.textsl.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)text)(\{)'
+    - match: ((\\)text)(\{)
       captures:
         1: support.function.text.latex
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.latex
       push:
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
-    - match: '((\\)underline)(\{)'
+    - match: ((\\)underline)(\{)
       captures:
         1: support.function.text.latex
         2: punctuation.definition.backslash.latex
@@ -631,7 +631,7 @@ contexts:
       push:
         - meta_scope: meta.function.underline.latex
         - meta_content_scope: markup.underline.underline.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: main
@@ -644,16 +644,16 @@ contexts:
       push:
         - meta_scope: meta.function.footnote.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           set:
             - meta_scope: meta.function.footnote.latex meta.group.brace.latex
             - meta_content_scope: markup.italic.footnote.latex
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               pop: true
             - include: main
-        - match: '(?=\S)'
+        - match: (?=\S)
           pop: true
     - match: |-
         (?x)
@@ -695,7 +695,7 @@ contexts:
       push:
         - meta_scope: meta.function.citation.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           # Some commands, e.g. \parencites, allow multiple [][]{} argument sequences,
           # so we `push` instead of `set`.
@@ -703,7 +703,7 @@ contexts:
             - meta_scope: meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.citation.latex
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               pop: true
         - match: ''
@@ -721,18 +721,18 @@ contexts:
       push:
         - meta_scope: meta.function.reference.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           set:
             - meta_scope: meta.function.reference.latex meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.reference.latex
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               pop: true
         - match: ''
           pop: true
-    - match: '((\\)label)(\{)'
+    - match: ((\\)label)(\{)
       captures:
         1: support.function.label.latex storage.type.label.latex
         2: punctuation.definition.backslash.latex
@@ -741,12 +741,12 @@ contexts:
         - meta_scope: meta.function.label.latex
         - match: '[a-zA-Z0-9\.:/*!^_-]+'
           scope: entity.name.label.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
 
   begin-end-commands:
-    - match: '((\\)begin)(\{)\s*(\w*)\*?\s*(\})'
+    - match: ((\\)begin)(\{)\s*(\w*)\*?\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -757,7 +757,7 @@ contexts:
         - include: general-optional-arguments
         - match: ''
           pop: true
-    - match: '((\\)end)(\{)\s*(\w*)\*?\s*(\})'
+    - match: ((\\)end)(\{)\s*(\w*)\*?\s*(\})
       captures:
         1: support.function.end.latex keyword.control.flow.end.latex
         2: punctuation.definition.backslash.latex
@@ -783,7 +783,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.lstinline.latex
         - include: general-optional-arguments
-        - match: '\{'
+        - match: \{
           scope: punctuation.definition.group.brace.begin.latex
           set:
             - meta_include_prototype: false
@@ -792,12 +792,12 @@ contexts:
             - match: '\}'
               scope: meta.environment.verbatim.lstinline.latex punctuation.definition.group.brace.end.latex
               pop: true
-        - match: '(\W)'
+        - match: (\W)
           scope: punctuation.definition.verb.latex
           set:
             - meta_include_prototype: false
             - meta_content_scope: meta.environment.verbatim.lstinline.latex markup.raw.verb.latex
-            - match: '\1'
+            - match: \1
               scope: meta.environment.verbatim.lstinline.latex punctuation.definition.verb.latex
               pop: true
 
@@ -811,7 +811,7 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.lstlisting.latex
-        - match: '((\\)end)(\{)(lstlisting)(\})'
+        - match: ((\\)end)(\{)(lstlisting)(\})
           captures:
             1: support.function.end.latex keyword.control.flow.end.latex
             2: punctuation.definition.backslash.latex
@@ -820,112 +820,112 @@ contexts:
             5: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-optional-arguments
-        - match: '.*(%\s*(?i:c))$'
+        - match: .*(%\s*(?i:c))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.c
           embed_scope: meta.environment.embedded.c.latex source.c.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:cpp|c\+\+))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:cpp|c\+\+))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.c++
           embed_scope: meta.environment.embedded.c++.latex source.c++.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:haskell|hs))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:haskell|hs))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.haskell
           embed_scope: meta.environment.embedded.haskell.latex source.haskell.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:java))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:java))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.java
           embed_scope: meta.environment.embedded.java.latex source.java.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:html))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:html))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:text.html.basic
           embed_scope: meta.environment.embedded.html.latex source.html.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:tex|latex))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:tex|latex))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:text.tex.latex
           embed_scope: meta.environment.embedded.latex.latex source.latex.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:lisp))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:lisp))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.lisp
           embed_scope: meta.environment.embedded.lisp.latex source.lisp.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:lua))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:lua))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.lua
           embed_scope: meta.environment.embedded.lua.latex source.lua.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:perl))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:perl))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.perl
           embed_scope: meta.environment.embedded.perl.latex source.perl.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:php))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:php))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.php
           embed_scope: meta.environment.embedded.php.latex source.php.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:python|py))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:python|py))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.python
           embed_scope: meta.environment.embedded.python.latex source.python.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:r))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:r))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.r
           embed_scope: meta.environment.embedded.r.latex source.r.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:ruby))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:ruby))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.ruby
           embed_scope: meta.environment.embedded.ruby.latex source.ruby.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:sh|shell|bash ))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:sh|shell|bash ))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.shell
           embed_scope: meta.environment.embedded.shell.latex source.shell.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:sql|mysql|ddl|dml))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:sql|mysql|ddl|dml))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.sql
           embed_scope: meta.environment.embedded.sql.latex source.sql.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:xml))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:xml))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:text.xml
           embed_scope: meta.environment.embedded.xml.latex source.xml.embedded
-          escape: '(?=\\end\{lstlisting\})'
-        - match: '.*(%\s*(?i:yaml))$'
+          escape: (?=\\end\{lstlisting\})
+        - match: .*(%\s*(?i:yaml))$
           captures:
             1: comment.line.percentage.latex
           embed: scope:source.yaml
           embed_scope: meta.environment.embedded.yaml.latex source.yaml.embedded
-          escape: '(?=\\end\{lstlisting\})'
+          escape: (?=\\end\{lstlisting\})
         - match: ''
           push:
             - meta_scope: meta.environment.embedded.generic.latex markup.raw.verb.latex
-            - match: '(?=\\end\{lstlisting\})'
+            - match: (?=\\end\{lstlisting\})
               pop: true
 
   minted:
@@ -943,7 +943,7 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: meta.environment.verbatim.minted.latex
-        - match: '((\\)end)(\{)(minted)(\})'
+        - match: ((\\)end)(\{)(minted)(\})
           captures:
             1: support.function.end.latex keyword.control.flow.end.latex
             2: punctuation.definition.backslash.latex
@@ -952,194 +952,194 @@ contexts:
             5: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-optional-arguments
-        - match: '(\{)(c)(\})'
+        - match: (\{)(c)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.c
           embed_scope: meta.environment.embedded.c.latex source.c.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(cpp|c\+\+)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(cpp|c\+\+)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.c++
           embed_scope: meta.environment.embedded.c++.latex source.c++.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(diff)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(diff)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.diff
           embed_scope: meta.environment.embedded.diff.latex source.diff.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(go|golang)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(go|golang)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.go
           embed_scope: meta.environment.embedded.go.latex source.go.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(haskell|hs)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(haskell|hs)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.haskell
           embed_scope: meta.environment.embedded.haskell.latex source.haskell.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(html)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(html)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:text.html.basic
           embed_scope: meta.environment.embedded.html.latex text.html.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(java)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(java)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.java
           embed_scope: meta.environment.embedded.java.latex source.java.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(javascript|js)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(javascript|js)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.js
           embed_scope: meta.environment.embedded.js.latex source.js.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(json)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(json)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.json
           embed_scope: meta.environment.embedded.json.latex source.json.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(tex|latex)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(tex|latex)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:text.tex.latex
           embed_scope: meta.environment.embedded.latex.latex text.tex.latex.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(lisp)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(lisp)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.lisp
           embed_scope: meta.environment.embedded.lisp.latex source.lisp.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(lua)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(lua)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.lua
           embed_scope: meta.environment.embedded.lua.latex source.lua.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(obj(?:ective\-|)c)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(obj(?:ective\-|)c)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.objc
           embed_scope: meta.environment.embedded.objc.latex source.objc.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(obj(?:ective\-|)c\+\+)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(obj(?:ective\-|)c\+\+)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.objc++
           embed_scope: meta.environment.embedded.objc++.latex source.objc++.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(perl)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(perl)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.perl
           embed_scope: meta.environment.embedded.perl.latex source.perl.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(php)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(php)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.php
           embed_scope: meta.environment.embedded.php.latex source.php.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(python|py)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(python|py)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.python
           embed_scope: meta.environment.embedded.python.latex source.python.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(r)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(r)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.r
           embed_scope: meta.environment.embedded.r.latex source.r.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(ruby)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(ruby)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.ruby
           embed_scope: meta.environment.embedded.ruby.latex source.ruby.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(sh|shell|bash )(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(sh|shell|bash )(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.shell
           embed_scope: meta.environment.embedded.shell.latex source.shell.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(sql|mysql|ddl|dml)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(sql|mysql|ddl|dml)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.sql
           embed_scope: meta.environment.embedded.sql.latex source.sql.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(xml)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(xml)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:text.xml
           embed_scope: meta.environment.embedded.xml.latex text.xml.embedded
-          escape: '(?=\\end\{minted\})'
-        - match: '(\{)(yaml)(\})'
+          escape: (?=\\end\{minted\})
+        - match: (\{)(yaml)(\})
           captures:
             1: punctuation.definition.group.brace.begin.latex
             2: variable.parameter.function.latex
             3: punctuation.definition.group.brace.end.latex
           embed: scope:source.yaml
           embed_scope: meta.environment.embedded.yaml.latex source.yaml.embedded
-          escape: '(?=\\end\{minted\})'
+          escape: (?=\\end\{minted\})
         - match: ''
           push:
             - meta_scope: meta.environment.embedded.generic.latex markup.raw.verb.latex
-            - match: '(?=\\end\{minted\})'
+            - match: (?=\\end\{minted\})
               pop: true
 
   mint:
@@ -1152,7 +1152,7 @@ contexts:
       push:
         - meta_scope: meta.environment.verbatim.minted.latex
         - include: general-optional-arguments
-        - match: '(\{)(c)(\})((\{)|(\W))'
+        - match: (\{)(c)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1162,11 +1162,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.c
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.c.latex source.c.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(cpp|c\+\+)(\})((\{)|(\W))'
+        - match: (\{)(cpp|c\+\+)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1176,11 +1176,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.c++
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.c++.latex source.c++.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(diff)(\})((\{)|(\W))'
+        - match: (\{)(diff)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1190,11 +1190,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.diff
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.diff.latex source.diff.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(go|golang)(\})((\{)|(\W))'
+        - match: (\{)(go|golang)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1204,11 +1204,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.go
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.go.latex source.go.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(haskell|hs)(\})((\{)|(\W))'
+        - match: (\{)(haskell|hs)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1218,11 +1218,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.haskell
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.haskell.latex source.haskell.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(html)(\})((\{)|(\W))'
+        - match: (\{)(html)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1232,11 +1232,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:text.html.basic
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.html.latex text.html.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(java)(\})((\{)|(\W))'
+        - match: (\{)(java)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1246,11 +1246,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.java
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.java.latex source.java.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(javascript|js)(\})((\{)|(\W))'
+        - match: (\{)(javascript|js)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1260,11 +1260,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.js
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.js.latex source.js.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(json)(\})((\{)|(\W))'
+        - match: (\{)(json)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1274,11 +1274,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.json
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.json.latex source.json.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(tex|latex)(\})((\{)|(\W))'
+        - match: (\{)(tex|latex)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1288,11 +1288,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:text.tex.latex
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.latex.latex text.tex.latex.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(lisp)(\})((\{)|(\W))'
+        - match: (\{)(lisp)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1302,11 +1302,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.lisp
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.lisp.latex source.lisp.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(lua)(\})((\{)|(\W))'
+        - match: (\{)(lua)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1316,11 +1316,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.lua
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.lua.latex source.lua.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(obj(?:ective\-|)c)(\})((\{)|(\W))'
+        - match: (\{)(obj(?:ective\-|)c)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1330,11 +1330,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.objc
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.objc.latex source.objc.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(obj(?:ective\-|)c\+\+)(\})((\{)|(\W))'
+        - match: (\{)(obj(?:ective\-|)c\+\+)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1344,11 +1344,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.objc++
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.objc++.latex source.objc++.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(perl)(\})((\{)|(\W))'
+        - match: (\{)(perl)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1358,11 +1358,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.perl
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.perl.latex source.perl.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(php)(\})((\{)|(\W))'
+        - match: (\{)(php)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1372,11 +1372,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.php
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.php.latex source.php.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(python|py)(\})((\{)|(\W))'
+        - match: (\{)(python|py)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1386,11 +1386,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.python
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.python.latex source.python.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(r)(\})((\{)|(\W))'
+        - match: (\{)(r)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1400,11 +1400,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.r
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.r.latex source.r.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(ruby)(\})((\{)|(\W))'
+        - match: (\{)(ruby)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1414,11 +1414,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.ruby
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.ruby.latex source.ruby.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(sh|shell|bash )(\})((\{)|(\W))'
+        - match: (\{)(sh|shell|bash )(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1428,11 +1428,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.shell
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.shell.latex source.shell.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(sql|mysql|ddl|dml)(\})((\{)|(\W))'
+        - match: (\{)(sql|mysql|ddl|dml)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1442,11 +1442,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.sql
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.sql.latex source.sql.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(xml)(\})((\{)|(\W))'
+        - match: (\{)(xml)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1456,11 +1456,11 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:text.xml
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.xml.latex text.xml.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
-        - match: '(\{)(yaml)(\})((\{)|(\W))'
+        - match: (\{)(yaml)(\})((\{)|(\W))
           scope: meta.environment.verbatim.minted.latex
           captures:
             1: punctuation.definition.group.brace.begin.latex
@@ -1470,7 +1470,7 @@ contexts:
             6: punctuation.definition.verb.latex
           embed: scope:source.yaml
           embed_scope: meta.environment.verbatim.minted.latex meta.environment.embedded.yaml.latex source.yaml.embedded
-          escape: '(\})|(\4)'
+          escape: (\})|(\4)
           escape_captures:
             1: punctuation.definition.group.brace.begin.latex
             2: punctuation.definition.verb.latex
@@ -1479,18 +1479,18 @@ contexts:
 
   # comment package
   pkgcomment:
-    - match: '^(\\)comment\b'
+    - match: ^(\\)comment\b
       captures:
         0: punctuation.definition.comment.start.latex
         1: punctuation.definition.backslash.latex
       push:
         - meta_scope: meta.environment.comment.latex comment.block.command.comment.latex
-        - match: '^(\\)endcomment\b'
+        - match: ^(\\)endcomment\b
           captures:
             0: punctuation.definition.comment.end.latex
             1: punctuation.definition.backslash.latex
           pop: true
-    - match: '((\\)begin)(\{)\s*(comment)\s*(\})'
+    - match: ((\\)begin)(\{)\s*(comment)\s*(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -1500,7 +1500,7 @@ contexts:
       push:
         - meta_scope: meta.environment.comment.latex
         - meta_content_scope: comment.block.environment.comment.latex
-        - match: '((\\)end)(\{)\s*(comment)\s*(\})'
+        - match: ((\\)end)(\{)\s*(comment)\s*(\})
           captures:
             1: support.function.end.latex keyword.control.flow.end.latex
             2: punctuation.definition.backslash.latex
@@ -1511,7 +1511,7 @@ contexts:
 
   # beamer support
   beamer:
-    - match: '((\\)begin)(\{)(frame)(\})'
+    - match: ((\\)begin)(\{)(frame)(\})
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex
@@ -1520,7 +1520,7 @@ contexts:
         5: punctuation.definition.group.brace.end.latex
       push:
         - meta_scope: meta.environment.frame.latex
-        - match: '((\\)end)(\{)(frame)(\})'
+        - match: ((\\)end)(\{)(frame)(\})
           captures:
             1: support.function.end.latex keyword.control.flow.end.latex
             2: punctuation.definition.backslash.latex
@@ -1532,7 +1532,7 @@ contexts:
         - include: main
 
   frametitles:
-    - match: '((\\)frametitle)(\{)(.*)(\})'
+    - match: ((\\)frametitle)(\{)(.*)(\})
       scope: meta.function.frametitle.latex
       captures:
        1: support.function.frametitle.latex
@@ -1591,16 +1591,16 @@ contexts:
         7: punctuation.definition.group.bracket.end.latex
       push:
         - meta_scope: meta.environment.tabular.latex
-        - match: '\{'
+        - match: \{
           scope: meta.function.column-spec.latex punctuation.definition.group.brace.begin.latex
           set:
             - meta_content_scope: meta.environment.tabular.latex meta.function.column-spec.latex
             - include: array-preamble
-            - match: '\}'
+            - match: \}
               scope: punctuation.definition.group.brace.end.latex
               set:
                 - meta_content_scope: meta.environment.tabular.latex
-                - match: '((\\)end)(\{)(tabular)(\})'
+                - match: ((\\)end)(\{)(tabular)(\})
                   scope: meta.environment.tabular.latex
                   captures:
                     1: support.function.end.latex keyword.control.flow.end.latex
@@ -1613,98 +1613,98 @@ contexts:
 
 
   array-preamble:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
         - include: general-commands
         - include: array-preamble
 
-    - match: 'l|r|c'
+    - match: l|r|c
       scope: keyword.other.column-type.latex
 
-    - match: '(?:p|m|b)(?=\s*\{)'
+    - match: (?:p|m|b)(?=\s*\{)
       scope: support.function.parbox-column.latex
       push:
         - [{meta_scope: meta.function.parbox-column.latex}, {match: '', pop: true}]
         - argument
 
-    - match: '(>)\s*(\{)'
+    - match: (>)\s*(\{)
       captures:
         1: support.function.insert-before-column.latex
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.before-column-decl.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
         - include: general-commands
         - include: macro-braces
 
-    - match: '(<)\s*(\{)'
+    - match: (<)\s*(\{)
       captures:
         1: support.function.insert-after-column.latex
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.after-column-decl.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
         - include: general-commands
         - include: macro-braces
 
-    - match: '\|'
+    - match: \|
       scope: keyword.operator.inter-column-line.latex
 
-    - match: '(@)\s*(\{)'
+    - match: (@)\s*(\{)
       captures:
         1: support.function.inter-column-nospace.latex
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
         - include: general-commands
         - include: macro-braces
 
-    - match: '(!)\s*(\{)'
+    - match: (!)\s*(\{)
       captures:
         1: support.function.inter-column.latex
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           pop: true
         - include: general-constants
         - include: general-commands
         - include: macro-braces
 
-    - match: '(\*)\s*(\{)'
+    - match: (\*)\s*(\{)
       captures:
         1: support.function.insert-repeated.latex
         2: meta.function.insert-repeated-count.latex punctuation.definition.group.brace.begin.latex
       push:
         - meta_content_scope: meta.function.insert-repeated-count.latex
-        - match: '\d+'
+        - match: \d+
           scope: constant.numeric.array-count.latex
         - include: general-commands
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.latex
           set:
-            - match: '\{'
+            - match: \{
               scope: meta.function.insert-repeated-content.latex punctuation.definition.group.brace.begin.latex
               set:
                 - meta_content_scope: meta.function.insert-repeated-content.latex
                 - include: array-preamble
-                - match: '\}'
+                - match: \}
                   scope: meta.function.insert-repeated-content.latex punctuation.definition.group.brace.end.latex
                   pop: true
             - match: ''

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -69,7 +69,7 @@ contexts:
     - include: general-commands
 
   general-commands:
-    - match: '(\\)[A-Za-z@]+'
+    - match: (\\)[A-Za-z@]+
       scope: support.function.general.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -77,7 +77,7 @@ contexts:
   general-constants:
     - match: \\\\
       scope: constant.character.newline.tex
-    - match: '(\\)[^A-Za-z@]'
+    - match: (\\)[^A-Za-z@]
       scope: constant.character.escape.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -95,7 +95,7 @@ contexts:
       captures:
         1: keyword.control.tex
         2: punctuation.definition.backslash.tex
-    - match: '((\\)(?:input))\b'
+    - match: ((\\)(?:input))\b
       scope: meta.function.input.tex
       captures:
         1: keyword.control.input.tex
@@ -110,11 +110,11 @@ contexts:
         3: constant.numeric.category.tex
 
   braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.tex
           pop: true
         - include: main
@@ -123,11 +123,11 @@ contexts:
   # is present. To prevent this from causing problems, here we only match
   # elements that are simple, i.e. that do not push to the stack.
   macro-braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.tex
           pop: true
         - include: general-constants
@@ -135,20 +135,20 @@ contexts:
         - include: macro-braces
 
   boxes:
-    - match: '((\\)[hv]box)\s*(\{)'
+    - match: ((\\)[hv]box)\s*(\{)
       captures:
         1: support.function.box.tex
         2: punctuation.definition.backslash.tex
         3: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.function.box.tex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.tex
           pop: true
         - include: main
 
   macros:
-    - match: '(\\def)\s*((\\)[A-Za-z@]+)\s*[^\{]*?\s*(\{)'
+    - match: (\\def)\s*((\\)[A-Za-z@]+)\s*[^\{]*?\s*(\{)
       captures:
         1: support.function.definition.tex storage.modifier.definition.tex
         2: support.function.general.tex entity.name.definition.tex
@@ -156,7 +156,7 @@ contexts:
         4: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.function.definition.tex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.tex
           pop: true
         - include: general-constants
@@ -229,7 +229,7 @@ contexts:
         1: punctuation.definition.backslash.tex
 
   math-commands:
-    - match: '(\\)[A-Za-z@]+'
+    - match: (\\)[A-Za-z@]+
       scope: support.function.math.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -239,11 +239,11 @@ contexts:
       scope: keyword.operator.math.tex
 
   math-braces:
-    - match: '\{'
+    - match: \{
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: '\}'
+        - match: \}
           scope: punctuation.definition.group.brace.end.tex
           pop: true
         - include: math-content
@@ -253,17 +253,17 @@ contexts:
       scope: constant.character.parenthesis.tex
     - match: '[\[\]]'
       scope: constant.character.bracket.tex
-    - match: '(\\)[\{\}]'
+    - match: (\\)[\{\}]
       scope: constant.character.brace.escape.tex
       captures:
         1: punctuation.definition.backslash.brace.escape.tex
 
   math-numerics:
-    - match: '(([[:digit:]]*\.[[:digit:]]+)|[[:digit:]]+)'
+    - match: (([[:digit:]]*\.[[:digit:]]+)|[[:digit:]]+)
       scope: constant.numeric.math.tex
 
   math-characters:
-    - match: "[A-Za-z]+"
+    - match: '[A-Za-z]+'
       scope: variable.other.math.tex
 
   math-content:


### PR DESCRIPTION
Following the discussion in #3508, this is a small PR that removes quotation marks around match patterns in (La)TeX's syntax definition.