### PR TITLE
[TeX] improved handling of (cat)code family of commands

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -249,7 +249,7 @@ contexts:
     - include: immediately-pop
 
   character-code-number:
-    - match: '(`)(\\)?({{charbycode}}|.)'
+    - match: (`)(\\)?({{charbycode}}|.)
       scope: meta.number.integer.tex
       captures:
         1: keyword.operator.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -69,6 +69,12 @@ variables:
   endcs: '(?!{{letter}})'
   # a command name: either a sequence of letters, or a single non-letter
   cmdname: '(?x: {{letter}}+ | {{nonletter}})'
+  # hexadecimal digits in different casing
+  lchexdigit: (?:[0-9a-f])
+  uchexdigit: (?:[0-9A-F])
+  anyhexdigit: (?:[0-9a-fA-F])
+  # special notation to refer to (non-printable) characters in TeX
+  charbycode: '(?x: \^\^(?:{{lchexdigit}}{{lchexdigit}}|.))'
 
 contexts:
   prototype:
@@ -77,7 +83,7 @@ contexts:
   main:
     - include: macros
     - include: controls
-    - include: catcode
+    - include: character-codes
     - include: braces
     - include: boxes
     - include: block-math
@@ -195,14 +201,6 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
 
-  catcode:
-    - match: ((\\)catcode)`(?:\\)?.=(\d+)
-      scope: meta.function.catcode.tex
-      captures:
-        1: keyword.control.catcode.tex
-        2: punctuation.definition.backslash.tex
-        3: constant.numeric.category.tex
-
   braces:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
@@ -230,6 +228,55 @@ contexts:
     - meta_scope: meta.function.box.tex
     - include: brace-group-end
     - include: main
+
+
+###[ CHARACTER CODES ]##########################################################
+
+  character-codes:
+    - match: (\\)(?:cat|math|uc|lc|del|sf)code{{endcs}}
+      scope: keyword.control.character-code.tex
+      captures:
+        1 : punctuation.definition.backslash.tex
+      push:
+        - character-code-scope
+        - character-code-value
+        - character-code-assignment
+        - character-code-number
+
+  character-code-scope:
+    - meta_scope: meta.function.character-code.tex
+    - include: immediately-pop
+
+  character-code-number:
+    - match: '(`)(\\)?({{charbycode}}|.)'
+      scope: meta.number.integer.tex
+      captures:
+        1: keyword.operator.tex
+        2: punctuation.definition.backslash.tex
+        3: constant.character.tex
+      pop: 1
+    - match: \d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+      set: character-code-assignment
+    - include: else-pop
+    - include: paragraph-pop
+
+  character-code-assignment:
+    - match: =
+      scope: keyword.operator.assignment.tex
+      pop: 1
+    - include: else-pop
+    - include: paragraph-pop
+
+  character-code-value:
+    - match: \d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+      pop: 1
+    - match: '"{{anyhexdigit}}+'
+      scope: meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+      pop: 1
+    - include: else-pop
+    - include: paragraph-pop
 
 ###[ MACROS ]##################################################################
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -236,7 +236,7 @@ contexts:
     - match: (\\)(?:cat|math|uc|lc|del|sf)code{{endcs}}
       scope: keyword.control.character-code.tex
       captures:
-        1 : punctuation.definition.backslash.tex
+        1: punctuation.definition.backslash.tex
       push:
         - character-code-scope
         - character-code-value

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -74,7 +74,7 @@ variables:
   uchexdigit: (?:[0-9A-F])
   anyhexdigit: (?:[0-9a-fA-F])
   # special notation to refer to (non-printable) characters in TeX
-  charbycode: '(?x: \^\^(?:{{lchexdigit}}{{lchexdigit}}|.))'
+  charbycode: (?:\^\^(?:{{lchexdigit}}{{lchexdigit}}|.))
 
 contexts:
   prototype:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -238,12 +238,13 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
       push:
-        - character-code-scope
+        - character-code-meta
         - character-code-value
         - character-code-assignment
         - character-code-number
 
-  character-code-scope:
+  character-code-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.function.character-code.tex
     - include: immediately-pop
 

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -192,3 +192,79 @@ some other text
 %^^^^ storage.type.tex
 %     ^^^^^ support.function.general.tex
 %     ^ punctuation.definition.backslash.tex
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Character Codes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\catcode65=12
+%^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%         ^ keyword.operator.assignment.tex
+%          ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+
+% here are some assignments that happen in `plain.tex`
+
+\catcode`@=11
+%^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^ meta.number.integer.tex
+%       ^ keyword.operator.tex
+%        ^ constant.character.tex
+%         ^ keyword.operator.assignment.tex
+%          ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+\catcode`\^^K=7
+%^^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^^^^ meta.number.integer.tex
+%       ^ keyword.operator.tex
+%        ^ punctuation.definition.backslash.tex
+%         ^^^ constant.character.tex
+%            ^ keyword.operator.assignment.tex
+%             ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+\mathcode`\^^D="225E
+%^^^^^^^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^^ keyword.control.character-code.tex
+%        ^^^^^ meta.number.integer.tex
+%        ^ keyword.operator.tex
+%         ^ punctuation.definition.backslash.tex
+%          ^^^ constant.character.tex
+%             ^ keyword.operator.assignment.tex
+%              ^^^^^ meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+
+\delcode`\\="26E30F
+%^^^^^^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^^ meta.number.integer.tex
+%       ^ keyword.operator.tex
+%        ^ punctuation.definition.backslash.tex
+%         ^ constant.character.tex
+%          ^ keyword.operator.assignment.tex
+%           ^^^^^^^ meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+
+% some other assignments
+
+% skip the = sign
+\catcode`@11
+%^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^ meta.number.integer.tex
+%       ^ keyword.operator.tex
+%        ^ constant.character.tex
+%         ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+% hex-specifier
+\catcode`\^^ab=11
+%^^^^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^^ keyword.control.character-code.tex
+%       ^^^^^^ meta.number.integer.tex
+%       ^ keyword.operator.tex
+%        ^ punctuation.definition.backslash.tex
+%         ^^^^ constant.character.tex
+%             ^ keyword.operator.assignment.tex
+%              ^^ meta.number.integer.decimal.tex constant.numeric.value.tex


### PR DESCRIPTION
extends the range of commands that will be highlighted to also include math, delimiter, and upper/lower case codes, allows for more forms of specifying the target character and the assigned number.