### PR TITLE
[Rust] Detect closures when they are used as the second argument

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -211,12 +211,13 @@ contexts:
         - include: statements
 
     - include: return-type
-    - include: symbols
     - include: keywords
 
     - match: ','
       scope: punctuation.separator.rust
       push: after-operator
+
+    - include: symbols
 
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
       scope: variable.function.rust

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -482,11 +482,13 @@ contexts:
     - match: '(?=\{)'
       set: closure-explicit-body
     - match: (?=\S)
-      set:
-        - meta_scope: meta.function.closure.rust
-        - match: '(?=[};)\]\n])'
-          pop: true
-        - include: statements
+      set: closure-implicit-body
+
+  closure-implicit-body:
+    - meta_scope: meta.function.closure.rust
+    - match: '(?=[};)\]\n,])'
+      pop: true
+    - include: statements
 
   closure-explicit-body:
     - meta_scope: meta.function.closure.rust

--- a/Rust/tests/syntax_test_closures.rs
+++ b/Rust/tests/syntax_test_closures.rs
@@ -32,6 +32,10 @@ call_func(|c| 1 + 2 + c);
 //        ^^^^^^^^^^^^^ meta.function.closure
 //        ^^^ meta.function.parameters
 
+call_func_2nd_param(0, |c| 1 + 2 + c);
+//                     ^^^^^^^^^^^^^ meta.function.closure
+//                     ^^^ meta.function.parameters
+
 fn lambdas() {
     let c = |foo,
 //          ^ meta.function.closure meta.function.parameters punctuation.section.parameters.begin

--- a/Rust/tests/syntax_test_closures.rs
+++ b/Rust/tests/syntax_test_closures.rs
@@ -32,8 +32,9 @@ call_func(|c| 1 + 2 + c);
 //        ^^^^^^^^^^^^^ meta.function.closure
 //        ^^^ meta.function.parameters
 
-call_func_2nd_param(0, |c| 1 + 2 + c);
+call_func_2nd_param(0, |c| 1 + 2 + c, 3);
 //                     ^^^^^^^^^^^^^ meta.function.closure
+//                                  ^^^ - meta.function.closure
 //                     ^^^ meta.function.parameters
 
 fn lambdas() {


### PR DESCRIPTION
The `symbols` context used to swallow the comma that we need to match for this.