### PR TITLE
[TeX] added \relax command

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -200,6 +200,10 @@ contexts:
       scope: meta.function.input.tex keyword.control.input.tex
       captures:
         1: punctuation.definition.backslash.tex
+    - match: (\\)relax{{endcs}}
+      scope: keyword.control.flow.relax.tex
+      captures:
+        1: punctuation.definition.backslash.tex
 
   braces:
     - match: \{

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -196,6 +196,8 @@ some other text
 \fi
 %^^ keyword.control.conditional.end.tex
 
+\relax
+%^^^^^ keyword.control.flow.relax.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                               Registers


### PR DESCRIPTION
Added the \relax command to control sequence. As its usage is similar to python's `pass`, if used the same scoping, i.e. as a special  `keyword.control.flow`