### PR TITLE
[Python] Fix with statements

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -409,13 +409,7 @@ contexts:
           pop: true
         - include: target-lists
     # async with ... as ...:
-    - match: \b(async +)?(with)\b
-      captures:
-        1: storage.modifier.async.python
-        2: keyword.control.flow.with.python
-      push:
-        - with-meta
-        - with-body
+    - include: with-statements
     # except ... as ...:
     - match: \bexcept\b
       scope: keyword.control.exception.catch.python
@@ -765,58 +759,71 @@ contexts:
 
 ###[ WITH STATEMENTS ]########################################################
 
-  with-meta:
-    - meta_include_prototype: false
+  with-statements:
+    - match: \b(?:(async) +)?(with)\b
+      captures:
+        1: storage.modifier.async.python
+        2: keyword.control.flow.with.python
+      branch_point: with-statement-tuple
+      branch:
+        - with-statement-tuple
+        - with-statement-plain
+
+  with-statement-plain:
     - meta_scope: meta.statement.with.python
-    - match: ''
-      pop: true
-
-  with-body:
-    - match: \(
-      scope: punctuation.section.sequence.begin.python
-      set: with-tuple-body
-    - match: (?=\S)
-      set: with-plain-body
-
-  with-tuple-body:
-    - meta_scope: meta.sequence.tuple.python
-    - match: \)
-      scope: punctuation.section.sequence.end.python
-      set: with-end
-    - match: \bas\b
-      scope: keyword.control.flow.with.as.python
-      push: with-tuple-as
-    - include: expression-in-a-group
-
-  with-tuple-as:
-    - match: (?=[,)])
-      pop: true
-    - include: comments
-    - include: name
-    - include: generators-groups-and-tuples
-    - include: lists
-
-  with-plain-body:
-    - match: \bas\b
-      scope: keyword.control.flow.with.as.python
-      set: with-plain-as
-    - include: with-end
-    - include: expression-in-a-statement
-
-  with-plain-as:
-    - match: ','
-      scope: punctuation.separator.sequence.python
-      set: with-plain-body
-    - include: with-end
-    - include: name
-    - include: generators-groups-and-tuples
-    - include: lists
-
-  with-end:
     - match: ':(?!=)'
       scope: punctuation.section.block.with.python
       pop: true
+    - match: \bas\b
+      scope: keyword.control.flow.with.as.python
+      push: with-statement-plain-as
     - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
+  with-statement-plain-as:
+    - include: line-continuation-or-pop
+    - include: generators-groups-and-tuples
+    - include: lists
+    - include: name
+    - include: else-pop
+
+  with-statement-tuple:
+    - meta_scope: meta.statement.with.python
+    - match: \(
+      scope: punctuation.section.sequence.begin.python
+      set:
+        - with-statement-tuple-end
+        - with-statement-tuple-body
+    - include: with-statement-tuple-else-fail
+
+  with-statement-tuple-body:
+    - meta_scope: meta.sequence.tuple.python
+    - match: \)
+      scope: punctuation.section.sequence.end.python
+      pop: 1
+    - match: \bas\b
+      scope: keyword.control.flow.with.as.python
+      push: with-statement-tuple-as
+    - include: expression-in-a-group
+
+  with-statement-tuple-as:
+    - include: comments
+    - include: generators-groups-and-tuples
+    - include: lists
+    - include: name
+    - include: else-pop
+
+  with-statement-tuple-end:
+    - meta_content_scope: meta.statement.with.python
+    - match: ':(?!=)'
+      scope: meta.statement.with.python punctuation.section.block.with.python
+      pop: true
+    - include: with-statement-tuple-else-fail
+
+  with-statement-tuple-else-fail:
+    - include: line-continuation
+    - match: (?=\S|$)
+      fail: with-statement-tuple
 
 ###[ EXPRESSIONS ]############################################################
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -746,8 +746,78 @@ def _():
         x:
 #       ^^ meta.statement.with
 
