### PR TITLE
[JSON] Bind jsonc extension by default

### DIFF
--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -6,6 +6,7 @@ version: 2
 
 file_extensions:
   - json
+  - jsonc
   - sublime-build
   - sublime-color-scheme
   - sublime-commands
@@ -28,7 +29,7 @@ hidden_file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \s* // .*? -\*- .*? \bjson\b .*? -\*-  # editorconfig
+    ^ \s* // .*? -\*- .*? \bjsonc?\b .*? -\*-  # editorconfig
   )
 
 contexts:


### PR DESCRIPTION
This commit binds jsonc file extension to JSON.sublime-syntax.

see: https://github.com/SublimeText/AFileIcon/issues/63