### PR TITLE
[Python] Refactor inline for statements

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -407,7 +407,7 @@ contexts:
         - match: ':(?!=)'
           scope: invalid.illegal.missing-in.python
           pop: true
-        - include: target-list
+        - include: target-lists
     # async with ... as ...:
     - match: \b(async +)?(with)\b
       captures:
@@ -434,7 +434,7 @@ contexts:
               scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
               pop: true
             - include: name
-        - include: target-list
+        - include: target-lists
     - match: \bif\b
       scope: keyword.control.conditional.if.python
       push:
@@ -2837,17 +2837,19 @@ contexts:
       captures:
         1: storage.modifier.async.python
         2: keyword.control.loop.for.generator.python
-      push:
-        - include: comments
-        - meta_scope: meta.expression.generator.python
-        - match: \bin\b
-          scope: keyword.control.loop.for.in.python
-          pop: true
-        - match: '(?=[)\]}])'
-          scope: invalid.illegal.missing-in.python
-          pop: true
-        - include: illegal-name
-        - include: target-list
+      push: inside-inline-for
+
+  inside-inline-for:
+    - meta_scope: meta.expression.generator.python
+    - match: \bin\b
+      scope: keyword.control.loop.for.in.python
+      pop: true
+    - match: (?=[)\]}])
+      scope: invalid.illegal.missing-in.python
+      pop: true
+    - include: comments
+    - include: illegal-name
+    - include: target-lists
 
   inline-if:
     - match: \bif\b
@@ -2855,18 +2857,18 @@ contexts:
     - match: \belse\b
       scope: keyword.control.conditional.else.python
 
-  target-list:
-    - match: ','
-      scope: punctuation.separator.target-list.python
+  target-lists:
     - match: \(
-      scope: punctuation.section.target-list.begin.python
-      push:
-        - include: comments
-        - match: ','
-          scope: punctuation.separator.target-list.python
-        - match: \)
-          scope: punctuation.section.target-list.end.python
-          pop: true
-        - include: target-list
-        - include: name
+      scope: punctuation.section.tuple.begin.python
+      push: inside-target-list
+    - match: ','
+      scope: punctuation.separator.sequence.python
     - include: name
+
+  inside-target-list:
+    - meta_scope: meta.sequence.tuple.python
+    - match: \)
+      scope: punctuation.section.tuple.end.python
+      pop: true
+    - include: comments
+    - include: target-lists

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1970,9 +1970,9 @@ generator = ((k1, k2, v) for ((k1, k2), v) in xs)
 #            ^^^^^^^^^^^ meta.sequence.tuple.python
 #           ^^ punctuation.section.sequence.begin.python
 #                      ^ punctuation.section.sequence.end.python
-#                            ^^ punctuation.section.target-list.begin.python
-#                                    ^ punctuation.section.target-list.end.python
-#                                        ^ punctuation.section.target-list.end.python
+#                            ^^ punctuation.section.tuple.begin.python
+#                                    ^ punctuation.section.tuple.end.python
+#                                        ^ punctuation.section.tuple.end.python
 #                                               ^ punctuation.section.sequence.end.python
 
 list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
@@ -1982,9 +1982,9 @@ list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
 #       ^ punctuation.section.sequence.begin.python
 #        ^ punctuation.section.sequence.begin.python
 #                  ^ punctuation.section.sequence.end.python
-#                        ^^ punctuation.section.target-list.begin.python
-#                                ^ punctuation.section.target-list.end.python
-#                                    ^ punctuation.section.target-list.end.python
+#                        ^^ punctuation.section.tuple.begin.python
+#                                ^ punctuation.section.tuple.end.python
+#                                    ^ punctuation.section.tuple.end.python
 #                                           ^ punctuation.section.sequence.end.python
 
 dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
@@ -1993,9 +1993,9 @@ dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
 #            ^^^^^^^ meta.sequence.tuple.python
 #            ^ punctuation.section.sequence.begin.python
 #                  ^ punctuation.section.sequence.end.python
-#                        ^^ punctuation.section.target-list.begin.python
-#                                ^ punctuation.section.target-list.end.python
-#                                    ^ punctuation.section.target-list.end.python
+#                        ^^ punctuation.section.tuple.begin.python
+#                                ^ punctuation.section.tuple.end.python
+#                                    ^ punctuation.section.tuple.end.python
 #                                           ^ punctuation.section.mapping.end.python
 
 list_ = [lambda: 1 for i in range(10)]
@@ -2161,7 +2161,7 @@ except (KeyError, NameError) as e:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch
 #^^^^^ keyword.control.exception.catch
 #       ^^^^^^^^ support.type.exception
-#               ^ punctuation.separator.target-list
+#               ^ punctuation.separator.sequence
 #                 ^^^^^^^^^ support.type.exception
 #                            ^^ keyword.control.exception.catch.as
 #                                ^ punctuation.section.block


### PR DESCRIPTION
This commit...

1. converts anonymous to named context for inline for statement body
2. renames `target-list` to `target-lists` to express non-popping behavior
3. removes some duplicate patterns for comma and name within target-list tuples
4. rename `target-list` scope to `tuple` and add corresponding `meta.sequence.tuple`