### PR TITLE
[JavaScript] Allow completions in function definitions

### DIFF
--- a/JavaScript/Completion Rules.tmPreferences
+++ b/JavaScript/Completion Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>^\s*(\{?\s*(else|return|do)|(function)\s*[a-zA-Z_0-9]+)$</string>
+		<string>^\s*\{?\s*(else|return|do)$</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #1480

This commit removes function definitions from the pattern of canceled completions. Other syntaxes such as Python or Java don't restrict it this way, too.