### PR TITLE
[PHP] Fix yield keyword category

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -53,6 +53,7 @@ variables:
     | {{builtin_variables}}
     | function\b
     | as\b
+    | yield\b
     )
 
   keywords: |-
@@ -71,7 +72,7 @@ variables:
     (?xi: case | catch | default | do | (?: end )? (?: for(?:each)? | if | switch | while )
     | else | elseif | finally | switch | try )\b
   flow_keywords: |-
-    (?xi: break | continue | die | exit | finally | goto | return | throw | yield )\b
+    (?xi: break | continue | die | exit | finally | goto | return | throw )\b
 
   # Expression Level Keywords
   builtin_functions: |-
@@ -1277,21 +1278,10 @@ contexts:
       scope: keyword.control.flow.return.php
     - match: (?i:throw)\b
       scope: keyword.control.flow.throw.php
-    # yield from ( http://php.net/manual/en/language.generators.syntax.php#control-structures.yield.from )
-    - match: (?i:yield)\b
-      scope: keyword.control.flow.yield.php
-      push: yield-from
 
   goto-label:
     - match: '{{guarded_identifier}}'
       scope: variable.label.php
-    - include: comments
-    - include: else-pop
-
-  yield-from:
-    - match: (?i:from)\b
-      scope: keyword.control.flow.yield.php
-      pop: 1
     - include: comments
     - include: else-pop
 
@@ -2162,6 +2152,17 @@ contexts:
       scope: keyword.other.clone.php
     - match: (?i:insteadof)\b
       scope: keyword.other.insteadof.php
+    # yield from ( http://php.net/manual/en/language.generators.syntax.php#control-structures.yield.from )
+    - match: (?i:yield)\b
+      scope: keyword.control.flow.yield.php
+      push: yield-from
+
+  yield-from:
+    - match: (?i:from)\b
+      scope: keyword.control.flow.yield.php
+      pop: 1
+    - include: comments
+    - include: else-pop
 
   # Trailing underscores are allowed to prevent numbers from flickering while typing
   # The underscore is for PHP 7.4: https://wiki.php.net/rfc/numeric_literal_separator

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2290,6 +2290,26 @@ function testGenerator1()
 //  ^^^^^ keyword.control.flow.yield.php
 //        ^ constant.numeric.value.php
 //         ^ punctuation.terminator.statement.php
+
+   (yield);
+// ^^^^^^^ meta.group.php
+// ^ punctuation.section.group.begin.php
+//  ^^^^^ keyword.control.flow.yield.php
+//       ^ punctuation.section.group.end.php
+//        ^ punctuation.terminator.statement.php
+
+   [yield];
+// ^^^^^^^ meta.sequence.array.php
+// ^ punctuation.section.sequence.begin.php
+//  ^^^^^ keyword.control.flow.yield.php
+//       ^ punctuation.section.sequence.end.php
+//        ^ punctuation.terminator.statement.php
+
+    $send = yield $value;
+//  ^^^^^ variable.other.php
+//        ^ keyword.operator.assignment.php
+//          ^^^^^ keyword.control.flow.yield.php
+//                ^^^^^^ variable.other.php
 }
 
 function testGenerator2()
@@ -2301,6 +2321,14 @@ function testGenerator2()
 //                           ^ punctuation.section.group.begin.php
 //                            ^ punctuation.section.group.end.php
 //                             ^ punctuation.terminator.statement.php
+
+    $a = yield from test(1);
+//  ^^ variable.other.php
+//     ^ keyword.operator.assignment.php
+//       ^^^^^ keyword.control.flow.yield.php
+//             ^^^^ keyword.control.flow.yield.php
+//                  ^^^^ meta.function-call.identifier.php variable.function.php
+//                      ^^^ meta.function-call.arguments.php meta.group.php
 }
 
 


### PR DESCRIPTION
Fixes #3549

This commit re-categorizes `yield` from control flow statement to ordinary expression keyword to enable its usage within groups/brackets.

That's required as PHP supports bi-directional communication between generators and their controllers.

see: https://sof3.github.io/await-generator/master/generators.html#sending-data-intoout-of-the-generator