### PR TITLE
[TeX] extended control flow matches and scopes

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -116,43 +116,42 @@ contexts:
       scope: comment.line.percentage.tex
 
   controls:
-    - match: ((\\)ifcase){{endcs}}
+    - match: (\\)ifcase{{endcs}}
+      scope: keyword.control.conditional.switch.tex
       captures:
-        1: keyword.control.conditional.switch.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)or){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)or{{endcs}}
+      scope: keyword.control.conditional.case.tex
       captures:
-        1: keyword.control.conditional.case.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)loop){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)loop{{endcs}}
+      scope: keyword.control.loop.do-while.tex
       captures:
-        1: keyword.control.loop.do-while.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)repeat){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)repeat{{endcs}}
+      scope: keyword.control.loop.end.tex
       captures:
-        1: keyword.control.loop.end.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)expandafter){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)expandafter{{endcs}}
+      scope: keyword.control.flow.tex
       captures:
-        1: keyword.control.flow.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)if(?:cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)if(?:cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?{{endcs}}
+      scope: keyword.control.conditional.if.tex
       captures:
-        1: keyword.control.conditional.if.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)else){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)else{{endcs}}
+      scope: keyword.control.conditional.else.tex
       captures:
-        1: keyword.control.conditional.else.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)fi){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)fi{{endcs}}
+      scope: keyword.control.conditional.end.tex
       captures:
-        1: keyword.control.conditional.end.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)(?:input)){{endcs}}
-      scope: meta.function.input.tex
+        1: punctuation.definition.backslash.tex
+    - match: (\\)(?:input){{endcs}}
+      scope: meta.function.input.tex keyword.control.input.tex
       captures:
-        1: keyword.control.input.tex
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   catcode:
     - match: ((\\)catcode)`(?:\\)?.=(\d+)

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -116,9 +116,37 @@ contexts:
       scope: comment.line.percentage.tex
 
   controls:
-    - match: ((\\)(else|expandafter|fi|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)){{endcs}}
+    - match: ((\\)ifcase){{endcs}}
       captures:
-        1: keyword.control.tex
+        1: keyword.control.conditional.switch.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)or){{endcs}}
+      captures:
+        1: keyword.control.conditional.case.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)loop){{endcs}}
+      captures:
+        1: keyword.control.loop.do-while.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)repeat){{endcs}}
+      captures:
+        1: keyword.control.loop.end.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)expandafter){{endcs}}
+      captures:
+        1: keyword.control.flow.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)if(?:cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?){{endcs}}
+      captures:
+        1: keyword.control.conditional.if.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)else){{endcs}}
+      captures:
+        1: keyword.control.conditional.else.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)fi){{endcs}}
+      captures:
+        1: keyword.control.conditional.end.tex
         2: punctuation.definition.backslash.tex
     - match: ((\\)(?:input)){{endcs}}
       scope: meta.function.input.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -148,7 +148,7 @@ contexts:
       scope: keyword.control.conditional.end.tex
       captures:
         1: punctuation.definition.backslash.tex
-    - match: (\\)(?:input){{endcs}}
+    - match: (\\)input{{endcs}}
       scope: meta.function.input.tex keyword.control.input.tex
       captures:
         1: punctuation.definition.backslash.tex

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -57,7 +57,7 @@
 %     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
-% edef as an immediately expanded version of def. Note that here, 
+% edef as an immediately expanded version of def. Note that here,
 % argument specifications would not be allowed by TeX.
  \edef\macro{replacement}
 %^^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
@@ -97,7 +97,7 @@
 %      ^^^^^^^^^^^^ meta.function.body.tex
 
 %  stop scope for incomplete defs
-\def\text 
+\def\text
 
 some other text
 % ^^^^^^^^^^^^^^ - meta.function%
@@ -117,5 +117,34 @@ some other text
 %                 Control flow / Conditionals
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\fi@other
-%^^ - keyword
+\if something \fi
+%^^ keyword.control.conditional.if.tex
+%             ^^^ keyword.control.conditional.end.tex
+
+
+\ifcase 2 a\or b\or c\or d\else e\fi
+%^^^^^^ keyword.control.conditional.switch.tex
+%          ^^^ keyword.control.conditional.case.tex
+%                         ^^^^^ keyword.control.conditional.else.tex
+%                                ^^^ keyword.control.conditional.end.tex
+
+
+% a loop example from https://en.wikibooks.org/wiki/LaTeX/Plain_TeX#Loops
+\count255 = 1
+\loop
+%^^^^ keyword.control.loop.do-while.tex
+  \TeX
+\ifnum\count255 < 10
+%^^^^^ keyword.control.conditional.if.tex
+\advance\count255 by 1
+\repeat
+%^^^^^^ keyword.control.loop.end.tex
+
+
+\if@director
+%^^ - keyword.control.conditional.if
+ custom if
+\else
+%^^^^ keyword.control.conditional.else.tex
+\fi
+%^^ keyword.control.conditional.end.tex


### PR DESCRIPTION
As requested by @michaelblyons , some more fine-grained scoping for control structures in TeX.

Q: How important is it that these scopes are balanced? In the examples in the test, 
the `keyword.control.conditional.if.tex` never has any corresponding `end` scope, because the loop-ending `repeat` closes both the `loop`, and the `if` as part of the loop condition.

 And the conditions `\if@director` would be using a custom-defined if condition. So we have `else` and `fi` without a corresponding start of that scope. I'm not sure if this can be fixed. Maybe we can assume that all commands that start with the sequence `\if` and are not followed by brace-enclosed arguments probably constitute the beginning of an `if`, but I'm not sure how many false positives (or false negatives) this would bring.