### PR TITLE
[All] Re-enable indentation based folding

### DIFF
--- a/C#/Fold.tmPreferences
+++ b/C#/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.cs</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/D/Fold.tmPreferences
+++ b/D/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.d</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/Graphviz/Fold.tmPreferences
+++ b/Graphviz/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.dot</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/JSON/Fold.tmPreferences
+++ b/JSON/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.json</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/JavaScript/JSX Fold.tmPreferences
+++ b/JavaScript/JSX Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.jsx | source.tsx</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <true/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/Lisp/Fold.tmPreferences
+++ b/Lisp/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.lisp</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/Python/Fold.tmPreferences
+++ b/Python/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.python</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <true/>
         <key>foldScopes</key>
         <array>
             <dict>

--- a/Rust/Fold.tmPreferences
+++ b/Rust/Fold.tmPreferences
@@ -5,8 +5,6 @@
     <string>source.rust</string>
     <key>settings</key>
     <dict>
-        <key>indentationFoldingEnabled</key>
-        <false/>
         <key>foldScopes</key>
         <array>
             <dict>


### PR DESCRIPTION
This commit re-enables indentation based folding for all syntaxes which have not yet been covered by other PRs.

Syntax based folding doesn't cover all possible use cases and therefore shouldn't be the only one.

Related with #3568, #3601