### PR TITLE
[TeX] improved support for \def and friends

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -62,6 +62,8 @@ variables:
   # type names, and if they were highlighted wrongly the user could not fix this.
   letter: '[A-Za-z@]'
   nonletter: '[^A-Za-z@]'
+  # look-ahead for end of command sequence
+  endcs: '(?!{{letter}})'
 
 contexts:
   prototype:
@@ -114,11 +116,11 @@ contexts:
       scope: comment.line.percentage.tex
 
   controls:
-    - match: ((\\)(else|expandafter|fi|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?))\b
+    - match: ((\\)(else|expandafter|fi|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)){{endcs}}
       captures:
         1: keyword.control.tex
         2: punctuation.definition.backslash.tex
-    - match: ((\\)(?:input))\b
+    - match: ((\\)(?:input)){{endcs}}
       scope: meta.function.input.tex
       captures:
         1: keyword.control.input.tex
@@ -176,7 +178,7 @@ contexts:
     # so syntax highlighting will work properly with correct code.
     # we need to make sure to match only full commands, so we look-ahead for
     # any following non-letter
-    - match: (\\)[gex]?def(?={{nonletter}})
+    - match: (\\)[gex]?def{{endcs}}
       scope: keyword.declaration.function.tex storage.modifier.definition.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -245,61 +247,61 @@ contexts:
     - include: math-delimiters
 
   math-greeks:
-    - match: (\\){{greeks}}(?=\b|_)
+    - match: (\\){{greeks}}{{endcs}}
       scope: keyword.other.math.greek.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-functions:
-    - match: (\\){{mathfun}}(?=\b|_)
+    - match: (\\){{mathfun}}{{endcs}}
       scope: keyword.other.math.function.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-relations:
-    - match: (\\){{relations}}(?=\b|_)
+    - match: (\\){{relations}}{{endcs}}
       scope: keyword.other.math.relation.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-largeops:
-    - match: (\\){{largeops}}(?=\b|_)
+    - match: (\\){{largeops}}{{endcs}}
       scope: keyword.other.math.large-operator.tex
       captures:
         1: punctuation.definition.backslash.texpunctuation.definition.backslash.tex
 
   math-binops:
-    - match: (\\){{binops}}(?=\b|_)
+    - match: (\\){{binops}}{{endcs}}
       scope: keyword.other.math.binary-operator.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-symbols:
-    - match: (\\){{symbols}}(?=\b|_)
+    - match: (\\){{symbols}}{{endcs}}
       scope: keyword.other.math.symbol.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-accents:
-    - match: (\\){{accents}}(?=\b|_)
+    - match: (\\){{accents}}{{endcs}}
       scope: keyword.other.math.accent.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-arrows:
-    - match: (\\){{arrows}}(?=\b|_)
+    - match: (\\){{arrows}}{{endcs}}
       scope: keyword.other.math.arrow.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-delimiters:
-    - match: (\\){{delimiters}}(?=\b|_)
+    - match: (\\){{delimiters}}{{endcs}}
       scope: keyword.other.math.delimiter.tex
       captures:
         1: punctuation.definition.backslash.tex
 
   math-commands:
-    - match: (\\)[A-Za-z@]+
+    - match: (\\){{letter}}+
       scope: support.function.math.tex
       captures:
         1: punctuation.definition.backslash.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -53,6 +53,16 @@ variables:
     (?x: lbrack | lbrace | langle | rbrack | rbrace | rangle
     | vert | lfloor | lceil | Vert | rfloor | rceil)
 
+  # letters in the sense of macro names. Whether @ is a letter or not can vary
+  # from a syntax-highlighting perspective, however, we are much safer to
+  # assume it is a letter. Situations where we have `\macro` followed immediately
+  # by `@text` that is to be typeset should be very rare, and if it happens, the
+  # user can still put an explicit space (ignored by TeX) to ensure correct
+  # highlighting. On the other hand, within packages we get lots of \module@macro
+  # type names, and if they were highlighted wrongly the user could not fix this.
+  letter: '[A-Za-z@]'
+  nonletter: '[^A-Za-z@]'
+
 contexts:
   prototype:
     - include: comments
