### PR TITLE
[TypeScript] Fix deadlock caused by type expressions

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -888,20 +888,8 @@ contexts:
     - include: ts-type-special
     - include: ts-type-primitive
     - include: ts-type-basic
-
-    - match: (?=\<)
-      set:
-        - ts-type-function
-        - ts-generic-function-type-check
-        - ts-type-parameter-list
-
-    - match: (?=\()
-      pop: 1
-      branch_point: ts-function-type
-      branch:
-        - ts-type-function
-        - ts-type-parenthesized
-
+    - include: ts-type-generic-function
+    - include: ts-type-function-or-group
     - include: literal-string
     - include: literal-number
     - include: ts-type-template-string
@@ -910,12 +898,6 @@ contexts:
       scope: keyword.operator.arithmetic.js
 
     - include: else-pop
-
-  ts-generic-function-type-check:
-    - match: (?=\()
-      pop: 1
-    - match: (?=\S)
-      pop: 2
 
   ts-type-tuple:
     - match: \[
@@ -1015,46 +997,82 @@ contexts:
               - ts-type-expression-begin
         - include: string-content
 
-  ts-type-parenthesized:
+  ts-type-generic-function:
+    - match: (?=\<)
+      set:
+        - ts-type-generic-function-parameter-list
+        - ts-type-parameter-list
+
+  ts-type-generic-function-parameter-list:
     - match: \(
       scope: punctuation.section.group.begin.js
       set:
-        - - meta_scope: meta.group.js
-          - match: \)
-            scope: punctuation.section.group.end.js
-            pop: 1
-          - match: (?=\S)
-            fail: ts-function-type
+        - ts-type-generic-function-body
+        - ts-type-function-parameter-list-body
+    - include: else-pop
+
+  ts-type-generic-function-body:
+    - include: ts-type-function-arrow
+    - include: else-pop
+
+  ts-type-function-or-group:
+    - match: (?=\()
+      pop: 1
+      branch_point: ts-function-type
+      branch:
+        - ts-type-function-parameter-list
+        - ts-type-group
+
+  ts-type-function-parameter-list:
+    - match: \(
+      scope: punctuation.section.group.begin.js
+      set:
+        - ts-type-function-body
+        - ts-type-function-parameter-list-body
+
+  ts-type-function-parameter-list-body:
+    - meta_scope: meta.group.js
+    - match: \)
+      scope: punctuation.section.group.end.js
+      pop: 1
+    - match: \.\.\.
+      scope: keyword.operator.spread.js
+    - match: '{{identifier_name}}'
+      scope: variable.parameter.js
+      push:
+        - ts-type-annotation
+        - ts-type-annotation-optional
+    - include: comma-separator
+    - include: else-pop
+
+  ts-type-function-body:
+    - include: ts-type-function-arrow
+    - match: (?=\S)
+      fail: ts-function-type
+
+  ts-type-function-arrow:
+    - match: =>
+      scope: keyword.declaration.function.js
+      set:
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
         - ts-type-expression-begin
 
-  ts-type-function:
+  ts-type-group:
     - match: \(
       scope: punctuation.section.group.begin.js
       set:
-        - meta_scope: meta.group.js
-        - match: \)
-          scope: punctuation.section.group.end.js
-          set:
-            - match: =>
-              scope: keyword.declaration.function.js
-              set:
-                - ts-type-expression-end
-                - ts-type-expression-end-no-line-terminator
-                - ts-type-expression-begin
-            - match: (?=\S)
-              fail: ts-function-type
-        - include: comma-separator
-        - match: '\.\.\.'
-          scope: keyword.operator.spread.js
-        - match: '{{identifier_name}}'
-          scope: variable.parameter.js
-          push:
-            - ts-type-annotation
-            - ts-type-annotation-optional
-        - match: (?=\S)
-          fail: ts-function-type
+        - ts-type-group-end
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
+
+  ts-type-group-end:
+    - meta_scope: meta.group.js
+    - match: \)
+      scope: punctuation.section.group.end.js
+      pop: 1
+    - include: else-pop
 
   object-literal-contents:
     - meta_prepend: true

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -344,6 +344,25 @@ import foo;
 //                     ^ keyword.operator.assignment
 //                       ^^^ meta.type-alias support.type.any
 
+    // ensure fixed deadlock caused by incomplete/invalid type expressions
+    // https://github.com/sublimehq/Packages/issues/3598
+    type x = {
+        bar: (cb: (
+//     ^^^^^^ meta.type-alias.js meta.mapping.js - meta.group
+//           ^^^ meta.type-alias.js meta.mapping.js meta.type.js meta.group.js
+//              ^^ meta.type-alias.js meta.mapping.js - meta.group
+//                ^ meta.type-alias.js meta.function.parameters.js
+//      ^^^ variable.other.readwrite.js
+//         ^ punctuation.separator.type.js
+//           ^ punctuation.section.group.begin.js
+//            ^^ support.class.js
+//                ^ punctuation.section.group.begin.js
+    };
+//  ^ meta.type-alias.js meta.mapping.js
+//   ^ - meta.type-alias - meta.mapping
+//  ^ punctuation.section.mapping.end.js
+//   ^ punctuation.terminator.statement.empty.js
+
     class Foo {
         foo: any = 42;
 //      ^^^ variable.other.readwrite


### PR DESCRIPTION
Fixes #3598

This commit refactors anonymous type functions to...

1. ensure one of type-function or type-group to be applied. Old implementation may have caused both branches to fail, which can cause an infinite loop.
2. ensures not to invoke `fail` command in generic type functions, which are not part of a branch point.
3. add named contexts to differentiate generic from normal type functions and all their different parts.

_Note: The syntax needs to be applied to Sublime Merge in order to use it for review. Otherwise it will end up in the endless loop, caused by the test case which verifies the bug is fixed._