### PR TITLE
[LaTeX] Text formatting

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -709,6 +709,10 @@ contexts:
 
   # https://en.wikibooks.org/wiki/LaTeX/Fonts#Font_styles
   text-decorators:
+    - include: text-normal-select-font-family
+    - include: text-normal-select-font-shape
+    - include: text-normal-select-font-weight
+
     - match: (\\)textnormal{{endcs}}
       scope: support.function.textnormal.latex
       captures:
@@ -717,10 +721,6 @@ contexts:
         - textnormal-meta
         - text-normal-body
         - expect-text-markup-open-brace
-
-    - include: text-normal-select-font-family
-    - include: text-normal-select-font-shape
-    - include: text-normal-select-font-weight
 
     - match: ((\\)text)(\{)
       captures:

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -702,57 +702,23 @@ contexts:
           scope: punctuation.definition.verb.latex
           pop: true
 
+###[ FONTS ]####################################################################
+
+  # https://en.wikibooks.org/wiki/LaTeX/Fonts#Font_styles
   text-decorators:
-    - match: ((\\)emph)(\{)
+    - match: (\\)textnormal{{endcs}}
+      scope: support.function.textnormal.latex
       captures:
-        1: support.function.emph.latex
-        2: punctuation.definition.backslash.latex
-        3: punctuation.definition.group.brace.begin.tex
+        1: punctuation.definition.backslash.latex
       push:
-        - meta_scope: meta.function.emph.latex
-        - meta_content_scope: markup.italic.emph.latex
-        - include: brace-group-end
-        - include: main
-    - match: ((\\)textit)(\{)
-      captures:
-        1: support.function.textit.latex
-        2: punctuation.definition.backslash.latex
-        3: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.textit.latex
-        - meta_content_scope: markup.italic.textit.latex
-        - include: brace-group-end
-        - include: main
-    - match: ((\\)textbf)(\{)
-      captures:
-        1: support.function.textbf.latex
-        2: punctuation.definition.backslash.latex
-        3: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.textbf.latex
-        - meta_content_scope: markup.bold.textbf.latex
-        - include: brace-group-end
-        - include: main
-    - match: ((\\)texttt)(\{)
-      captures:
-        1: support.function.texttt.latex
-        2: punctuation.definition.backslash.latex
-        3: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.texttt.latex
-        - meta_content_scope: markup.raw.texttt.latex
-        - include: brace-group-end
-        - include: main
-    - match: ((\\)textsl)(\{)
-      captures:
-        1: support.function.textsl.latex
-        2: punctuation.definition.backslash.latex
-        3: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.textsl.latex
-        - meta_content_scope: markup.italic.textsl.latex
-        - include: brace-group-end
-        - include: main
+        - textnormal-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+
+    - include: text-normal-select-font-family
+    - include: text-normal-select-font-shape
+    - include: text-normal-select-font-weight
+
     - match: ((\\)text)(\{)
       captures:
         1: support.function.text.latex
@@ -761,6 +727,7 @@ contexts:
       push:
         - include: brace-group-end
         - include: main
+
     - match: ((\\)underline)(\{)
       captures:
         1: support.function.text.latex
@@ -771,6 +738,346 @@ contexts:
         - meta_content_scope: markup.underline.underline.latex
         - include: brace-group-end
         - include: main
+
+  text-normal-select-font-family:
+    - match: (\\)textrm{{endcs}}
+      scope: support.function.textrm.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textrm-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsf{{endcs}}
+      scope: support.function.textsf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsf-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+    - match: (\\)texttt{{endcs}}
+      scope: support.function.texttt.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - texttt-meta
+        - texttt-body
+        - expect-text-markup-open-brace
+
+  text-normal-select-font-shape:
+    - match: (\\)textup{{endcs}}
+      scope: support.function.textup.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textup-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+    - match: (\\)textit{{endcs}}
+      scope: support.function.textit.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textit-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsl{{endcs}}
+      scope: support.function.textsl.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsl-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsc{{endcs}}
+      scope: support.function.textsc.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsc-meta
+        - texttt-body
+        - expect-text-markup-open-brace
+    - match: (\\)emph{{endcs}}
+      scope: support.function.emph.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - emph-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+
+  text-normal-select-font-weight:
+    - match: (\\)textbf{{endcs}}
+      scope: support.function.textbf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textbf-meta
+        - text-bold-body
+        - expect-text-markup-open-brace
+    - match: (\\)textmd{{endcs}}
+      scope: support.function.textmd.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textmd-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+    - match: (\\)textlf{{endcs}}
+      scope: support.function.textlf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textlf-meta
+        - text-normal-body
+        - expect-text-markup-open-brace
+
+  # utility that waits for the brace, and pops the three contexts
+  # we push for each \text... command otherwise
+  expect-text-markup-open-brace:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      pop: true
+    - match: (?=\S)
+      pop: 3
+
+  textnormal-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textnormal.latex
+    - include: immediately-pop
+
+  textbf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textbf.latex
+    - include: immediately-pop
+
+  textmd-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textmd.latex
+    - include: immediately-pop
+
+  textlf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textlf.latex
+    - include: immediately-pop
+
+  textsf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsf.latex
+    - include: immediately-pop
+
+  textup-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textup.latex
+    - include: immediately-pop
+
+  textsc-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsc.latex
+    - include: immediately-pop
+
+  textrm-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textrm.latex
+    - include: immediately-pop
+
+  textit-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textit.latex
+    - include: immediately-pop
+
+  texttt-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.texttt.latex
+    - include: immediately-pop
+
+  textsl-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsl.latex
+    - include: immediately-pop
+
+  emph-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.emph.latex
+    - include: immediately-pop
+
+  text-normal-body:
+    - include: brace-group-end
+    - include: main
+
+  text-bold-body:
+    - include: brace-group-end
+    - include: text-bold-select-font-family
+    - include: text-bold-select-font-shape
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: text-bold-brace-group-body
+    - include: main
+    - match: .
+      scope: markup.bold.latex
+
+  text-bold-select-font-family:
+    - match: (\\)textrm{{endcs}}
+      scope: support.function.textrm.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textrm-meta
+        - text-bold-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsf{{endcs}}
+      scope: support.function.textsf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsf-meta
+        - text-bold-body
+        - expect-text-markup-open-brace
+    - match: (\\)texttt{{endcs}}
+      scope: support.function.texttt.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - texttt-meta
+        - texttt-body
+        - expect-text-markup-open-brace
+
+  text-bold-select-font-shape:
+    - match: (\\)textup{{endcs}}
+      scope: support.function.textup.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textup-meta
+        - text-bold-body
+        - expect-text-markup-open-brace
+    - match: (\\)textit{{endcs}}
+      scope: support.function.textit.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textit-meta
+        - text-it-and-bf-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsl{{endcs}}
+      scope: support.function.textsl.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsl-meta
+        - text-it-and-bf-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsc{{endcs}}
+      scope: support.function.textsc.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsc-meta
+        - texttt-body
+        - expect-text-markup-open-brace
+    - match: (\\)emph{{endcs}}
+      scope: support.function.emph.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - emph-meta
+        - text-it-and-bf-body
+        - expect-text-markup-open-brace
+
+  text-bold-brace-group-body:
+    - meta_scope: meta.group.brace.tex
+    - include: brace-group-end
+    - include: text-bold-body
+
+  text-italic-body:
+    - include: brace-group-end
+    - include: text-italic-select-font-family
+    - include: text-italic-select-font-weight
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      push: text-italic-brace-group-body
+    # special support for nested \emph-asis
+    - match: (\\)emph{{endcs}}
+      scope: support.function.emph.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - emph-meta
+        - text-normal-body
+        - brace-group-begin
+    - include: main
+    - match: .
+      scope: markup.italic.latex
+
+  text-italic-select-font-family:
+    - match: (\\)textrm{{endcs}}
+      scope: support.function.textrm.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textrm-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+    - match: (\\)textsf{{endcs}}
+      scope: support.function.textsf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textsf-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+    - match: (\\)texttt{{endcs}}
+      scope: support.function.texttt.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - texttt-meta
+        - texttt-body
+        - expect-text-markup-open-brace
+
+  text-italic-select-font-weight:
+    - match: (\\)textbf{{endcs}}
+      scope: support.function.textbf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textbf-meta
+        - text-it-and-bf-body
+        - expect-text-markup-open-brace
+    - match: (\\)textmd{{endcs}}
+      scope: support.function.textmd.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textmd-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+    - match: (\\)textlf{{endcs}}
+      scope: support.function.textlf.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      push:
+        - textlf-meta
+        - text-italic-body
+        - expect-text-markup-open-brace
+
+  text-italic-brace-group-body:
+    - meta_scope: meta.group.brace.tex
+    - include: brace-group-end
+    - include: text-italic-body
+
+  text-it-and-bf-body:
+    - include: brace-group-end
+    - include: main
+    - match: .
+      scope: markup.bold.latex markup.italic.latex
+
+  texttt-body:
+    - include: brace-group-end
+    - include: main
+    - match: .
+      scope: markup.raw.inline.latex
 
   footnote:
     - match: ((\\)footnote(?:text)?)\b

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -16,7 +16,7 @@ first_line_match: |-
   )
 
 variables:
-  simpletext: '.[^\\{}%$~&#_^]+'
+  simpletext: '[^\\{}%$~&#_^]*'
 
 contexts:
 

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -15,6 +15,9 @@ first_line_match: |-
     ^ \s* \%+ .*? -\*- .*? \blatex\b .*? -\*-  # editorconfig
   )
 
+variables:
+  simpletext: '.[^\\{}%$~&#_^]+'
+
 contexts:
 
   main:
@@ -914,7 +917,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push: text-bold-brace-group-body
     - include: main
-    - match: .
+    - match: .{{simpletext}}
       scope: markup.bold.latex
 
   text-bold-select-font-family:
@@ -1007,7 +1010,7 @@ contexts:
         - text-normal-body
         - brace-group-begin
     - include: main
-    - match: .
+    - match: .{{simpletext}}
       scope: markup.italic.latex
 
   text-italic-select-font-family:
@@ -1070,13 +1073,13 @@ contexts:
   text-it-and-bf-body:
     - include: brace-group-end
     - include: main
-    - match: .
+    - match: .{{simpletext}}
       scope: markup.bold.latex markup.italic.latex
 
   texttt-body:
     - include: brace-group-end
     - include: main
-    - match: .
+    - match: .{{simpletext}}
       scope: markup.raw.inline.latex
 
   footnote:

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -836,75 +836,6 @@ contexts:
         - text-normal-body
         - expect-text-markup-open-brace
 
-  # utility that waits for the brace, and pops the three contexts
-  # we push for each \text... command otherwise
-  expect-text-markup-open-brace:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      pop: true
-    - match: (?=\S)
-      pop: 3
-
-  textnormal-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textnormal.latex
-    - include: immediately-pop
-
-  textbf-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textbf.latex
-    - include: immediately-pop
-
-  textmd-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textmd.latex
-    - include: immediately-pop
-
-  textlf-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textlf.latex
-    - include: immediately-pop
-
-  textsf-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textsf.latex
-    - include: immediately-pop
-
-  textup-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textup.latex
-    - include: immediately-pop
-
-  textsc-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textsc.latex
-    - include: immediately-pop
-
-  textrm-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textrm.latex
-    - include: immediately-pop
-
-  textit-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textit.latex
-    - include: immediately-pop
-
-  texttt-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.texttt.latex
-    - include: immediately-pop
-
-  textsl-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.textsl.latex
-    - include: immediately-pop
-
-  emph-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.emph.latex
-    - include: immediately-pop
-
   text-normal-body:
     - include: brace-group-end
     - include: main
@@ -1081,6 +1012,75 @@ contexts:
     - include: main
     - match: .{{simpletext}}
       scope: markup.raw.inline.latex
+
+  # utility that waits for the brace, and pops the three contexts
+  # we push for each \text... command otherwise
+  expect-text-markup-open-brace:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      pop: true
+    - match: (?=\S)
+      pop: 3
+
+  textnormal-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textnormal.latex
+    - include: immediately-pop
+
+  textbf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textbf.latex
+    - include: immediately-pop
+
+  textmd-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textmd.latex
+    - include: immediately-pop
+
+  textlf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textlf.latex
+    - include: immediately-pop
+
+  textsf-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsf.latex
+    - include: immediately-pop
+
+  textup-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textup.latex
+    - include: immediately-pop
+
+  textsc-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsc.latex
+    - include: immediately-pop
+
+  textrm-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textrm.latex
+    - include: immediately-pop
+
+  textit-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textit.latex
+    - include: immediately-pop
+
+  texttt-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.texttt.latex
+    - include: immediately-pop
+
+  textsl-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.textsl.latex
+    - include: immediately-pop
+
+  emph-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.emph.latex
+    - include: immediately-pop
 
   footnote:
     - match: ((\\)footnote(?:text)?)\b

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -727,20 +727,25 @@ contexts:
         1: support.function.text.latex
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.tex
-      push:
-        - include: brace-group-end
-        - include: main
+      push: text-body
 
     - match: ((\\)underline)(\{)
       captures:
         1: support.function.text.latex
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.tex
-      push:
-        - meta_scope: meta.function.underline.latex
-        - meta_content_scope: markup.underline.underline.latex
-        - include: brace-group-end
-        - include: main
+      push: text-underline-body
+
+  text-body:
+    - meta_scope: meta.function.text.latex
+    - include: brace-group-end
+    - include: main
+
+  text-underline-body:
+    - meta_scope: meta.function.underline.latex
+    - meta_content_scope: markup.underline.other.latex
+    - include: brace-group-end
+    - include: main
 
   text-normal-select-font-family:
     - match: (\\)textrm{{endcs}}

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -623,6 +623,20 @@
 %              ^ punctuation.definition.group.brace.end.tex - markup
 
 
+% Check math in markup
+\textbf{bold $normal math$}
+%            ^^^^^^^^^^^^^ meta.environment.math.inline.dollar.tex - markup.bold.latex
+%            ^ string.other.math.tex punctuation.definition.string.begin.tex
+%                        ^ string.other.math.tex punctuation.definition.string.end.tex
+
+\textbf{bold %with comment}
+%            ^^^^^^^^^^^^^^ comment.line.percentage.tex -markup.bold.latex
+}
+
+\textit{italics~with~nbsp}
+%              ^ constant.character.space.tex -markup.italic.latex
+%                   ^ constant.character.space.tex -markup.italic.latex
+
 % check that incomplete code does not break too much
 \textbf no braces here
 %^^^^^^^ meta.function.textbf.latex

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -545,7 +545,7 @@
 %^^^^^^ support.function.textbf.latex - markup
 %       ^^^^^ markup.bold.latex
 %            ^^^^^ support.function.emph.latex - markup
-%            ^^^^^^^^^^^^^^^^^ meta.function.emph.latex 
+%            ^^^^^^^^^^^^^^^^^ meta.function.emph.latex
 %                  ^^^^^^^^^^ markup.bold.latex markup.italic.latex
 
 \textbf{text {in braces} still bold}
@@ -615,7 +615,7 @@
 \textit{italic \textnormal{upright}}
 %              ^^^^^^^^^^^^^^^^^^^^ meta.function.textnormal.latex
 %              ^^^^^^^^^^^ support.function.textnormal.latex
-%                          ^^^^^^^ - markup 
+%                          ^^^^^^^ - markup
 
 \textit{text {in braces} still italic}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textit.latex
@@ -626,7 +626,7 @@
 %^^^^^^^^^^^^^^^ meta.function.underline.latex
 %^^^^^^^^^ support.function.text.latex
 %         ^ punctuation.definition.group.brace.begin.tex - markup
-%          ^^^^ markup.underline.underline.latex
+%          ^^^^ markup.underline.other.latex
 %              ^ punctuation.definition.group.brace.end.tex - markup
 
 

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -381,23 +381,253 @@
 
 % MARKUP COMMANDS
 
-\emph{text}
-%     ^ markup.italic.emph.latex
-\textbf{text}
-%       ^ markup.bold.textbf.latex
-\textit{text}
-%       ^ markup.italic.textit.latex
-\texttt{text}
-%       ^ markup.raw.texttt.latex
-\textsl{text}
-%       ^ markup.italic.textsl.latex
-\textbf{\textit{text}}
-%               ^ markup.bold.textbf.latex markup.italic.textit.latex
-\textit{\textbf{text}}
-%               ^ markup.italic.textit.latex markup.bold.textbf.latex
-\underline{text}
-%          ^ markup.underline.underline.latex
+\textnormal{text}
+%^^^^^^^^^^^^^^^^ meta.function.textnormal.latex
+%^^^^^^^^^^ support.function.textnormal.latex
+%          ^ punctuation.definition.group.brace.begin.tex
+%               ^ punctuation.definition.group.brace.end.tex
 
+\textrm{text}
+%^^^^^^^^^^^^ meta.function.textrm.latex
+%^^^^^^ support.function.textrm.latex
+%      ^ punctuation.definition.group.brace.begin.tex
+%           ^ punctuation.definition.group.brace.end.tex
+
+\textsf{text}
+%^^^^^^^^^^^^ meta.function.textsf.latex
+%^^^^^^ support.function.textsf.latex
+%      ^ punctuation.definition.group.brace.begin.tex
+%           ^ punctuation.definition.group.brace.end.tex
+
+\emph{text}
+%^^^^^^^^^^ meta.function.emph.latex
+%^^^^ support.function.emph.latex
+%    ^ punctuation.definition.group.brace.begin.tex - markup
+%     ^^^^ markup.italic.latex
+%         ^ punctuation.definition.group.brace.end.tex - markup
+
+\emph{text \emph{nested} emph}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.emph.latex
+%^^^^ support.function.emph.latex
+%    ^ punctuation.definition.group.brace.begin.tex
+%     ^^^^^ markup.italic.latex
+%          ^^^^^^^^^^^^^ meta.function.emph.latex - markup
+%          ^^^^^ support.function.emph.latex
+%          ^ punctuation.definition.backslash.latex
+%               ^ punctuation.definition.group.brace.begin.tex
+%                      ^ punctuation.definition.group.brace.end.tex
+%                       ^^^^^ markup.italic.latex
+%                            ^ punctuation.definition.group.brace.end.tex
+
+\textbf{text}
+%^^^^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^ markup.bold.latex
+%           ^ punctuation.definition.group.brace.end.tex - markup
+
+\textbf{text \command and text}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%       ^^^^ markup.bold.latex
+%            ^^^^^^^^ support.function.general.latex - markup
+%                     ^^^^^^^^ markup.bold.latex
+
+
+\textit{text@"special"}
+%^^^^^^^^^^^^^^^^^^^^^^ meta.function.textit.latex
+%^^^^^^ support.function.textit.latex
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^^^^^^^^^^^ markup.italic.latex
+%                     ^ punctuation.definition.group.brace.end.tex - markup
+
+\texttt{text 123}
+%^^^^^^^^^^^^^^^^ meta.function.texttt.latex
+%^^^^^^ support.function.texttt.latex
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^^^^^ markup.raw.inline.latex
+%               ^ punctuation.definition.group.brace.end.tex - markup
+
+\textsc{smallcaps}
+%^^^^^^^^^^^^^^^^^ meta.function.textsc.latex
+%^^^^^^ support.function.textsc.latex
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^^^^^^ markup.raw.inline.latex
+%                ^ punctuation.definition.group.brace.end.tex - markup
+
+\textup{upright}
+%^^^^^^^^^^^^^^^ meta.function.textup.latex
+%^^^^^^ support.function.textup.latex
+%       ^^^^^^^ - markup
+
+\textlf{upright}
+%^^^^^^^^^^^^^^^ meta.function.textlf.latex
+%^^^^^^ support.function.textlf.latex
+%       ^^^^^^^ - markup
+
+\textmd{upright}
+%^^^^^^^^^^^^^^^ meta.function.textmd.latex
+%^^^^^^ support.function.textmd.latex
+%       ^^^^^^^ - markup
+
+%% combinations
+
+\textbf{text \textrm{roman font}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%       ^^^^^ markup.bold.latex
+%            ^^^^^^^^^^^^^^^^^^^ meta.function.textrm.latex
+%            ^^^^^^^ support.function.textrm.latex
+%                    ^^^^^^^^^^ markup.bold.latex
+
+\textbf{\textit{text} just bold \textsl{slanted}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%       ^^^^^^^^^^^^^ meta.function.textit.latex
+%                               ^^^^^^^^^^^^^^^^ meta.function.textsl.latex
+%^^^^^^ support.function.textbf.latex - markup
+%       ^^^^^^^ support.function.textit.latex - markup
+%                               ^^^^^^^ support.function.textsl.latex - markup
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^ punctuation.definition.backslash.latex - markup
+%               ^^^^ markup.bold.latex markup.italic.latex
+%                    ^^^^^^^^^^^ markup.bold.latex
+%                                       ^^^^^^^ markup.bold.latex markup.italic.latex
+%              ^ punctuation.definition.group.brace.begin.tex - markup
+%                   ^ punctuation.definition.group.brace.end.tex - markup
+%                               ^ punctuation.definition.backslash.latex - markup
+%                                      ^ punctuation.definition.group.brace.begin.tex - markup
+%                                              ^ punctuation.definition.group.brace.end.tex - markup
+%                                               ^ punctuation.definition.group.brace.end.tex - markup
+
+
+\textbf{bold \textnormal{not bold}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%            ^^^^^^^^^^^ support.function.textnormal.latex
+%       ^^^^^ markup.bold.latex
+%            ^^^^^^^^^^^^^^^^^^^^^ meta.function.textnormal.latex - markup
+
+
+\textbf{bold \textsf{still bold}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%            ^^^^^^^ support.function.textsf.latex
+%       ^^^^^ markup.bold.latex
+%            ^^^^^^^^^^^^^^^^^^^ meta.function.textsf.latex
+%                    ^^^^^^^^^^ markup.bold.latex
+
+\textbf{bold \textup{still bold}}
+%                    ^^^^^^^^^^ markup.bold.latex
+
+\textbf{bold \textmd{not bold}}
+%                    ^^^^^^^^ - markup.bold.latex
+
+\textbf{bold \textlf{not bold}}
+%                    ^^^^^^^^ - markup.bold.latex
+
+\textbf{bold \textbf{still bold}}
+%                    ^^^^^^^^^^ markup.bold.latex
+
+\textbf{bold \texttt{not bold}}
+%                    ^^^^^^^^ markup.raw.inline.latex
+
+\textbf{bold \textsc{not bold}}
+%                    ^^^^^^^^ markup.raw.inline.latex
+
+\textbf{bold \emph{and italic}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex - markup
+%       ^^^^^ markup.bold.latex
+%            ^^^^^ support.function.emph.latex - markup
+%            ^^^^^^^^^^^^^^^^^ meta.function.emph.latex 
+%                  ^^^^^^^^^^ markup.bold.latex markup.italic.latex
+
+\textbf{text {in braces} still bold}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textbf.latex
+%             ^^^^^^^^^ markup.bold.latex
+%                        ^^^^^^^^^^ markup.bold.latex
+
+\textit{italic \textbf{bold} italic}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textit.latex
+%^^^^^^ support.function.textit.latex - markup
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^^^^ markup.italic.latex
+%              ^^^^^^^^^^^^^ meta.function.textbf.latex
+%              ^^^^^^^ support.function.textbf.latex - markup
+%              ^ punctuation.definition.backslash.latex - markup
+%                     ^ punctuation.definition.group.brace.begin.tex - markup
+%                      ^^^^ markup.bold.latex markup.italic.latex
+%                          ^ punctuation.definition.group.brace.end.tex - markup
+%                           ^^^^^^^ markup.italic.latex
+%                                  ^ punctuation.definition.group.brace.end.tex - markup
+
+\textit{italic \textup{upright}}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textit.latex
+%^^^^^^ support.function.textit.latex
+%       ^^^^^^^ markup.italic.latex
+%              ^^^^^^^^^^^^^^^^ meta.function.textup.latex
+%              ^^^^^^^ support.function.textup.latex
+%                      ^^^^^^^ - markup
+
+\textsl{text \textbf{bold} slanted}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textsl.latex
+%^^^^^^ support.function.textsl.latex
+%      ^ punctuation.definition.group.brace.begin.tex - markup
+%       ^^^^^ markup.italic.latex
+%                    ^^^^ markup.bold.latex markup.italic.latex
+%                        ^ punctuation.definition.group.brace.end.tex - markup
+%                         ^^^^^^^^ markup.italic.latex - markup.bold
+%                                 ^ punctuation.definition.group.brace.end.tex - markup
+
+\textit{italic \textmd{upright}}
+%                      ^^^^^^^ markup.italic.latex
+
+\textit{italic \emph{upright}}
+%                    ^^^^^^^ - markup.italic.latex
+
+\textit{italic \textsf{italic}}
+%                      ^^^^^^ markup.italic.latex
+
+\textit{italic \textlf{italic}}
+%                      ^^^^^^ markup.italic.latex
+
+\textit{italic \textrm{italic}}
+%                      ^^^^^^ markup.italic.latex
+
+\textit{italic \textsl{italic}}
+%                      ^^^^^^ markup.italic.latex
+
+\textsl{italic \textit{italic}}
+%                      ^^^^^^ markup.italic.latex
+
+\textit{italic \textsc{upright}}
+%                      ^^^^^^^ markup.raw.inline.latex
+
+\textsl{italic \texttt{upright}}
+%                      ^^^^^^^ markup.raw.inline.latex
+
+\textit{italic \textnormal{upright}}
+%              ^^^^^^^^^^^^^^^^^^^^ meta.function.textnormal.latex
+%              ^^^^^^^^^^^ support.function.textnormal.latex
+%                          ^^^^^^^ - markup 
+
+\textit{text {in braces} still italic}
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.textit.latex
+%             ^^^^^^^^^ markup.italic.latex
+%                        ^^^^^^^^^^^^ markup.italic.latex
+
+\underline{text}
+%^^^^^^^^^^^^^^^ meta.function.underline.latex
+%^^^^^^^^^ support.function.text.latex
+%         ^ punctuation.definition.group.brace.begin.tex - markup
+%          ^^^^ markup.underline.underline.latex
+%              ^ punctuation.definition.group.brace.end.tex - markup
+
+
+% check that incomplete code does not break too much
+\textbf no braces here
+%^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%       ^^^^^^^^^^^^^^^ - meta.function
 
 % FOOTNOTE COMMANDS
 

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -419,6 +419,13 @@
 %                       ^^^^^ markup.italic.latex
 %                            ^ punctuation.definition.group.brace.end.tex
 
+\textbf{a}
+%^^^^^^^^^ meta.function.textbf.latex
+%^^^^^^ support.function.textbf.latex
+%      ^ punctuation.definition.group.brace.begin.tex
+%       ^ markup.bold.latex
+%        ^ punctuation.definition.group.brace.end.tex
+
 \textbf{text}
 %^^^^^^^^^^^^ meta.function.textbf.latex
 %^^^^^^ support.function.textbf.latex


### PR DESCRIPTION
The PR reworks the handling of text formatting commands in LaTeX. In particular, in cases where there are commands within formatted text, e.g. `\textbf{\TeX in bold}`, we no longer format the command names. 

One challenge is that there are several font properties that can be changed independently: Font family (roman, sans serif, typewriter), font weight (bold, medium, (possibly) light), and font shape (upright, italic, slanted, small-caps). Most of these do not have any corresponding `markup` scopes and highlighting rules (at least with default color schemes). At this point, only a subset of nesting of these properties is actually handled: Bold/italic combination, and nested \emph emphasize, as well as ensuring that all the commands that do not change one of these properties still typeset their arguments according to the outer command.

No provision has been made for any form of triple-nesting, i.e. `\textbf{\textit{\textup{a}}}` would not result in bold `a` right now. Not sure if supporting this would be worth it.

Finally, there is also an \underline command that could be combined with bold/italic. So far, I've not included this, because in LaTeX underline comes with some caveats, so that package commands like `\uline` or `\ul` are often recommended.

A more general question, is there a way to generate variations of the same context without excessive copy-and-paste? I've seen that there is a json-macro plugin, but I'm not sure if this is officially supported. 