### PR TITLE
[LaTeX] Fixups for command names

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -167,7 +167,7 @@ contexts:
   latex-newcommand-bare-commandname:
     - clear_scopes: 1
     - meta_scope: meta.function.identifier.latex
-    - match: (\\){{letter}}+
+    - match: (\\){{cmdname}}
       scope: entity.name.newcommand.latex
       captures:
         1: punctuation.definition.backslash.latex
@@ -179,7 +179,7 @@ contexts:
     - clear_scopes: 1
     - meta_scope: meta.function.identifier.latex
     - include: brace-group-end
-    - match: (\\){{letter}}+
+    - match: (\\){{cmdname}}
       scope: entity.name.newcommand.latex
       captures:
         1: punctuation.definition.backslash.latex
@@ -201,14 +201,14 @@ contexts:
     - meta_scope: meta.function.body.latex
     # but in principle, a single token is also valid,
     # thus either a command sequence ...
-    - match: (\\){{letter}}+
+    - match: (\\){{cmdname}}
       scope: support.function.general.latex
       captures:
         1: punctuation.definition.backslash.latex
       pop: 1
-    # or a single, potentially escaped character. no further effort at
+    # or a single character. no further effort at
     # differentiation here
-    - match: (\\)?\S\b
+    - match: \S\b
       scope: constant.character.escape.latex
       captures:
         1: punctuation.definition.backslash.latex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -225,6 +225,14 @@
   \alpha
 % ^^^^^^ support.function.general.latex
 
+\newcommand\"{quote}
+%^^^^^^^^^^ meta.function.latex keyword.declaration.function.latex storage.modifier.newcommand.latex
+%          ^^ meta.function.identifier.latex entity.name.newcommand.latex
+%            ^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%          ^ punctuation.definition.backslash.latex
+%            ^ punctuation.definition.group.brace.begin.tex
+%                  ^ punctuation.definition.group.brace.end.tex
+
 \newcommandprefix
 %^^^^^^^^^^^^^^^^ support.function.general.latex
 


### PR DESCRIPTION
Thanks @deathaxe for cleaning up the newcommand contexts.
Here are some small adjustments, using the {{cmdname}} variable to cover both commands based on a sequence of letters, and commands of a single non-letter.