### PR TITLE
[Rust] Match attributes in struct tuple constructors

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -251,37 +251,38 @@ contexts:
         1: punctuation.definition.annotation.rust
         2: punctuation.definition.annotation.rust
         3: punctuation.section.group.begin.rust
-      push:
-        # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
-        - meta_scope: meta.annotation.rust
-        - match: '(?:{{identifier}}\s*::\s*)*({{identifier}})'
-          scope: meta.path.rust
-          captures:
-            1: variable.annotation.rust
-        - match: '\('
-          scope: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.begin.rust
-          push:
-            - meta_content_scope: meta.annotation.parameters.rust meta.group.rust
-            - match: \)
-              scope: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.end.rust
-              pop: true
-            - include: attribute-call
-        - match: '='
-          scope: keyword.operator.assignment.rust
-          set:
-            - meta_content_scope: meta.annotation.rust
-            - include: strings
-            - include: chars
-            - include: numbers
-            - include: comments
-            - match: '\]'
-              scope: meta.annotation.rust punctuation.section.group.end.rust
-              pop: true
+      push: inside-attribute
 
-        - match: '\]'
-          scope: punctuation.section.group.end.rust
+  inside-attribute:
+    # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
+    - meta_scope: meta.annotation.rust
+    - match: '(?:{{identifier}}\s*::\s*)*({{identifier}})'
+      scope: meta.path.rust
+      captures:
+        1: variable.annotation.rust
+    - match: '\('
+      scope: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.begin.rust
+      push:
+        - meta_content_scope: meta.annotation.parameters.rust meta.group.rust
+        - match: \)
+          scope: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.end.rust
           pop: true
+        - include: attribute-call
+    - match: '='
+      scope: keyword.operator.assignment.rust
+      set:
+        - meta_content_scope: meta.annotation.rust
+        - include: strings
+        - include: chars
+        - include: numbers
         - include: comments
+        - match: '\]'
+          scope: meta.annotation.rust punctuation.section.group.end.rust
+          pop: true
+    - match: '\]'
+      scope: punctuation.section.group.end.rust
+      pop: true
+    - include: comments
 
   attribute-call:
     - match: \)
@@ -750,15 +751,18 @@ contexts:
       pop: true
     - match: '\('
       scope: punctuation.section.group.begin.rust
-      push:
-        - match: '(?=\))'
-          pop: true
-        - meta_scope: meta.group.rust
-        - include: comments
-        - include: visibility
-        - include: types-any
-        - match: ','
-          scope: punctuation.separator.rust
+      push: inside-struct-tuple
+
+  inside-struct-tuple:
+    - match: '(?=\))'
+      pop: true
+    - meta_scope: meta.group.rust
+    - include: comments
+    - include: attribute
+    - include: visibility
+    - include: types-any
+    - match: ','
+      scope: punctuation.separator.rust
 
   struct-classic:
     - meta_scope: meta.struct.rust

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -148,7 +148,7 @@ contexts:
       push: macro-block
 
     - include: comments
-    - include: attribute
+    - include: attributes
     - include: strings
     - include: chars
 
@@ -245,7 +245,7 @@ contexts:
     - match: '\bpub\b'
       scope: storage.modifier.rust
 
-  attribute:
+  attributes:
     - match: '(#)\s*(!?)\s*(\[)'
       captures:
         1: punctuation.definition.annotation.rust
@@ -321,7 +321,7 @@ contexts:
     - match: '(?=\})'
       pop: true
     - include: statements
-    - include: attribute
+    - include: attributes
 
   group:
     - match: '\)'
@@ -505,7 +505,7 @@ contexts:
 
   generic-angles-contents:
     - include: comments
-    - include: attribute
+    - include: attributes
     - match: '(?=>)'
       pop: true
     - match: '<'
@@ -758,7 +758,7 @@ contexts:
       pop: true
     - meta_scope: meta.group.rust
     - include: comments
-    - include: attribute
+    - include: attributes
     - include: visibility
     - include: types-any
     - match: ','
@@ -781,7 +781,7 @@ contexts:
     - match: '(?=\})'
       pop: true
     - include: comments
-    - include: attribute
+    - include: attributes
     - include: visibility
     - match: '{{identifier}}(?=\s*:)'
       scope: variable.other.member.rust
@@ -861,7 +861,7 @@ contexts:
   enum-body:
     - meta_scope: meta.block.rust meta.enum.rust
     - include: comments
-    - include: attribute
+    - include: attributes
     - match: '\}'
       scope: punctuation.section.block.end.rust
       pop: true

--- a/Rust/tests/syntax_test_attributes.rs
+++ b/Rust/tests/syntax_test_attributes.rs
@@ -64,7 +64,12 @@ enum E {
 //  ^^^^^^^^^^^^^^^^^^^ meta.enum meta.annotation
 //    ^^^^^ variable.annotation
     A(i32),
-//    ^^^ meta.enum meta.struct meta.group storage.type
+//  ^^^^^^^^ meta.block.rust meta.enum.rust
+//    ^^^ storage.type
+    BadInt(#[from] ParseIntError),
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.rust meta.enum.rust
+//         ^^^^^^^ meta.annotation
+
 }
 
 // Generic parameters.


### PR DESCRIPTION
This form is used by the `thiserror` package.

Also name a few anonymous contexts and add an `s` to the `attribute` context name.