### PR TITLE
[TeX.DocStrip] Basic DocStrip support

### DIFF
--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# https://www.sublimetext.com/docs/syntax.html
 name: TeX (DocStrip)
 file_extensions:
   - ins

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -19,11 +19,11 @@ contexts:
 
   controls:
     - meta_append: true
-    - match: (\\)(?:endbatchfile){{endcs}}
+    - match: (\\)endbatchfile{{endcs}}
       scope: keyword.control.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
-    - match: (\\)(?:(?:batch)?input){{endcs}}
+    - match: (\\)(?:batch)?input{{endcs}}
       scope: meta.function.input.tex keyword.control.input.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -33,7 +33,7 @@ contexts:
         1: punctuation.definition.backslash.tex
 
   docstrip-preamble:
-    - match: (\\)((?:declare)?(?:pre|post)amble){{endcs}}
+    - match: (\\)(?:declare)?(?:pre|post)amble{{endcs}}
       scope: keyword.context.block.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
@@ -43,19 +43,19 @@ contexts:
   preamble-content:
     - meta_include_prototype: false
     - meta_content_scope: markup.raw.verbatim.tex
-    - match: (\\)(?:end(?:pre|post)amble){{endcs}}
+    - match: (\\)end(?:pre|post)amble{{endcs}}
       scope: keyword.context.block.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
       pop: 1
 
   docstrip-keywords:
-    - match: (\\)(:?file|from|generateFile){{endcs}}
+    - match: (\\)(?:file|from|generateFile){{endcs}}
       scope: keyword.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
       push: file-argument
-    - match: (\\)(:?generate|needed){{endcs}}
+    - match: (\\)(?:generate|needed){{endcs}}
       scope: keyword.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
@@ -73,13 +73,13 @@ contexts:
     - include: macro-brace-content
 
   docstrip-config:
-    - match: ((\\)(:?usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles)){{endcs}}
+    - match: (\\)(?:usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles){{endcs}}
       scope: support.function.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
 
   docstrip-user-io:
-     - match: (\\)(:?Msg|Ask){{endcs}}
+     - match: (\\)(?:Msg|Ask){{endcs}}
        scope: support.function.tex.docstrip
        captures:
          1: punctuation.definition.backslash.tex
@@ -90,7 +90,7 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
 
-    - match: (\\)(?:(?:Double)perCent|MetaPrefix|empty){{endcs}}
+    - match: (\\)(?:(?:Double)?perCent|MetaPrefix|empty){{endcs}}
       scope: constant.language.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -39,10 +39,9 @@ contexts:
       scope: keyword.context.block.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
-      push: preamble-content
+      push: docstrip-preamble-content
 
-
-  preamble-content:
+  docstrip-preamble-content:
     - meta_include_prototype: false
     - meta_content_scope: markup.raw.verbatim.tex
     - match: (\\)end(?:pre|post)amble{{endcs}}
@@ -56,21 +55,20 @@ contexts:
       scope: keyword.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
-      push: file-argument
+      push: docstrip-file-argument
     - match: (\\)(?:generate|needed){{endcs}}
       scope: keyword.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
 
-
-  file-argument:
+  docstrip-file-argument:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
-      set: file-argument-path
+      set: docstrip-file-argument-path
     - include: else-pop
     - include: paragraph-pop
 
-  file-argument-path:
+  docstrip-file-argument-path:
     - meta_content_scope: meta.path.tex.docstrip
     - include: macro-brace-content
 

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -70,7 +70,7 @@ contexts:
 
   docstrip-file-argument-path:
     - meta_content_scope: meta.path.tex.docstrip
-    - include: macro-brace-content
+    - include: macro-braces-body
 
   docstrip-config:
     - match: (\\)(?:usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles){{endcs}}

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -1,12 +1,14 @@
 %YAML 1.2
 ---
 # https://www.sublimetext.com/docs/syntax.html
+# https://www.texlive.info/CTAN/macros/latex/base/docstrip.pdf
 name: TeX (DocStrip)
