### PR TITLE
[TeX] refactor LaTeX Log syntax

### DIFF
--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -78,7 +78,7 @@ contexts:
       scope: punctuation.definition.string.end.log.latex
       pop: 1
 
-    - match: (?:.*/.*\.pdf)
+    - match: '.*/.*\.pdf'
       scope: >-
         support.function.with-arg.latex
         entity.name.function.filename.latex

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
       push:
         - meta_scope: meta.log.latex.hyphenation
 
-        - match: '(?:\[\]\n)'
+        - match: \[\]\n
           scope: keyword.control.hyphenation.latex
           pop: 1
 

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -5,21 +5,21 @@ scope: text.log.latex
 
 first_line_match: "This is (pdf|pdfe)?TeXk?, Version "
 
+################################################################################
+
 contexts:
-  eol-pop:
-    - match: '$\n?'
-      pop: 1
-
   main:
-    - include: invalids
-    - include: functions
-    - include: types
-    - include: tags
-    - include: comments
+    - include: log-entries
+    - include: file-paths
+    - include: doc-comments
+    - include: under-over-full
+    - include: strings
 
+  doc-comments:
     - match: ".*FiXme:"
       scope: meta.log.latex.fixme
 
+  under-over-full:
     - match: (?:Overfull|Underfull)
       scope: keyword.control.hyphenation.latex
       push:
@@ -32,36 +32,49 @@ contexts:
         - match: '[0-9]+\-\-[0-9]+'
           scope: variable.parameter.hyphenation.latex2
 
-    - include: strings
+###[ File paths ]###############################################################
 
-  invalids:
-    - match: ".*Warning:"
-      scope: invalid.deprecated
+  file-paths:
+    - include: function-file-paths
+    - include: tag-file-paths
+    - include: type-file-paths
 
-    - match: '[^:]*:\d*:.*'
-      scope: invalid.deprecated
-
-    - match: .*Error|^!.*
-      scope: invalid.illegal
-
-  functions:
+  function-file-paths:
     - match: .*\.sty
       scope: entity.name.function
 
-  types:
-    - match: .*\.cls
-      scope: entity.name.type.class
-
-  tags:
+  tag-file-paths:
     - match: .*\.cfg
       scope: entity.name.tag.configuration
-
     - match: .*\.def
       scope: entity.name.tag.definition
 
-  comments:
-    - match: .*Info.*
+  type-file-paths:
+    - match: .*\.cls
+      scope: entity.name.type.class
+
+###[ Log entries ]##############################################################
+
+  log-entries:
+    - include: error-log-entries
+    - include: warning-log-entries
+    - include: info-log-entries
+
+  error-log-entries:
+    - match: '.*Error|^!.*'
+      scope: invalid.illegal
+
+  warning-log-entries:
+    - match: '.*Warning:'
+      scope: invalid.deprecated
+    - match: '[^:]*:\d*:.*'
+      scope: invalid.deprecated
+
+  info-log-entries:
+    - match: '.*Info.*'
       scope: comment.block.documentation
+
+###[ Strings ]##################################################################
 
   strings:
     - include: angle-bracket-strings
@@ -79,8 +92,14 @@ contexts:
       pop: 1
 
     - match: '.*/.*\.pdf'
-      scope:
+      scope: >-
         support.function.with-arg.latex
         entity.name.function.filename.latex
 
     - include: eol-pop
+
+###[ Helpers ]##################################################################
+
+  eol-pop:
+    - match: '$\n?'
+      pop: 1

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -16,23 +16,19 @@ contexts:
     - match: ".*FiXme:"
       scope: meta.log.latex.fixme
 
-    - match: (Overfull|Underfull)
-      captures:
-        1: keyword.control.hyphenation.latex
+    - match: (?:Overfull|Underfull)
+      scope: keyword.control.hyphenation.latex
       push:
         - meta_scope: meta.log.latex.hyphenation
 
-        - match: '(\[\]\n)'
-          captures:
-            1: keyword.control.hyphenation.latex
+        - match: '(?:\[\]\n)'
+          scope: keyword.control.hyphenation.latex
           pop: 1
 
         - match: '[0-9]+\-\-[0-9]+'
           scope: variable.parameter.hyphenation.latex2
 
-    - match: '<'
-      scope: punctuation.definition.string.begin.log.latex
-      push: angle-bracket-strings
+    - include: strings
 
   invalids:
     - match: ".*Warning:"
@@ -63,14 +59,21 @@ contexts:
     - match: .*Info.*
       scope: comment.block.documentation
 
+  strings:
+    - include: angle-bracket-strings
+
   angle-bracket-strings:
+    - match: '<'
+      scope: punctuation.definition.string.begin.log.latex
+      push: angle-bracket-string-content
+
+  angle-bracket-string-content:
     - meta_scope: string.unquoted.other.filename.log.latex
 
     - match: '>'
       scope: punctuation.definition.string.end.log.latex
       pop: 1
 
-    - match: (.*/.*\.pdf)
+    - match: (?:.*/.*\.pdf)
       scope: support.function.with-arg.latex
