### PR TITLE
[Lisp] Add sld file extension for rsr7 libraries

### DIFF
--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -19,6 +19,7 @@ file_extensions:
   - ss
   - lsp
   - fasl # Scheme dialect of Lisp
+  - sld  # Scheme r7rs library
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
The Scheme r7rs community has adopted `.sld` as an extension for libraries (in part to distinguish them from r6rs libraries). 

Supporting references:

 - Guile 3.0.1 added support: https://lists.gnu.org/archive/html/guile-devel/2020-03/msg00012.html
 - Chibi Module system naming: https://synthcode.com/scheme/chibi/#h3_ModuleSystem
 - various r7rs-supporting SRFI, e.g. SRFI 133 https://github.com/scheme-requests-for-implementation/srfi-133
 - widely used Scheme tools, e.g. https://github.com/drewc/drewc-r7rs-swank