### PR TITLE
[ShellScript] Fix pattern termination in parameter expansions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1887,6 +1887,13 @@ contexts:
         2: keyword.operator.logical.regexp.shell
       push: expansions-pattern-set-body
 
+  expansions-pattern-set-end:
+    - match: -?(\])([*?+]*)
+      captures:
+        1: punctuation.definition.set.end.regexp.shell
+        2: keyword.operator.quantifier.regexp.shell
+      pop: 1
+
   expansions-pattern-set-common:
     - match: ((\.)[[:word:]](\.))(\])
       captures:
@@ -1918,13 +1925,6 @@ contexts:
     - include: any-escapes
     - include: expansions-variables
     - include: eol-pop
-
-  expansions-pattern-set-end:
-    - match: -?(\])([*?+]*)
-      captures:
-        1: punctuation.definition.set.end.regexp.shell
-        2: keyword.operator.quantifier.regexp.shell
-      pop: 1
 
   expansions-tilde:
     - match: '~'

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -128,6 +128,10 @@ contexts:
 
 ###[ PROTOTYPES ]##############################################################
 
+  brace-pop:
+    - match: (?=\})
+      pop: 1
+
   else-pop:
     - match: (?=\S)
       pop: 1
@@ -1754,7 +1758,7 @@ contexts:
       captures:
         1: variable.language.shell
         2: keyword.operator.expansion.shell
-      set: expansions-parameter-pattern
+      set: expansions-parameter-regexp
     - match: ([@*]?)(@)([QEPAa])(?=})
       captures:
         1: variable.language.shell
@@ -1772,16 +1776,57 @@ contexts:
     - include: line-continuations
     - include: strings
 
-  expansions-parameter-pattern:
+  expansions-parameter-regexp:
     - include: expansions-parameter-common
-    - include: expansions-pattern
+    - include: expansions-parameter-pattern
     - include: expansions-variables
+
+  expansions-parameter-pattern:
+    # [3.5.8.1] Pattern Matching
+    - match: ([?*+@!])(\()
+      captures:
+        1: keyword.operator.quantifier.regexp.shell
+        2: meta.group.regexp.shell
+           punctuation.definition.group.begin.regexp.shell
+      push: expansions-parameter-pattern-group-body
+    - match: (\[)(?:([!^])|-)?(?=.*])
+      captures:
+        1: punctuation.definition.set.begin.regexp.shell
+        2: keyword.operator.logical.regexp.shell
+      push: expansions-parameter-pattern-set-body
+    - match: '[*?]'
+      scope: keyword.operator.quantifier.regexp.shell
+
+  expansions-parameter-pattern-common:
+    - match: \|
+      scope: keyword.operator.logical.regexp.shell
+    - include: strings
+    - include: expansions-parameter-pattern
+    - include: expansions-variables
+    - include: brace-pop
+    - include: eol-pop
+
+  expansions-parameter-pattern-group-body:
+    - meta_content_scope: meta.group.regexp.shell
+    - include: expansions-pattern-group-end
+    - include: expansions-parameter-pattern-common
+
+  expansions-parameter-pattern-set-body:
+    - meta_scope: meta.set.regexp.shell
+    - include: expansions-pattern-set-end
+    - include: expansions-pattern-set-common
+    - match: (\[)([!^])?(?=[\.=:])
+      captures:
+        1: punctuation.definition.set.begin.regexp.shell
+        2: keyword.operator.logical.regexp.shell
+      push: expansions-parameter-pattern-set-body
+    - include: brace-pop
 
   expansions-parameter-substitution:
     - match: /
       scope: keyword.operator.substitution.shell
       set: expressions-parameter-variable
-    - include: expansions-parameter-pattern
+    - include: expansions-parameter-regexp
 
   expansions-parameter-switch:
     - match: '[/#%]'
@@ -1820,20 +1865,27 @@ contexts:
 
   expansions-pattern-group-body:
     - meta_content_scope: meta.group.regexp.shell
+    - include: expansions-pattern-group-end
+    - include: expansions-pattern-common
+
+  expansions-pattern-group-end:
     - match: \)
       scope:
         meta.group.regexp.shell
         punctuation.definition.group.end.regexp.shell
       pop: 1
-    - include: expansions-pattern-common
 
   expansions-pattern-set-body:
     - meta_scope: meta.set.regexp.shell
-    - match: -?(\])([*?+]*)
+    - include: expansions-pattern-set-end
+    - include: expansions-pattern-set-common
+    - match: (\[)([!^])?(?=[\.=:])
       captures:
-        1: punctuation.definition.set.end.regexp.shell
-        2: keyword.operator.quantifier.regexp.shell
-      pop: 1
+        1: punctuation.definition.set.begin.regexp.shell
+        2: keyword.operator.logical.regexp.shell
+      push: expansions-pattern-set-body
+
+  expansions-pattern-set-common:
     - match: ((\.)[[:word:]](\.))(\])
       captures:
         1: constant.character.collate.regexp.shell
