### PR TITLE
[CSS] Fix html style tag folding not working

### DIFF
--- a/CSS/Fold.tmPreferences
+++ b/CSS/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.css</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>


### PR DESCRIPTION
This commit re-enables indentation based folding in CSS to fix an issue which causes `<style>` tags not being foldable in HTML syntax anymore.

As `source.css` begins immediately after the style tag, CSS's folding settings start ot apply directly after a style tag. ST therefore disables indentation based folding of `<style>` tags.

reported at:
- https://forum.sublimetext.com/t/can-no-longer-fold-html-style-tags/66219
- https://forum.sublimetext.com/t/code-folding-doesnt-work-js-go-html-maybe-more/66250/7
- https://forum.sublimetext.com/t/css-code-folding/66404

Other users reported folding issues in scenarious they use indentation to organize complex CSS sources. Hence it's probably a bad idea in general to disable indentation based folding.