### PR TITLE
[PHP] Fix placeholders in single quoted strings

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -2645,7 +2645,7 @@ contexts:
     - meta_scope: meta.string.php
     - meta_content_scope: string.quoted.single.php
     - include: string-single-quoted-end
-    - include: string-placeholders
+    - include: string-single-quoted-placeholders
     - match: \\[\\'']
       scope: constant.character.escape.php
 
@@ -2695,6 +2695,24 @@ contexts:
         (%)                         # punctuation
         (?: \d+\$ )?                # argnum
         [-+]? (?: [ 0] | '. )?      # flags
+        \d*                         # width
+        (?: (\.) \d* )?             # precision
+        [bcdeEfFgGhHosuxX]          # specifier
+      scope: constant.other.placeholder.php
+      captures:
+        1: punctuation.definition.placeholder.php
+        2: punctuation.separator.decimal.php
+
+  string-single-quoted-placeholders:
+    # https://www.php.net/manual/en/function.printf.php
+    - match: '%%'
+      scope: constant.character.escape.php
+    # %[argnum$][flags][width][.precision]specifier
+    - match: |-
+        (?x)
+        (%)                         # punctuation
+        (?: \d+\$ )?                # argnum
+        [-+]? (?: [ 0] | \\'. )?    # flags
         \d*                         # width
         (?: (\.) \d* )?             # precision
         [bcdeEfFgGhHosuxX]          # specifier

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -4137,7 +4137,7 @@ $var4 = 0b0_1_1_1;
 //                                                              ^^ constant.character.escape.php - punctuation
 //                                                                ^ - constant
 
-    'format: %5$- .9f | %-.9g | %+0d | %'ff'
+    'format: %5$- .9f | %-.9g | %+0d | %\'ff'
 //           ^ punctuation.definition.placeholder.php
 //           ^^^^^^^^ constant.other.placeholder.php
 //                   ^^^ - constant
@@ -4149,7 +4149,7 @@ $var4 = 0b0_1_1_1;
 //                              ^^^^ constant.other.placeholder.php
 //                                  ^^^ - constant
 //                                     ^ punctuation.definition.placeholder.php
-//                                     ^^^^ constant.other.placeholder.php
+//                                     ^^^^^ constant.other.placeholder.php
 
     "format: %5$- .9f | %-.9g | %+0d | %'ff"
 //           ^ punctuation.definition.placeholder.php
@@ -4179,6 +4179,11 @@ $var4 = 0b0_1_1_1;
 //   ^^^^^^ constant.other.placeholder.php
    "[%-10.9s]"  // left-justification but with a cutoff of 8 characters
 //   ^^^^^^^ constant.other.placeholder.php
+
+    'foo "%'.urldecode($_REQUEST['searchterm']);
+//  ^^^^^^^^ meta.string.php string.quoted.single.php - constant.other.placeholder
+//          ^ keyword.operator.concatenation.php
+//           ^^^^^^^^^ support.function.url.php
 
     '$a then $b->c or ${d} with {$e} then $f[0] followed by $g[$h] or $i[k] and finally {$l . $m->n . o}'
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php - meta.interpolation


### PR DESCRIPTION
Fixes #3539

The token `%'.u` is a valid format-string placeholder according to https://www.php.net/manual/en/function.printf.php

The `'` needs to be escaped in single quoted strings to avoid it being parsed as end of string.

Example: `"%'.u"` vs. `'%\'.u'`