+scope: source.tex.docstrip
+version: 1
+extends: Packages/LaTeX/TeX.sublime-syntax
+
 file_extensions:
   - ins
-scope: source.tex.docstrip
-
-extends: Packages/LaTeX/TeX.sublime-syntax
 
 contexts:
   main:

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -19,35 +19,34 @@ contexts:
 
   controls:
     - meta_append: true
-    - match: ((\\)(?:endbatchfile)){{endcs}}
+    - match: (\\)(?:endbatchfile){{endcs}}
+      scope: keyword.control.tex.docstrip
       captures:
-        1: keyword.control.tex.docstrip
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)(?:(?:batch)?input)){{endcs}}
-      scope: meta.function.input.tex
+        1: punctuation.definition.backslash.tex
+    - match: (\\)(?:(?:batch)?input){{endcs}}
+      scope: meta.function.input.tex keyword.control.input.tex
       captures:
-        1: keyword.control.input.tex
-        2: punctuation.definition.backslash.tex
-    - match: ((\\)ifToplevel){{endcs}}
+        1: punctuation.definition.backslash.tex
+    - match: (\\)ifToplevel{{endcs}}
+      scope: keyword.control.conditional.tex.docstrip
       captures:
-        1: keyword.control.conditional.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   docstrip-preamble:
-    - match: ((\\)((?:declare)?(?:pre|post)amble)){{endcs}}
+    - match: (\\)((?:declare)?(?:pre|post)amble){{endcs}}
+      scope: keyword.context.block.tex.docstrip
       captures:
-        1: keyword.context.block.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
       push: preamble-content
 
 
   preamble-content:
     - meta_include_prototype: false
     - meta_content_scope: markup.raw.verbatim.tex
-    - match: ((\\)(?:end(?:pre|post)amble)){{endcs}}
+    - match: (\\)(?:end(?:pre|post)amble){{endcs}}
+      scope: keyword.context.block.tex.docstrip
       captures:
-        1: keyword.context.block.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
       pop: 1
 
   docstrip-keywords:
@@ -56,10 +55,10 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
       push: file-argument
-    - match: ((\\)(:?generate|needed)){{endcs}}
+    - match: (\\)(:?generate|needed){{endcs}}
+      scope: keyword.tex.docstrip
       captures:
-        1: keyword.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
 
   file-argument:
@@ -75,23 +74,23 @@ contexts:
 
   docstrip-config:
     - match: ((\\)(:?usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles)){{endcs}}
+      scope: support.function.tex.docstrip
       captures:
-        1: support.function.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
   docstrip-user-io:
-     - match: ((\\)(:?Msg|Ask)){{endcs}}
+     - match: (\\)(:?Msg|Ask){{endcs}}
+       scope: support.function.tex.docstrip
        captures:
-         1: support.function.tex.docstrip
-         2: punctuation.definition.backslash.tex
+         1: punctuation.definition.backslash.tex
 
   docstrip-constants:
-    - match: ((\\)(?:askforoverwrite(?:true|false)|askonceonly|(?:use|no)(?:pre|post)amble|showprogress|keepsilent)){{endcs}}
+    - match: (\\)(?:askforoverwrite(?:true|false)|askonceonly|(?:use|no)(?:pre|post)amble|showprogress|keepsilent){{endcs}}
+      scope: constant.language.tex.docstrip
       captures:
-        1: constant.language.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
 
-    - match: ((\\)(?:(?:Double)perCent|MetaPrefix|empty)){{endcs}}
+    - match: (\\)(?:(?:Double)perCent|MetaPrefix|empty){{endcs}}
+      scope: constant.language.tex.docstrip
       captures:
