### PR TITLE
[TeX] Improved highlighting in macro definition bodies

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -122,17 +122,19 @@ contexts:
   newcommand-optarg:
     - match: \[
       scope: punctuation.definition.group.bracket.begin.latex
-      push:
-        - clear_scopes: 1
-        - meta_scope: meta.function.parameters.default-value.latex
-        - match: \]
-          scope: punctuation.definition.group.bracket.end.latex
-          pop: 2
-        - include: general-constants
-        - include: general-commands
-        - include: macro-braces
+      push: newcommand-optarg-body
     - include: paragraph-pop
     - include: else-pop
+
+  newcommand-optarg-body:
+    - clear_scopes: 1
+    - meta_scope: meta.function.parameters.default-value.latex
+    - match: \]
+      scope: punctuation.definition.group.bracket.end.latex
+      pop: 2
+    - include: general-constants
+    - include: general-commands
+    - include: macro-braces
 
   newcommand-commandname:
     # version one: brace-wrapped command name
@@ -168,26 +170,14 @@ contexts:
   newcommand-definition:
     - meta_scope: meta.function.latex
     - match: (?=\{)
-      set: newcommand-block
+      set:
+        - def-scope-as-body
+        - macro-braces-begin
     - match: (?=\\)
       set: newcommand-expression
     - include: paragraph-pop
     - include: else-pop
 
-  newcommand-block:
-    # usually, a command definition is a brace-enclosed group of tokens
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.latex
-      set: newcommand-block-body
-
-  newcommand-block-body:
-    - meta_scope: meta.function.body.latex meta.group.brace.latex
-    - match: \}
-      scope: punctuation.definition.group.brace.end.latex
-      pop: 1
-    - include: general-constants
-    - include: general-commands
-    - include: macro-braces
 
   newcommand-expression:
     - meta_scope: meta.function.body.latex

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -171,7 +171,7 @@ contexts:
     - meta_scope: meta.function.latex
     - match: (?=\{)
       set:
-        - def-scope-as-body
+        - def-function-body-meta
         - macro-braces-begin
     - match: (?=\\)
       set: newcommand-expression

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -283,6 +283,10 @@ contexts:
     - meta_scope: meta.function.body.tex
     - include: immediately-pop
 
+  macro-braces:
+    - match: (?=\{)
+      push: macro-braces-begin
+
   macro-braces-begin:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
@@ -298,12 +302,12 @@ contexts:
   # only partially matched.
   macro-braces-content:
     - meta_scope: meta.group.brace.tex
-    - match: (?=\{)
-      push: macro-braces-begin
+    - include: macro-braces
     - include: macro-braces-end
     - include: macro-placeholders
     - include: controls
     - include: registers
+    - include: math-builtin
     - include: general-constants
     - include: general-commands
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -248,7 +248,6 @@ contexts:
     - include: else-pop
 
   def-commandname:
-    - clear_scopes: 1
     - meta_scope: meta.function.identifier.tex
     - match: (\\){{cmdname}}
       scope: entity.name.definition.tex
@@ -259,27 +258,21 @@ contexts:
     - include: else-pop
 
   def-argspec:
-    - clear_scopes: 1
     - meta_content_scope: meta.function.parameters.tex
     - include: escaped-character
     - match: (?=\{)
-      scope: punctuation.definition.group.bracket.end.tex
-      set: def-definition
+      set:
+        - def-function-body-meta
+        - macro-braces-begin
+
     - match: (\#)[0-9]
       scope: variable.parameter.tex
       captures:
         1: punctuation.definition.variable.tex
     - include: paragraph-pop
 
-  def-definition:
-    - match: (?=\{)
-      set:
-        - def-scope-as-body
-        - macro-braces-begin
-    - include: paragraph-pop
-    - include: else-pop
-
-  def-scope-as-body:
+  def-function-body-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.function.body.tex
     - include: immediately-pop
 
@@ -290,20 +283,23 @@ contexts:
   macro-braces-begin:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
-      set: macro-braces-content
+      set: macro-braces-body
 
   macro-braces-end:
      - match: \}
        scope: punctuation.definition.group.brace.end.tex
        pop: 1
 
+  macro-braces-body:
+    - meta_scope: meta.group.brace.tex
+    - include: macro-braces-end
+    - include: macro-braces-content
+
   # within macros, it is possible that only part of some nested struture
   # is present. Don't include any context's here that break if they are
   # only partially matched.
   macro-braces-content:
-    - meta_scope: meta.group.brace.tex
     - include: macro-braces
-    - include: macro-braces-end
     - include: macro-placeholders
     - include: controls
     - include: registers

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -234,11 +234,6 @@ contexts:
 ###[ MACROS ]##################################################################
 
   macros:
-    # Note \edef and \xdef have slightly different syntax, in that they do not
-    # allow for arguments. However, every valid \edef could be a valid \def,
-    # so syntax highlighting will work properly with correct code.
-    # we need to make sure to match only full commands, so we look-ahead for
-    # any following non-letter
     - match: (\\)[gex]?def{{endcs}}
       scope: keyword.declaration.function.tex storage.modifier.definition.tex
       captures:
@@ -277,30 +272,47 @@ contexts:
     - include: paragraph-pop
 
   def-definition:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      set: def-definition-body
+    - match: (?=\{)
+      set:
+        - def-scope-as-body
+        - macro-braces-begin
     - include: paragraph-pop
     - include: else-pop
 
-  def-definition-body:
-    - meta_scope: meta.function.body.tex meta.group.brace.tex
-    - include: macro-brace-group-body
+  def-scope-as-body:
+    - meta_scope: meta.function.body.tex
+    - include: immediately-pop
 
-  # within macros, it is possible that only part of some nested struture
-  # is present. To prevent this from causing problems, here we only match
-  # elements that are simple, i.e. that do not push to the stack.
-  macro-braces:
+  macro-braces-begin:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
-      push: macro-brace-group-body
+      set: macro-braces-content
 
-  macro-brace-group-body:
+  macro-braces-end:
+     - match: \}
+       scope: punctuation.definition.group.brace.end.tex
+       pop: 1
+
+  # within macros, it is possible that only part of some nested struture
+  # is present. Don't include any context's here that break if they are
+  # only partially matched.
+  macro-braces-content:
     - meta_scope: meta.group.brace.tex
-    - include: brace-group-end
+    - match: (?=\{)
+      push: macro-braces-begin
+    - include: macro-braces-end
+    - include: macro-placeholders
+    - include: controls
+    - include: registers
     - include: general-constants
     - include: general-commands
-    - include: macro-braces
+
+  macro-placeholders:
+    - match: '(#+)(\d)'
+      scope: variable.parameter.tex
+      captures:
+        1: punctuation.definition.placeholder.tex
+        2: meta.number.integer.decimal.tex constant.numeric.value.tex
 
 ###[ MATH ]####################################################################
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -238,26 +238,26 @@ contexts:
       scope: keyword.declaration.function.tex storage.modifier.definition.tex
       captures:
         1: punctuation.definition.backslash.tex
-      push: def-maybe-commandname
+      push: def-function-expect-identifier
 
-  def-maybe-commandname:
+  def-function-expect-identifier:
     - meta_scope: meta.function.tex
     - match: (?=\\)
-      set: def-commandname
+      set: def-function-identifier
     - include: paragraph-pop
     - include: else-pop
 
-  def-commandname:
+  def-function-identifier:
     - meta_scope: meta.function.identifier.tex
     - match: (\\){{cmdname}}
       scope: entity.name.definition.tex
       captures:
         1: punctuation.definition.backslash.tex
-      set: def-argspec
+      set: def-function-parameters
     - include: paragraph-pop
     - include: else-pop
 
-  def-argspec:
+  def-function-parameters:
     - meta_content_scope: meta.function.parameters.tex
     - match: (?=\{)
       set:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -259,16 +259,15 @@ contexts:
 
   def-argspec:
     - meta_content_scope: meta.function.parameters.tex
-    - include: escaped-character
     - match: (?=\{)
       set:
         - def-function-body-meta
         - macro-braces-begin
-
     - match: (\#)[0-9]
       scope: variable.parameter.tex
       captures:
         1: punctuation.definition.variable.tex
+    - include: escaped-character
     - include: paragraph-pop
 
   def-function-body-meta:
@@ -277,8 +276,9 @@ contexts:
     - include: immediately-pop
 
   macro-braces:
-    - match: (?=\{)
-      push: macro-braces-begin
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: macro-braces-body
 
   macro-braces-begin:
     - match: \{

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -31,27 +31,30 @@
 %^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^ meta.function.identifier.latex
-%                ^^^^^^ meta.function.body.latex
+%                ^^^^^^ meta.function.body
 %^^^^^^^^^^ keyword.declaration.function.latex
-%          ^ punctuation.definition.group.brace.begin.latex
+%          ^ punctuation.definition.group.brace.begin
 %           ^^^^ entity.name.newcommand.latex
 %           ^ punctuation.definition.backslash.latex
-%               ^ punctuation.definition.group.brace.end.latex
-%                ^ punctuation.definition.group.brace.begin.latex
+%               ^ punctuation.definition.group.brace.end
+%                ^ punctuation.definition.group.brace.begin
 %                 ^^^^ support.function.general.latex
 %                 ^ punctuation.definition.backslash.latex
-%                     ^ punctuation.definition.group.brace.end.latex
+%                     ^ punctuation.definition.group.brace.end
 
 \newcommand{\foo}[1]{\bar #1}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^ meta.function.identifier.latex
 %                ^^^ meta.function.parameters.latex
-%                   ^^^^^^^^^ meta.function.body.latex
+%                   ^^^^^^^^^ meta.function.body
 %^^^^^^^^^^ keyword.declaration.function.latex
 %           ^^^^ entity.name.newcommand.latex
 %                 ^ constant.numeric.value.latex
 %                    ^^^^ support.function.general.latex
+%                         ^ punctuation.definition.placeholder.tex
+%                         ^^ variable.parameter.tex
+%                          ^ meta.number.integer.decimal constant.numeric.value.tex
 
 \newcommand{\foo}[2][default]{\bar #1 #2}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -59,7 +62,7 @@
 %          ^^^^^^ meta.function.identifier.latex
 %                ^^^ meta.function.parameters.latex
 %                   ^^^^^^^^^ meta.function.parameters.default-value.latex
-%                            ^^^^^^^^^^^^ meta.function.body.latex
+%                            ^^^^^^^^^^^^ meta.function.body
 %^^^^^^^^^^ keyword.declaration.function.latex
 %           ^^^^ entity.name.newcommand.latex
 %                 ^ constant.numeric.value.latex
@@ -70,7 +73,7 @@
 %^^^^^^^^^^^^ meta.function.latex
 %            ^^^^^^ meta.function.identifier.latex
 %                  ^^^ meta.function.parameters.latex
-%                     ^^^^^^^^^ meta.function.body.latex
+%                     ^^^^^^^^^ meta.function.body
 %^^^^^^^^^^^^ keyword.declaration.function.latex
 %             ^^^^ entity.name.newcommand.latex
 %                      ^^^^ support.function.general.latex
@@ -81,7 +84,7 @@
 %                ^^^^^^ meta.function.identifier.latex
 %                      ^^^ meta.function.parameters.latex
 %                         ^^^^^^^^^ meta.function.parameters.default-value.latex
-%                                  ^^^^^^^^^^^^ meta.function.body.latex
+%                                  ^^^^^^^^^^^^ meta.function.body
 % ^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 % ^ punctuation.definition.backslash.latex
 %                 ^^^^ entity.name.newcommand.latex
@@ -92,7 +95,7 @@
 %^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^ meta.function.identifier.latex
-%              ^^^^^^ meta.function.body.latex
+%              ^^^^^^ meta.function.body
 %^^^^^^^^^^ keyword.declaration.function.latex
 %          ^^^^ entity.name.newcommand.latex
 %               ^^^ support.function.general.latex
@@ -101,7 +104,7 @@
 %^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^^^ meta.function.identifier.latex
-%                  ^^^^^^ meta.function.body.latex
+%                  ^^^^^^ meta.function.body
 %            ^^^^ entity.name.newcommand.latex
 %                   ^^^^ support.function.general.latex
 
@@ -109,7 +112,7 @@
 %^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^^^ meta.function.latex
 %            ^^^^^^^ meta.function.identifier.latex
-%                   ^^^^^^ meta.function.body.latex
+%                   ^^^^^^ meta.function.body
 %             ^^^^ entity.name.newcommand.latex
 %                      ^ support.function.general.latex
 
@@ -118,7 +121,7 @@
 %^^^^^^^^^^^ meta.function.latex
 %           ^^^^ meta.function.identifier.latex
 %               ^ meta.function.latex
-%                ^^^^^^ meta.function.body.latex
+%                ^^^^^^ meta.function.body
 %           ^^^^ entity.name.newcommand.latex
 %                 ^^^^ support.function.general.latex
 
@@ -131,7 +134,7 @@
  {\bar}
 %^^^^^^ - meta.function meta.function
 % <- meta.function.latex
-%^^^^^^ meta.function.body.latex
+%^^^^^^ meta.function.body
 %      ^ - meta.function
 % ^^^^ support.function.general.latex
 
@@ -143,11 +146,31 @@
 
 
 \newcommand \baz [1] [def] {\textbf{#1}}
-%   ^ meta.function.latex
-%           ^^^^ entity.name.newcommand.latex
-%                 ^ constant.numeric.value.latex
-%                     ^^^ meta.function.parameters.default-value.latex
-%                               ^ support.function.general.latex
+%^^^^^^^^^^^ meta.function.latex
+%^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%           ^^^^ meta.function.identifier.latex entity.name.newcommand.latex
+%           ^ punctuation.definition.backslash.latex
+%               ^ meta.function.latex
+%                ^^^ meta.function.parameters.latex
+%                ^ punctuation.definition.group.bracket.begin.latex
+%                 ^ meta.number.integer.decimal.latex constant.numeric.value.latex
+%                  ^ punctuation.definition.group.bracket.end.latex
+%                   ^ meta.function.latex
+%                    ^^^^^ meta.function.parameters.default-value.latex
+%                    ^ punctuation.definition.group.bracket.begin.latex
+%                        ^ punctuation.definition.group.bracket.end.latex
+%                         ^ meta.function.latex
+%                          ^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%                          ^ punctuation.definition.group.brace.begin.tex
+%                           ^^^^^^^ support.function.general.latex
+%                           ^ punctuation.definition.backslash.latex
+%                                  ^^^^ meta.group.brace.tex
+%                                  ^ punctuation.definition.group.brace.begin.tex
+%                                   ^^ variable.parameter.tex
+%                                   ^ punctuation.definition.placeholder.tex
+%                                    ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                     ^ punctuation.definition.group.brace.end.tex
+%                                      ^ punctuation.definition.group.brace.end.tex
 
 % This example checks that we can split over multiple lines, including with comments
 \newcommand\baz %
@@ -161,7 +184,7 @@
 %      ^^^^^^^^ meta.function.parameters.default-value.latex comment.line.percentage.tex
   cu{]}t] {\textbf{#1}}
 % ^^^^^^^ meta.function.parameters.default-value.latex
-%         ^^^^^^^^^^^^^ meta.function.body.latex
+%         ^^^^^^^^^^^^^ meta.function.body
 
 % The argument count can also be based on another macro. Check that we accept this
 \def\one{1}
@@ -173,13 +196,13 @@
 %                          ^ meta.function.latex
 %                           ^^^^^^^^^ meta.function.parameters.default-value.latex
 %                                    ^ meta.function.latex
-%                                     ^^^^^^^^^^^^^^^^ meta.function.body.latex
+%                                     ^^^^^^^^^^^^^^^^ meta.function.body
 
 % newcommand entirely without braces
 \newcommand\cmd\src
 %^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %          ^^^^ meta.function.identifier.latex entity.name.newcommand.latex
-%              ^^^^ meta.function.body.latex support.function.general.latex
+%              ^^^^ meta.function.body support.function.general.latex
 
 \DeclareMathOperator{\op } {op}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -187,7 +210,7 @@
 %^^^^^^^^^^^^^^^^^^^ meta.function.latex
 %                   ^^^^^^ meta.function.identifier.latex
 %                         ^ meta.function.latex
-%                          ^^^^ meta.function.body.latex
+%                          ^^^^ meta.function.body
 %                    ^^^ entity.name.newcommand.latex
 %                           ^^ text.tex.latex
 
@@ -380,10 +403,10 @@
 %         ^ punctuation.definition.group.bracket.begin.latex
 %         ^^^^^ meta.function.footnote.latex meta.group.bracket.latex
 %             ^ punctuation.definition.group.bracket.end.latex
-%               ^ punctuation.definition.group.brace.begin.latex
+%               ^ punctuation.definition.group.brace.begin
 %               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.footnote.latex meta.group.brace.latex
 %                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.italic.footnote.latex
-%                                                                 ^ punctuation.definition.group.brace.end.latex
+%                                                                 ^ punctuation.definition.group.brace.end
 
 \footnotetext{Footnote text without creating a mark}
 % ^^^^^^^^^^^ meta.function.footnote.latex support.function.footnote.latex
@@ -469,9 +492,9 @@ The \emph{verbatim} environment sets everything in verbatim.
 %                        ^ meta.group.bracket.latex
 %                          ^ support.function.general.latex
 %                               ^ meta.group.bracket.latex
-%                                     ^ punctuation.definition.group.brace.begin.latex
+%                                     ^ punctuation.definition.group.brace.begin
 %                                        ^ meta.group.brace.latex
-%                                         ^ punctuation.definition.group.brace.end.latex
+%                                         ^ punctuation.definition.group.brace.end
 
 
 % MATH
@@ -585,9 +608,9 @@ class MyClass() {
 \lstinline{var x = 15;}
 % ^^^^^^^^^^^^^^^^^^^^^ meta.environment.verbatim.lstinline.latex
 %         ^^^^^^^^^^^^^ meta.group.brace.latex
-%         ^ punctuation.definition.group.brace.begin.latex
+%         ^ punctuation.definition.group.brace.begin
 %          ^^^^^^^^^^^ markup.raw.verb.latex
-%                     ^ punctuation.definition.group.brace.end.latex
+%                     ^ punctuation.definition.group.brace.end
 %                      ^ - meta.environment.verbatim.lstinline.latex
 
 \lstinline|var x = 15;|

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -27,7 +27,7 @@
 % line comment
 % <- comment.line.percentage.tex
 
-\newcommand{\foo}{\bar}
+\newcommand{\foo}{\baz}
 %^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^ meta.function.identifier.latex
@@ -42,7 +42,7 @@
 %                 ^ punctuation.definition.backslash.latex
 %                     ^ punctuation.definition.group.brace.end
 
-\newcommand{\foo}[1]{\bar #1}
+\newcommand{\foo}[1]{\baz #1}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^ meta.function.identifier.latex
@@ -56,7 +56,7 @@
 %                         ^^ variable.parameter.tex
 %                          ^ meta.number.integer.decimal constant.numeric.value.tex
 
-\newcommand{\foo}[2][default]{\bar #1 #2}
+\newcommand{\foo}[2][default]{\baz #1 #2}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^ meta.function.identifier.latex
@@ -68,7 +68,7 @@
 %                 ^ constant.numeric.value.latex
 %                             ^^^^ support.function.general.latex
 
-\renewcommand{\foo}[1]{\bar #1}
+\renewcommand{\foo}[1]{\baz #1}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^^^ meta.function.latex
 %            ^^^^^^ meta.function.identifier.latex
@@ -78,7 +78,7 @@
 %             ^^^^ entity.name.newcommand.latex
 %                      ^^^^ support.function.general.latex
 
-  \providecommand{\f@o}[2][default]{\bar #1 #2}
+  \providecommand{\f@o}[2][default]{\baz #1 #2}
 % ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 % ^^^^^^^^^^^^^^^ meta.function.latex
 %                ^^^^^^ meta.function.identifier.latex
@@ -91,7 +91,7 @@
 %                       ^ constant.numeric.value.latex
 %                                   ^^^^ support.function.general.latex
 
-\newcommand\foo{\bar}
+\newcommand\foo{\baz}
 %^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^ meta.function.identifier.latex
@@ -100,7 +100,7 @@
 %          ^^^^ entity.name.newcommand.latex
 %               ^^^ support.function.general.latex
 
-\newcommand{ \foo }{\bar}
+\newcommand{ \foo }{\baz}
 %^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^ meta.function.latex
 %          ^^^^^^^^ meta.function.identifier.latex
@@ -108,7 +108,7 @@
 %            ^^^^ entity.name.newcommand.latex
 %                   ^^^^ support.function.general.latex
 
-\newcommand* {\foo }{\bar}
+\newcommand* {\foo }{\baz}
 %^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^^^ meta.function.latex
 %            ^^^^^^^ meta.function.identifier.latex
@@ -116,7 +116,7 @@
 %             ^^^^ entity.name.newcommand.latex
 %                      ^ support.function.general.latex
 
-\newcommand \foo {\bar}
+\newcommand \foo {\baz}
 %^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 %^^^^^^^^^^^ meta.function.latex
 %           ^^^^ meta.function.identifier.latex
@@ -131,7 +131,7 @@
 %           ^^^^ meta.function.identifier.latex
 %               ^^^^^^^^^^^^^^^^^^^^^ meta.function.latex
 %           ^^^^ entity.name.newcommand.latex
- {\bar}
+ {\baz}
 %^^^^^^ - meta.function meta.function
 % <- meta.function.latex
 %^^^^^^ meta.function.body
@@ -141,7 +141,7 @@
 % note: with an actual empty line in-between, this is a new paragraph
 \newcommand \foo
 
- {\bar}
+ {\baz}
 %^^^^^^ - meta.function
 
 

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -132,12 +132,13 @@ some other text
 
 
 % testing registers and nested braces
-\def\test{\dimen5 {#2}}
+\def\test{\dimen5 {#2} \alpha}
 %        ^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %         ^^^^^^^ meta.register.tex
 %                 ^^^^ meta.group.brace.tex
 %                  ^^ variable.parameter.tex
+%                      ^^^^^^ keyword.other.math.greek.tex
 
 
 % testing incomplete register specification

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -119,7 +119,12 @@ some other text
 
 % testing control keywords, parameter placeholders, and escaping of placeholders
 \def\test{\ifmmode #2 \#2}
+%^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+%^^^ meta.function.tex
+%   ^^^^^ meta.function.identifier.tex
 %        ^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%   ^^^^^ entity.name.definition.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %         ^^^^^^^^ keyword.control.conditional.if.tex
 %         ^ punctuation.definition.backslash.tex
@@ -133,16 +138,24 @@ some other text
 
 % testing registers and nested braces
 \def\test{\dimen5 {#2} \alpha}
-%        ^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
-%        ^ punctuation.definition.group.brace.begin.tex
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+%^^^ meta.function.tex
+%   ^^^^^ meta.function.identifier.tex
+%        ^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %         ^^^^^^^ meta.register.tex
-%                 ^^^^ meta.group.brace.tex
+%                 ^^^^ meta.group.brace.tex meta.group.brace.tex
+%^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%   ^^^^^ entity.name.definition.tex
+%        ^ punctuation.definition.group.brace.begin.tex
 %                  ^^ variable.parameter.tex
 %                      ^^^^^^ keyword.other.math.greek.tex
 
 
 % testing incomplete register specification
 \def\test{\dimen} other text
+%^^^^^^^^^^^^^^^^ - meta.function meta.function
+%^^^ meta.function.tex
+%   ^^^^^ meta.function.identifier.tex
 %        ^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %         ^^^^^^ meta.register.tex
 %                ^^^^^^^^^^^ - meta.function.body

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -114,6 +114,39 @@ some other text
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Macro definition contents
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% testing control keywords, parameter placeholders, and escaping of placeholders
+\def\test{\ifmmode #2 \#2}
+%        ^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%        ^ punctuation.definition.group.brace.begin.tex
+%         ^^^^^^^^ keyword.control.conditional.if.tex
+%         ^ punctuation.definition.backslash.tex
+%                  ^^ variable.parameter.tex
+%                  ^ punctuation.definition.placeholder.tex
+%                   ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                     ^^ constant.character.escape.tex
+%                     ^ punctuation.definition.backslash.tex
+%                        ^ punctuation.definition.group.brace.end.tex
+
+
+% testing registers and nested braces
+\def\test{\dimen5 {#2}}
+%        ^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%        ^ punctuation.definition.group.brace.begin.tex
+%         ^^^^^^^ meta.register.tex
+%                 ^^^^ meta.group.brace.tex
+%                  ^^ variable.parameter.tex
+
+
+% testing incomplete register specification
+\def\test{\dimen} other text
+%        ^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%         ^^^^^^ meta.register.tex
+%                ^^^^^^^^^^^ - meta.function.body
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Control flow / Conditionals
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This PR performs a slight reorganization of the macro-braces context, and increases the amount of constructs that are highlighted within. This also unifies (to the extend possible) the handling of "function bodies" in TeX and LaTeX.
Most importantly, now we have highlighting for the replacement-placeholders.