### PR TITLE
[TeX] Initial support for registers

### DIFF
--- a/LaTeX/Symbol List - Commands.tmPreferences
+++ b/LaTeX/Symbol List - Commands.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>entity.name.newcommand.latex, entity.name.definition.tex</string>
+	<string>entity.name.newcommand.latex, entity.name.definition.tex, entity.name.constant.tex</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -145,26 +145,26 @@ contexts:
       push: def-registername
 
   def-registername:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: inside-register-name-group
     - match: (\\){{cmdname}}
       scope: entity.name.constant.tex
       captures:
         1: punctuation.definition.backslash.tex
       pop: 1
-
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.group.brace.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: 2
-        - match: (\\){{cmdname}}
-          scope: entity.name.constant.tex
-          captures:
-            1: punctuation.definition.backslash.tex
-
     - include: paragraph-pop
     - include: else-pop
+
+  inside-register-name-group:
+    - meta_scope: meta.group.brace.latex
+    - match: \}
+      scope: punctuation.definition.group.brace.end.tex
+      pop: 2
+    - match: (\\){{cmdname}}
+      scope: entity.name.constant.tex
+      captures:
+        1: punctuation.definition.backslash.tex
 
   comments:
     - match: '%.*$\n?'

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -123,13 +123,12 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
         2: storage.type.tex
-      push:
-        - meta_scope: variable.language.tex
-        - include: register-id
+      push: register-id
 
   register-id:
+    - meta_scope: meta.register.tex
     - match: \d+
-      scope: constant.numeric.tex
+      scope: meta.number.integer.decimal constant.numeric.value.tex
       pop: 1
     - match: (\\){{cmdname}}
       captures:
@@ -146,15 +145,24 @@ contexts:
       push: def-registername
 
   def-registername:
-    - match: (?=\\)
-      set:
+    - match: (\\){{cmdname}}
+      scope: entity.name.constant.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      pop: 1
+
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push:
+        - meta_scope: meta.group.brace.latex
+        - match: \}
+          scope: punctuation.definition.group.brace.end.tex
+          pop: 2
         - match: (\\){{cmdname}}
           scope: entity.name.constant.tex
           captures:
             1: punctuation.definition.backslash.tex
-          pop: 1
-        - include: paragraph-pop
-        - include: else-pop
+
     - include: paragraph-pop
     - include: else-pop
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -67,6 +67,8 @@ variables:
   nonletter: '[^A-Za-z@]'
   # look-ahead for end of command sequence
   endcs: '(?!{{letter}})'
+  # a command name: either a sequence of letters, or a single non-letter
+  cmdname: '(?x: {{letter}}+ | {{nonletter}})'
 
 contexts:
   prototype:
@@ -81,6 +83,7 @@ contexts:
     - include: block-math
     - include: inline-math
     - include: registers
+    - include: register-allocations
     - include: general-constants
     - include: general-commands
 
@@ -116,12 +119,44 @@ contexts:
         1: punctuation.definition.backslash.tex
 
   registers:
-    - match: (\\)({{registers}})(\d*)
-      scope: variable.language.tex
+    - match: (\\)({{registers}}){{endcs}}
       captures:
         1: punctuation.definition.backslash.tex
         2: storage.type.tex
-        3: constant.numeric.tex
+      push:
+        - meta_scope: variable.language.tex
+        - include: register-id
+
+  register-id:
+    - match: \d+
+      scope: constant.numeric.tex
+      pop: 1
+    - match: (\\){{cmdname}}
+      captures:
+        1: punctuation.definition.backslash.tex
+      pop: 1
+    - include: paragraph-pop
+    - include: else-pop
+
+  register-allocations:
+    - match: (\\)new{{registers}}{{endcs}}
+      scope: keyword.declaration.register.tex storage.modifier.register.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      push: def-registername
+
+  def-registername:
+    - match: (?=\\)
+      set:
+        - match: (\\){{cmdname}}
+          scope: entity.name.constant.tex
+          captures:
+            1: punctuation.definition.backslash.tex
+          pop: 1
+        - include: paragraph-pop
+        - include: else-pop
+    - include: paragraph-pop
+    - include: else-pop
 
   comments:
     - match: '%.*$\n?'
@@ -229,12 +264,7 @@ contexts:
       set:
         - clear_scopes: 1
         - meta_scope: meta.function.identifier.tex
-        - match: (\\){{letter}}+
-          scope: entity.name.definition.tex
-          captures:
-            1: punctuation.definition.backslash.tex
-          set: def-argspec
-        - match: (\\){{nonletter}}
+        - match: (\\){{cmdname}}
           scope: entity.name.definition.tex
           captures:
             1: punctuation.definition.backslash.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -130,10 +130,7 @@ contexts:
     - match: \d+
       scope: meta.number.integer.decimal constant.numeric.value.tex
       pop: 1
