### PR TITLE
[Graphviz] Fix embedded html termination

### DIFF
--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -60,17 +60,16 @@ contexts:
   embedded-html:
     - match: '<'
       scope: punctuation.section.embedded.begin.dot
-      push:
-        - meta_content_scope: source.dot.embedded.html
-        - match: '((>)?\s*)(>)'
-          captures:
-            1: source.dot.embedded.html
-            2: meta.tag punctuation.definition.tag.end.html
-            3: punctuation.section.embedded.end.dot
-          pop: true
-        - match: ''
-          embed: scope:text.html.basic
-          escape: (?=>\s*>)
+      push: embedded-html-body
+
+  embedded-html-body:
+    - meta_scope: meta.embedded.html.dot
+    - meta_content_scope: text.html.embedded.dot
+    - match: '>'
+      scope: punctuation.section.embedded.end.dot
+      pop: true
+    - include: scope:text.html.basic#html
+      apply_prototype: true
 
   braces:
     - match: \{

--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -68,7 +68,7 @@ contexts:
     - match: '>'
       scope: punctuation.section.embedded.end.dot
       pop: true
-    - include: scope:text.html.basic#html
+    - include: scope:text.html.plain#html
       apply_prototype: true
 
   braces:

--- a/Graphviz/syntax_test_dot.dot
+++ b/Graphviz/syntax_test_dot.dot
@@ -57,30 +57,38 @@ graph cluster_n {
 digraph structs {
     node [shape=plaintext]
     struct1 [label=<
-//                ^    keyword.operator.assignment.dot
-//                 ^   punctuation.section.embedded.begin.dot
-//                  ^^ source.dot.embedded.html
+//                ^ keyword.operator.assignment.dot
+//                 ^ punctuation.section.embedded.begin.dot
+//                  ^ text.html.embedded.dot
 <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
 //                                              ^ punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
   <TR><TD>left</TD><TD PORT="f1">mid dle</TD><TD PORT="f2">right</TD></TR>
 </TABLE>>];
-// ^^^^      source.dot.embedded.html
-// ^^^^^     source.dot.embedded.html
+// ^^^^      text.html.embedded.
+// ^^^^^     text.html.embedded.
 //     ^     punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
-//      ^    punctuation.section.embedded.end.dot - source.dot.embedded.html
+//      ^    punctuation.section.embedded.end.dot - text.html.embedded.
     struct2 [label=<
 //                ^    keyword.operator.assignment.dot
 //                 ^   punctuation.section.embedded.begin.dot
-//                  ^^ source.dot.embedded.html
+//                  ^^ text.html.embedded.
 <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
 //                                              ^ punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
   <TR><TD PORT="f0">one</TD><TD>two</TD></TR>
 </TABLE> >];
-// ^^^^^^     source.dot.embedded.html
+// ^^^^^^     text.html.embedded.
 //^^^^^^ meta.tag
 //      ^ - meta.tag
 //     ^      punctuation.definition.tag.end.html - punctuation.section.embedded.end.dot
-//       ^    punctuation.section.embedded.end.dot - source.dot.embedded.html
+//       ^    punctuation.section.embedded.end.dot - text.html.embedded.
     struct1:f1 -> struct2:f0;
     struct2:f0 -> struct1:f2;
 }
+
+label = <<u>this is underscored</u><br/>this is not>
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.html.dot
+//      ^ punctuation.section.embedded.begin.dot
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.embedded.dot
+//       ^^^ meta.tag
+//                             ^^^^^^^^^ meta.tag
+//                                                 ^ punctuation.section.embedded.end.dot


### PR DESCRIPTION
Fixes #3627

This commit ...

1. includes HTML source into Graphviz to be able to correctly terminate it if an otherwise stray `>` is matched.
2. fixes embedded scope to `meta.embedded.dot text.html.embedded.dot`