### PR TITLE
[HTML] Treat CDATA as string with regards to interpolation

### DIFF
--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -30,6 +30,10 @@ contexts:
     - meta_prepend: true
     - include: asp-tags
 
+  cdata-content:
+    - meta_prepend: true
+    - include: asp-interpolations
+
   tag-attribute-value-content:
     - meta_prepend: true
     - include: asp-interpolations

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1292,6 +1292,14 @@ test = "hello%>
 '           ^ comment
 
 '<- - comment - source.asp.embedded.html
+
+<![CDATA[Text with <%= vbscript %> interpolation.]]>
+'        ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+'                  ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.html - string
+'                                 ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+'                  ^^^ punctuation.section.embedded.begin.asp
+'                               ^^ punctuation.section.embedded.end.asp
+
  </body>
 '^^^^^^^ meta.tag.structure.any.html
 <script type="text/javascript">

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -34,6 +34,10 @@
 #        - meta_prepend: true
 #        - include: asp-tags
 #
+#      cdata-content:
+#        - meta_prepend: true
+#        - include: asp-interpolations
+#
 #      tag-attribute-value-content:
 #        - meta_prepend: true
 #        - include: asp-interpolations
@@ -112,6 +116,7 @@ contexts:
       push: cdata-content
 
   cdata-content:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.sgml.cdata.html
     - meta_content_scope: meta.string.html string.unquoted.cdata.html
     - match: ']]>'

--- a/Haskell/Embeddings/HTML (for HSX).sublime-syntax
+++ b/Haskell/Embeddings/HTML (for HSX).sublime-syntax
@@ -20,7 +20,6 @@ contexts:
 
   cdata-content:
     - meta_prepend: true
-    - meta_include_prototype: false
     - include: haskell-string-interpolations
 
   tag-attribute-value-content:

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -49,6 +49,10 @@ contexts:
     - include: tag-jsp-other
     - include: tag-jstl
 
+  cdata-content:
+    - meta_prepend: true
+    - include: jsp-interpolations
+
   script-javascript-content:
     - meta_include_prototype: false
     - match: \s*((<!\[)(CDATA)(\[))

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -158,9 +158,18 @@
 </head>
 <body>
 
+    <![CDATA[This is text with <% java.text() %> interpolation.]]>
+//           ^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html - meta.interpolation
+//                             ^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.jsp meta.embedded.scriptlet.jsp - string
+//                                              ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html - meta.interpolation
+
+    <![CDATA[This is text with ${jstl} interpolation.]]>
+//           ^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html - meta.interpolation
+//                             ^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.jsp meta.embedded.expression.jstl - string
+//                                    ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html - meta.interpolation
+
     <%-- This is a comment --%>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.jsp
-
 
     <!--
     ---------------------------------------------------------------------------

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -68,7 +68,6 @@ contexts:
 
   cdata-content:
     - meta_prepend: true
-    - meta_include_prototype: false
     - include: php-interpolations
 
   script-javascript-content:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5598,6 +5598,11 @@ h1 {
 //          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html meta.interpolation.html source.js.embedded.html meta.function-call.js
 //                                  ^ meta.attribute-with-value.event.html meta.string.html string.quoted.single.html punctuation.definition.string.end.html - meta.interpolation
 
+<![CDATA[Text with <? $php ?> interpolation.]]>
+//       ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+//                 ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.embedded.php - string
+//                           ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+
   <?phpzzzz
 //^^ punctuation.section.embedded.begin.php
 //  ^^^^^^^ constant.other.php

--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -20,11 +20,7 @@ contexts:
     - meta_prepend: true
     - include: rails-embedded
 
-  strings-common-content:
-    - meta_prepend: true
-    - include: rails-interpolations
-
-  tag-attribute-value-content:
+  cdata-content:
     - meta_prepend: true
     - include: rails-interpolations
 
@@ -111,6 +107,14 @@ contexts:
         0: meta.string.html string.quoted.single.html
            punctuation.definition.string.end.html
     - include: else-pop
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: rails-interpolations
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: rails-interpolations
 
 ###[ EMBEDDED RUBY ]##########################################################
 

--- a/Rails/HTML (for HAML).sublime-syntax
+++ b/Rails/HTML (for HAML).sublime-syntax
@@ -12,6 +12,10 @@ contexts:
     - meta_prepend: true
     - include: HAML.sublime-syntax#interpolations
 
+  cdata-content:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#string-interpolations
+
   script-javascript-content:
     - meta_include_prototype: false
     - match: '{{script_content_begin}}'

--- a/Rails/tests/syntax_test_rails.haml
+++ b/Rails/tests/syntax_test_rails.haml
@@ -453,6 +453,11 @@
   /        ^^^^^ source.ruby.rails.embedded.haml variable.other.readwrite.instance.ruby
   /             ^ punctuation.section.interpolation.end.haml
 
+  <![CDATA[Text with #{@ruby} interpolation.]]>
+  /        ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+  /                  ^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.haml - string
+  /                          ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+
   <style  lang="#{@style_type}"> p { font-family: #{@font_name}; }
 /               ^^^^^^^^^^^^^^ meta.string.html meta.interpolation.haml
 /                                                 ^^^^^^^^^^^^^ meta.property-value.css meta.interpolation.haml

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -155,3 +155,8 @@
 #                                                                                              ^^ punctuation.section.embedded.end.rails
 #                                                                                                ^ string.quoted.single.css
 #                                                                                                 ^ punctuation.terminator.rule.css
+
+<![CDATA[Text with <% @ruby %> interpolation.]]>
+#        ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+#                  ^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.rails meta.embedded.rails - string
+#                             ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html


### PR DESCRIPTION
This commit clears `string` scope from embedded/interpolated code within <![CDATA[...]]> tags to bring scoping/highlighting inline with tag attribute values and other kinds of quoted or unquoted strings in HTML like syntaxes.

1. HTML (Plain) is modified to enforce inheriting syntaxes to treat CDATA as string by adding `meta_include_prototype: false` to `cdata-content`.
2. HSX, JSP, PHP already implement CDATA string interpolation. So obsolete `meta_include_prototype: false` is removed, only.
3. ASP and Rails are adjusted to follow the others.
4. some contexts are re-ordered to be inline across syntaxes.
5. Scope names keep unchanged.
6. Tests are added to verify correct scoping.