### PR TITLE
[C#] Add folding rule for #region directive

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -178,20 +178,24 @@ contexts:
       pop: true
 
   preprocessor_region:
-    - match: '^\s*(#)\s*(region)\b[^\S\n]*(.*)($\n?)'
+    - match: '^\s*(#)\s*(region)\b\s*(\S.*)'
       scope: meta.preprocessor.region.cs
       captures:
         1: keyword.other.preprocessor.cs
         2: keyword.other.preprocessor.cs
-        3: entity.name.section.cs
-        4: meta.whitespace.newline.cs
+        3: entity.name.section.cs meta.fold.begin.cs
+    - match: '^\s*(#)\s*(region)\b\s*'
+      scope: meta.preprocessor.region.cs
+      captures:
+        1: keyword.other.preprocessor.cs
+        2: keyword.other.preprocessor.cs meta.fold.begin.cs
     - match: '^\s*(#)\s*(endregion)\b[^\S\n]*(.*)($\n?)'
-      scope: meta.preprocessor.endregion.cs
+      scope: meta.preprocessor.region.cs
       captures:
         1: keyword.other.preprocessor.cs
         2: keyword.other.preprocessor.cs
         3: variable.other.section.cs
-        4: meta.whitespace.newline.cs
+        4: meta.fold.end.cs
 
   # Pops out at the end of the line and handles comments.
   # Marks the rest of the line as invalid.

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -52,6 +52,7 @@ variables:
 contexts:
   prototype:
     - include: comments
+    - include: preprocessor_region
     - match: '^\s*((#)\s*)'
       captures:
         1: keyword.other.preprocessor.cs
@@ -118,14 +119,6 @@ contexts:
       captures:
         1: keyword.other.preprocessor.cs
         2: string.unquoted.cs
-    - match: '\b(region)\b\s*(.*)'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: entity.name.section.cs
-    - match: '\b(endregion)\b\s*(.*)'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: variable.other.section.cs
 
     - match: '\b(line)\s+(default|hidden)\b'
       captures:
@@ -183,6 +176,22 @@ contexts:
       scope: invalid.illegal.cs
     - match: $
       pop: true
+
+  preprocessor_region:
+    - match: '^\s*(#)\s*(region)\b[^\S\n]*(.*)($\n?)'
+      scope: meta.preprocessor.region.cs
+      captures:
+        1: keyword.other.preprocessor.cs
+        2: keyword.other.preprocessor.cs
+        3: entity.name.section.cs
+        4: meta.whitespace.newline.cs
+    - match: '^\s*(#)\s*(endregion)\b[^\S\n]*(.*)($\n?)'
+      scope: meta.preprocessor.endregion.cs
+      captures:
+        1: keyword.other.preprocessor.cs
+        2: keyword.other.preprocessor.cs
+        3: variable.other.section.cs
+        4: meta.whitespace.newline.cs
 
   # Pops out at the end of the line and handles comments.
   # Marks the rest of the line as invalid.

--- a/C#/Fold.tmPreferences
+++ b/C#/Fold.tmPreferences
@@ -57,6 +57,12 @@
                 <key>end</key>
                 <string>punctuation.definition.generic.end</string>
             </dict>
+            <dict>
+                <key>begin</key>
+                <string>meta.preprocessor.region meta.whitespace.newline</string>
+                <key>end</key>
+                <string>meta.preprocessor.endregion meta.whitespace.newline</string>
+            </dict>
         </array>
     </dict>
 </dict>

--- a/C#/Fold.tmPreferences
+++ b/C#/Fold.tmPreferences
@@ -59,9 +59,9 @@
             </dict>
             <dict>
                 <key>begin</key>
-                <string>meta.preprocessor.region meta.whitespace.newline</string>
+                <string>meta.preprocessor.region meta.fold.begin</string>
                 <key>end</key>
-                <string>meta.preprocessor.endregion meta.whitespace.newline</string>
+                <string>meta.preprocessor.region meta.fold.end</string>
             </dict>
         </array>
     </dict>

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -7,13 +7,13 @@
 
 using System;
 #pragma warning disable warning-list
-// ^ keyword.other.preprocessor
-//       ^ keyword.other.preprocessor
+/// ^ keyword.other.preprocessor
+///       ^ keyword.other.preprocessor
 #pragma warning restore warning-list
 #pragma checksum "file.cs" "{3673e4ca-6098-4ec1-890f-8fceb2a794a2}" "{012345678AB}" // New checksum
-//       ^ keyword.other.preprocessor
-//                 ^ stirng.quoted.double
-//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.integer.hexadecimal
+///       ^ keyword.other.preprocessor
+///                 ^ string.quoted.double
+///                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal constant.numeric.value
 
 #region
 /// ^^ meta.preprocessor keyword.other.preprocessor
@@ -66,12 +66,12 @@ public class MyClass
     }
 }
 #endregion a / b
