### PR TITLE
[Python] Refactor string contexts to support inheritance

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1940,29 +1940,33 @@ contexts:
         )__\b
       scope: support.variable.magic.python
 
+###[ STRINGS ]################################################################
+
   docstrings:
-    - match: ^\s*(?=(?i)(ur|ru|u|r)?("""|'''))
-      push:
-      - match: (?i)(u)?("""|''')
-        captures:
-          1: storage.type.string.python
-          2: punctuation.definition.comment.begin.python
-        set:
-          - meta_scope: comment.block.documentation.python
-          - include: escaped-unicode-char
-          - include: escaped-char
-          - match: '\2'
-            scope: punctuation.definition.comment.end.python
-            pop: true
-      - match: (?i)(u?ru?)("""|''')
-        captures:
-          1: storage.type.string.python
-          2: punctuation.definition.comment.begin.python
-        set:
-          - meta_scope: comment.block.documentation.python
-          - match: '\2'
-            scope: punctuation.definition.comment.end.python
-            pop: true
+    - match: ^\s*(?i)(u)?("""|''')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.comment.begin.python
+      push: inside-docstring
+    - match: ^\s*(?i)(ur|ru?)("""|''')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.comment.begin.python
+      push: inside-raw-docstring
+
+  inside-docstring:
+    - meta_scope: comment.block.documentation.python
+    - match: \2
+      scope: punctuation.definition.comment.end.python
+      pop: true
+    - include: escaped-unicode-char
+    - include: escaped-char
+
+  inside-raw-docstring:
+    - meta_scope: comment.block.documentation.python
+    - match: \2
+      scope: punctuation.definition.comment.end.python
+      pop: true
 
   escaped-char:
     - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2226,12 +2226,14 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
 
   double-quoted-string-pop:
     - match: (?="|\n)
       pop: true
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
 
   double-quoted-plain-raw-b-strings:
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -2343,7 +2345,8 @@ contexts:
     - match: '"'
       scope: string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2417,7 +2420,8 @@ contexts:
     - match: '"'
       scope: string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2669,12 +2673,14 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
 
   single-quoted-string-pop:
     - match: (?='|\n)
       pop: true
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
 
   single-quoted-plain-raw-b-strings:
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -2755,7 +2761,8 @@ contexts:
     - match: "'"
       scope: string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2861,7 +2868,8 @@ contexts:
     - match: "'"
       scope: string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
-    - include: string-continuation-or-illegal-end
+    - include: illegal-string-end
+    - include: string-continuations
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2876,17 +2884,18 @@ contexts:
 
 ###[ STRING CONTENTS ]########################################################
 
-  string-continuations:
-    - match: \\$
-      scope: punctuation.separator.continuation.line.python
-
-  string-continuation-or-illegal-end:
-    - match: (\\)$\n?
-      captures:
-        1: punctuation.separator.continuation.line.python
+  illegal-string-end:
     - match: \n
       scope: invalid.illegal.unclosed-string.python
       set: after-expression
+
+  string-continuations:
+    - match: \\$
+      scope: punctuation.separator.continuation.line.python
+      push:
+        - meta_include_prototype: false
+        - match: ^
+          pop: 1
 
   escaped-chars:
     - match: \\x\h{2}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2140,7 +2140,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-chars
     - include: string-placeholders
     - include: string-replacements
@@ -2157,7 +2157,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2175,7 +2175,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: triple-double-quoted-u-string-syntax
 
   triple-double-quoted-u-string-syntax:
@@ -2203,7 +2203,7 @@ contexts:
         - include: triple-double-quoted-plain-u-string-content
 
   triple-double-quoted-plain-u-string-content:
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-unicode-chars
     - include: escaped-chars
     - include: string-placeholders
@@ -2226,12 +2226,12 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
 
   double-quoted-string-pop:
     - match: (?="|\n)
       pop: true
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
 
   double-quoted-plain-raw-b-strings:
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -2343,7 +2343,7 @@ contexts:
     - match: '"'
       scope: string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2417,7 +2417,7 @@ contexts:
     - match: '"'
       scope: string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2583,7 +2583,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-chars
     - include: string-placeholders
     - include: string-replacements
@@ -2600,7 +2600,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2618,7 +2618,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: triple-single-quoted-u-string-syntax
 
   triple-single-quoted-u-string-syntax:
@@ -2646,7 +2646,7 @@ contexts:
         - include: triple-single-quoted-u-string-content
 
   triple-single-quoted-u-string-content:
-    - include: line-continuation-inside-block-string
+    - include: string-continuations
     - include: escaped-unicode-chars
     - include: escaped-chars
     - include: string-placeholders
@@ -2669,12 +2669,12 @@ contexts:
     - match: "'"
       scope: punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
 
   single-quoted-string-pop:
     - match: (?='|\n)
       pop: true
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
 
   single-quoted-plain-raw-b-strings:
     # Single-line capital R raw string, bytes, no syntax embedding
@@ -2755,7 +2755,7 @@ contexts:
     - match: "'"
       scope: string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2861,7 +2861,7 @@ contexts:
     - match: "'"
       scope: string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
-    - include: line-continuation-inside-string
+    - include: string-continuation-or-illegal-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2876,11 +2876,11 @@ contexts:
 
 ###[ STRING CONTENTS ]########################################################
 
-  line-continuation-inside-block-string:
+  string-continuations:
     - match: \\$
       scope: punctuation.separator.continuation.line.python
 
-  line-continuation-inside-string:
+  string-continuation-or-illegal-end:
     - match: (\\)$\n?
       captures:
         1: punctuation.separator.continuation.line.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1940,7 +1940,7 @@ contexts:
         )__\b
       scope: support.variable.magic.python
 
-###[ STRINGS ]################################################################
+###[ DOCSTRINGS ]#############################################################
 
   docstrings:
     - match: ^\s*(?i)(u)?("""|''')
@@ -1967,6 +1967,8 @@ contexts:
     - match: \2
       scope: punctuation.definition.comment.end.python
       pop: true
+
+###[ STRING CONTENTS ]########################################################
 
   escaped-char:
     - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
@@ -2186,12 +2188,16 @@ contexts:
       scope: punctuation.section.interpolation.end.python
       pop: 2
 
+###[ STRINGS ]################################################################
+
   strings:
     # triple-quoted versions must be matched first
     - include: triple-double-quoted-strings
     - include: double-quoted-strings
     - include: triple-single-quoted-strings
     - include: single-quoted-strings
+
+###[ TRIPLE DOUBLE QUOTED STRINGS ]###########################################
 
   triple-double-quoted-strings:
     - include: triple-double-quoted-plain-raw-b-strings
@@ -2412,6 +2418,8 @@ contexts:
     - include: escaped-char
     - include: constant-placeholder
 
+###[ DOUBLE QUOTED STRINGS ]##################################################
+
   double-quoted-strings:
     - include: double-quoted-plain-raw-b-strings
     - include: double-quoted-raw-b-strings
@@ -2627,6 +2635,8 @@ contexts:
     - include: escaped-unicode-char
     - include: escaped-char
     - include: constant-placeholder
+
+###[ TRIPLE SINGLE QUOTED STRINGS ]###########################################
 
   triple-single-quoted-strings:
     - include: triple-single-quoted-plain-raw-b-strings
@@ -2844,6 +2854,8 @@ contexts:
     - include: escaped-unicode-char
     - include: escaped-char
     - include: constant-placeholder
+
+###[ SINGLE QUOTED STRINGS ]##################################################
 
   single-quoted-strings:
     - include: single-quoted-plain-raw-b-strings

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2182,655 +2182,881 @@ contexts:
       scope: punctuation.section.interpolation.end.python
       pop: 2
 
-  string-quoted-double-block:
-    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
+  strings:
+    # triple-quoted versions must be matched first
+    - include: triple-double-quoted-strings
+    - include: double-quoted-strings
+    - include: triple-single-quoted-strings
+    - include: single-quoted-strings
+
+  triple-double-quoted-strings:
+    - include: triple-double-quoted-plain-raw-b-strings
+    - include: triple-double-quoted-raw-b-strings
+    - include: triple-double-quoted-plain-raw-f-strings
+    - include: triple-double-quoted-raw-f-strings
+    - include: triple-double-quoted-plain-raw-u-strings
+    - include: triple-double-quoted-raw-u-strings
+    - include: triple-double-quoted-b-strings
+    - include: triple-double-quoted-f-strings
+    - include: triple-double-quoted-u-strings
+
+  triple-double-quoted-string-end:
+    - match: '"""'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+
+  triple-double-quoted-string-pop:
+    - match: (?=""")
+      pop: true
+
+  triple-double-quoted-plain-raw-b-strings:
     # Triple-quoted capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])(""")'
+    - match: ([bB]R|R[bB])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
-    - match: '([uU]?r)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: '"""'
-              scope: string.quoted.double.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: escaped-unicode-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.double.block.python
-            - match: '"""'
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.regexp.python
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: escaped-unicode-char
+      push: inside-triple-double-quoted-plain-raw-b-string
+
+  inside-triple-double-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+
+  triple-double-quoted-raw-b-strings:
     # Triple-quoted raw string, bytes, will use regex
-    - match: '([bB]r|r[bB])(""")'
+    - match: ([bB]r|r[bB])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?=""")
+      push: inside-triple-double-quoted-raw-b-string
+
+  inside-triple-double-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?=""")
+
+  triple-double-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
     - match: ([fF]R|R[fF])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: f-string-content
