### PR TITLE
[TeX] register assignment

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -380,14 +380,14 @@ contexts:
         3: punctuation.separator.decimal.tex
       set:
         - tex-dimension-glue
-        - decimal-float
+        - tex-dimension-decimal-float
     - match: (-?)\d+
       scope: constant.numeric.value.tex
       captures:
         1: keyword.operator.arithmetic.tex
       set:
         - tex-dimension-glue
-        - decimal-integer
+        - tex-dimension-decimal-integer
     - match: (`)(\\)?({{charbycode}}|.)
       captures:
         1: keyword.operator.tex
@@ -395,7 +395,7 @@ contexts:
         3: constant.character.tex
       set:
         - tex-dimension-glue
-        - decimal-integer
+        - tex-dimension-decimal-integer
     - include: else-pop
     - include: paragraph-pop
 
@@ -406,11 +406,11 @@ contexts:
     - include: else-pop
     - include: paragraph-pop
 
-  decimal-float:
+  tex-dimension-decimal-float:
     - meta_scope: meta.number.float.decimal.tex
     - include: tex-dimension-suffix
 
-  decimal-integer:
+  tex-dimension-decimal-integer:
     - meta_scope: meta.number.integer.decimal.tex
     - include: tex-dimension-suffix
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -144,21 +144,6 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
 
-  general-constants:
-    - match: \\\\
-      scope: constant.character.newline.tex
-    - match: '&'
-      scope: constant.character.ampersand.tex
-    - match: '~'
-      scope: constant.character.space.tex
-    - include: escaped-character
-
-  escaped-character:
-    - match: (\\){{nonletter}}
-      scope: constant.character.escape.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-
   comments:
     - match: '%.*$\n?'
       scope: comment.line.percentage.tex
@@ -205,19 +190,6 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
 
-  tex-constants:
-    - match: (\\){{constants}}{{endcs}}
-      scope: constant.language.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-      push:
-        - tex-dimension-value
-        - tex-assignment
-    - match: (\\){{macroconst}}{{endcs}}
-      scope: constant.language.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-
   braces:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
@@ -251,6 +223,36 @@ contexts:
     - meta_scope: meta.function.box.tex
     - include: brace-group-end
     - include: main
+
+###[ CONSTANTS ]################################################################
+
+  general-constants:
+    - match: \\\\
+      scope: constant.character.newline.tex
+    - match: '&'
+      scope: constant.character.ampersand.tex
+    - match: '~'
+      scope: constant.character.space.tex
+    - include: escaped-character
+
+  escaped-character:
+    - match: (\\){{nonletter}}
+      scope: constant.character.escape.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
+  tex-constants:
+    - match: (\\){{constants}}{{endcs}}
+      scope: constant.language.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      push:
+        - tex-dimension-value
+        - tex-assignment
+    - match: (\\){{macroconst}}{{endcs}}
+      scope: constant.language.tex
+      captures:
+        1: punctuation.definition.backslash.tex
 
 ###[ REGISTERS ]################################################################
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -154,6 +154,58 @@ contexts:
       scope: constant.character.space.tex
     - include: escaped-character
 
+  escaped-character:
+    - match: (\\){{nonletter}}
+      scope: constant.character.escape.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
+  comments:
+    - match: '%.*$\n?'
+      scope: comment.line.percentage.tex
+
+  controls:
+    - match: (\\)ifcase{{endcs}}
+      scope: keyword.control.conditional.switch.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)or{{endcs}}
+      scope: keyword.control.conditional.case.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)loop{{endcs}}
+      scope: keyword.control.loop.do-while.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)repeat{{endcs}}
+      scope: keyword.control.loop.end.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)expandafter{{endcs}}
+      scope: keyword.control.flow.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)if(?:cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?{{endcs}}
+      scope: keyword.control.conditional.if.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)else{{endcs}}
+      scope: keyword.control.conditional.else.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)fi{{endcs}}
+      scope: keyword.control.conditional.end.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)input{{endcs}}
+      scope: meta.function.input.tex keyword.control.input.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+    - match: (\\)relax{{endcs}}
+      scope: keyword.control.flow.relax.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
   tex-constants:
     - match: (\\){{constants}}{{endcs}}
       scope: constant.language.tex
@@ -161,18 +213,105 @@ contexts:
         1: punctuation.definition.backslash.tex
       push:
         - tex-dimension-value
-        - tex-constant-assignment
+        - tex-assignment
     - match: (\\){{macroconst}}{{endcs}}
       scope: constant.language.tex
       captures:
         1: punctuation.definition.backslash.tex
 
-  tex-constant-assignment:
+  braces:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: brace-group-body
+
+  brace-group-body:
+    - meta_scope: meta.group.brace.tex
+    - include: brace-group-end
+    - include: main
+
+  brace-group-end:
+    - match: \}
+      scope: punctuation.definition.group.brace.end.tex
+      pop: true
+
+  boxes:
+    - match: ((\\)[hv]box)\s*(\{)
+      captures:
+        1: support.function.box.tex
+        2: punctuation.definition.backslash.tex
+        3: punctuation.definition.group.brace.begin.tex
+      push: box-body
+
+  box-body:
+    - meta_scope: meta.function.box.tex
+    - include: brace-group-end
+    - include: main
+
+###[ Registers ]################################################################
+
+  registers:
+    - match: (\\)({{registers}}){{endcs}}
+      captures:
+        1: punctuation.definition.backslash.tex
+        2: storage.type.tex
+      push: register-id
+
+  register-id:
+    - meta_scope: meta.register.tex
+    - match: \d+
+      scope: meta.number.integer.decimal constant.numeric.value.tex
+      set:
+        - tex-dimension-value
+        - tex-assignment
+    - match: (\\){{letter}}+
+      scope: support.function.general.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      set:
+        - tex-dimension-value
+        - tex-assignment
+    - include: paragraph-pop
+    - include: else-pop
+
+  register-allocations:
+    - match: (\\)new{{registers}}{{endcs}}
+      scope: keyword.declaration.register.tex storage.modifier.register.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      push: def-registername
+
+  def-registername:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: register-name-group-body
+    - match: (\\){{cmdname}}
+      scope: entity.name.constant.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      pop: 1
+    - include: paragraph-pop
+    - include: else-pop
+
+  register-name-group-body:
+    - meta_scope: meta.group.brace.tex
+    - match: \}
+      scope: punctuation.definition.group.brace.end.tex
+      pop: 2
+    - match: (\\){{cmdname}}
+      scope: entity.name.constant.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
+
+###[ Dimensions ]###############################################################
+
+  tex-assignment:
     - match: =
       scope: keyword.operator.assignment.tex
       pop: 1
     - include: else-pop
     - include: paragraph-pop
+
 
   tex-dimension-value:
     - match: (-?)(?:\d+(\.)\d*|(\.)\d+)
@@ -224,132 +363,6 @@ contexts:
 
     - include: else-pop
     - include: paragraph-pop
-
-  escaped-character:
-    - match: (\\){{nonletter}}
-      scope: constant.character.escape.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-
-  registers:
-    - match: (\\)({{registers}}){{endcs}}
-      captures:
-        1: punctuation.definition.backslash.tex
-        2: storage.type.tex
-      push: register-id
-
-  register-id:
-    - meta_scope: meta.register.tex
-    - match: \d+
-      scope: meta.number.integer.decimal constant.numeric.value.tex
-      pop: 1
-    - include: general-commands
-    - include: paragraph-pop
-    - include: else-pop
-
-  register-allocations:
-    - match: (\\)new{{registers}}{{endcs}}
-      scope: keyword.declaration.register.tex storage.modifier.register.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-      push: def-registername
-
-  def-registername:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      push: register-name-group-body
-    - match: (\\){{cmdname}}
-      scope: entity.name.constant.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-      pop: 1
-    - include: paragraph-pop
-    - include: else-pop
-
-  register-name-group-body:
-    - meta_scope: meta.group.brace.tex
-    - match: \}
-      scope: punctuation.definition.group.brace.end.tex
-      pop: 2
-    - match: (\\){{cmdname}}
-      scope: entity.name.constant.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-
-  comments:
-    - match: '%.*$\n?'
-      scope: comment.line.percentage.tex
-
-  controls:
-    - match: (\\)ifcase{{endcs}}
-      scope: keyword.control.conditional.switch.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)or{{endcs}}
-      scope: keyword.control.conditional.case.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)loop{{endcs}}
-      scope: keyword.control.loop.do-while.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)repeat{{endcs}}
-      scope: keyword.control.loop.end.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)expandafter{{endcs}}
-      scope: keyword.control.flow.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)if(?:cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?{{endcs}}
-      scope: keyword.control.conditional.if.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)else{{endcs}}
-      scope: keyword.control.conditional.else.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)fi{{endcs}}
-      scope: keyword.control.conditional.end.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)input{{endcs}}
-      scope: meta.function.input.tex keyword.control.input.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-    - match: (\\)relax{{endcs}}
-      scope: keyword.control.flow.relax.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-
-  braces:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      push: brace-group-body
-
-  brace-group-body:
-    - meta_scope: meta.group.brace.tex
-    - include: brace-group-end
-    - include: main
-
-  brace-group-end:
-    - match: \}
-      scope: punctuation.definition.group.brace.end.tex
-      pop: true
-
-  boxes:
-    - match: ((\\)[hv]box)\s*(\{)
-      captures:
-        1: support.function.box.tex
-        2: punctuation.definition.backslash.tex
-        3: punctuation.definition.group.brace.begin.tex
-      push: box-body
-
-  box-body:
-    - meta_scope: meta.function.box.tex
-    - include: brace-group-end
-    - include: main
-
 
 ###[ CHARACTER CODES ]##########################################################
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -134,7 +134,6 @@ contexts:
     - include: block-math
     - include: inline-math
     - include: registers
-    - include: register-allocations
     - include: tex-constants
     - include: general-constants
     - include: general-commands
@@ -256,13 +255,17 @@ contexts:
 ###[ REGISTERS ]################################################################
 
   registers:
+    - include: register-definitions
+    - include: register-allocations
+
+  register-definitions:
     - match: (\\)({{registers}}){{endcs}}
       captures:
         1: punctuation.definition.backslash.tex
         2: storage.type.tex
-      push: register-id
+      push: register-definition-identifier
 
-  register-id:
+  register-definition-identifier:
     - meta_scope: meta.register.tex
     - match: \d+
       scope: meta.number.integer.decimal constant.numeric.value.tex
@@ -284,12 +287,12 @@ contexts:
       scope: keyword.declaration.register.tex storage.modifier.register.tex
       captures:
         1: punctuation.definition.backslash.tex
-      push: def-registername
+      push: register-allocation-identifier
 
-  def-registername:
+  register-allocation-identifier:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
-      push: register-name-group-body
+      set: register-allocation-wrapped-identifier
     - match: (\\){{cmdname}}
       scope: entity.name.constant.tex
       captures:
@@ -298,11 +301,9 @@ contexts:
     - include: paragraph-pop
     - include: else-pop
 
-  register-name-group-body:
+  register-allocation-wrapped-identifier:
     - meta_scope: meta.group.brace.tex
-    - match: \}
-      scope: punctuation.definition.group.brace.end.tex
-      pop: 2
+    - include: brace-group-end
     - match: (\\){{cmdname}}
       scope: entity.name.constant.tex
       captures:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -224,6 +224,55 @@ contexts:
     - include: brace-group-end
     - include: main
 
+###[ CHARACTER CODES ]##########################################################
+
+  character-codes:
+    - match: (\\)(?:cat|math|uc|lc|del|sf)code{{endcs}}
+      scope: keyword.control.character-code.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      push:
+        - character-code-meta
+        - character-code-value
+        - character-code-assignment
+        - character-code-number
+
+  character-code-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.character-code.tex
+    - include: immediately-pop
+
+  character-code-number:
+    - match: (`)(\\)?({{charbycode}}|.)
+      scope: meta.number.integer.tex
+      captures:
+        1: keyword.operator.tex
+        2: punctuation.definition.backslash.tex
+        3: constant.character.tex
+      pop: 1
+    - match: \d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+      set: character-code-assignment
+    - include: else-pop
+    - include: paragraph-pop
+
+  character-code-assignment:
+    - match: =
+      scope: keyword.operator.assignment.tex
+      pop: 1
+    - include: else-pop
+    - include: paragraph-pop
+
+  character-code-value:
+    - match: \d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+      pop: 1
+    - match: '"{{anyhexdigit}}+'
+      scope: meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+      pop: 1
+    - include: else-pop
+    - include: paragraph-pop
+
 ###[ CONSTANTS ]################################################################
 
   general-constants:
@@ -368,55 +417,6 @@ contexts:
   tex-dimension-suffix:
     - match: '{{dimunits}}'
       scope: constant.numeric.suffix.tex
-      pop: 1
-    - include: else-pop
-    - include: paragraph-pop
-
-###[ CHARACTER CODES ]##########################################################
-
-  character-codes:
-    - match: (\\)(?:cat|math|uc|lc|del|sf)code{{endcs}}
-      scope: keyword.control.character-code.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-      push:
-        - character-code-meta
-        - character-code-value
-        - character-code-assignment
-        - character-code-number
-
-  character-code-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.character-code.tex
-    - include: immediately-pop
-
-  character-code-number:
-    - match: (`)(\\)?({{charbycode}}|.)
-      scope: meta.number.integer.tex
-      captures:
-        1: keyword.operator.tex
-        2: punctuation.definition.backslash.tex
-        3: constant.character.tex
-      pop: 1
-    - match: \d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
-      set: character-code-assignment
-    - include: else-pop
-    - include: paragraph-pop
-
-  character-code-assignment:
-    - match: =
-      scope: keyword.operator.assignment.tex
-      pop: 1
-    - include: else-pop
-    - include: paragraph-pop
-
-  character-code-value:
-    - match: \d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
-      pop: 1
-    - match: '"{{anyhexdigit}}+'
-      scope: meta.number.integer.hexadecimal.tex constant.numeric.value.tex
       pop: 1
     - include: else-pop
     - include: paragraph-pop

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -253,7 +253,7 @@ contexts:
     - include: brace-group-end
     - include: main
 
-###[ Registers ]################################################################
+###[ REGISTERS ]################################################################
 
   registers:
     - match: (\\)({{registers}}){{endcs}}
@@ -308,8 +308,7 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
 
-
-###[ Dimensions ]###############################################################
+###[ DIMENSIONS ]###############################################################
 
   tex-assignment:
     - match: =
@@ -317,7 +316,6 @@ contexts:
       pop: 1
     - include: else-pop
     - include: paragraph-pop
-
 
   tex-dimension-value:
     - match: (-?)(?:\d+(\.)\d*|(\.)\d+)
@@ -366,7 +364,6 @@ contexts:
     - match: '{{dimunits}}'
       scope: constant.numeric.suffix.tex
       pop: 1
-
     - include: else-pop
     - include: paragraph-pop
 

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -266,9 +266,11 @@ contexts:
       push: register-allocation-identifier
 
   register-allocation-identifier:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      set: register-allocation-wrapped-identifier
+    - meta_scope: meta.register.tex
+    - match: (?=\{)
+      set:
+        - register-allocation-wrapped-identifier
+        - brace-group-begin
     - match: (\\){{cmdname}}
       scope: entity.name.constant.tex
       captures:
@@ -278,7 +280,7 @@ contexts:
     - include: else-pop
 
   register-allocation-wrapped-identifier:
-    - meta_scope: meta.group.brace.tex
+    - meta_scope: meta.register.tex meta.group.brace.tex
     - include: brace-group-end
     - match: (\\){{cmdname}}
       scope: entity.name.constant.tex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -255,32 +255,8 @@ contexts:
 ###[ REGISTERS ]################################################################
 
   registers:
-    - include: register-definitions
     - include: register-allocations
-
-  register-definitions:
-    - match: (\\)({{registers}}){{endcs}}
-      captures:
-        1: punctuation.definition.backslash.tex
-        2: storage.type.tex
-      push: register-definition-identifier
-
-  register-definition-identifier:
-    - meta_scope: meta.register.tex
-    - match: \d+
-      scope: meta.number.integer.decimal constant.numeric.value.tex
-      set:
-        - tex-dimension-value
-        - tex-assignment
-    - match: (\\){{letter}}+
-      scope: support.function.general.tex
-      captures:
-        1: punctuation.definition.backslash.tex
-      set:
-        - tex-dimension-value
-        - tex-assignment
-    - include: paragraph-pop
-    - include: else-pop
+    - include: register-definitions
 
   register-allocations:
     - match: (\\)new{{registers}}{{endcs}}
@@ -308,6 +284,30 @@ contexts:
       scope: entity.name.constant.tex
       captures:
         1: punctuation.definition.backslash.tex
+
+  register-definitions:
+    - match: (\\)({{registers}}){{endcs}}
+      captures:
+        1: punctuation.definition.backslash.tex
+        2: storage.type.tex
+      push: register-definition-identifier
+
+  register-definition-identifier:
+    - meta_scope: meta.register.tex
+    - match: \d+
+      scope: meta.number.integer.decimal constant.numeric.value.tex
+      set:
+        - tex-dimension-value
+        - tex-assignment
+    - match: (\\){{letter}}+
+      scope: support.function.general.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      set:
+        - tex-dimension-value
+        - tex-assignment
+    - include: paragraph-pop
+    - include: else-pop
 
 ###[ DIMENSIONS ]###############################################################
 

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -237,10 +237,33 @@ some other text
 % we just scope the macro like we would any other.
 \def\five{5}
 \toks \five = 8
-%^^^^^^^^^^^ meta.register.tex
+%^^^^^^^^^^ meta.register.tex
 %^^^^ storage.type.tex
 %     ^^^^^ support.function.general.tex
 %     ^ punctuation.definition.backslash.tex
+%           ^ keyword.operator.assignment.tex
+%             ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+
+\count255 = 1
+%^^^^^^^^ meta.register.tex
+%^^^^^ storage.type.tex
+%     ^^^ meta.number.integer.decimal constant.numeric.value.tex
+%         ^ keyword.operator.assignment.tex
+%           ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+\dimen\dim50em plus 1ex
+%^^^^^^^^^ meta.register.tex
+%^^^^^ storage.type.tex
+%     ^^^^ support.function.general.tex
+%     ^ punctuation.definition.backslash.tex
+%         ^^^^ meta.number.integer.decimal.tex
+%         ^^ constant.numeric.value.tex
+%           ^^ constant.numeric.suffix.tex
+%              ^^^^ keyword.operator.arithmetic.tex
+%                   ^^^ meta.number.integer.decimal.tex
+%                   ^ constant.numeric.value.tex
+%                    ^^ constant.numeric.suffix.tex
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -241,11 +241,13 @@ some other text
 %^^^^^^^^ - meta.register.tex
 
 \newdimen\mydimen
+%^^^^^^^^^^^^^^^^ meta.register.tex - meta.register meta.register
 %^^^^^^^^ keyword.declaration.register.tex storage.modifier.register.tex
 %        ^^^^^^^^ entity.name.constant.tex
 %        ^ punctuation.definition.backslash.tex
 
 \newcount { \mycounter }
+%^^^^^^^^^^^^^^^^^^^^^^^ meta.register.tex - meta.register meta.register
 %^^^^^^^^ keyword.declaration.register.tex storage.modifier.register.tex
 %         ^^^^^^^^^^^^^^ meta.group.brace.tex
 %           ^^^^^^^^^^ entity.name.constant.tex


### PR DESCRIPTION
Now that we have scopes for numbers and dimensions, we can also easily add scoping for assignment to registers.
I've re-ordered the TeX scopes a bit here, to improve the grouping.