-        1: constant.language.tex.docstrip
-        2: punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -1,0 +1,89 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: TeX (DocStrip)
+file_extensions:
+  - ins
+scope: source.tex.docstrip
+
+extends: Packages/LaTeX/TeX.sublime-syntax
+
+contexts:
+  main:
+    - meta_prepend: true
+    - include: docstrip-preamble
+    - include: docstrip-config
+    - include: docstrip-keywords
+    - include: docstrip-constants
+
+  controls:
+    - meta_append: true
+    - match: ((\\)(?:endbatchfile))\b
+      captures:
+        1: keyword.control.tex.docstrip
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)(?:(?:batch)?input))\b
+      scope: meta.function.input.tex
+      captures:
+        1: keyword.control.input.tex
+        2: punctuation.definition.backslash.tex
+    - match: ((\\)ifToplevel)\b
+      captures:
+        1: keyword.control.conditional.tex.docstrip
+        2: punctuation.definition.backslash.tex
+
+  docstrip-preamble:
+    - match: ((\\)((?:declare)?(?:pre|post)amble))\b
+      captures:
+        1: keyword.context.block.tex.docstrip
+        2: punctuation.definition.backslash.tex
+      push: preamble-content
+
+
+  preamble-content:
+    - meta_include_prototype: false
+    - meta_content_scope: markup.raw.verbatim.tex
+    - match: ((\\)(?:end(?:pre|post)amble))\b
+      captures:
+        1: keyword.context.block.tex.docstrip
+        2: punctuation.definition.backslash.tex
+      pop: 1
+
+  docstrip-keywords:
+    - match: ((\\)(:?generate|needed))
+      captures:
+        1: keyword.tex.docstrip
+        2: punctuation.definition.backslash.tex
+    - match: (\\)(:?file|from)
+      scope: keyword.tex.docstrip
+      captures:
+        1: punctuation.definition.backslash.tex
+      push: file-argument
+
+  file-argument:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      set: file-argument-path
+    - include: else-pop
+    - include: paragraph-pop
+
+  file-argument-path:
+    - meta_content_scope: meta.path.tex.docstrip
+    - include: macro-brace-content
+
+  docstrip-config:
+    - match: ((\\)(:?usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles))
+      captures:
+        1: support.function.tex.docstrip
+        2: punctuation.definition.backslash.tex
+
+  docstrip-constants:
+    - match: ((\\)(?:askforoverwrite(?:true|false)|askonceonly|(?:use|no)(?:pre|post)amble|showprogress|keepsilent))
+      captures:
+        1: constant.language.tex.docstrip
+        2: punctuation.definition.backslash.tex
+
+    - match: ((\\)(?:DoubleperCent|MetaPrefix|empty))
+      captures:
+        1: constant.language.tex.docstrip
+        2: punctuation.definition.backslash.tex

--- a/LaTeX/DocStrip.sublime-syntax
+++ b/LaTeX/DocStrip.sublime-syntax
@@ -13,27 +13,28 @@ contexts:
     - meta_prepend: true
     - include: docstrip-preamble
     - include: docstrip-config
+    - include: docstrip-user-io
     - include: docstrip-keywords
     - include: docstrip-constants
 
   controls:
     - meta_append: true
-    - match: ((\\)(?:endbatchfile))\b
+    - match: ((\\)(?:endbatchfile)){{endcs}}
       captures:
         1: keyword.control.tex.docstrip
         2: punctuation.definition.backslash.tex
-    - match: ((\\)(?:(?:batch)?input))\b
+    - match: ((\\)(?:(?:batch)?input)){{endcs}}
       scope: meta.function.input.tex
       captures:
         1: keyword.control.input.tex
         2: punctuation.definition.backslash.tex
-    - match: ((\\)ifToplevel)\b
+    - match: ((\\)ifToplevel){{endcs}}
       captures:
         1: keyword.control.conditional.tex.docstrip
         2: punctuation.definition.backslash.tex
 
   docstrip-preamble:
-    - match: ((\\)((?:declare)?(?:pre|post)amble))\b
+    - match: ((\\)((?:declare)?(?:pre|post)amble)){{endcs}}
       captures:
         1: keyword.context.block.tex.docstrip
         2: punctuation.definition.backslash.tex
@@ -43,22 +44,23 @@ contexts:
   preamble-content:
     - meta_include_prototype: false
     - meta_content_scope: markup.raw.verbatim.tex
