### PR TITLE
[ShellScript] Enforce string interpolation

### DIFF
--- a/Makefile/Makefile Shell.sublime-syntax
+++ b/Makefile/Makefile Shell.sublime-syntax
@@ -12,10 +12,6 @@ contexts:
     - meta_prepend: true
     - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions
 
-  string-ansi-c-body:
-    - meta_append: true
-    - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions
-
-  string-quoted-single-body:
+  string-prototype:
     - meta_append: true
     - include: Packages/Makefile/Makefile.sublime-syntax#variable-substitutions

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -994,3 +994,20 @@ html:
 #                                          ^^ variable.parameter.option.shell
 #                                             ^^^^^^^^^^^ variable.parameter.makefile
 #                                                         ^^^^^^^^^^^^^^ variable.parameter.makefile
+
+shell_string_interpolation:
+    var1="double nquoted $(string) value"
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.quoted.double.shell
+    #                    ^^^^^^^^^ variable.parameter.makefile
+    #                    ^^ keyword.other.block.begin.makefile
+    #                            ^ keyword.other.block.end.makefile
+    var1='single nquoted $(string) value'
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.quoted.single.shell
+    #                    ^^^^^^^^^ variable.parameter.makefile
+    #                    ^^ keyword.other.block.begin.makefile
+    #                            ^ keyword.other.block.end.makefile
+    var1=unquoted\ $(string)\ value
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.unquoted.shell
+    #              ^^^^^^^^^ variable.parameter.makefile
+    #              ^^ keyword.other.block.begin.makefile
+    #                      ^ keyword.other.block.end.makefile

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1520,21 +1520,25 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell entity.name.function.shell
         - include: string-quoted-single-body
     - match: \"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell entity.name.function.shell
         - include: string-quoted-double-body
     - match: \$'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell entity.name.function.shell
         - include: string-ansi-c-body
     - match: \$"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell entity.name.function.shell
         - include: string-quoted-double-body
     - include: expansions-variables
@@ -1545,21 +1549,25 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell variable.function.shell
         - include: string-quoted-single-body
     - match: \"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell variable.function.shell
         - include: string-quoted-double-body
     - match: \$'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell variable.function.shell
         - include: string-ansi-c-body
     - match: \$"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell variable.function.shell
         - include: string-quoted-double-body
     - include: expansions-variables
@@ -1888,21 +1896,25 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.shell
         - include: string-quoted-single-body
     - match: \"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.shell
-        - include:  string-quoted-double-body
+        - include: string-quoted-double-body
     - match: \$'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.single.ansi-c.shell
         - include: string-ansi-c-body
     - match: \$"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.double.locale.shell
         - include: string-quoted-double-body
     - include: any-escapes
@@ -1916,17 +1928,20 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell string.quoted.single.shell
         - include: string-quoted-single-body
     - match: \"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell string.quoted.double.shell
-        - include:  string-quoted-double-body
+        - include: string-quoted-double-body
     # [Bash] 3.1.2.4
     - match: \$'
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell string.quoted.single.ansi-c.shell
         - include: string-ansi-c-body
     # [Bash] 3.1.2.5
@@ -1934,6 +1949,7 @@ contexts:
     - match: \$"
       scope: punctuation.definition.string.begin.shell
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.string.shell string.quoted.double.locale.shell
         - include: string-quoted-double-body
 
@@ -1941,6 +1957,7 @@ contexts:
     - match: \"
       scope: punctuation.definition.string.end.shell
       pop: 1
+    - include: string-prototype
     - include: line-continuations
     - include: string-escapes
     - include: string-interpolations
@@ -1949,6 +1966,7 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.shell
       pop: 1
+    - include: string-prototype
     - include: line-continuations
     - include: string-escapes-ansi-c
 
@@ -1956,6 +1974,11 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.shell
       pop: 1
+    - include: string-prototype
+
+  # for use by inheriting syntaxes to easily inject string interpolation
+  # in any kind of quoted or unquoted string
+  string-prototype: []
 
   any-escapes:
     - match: \\.

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1890,37 +1890,42 @@ contexts:
       set: string-unquoted-body
 
   string-unquoted-body:
-    - meta_scope: meta.string.shell
-    - match: '{{cmd_literal_char}}+'
-      scope: string.unquoted.shell
+    - meta_include_prototype: false
+    - meta_scope: meta.string.shell string.unquoted.shell
+    - include: string-prototype
+    - include: line-continuations
+    - include: any-escapes
+    - include: string-interpolations
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push:
+        - clear_scopes: 1
         - meta_include_prototype: false
         - meta_scope: string.quoted.single.shell
         - include: string-quoted-single-body
     - match: \"
       scope: punctuation.definition.string.begin.shell
       push:
+        - clear_scopes: 1
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.shell
         - include: string-quoted-double-body
     - match: \$'
       scope: punctuation.definition.string.begin.shell
       push:
+        - clear_scopes: 1
         - meta_include_prototype: false
         - meta_scope: string.quoted.single.ansi-c.shell
         - include: string-ansi-c-body
     - match: \$"
       scope: punctuation.definition.string.begin.shell
       push:
+        - clear_scopes: 1
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.locale.shell
         - include: string-quoted-double-body
-    - include: any-escapes
-    - include: line-continuations
-    - include: expansions
-    - include: immediately-pop
+    - match: (?!{{cmd_literal_char}})
+      pop: 1
 
   strings:
     - include: any-escapes
@@ -1976,10 +1981,6 @@ contexts:
       pop: 1
     - include: string-prototype
 
-  # for use by inheriting syntaxes to easily inject string interpolation
-  # in any kind of quoted or unquoted string
-  string-prototype: []
-
   any-escapes:
     - match: \\.
       scope: constant.character.escape.shell
@@ -2000,3 +2001,7 @@ contexts:
         - clear_scopes: 1
         - include: expansions-variables
         - include: immediately-pop
+
+  # for use by inheriting syntaxes to easily inject string interpolation
+  # in any kind of quoted or unquoted string
+  string-prototype: []


### PR DESCRIPTION
This PR excludes `prototype` context from quoted strings by default in order to enforce extra treatment by inheriting syntaxes.

It is to make sure string scope is cleared by interpolations.

A `string-prototype` context is introduced as common entry point for inheriting syntaxes to inject interpolation.

Possible use cases:

1. String interpolations in Makefile syntax
2. https://github.com/nk9/just_sublime/pull/2


Note: Makefile makes use of new `string-prototype` context, but seriously implementing string interpolation seems to be a more sophisticated task especially as some scope naming changes with regards to punctuation might be needed. Hence that's probably better handled in a separate PR.