+      push: inside-triple-double-quoted-plain-raw-f-string
+
+  inside-triple-double-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: f-string-content
+
+  triple-double-quoted-raw-f-strings:
     # Triple-quoted raw f-string, treated as regex
     - match: ([fF]r|r[fF])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=""")'
-              pop: true
-            - include: f-string-content-with-regex
+      push: inside-triple-double-quoted-raw-f-string
+
+  inside-triple-double-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: f-string-content-with-regex
+
+  triple-double-quoted-plain-raw-u-strings:
+    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-plain-raw-u-string
+
+  inside-triple-double-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: escaped-unicode-char
+
+  triple-double-quoted-raw-u-strings:
+    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
+    - match: ([uU]?r)(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-raw-u-string
+
+  inside-triple-double-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-raw-u-string-syntax
+
+  triple-double-quoted-raw-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-double-quoted-sql-raw-u-string
+    - match: (?=\S)
+      set: inside-triple-double-quoted-regexp-raw-u-string
+
+  inside-triple-double-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"""'
+      scope: string.quoted.double.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: escaped-unicode-char
+        - include: constant-placeholder
+
+  inside-triple-double-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - match: '"""'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: escaped-unicode-char
+
+  triple-double-quoted-b-strings:
+    # Triple-quoted string, bytes, no syntax embedding
+    - match: ([bB])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-b-string
+
+  inside-triple-double-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: escaped-char
+    - include: constant-placeholder
+
+  triple-double-quoted-f-strings:
     # Triple-quoted f-string
     - match: ([fF])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: f-string-content
-    # Triple-quoted string, unicode or not, will detect SQL
-    - match: '([uU]?)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: '"""'
-              scope: string.quoted.double.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: line-continuation-inside-block-string
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.double.block.python
-            - match: '"""'
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - include: line-continuation-inside-block-string
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: constant-placeholder
-    # Triple-quoted string, bytes, no syntax embedding
-    - match: '([bB])(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-char
-        - include: constant-placeholder
+      push: inside-triple-double-quoted-f-string
 
