### PR TITLE
[Rust] More small tweaks to type matching

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -525,7 +525,6 @@ contexts:
       scope: keyword.operator.arithmetic.rust
     - include: integers
     - include: block
-    - match: '{{identifier}}'
     - match: ':|,'
       scope: punctuation.separator.rust
     - match: '\+|='
@@ -638,7 +637,7 @@ contexts:
       pop: true
     - match: '!'
       scope: keyword.operator.negated-type.rust
-    - include: type-identifiers
+    - include: type-any-identifiers
 
   type-any-identifiers:
     - match: '!'
@@ -650,6 +649,7 @@ contexts:
     - match: '{{type_identifier}}'
       scope: storage.type.rust
     - match: '{{identifier}}'
+      scope: meta.identifier.expected-type.rust
 
   support-type:
     - match: '(Vec|Option|Result|BTreeMap|HashMap|Box|Rc|Arc|AsRef|AsMut|Into|From)\s*(?=<)'
@@ -661,6 +661,7 @@ contexts:
   type:
     # A low-level type. Typically you want types-any for the full type grammar.
     - match: '{{identifier}}(?=<)'
+      scope: storage.type.rust
       push: generic-angles
     - match: \b(Self|{{int_suffixes}}|{{float_suffixes}}|bool|char|str)\b
       scope: storage.type.rust

--- a/Rust/tests/syntax_test_types.rs
+++ b/Rust/tests/syntax_test_types.rs
@@ -158,8 +158,22 @@ type Snail = Vec<SnailNum>;
 //                       ^ punctuation.definition.generic.end.rust
 
 type ExampleRawPointer = HashMap<*const i32, Option<i32>, BuildHasherDefault<FnvHasher>>;
-//                               ^^^^^^ meta.generic storage.modifier
+//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.rust
+//                               ^^^^^^ storage.modifier
 //                                      ^^^ meta.generic storage.type
+//                                         ^ punctuation.separator.rust
+//                                           ^^^^^^^^^^^ meta.generic.rust meta.generic.rust
+//                                           ^^^^^^ support.type.rust
+//                                                 ^ punctuation.definition.generic.begin.rust
+//                                                  ^^^ storage.type.rust
+//                                                     ^ punctuation.definition.generic.end.rust
+//                                                      ^ punctuation.separator.rust
+//                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.rust meta.generic.rust
+//                                                        ^^^^^^^^^^^^^^^^^^ storage.type
+//                                                                          ^ punctuation.definition.generic.begin.rust
+//                                                                           ^^^^^^^^^ storage.type.rust
+//                                                                                    ^^ punctuation.definition.generic.end.rust
+//                                                                                      ^ punctuation.terminator.rust
 
 
 // Anonymous lifetimes.


### PR DESCRIPTION
- Fixes highlighting of unknown generic types
- Adds stacking of `storage.type` under `support.type`