### PR TITLE
[Python] Remove unapplied scope from lookahead pattern

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2845,7 +2845,6 @@ contexts:
       scope: keyword.control.loop.for.in.python
       pop: true
     - match: (?=[)\]}])
-      scope: invalid.illegal.missing-in.python
       pop: true
     - include: comments
     - include: illegal-name


### PR DESCRIPTION
Lookahead patterns don't consume anything and thus assigning scopes is nonsense.