-// ^^ storage.type.section
-//         ^^^^^ variable.other.section
-//              ^ meta.preprocessor.endregion meta.whitespace.newline
+/// ^^ keyword.other.preprocessor
+///        ^^^^^ variable.other.section
+///             ^ meta.preprocessor.endregion meta.whitespace.newline
 #endregion
-// ^^ storage.type.section
-//        ^ meta.preprocessor.endregion meta.whitespace.newline
+/// ^^ keyword.other.preprocessor
+///       ^ meta.preprocessor.endregion meta.whitespace.newline
 
 #nullable enable
 /// ^^ meta.preprocessor keyword.other.preprocessor
@@ -93,4 +93,4 @@ public class MyClass
 #nullable disable warnings
 /// ^^ meta.preprocessor keyword.other.preprocessor
 ///       ^^ meta.preprocessor keyword.other.preprocessor
-// /              ^^ meta.preprocessor keyword.other.preprocessor
+///               ^^ meta.preprocessor keyword.other.preprocessor

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -16,12 +16,10 @@ using System;
 ///                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal constant.numeric.value
 
 #region
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///    ^ meta.preprocessor.region meta.whitespace.newline
+/// ^^ meta.preprocessor.region keyword.other.preprocessor meta.fold.begin
 #region MyClass definition
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///     ^^ meta.preprocessor entity.name.section
-///                       ^ meta.preprocessor.region meta.whitespace.newline
+/// ^^ meta.preprocessor.region keyword.other.preprocessor - meta.fold
+///     ^^ meta.preprocessor.region entity.name.section meta.fold.begin
 public class MyClass
 {
     static void Main()
@@ -68,10 +66,10 @@ public class MyClass
 #endregion a / b
 /// ^^ keyword.other.preprocessor
 ///        ^^^^^ variable.other.section
-///             ^ meta.preprocessor.endregion meta.whitespace.newline
+///             ^ meta.preprocessor.region meta.fold.end
 #endregion
 /// ^^ keyword.other.preprocessor
-///       ^ meta.preprocessor.endregion meta.whitespace.newline
+///       ^ meta.preprocessor.region meta.fold.end
 
 #nullable enable
 /// ^^ meta.preprocessor keyword.other.preprocessor

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -17,9 +17,11 @@ using System;
 
 #region
 /// ^^ meta.preprocessor keyword.other.preprocessor
+///    ^ meta.preprocessor.region meta.whitespace.newline
 #region MyClass definition
 /// ^^ meta.preprocessor keyword.other.preprocessor
 ///     ^^ meta.preprocessor entity.name.section
+///                       ^ meta.preprocessor.region meta.whitespace.newline
 public class MyClass
 {
     static void Main()
@@ -66,8 +68,10 @@ public class MyClass
 #endregion a / b
 // ^^ storage.type.section
 //         ^^^^^ variable.other.section
+//              ^ meta.preprocessor.endregion meta.whitespace.newline
 #endregion
 // ^^ storage.type.section
+//        ^ meta.preprocessor.endregion meta.whitespace.newline
 
 #nullable enable
 /// ^^ meta.preprocessor keyword.other.preprocessor


### PR DESCRIPTION
This adds the ability to fold `#region` preprocessor directives in C\#.

I've noticed one small occasion where it doesn't work correctly:
If there are nested regions with the same (meta-)scope, and the inner region is folded, then the folding range of the outer region erroneously stops at the end of the folded inner region too. However, if the inner region is not folded and you only fold the outer region, then everything works as expected.

For example, this works fine for any folding order (the inner regions are inside the meta-scope from the class):
```cs
#region Outer
public class MyClass {
    #region Inner 1
    // Hello
    #endregion

    #region Inner 2
    // World
    #endregion
}
#endregion
```

But the following example doesn't work correctly for the outer region if one of the inner regions was folded first:
```cs
#region Outer
// public class MyClass {
    #region Inner 1
    // Hello
    #endregion

    #region Inner 2
    // World
    #endregion
// }
#endregion
```

This issue could perhaps be mitigated if the `#region ... #endregion` block would push its own meta-scope, but I don't think that's even possible when these preprocessor lines are allowed to occur on any line, i.e. on any level of the current context stack.

But ultimately I think that it is a Sublime Text core issue, because the behavior whether the folding of the outer region works correctly, depends on the current folding state of the inner regions. I would expect that it must only be affected by the syntax scopes and nothing else.

---

By the way, some of the syntax tests on the master branch use a wrong comment marker and would not pass otherwise :D
https://github.com/sublimehq/Packages/blob/d04bd5e1c492ad0a2b1c552b42dc80f3e1828e9a/C%23/tests/syntax_test_PreprocessorDirectives.cs#L69-L70
I fixed it in an additional commit.