### PR TITLE
[TeX] Modifiers for \def's

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -409,6 +409,11 @@ contexts:
         1: punctuation.definition.backslash.tex
       push: def-function-expect-identifier
 
+    - match: (\\)(:?outer|long|global){{endcs}}
+      scope: storage.modifier.definition.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+
   def-function-expect-identifier:
     - meta_scope: meta.function.tex
     - match: (?=\\)

--- a/LaTeX/syntax_test_tex.tex
+++ b/LaTeX/syntax_test_tex.tex
@@ -112,6 +112,27 @@ some other text
 \deftext
 %^^^^^^^ support.function.general.tex
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Modifiers
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+ \long\def\test#1{#1}
+%^^^^^ storage.modifier.definition.tex
+%^ punctuation.definition.backslash.tex
+%     ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+
+ \outer\def\test#1{#1}
+%^^^^^^ storage.modifier.definition.tex
+%^ punctuation.definition.backslash.tex
+%      ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+
+ \global\def\test#1{#1}
+%^^^^^^^ storage.modifier.definition.tex
+%^ punctuation.definition.backslash.tex
+%       ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Macro definition contents


### PR DESCRIPTION
This adds scoping for the `outer`, `global`, and `long` modifiers available to alter the behaviour of TeXs `\def` command.