### PR TITLE
[C#] Drop "build" file extension assignment

### DIFF
--- a/C#/Build.sublime-syntax
+++ b/C#/Build.sublime-syntax
@@ -1,10 +1,9 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# http://www.sublimetext.com/docs/syntax.html
 name: NAnt Build File
-file_extensions:
-  - build
 scope: source.nant-build
+
 contexts:
   main:
     - match: <!--


### PR DESCRIPTION
Fixes #1862

This commit unassignes `build` file extension from NAnt Build File syntax as it is a too generic extension used by many syntaxes.

With this change `*.build` files need to be assigned to NAnt Build File manually if desired.