### PR TITLE
[PHP] Adjust snippet selectors

### DIFF
--- a/PHP/Snippets/php (begin tag).sublime-snippet
+++ b/PHP/Snippets/php (begin tag).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[${TM_PHP_OPEN_TAG:php} $0 ?>]]></content>
 	<tabTrigger>php</tabTrigger>
-	<scope>embedding.php text.html punctuation.section.embedded.begin.php</scope>
+	<scope>(embedding.php | text.html.php) & punctuation.section.embedded.begin.php</scope>
 	<description>&lt;?php … ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-$this.sublime-snippet
+++ b/PHP/Snippets/php-$this.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG:php} \$this->$0 ?>]]></content>
 	<tabTrigger>this</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php $this-&gt;… ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-echo-$this.sublime-snippet
+++ b/PHP/Snippets/php-echo-$this.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG_WITH_ECHO:php echo} \$this->$0 ?>]]></content>
 	<tabTrigger>ethis</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php echo $this-&gt;… ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-echo-___.sublime-snippet
+++ b/PHP/Snippets/php-echo-___.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG_WITH_ECHO:php echo} ${1:\$var} ?>$0]]></content>
 	<tabTrigger>echo</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php echo … ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-echo-htmlentities(___).sublime-snippet
+++ b/PHP/Snippets/php-echo-htmlentities(___).sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG_WITH_ECHO:php echo} htmlentities(${1:\$var}, ENT_QUOTES, 'utf-8') ?>$0]]></content>
 	<tabTrigger>echoh</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php echo htmlentities(…) ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-else.sublime-snippet
+++ b/PHP/Snippets/php-else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG:php} else: ?>]]></content>
 	<tabTrigger>else</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php else: ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-foreach-(___)-___-php-endforeach.sublime-snippet
+++ b/PHP/Snippets/php-foreach-(___)-___-php-endforeach.sublime-snippet
@@ -3,6 +3,6 @@
 	${0}
 <?${TM_PHP_OPEN_TAG:php} endforeach ?>]]></content>
 	<tabTrigger>foreach</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php foreach (…) … &lt;?php endforeach ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-if-(___)-___-php-else-___-php-endif.sublime-snippet
+++ b/PHP/Snippets/php-if-(___)-___-php-else-___-php-endif.sublime-snippet
@@ -5,6 +5,6 @@
 	$0
 <?${TM_PHP_OPEN_TAG:php} endif ?>]]></content>
 	<tabTrigger>ifelse</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php if (…) ?&gt; … &lt;?php else ?&gt; … &lt;?php endif ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php-if-(___)-___-php-endif.sublime-snippet
+++ b/PHP/Snippets/php-if-(___)-___-php-endif.sublime-snippet
@@ -3,6 +3,6 @@
 	$0
 <?${TM_PHP_OPEN_TAG:php} endif ?>]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>embedding.php text.html - source.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php</scope>
 	<description>&lt;?php if (…) ?&gt; … &lt;?php endif ?&gt;</description>
 </snippet>

--- a/PHP/Snippets/php.sublime-snippet
+++ b/PHP/Snippets/php.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?${TM_PHP_OPEN_TAG:php} $0 ?>]]></content>
 	<tabTrigger>php</tabTrigger>
-	<scope>embedding.php text.html - source.php - punctuation.section.embedded.begin.php</scope>
+	<scope>(embedding.php | text.html.php) - source.php - punctuation.section.embedded.begin.php</scope>
 	<description>&lt;?php … ?&gt;</description>
 </snippet>


### PR DESCRIPTION
This commit adds `text.html.php` to those snippets which are currently triggered by `embedding.php - source.php` only.

The goal is to enable those snippets in inherit syntax such as Laravel Blade, which don't use `embedding.php` but will probably be scoped `text.html.php.blade`.

> **Note**
> 
> Basically `embedding.php` is maintained only in order to enable those snippets in an empty document, as `text.html.php` is added to stack not before the first character is typed.