@@ -1859,16 +1911,18 @@ contexts:
       pop: 1
     - match: \-
       scope: punctuation.separator.range.regexp.shell
-    - match: (\[)([!^])?(?=[\.=:])
-      captures:
-        1: punctuation.definition.set.begin.regexp.shell
-        2: keyword.operator.logical.regexp.shell
-      push: expansions-pattern-set-body
     # [Bash] 3.2.4.2: Each pattern undergoes tilde expansion, parameter
     # expansion, command substitution, and arithmetic expansion.
     - include: any-escapes
     - include: expansions-variables
     - include: eol-pop
+
+  expansions-pattern-set-end:
+    - match: -?(\])([*?+]*)
+      captures:
+        1: punctuation.definition.set.end.regexp.shell
+        2: keyword.operator.quantifier.regexp.shell
+      pop: 1
 
   expansions-tilde:
     - match: '~'

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1105,7 +1105,7 @@ contexts:
           pop: 1
         - include: case-clause-patterns-body
     - include: case-end-ahead
-    - include: expansions-pattern-common
+    - include: expansions-pattern-group-common
 
   case-clause-commands:
     - clear_scopes: 1  # remove meta.conditional.case.shell
@@ -1855,18 +1855,10 @@ contexts:
     - match: '[*?]'
       scope: keyword.operator.quantifier.regexp.shell
 
-  expansions-pattern-common:
-    - match: \|
-      scope: keyword.operator.logical.regexp.shell
-    - include: strings
-    - include: expansions-pattern
-    - include: expansions-variables
-    - include: eol-pop
-
   expansions-pattern-group-body:
     - meta_content_scope: meta.group.regexp.shell
     - include: expansions-pattern-group-end
-    - include: expansions-pattern-common
+    - include: expansions-pattern-group-common
 
   expansions-pattern-group-end:
     - match: \)
@@ -1874,6 +1866,14 @@ contexts:
         meta.group.regexp.shell
         punctuation.definition.group.end.regexp.shell
       pop: 1
+
+  expansions-pattern-group-common:
+    - match: \|
+      scope: keyword.operator.logical.regexp.shell
+    - include: strings
+    - include: expansions-pattern
+    - include: expansions-variables
+    - include: eol-pop
 
   expansions-pattern-set-body:
     - meta_scope: meta.set.regexp.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1794,8 +1794,7 @@ contexts:
         1: punctuation.definition.set.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       push: expansions-parameter-pattern-set-body
-    - match: '[*?]'
-      scope: keyword.operator.quantifier.regexp.shell
+    - include: expansions-pattern-quantifiers
 
   expansions-parameter-pattern-common:
     - match: \|
@@ -1852,6 +1851,9 @@ contexts:
         1: punctuation.definition.set.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       push: expansions-pattern-set-body
+    - include: expansions-pattern-quantifiers
+
+  expansions-pattern-quantifiers:
     - match: '[*?]'
       scope: keyword.operator.quantifier.regexp.shell
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1105,6 +1105,7 @@ contexts:
           pop: 1
         - include: case-clause-patterns-body
     - include: case-end-ahead
+    - include: expansions-pattern
     - include: expansions-pattern-group-common
 
   case-clause-commands:
@@ -1796,19 +1797,12 @@ contexts:
       push: expansions-parameter-pattern-set-body
     - include: expansions-pattern-quantifiers
 
