### PR TITLE
[Diff] Cleanup imports of diff module

### DIFF
--- a/Diff/diff.py
+++ b/Diff/diff.py
@@ -1,6 +1,5 @@
-import codecs
 import difflib
-import os.path
+import os
 import time
 
 import sublime


### PR DESCRIPTION
The `codecs` module is is removed as it is not used.

The `os.path` import is replaced by `os` to fix linter issues caused by calling `os.stat()` in `DiffFilesCommand.run()`.