### PR TITLE
[TeX] added scoping of "constants"

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -205,15 +205,13 @@ contexts:
     - include: else-pop
     - include: paragraph-pop
 
-  decimal-float-meta:
-    - meta_include_prototype: false
+  decimal-float:
     - meta_scope: meta.number.float.decimal.tex
-    - include: immediately-pop
+    - include: tex-dimension-suffix
 
-  decimal-integer-meta:
-    - meta_include_prototype: false
+  decimal-integer:
     - meta_scope: meta.number.integer.decimal.tex
-    - include: immediately-pop
+    - include: tex-dimension-suffix
 
   tex-dimension-suffix:
     - match: '{{dimunits}}'

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -175,10 +175,19 @@ contexts:
     - include: paragraph-pop
 
   tex-constant-value:
-    - match: -?\d+\.\d*
-      scope: meta.number.float.decimal.tex constant.numeric.value.tex
-    - match: -?\d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+    - match: ((-?)\d+(\.)\d*)({{dimunits}}?)
+      scope: meta.number.float.decimal.tex
+      captures:
+        1: constant.numeric.value.tex
+        2: keyword.operator.arithmetic.tex
+        3: punctuation.separator.decimal.tex
+        4: constant.numeric.suffix.tex
+    - match: ((-?)\d+)({{dimunits}}?)
+      scope: meta.number.integer.decimal.tex
+      captures:
+        1: constant.numeric.value.tex
+        2: keyword.operator.arithmetic.tex
+        3: constant.numeric.suffix.tex
     - match: (`)(\\)?({{charbycode}}|.)
       scope: meta.number.integer.tex
       captures:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -56,6 +56,52 @@ variables:
   registers: |-
     (?x: box | count | dimen | muskip | skip | toks)
 
+  # here, we define variables for the names of the constants and parameters
+  # of the TeX algorithm. Some of these are defined in terms of pre-reserved
+  # registers instead of built-ins, but in terms of syntax highlighting this
+  # should not make a difference
+  penalties: |-
+    (?x: line | hyphen | exhyphen | binop | rel | club | widow
+    | displaywidow | broken | predisplay | postdisplay | interline
+    | floating | output | inter(?:display|footnote)line)
+
+  tracings: |-
+    (?x: online | macros | stats | paragraphs | pages | output | lostchars
+    | commands | restores)
+
+  skips: |-
+    (?x: baseline | line | par | (?:above|below)display(?:short)?
+    | left | right | top | splittop | tab | space | xspace | parfill
+    | (?:thin|med|thick)mu | normalbaseline | normalline | hide)
+
+  constants: |-
+    (?x: (?:pre)?tolerance | [hv]badness
+    | (?:doublehyphen|finalhyphen|adj)demerits
+    | looseness | pausing | holdinginserts | language | uchyph | lefthyphenmin
+    | righthyphenmin | globaldefs | maxdeadcycles | hangafter | fam | mag
+    | (?:escape|defaulthyphen|defaultskew|endline|newline)char
+    | delimiterfactor | time | day | month | year
+    | showboxbreadth | showboxdepth | errorcontextlines
+    | [hv]fuzz | overfullrule | [hv]size | maxdepth | splitmaxdepth
+    | boxmaxdepth | lineskiplimit | delimitershortfall | nulldelimiterspace
+    | scriptspace | mathsurround | predisplaysize | displaywidth | displayindent
+    | parindent | hangindent | [hv]offset | (?:small|med|big)skipamount
+    | normallineskiplimit | jot | {{skips}}skip | tracing{{tracings}}
+    | {{penalties}}penalty | maxdimen | centering | p@ | z@ | z@skip | voidb@x
+    | magstephalf | magstep\d | @ne | tw@ | thr@@ | sixt@@n | @cclv | @cclvi
+    | @m | @M | @MM | m@ne | count@ | dimen@ | dimen@i | dimen@ii | skip@
+    | toks@ | insc@unt | allocationnumber)
+
+  # These constants are implemented as macros, and thus cannot be = assigned
+  macroconst: |-
+    (?x: (?:thin|negthin|en)space | enskip | q?quad | (?:small|med|big)skip
+    | [lr]q | [lr]brack | space | empty | null )
+
+
+  dimunits: |-
+    (?x: pt | pc | bp | in | cm | mm | dd | cc | sp | ex | em
+    | fil | fill | filll | mu)
+
   # letters in the sense of macro names. Whether @ is a letter or not can vary
   # from a syntax-highlighting perspective, however, we are much safer to
   # assume it is a letter. Situations where we have `\macro` followed immediately
@@ -90,6 +136,7 @@ contexts:
     - include: inline-math
     - include: registers
     - include: register-allocations
+    - include: tex-constants
     - include: general-constants
     - include: general-commands
 
@@ -107,6 +154,47 @@ contexts:
     - match: '~'
       scope: constant.character.space.tex
     - include: escaped-character
+
+  tex-constants:
+    - match: (\\){{constants}}{{endcs}}
+      scope: constant.language.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      push:
+        - tex-constant-value
+        - tex-constant-assignment
+    - match: (\\){{macroconst}}{{endcs}}
+      scope: constant.language.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
+
+  tex-constant-assignment:
+    - match: =
+      scope: keyword.operator.assignment.tex
+      pop: 1
+    - include: else-pop
+    - include: paragraph-pop
+
+  tex-constant-value:
+    - match: -?\d+\.\d*
+      scope: meta.number.float.decimal.tex constant.numeric.value.tex
+    - match: -?\d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+    - match: (`)(\\)?({{charbycode}}|.)
+      scope: meta.number.integer.tex
+      captures:
+        1: keyword.operator.tex
+        2: punctuation.definition.backslash.tex
+        3: constant.character.tex
+    - match: '{{dimunits}}'
+      scope: constant.numeric.suffix.tex
+
+    - match: plus|minus
+      scope: keyword.operator.tex
+
+    - include: else-pop
+    - include: paragraph-pop
 
   escaped-character:
     - match: (\\){{nonletter}}