-  expansions-parameter-pattern-common:
-    - match: \|
-      scope: keyword.operator.logical.regexp.shell
-    - include: strings
-    - include: expansions-parameter-pattern
-    - include: expansions-variables
-    - include: brace-pop
-    - include: eol-pop
-
   expansions-parameter-pattern-group-body:
     - meta_content_scope: meta.group.regexp.shell
     - include: expansions-pattern-group-end
-    - include: expansions-parameter-pattern-common
+    - include: expansions-parameter-pattern
+    - include: expansions-pattern-group-common
+    - include: brace-pop
 
   expansions-parameter-pattern-set-body:
     - meta_scope: meta.set.regexp.shell
@@ -1860,6 +1854,7 @@ contexts:
   expansions-pattern-group-body:
     - meta_content_scope: meta.group.regexp.shell
     - include: expansions-pattern-group-end
+    - include: expansions-pattern
     - include: expansions-pattern-group-common
 
   expansions-pattern-group-end:
@@ -1873,7 +1868,6 @@ contexts:
     - match: \|
       scope: keyword.operator.logical.regexp.shell
     - include: strings
-    - include: expansions-pattern
     - include: expansions-variables
     - include: eol-pop
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -3196,6 +3196,15 @@ ${foo:=bar}
 #             ^ punctuation.definition.string.end.shell
 #              ^ punctuation.section.interpolation.end.shell
 
+: ${foo//}/foo}
+# ^^^^^^^^ meta.interpolation.parameter.shell
+#         ^^^^^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^ keyword.operator.substitution.shell
+#       ^ variable.parameter.switch.shell
+#        ^ punctuation.section.interpolation.end.shell
+
 : ${foo//\}/foo}
 # ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
@@ -3205,6 +3214,49 @@ ${foo:=bar}
 #        ^^ constant.character.escape.shell
 #          ^ keyword.operator.substitution.shell
 #              ^ punctuation.section.interpolation.end.shell
+
+: ${foo//:/[}]
+# ^^^^^^^^^^^ meta.interpolation.parameter.shell
+#            ^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.substitution.shell
+#       ^ variable.parameter.switch.shell
+#         ^ keyword.operator.substitution.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${foo//:/[\}]}
+# ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.substitution.shell
+#       ^ variable.parameter.switch.shell
+#         ^ keyword.operator.substitution.shell
+#           ^^ constant.character.escape.shell
+#              ^ punctuation.section.interpolation.end.shell
+
+: ${^foo//:/[}]
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#             ^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^ keyword.operator.expansion.shell
+#    ^^^ variable.other.readwrite.shell
+#            ^ punctuation.section.interpolation.end.shell
+
+: ${^foo//:/[\}]}
+# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#           ^^^^ meta.set.regexp.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^ keyword.operator.expansion.shell
+#    ^^^ variable.other.readwrite.shell
+#           ^ punctuation.definition.set.begin.regexp.shell
+#            ^^ constant.character.escape.shell
+#              ^ punctuation.definition.set.end.regexp.shell
+#               ^ punctuation.section.interpolation.end.shell
 
 : ${foo//%/}
 #        ^ - keyword
@@ -3891,6 +3943,17 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #                        ^ punctuation.definition.group.end.regexp.shell
 #                          ^ punctuation.section.group.end.shell
 #                            ^^ support.function.test.end.shell
+
+[[ foo =~ ^foo//:/[}] ]]
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell
+#^^^^^^^^^ - meta.pattern.regexp.shell
+#         ^^^^^^^^ meta.pattern.regexp.shell - meta.set
+#                 ^^^ meta.pattern.regexp.shell meta.set.regexp.shell
+#                    ^^^ - meta.pattern.regexp.shell
+#      ^^ keyword.operator.comparison.shell
+#                 ^ punctuation.definition.set.begin.regexp.shell
+#                   ^ punctuation.definition.set.end.regexp.shell
+#                     ^^ support.function.test.end.shell
 
 [[ ' foobar' == [\ ]foo* ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.shell


### PR DESCRIPTION
Fixes #3553

If pattern matching or regexp substitution is performed within parameter expansions (e.g.: `${^pattern}`) braces must be escaped in order to not terminate the variable expansion.

Braces don't need to be escaped if pattern matching is not part of a parameter expansions.

This commit therefore introduces `expansions-parameter-pattern` context to ensure any unescaped `}` pops a context so parameter expansions are properly terminated.