-  string-quoted-double:
-    # Single-line capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)(")'
+  inside-triple-double-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: escaped-fstring-escape
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: f-string-content
+
+  triple-double-quoted-u-strings:
+    # Triple-quoted string, unicode or not, will detect SQL
+    - match: ([uU]?)(""")
       captures:
         1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-u-string
+
+  inside-triple-double-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: triple-double-quoted-u-string-syntax
+
+  triple-double-quoted-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-double-quoted-sql-u-strings
+    - match: (?=\S)
+      set: inside-double-quoted-plain-u-block-string
+
+  inside-double-quoted-plain-u-block-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-plain-u-string-content
+
+  inside-triple-double-quoted-sql-u-strings:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"""'
+      scope: string.quoted.double.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: triple-double-quoted-plain-u-string-content
+
+  triple-double-quoted-plain-u-string-content:
+    - include: line-continuation-inside-block-string
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: constant-placeholder
+
+  double-quoted-strings:
+    - include: double-quoted-plain-raw-b-strings
+    - include: double-quoted-raw-b-strings
+    - include: double-quoted-plain-raw-f-strings
+    - include: double-quoted-raw-f-strings
+    - include: double-quoted-plain-raw-u-strings
+    - include: double-quoted-raw-u-strings
+    - include: double-quoted-b-strings
+    - include: double-quoted-f-strings
+    - include: double-quoted-u-strings
+
+  double-quoted-string-end:
+    - match: '"'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+
+  double-quoted-string-pop:
+    - match: (?="|\n)
+      pop: true
+    - include: line-continuation-inside-string
+
+  double-quoted-plain-raw-b-strings:
     # Single-line capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])(")'
+    - match: ([bB]R|R[bB])(")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?r)(")(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: '"'
-          scope: string.quoted.double.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: constant-placeholder
-            - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, treated as regex
-    - match: '([uU]?r)(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: line-continuation-inside-string
+      push: inside-double-quoted-plain-raw-b-string
+
+  inside-double-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+
+  double-quoted-raw-b-strings:
     # Single-line raw string, bytes, treated as regex
-    - match: '([bB]r|r[bB])(")'
+    - match: ([bB]r|r[bB])(")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?="|\n)
+      push: inside-double-quoted-raw-b-string
+
+  inside-double-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?="|\n)
+
+  double-quoted-plain-raw-f-strings:
     # Single-line raw f-string
     - match: (R[fF]|[fF]R)(")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - include: f-string-content
+      push: inside-double-quoted-plain-raw-f-string
+
+  inside-double-quoted-plain-raw-f-string:
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - meta_include_prototype: false
+    - include: double-quoted-string-end
+    - include: f-string-content
+
+  double-quoted-raw-f-strings:
     # Single-line raw f-string, treated as regex
     - match: (r[fF]|[fF]r)(")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-            - include: f-string-content-with-regex
+      push: inside-double-quoted-raw-f-string
+
+  inside-double-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: f-string-content-with-regex
+
+  double-quoted-plain-raw-u-strings:
+    # Single-line capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-plain-raw-u-string
+
+  inside-double-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+
+  double-quoted-raw-u-strings:
+    - match: ([uU]?r)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-raw-u-string
+
+  inside-double-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: double-quoted-string-end
+    - include: double-quoted-raw-u-string-syntax
+
+  double-quoted-raw-u-string-syntax:
+    # Single-line raw string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-double-quoted-sql-raw-u-string
+    # Single-line raw string, unicode or not, treated as regex
+    - match: (?=\S)
+      set: inside-double-quoted-regexp-raw-u-string
+
+  inside-double-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: double-quoted-string-pop
+
+  inside-double-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"'
+      scope: string.quoted.double.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: constant-placeholder
+
+  double-quoted-b-strings:
+    # Single-line string, bytes
+    - match: ([bB])(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-b-string
+
+  inside-double-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: escaped-char
+    - include: constant-placeholder
+
+  double-quoted-f-strings:
     # Single-line f-string
     - match: ([fF])(")
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?)(")(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: '"'
-          scope: string.quoted.double.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line string, unicode or not
-    - match: '([uU]?)(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-    # Single-line string, bytes
-    - match: '([bB])(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
+      push: inside-double-quoted-f-string
 
-  string-quoted-single-block:
-    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
-    - match: ([uU]?R)(''')
+  inside-double-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: escaped-fstring-escape
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: f-string-content
+
+  double-quoted-u-strings:
+    - match: ([uU]?)(")
       captures:
         1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-u-string
+
+  inside-double-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: double-quoted-string-end
+    - include: double-quoted-u-string-syntax
+
+  double-quoted-u-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-double-quoted-sql-u-string
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: inside-double-quoted-plain-u-string
+
+  inside-double-quoted-plain-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: double-quoted-u-string-content
+
+  inside-double-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"'
+      scope: string.quoted.double.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: double-quoted-u-string-content
+
+  double-quoted-u-string-content:
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: constant-placeholder
+
+  triple-single-quoted-strings:
+    - include: triple-single-quoted-plain-raw-b-strings
+    - include: triple-single-quoted-raw-b-strings
+    - include: triple-single-quoted-plain-raw-f-strings
+    - include: triple-single-quoted-raw-f-strings
+    - include: triple-single-quoted-plain-raw-u-strings
+    - include: triple-single-quoted-raw-u-strings
+    - include: triple-single-quoted-b-strings
+    - include: triple-single-quoted-f-strings
+    - include: triple-single-quoted-u-strings
+
+  triple-single-quoted-string-end:
+    - match: "'''"
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+
+  triple-single-quoted-string-pop:
+    - match: (?=''')
+      pop: true
+
+  triple-single-quoted-plain-raw-b-strings:
     # Triple-quoted capital R raw string, bytes, no syntax embedding
     - match: ([bB]R|R[bB])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
-    - match: ([uU]?r)(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: "'''"
-              scope: string.quoted.single.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.single.block.python
-            - match: "'''"
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.regexp.python
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: escaped-unicode-char
+      push: inside-triple-single-quoted-plain-raw-b-string
+
+  inside-triple-single-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+
+  triple-single-quoted-raw-b-strings:
     # Triple-quoted raw string, bytes, will use regex
     - match: ([bB]r|r[bB])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?=''')
+      push: inside-triple-single-quoted-raw-b-string
+
+  inside-triple-single-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?=''')
+
+  triple-single-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
     - match: ([fF]R|R[fF])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: f-string-content
+      push: inside-triple-single-quoted-plain-raw-f-string
+
+  inside-triple-single-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: f-string-content
+
+  triple-single-quoted-raw-f-strings:
     # Triple-quoted raw f-string, treated as regex
     - match: ([fF]r|r[fF])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: (?=''')
-              pop: true
-            - include: f-string-content-with-regex
-    # Triple-quoted f-string
-    - match: ([fF])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: f-string-content
-    # Triple-quoted string, unicode or not, will detect SQL
-    - match: ([uU]?)(''')
+      push: inside-triple-single-quoted-raw-f-string
+
+  inside-triple-single-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: f-string-content-with-regex
+
+  triple-single-quoted-plain-raw-u-strings:
+    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: "'''"
-              scope: string.quoted.single.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: line-continuation-inside-block-string
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.single.block.python
-            - match: "'''"
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - include: line-continuation-inside-block-string
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: constant-placeholder
+      push: inside-triple-single-quoted-plain-raw-u-string
+
+  inside-triple-single-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+
+  triple-single-quoted-raw-u-strings:
+    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
+    - match: ([uU]?r)(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-raw-u-string
+
+  inside-triple-single-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-raw-u-string-syntax
+
+  triple-single-quoted-raw-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-single-quoted-sql-raw-u-string
+    - match: (?=\S)
+      set: inside-triple-single-quoted-regexp-raw-u-string
+
+  inside-triple-single-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: escaped-unicode-char
+
+  inside-triple-single-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'''"
+      scope: string.quoted.single.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: escaped-unicode-char
+        - include: escaped-char
+        - include: constant-placeholder
+
+  triple-single-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding
     - match: ([bB])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-char
+      push: inside-triple-single-quoted-b-string
+
+  inside-triple-single-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: escaped-char
+    - include: constant-placeholder
+
+  triple-single-quoted-f-strings:
+    # Triple-quoted f-string
+    - match: ([fF])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-f-string
+
+  inside-triple-single-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: escaped-fstring-escape
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: f-string-content
+
+  triple-single-quoted-u-strings:
+    # Triple-quoted string, unicode or not, will detect SQL
+    - match: ([uU]?)(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-u-string
+
+  inside-triple-single-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: line-continuation-inside-block-string
+    - include: triple-single-quoted-u-string-syntax
+
+  triple-single-quoted-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-single-quoted-sql-u-string
+    - match: (?=\S)
+      set: inside-single-quoted-plain-u-block-string
+
+  inside-single-quoted-plain-u-block-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-u-string-content
+
+  inside-triple-single-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'''"
+      scope: string.quoted.single.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: triple-single-quoted-u-string-content
+
+  triple-single-quoted-u-string-content:
+    - include: line-continuation-inside-block-string
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: constant-placeholder
+
+  single-quoted-strings:
+    - include: single-quoted-plain-raw-b-strings
+    - include: single-quoted-raw-b-strings
+    - include: single-quoted-plain-raw-f-strings
+    - include: single-quoted-raw-f-strings
+    - include: single-quoted-plain-raw-u-strings
+    - include: single-quoted-raw-u-strings
+    - include: single-quoted-b-strings
+    - include: single-quoted-f-strings
+    - include: single-quoted-u-strings
+
+  single-quoted-string-end:
+    - match: "'"
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+
+  single-quoted-string-pop:
+    - match: (?='|\n)
+      pop: true
+    - include: line-continuation-inside-string
+
+  single-quoted-plain-raw-b-strings:
+    # Single-line capital R raw string, bytes, no syntax embedding
+    - match: ([bB]R|R[bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-plain-raw-b-string
+
+  inside-single-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+
+  single-quoted-raw-b-strings:
+    # Single-line raw string, bytes, treated as regex
+    - match: ([bB]r|r[bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-raw-b-string
+
+  inside-single-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+
+  single-quoted-plain-raw-u-strings:
+    # Single-line capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-plain-raw-u-string
+
+  inside-single-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+
+  single-quoted-raw-u-strings:
+    - match: ([uU]?r)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-raw-u-string
+
+  inside-single-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-raw-u-string-syntax
+
+  single-quoted-raw-u-string-syntax:
+    # Single-line raw string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-single-quoted-sql-raw-u-string
+    # Single-line raw string, unicode or not, treated as regex
+    - match: (?=\S)
+      set: inside-single-quoted-regexp-raw-u-string
+
+  inside-single-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+
+  inside-single-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'"
+      scope: string.quoted.single.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: single-quoted-string-pop
         - include: constant-placeholder
 
-  string-quoted-single:
-    # Single-line capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?r)('')(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: "'"
-          scope: string.quoted.single.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line raw string, unicode or not, treated as regex
-    - match: '([uU]?r)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-    # Single-line raw string, bytes, treated as regex
-    - match: '([bB]r|r[bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
+  single-quoted-plain-raw-f-strings:
     # Single-line raw f-string
     - match: ([fF]R|R[fF])(')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - include: f-string-content
+      push: inside-single-quoted-plain-raw-f-string
+
+  inside-single-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: f-string-content
+
+  single-quoted-raw-f-strings:
     # Single-line raw f-string, treated as regex
     - match: ([fF]r|r[fF])(')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: (?='|\n)
-              pop: true
-            - include: line-continuation-inside-string
-            - include: f-string-content-with-regex
+      push: inside-single-quoted-raw-f-string
+
+  inside-single-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: f-string-content-with-regex
+
+  single-quoted-b-strings:
+    # Single-line string, bytes
+    - match: ([bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-b-string
+
+  inside-single-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: escaped-char
+    - include: constant-placeholder
+
+  single-quoted-f-strings:
     # Single-line f-string
     - match: ([fF])(')
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?)('')(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: "'"
-          scope: string.quoted.single.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line string, unicode or not
-    - match: '([uU]?)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-    # Single-line string, bytes
-    - match: '([bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
+      push: inside-single-quoted-f-string
 
-  strings:
-    # block versions must be matched first
-    - include: string-quoted-double-block
-    - include: string-quoted-double
-    - include: string-quoted-single-block
-    - include: string-quoted-single
+  inside-single-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: escaped-fstring-escape
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: f-string-content
+
+  single-quoted-u-strings:
+    - match: ([uU]?)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-u-string
+
+  inside-single-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-u-string-syntax
+
+  single-quoted-u-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-single-quoted-sql-u-string
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: inside-single-quoted-plain-u-string
+
+  inside-single-quoted-plain-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-u-string-content
+
+  inside-single-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'"
+      scope: string.quoted.single.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: line-continuation-inside-string
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: single-quoted-u-string-content
+
+  single-quoted-u-string-content:
+    - include: escaped-unicode-char
+    - include: escaped-char
+    - include: constant-placeholder
 
   inline-for:
     - match: \b(?:(async)\s+)?(for)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1959,8 +1959,8 @@ contexts:
     - match: \2
       scope: punctuation.definition.comment.end.python
       pop: true
-    - include: escaped-unicode-char
-    - include: escaped-char
+    - include: escaped-unicode-chars
+    - include: escaped-chars
 
   inside-raw-docstring:
     - meta_scope: comment.block.documentation.python
@@ -2040,7 +2040,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   triple-double-quoted-raw-f-strings:
     # Triple-quoted raw f-string, treated as regex
@@ -2058,7 +2058,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: f-string-content-with-regex
+        - include: f-string-replacements-regexp
 
   triple-double-quoted-plain-raw-u-strings:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -2072,7 +2072,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: escaped-unicode-char
+    - include: escaped-unicode-chars
 
   triple-double-quoted-raw-u-strings:
     # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
@@ -2104,8 +2104,9 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: escaped-unicode-char
-        - include: constant-placeholder
+        - include: escaped-unicode-chars
+        - include: string-placeholders
+        - include: string-replacements
 
   inside-triple-double-quoted-regexp-raw-u-string:
     - meta_include_prototype: false
@@ -2117,7 +2118,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: escaped-unicode-char
+        - include: escaped-unicode-chars
 
   triple-double-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding
@@ -2132,8 +2133,9 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - include: line-continuation-inside-block-string
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   triple-double-quoted-f-strings:
     # Triple-quoted f-string
@@ -2148,10 +2150,10 @@ contexts:
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - include: line-continuation-inside-block-string
-    - include: escaped-fstring-escape
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: f-string-content
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
 
   triple-double-quoted-u-strings:
     # Triple-quoted string, unicode or not, will detect SQL
@@ -2194,9 +2196,10 @@ contexts:
 
   triple-double-quoted-plain-u-string-content:
     - include: line-continuation-inside-block-string
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
 ###[ DOUBLE QUOTED STRINGS ]##################################################
 
@@ -2263,7 +2266,7 @@ contexts:
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - meta_include_prototype: false
     - include: double-quoted-string-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   double-quoted-raw-f-strings:
     # Single-line raw f-string, treated as regex
@@ -2281,7 +2284,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
-        - include: f-string-content-with-regex
+        - include: f-string-replacements-regexp
 
   double-quoted-plain-raw-u-strings:
     # Single-line capital R raw string, unicode or not, no syntax embedding
@@ -2337,7 +2340,8 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: double-quoted-string-pop
-        - include: constant-placeholder
+        - include: string-placeholders
+        - include: string-replacements
 
   double-quoted-b-strings:
     # Single-line string, bytes
@@ -2351,8 +2355,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   double-quoted-f-strings:
     # Single-line f-string
@@ -2366,10 +2371,10 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - include: double-quoted-string-end
-    - include: escaped-fstring-escape
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: f-string-content
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
 
   double-quoted-u-strings:
     - match: ([uU]?)(")
@@ -2412,9 +2417,10 @@ contexts:
         - include: double-quoted-u-string-content
 
   double-quoted-u-string-content:
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
 ###[ TRIPLE SINGLE QUOTED STRINGS ]###########################################
 
@@ -2479,7 +2485,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   triple-single-quoted-raw-f-strings:
     # Triple-quoted raw f-string, treated as regex
@@ -2497,7 +2503,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: f-string-content-with-regex
+        - include: f-string-replacements-regexp
 
   triple-single-quoted-plain-raw-u-strings:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -2540,7 +2546,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: escaped-unicode-char
+        - include: escaped-unicode-chars
 
   inside-triple-single-quoted-sql-raw-u-string:
     - meta_include_prototype: false
@@ -2552,9 +2558,10 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: constant-placeholder
+        - include: escaped-unicode-chars
+        - include: escaped-chars
+        - include: string-placeholders
+        - include: string-replacements
 
   triple-single-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding
@@ -2569,8 +2576,9 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - include: line-continuation-inside-block-string
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   triple-single-quoted-f-strings:
     # Triple-quoted f-string
@@ -2585,10 +2593,10 @@ contexts:
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - include: line-continuation-inside-block-string
-    - include: escaped-fstring-escape
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: f-string-content
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
 
   triple-single-quoted-u-strings:
     # Triple-quoted string, unicode or not, will detect SQL
@@ -2631,9 +2639,10 @@ contexts:
 
   triple-single-quoted-u-string-content:
     - include: line-continuation-inside-block-string
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
 ###[ SINGLE QUOTED STRINGS ]##################################################
 
@@ -2743,7 +2752,8 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: single-quoted-string-pop
-        - include: constant-placeholder
+        - include: string-placeholders
+        - include: string-replacements
 
   single-quoted-plain-raw-f-strings:
     # Single-line raw f-string
@@ -2757,7 +2767,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   single-quoted-raw-f-strings:
     # Single-line raw f-string, treated as regex
@@ -2775,7 +2785,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
-        - include: f-string-content-with-regex
+        - include: f-string-replacements-regexp
 
   single-quoted-b-strings:
     # Single-line string, bytes
@@ -2789,8 +2799,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   single-quoted-f-strings:
     # Single-line f-string
@@ -2804,10 +2815,10 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
-    - include: escaped-fstring-escape
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: f-string-content
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
 
   single-quoted-u-strings:
     - match: ([uU]?)(')
@@ -2850,35 +2861,16 @@ contexts:
         - include: single-quoted-u-string-content
 
   single-quoted-u-string-content:
-    - include: escaped-unicode-char
-    - include: escaped-char
-    - include: constant-placeholder
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
 
 ###[ STRING CONTENTS ]########################################################
 
-  escaped-char:
-    - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
-      captures:
-        1: constant.character.escape.hex.python
-        2: constant.character.escape.octal.python
-        3: constant.character.escape.python
-    - match: \\.  # deprecated in 3.6 and will eventually be a syntax error
-      scope: invalid.deprecated.character.escape.python
-
-  escaped-unicode-char:
-    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[-a-zA-Z ]+\})'
-      captures:
-        1: constant.character.escape.unicode.16-bit-hex.python
-        2: constant.character.escape.unicode.32-bit-hex.python
-        3: constant.character.escape.unicode.name.python
-
-  escaped-fstring-escape:
-    # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
-    - match: (\\)(\{\{|\}\})
-      scope: constant.character.escape.backslash.regexp
-      captures:
-        1: invalid.deprecated.character.escape.python
-        2: constant.character.escape.python
+  line-continuation-inside-block-string:
+    - match: \\$
+      scope: punctuation.separator.continuation.line.python
 
   line-continuation-inside-string:
     - match: (\\)$\n?
@@ -2888,11 +2880,33 @@ contexts:
       scope: invalid.illegal.unclosed-string.python
       set: after-expression
 
-  line-continuation-inside-block-string:
-    - match: \\$
-      scope: punctuation.separator.continuation.line.python
+  escaped-chars:
+    - match: \\x\h{2}
+      scope: constant.character.escape.hex.python
+    - match: \\[0-7]{1,3}
+      scope: constant.character.escape.octal.python
+    - match: \\[\\"'abfnrtv]
+      scope: constant.character.escape.python
+    - match: \\.  # deprecated in 3.6 and will eventually be a syntax error
+      scope: invalid.deprecated.character.escape.python
 
-  constant-placeholder:
+  escaped-unicode-chars:
+    - match: \\U\h{8}
+      scope: constant.character.escape.unicode.16-bit-hex.python
+    - match: \\u\h{4}
+      scope: constant.character.escape.unicode.32-bit-hex.python
+    - match: \\N\{[-a-zA-Z ]+\}
+      scope: constant.character.escape.unicode.name.python
+
+  escaped-f-string-braces:
+    # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
+    - match: (\\)(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: invalid.deprecated.character.escape.python
+        2: constant.character.escape.python
+
+  string-placeholders:
     - match: |- # printf style
         (?x)
         %
@@ -2911,11 +2925,10 @@ contexts:
         2: variable.other.placeholder.python
     - match: '{{strftime_spec}}'
       scope: constant.other.placeholder.python
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.python
-    - include: formatting-syntax
 
-  formatting-syntax:
+  string-replacements:
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
     # https://docs.python.org/3.6/library/string.html#formatstrings
     # Technically allows almost every character for the key,
     # but those are rarely used if ever.
@@ -2936,72 +2949,58 @@ contexts:
         4: meta.format-spec.python constant.other.format-spec.python
         5: punctuation.definition.placeholder.end.python
     - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
-      branch_point: formatting-syntax-branch
+      branch_point: string-replacement
       branch:
-        - formatting-syntax-complex
-        - formatting-syntax-fallback
+        - string-replacement
+        - string-replacement-fallback
 
-  formatting-syntax-fallback:
-    - match: \{
-      scope: meta.debug.formatting-syntax-fallback.python
-      pop: true
-
-  formatting-syntax-complex:
+  string-replacement:
     - match: \{
       scope: punctuation.definition.placeholder.begin.python
-      set:
-        - meta_scope: constant.other.placeholder.python
-        - match: \}
-          scope: punctuation.definition.placeholder.end.python
-          pop: true
-        # TODO could match numeric indices or everything else as a key
-        # and also [] indexing
-        - match: '![ars]'
-          scope: storage.modifier.conversion.python
-        - match: ':'
-          scope: punctuation.separator.format-spec.python
-          push:
-            - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
-            - match: (?=\})
-              pop: true
-            - match: (?=\{)
-              push: formatting-syntax-complex
-        - match: '[{"''\n]'
-          fail: formatting-syntax-branch
+      set: inside-string-replacement
 
-  f-string-content:
+  inside-string-replacement:
+    - meta_scope: constant.other.placeholder.python
+    - match: \}
+      scope: punctuation.definition.placeholder.end.python
+      pop: true
+    # TODO could match numeric indices or everything else as a key
+    # and also [] indexing
+    - match: '![ars]'
+      scope: storage.modifier.conversion.python
+    - match: ':'
+      scope: punctuation.separator.format-spec.python
+      push: inside-string-replacement-formatspec
+    - match: '[{"''\n]'
+      fail: string-replacement
+
+  inside-string-replacement-formatspec:
+    - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
+    - match: (?=\})
+      pop: true
+    - match: (?=\{)
+      push: string-replacement
+
+  string-replacement-fallback:
+    - match: \{
+      scope: meta.debug.string-replacement-fallback.python
+      pop: true
+
+  f-string-replacements:
     # https://www.python.org/dev/peps/pep-0498/
     # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
     - match: \{\{|\}\}
       scope: constant.character.escape.python
     - match: \{\s*\}
       scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements
-    - match: \}
-      scope: invalid.illegal.stray-brace.python
-
-  f-string-content-with-regex:
-    # Same as f-string-content, but will reset the entire scope stack
-    # and has an additional match.
-    - match: \\(\{\{|\}\})
-      scope: constant.character.escape.backslash.regexp
-      captures:
-        1: constant.character.escape.python
-    - match: \{\{|\}\}
-      scope: constant.character.escape.python
-    - match: \{\s*\}
-      scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements-reset
-    - match: \}
-      scope: invalid.illegal.stray-brace.python
-
-  f-string-replacements:
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-meta
         - f-string-replacement-modifier
         - f-string-replacement-expression
+    - match: \}
+      scope: invalid.illegal.stray-brace.python
 
   f-string-replacement-meta:
     - clear_scopes: 1
@@ -3025,15 +3024,27 @@ contexts:
     - match: =
       scope: storage.modifier.debug.python
 
-  f-string-replacements-reset:
+  f-string-replacements-regexp:
+    # Same as f-string-replacements, but will reset the entire scope stack
+    # and has an additional match.
+    - match: \\(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: constant.character.escape.python
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
+    - match: \{\s*\}
+      scope: invalid.illegal.empty-expression.python
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
-        - f-string-replacement-reset-meta
-        - f-string-replacement-reset-modifier
-        - f-string-replacement-reset-expression
+        - f-string-replacement-regexp-meta
+        - f-string-replacement-regexp-modifier
+        - f-string-replacement-regexp-expression
+    - match: \}
+      scope: invalid.illegal.stray-brace.python
 
-  f-string-replacement-reset-meta:
+  f-string-replacement-regexp-meta:
     # Same as f-string-replacement, but with clear_scopes: true
     - clear_scopes: true
     - meta_include_prototype: false
@@ -3041,7 +3052,7 @@ contexts:
     - match: ''
       pop: 1
 
-  f-string-replacement-reset-expression:
+  f-string-replacement-regexp-expression:
     - meta_content_scope: source.python.embedded
     - match: (?=![^=]|:|\})
       pop: 1
@@ -3050,7 +3061,7 @@ contexts:
     - include: inline-for
     - include: expression-in-a-group
 
-  f-string-replacement-reset-modifier:
+  f-string-replacement-regexp-modifier:
     - include: f-string-replacement-end
     - include: f-string-replacement-common
 
@@ -3067,7 +3078,7 @@ contexts:
     # basically any character is valid and matching {{format_spec}} is useless.
     # - match: '{{format_spec}}'
     - include: f-string-replacement-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   f-string-replacement-end:
     - match: \}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1968,226 +1968,6 @@ contexts:
       scope: punctuation.definition.comment.end.python
       pop: true
 
-###[ STRING CONTENTS ]########################################################
-
-  escaped-char:
-    - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
-      captures:
-        1: constant.character.escape.hex.python
-        2: constant.character.escape.octal.python
-        3: constant.character.escape.python
-    - match: \\.  # deprecated in 3.6 and will eventually be a syntax error
-      scope: invalid.deprecated.character.escape.python
-
-  escaped-unicode-char:
-    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[-a-zA-Z ]+\})'
-      captures:
-        1: constant.character.escape.unicode.16-bit-hex.python
-        2: constant.character.escape.unicode.32-bit-hex.python
-        3: constant.character.escape.unicode.name.python
-
-  escaped-fstring-escape:
-    # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
-    - match: (\\)(\{\{|\}\})
-      scope: constant.character.escape.backslash.regexp
-      captures:
-        1: invalid.deprecated.character.escape.python
-        2: constant.character.escape.python
-
-  line-continuation-inside-string:
-    - match: (\\)$\n?
-      captures:
-        1: punctuation.separator.continuation.line.python
-    - match: \n
-      scope: invalid.illegal.unclosed-string.python
-      set: after-expression
-
-  line-continuation-inside-block-string:
-    - match: \\$
-      scope: punctuation.separator.continuation.line.python
-
-  constant-placeholder:
-    - match: |- # printf style
-        (?x)
-        %
-          ( \( ({{identifier}}) \) )? # mapping key
-          \#?            # alternate form
-          0?             # pad with zeros
-          \-?            # left-adjust
-          \ ?            # implicit sign
-          [+-]?          # sign
-          (\d*|\*)       # width
-          (\. (\d*|\*))? # precision
-          [hlL]?         # length modifier (but ignored)
-          [acdeEfFgGiorsuxX%]
-      scope: constant.other.placeholder.python
-      captures:
-        2: variable.other.placeholder.python
-    - match: '{{strftime_spec}}'
-      scope: constant.other.placeholder.python
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.python
-    - include: formatting-syntax
-
-  formatting-syntax:
-    # https://docs.python.org/3.6/library/string.html#formatstrings
-    # Technically allows almost every character for the key,
-    # but those are rarely used if ever.
-    - match: |- # simple form
-        (?x)
-        (\{)
-          (?: [\w.\[\]]+)?           # field_name
-          (   ! [ars])?              # conversion
-          (?: (:) ({{format_spec}}|  # format_spec OR
-                   [^}%]*%.[^}]*)    # any format-like string
-          )?
-        (\})
-      scope: constant.other.placeholder.python
-      captures:
-        1: punctuation.definition.placeholder.begin.python
-        2: storage.modifier.conversion.python
-        3: punctuation.separator.format-spec.python
-        4: meta.format-spec.python constant.other.format-spec.python
-        5: punctuation.definition.placeholder.end.python
-    - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
-      branch_point: formatting-syntax-branch
-      branch:
-        - formatting-syntax-complex
-        - formatting-syntax-fallback
-
-  formatting-syntax-fallback:
-    - match: \{
-      scope: meta.debug.formatting-syntax-fallback.python
-      pop: true
-
-  formatting-syntax-complex:
-    - match: \{
-      scope: punctuation.definition.placeholder.begin.python
-      set:
-        - meta_scope: constant.other.placeholder.python
-        - match: \}
-          scope: punctuation.definition.placeholder.end.python
-          pop: true
-        # TODO could match numeric indices or everything else as a key
-        # and also [] indexing
-        - match: '![ars]'
-          scope: storage.modifier.conversion.python
-        - match: ':'
-          scope: punctuation.separator.format-spec.python
-          push:
-            - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
-            - match: (?=\})
-              pop: true
-            - match: (?=\{)
-              push: formatting-syntax-complex
-        - match: '[{"''\n]'
-          fail: formatting-syntax-branch
-
-  f-string-content:
-    # https://www.python.org/dev/peps/pep-0498/
-    # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
-    - match: \{\{|\}\}
-      scope: constant.character.escape.python
-    - match: \{\s*\}
-      scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements
-    - match: \}
-      scope: invalid.illegal.stray-brace.python
-
-  f-string-content-with-regex:
-    # Same as f-string-content, but will reset the entire scope stack
-    # and has an additional match.
-    - match: \\(\{\{|\}\})
-      scope: constant.character.escape.backslash.regexp
-      captures:
-        1: constant.character.escape.python
-    - match: \{\{|\}\}
-      scope: constant.character.escape.python
-    - match: \{\s*\}
-      scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements-reset
-    - match: \}
-      scope: invalid.illegal.stray-brace.python
-
-  f-string-replacements:
-    - match: \{
-      scope: punctuation.section.interpolation.begin.python
-      push:
-        - f-string-replacement-meta
-        - f-string-replacement-modifier
-        - f-string-replacement-expression
-
-  f-string-replacement-meta:
-    - clear_scopes: 1
-    - meta_include_prototype: false
-    - meta_scope: meta.interpolation.python
-    - match: ''
-      pop: 1
-
-  f-string-replacement-expression:
-    - meta_content_scope: source.python.embedded
-    - match: (?=\s*(?:=\s*)?(![^=]|:|\}))
-      pop: 1
-    - match: \\
-      scope: invalid.illegal.backslash-in-fstring.python
-    - include: inline-for
-    - include: expression-in-a-group
-
-  f-string-replacement-modifier:
-    - include: f-string-replacement-end
-    - include: f-string-replacement-common
-    - match: =
-      scope: storage.modifier.debug.python
-
-  f-string-replacements-reset:
-    - match: \{
-      scope: punctuation.section.interpolation.begin.python
-      push:
-        - f-string-replacement-reset-meta
-        - f-string-replacement-reset-modifier
-        - f-string-replacement-reset-expression
-
-  f-string-replacement-reset-meta:
-    # Same as f-string-replacement, but with clear_scopes: true
-    - clear_scopes: true
-    - meta_include_prototype: false
-    - meta_scope: source.python meta.string.interpolated.python meta.interpolation.python
-    - match: ''
-      pop: 1
-
-  f-string-replacement-reset-expression:
-    - meta_content_scope: source.python.embedded
-    - match: (?=![^=]|:|\})
-      pop: 1
-    - match: \\
-      scope: invalid.illegal.backslash-in-fstring.python
-    - include: inline-for
-    - include: expression-in-a-group
-
-  f-string-replacement-reset-modifier:
-    - include: f-string-replacement-end
-    - include: f-string-replacement-common
-
-  f-string-replacement-common:
-    - match: '![ars]'
-      scope: storage.modifier.conversion.python
-    - match: ':'
-      scope: meta.format-spec.python constant.other.format-spec.python punctuation.separator.format-spec.python
-      set: f-string-format-spec
-
-  f-string-format-spec:
-    - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
-    # Because replacements can also be used *within* the format-spec,
-    # basically any character is valid and matching {{format_spec}} is useless.
-    # - match: '{{format_spec}}'
-    - include: f-string-replacement-end
-    - include: f-string-content
-
-  f-string-replacement-end:
-    - match: \}
-      scope: punctuation.section.interpolation.end.python
-      pop: 2
-
 ###[ STRINGS ]################################################################
 
   strings:
@@ -3073,6 +2853,228 @@ contexts:
     - include: escaped-unicode-char
     - include: escaped-char
     - include: constant-placeholder
+
+###[ STRING CONTENTS ]########################################################
+
+  escaped-char:
+    - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
+      captures:
+        1: constant.character.escape.hex.python
+        2: constant.character.escape.octal.python
+        3: constant.character.escape.python
+    - match: \\.  # deprecated in 3.6 and will eventually be a syntax error
+      scope: invalid.deprecated.character.escape.python
+
+  escaped-unicode-char:
+    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[-a-zA-Z ]+\})'
+      captures:
+        1: constant.character.escape.unicode.16-bit-hex.python
+        2: constant.character.escape.unicode.32-bit-hex.python
+        3: constant.character.escape.unicode.name.python
+
+  escaped-fstring-escape:
+    # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
+    - match: (\\)(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: invalid.deprecated.character.escape.python
+        2: constant.character.escape.python
+
+  line-continuation-inside-string:
+    - match: (\\)$\n?
+      captures:
+        1: punctuation.separator.continuation.line.python
+    - match: \n
+      scope: invalid.illegal.unclosed-string.python
+      set: after-expression
+
+  line-continuation-inside-block-string:
+    - match: \\$
+      scope: punctuation.separator.continuation.line.python
+
+  constant-placeholder:
+    - match: |- # printf style
+        (?x)
+        %
+          ( \( ({{identifier}}) \) )? # mapping key
+          \#?            # alternate form
+          0?             # pad with zeros
+          \-?            # left-adjust
+          \ ?            # implicit sign
+          [+-]?          # sign
+          (\d*|\*)       # width
+          (\. (\d*|\*))? # precision
+          [hlL]?         # length modifier (but ignored)
+          [acdeEfFgGiorsuxX%]
+      scope: constant.other.placeholder.python
+      captures:
+        2: variable.other.placeholder.python
+    - match: '{{strftime_spec}}'
+      scope: constant.other.placeholder.python
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.python
+    - include: formatting-syntax
+
+  formatting-syntax:
+    # https://docs.python.org/3.6/library/string.html#formatstrings
+    # Technically allows almost every character for the key,
+    # but those are rarely used if ever.
+    - match: |- # simple form
+        (?x)
+        (\{)
+          (?: [\w.\[\]]+)?           # field_name
+          (   ! [ars])?              # conversion
+          (?: (:) ({{format_spec}}|  # format_spec OR
+                   [^}%]*%.[^}]*)    # any format-like string
+          )?
+        (\})
+      scope: constant.other.placeholder.python
+      captures:
+        1: punctuation.definition.placeholder.begin.python
+        2: storage.modifier.conversion.python
+        3: punctuation.separator.format-spec.python
+        4: meta.format-spec.python constant.other.format-spec.python
+        5: punctuation.definition.placeholder.end.python
+    - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
+      branch_point: formatting-syntax-branch
+      branch:
+        - formatting-syntax-complex
+        - formatting-syntax-fallback
+
+  formatting-syntax-fallback:
+    - match: \{
+      scope: meta.debug.formatting-syntax-fallback.python
+      pop: true
+
+  formatting-syntax-complex:
+    - match: \{
+      scope: punctuation.definition.placeholder.begin.python
+      set:
+        - meta_scope: constant.other.placeholder.python
+        - match: \}
+          scope: punctuation.definition.placeholder.end.python
+          pop: true
+        # TODO could match numeric indices or everything else as a key
+        # and also [] indexing
+        - match: '![ars]'
+          scope: storage.modifier.conversion.python
+        - match: ':'
+          scope: punctuation.separator.format-spec.python
+          push:
+            - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
+            - match: (?=\})
+              pop: true
+            - match: (?=\{)
+              push: formatting-syntax-complex
+        - match: '[{"''\n]'
+          fail: formatting-syntax-branch
+
+  f-string-content:
+    # https://www.python.org/dev/peps/pep-0498/
+    # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
+    - match: \{\s*\}
+      scope: invalid.illegal.empty-expression.python
+    - include: f-string-replacements
+    - match: \}
+      scope: invalid.illegal.stray-brace.python
+
+  f-string-content-with-regex:
+    # Same as f-string-content, but will reset the entire scope stack
+    # and has an additional match.
+    - match: \\(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: constant.character.escape.python
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
+    - match: \{\s*\}
+      scope: invalid.illegal.empty-expression.python
+    - include: f-string-replacements-reset
+    - match: \}
+      scope: invalid.illegal.stray-brace.python
+
+  f-string-replacements:
+    - match: \{
+      scope: punctuation.section.interpolation.begin.python
+      push:
+        - f-string-replacement-meta
+        - f-string-replacement-modifier
+        - f-string-replacement-expression
+
+  f-string-replacement-meta:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - meta_scope: meta.interpolation.python
+    - match: ''
+      pop: 1
+
+  f-string-replacement-expression:
+    - meta_content_scope: source.python.embedded
+    - match: (?=\s*(?:=\s*)?(![^=]|:|\}))
+      pop: 1
+    - match: \\
+      scope: invalid.illegal.backslash-in-fstring.python
+    - include: inline-for
+    - include: expression-in-a-group
+
+  f-string-replacement-modifier:
+    - include: f-string-replacement-end
+    - include: f-string-replacement-common
+    - match: =
+      scope: storage.modifier.debug.python
+
+  f-string-replacements-reset:
+    - match: \{
+      scope: punctuation.section.interpolation.begin.python
+      push:
+        - f-string-replacement-reset-meta
+        - f-string-replacement-reset-modifier
+        - f-string-replacement-reset-expression
+
+  f-string-replacement-reset-meta:
+    # Same as f-string-replacement, but with clear_scopes: true
+    - clear_scopes: true
+    - meta_include_prototype: false
+    - meta_scope: source.python meta.string.interpolated.python meta.interpolation.python
+    - match: ''
+      pop: 1
+
+  f-string-replacement-reset-expression:
+    - meta_content_scope: source.python.embedded
+    - match: (?=![^=]|:|\})
+      pop: 1
+    - match: \\
+      scope: invalid.illegal.backslash-in-fstring.python
+    - include: inline-for
+    - include: expression-in-a-group
+
+  f-string-replacement-reset-modifier:
+    - include: f-string-replacement-end
+    - include: f-string-replacement-common
+
+  f-string-replacement-common:
+    - match: '![ars]'
+      scope: storage.modifier.conversion.python
+    - match: ':'
+      scope: meta.format-spec.python constant.other.format-spec.python punctuation.separator.format-spec.python
+      set: f-string-format-spec
+
+  f-string-format-spec:
+    - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
+    # Because replacements can also be used *within* the format-spec,
+    # basically any character is valid and matching {{format_spec}} is useless.
+    # - match: '{{format_spec}}'
+    - include: f-string-replacement-end
+    - include: f-string-content
+
+  f-string-replacement-end:
+    - match: \}
+      scope: punctuation.section.interpolation.end.python
+      pop: 2
+
+###[ INLINE EXPRESSIONS ]#####################################################
 
   inline-for:
     - match: \b(?:(async)\s+)?(for)\b


### PR DESCRIPTION
Fixes #3462

This PR contains structural changes to enable 3rd-party syntaxes to support more syntaxes within strings.

_Note: Python is still sublime-syntax V1, which may change in a future commit and will therefore require adjustments in each 3rd-party syntax which is going to extend it._