-    with open(), open() as x, open() as y:
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
+    with (folder / "file.txt").open() as x:
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
+#        ^^^^^^^^^^^^^^^^^^^^^ meta.group.python
+#                             ^^^^^ meta.function-call.python meta.qualified-name.python
+#                                  ^^ meta.function-call.arguments.python
+#   ^^^^ keyword.control.flow.with.python
+#        ^ punctuation.section.group.begin.python
+#         ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                ^ keyword.operator.arithmetic.python
+#                  ^^^^^^^^^^ meta.string.python string.quoted.double.python
+#                            ^ punctuation.section.group.end.python
+#                             ^ punctuation.accessor.dot.python
+#                              ^^^^ variable.function.python
+#                                  ^ punctuation.section.arguments.begin.python
+#                                   ^ punctuation.section.arguments.end.python
+#                                     ^^ keyword.control.flow.with.as.python
+#                                        ^ meta.generic-name.python
+#                                         ^ punctuation.section.block.with.python
+
+    with ((folder / "file.txt").open() as x):
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
+#        ^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
+#         ^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python meta.group.python - meta.sequence meta.sequence
+#                              ^^^^^^^^^^^^^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
+#                               ^^^^ meta.function-call.python meta.qualified-name.python
+#                                   ^^ meta.function-call.arguments.python
+#                                           ^ - meta.sequence
+#   ^^^^ keyword.control.flow.with.python
+#        ^ punctuation.section.sequence.begin.python
+#         ^ punctuation.section.group.begin.python
+#          ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                 ^ keyword.operator.arithmetic.python
+#                   ^^^^^^^^^^ meta.string.python string.quoted.double.python
+#                             ^ punctuation.section.group.end.python
+#                              ^ meta.function-call.python meta.qualified-name.python punctuation.accessor.dot.python
+#                               ^^^^ meta.qualified-name.python variable.function.python
+#                                   ^ punctuation.section.arguments.begin.python
+#                                    ^ punctuation.section.arguments.end.python
+#                                      ^^ keyword.control.flow.with.as.python
+#                                         ^ meta.generic-name.python
+#                                          ^ punctuation.section.sequence.end.python
+#                                           ^ punctuation.section.block.with.python
+#
+
+    # multiple nesting is not allowed
+    with (((folder / "file.txt").open() as x)):
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
+#        ^ meta.group.python - meta.group meta.group
+#         ^ meta.group.python meta.group.python - meta.group meta.group meta.group
+#          ^^^^^^^^^^^^^^^^^^^^^ meta.group.python meta.group.python meta.group.python
+#                               ^^^^^^^^^^ meta.group.python meta.group.python - meta.group meta.group meta.group
+#                                         ^^^ meta.group.python - meta.group meta.group
+#                                            ^ - meta.group
+#   ^^^^ keyword.control.flow.with.python
+#        ^ punctuation.section.group.begin.python
+#         ^^ punctuation.section.group.begin.python
+#           ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                  ^ keyword.operator.arithmetic.python
+#                    ^^^^^^^^^^ meta.string.python string.quoted.double.python
+#                              ^ punctuation.section.group.end.python
+#                               ^ meta.function-call.python meta.qualified-name.python punctuation.accessor.dot.python
+#                                ^^^^ variable.function.python
+#                                    ^ punctuation.section.arguments.begin.python
+#                                     ^ punctuation.section.arguments.end.python
+#                                       ^^ invalid.illegal.name.python
+#                                          ^ meta.qualified-name.python meta.generic-name.python
+#                                           ^ punctuation.section.group.end.python
+#                                            ^ invalid.illegal.stray.python
+#                                             ^ punctuation.section.block.with.python
+
+    with open(), open() as x, open() as as:
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
 #   ^^^^ keyword.control.flow.with
 #        ^^^^ support.function
 #              ^ punctuation.separator.sequence
@@ -755,6 +825,7 @@ def _():
 #                           ^ punctuation.separator.sequence
 #                             ^^^^ support.function
 #                                    ^^ keyword.control.flow.with.as
+#                                       ^^ invalid.illegal.name.python
 
     with (
 #   ^^^^^^^ - meta.statement.with meta.statement.with


### PR DESCRIPTION
Fixes #3619

This commit uses branching to distinguish parenthesized and plain with argument lists.

If a parenthesized expression directly following a `with` keyword is not followed by colon it is scoped as part of a plain arguments list.

_Note: All that effort just to satisfy all the pseudo-linting like illegal highlighting._