### PR TITLE
[HTML] optional style tag attribute completions

### DIFF
--- a/HTML/html_completions.py
+++ b/HTML/html_completions.py
@@ -132,7 +132,7 @@ def get_tag_completions(inside_tag=True):
         ('script', 'script${2: type=\"${1:text/javascript}\"}>$0</script>'),
         ('slot', 'slot name=\"$1\">$0</slot>'),
         ('source', 'source src=\"$1\" type=\"$2\">'),
-        ('style', 'style type=\"${1:text/css}\">$0</style>'),
+        ('style', 'style${2: type=\"${1:text/css}\"}>$0</style>'),
         ('track', 'track kind=\"$1\" src=\"$2\">'),
         ('wbr', 'wbr>'),
         ('video', 'video src=\"$1\">$0</video>')


### PR DESCRIPTION
This commit modifies completion for <style> tags to make in behave like <script> tag completions.

This way hitting tab key twice enables a user to completely remove the type attribute.

inspired by https://forum.sublimetext.com/t/how-to-customize-auto-complete-for-html-tags/66116