@@ -352,6 +440,7 @@ contexts:
     - include: controls
     - include: registers
     - include: math-builtin
+    - include: tex-constants
     - include: general-constants
     - include: general-commands
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -198,9 +198,6 @@ contexts:
       set:
         - tex-dimension-glue
         - decimal-integer
-    - include: else-pop
-    - include: paragraph-pop
-
     - match: (`)(\\)?({{charbycode}}|.)
       captures:
         1: keyword.operator.tex
@@ -209,6 +206,8 @@ contexts:
       set:
         - tex-dimension-glue
         - decimal-integer
+    - include: else-pop
+    - include: paragraph-pop
 
   tex-dimension-glue:
     - match: (?:plus|minus){{endcs}}

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -97,7 +97,6 @@ variables:
     (?x: (?:thin|negthin|en)space | enskip | q?quad | (?:small|med|big)skip
     | [lr]q | [lr]brack | space | empty | null )
 
-
   dimunits: |-
     (?x: pt | pc | bp | in | cm | mm | dd | cc | sp | ex | em
     | fil | fill | filll | mu)
@@ -167,7 +166,6 @@ contexts:
       scope: constant.language.tex
       captures:
         1: punctuation.definition.backslash.tex
-
 
   tex-constant-assignment:
     - match: =

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -160,7 +160,8 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
       push:
-        - tex-constant-value
+        - tex-dimension-glue
+        - tex-dimension-value
         - tex-constant-assignment
     - match: (\\){{macroconst}}{{endcs}}
       scope: constant.language.tex
@@ -174,28 +175,43 @@ contexts:
     - include: else-pop
     - include: paragraph-pop
 
-  tex-constant-value:
+  tex-dimension-value:
+    - include: tex-dimension-value-content
+    # if we don't find a valid value, we also need to pop the enclosing glue
+    # context.
+    - match: (?=\S|^\s*$)
+      pop: 2
+
+  tex-dimension-value-content:
     - match: (-?)\d+(\.)\d*
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
-      push: decimal-float
+      set: decimal-float
+    - match: (-?)(\.)\d+
+      scope: constant.numeric.value.tex
+      captures:
+        1: keyword.operator.arithmetic.tex
+        2: punctuation.separator.decimal.tex
+      set: decimal-float
     - match: (-?)\d+
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
-      push: decimal-integer
+      set: decimal-integer
 
     - match: (`)(\\)?({{charbycode}}|.)
-      scope: meta.number.integer.tex
       captures:
         1: keyword.operator.tex
         2: punctuation.definition.backslash.tex
         3: constant.character.tex
+      set: decimal-integer
 
-    - match: plus|minus
+  tex-dimension-glue:
+    - match: (?:plus|minus){{endcs}}
       scope: keyword.operator.arithmetic.tex
+      push: tex-dimension-value
 
     - include: else-pop
     - include: paragraph-pop

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -175,30 +175,50 @@ contexts:
     - include: paragraph-pop
 
   tex-constant-value:
-    - match: ((-?)\d+(\.)\d*)({{dimunits}}?)
-      scope: meta.number.float.decimal.tex
+    - match: (-?)\d+(\.)\d*
+      scope: constant.numeric.value.tex
       captures:
-        1: constant.numeric.value.tex
-        2: keyword.operator.arithmetic.tex
-        3: punctuation.separator.decimal.tex
-        4: constant.numeric.suffix.tex
-    - match: ((-?)\d+)({{dimunits}}?)
-      scope: meta.number.integer.decimal.tex
+        1: keyword.operator.arithmetic.tex
+        2: punctuation.separator.decimal.tex
+      push:
+        - decimal-float-meta
+        - tex-dimension-suffix
+    - match: ((-?)\d+)
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
       captures:
-        1: constant.numeric.value.tex
-        2: keyword.operator.arithmetic.tex
-        3: constant.numeric.suffix.tex
+        1: keyword.operator.arithmetic.tex
+        2: constant.numeric.suffix.tex
+      push:
+        - decimal-integer-meta
+        - tex-dimension-suffix
+
     - match: (`)(\\)?({{charbycode}}|.)
       scope: meta.number.integer.tex
       captures:
         1: keyword.operator.tex
         2: punctuation.definition.backslash.tex
         3: constant.character.tex
-    - match: '{{dimunits}}'
-      scope: constant.numeric.suffix.tex
 
     - match: plus|minus
       scope: keyword.operator.arithmetic.tex
+
+    - include: else-pop
+    - include: paragraph-pop
+
+  decimal-float-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.number.float.decimal.tex
+    - include: immediately-pop
+
+  decimal-integer-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.number.integer.decimal.tex
+    - include: immediately-pop
+
+  tex-dimension-suffix:
+    - match: '{{dimunits}}'
+      scope: constant.numeric.suffix.tex
+      pop: 1
 
     - include: else-pop
     - include: paragraph-pop

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -175,19 +175,12 @@ contexts:
     - include: paragraph-pop
 
   tex-dimension-value:
-    - match: (-?)\d+(\.)\d*
+    - match: (-?)(?:\d+(\.)\d*|(\.)\d+)
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
-      set:
-        - tex-dimension-glue
-        - decimal-float
-    - match: (-?)(\.)\d+
-      scope: constant.numeric.value.tex
-      captures:
-        1: keyword.operator.arithmetic.tex
-        2: punctuation.separator.decimal.tex
+        3: punctuation.separator.decimal.tex
       set:
         - tex-dimension-glue
         - decimal-float

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -160,7 +160,6 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
       push:
-        - tex-dimension-glue
         - tex-dimension-value
         - tex-constant-assignment
     - match: (\\){{macroconst}}{{endcs}}
@@ -177,10 +176,8 @@ contexts:
 
   tex-dimension-value:
     - include: tex-dimension-value-content
-    # if we don't find a valid value, we also need to pop the enclosing glue
-    # context.
-    - match: (?=\S|^\s*$)
-      pop: 2
+    - include: else-pop
+    - include: paragraph-pop
 
   tex-dimension-value-content:
     - match: (-?)\d+(\.)\d*
@@ -188,31 +185,38 @@ contexts:
       captures:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
-      set: decimal-float
+      set:
+        - tex-dimension-glue
+        - decimal-float
     - match: (-?)(\.)\d+
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
-      set: decimal-float
+      set:
+        - tex-dimension-glue
+        - decimal-float
     - match: (-?)\d+
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
-      set: decimal-integer
+      set:
+        - tex-dimension-glue
+        - decimal-integer
 
     - match: (`)(\\)?({{charbycode}}|.)
       captures:
         1: keyword.operator.tex
         2: punctuation.definition.backslash.tex
         3: constant.character.tex
-      set: decimal-integer
+      set:
+        - tex-dimension-glue
+        - decimal-integer
 
   tex-dimension-glue:
     - match: (?:plus|minus){{endcs}}
       scope: keyword.operator.arithmetic.tex
-      push: tex-dimension-value
-
+      set: tex-dimension-value
     - include: else-pop
     - include: paragraph-pop
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -180,17 +180,13 @@ contexts:
       captures:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
-      push:
-        - decimal-float-meta
-        - tex-dimension-suffix
+      push: decimal-float
     - match: ((-?)\d+)
       scope: meta.number.integer.decimal.tex constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
         2: constant.numeric.suffix.tex
-      push:
-        - decimal-integer-meta
-        - tex-dimension-suffix
+      push: decimal-integer
 
     - match: (`)(\\)?({{charbycode}}|.)
       scope: meta.number.integer.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -198,7 +198,7 @@ contexts:
       scope: constant.numeric.suffix.tex
 
     - match: plus|minus
-      scope: keyword.operator.tex
+      scope: keyword.operator.arithmetic.tex
 
     - include: else-pop
     - include: paragraph-pop

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -175,11 +175,6 @@ contexts:
     - include: paragraph-pop
 
   tex-dimension-value:
-    - include: tex-dimension-value-content
-    - include: else-pop
-    - include: paragraph-pop
-
-  tex-dimension-value-content:
     - match: (-?)\d+(\.)\d*
       scope: constant.numeric.value.tex
       captures:
@@ -203,6 +198,8 @@ contexts:
       set:
         - tex-dimension-glue
         - decimal-integer
+    - include: else-pop
+    - include: paragraph-pop
 
     - match: (`)(\\)?({{charbycode}}|.)
       captures:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -181,11 +181,10 @@ contexts:
         1: keyword.operator.arithmetic.tex
         2: punctuation.separator.decimal.tex
       push: decimal-float
