### PR TITLE
[Markdown] Fix inline reference definition attributes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1986,24 +1986,43 @@ contexts:
         3: punctuation.definition.reference.end.markdown
         4: punctuation.separator.key-value.markdown
       push:
-        - link-def-end
+        - link-def-meta
+        - link-def-attr
         - link-def-title
         - link-def-url
 
-  link-def-end:
+  link-def-meta:
     - meta_include_prototype: false
     - meta_scope: meta.link.reference.def.markdown
     - include: immediately-pop
+
+  link-def-attr:
+    - match: \{
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-def-attr-body
+    - match: ^(?!\s*{)|(?=\S)
+      pop: 1
+
+  link-def-attr-body:
+    - meta_scope: meta.attributes.markdown
+    - include: tag-attributes
 
   link-def-title:
     - match: ^(?!\s*["'(])
       pop: 1
     - match: (?=["'(])
       set:
-        - expect-eol
+        - expect-attr-or-eol
         - link-title
+    - match: (?=\{)
+      pop: 1
     - match: \S.+
       scope: invalid.illegal.expected-eol.markdown
+
+  expect-attr-or-eol:
+    - match: (?=\{)
+      pop: 1
+    - include: expect-eol
 
   link-def-url:
     - match: <
@@ -2769,6 +2788,7 @@ contexts:
       scope: invalid.illegal.attribute-name.markdown
 
   tag-attr-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.attribute-with-value.markdown
     - include: immediately-pop
 

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -2765,6 +2765,41 @@ Foo
 |      ^ punctuation.separator.key-value.markdown
 |        ^^^^ markup.underline.link.markdown
 
+## https://custom-tests/link-reference-definitions/with-attributes
+
+[link]: /url {#id .class width=30}
+|            ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+[link]: /url (description) {#id .class width=30}
+|                          ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+[link]: /url "description" {#id .class width=30}
+|                          ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+[link]: 
+  /url 
+  {#id .class width=30}
+| ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+[link]: 
+  /url 
+
+  {#id .class width=30}
+| ^^^^^^^^^^^^^^^^^^^^^ - meta.link - meta.attributes
+
+[link]: 
+  /url 
+  "description" 
+  {#id .class width=30}
+| ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+[link]: 
+  /url 
+  "description" 
+
+  {#id .class width=30}
+| ^^^^^^^^^^^^^^^^^^^^^ - meta.link - meta.attributes
+
 ## https://custom-tests/link-reference-definitions/in-block-quotes
 
 > [foo]: /url "description"


### PR DESCRIPTION
This commit adds support for pandoc style inline attributes in reference definition blocks.

This kind of attributes is already supported by inline links and images.

See: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/712