### PR TITLE
[Git Formats] Align section header formats

### DIFF
--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
     - include: macro
     - include: pattern
 
-##[ MACROS ]###########################################################
+###[ MACROS ]##################################################################
 
   macro:
     - match: (\[)([^-!]\S*)(\])
@@ -33,7 +33,7 @@ contexts:
         3: punctuation.definition.brackets.end.git.attributes
       push: attributes-list
 
-##[ PATH PATTERN ]#####################################################
+###[ PATH PATTERN ]############################################################
 
   pattern:
     # ignore whitespace at the beginning of a line
@@ -69,7 +69,7 @@ contexts:
     - match: ''
       set: attributes-list
 
-##[ ATTRIBUTES LIST ]##################################################
+###[ ATTRIBUTES LIST ]#########################################################
 
   attributes-list:
     - meta_content_scope: meta.attributes-list.git.attributes
@@ -145,7 +145,7 @@ contexts:
     - meta_scope: meta.attribute.other.git.attributes
     - include: immediately-pop
 
-##[ ATTRIBUTE KEY VALUE ]##############################################
+###[ ATTRIBUTE KEY VALUE ]#####################################################
 
   attribute-key:
     - match: \w+[-\w]*\b
@@ -202,7 +202,7 @@ contexts:
       scope: meta.mapping.git.attributes punctuation.separator.sequence.git.attributes
       pop: 1
 
-##[ PROTOTYPES ]#######################################################
+###[ PROTOTYPES ]##############################################################
 
   string-content:
     - meta_include_prototype: false

--- a/Git Formats/Git Commit Message.sublime-syntax
+++ b/Git Formats/Git Commit Message.sublime-syntax
@@ -13,7 +13,7 @@ contexts:
     - match: ^\s*(?=\S)
       set: commit-subject
 
-##[ COMMENTS ]#########################################################
+###[ COMMENTS ]################################################################
 
   comments:
     - match: ^{{comment_char}}
@@ -35,7 +35,7 @@ contexts:
     - meta_scope: comment.line.git.commit
     - include: comment-content
 
-##[ COMMIT MESSAGE ]###################################################
+###[ COMMIT MESSAGE ]##########################################################
 
   commit-subject:
     # first none empty none comment line is commit subject

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
   main:
     - include: references
 
-##[ PROTOTYPES ]#######################################################
+###[ PROTOTYPES ]##############################################################
 
   # Trailing slashes can be used to break up long lines. '\' is only legal at
   # the end of a line, or in an escape such as '\"'. Anywhere else it will cause
@@ -47,7 +47,7 @@ contexts:
       scope: invalid.illegal.unexpected.eol.git
       pop: 1
 
-##[ COMMENTS ]#########################################################
+###[ COMMENTS ]################################################################
 
   comments:
     # comment which may start in the middle of a line
@@ -63,7 +63,7 @@ contexts:
       captures:
         1: punctuation.definition.comment.git
 
-##[ REFERENCES ]#######################################################
+###[ REFERENCES ]##############################################################
 
   references:
     # all github references
@@ -153,7 +153,7 @@ contexts:
         [\w\d\-~:/#@$*+=]                                        # allowed end chars
       scope: markup.underline.link.git
 
-##[ FNMATCH ]##########################################################
+###[ FNMATCH ]#################################################################
 
   # The first characters of a path pattern may have special meaning and
   # must therefore be treated differently. This scope finally pops off
@@ -239,7 +239,7 @@ contexts:
     - match: \S
       scope: constant.character.char-class.fnmatch.git
 
-##[ PRETTY FORMATS ]###################################################
+###[ PRETTY FORMATS ]##########################################################
 
   # https://git-scm.com/docs/pretty-formats
 

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -36,7 +36,7 @@ contexts:
     - match: ^\s*(?=\[)
       push: [key-value-pair, section-header]
 
-##[ SECTION HEADERS ]##################################################
+###[ SECTION HEADERS ]#########################################################
 
   section-header:
     - match: \[
@@ -108,7 +108,7 @@ contexts:
     - match: \]
       scope: invalid.illegal.stray-bracket.git.config
 
-##[ SECTION BODY ]#####################################################
+###[ SECTION BODY ]############################################################
 
   # changed = red
   # untracked = bold green
@@ -141,7 +141,7 @@ contexts:
         - include: line-end
     - include: expect-section
 
-##[ VALUES ]###########################################################
+###[ VALUES ]##################################################################
 
   color-value:
     # example: bold, italic, underline
@@ -205,7 +205,7 @@ contexts:
         - include: line-end
         - include: Git Common.sublime-syntax#pretty-formats-as-arg-minimal
 
-##[ PROTOTYPES ]#######################################################
+###[ PROTOTYPES ]##############################################################
 
   # The only valid escapes: '\b', '\n', '\t', '\"', '\\'.
   escape:
@@ -235,7 +235,7 @@ contexts:
     - match: \S
       scope: invalid.illegal.expected.eol.git.config
 
-##[ ILLEGAL ]##########################################################
+###[ ILLEGAL ]#################################################################
 
   illegal-line-end:
     - match: $\n?

--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -24,7 +24,7 @@ contexts:
     - include: branch-commands
     - include: commit-commands
 
-##[ COMMENTS ]#########################################################
+###[ COMMENTS ]################################################################
 
   comments:
     - match: '{{comment_char}}'
@@ -209,7 +209,7 @@ contexts:
         4: constant.other.hash.git.rebase
       pop: 1
 
-##[ COMMANDS ]#########################################################
+###[ COMMANDS ]################################################################
 
   branch-commands:
     - match: ^\s*(l|label)\s+(\S+)
@@ -309,7 +309,7 @@ contexts:
       captures:
         1: punctuation.definition.variable.git.rebase
 
-##[ PROTOTYPES ]#######################################################
+###[ PROTOTYPES ]##############################################################
 
   line-end:
     - match: $\n?


### PR DESCRIPTION
This commit brings section header formats inline with all other syntaxes in this repository.

- start with 3 hashes
- 80 chars wide

It is a formal change without functional changes.