### PR TITLE
[Git Formats] Adjust file extensions and hidden file extensions

### DIFF
--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -11,9 +11,11 @@ scope: text.git.attributes
 version: 2
 
 file_extensions:
-  - attributes                # .git/info/attributes
   - gitattributes             # *.gitattributes
+
+hidden_file_extensions:
   - .gitattributes            # ~/.gitattributes
+  - attributes                # .git/info/attributes
 
 contexts:
 

--- a/Git Formats/Git Code Owners.sublime-syntax
+++ b/Git Formats/Git Code Owners.sublime-syntax
@@ -9,7 +9,7 @@ scope: text.git.codeowners
 version: 2
 
 file_extensions:
-  - CODEOWNERS
+  - CODEOWNERS                # *.codeowners, ./CODEOWNERS
 
 contexts:
 

--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -8,7 +8,7 @@ version: 2
 
 extends: Git Commit Message.sublime-syntax
 
-file_extensions:
+hidden_file_extensions:
   - COMMIT_EDITMSG
   - MERGE_MSG
   - TAG_EDITMSG

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -8,7 +8,9 @@ scope: text.git.config
 version: 2
 
 file_extensions:
-  - gitconfig                # /etc/gitconfig
+  - gitconfig                # *.gitconfig, /etc/gitconfig
+
+hidden_file_extensions:
   - .gitconfig               # ~/.gitconfig
   - .gitmodules              # ~/.gitmodules
 

--- a/Git Formats/Git Ignore.sublime-syntax
+++ b/Git Formats/Git Ignore.sublime-syntax
@@ -10,9 +10,11 @@ scope: text.git.ignore
 version: 2
 
 file_extensions:
-  - exclude               # .git/info/exclude
   - gitignore             # *.gitignore
+
+hidden_file_extensions:
   - .gitignore            # ~/.gitignore
+  - exclude               # .git/info/exclude
   - sparse-checkout       # .git/info/sparse-checkout
 
 contexts:

--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -8,8 +8,10 @@ scope: text.git.mailmap
 version: 2
 
 file_extensions:
-  - .mailmap
   - mailmap
+
+hidden_file_extensions:
+  - .mailmap
 
 contexts:
   main:

--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -6,7 +6,7 @@ name: Git Rebase Todo
 scope: text.git.rebase
 version: 2
 
-file_extensions:
+hidden_file_extensions:
   - git-rebase-todo
 
 first_line_match: '^(?:drop|edit|fixup|pick|reword|squash|[defprsx]) \h{7,} '


### PR DESCRIPTION
This commit moves all full file names to `hidden_file_extensions` in order to not suggest them as possible extension in _Save as..._ dialog.