-      captures:
-        1: entity.name.function.filename.latex
+      scope: entity.name.function.filename.latex

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -6,6 +6,10 @@ scope: text.log.latex
 first_line_match: "This is (pdf|pdfe)?TeXk?, Version "
 
 contexts:
+  eol-pop:
+    - match: '$\n?'
+      pop: 1
+
   main:
     - include: invalids
     - include: functions
@@ -78,3 +82,5 @@ contexts:
       scope: >-
         support.function.with-arg.latex
         entity.name.function.filename.latex
+
+    - include: eol-pop

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -79,7 +79,7 @@ contexts:
       pop: 1
 
     - match: '.*/.*\.pdf'
-      scope: >-
+      scope:
         support.function.with-arg.latex
         entity.name.function.filename.latex
 

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -71,7 +71,7 @@ contexts:
       scope: comment.block.documentation
 
   fixme-log-entries:
-    - match: ".*FiXme:"
+    - match: '.*FiXme:'
       scope: meta.log.latex.fixme
 
 ###[ Strings ]##################################################################

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -7,43 +7,70 @@ first_line_match: "This is (pdf|pdfe)?TeXk?, Version "
 
 contexts:
   main:
-    - match: ".*Warning:"
-      scope: invalid.deprecated
-    - match: '[^:]*:\d*:.*'
-      scope: invalid.deprecated
-    - match: .*Error|^!.*
-      scope: invalid.illegal
-    - match: .*\.sty
-      scope: entity.name.function
-    - match: .*\.cls
-      scope: entity.name.type.class
-    - match: .*\.cfg
-      scope: entity.name.tag.configuration
-    - match: .*\.def
-      scope: entity.name.tag.definition
-    - match: .*Info.*
-      scope: comment.block.documentation
+    - include: invalids
+    - include: functions
+    - include: types
+    - include: tags
+    - include: comments
+
     - match: ".*FiXme:"
       scope: meta.log.latex.fixme
+
     - match: (Overfull|Underfull)
       captures:
         1: keyword.control.hyphenation.latex
       push:
         - meta_scope: meta.log.latex.hyphenation
+
         - match: '(\[\]\n)'
           captures:
             1: keyword.control.hyphenation.latex
-          pop: true
+          pop: 1
+
         - match: '[0-9]+\-\-[0-9]+'
           scope: variable.parameter.hyphenation.latex2
-    - match: (<)
+
+    - match: '<'
       scope: punctuation.definition.string.begin.log.latex
-      push:
-        - meta_scope: string.unquoted.other.filename.log.latex
-        - match: (>)
-          scope: punctuation.definition.string.end.log.latex
-          pop: true
-        - match: (.*/.*\.pdf)
-          scope: support.function.with-arg.latex
-          captures:
-            1: entity.name.function.filename.latex
+      push: angle-bracket-strings
+
+  invalids:
+    - match: ".*Warning:"
+      scope: invalid.deprecated
+
+    - match: '[^:]*:\d*:.*'
+      scope: invalid.deprecated
+
+    - match: .*Error|^!.*
+      scope: invalid.illegal
+
+  functions:
+    - match: .*\.sty
+      scope: entity.name.function
+
+  types:
+    - match: .*\.cls
+      scope: entity.name.type.class
+
+  tags:
+    - match: .*\.cfg
+      scope: entity.name.tag.configuration
+
+    - match: .*\.def
+      scope: entity.name.tag.definition
+
+  comments:
+    - match: .*Info.*
+      scope: comment.block.documentation
+
+  angle-bracket-strings:
+    - meta_scope: string.unquoted.other.filename.log.latex
+
+    - match: '>'
+      scope: punctuation.definition.string.end.log.latex
+      pop: 1
+
+    - match: (.*/.*\.pdf)
+      scope: support.function.with-arg.latex
+      captures:
+        1: entity.name.function.filename.latex

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -75,5 +75,6 @@ contexts:
       pop: 1
 
     - match: (?:.*/.*\.pdf)
-      scope: support.function.with-arg.latex
-      scope: entity.name.function.filename.latex
+      scope: >-
+        support.function.with-arg.latex
+        entity.name.function.filename.latex

--- a/LaTeX/LaTeX Log.sublime-syntax
+++ b/LaTeX/LaTeX Log.sublime-syntax
@@ -11,13 +11,8 @@ contexts:
   main:
     - include: log-entries
     - include: file-paths
-    - include: doc-comments
     - include: under-over-full
     - include: strings
-
-  doc-comments:
-    - match: ".*FiXme:"
-      scope: meta.log.latex.fixme
 
   under-over-full:
     - match: (?:Overfull|Underfull)
@@ -59,6 +54,7 @@ contexts:
     - include: error-log-entries
     - include: warning-log-entries
     - include: info-log-entries
+    - include: fixme-log-entries
 
   error-log-entries:
     - match: '.*Error|^!.*'
@@ -73,6 +69,10 @@ contexts:
   info-log-entries:
     - match: '.*Info.*'
       scope: comment.block.documentation
+
+  fixme-log-entries:
+    - match: ".*FiXme:"
+      scope: meta.log.latex.fixme
 
 ###[ Strings ]##################################################################
 


### PR DESCRIPTION
This commit adds named contexts and a missing EOL pop for strings.