### PR TITLE
Add support for zsh completions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -40,6 +40,7 @@ first_line_match: |-
   (?xi:
     ^ \#! .* \b(bash|zsh|sh|tcsh|ash|dash)\b            # shebang
   | ^ \s* \# .*? -\*- .*? \bshell(-script)?\b .*? -\*-  # editorconfig
+  | ^ \#(autoload|compdef)\b                            # zsh completions
   )
 
 ###############################################################################


### PR DESCRIPTION
All zsh completions found in /usr/share/zsh/ start with a magic word `#compdef` or `#autoload`, the exact format of which is documented in ZSHCOMPSYS(1) man page:

> The # is part of the tag name and no white space is allowed after it.
> The #compdef tags use the compdef function described below; the main
> difference is that the name of the function is supplied implicitly.