@@ -68,8 +78,18 @@ contexts:
     - include: general-constants
     - include: general-commands
 
+  # matches any nospace and pops the context
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  # pops out of the current context if there is a new paragraph
+  paragraph-pop:
+    - match: ^(?=\s*$)
+      pop: true
+
   general-commands:
-    - match: (\\)[A-Za-z@]+
+    - match: (\\){{letter}}+
       scope: support.function.general.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -77,14 +97,17 @@ contexts:
   general-constants:
     - match: \\\\
       scope: constant.character.newline.tex
-    - match: (\\)[^A-Za-z@]
-      scope: constant.character.escape.tex
-      captures:
-        1: punctuation.definition.backslash.tex
     - match: '&'
       scope: constant.character.ampersand.tex
     - match: '~'
       scope: constant.character.space.tex
+    - include: escaped-character
+
+  escaped-character:
+    - match: (\\){{nonletter}}
+      scope: constant.character.escape.tex
+      captures:
+        1: punctuation.definition.backslash.tex
 
   comments:
     - match: '%.*$\n?'
@@ -148,21 +171,67 @@ contexts:
         - include: main
 
   macros:
-    - match: ((\\)def)\s*((\\)[A-Za-z@]+)\s*[^\{]*?\s*(\{)
+    # Note \edef and \xdef have slightly different syntax, in that they do not
+    # allow for arguments. However, every valid \edef could be a valid \def,
+    # so syntax highlighting will work properly with correct code.
+    # we need to make sure to match only full commands, so we look-ahead for
+    # any following non-letter
+    - match: (\\)[gex]?def(?={{nonletter}})
+      scope: keyword.declaration.function.tex storage.modifier.definition.tex
       captures:
-        1: support.function.definition.tex storage.modifier.definition.tex
-        2: punctuation.definition.backslash.tex
-        3: support.function.general.tex entity.name.definition.tex
-        4: punctuation.definition.backslash.tex
-        5: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.definition.tex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: true
-        - include: general-constants
-        - include: general-commands
-        - include: macro-braces
+        1: punctuation.definition.backslash.tex
+      push: def-commandname
+
+  def-commandname:
+    - meta_scope: meta.function.tex
+    - match: (?=\\)
+      set:
+        - clear_scopes: 1
+        - meta_scope: meta.function.identifier.tex
+        - match: (\\){{letter}}+
+          scope: entity.name.definition.tex
+          captures:
+            1: punctuation.definition.backslash.tex
+          set: def-argspec
+        - match: (\\){{nonletter}}
+          scope: entity.name.definition.tex
+          captures:
+            1: punctuation.definition.backslash.tex
+          set: def-argspec
+        - include: paragraph-pop
+        - include: else-pop
+    - include: paragraph-pop
+    - include: else-pop
+
+  def-argspec:
+    - clear_scopes: 1
+    - meta_content_scope: meta.function.parameters.tex
+    - include: escaped-character
+    - match: (?=\{)
+      scope: punctuation.definition.group.bracket.end.tex
+      set: def-definition
+    - match: (\#)[0-9]
+      scope: variable.parameter.tex
+      captures:
+        1: punctuation.definition.variable.tex
+    - include: paragraph-pop
+
+  def-definition:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      set: def-definition-body
+    - include: paragraph-pop
+    - include: else-pop
+
+  def-definition-body:
+    - meta_scope: meta.function.body.tex meta.group.brace.tex
+    - match: \}
+      scope: punctuation.definition.group.brace.end.tex
+      pop: 1
+    - include: general-constants
+    - include: general-commands
+    - include: macro-braces
+
 
   math-builtin:
     - include: math-greeks

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -1,0 +1,113 @@
+% SYNTAX TEST "Packages/LaTeX/TeX.sublime-syntax"
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Macro definitions - \def, \gdef, \edef, \xdef
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Check the main scopes
+  \def\macro{replacement}
+% ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%            ^^^^^^^^^^^^ meta.function.body.tex
+
+% Check puncutation scopes
+  \def\macro{replacement}
+% ^ punctuation.definition.backslash.tex
+%     ^ punctuation.definition.backslash.tex
+%           ^ punctuation.definition.group.brace.begin.tex
+%                       ^ punctuation.definition.group.brace.end.tex
+
+
+% examples taken from https://en.wikibooks.org/wiki/TeX/def
+
+% With spaces and parameter specification
+ \def \foo [#1]#2{The first argument is ``#1'', the second one is ``#2''}
+%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^^ meta.function.tex
+%     ^^^^ meta.function.identifier.tex entity.name.definition.tex
+%         ^^^^^^^ meta.function.parameters.tex -meta.function.tex
+%           ^^ variable.parameter.tex
+%              ^^ variable.parameter.tex
+%                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
+
+% With line continuation
+ \def \foo [#1]#2%
+%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^^meta.function.tex
+%     ^^^^ meta.function.identifier.tex entity.name.definition.tex
+%         ^^^^^^^ meta.function.parameters.tex
+%                ^^ comment.line.percentage.tex
+  {The first argument is ``#1''.
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
+  The second one is ``#2''}
+% ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
+
+% With nested braces
+ \def \author {William {\sc Smith}}
+%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^^ meta.function.tex
+%     ^^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%            ^ meta.function.parameters.tex
+%             ^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
+
+
+% gdef as a global variation of def
+ \gdef\macro{replacement}
+%^^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%            ^^^^^^^^^^^^ meta.function.body.tex
+
+% edef as an immediately expanded version of def. Note that here, 
+% argument specifications would not be allowed by TeX.
+ \edef\macro{replacement}
+%^^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%            ^^^^^^^^^^^^ meta.function.body.tex
+
+
+
+% And now, the really weird cases
+%  escaped characters in the argument specification
+%   hash
+ \def\macro\#1#1{replacement}
+%          ^^^^^ meta.function.parameters.tex
+%          ^^ constant.character.escape.tex
+%            ^ - variable.parameter.tex
+%             ^^ variable.parameter.tex
+
+%   open-brace
+ \def\macro\{#1{replacement}
+%          ^^^^ meta.function.parameters.tex
+%          ^^ constant.character.escape.tex
+%            ^^ variable.parameter.tex
+%              ^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+
+
+%    double escape
+ \def\macro\\#1{replacement}
+%          ^^^^ meta.function.parameters.tex
+%          ^^constant.character.escape.tex
+%            ^^ variable.parameter.tex
+
+
+%  defining special character macros
+ \def\_{underscore}
+%^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%    ^^ meta.function.identifier.tex entity.name.definition.tex
+%      ^^^^^^^^^^^^ meta.function.body.tex
+
+%  stop scope for incomplete defs
+\def\text 
+
+some other text
+% ^^^^^^^^^^^^^^ - meta.function%
+
+%  incomplete but with parameters; the { comes too late to open the function definition
+\def\text A#1A
+
+  { some other text
+% ^^^^^^^^^^^^^^ - meta.function
+
+%  command just prefixed with def. Needs to be picked up as a custom command
+\deftext
+%^^^^^^^ support.function.general.tex

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -111,3 +111,11 @@ some other text
 %  command just prefixed with def. Needs to be picked up as a custom command
 \deftext
 %^^^^^^^ support.function.general.tex
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Control flow / Conditionals
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\fi@other
+%^^ - keyword


### PR DESCRIPTION
Improvements:
* Added better scoping for argument specifications of `\def`
* Allowed `\def` also for backslash+nonletter type commands
* Accept `\def`, `\edef`, `\gdef`, and `\xdef`
* Started a `syntax-test-tex.tex` file

I've tried to implement this like the LaTeX `\newcommand` #3508, i.e. with multiple pushes, but could not get the scopes to work, so right now this is a chain of `set`s.

The `\edef` and `\xdef` variations are slightly different in terms of TeX, as they do not accept arguments, but based on the not-a-linter argument I've decided to go with the simpler implementation that treats all these as the same. For correct code, this does not make a difference. 

 