### PR TITLE
[Rust] Add string punctuation scope fold rules

### DIFF
--- a/Rust/Fold.tmPreferences
+++ b/Rust/Fold.tmPreferences
@@ -27,6 +27,12 @@
                 <key>end</key>
                 <string>punctuation.section.parameters.end</string>
             </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.definition.string.begin</string>
+                <key>end</key>
+                <string>punctuation.definition.string.end</string>
+            </dict>
         </array>
     </dict>
 </dict>


### PR DESCRIPTION
You can continue multi-line strings by ending a line within the string with a single backslash.