-    - match: ((\\)(?:end(?:pre|post)amble))\b
+    - match: ((\\)(?:end(?:pre|post)amble)){{endcs}}
       captures:
         1: keyword.context.block.tex.docstrip
         2: punctuation.definition.backslash.tex
       pop: 1
 
   docstrip-keywords:
-    - match: ((\\)(:?generate|needed))
-      captures:
-        1: keyword.tex.docstrip
-        2: punctuation.definition.backslash.tex
-    - match: (\\)(:?file|from)
+    - match: (\\)(:?file|from|generateFile){{endcs}}
       scope: keyword.tex.docstrip
       captures:
         1: punctuation.definition.backslash.tex
       push: file-argument
+    - match: ((\\)(:?generate|needed)){{endcs}}
+      captures:
+        1: keyword.tex.docstrip
+        2: punctuation.definition.backslash.tex
+
 
   file-argument:
     - match: \{
@@ -72,18 +74,24 @@ contexts:
     - include: macro-brace-content
 
   docstrip-config:
-    - match: ((\\)(:?usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles))
+    - match: ((\\)(:?usedir|showdirectory|BaseDirectory|DeclareDir|UseTDS|maxfiles|maxoutfiles)){{endcs}}
       captures:
         1: support.function.tex.docstrip
         2: punctuation.definition.backslash.tex
 
+  docstrip-user-io:
+     - match: ((\\)(:?Msg|Ask)){{endcs}}
+       captures:
+         1: support.function.tex.docstrip
+         2: punctuation.definition.backslash.tex
+
   docstrip-constants:
-    - match: ((\\)(?:askforoverwrite(?:true|false)|askonceonly|(?:use|no)(?:pre|post)amble|showprogress|keepsilent))
+    - match: ((\\)(?:askforoverwrite(?:true|false)|askonceonly|(?:use|no)(?:pre|post)amble|showprogress|keepsilent)){{endcs}}
       captures:
         1: constant.language.tex.docstrip
         2: punctuation.definition.backslash.tex
 
-    - match: ((\\)(?:DoubleperCent|MetaPrefix|empty))
+    - match: ((\\)(?:(?:Double)perCent|MetaPrefix|empty)){{endcs}}
       captures:
         1: constant.language.tex.docstrip
         2: punctuation.definition.backslash.tex

--- a/LaTeX/syntax_test_docstrip.ins
+++ b/LaTeX/syntax_test_docstrip.ins
@@ -57,9 +57,10 @@ some text to copy
 \batchinput{other.docstrip}
 %^^^^^^^^^^ meta.function.input.tex keyword.control.input.tex
 
-\let\MetaPrefix \DoubleperCent
+\let\MetaPrefix \DoubleperCent \perCent
 %   ^^^^^^^^^^^ constant.language.tex.docstrip
 %               ^^^^^^^^^^^^^^ constant.language.tex.docstrip
+%                              ^^^^^^^^ constant.language.tex.docstrip
 %   ^ punctuation.definition.backslash.tex
 %               ^ punctuation.definition.backslash.tex
 

--- a/LaTeX/syntax_test_docstrip.ins
+++ b/LaTeX/syntax_test_docstrip.ins
@@ -74,5 +74,15 @@ some text to copy
 %                           ^^^^^ keyword.tex.docstrip
 %                                 ^^^^^^^^^^ meta.path.tex.docstrip
 
+
+% Old but still supported syntax:
+\generateFile{README.txt}{t}{\from{test.dtx}{README}}
+%^^^^^^^^^^^^ keyword.tex.docstrip
+%             ^^^^^^^^^^ meta.path.tex.docstrip
+%                            ^^^^^ keyword.tex.docstrip
+%                                  ^^^^^^^^ meta.path.tex.docstrip
+
+\Msg{* "example" package is now generated}
+%^^^ support.function.tex.docstrip
 \endbatchfile
 %^^^^^^^^^^^^ keyword.control.tex

--- a/LaTeX/syntax_test_docstrip.ins
+++ b/LaTeX/syntax_test_docstrip.ins
@@ -1,0 +1,78 @@
+% SYNTAX TEST "Packages/LaTeX/DocStrip.sublime-syntax"
+
+\input docstrip.tex
+%^^^^^ meta.function.input.tex keyword.control.input.tex
+
+
+\keepsilent
+%^^^^^^^^^^ constant.language.tex.docstrip
+
+
+\usedir{tex/latex/somewhere}
+%^^^^^^ support.function.tex.docstrip
+
+
+
+\preamble
+%^^^^^^^^ keyword.context.block.tex.docstrip
+This is a generated file.
+
+This file may be distributed and/or modified under the
+conditions of the LaTeX Project Public License, either
+version 1.3 of this license or (at your option) any later
+version. The latest version of this license is in:
+http://www.latex-project.org/lppl.txt
+and version 1.3 or later is part of all distributions of
+LaTeX version 2005/12/01 or later.
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.verbatim.tex
+\endpreamble
+%^^^^^^^^^^^ keyword.context.block.tex.docstrip
+
+\declarepostamble
+%^^^^^^^^^^^^^^^^ keyword.context.block.tex.docstrip
+some text to copy
+%^^^^^^^^^^^^^^^^^ markup.raw.verbatim.tex
+\endpostamble
+%^^^^^^^^^^^^ keyword.context.block.tex.docstrip
+
+\askforoverwritefalse
+%^^^^^^^^^^^^^^^^^^^^ constant.language.tex.docstrip
+
+\askforoverwritetrue
+%^^^^^^^^^^^^^^^^^^^ constant.language.tex.docstrip
+
+\nopreamble
+%^^^^^^^^^^ constant.language.tex.docstrip
+
+\usepostamble
+%^^^^^^^^^^^^ constant.language.tex.docstrip
+
+\askonceonly
+%^^^^^^^^^^^ constant.language.tex.docstrip
+
+\showprogress
+%^^^^^^^^^^^^ constant.language.tex.docstrip
+
+
+\batchinput{other.docstrip}
+%^^^^^^^^^^ meta.function.input.tex keyword.control.input.tex
+
+\let\MetaPrefix \DoubleperCent
+%   ^^^^^^^^^^^ constant.language.tex.docstrip
+%               ^^^^^^^^^^^^^^ constant.language.tex.docstrip
+%   ^ punctuation.definition.backslash.tex
+%               ^ punctuation.definition.backslash.tex
+
+
+\ifToplevel{Conditional code executed}
+%^^^^^^^^^^ keyword.control.conditional.tex.docstrip
+
+\generate{\file{target.sty}{\from{source.dtx}{pattern}}}
+%^^^^^^^^ keyword.tex.docstrip
+%         ^^^^^ keyword.tex.docstrip
+%               ^^^^^^^^^^ meta.path.tex.docstrip
+%                           ^^^^^ keyword.tex.docstrip
+%                                 ^^^^^^^^^^ meta.path.tex.docstrip
+
+\endbatchfile
+%^^^^^^^^^^^^ keyword.control.tex


### PR DESCRIPTION
This PR adds support for the `DocStrip` format of TeX, used by many LaTeX packages to specify their installation. 
https://www.texlive.info/CTAN/macros/latex/base/docstrip.pdf

I've inherited from the base `TeX` syntax, and just prepended the new commands to the `main` context. This is not quite accurate, in the sense that many `plainTeX` constructs would simply be invalid in a docstrip file -- as there is no typesetting to be done, typesetting and math commands don't really make sense. But I think it is OK to highlight these commands, and probably better to handle things like this, because if we manually select the subset that is supported, and later on add something new in `TeX` that also works in `DocStrip`, we might forget to change `DocStrips` `main` context.

In general, `DocStrip` files are usually rather short and simple, and typically look like the examples given in https://texdoc.org/serve/dtxtut.pdf/0 (appendix A).

Finally, since the goal is not to produce typeset output, but instead to describe how files are generated, I've used a `source` main scope.