-    - match: (\\){{cmdname}}
-      captures:
-        1: punctuation.definition.backslash.tex
-      pop: 1
+    - include: general-commands
     - include: paragraph-pop
     - include: else-pop
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -53,6 +53,9 @@ variables:
     (?x: lbrack | lbrace | langle | rbrack | rbrace | rangle
     | vert | lfloor | lceil | Vert | rfloor | rceil)
 
+  registers: |-
+    (?x: box | count | dimen | muskip | skip | toks)
+
   # letters in the sense of macro names. Whether @ is a letter or not can vary
   # from a syntax-highlighting perspective, however, we are much safer to
   # assume it is a letter. Situations where we have `\macro` followed immediately
@@ -77,6 +80,7 @@ contexts:
     - include: boxes
     - include: block-math
     - include: inline-math
+    - include: registers
     - include: general-constants
     - include: general-commands
 
@@ -110,6 +114,14 @@ contexts:
       scope: constant.character.escape.tex
       captures:
         1: punctuation.definition.backslash.tex
+
+  registers:
+    - match: (\\)({{registers}})(\d*)
+      scope: variable.language.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+        2: storage.type.tex
+        3: constant.numeric.tex
 
   comments:
     - match: '%.*$\n?'

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -105,7 +105,7 @@ some other text
 %  incomplete but with parameters; the { comes too late to open the function definition
 \def\text A#1A
 
-  { some other text
+  { some other text}
 % ^^^^^^^^^^^^^^ - meta.function
 
 %  command just prefixed with def. Needs to be picked up as a custom command
@@ -148,3 +148,36 @@ some other text
 %^^^^ keyword.control.conditional.else.tex
 \fi
 %^^ keyword.control.conditional.end.tex
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                               Registers
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\muskip5
+%^^^^^^ storage.type.tex
+%^^^^^^^ variable.language.tex
+%      ^ constant.numeric.tex
+
+\box 60
+%^^^ storage.type.tex
+%^^^^^^ variable.language.tex
+%    ^^ constant.numeric.tex
+
+\skip5 10
+%^^^^^ variable.language.tex
+%      ^^ - variable.language.tex
+
+\counting
+%^^^^^^^^ - variable.language.tex
+
+\newdimen\mydimen
+%^^^^^^^^ keyword.declaration.register.tex storage.modifier.register.tex
+%        ^^^^^^^^ entity.name.constant.tex
+%        ^ punctuation.definition.backslash.tex
+
+\def\five{5}
+\toks \five = 8
+%^^^^^^^^^^ variable.language.tex
+%^^^^ storage.type.tex
+%     ^ punctuation.definition.backslash.tex

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -156,28 +156,36 @@ some other text
 
 \muskip5
 %^^^^^^ storage.type.tex
-%^^^^^^^ variable.language.tex
-%      ^ constant.numeric.tex
+%^^^^^^^ meta.register.tex
+%      ^ meta.number.integer.decimal constant.numeric.value.tex
 
 \box 60
 %^^^ storage.type.tex
-%^^^^^^ variable.language.tex
-%    ^^ constant.numeric.tex
+%^^^^^^ meta.register.tex
+%    ^^ meta.number.integer.decimal constant.numeric.value.tex
 
 \skip5 10
-%^^^^^ variable.language.tex
-%      ^^ - variable.language.tex
+%^^^^^ meta.register.tex
+%      ^^ - meta.register.tex
 
 \counting
-%^^^^^^^^ - variable.language.tex
+%^^^^^^^^ - meta.register.tex
 
 \newdimen\mydimen
 %^^^^^^^^ keyword.declaration.register.tex storage.modifier.register.tex
 %        ^^^^^^^^ entity.name.constant.tex
 %        ^ punctuation.definition.backslash.tex
 
+\newcount { \mycounter }
+%^^^^^^^^ keyword.declaration.register.tex storage.modifier.register.tex
+%         ^^^^^^^^^^^^^^ meta.group.brace.latex
+%           ^^^^^^^^^^ entity.name.constant.tex
+%         ^ punctuation.definition.group.brace.begin.tex
+%           ^ punctuation.definition.backslash.tex
+%                      ^ punctuation.definition.group.brace.end.tex
+
 \def\five{5}
 \toks \five = 8
-%^^^^^^^^^^ variable.language.tex
+%^^^^^^^^^^ meta.register.tex
 %^^^^ storage.type.tex
 %     ^ punctuation.definition.backslash.tex

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -184,8 +184,11 @@ some other text
 %           ^ punctuation.definition.backslash.tex
 %                      ^ punctuation.definition.group.brace.end.tex
 
+% A very weird case where we use a macro for the register id. In this case
+% we just scope the macro like we would any other.
 \def\five{5}
 \toks \five = 8
-%^^^^^^^^^^ meta.register.tex
+%^^^^^^^^^^^ meta.register.tex
 %^^^^ storage.type.tex
+%     ^^^^^ support.function.general.tex
 %     ^ punctuation.definition.backslash.tex


### PR DESCRIPTION
This PR adds highlighting for registers, as well as for register allocation functions. Registers created with `\new...` functions will be visible in the symbol list. 