### PR TITLE
[TeX] Improved integer handling

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -200,7 +200,7 @@ contexts:
     - include: immediately-pop
 
   character-code-number:
-    - include: tex-simple-integer-content
+    - include: tex-simple-integer
     - include: else-pop
     - include: paragraph-pop
 
@@ -212,7 +212,7 @@ contexts:
     - include: paragraph-pop
 
   character-code-value:
-    - include: tex-simple-integer-content
+    - include: tex-simple-integer
     - include: else-pop
     - include: paragraph-pop
 
@@ -350,7 +350,7 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
       pop: 1
-    - include: tex-simple-integer-content
+    - include: tex-simple-integer
     - include: paragraph-pop
     - include: else-pop
 
@@ -360,7 +360,7 @@ contexts:
   # across lines
   # we are also not handling the case where there are multiple signs
 
-  tex-simple-integer-content:
+  tex-simple-integer:
     - match: ([+-]?)\s*\d+
       scope: meta.number.integer.decimal.tex constant.numeric.value.tex
       captures:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -191,7 +191,7 @@ contexts:
       push:
         - character-code-meta
         - character-code-value
-        - character-code-assignment
+        - tex-assignment
         - character-code-number
 
   character-code-meta:
@@ -200,16 +200,7 @@ contexts:
     - include: immediately-pop
 
   character-code-number:
-    - match: (`)(\\)?({{charbycode}}|.)
-      scope: meta.number.integer.tex
-      captures:
-        1: keyword.operator.tex
-        2: punctuation.definition.backslash.tex
-        3: constant.character.tex
-      pop: 1
-    - match: \d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
-      set: character-code-assignment
+    - include: tex-simple-integer-content
     - include: else-pop
     - include: paragraph-pop
 
@@ -221,12 +212,7 @@ contexts:
     - include: paragraph-pop
 
   character-code-value:
-    - match: \d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
-      pop: 1
-    - match: '"{{anyhexdigit}}+'
-      scope: meta.number.integer.hexadecimal.tex constant.numeric.value.tex
-      pop: 1
+    - include: tex-simple-integer-content
     - include: else-pop
     - include: paragraph-pop
 
@@ -352,24 +338,53 @@ contexts:
       captures:
         1: punctuation.definition.backslash.tex
         2: storage.type.tex
-      push: register-definition-identifier
+      push: 
+        - tex-dimension-value
+        - tex-assignment
+        - register-definition-identifier
 
   register-definition-identifier:
     - meta_scope: meta.register.tex
-    - match: \d+
-      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
-      set:
-        - tex-dimension-value
-        - tex-assignment
-    - match: (\\){{letter}}+
+    - match: (\\){{cmdname}}
       scope: support.function.general.tex
       captures:
         1: punctuation.definition.backslash.tex
-      set:
-        - tex-dimension-value
-        - tex-assignment
+      pop: 1
+    - include: tex-simple-integer-content
     - include: paragraph-pop
     - include: else-pop
+
+###[ NUMBERS ]##################################################################
+
+  # These match integers/floats that are written in a simple form, i.e. not extending
+  # across lines
+  # we are also not handling the case where there are multiple signs
+
+  tex-simple-integer-content:
+    - match: ([+-]?)\s*\d+
+      scope: meta.number.integer.decimal.tex constant.numeric.value.tex
+      captures:
+        1: keyword.operator.arithmetic.tex
+      pop: 1
+    - match: ([+-]?)\s*"{{uchexdigit}}+
+      scope: meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+      captures:
+        1: keyword.operator.arithmetic.tex
+      pop: 1
+    - match: ([+-]?)\s*'[0-7]+
+      scope: meta.number.integer.octal.tex constant.numeric.value.tex
+      captures:
+        1: keyword.operator.arithmetic.tex
+      pop: 1
+    - match: ([+-]?)\s*(`)(\\)?({{charbycode}}|.)
+      scope: meta.number.integer.tex constant.numeric.value.tex
+      captures:
+        1: keyword.operator.arithmetic.tex
+        2: keyword.operator.tex
+        3: punctuation.definition.backslash.tex
+        4: constant.character.tex
+      pop: 1
+
 
 ###[ DIMENSIONS ]###############################################################
 

--- a/LaTeX/tests/syntax_test_tex.tex
+++ b/LaTeX/tests/syntax_test_tex.tex
@@ -237,6 +237,32 @@ some other text
 \skip5 10
 %^^^^^ meta.register.tex
 %      ^^ - meta.register.tex
+%    ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+\count"AB 10
+%^^^^^^^^ meta.register.tex
+%         ^^ - meta.register.tex
+%     ^^^ meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+
+
+% tricky case: 9 is not an octal digit
+\dimen'569
+%^^^^^^^^ meta.register.tex
+%        ^ - meta.register.tex
+%     ^^^ meta.number.integer.octal.tex constant.numeric.value.tex
+%        ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+
+% tricky case: 9 is not an octal digit
+\dimen`\a  
+%^^^^^^^^ meta.register.tex
+%        ^ - meta.register.tex
+%     ^^^ meta.number.integer.tex constant.numeric.value.tex
+
+% tricky case: 9 is not an octal digit
+\dimen`16 
+%^^^^^^^ meta.register.tex
+%       ^ - meta.register.tex
+%     ^^ meta.number.integer.tex constant.numeric.value.tex
 
 \counting
 %^^^^^^^^ - meta.register.tex
@@ -341,6 +367,20 @@ some other text
 %         ^ constant.character.tex
 %          ^ keyword.operator.assignment.tex
 %           ^^^^^^^ meta.number.integer.hexadecimal.tex constant.numeric.value.tex
+
+\lccode65='123
+%^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^ keyword.control.character-code.tex
+%      ^^ meta.number.integer.decimal.tex
+%        ^ keyword.operator.assignment.tex
+%          ^^^ meta.number.integer.octal.tex constant.numeric.value.tex
+
+\lccode"AB=`\a
+%^^^^^^^^^^^^^ meta.function.character-code.tex
+%^^^^^^ keyword.control.character-code.tex
+%      ^^^ meta.number.integer.hexadecimal.tex
+%         ^ keyword.operator.assignment.tex
+%          ^^^ meta.number.integer.tex constant.numeric.value.tex
 
 % some other assignments
 


### PR DESCRIPTION
This PR does a first step at generalizing and unifying the handling of integers. 
It provides a general context that matches decimal, octal, hexadecimal, and "based on character" integers. I've not yet used this for the definition of dimensions, because here we currently enter different scopes based on whether we've matched an integer or a float.
The syntax specified here assumes that everything will be written on one line. It also does not handle the case of multiple leading signs.