-    - match: ((-?)\d+)
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+    - match: (-?)\d+
+      scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
-        2: constant.numeric.suffix.tex
       push: decimal-integer
 
     - match: (`)(\\)?({{charbycode}}|.)

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -411,7 +411,7 @@ some other text
 \escapechar=`\\
 %^^^^^^^^^^ constant.language.tex
 %          ^ keyword.operator.assignment.tex
-%           ^^^ meta.number.integer.tex
+%           ^^^ meta.number.integer
 %           ^ keyword.operator.tex
 %            ^ punctuation.definition.backslash.tex
 %             ^ constant.character.tex
@@ -480,8 +480,15 @@ some other text
 %      ^^^ constant.numeric.value.tex
 %       ^ punctuation.separator.decimal.tex
 %         ^^ constant.numeric.suffix.tex
-\maxdepth=4pt
+\maxdepth=.4pt
 %^^^^^^^^ constant.language.tex
+%        ^ keyword.operator.assignment.tex
+%         ^^^^ meta.number.float.decimal.tex
+%         ^^ constant.numeric.value.tex
+%         ^ punctuation.separator.decimal.tex
+%           ^^ constant.numeric.suffix.tex
+
+
 \splitmaxdepth=\maxdimen
 %^^^^^^^^^^^^^ constant.language.tex
 %             ^ keyword.operator.assignment.tex
@@ -667,6 +674,25 @@ some other text
 %                 ^^^ constant.language.tex
 %                 ^ punctuation.definition.backslash.tex
 
+% Using weird ways to specify a number
+\abovedisplayskip=`\^^Z ex
+%^^^^^^^^^^^^^^^^ constant.language.tex
+%                ^ keyword.operator.assignment.tex
+%                 ^^^^^^^ meta.number.integer.decimal.tex
+%                 ^ keyword.operator.tex
+%                  ^ punctuation.definition.backslash.tex
+%                   ^^^ constant.character.tex
+%                       ^^ constant.numeric.suffix.tex
+
+\abovedisplayskip=`\a ex
+%^^^^^^^^^^^^^^^^ constant.language.tex
+%                ^ keyword.operator.assignment.tex
+%                 ^^^^^^ meta.number.integer.decimal.tex
+%                 ^ keyword.operator.tex
+%                  ^ punctuation.definition.backslash.tex
+%                   ^ constant.character.tex
+%                     ^^ constant.numeric.suffix.tex
+
 
 % The macro-type constants. They cannot be assigned using =
 \thinspace=5pt
@@ -713,6 +739,15 @@ some other text
 %    ^^ - constant.numeric.suffix.tex
 \jot=5pt pt
 %        ^^ - constant.numeric.suffix.tex
+
+\jot=5pt plus plus 
+%             ^^^^ - keyword
+
+\jot=5pt plusword
+%        ^^^^ - keyword
+
+\jot=plus
+%    ^^^^ - keyword
 
 % \relax is a no-op that can be used to ensure that the following characters
 % will not be parsed as part of the quantity

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -449,19 +449,23 @@ some other text
 %      ^^^ constant.numeric.value.tex
 %       ^ punctuation.separator.decimal.tex
 %         ^^ constant.numeric.suffix.tex
-\vfuzz=0.1pt
+\vfuzz=0.1 pt
 %^^^^^ constant.language.tex
 %     ^ keyword.operator.assignment.tex
-%      ^^^^^ meta.number.float.decimal.tex
+%      ^^^^^^ meta.number.float.decimal.tex
 %      ^^^ constant.numeric.value.tex
 %       ^ punctuation.separator.decimal.tex
-%         ^^ constant.numeric.suffix.tex
-\overfullrule=5pt
+%          ^^ constant.numeric.suffix.tex
+
+% check that we can put comment-based line breaks here
+\overfullrule=%
 %^^^^^^^^^^^^ constant.language.tex
 %            ^ keyword.operator.assignment.tex
-%             ^^^ meta.number.integer.decimal.tex
-%             ^ constant.numeric.value.tex
-%              ^^ constant.numeric.suffix.tex
+   5pt
+%  ^^^ meta.number.integer.decimal.tex
+%  ^ constant.numeric.value.tex
+%   ^^ constant.numeric.suffix.tex
+
 \hsize=6.5in
 %^^^^^ constant.language.tex
 %     ^ keyword.operator.assignment.tex
@@ -519,7 +523,7 @@ some other text
 %       ^ keyword.operator.assignment.tex
 %        ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %         ^^ constant.numeric.suffix.tex
-%            ^^^^ keyword.operator.tex
+%            ^^^^ keyword.operator.arithmetic.tex
 %                 ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                  ^^ constant.numeric.suffix.tex
 
@@ -528,10 +532,10 @@ some other text
 %                ^ keyword.operator.assignment.tex
 %                 ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                   ^^ constant.numeric.suffix.tex
-%                      ^^^^ keyword.operator.tex
+%                      ^^^^ keyword.operator.arithmetic.tex
 %                           ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                            ^^ constant.numeric.suffix.tex
-%                               ^^^^^ keyword.operator.tex
+%                               ^^^^^ keyword.operator.arithmetic.tex
 %                                     ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                                      ^^ constant.numeric.suffix.tex
 \abovedisplayshortskip=0pt plus 3pt
@@ -559,7 +563,7 @@ some other text
 %           ^ keyword.operator.assignment.tex
 %            ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %             ^^ constant.numeric.suffix.tex
-%                ^^^^ keyword.operator.tex
+%                ^^^^ keyword.operator.arithmetic.tex
 %                     ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                      ^^^ constant.numeric.suffix.tex
 
@@ -575,10 +579,10 @@ some other text
 %         ^ keyword.operator.assignment.tex
 %          ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %           ^^ constant.numeric.suffix.tex
-%              ^^^^ keyword.operator.tex
+%              ^^^^ keyword.operator.arithmetic.tex
 %                   ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                    ^^ constant.numeric.suffix.tex
-%                       ^^^^^ keyword.operator.tex
+%                       ^^^^^ keyword.operator.arithmetic.tex
 %                             ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                              ^^ constant.numeric.suffix.tex
 \thickmuskip=5mu plus 5mu
@@ -703,6 +707,12 @@ some other text
 % check that we don't pick it up if it is just the beginning of a word
 \jota
 %^^^^ - constant.language.tex
+
+% Check that a number is required
+\jot=pt
+%    ^^ - constant.numeric.suffix.tex
+\jot=5pt pt
+%        ^^ - constant.numeric.suffix.tex
 
 % \relax is a no-op that can be used to ensure that the following characters
 % will not be parsed as part of the quantity

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -445,19 +445,37 @@ some other text
 \hfuzz=0.1pt
 %^^^^^ constant.language.tex
 %     ^ keyword.operator.assignment.tex
-%      ^^^ meta.number.float.decimal.tex constant.numeric.value.tex
+%      ^^^^^ meta.number.float.decimal.tex
+%      ^^^ constant.numeric.value.tex
+%       ^ punctuation.separator.decimal.tex
 %         ^^ constant.numeric.suffix.tex
 \vfuzz=0.1pt
 %^^^^^ constant.language.tex
+%     ^ keyword.operator.assignment.tex
+%      ^^^^^ meta.number.float.decimal.tex
+%      ^^^ constant.numeric.value.tex
+%       ^ punctuation.separator.decimal.tex
+%         ^^ constant.numeric.suffix.tex
 \overfullrule=5pt
 %^^^^^^^^^^^^ constant.language.tex
+%            ^ keyword.operator.assignment.tex
+%             ^^^ meta.number.integer.decimal.tex
+%             ^ constant.numeric.value.tex
+%              ^^ constant.numeric.suffix.tex
 \hsize=6.5in
 %^^^^^ constant.language.tex
 %     ^ keyword.operator.assignment.tex
-%      ^^^ meta.number.float.decimal.tex constant.numeric.value.tex
+%      ^^^^^ meta.number.float.decimal.tex
+%      ^^^ constant.numeric.value.tex
+%       ^ punctuation.separator.decimal.tex
 %         ^^ constant.numeric.suffix.tex
 \vsize=8.9in
 %^^^^^ constant.language.tex
+%     ^ keyword.operator.assignment.tex
+%      ^^^^^ meta.number.float.decimal.tex
+%      ^^^ constant.numeric.value.tex
+%       ^ punctuation.separator.decimal.tex
+%         ^^ constant.numeric.suffix.tex
 \maxdepth=4pt
 %^^^^^^^^ constant.language.tex
 \splitmaxdepth=\maxdimen
@@ -641,6 +659,7 @@ some other text
 \baselineskip-1000\p@
 %^^^^^^^^^^^^ constant.language.tex
 %            ^^^^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%            ^ keyword.operator.arithmetic.tex
 %                 ^^^ constant.language.tex
 %                 ^ punctuation.definition.backslash.tex
 
@@ -651,7 +670,7 @@ some other text
 %         ^ - keyword.operator.assignment.tex
 
 \negthinspace
-%^^^^^^^^^^^^ constant.language.tex          
+%^^^^^^^^^^^^ constant.language.tex
 \enspace
 %^^^^^^^ constant.language.tex
 \enskip

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -315,3 +315,402 @@ some other text
 %         ^^^^ constant.character.tex
 %             ^ keyword.operator.assignment.tex
 %              ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Constants
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\pretolerance=100
+%^^^^^^^^^^^^ constant.language.tex
+%            ^ keyword.operator.assignment.tex
+%             ^^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+\tolerance=200
+%^^^^^^^^^ constant.language.tex
+\hbadness=1000
+%^^^^^^^^ constant.language.tex
+\vbadness=1000
+%^^^^^^^^ constant.language.tex
+\linepenalty=10
+%^^^^^^^^^^^ constant.language.tex
+\hyphenpenalty=50
+%^^^^^^^^^^^^^ constant.language.tex
+\exhyphenpenalty=50
+%^^^^^^^^^^^^^^^ constant.language.tex
+\binoppenalty=700
+%^^^^^^^^^^^^ constant.language.tex
+\relpenalty=500
+%^^^^^^^^^^ constant.language.tex
+\clubpenalty=150
+%^^^^^^^^^^^ constant.language.tex
+\widowpenalty=150
+%^^^^^^^^^^^^ constant.language.tex
+\displaywidowpenalty=50
+%^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\brokenpenalty=100
+%^^^^^^^^^^^^^ constant.language.tex
+\predisplaypenalty=10000
+%^^^^^^^^^^^^^^^^^ constant.language.tex
+\postdisplaypenalty=0
+%^^^^^^^^^^^^^^^^^^ constant.language.tex
+\interlinepenalty=0
+%^^^^^^^^^^^^^^^^ constant.language.tex
+\floatingpenalty=0
+%^^^^^^^^^^^^^^^ constant.language.tex
+\outputpenalty=0
+%^^^^^^^^^^^^^ constant.language.tex
+\doublehyphendemerits=10000
+%^^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\finalhyphendemerits=5000
+%^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\adjdemerits=10000
+%^^^^^^^^^^^ constant.language.tex
+\looseness=0
+%^^^^^^^^^ constant.language.tex
+\pausing=0
+%^^^^^^^ constant.language.tex
+\holdinginserts=0
+%^^^^^^^^^^^^^^ constant.language.tex
+\tracingonline=0
+%^^^^^^^^^^^^^ constant.language.tex
+\tracingmacros=0
+%^^^^^^^^^^^^^ constant.language.tex
+\tracingstats=0
+%^^^^^^^^^^^^ constant.language.tex
+\tracingparagraphs=0
+%^^^^^^^^^^^^^^^^^constant.language.tex
+\tracingpages=0
+%^^^^^^^^^^^^ constant.language.tex
+\tracingoutput=0
+%^^^^^^^^^^^^^ constant.language.tex
+\tracinglostchars=1
+%^^^^^^^^^^^^^^^^ constant.language.tex
+\tracingcommands=0
+%^^^^^^^^^^^^^^^ constant.language.tex
+\tracingrestores=0
+%^^^^^^^^^^^^^^^ constant.language.tex
+\language=0
+%^^^^^^^^ constant.language.tex
+\uchyph=1
+%^^^^^^ constant.language.tex
+\lefthyphenmin=2
+%^^^^^^^^^^^^^ constant.language.tex
+\righthyphenmin=3
+%^^^^^^^^^^^^^^ constant.language.tex
+\globaldefs=0
+%^^^^^^^^^^ constant.language.tex
+\maxdeadcycles=25
+%^^^^^^^^^^^^^ constant.language.tex
+\hangafter=1
+%^^^^^^^^^ constant.language.tex
+\fam=0
+%^^^ constant.language.tex
+\mag=1000
+%^^^ constant.language.tex
+
+\escapechar=`\\
+%^^^^^^^^^^ constant.language.tex
+%          ^ keyword.operator.assignment.tex
+%           ^^^ meta.number.integer.tex
+%           ^ keyword.operator.tex
+%            ^ punctuation.definition.backslash.tex
+%             ^ constant.character.tex
+\defaulthyphenchar=`\-
+%^^^^^^^^^^^^^^^^^ constant.language.tex
+\defaultskewchar=-1
+%^^^^^^^^^^^^^^^ constant.language.tex
+%               ^ keyword.operator.assignment.tex
+%                ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+\endlinechar=`\^^M
+%^^^^^^^^^^^ constant.language.tex
+\newlinechar=-1
+%^^^^^^^^^^^ constant.language.tex
+\delimiterfactor=901
+%^^^^^^^^^^^^^^^ constant.language.tex
+\time
+%^^^^ constant.language.tex
+\day
+%^^^ constant.language.tex
+\month
+%^^^^^ constant.language.tex
+\year
+%^^^^ constant.language.tex
+\showboxbreadth=5
+%^^^^^^^^^^^^^^ constant.language.tex
+\showboxdepth=3
+%^^^^^^^^^^^^ constant.language.tex
+\errorcontextlines=5
+%^^^^^^^^^^^^^^^^^ constant.language.tex
+
+\hfuzz=0.1pt
+%^^^^^ constant.language.tex
+%     ^ keyword.operator.assignment.tex
+%      ^^^ meta.number.float.decimal.tex constant.numeric.value.tex
+%         ^^ constant.numeric.suffix.tex
+\vfuzz=0.1pt
+%^^^^^ constant.language.tex
+\overfullrule=5pt
+%^^^^^^^^^^^^ constant.language.tex
+\hsize=6.5in
+%^^^^^ constant.language.tex
+%     ^ keyword.operator.assignment.tex
+%      ^^^ meta.number.float.decimal.tex constant.numeric.value.tex
+%         ^^ constant.numeric.suffix.tex
+\vsize=8.9in
+%^^^^^ constant.language.tex
+\maxdepth=4pt
+%^^^^^^^^ constant.language.tex
+\splitmaxdepth=\maxdimen
+%^^^^^^^^^^^^^ constant.language.tex
+%             ^ keyword.operator.assignment.tex
+%              ^^^^^^^^^ constant.language.tex
+%              ^ punctuation.definition.backslash.tex
+\boxmaxdepth=\maxdimen
+%^^^^^^^^^^^ constant.language.tex
+\lineskiplimit=0pt
+%^^^^^^^^^^^^^ constant.language.tex
+\delimitershortfall=5pt
+%^^^^^^^^^^^^^^^^^^ constant.language.tex
+\nulldelimiterspace=1.2pt
+%^^^^^^^^^^^^^^^^^^ constant.language.tex
+\scriptspace=0.5pt
+%^^^^^^^^^^^ constant.language.tex
+\mathsurround=0pt
+%^^^^^^^^^^^^ constant.language.tex
+\predisplaysize=0pt
+%^^^^^^^^^^^^^^ constant.language.tex
+\displaywidth=0pt
+%^^^^^^^^^^^^ constant.language.tex
+\displayindent=0pt
+%^^^^^^^^^^^^^ constant.language.tex
+\parindent=20pt
+%^^^^^^^^^ constant.language.tex
+\hangindent=0pt
+%^^^^^^^^^^ constant.language.tex
+\hoffset=0pt
+%^^^^^^^ constant.language.tex
+\voffset=0pt
+%^^^^^^^ constant.language.tex
+
+\baselineskip=0pt
+%^^^^^^^^^^^^ constant.language.tex
+\lineskip=0pt
+%^^^^^^^^ constant.language.tex
+\parskip=0pt plus 1pt
+%^^^^^^^ constant.language.tex
+%       ^ keyword.operator.assignment.tex
+%        ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%         ^^ constant.numeric.suffix.tex
+%            ^^^^ keyword.operator.tex
+%                 ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                  ^^ constant.numeric.suffix.tex
+
+\abovedisplayskip=12pt plus 3pt minus 9pt
+%^^^^^^^^^^^^^^^^ constant.language.tex
+%                ^ keyword.operator.assignment.tex
+%                 ^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                   ^^ constant.numeric.suffix.tex
+%                      ^^^^ keyword.operator.tex
+%                           ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                            ^^ constant.numeric.suffix.tex
+%                               ^^^^^ keyword.operator.tex
+%                                     ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                      ^^ constant.numeric.suffix.tex
+\abovedisplayshortskip=0pt plus 3pt
+%^^^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\belowdisplayskip=12pt plus 3pt minus 9pt
+%^^^^^^^^^^^^^^^^ constant.language.tex
+\belowdisplayshortskip=7pt plus 3pt minus 4pt
+%^^^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\leftskip=0pt
+%^^^^^^^^ constant.language.tex
+\rightskip=0pt
+%^^^^^^^^^ constant.language.tex
+\topskip=10pt
+%^^^^^^^ constant.language.tex
+\splittopskip=10pt
+%^^^^^^^^^^^^ constant.language.tex
+\tabskip=0pt
+%^^^^^^^ constant.language.tex
+\spaceskip=0pt
+%^^^^^^^^^ constant.language.tex
+\xspaceskip=0pt
+%^^^^^^^^^^ constant.language.tex
+\parfillskip=0pt plus 1fil
+%^^^^^^^^^^^ constant.language.tex
+%           ^ keyword.operator.assignment.tex
+%            ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%             ^^ constant.numeric.suffix.tex
+%                ^^^^ keyword.operator.tex
+%                     ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                      ^^^ constant.numeric.suffix.tex
+
+
+\thinmuskip=3mu
+%^^^^^^^^^^ constant.language.tex
+%          ^ keyword.operator.assignment.tex
+%           ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%            ^^ constant.numeric.suffix.tex
+
+\medmuskip=4mu plus 2mu minus 4mu
+%^^^^^^^^^ constant.language.tex
+%         ^ keyword.operator.assignment.tex
+%          ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%           ^^ constant.numeric.suffix.tex
+%              ^^^^ keyword.operator.tex
+%                   ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                    ^^ constant.numeric.suffix.tex
+%                       ^^^^^ keyword.operator.tex
+%                             ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                              ^^ constant.numeric.suffix.tex
+\thickmuskip=5mu plus 5mu
+%^^^^^^^^^^^ constant.language.tex
+
+\smallskipamount=3pt plus 1pt minus 1pt
+%^^^^^^^^^^^^^^^ constant.language.tex
+\medskipamount=6pt plus 2pt minus 2pt
+%^^^^^^^^^^^^^ constant.language.tex
+\bigskipamount=12pt plus 4pt minus 4pt
+%^^^^^^^^^^^^^ constant.language.tex
+\normalbaselineskip=12pt
+%^^^^^^^^^^^^^^^^^^ constant.language.tex
+\normallineskip=1pt
+%^^^^^^^^^^^^^^ constant.language.tex
+\normallineskiplimit=0pt
+%^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\jot=3pt
+%^^^ constant.language.tex
+\interdisplaylinepenalty=100
+%^^^^^^^^^^^^^^^^^^^^^^^ constant.language.tex
+\interfootnotelinepenalty=100
+%^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.tex
+
+\maxdimen
+%^^^^^^^^ constant.language.tex
+\centering
+%^^^^^^^^^ constant.language.tex
+\p@
+%^^ constant.language.tex
+\z@
+%^^ constant.language.tex
+\z@skip
+%^^^^^^ constant.language.tex
+\voidb@x
+%^^^^^^^ constant.language.tex
+\magstephalf
+%^^^^^^^^^^^ constant.language.tex
+\magstep4
+%^^^^^^^^ constant.language.tex
+\@ne
+%^^^ constant.language.tex
+\tw@
+%^^^ constant.language.tex
+\thr@@
+%^^^^^ constant.language.tex
+\sixt@@n
+%^^^^^^^ constant.language.tex
+\@cclv
+%^^^^^ constant.language.tex
+\@cclvi
+%^^^^^^ constant.language.tex
+\@m
+%^^ constant.language.tex
+\@M
+%^^ constant.language.tex
+\@MM
+%^^^ constant.language.tex
+\m@ne
+%^^^^ constant.language.tex
+
+\count@=255
+%^^^^^^ constant.language.tex
+%      ^ keyword.operator.assignment.tex
+%       ^^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+\dimen@=0
+%^^^^^^ constant.language.tex
+\dimen@i=1
+%^^^^^^^ constant.language.tex
+\dimen@ii=2
+%^^^^^^^^ constant.language.tex
+\skip@=0
+%^^^^^ constant.language.tex
+\toks@=0
+%^^^^^ constant.language.tex
+
+% Assignments without equals sign
+\baselineskip-1000\p@
+%^^^^^^^^^^^^ constant.language.tex
+%            ^^^^^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                 ^^^ constant.language.tex
+%                 ^ punctuation.definition.backslash.tex
+
+
+% The macro-type constants. They cannot be assigned using =
+\thinspace=5pt
+%^^^^^^^^^ constant.language.tex
+%         ^ - keyword.operator.assignment.tex
+
+\negthinspace
+%^^^^^^^^^^^^ constant.language.tex          
+\enspace
+%^^^^^^^ constant.language.tex
+\enskip
+%^^^^^^ constant.language.tex
+\quad
+%^^^^ constant.language.tex
+\qquad
+%^^^^^ constant.language.tex
+\smallskip
+%^^^^^^^^^ constant.language.tex
+\medskip
+%^^^^^^^ constant.language.tex
+\bigskip
+%^^^^^^^ constant.language.tex
+\space
+%^^^^^ constant.language.tex
+\empty
+%^^^^^ constant.language.tex
+\null
+%^^^^ constant.language.tex
+\lq
+%^^ constant.language.tex
+\rq
+%^^ constant.language.tex
+\lbrack
+%^^^^^^ constant.language.tex
+\rbrack
+%^^^^^^ constant.language.tex
+
+% check that we don't pick it up if it is just the beginning of a word
+\jota
+%^^^^ - constant.language.tex
+
+% \relax is a no-op that can be used to ensure that the following characters
+% will not be parsed as part of the quantity
+\jot=5pt \relax plus 10pt
+%               ^^^^ - keyword.operator
+%^^^ constant.language.tex
+%   ^ keyword.operator.assignment.tex
+%    ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%     ^^ constant.numeric.suffix.tex
+%        ^^^^^^ support.function.general.tex
+%        ^ punctuation.definition.backslash.tex
+
+% Finally, test that we can safely use constants inside macro definitions
+
+% No assignment, the = is outside of the macro
+\def\macro{\abovedisplayskip}=5pt
+%                            ^ - keyword.operator.assignment.tex
+%^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%   ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%   ^ punctuation.definition.backslash.tex
+%         ^^^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%         ^ punctuation.definition.group.brace.begin.tex
+%          ^^^^^^^^^^^^^^^^^ constant.language.tex
+%          ^ punctuation.definition.backslash.tex
+%                           ^ punctuation.definition.group.brace.end.tex
+
+% No value, the 5 is outside of the macro
+\def\macro{\abovedisplayskip=}5
+%                             ^ - meta.number
+


### PR DESCRIPTION
This adds scoping/highlighting for the built-in constant-like objects in TeX.

The decision which control sequences to include here is based more on expected usage, than on how this is defined in the underlying language. I think for a macro-processing system like TeX, this is probably the best approach. 

Thus I've considered as constants in this sense:
 * The underlying parameters of the TeX typesetting algorithm. 
 * Registers with pre-defined meaning
 * simple macros (i.e. without parameters) that insert a fixed element into the typesetting
 
In particular, a parameterless macro that a) assigns to some internal value, or b) changes how subsequent input tokens will be interpreted are not considered constants here.

The typesetting parameters and registers can be assigned-to, though for most of these this would typically only happen once in the beginning of the document (usually hidden from the user, as part of the TeX format that is used). However, it is possible to change these values in the middle of the document (though some **really** should not be changed), so in that sense these are not all technically constants. 

For the assignment, I've opted to not try to distinguish constants that are dimensions from constants that are pure numbers, so both get the same scoping. In extremely weird corner cases, this might lead to erroneous scoping, e.g. if you write 
```
\hyphenpenalty=5pt
```
then the current scoping would not know that the penalty is a number, so the `pt` are actually letters to typeset, and not part of the unit. Such cases should be very rare, though.

Similarly, since macros can hide part of the syntax, there are situations where we have no chance of knowing which scoping is correct. For example, in
```
\abovedisplayskip\value plus 5pt
```
if `\value` evaluates to some measurement, then the `plus 5pt` would be part of the measurement, otherwise, it is normal text.