### PR TITLE
[PHP] Improve event/style attribute value contexts

### DIFF
--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -125,6 +125,7 @@ contexts:
         4: comment.block.html punctuation.definition.comment.end.html
 
   tag-event-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.begin.html
       set: tag-event-attribute-value-double-quoted-content
@@ -134,6 +135,7 @@ contexts:
     - include: else-pop
 
   tag-event-attribute-value-double-quoted-content:
+    - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.js.embedded.html
     - match: \"
@@ -142,6 +144,7 @@ contexts:
     - include: scope:source.js.embedded.string.quoted.double.php
 
   tag-event-attribute-value-single-quoted-content:
+    - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.js.embedded.html
     - match: \'
@@ -150,6 +153,7 @@ contexts:
     - include: scope:source.js.embedded.string.quoted.single.php
 
   tag-style-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.begin.html
       set: tag-style-attribute-value-double-quoted-content
@@ -159,6 +163,7 @@ contexts:
     - include: else-pop
 
   tag-style-attribute-value-double-quoted-content:
+    - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.css.embedded.html
     - match: \"
@@ -167,6 +172,7 @@ contexts:
     - include: scope:source.css.embedded.string.quoted.double.php
 
   tag-style-attribute-value-single-quoted-content:
+    - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.css.embedded.html
     - match: \'

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -128,56 +128,68 @@ contexts:
     - meta_include_prototype: false
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.begin.html
-      set: tag-event-attribute-value-double-quoted-content
+      set: tag-event-attribute-value-double-quoted-body
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.begin.html
-      set: tag-event-attribute-value-single-quoted-content
+      set: tag-event-attribute-value-single-quoted-body
     - include: else-pop
 
-  tag-event-attribute-value-double-quoted-content:
+  tag-event-attribute-value-double-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.js.embedded.html
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.end.html
       pop: 1
+    - include: tag-event-attribute-value-double-quoted-content
+
+  tag-event-attribute-value-double-quoted-content:
     - include: scope:source.js.embedded.string.quoted.double.php
 
-  tag-event-attribute-value-single-quoted-content:
+  tag-event-attribute-value-single-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.js.embedded.html
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.end.html
       pop: 1
+    - include: tag-event-attribute-value-single-quoted-content
+
+  tag-event-attribute-value-single-quoted-content:
     - include: scope:source.js.embedded.string.quoted.single.php
 
   tag-style-attribute-value:
     - meta_include_prototype: false
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.begin.html
-      set: tag-style-attribute-value-double-quoted-content
+      set: tag-style-attribute-value-double-quoted-body
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.begin.html
-      set: tag-style-attribute-value-single-quoted-content
+      set: tag-style-attribute-value-single-quoted-body
     - include: else-pop
 
-  tag-style-attribute-value-double-quoted-content:
+  tag-style-attribute-value-double-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.css.embedded.html
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.end.html
       pop: 1
+    - include: tag-style-attribute-value-double-quoted-content
+
+  tag-style-attribute-value-double-quoted-content:
     - include: scope:source.css.embedded.string.quoted.double.php
 
-  tag-style-attribute-value-single-quoted-content:
+  tag-style-attribute-value-single-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
     - meta_content_scope: meta.interpolation.html source.css.embedded.html
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.end.html
       pop: 1
+    - include: tag-style-attribute-value-single-quoted-content
+
+  tag-style-attribute-value-single-quoted-content:
     - include: scope:source.css.embedded.string.quoted.single.php
 
   tag-attribute-value-content:


### PR DESCRIPTION
This PR...

1. excludes `prototype` from event/style attribute values as PHP is already handled by included js/css syntax.
2. splits value contexts into `-body` and `-content` so inheriting syntax can replace included js/css without touching low-level string patterns.  
   _An alternative would be: https://github.com/sublimehq/sublime_text/issues/3787._