### PR TITLE
[ShellScript] scope colon as a path separator inside quoted strings

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1332,7 +1332,6 @@ contexts:
     # characters ‘\’, ‘$’, and ‘`’.
     - include: string-escapes
     - include: string-interpolations
-    - include: string-path-separators
 
   heredocs-body-no-expansion:
     - meta_scope: meta.string.heredoc.shell
@@ -1996,7 +1995,7 @@ contexts:
       scope: constant.character.escape.shell
 
   string-path-separators:
-    - match: ':(?!$|\s|//)'
+    - match: ':(?=\$|/(?!/))'
       scope: punctuation.separator.sequence.shell
 
   string-escapes-ansi-c:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1925,6 +1925,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.locale.shell
         - include: string-quoted-double-body
+    - include: string-commons
     - match: (?!{{cmd_literal_char}})
       pop: 1
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1332,7 +1332,7 @@ contexts:
     # characters ‘\’, ‘$’, and ‘`’.
     - include: string-escapes
     - include: string-interpolations
-    - include: string-commons
+    - include: string-path-separators
 
   heredocs-body-no-expansion:
     - meta_scope: meta.string.heredoc.shell
@@ -1925,7 +1925,7 @@ contexts:
         - meta_include_prototype: false
         - meta_scope: string.quoted.double.locale.shell
         - include: string-quoted-double-body
-    - include: string-commons
+    - include: string-path-separators
     - match: (?!{{cmd_literal_char}})
       pop: 1
 
@@ -1968,7 +1968,7 @@ contexts:
     - include: line-continuations
     - include: string-escapes
     - include: string-interpolations
-    - include: string-commons
+    - include: string-path-separators
 
   string-ansi-c-body:
     - match: \'
@@ -1983,7 +1983,7 @@ contexts:
       scope: punctuation.definition.string.end.shell
       pop: 1
     - include: string-prototype
-    - include: string-commons
+    - include: string-path-separators
 
   any-escapes:
     - match: \\.
@@ -1995,7 +1995,7 @@ contexts:
     - match: \\[$`"\\]
       scope: constant.character.escape.shell
 
-  string-commons:
+  string-path-separators:
     - match: ':(?!$|\s|//)'
       scope: punctuation.separator.sequence.shell
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1995,7 +1995,7 @@ contexts:
       scope: constant.character.escape.shell
 
   string-commons:
-    - match: ':'
+    - match: ':(?!$|\s|//)'
       scope: punctuation.separator.sequence.shell
 
   string-escapes-ansi-c:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1995,7 +1995,7 @@ contexts:
       scope: constant.character.escape.shell
 
   string-path-separators:
-    - match: ':(?=\$|/(?!/))'
+    - match: ':(?=\$|(?:~|\.?\.)?/(?!/))'
       scope: punctuation.separator.sequence.shell
 
   string-escapes-ansi-c:

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1332,6 +1332,7 @@ contexts:
     # characters ‘\’, ‘$’, and ‘`’.
     - include: string-escapes
     - include: string-interpolations
+    - include: string-commons
 
   heredocs-body-no-expansion:
     - meta_scope: meta.string.heredoc.shell
@@ -1966,6 +1967,7 @@ contexts:
     - include: line-continuations
     - include: string-escapes
     - include: string-interpolations
+    - include: string-commons
 
   string-ansi-c-body:
     - match: \'
@@ -1980,6 +1982,7 @@ contexts:
       scope: punctuation.definition.string.end.shell
       pop: 1
     - include: string-prototype
+    - include: string-commons
 
   any-escapes:
     - match: \\.
@@ -1990,6 +1993,10 @@ contexts:
       scope: constant.character.escape.color.shell
     - match: \\[$`"\\]
       scope: constant.character.escape.shell
+
+  string-commons:
+    - match: ':'
+      scope: punctuation.separator.sequence.shell
 
   string-escapes-ansi-c:
     - match: \\([abfnrtv'"?$`\\]|[0-8]{1,3}|x\h{1,8}|c[a-z])

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1755,7 +1755,17 @@ export PATH="$PATH:$HOME/.local/bin"
 #                       ^^^^^^^^^^^^ string.quoted.double
 #                                  ^ punctuation.definition.string.end
 
-export SOMETHING='/etc/test:/var/test'
+export PATH="$PATH:~/.local/bin"
+# ^^^^ meta.function-call.identifier.shell support.function.export.shell
+#      ^^^^ meta.variable variable.other.readwrite
+#          ^ keyword.operator.assignment
+#           ^ string.quoted.double punctuation.definition.string.begin
+#            ^^^^^ meta.interpolation.parameter variable.other.readwrite
+#            ^ punctuation.definition.variable
+#                 ^ string.quoted.double punctuation.separator.sequence
+#                              ^ punctuation.definition.string.end
+
+export SOMETHING='/etc/test:/var/test:../foo:./foo'
 # ^^^^ meta.function-call.identifier.shell support.function.export.shell
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
 #      ^^^^^^^^^ meta.variable variable.other.readwrite
@@ -1763,7 +1773,9 @@ export SOMETHING='/etc/test:/var/test'
 #                ^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
 #                ^ punctuation.definition.string.begin
 #                          ^ punctuation.separator.sequence
-#                                    ^ punctuation.definition.string.end
+#                                    ^ punctuation.separator.sequence
+#                                           ^ punctuation.separator.sequence
+#                                                 ^ punctuation.definition.string.end
 
 export SOMETHING=/etc/test:/var/test
 # ^^^^ meta.function-call.identifier.shell support.function.export.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1740,6 +1740,31 @@ export -f foo
 #      ^^ meta.parameter.option.shell variable.parameter.option.shell
 #         ^^^ meta.variable.shell variable.function.shell
 
+export PATH="$PATH:$HOME/.local/bin"
+# ^^^^ meta.function-call.identifier.shell support.function.export.shell
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
+#      ^^^^ meta.variable variable.other.readwrite
+#          ^ keyword.operator.assignment
+#           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+#           ^ string.quoted.double punctuation.definition.string.begin
+#            ^^^^^ meta.interpolation.parameter variable.other.readwrite
+#            ^ punctuation.definition.variable
+#                 ^ string.quoted.double punctuation.separator.sequence
+#                  ^^^^^ meta.interpolation.parameter variable.other.readwrite
+#                  ^ punctuation.definition.variable
+#                       ^^^^^^^^^^^^ string.quoted.double
+#                                  ^ punctuation.definition.string.end
+
+export SOMETHING='/etc/test:/var/test'
+# ^^^^ meta.function-call.identifier.shell support.function.export.shell
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
+#      ^^^^^^^^^ meta.variable variable.other.readwrite
+#               ^ keyword.operator.assignment
+#                ^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
+#                ^ punctuation.definition.string.begin
+#                          ^ punctuation.separator.sequence
+#                                    ^ punctuation.definition.string.end
+
 ####################################################################
 # local builtin                                                    #
 ####################################################################

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1765,6 +1765,12 @@ export SOMETHING='/etc/test:/var/test'
 #                          ^ punctuation.separator.sequence
 #                                    ^ punctuation.definition.string.end
 
+msg="Count: ${count}"
+#         ^ meta.string string.quoted.double - punctuation.separator
+
+url="https://sublimetext.com/"
+#         ^ meta.string string.quoted.double - punctuation.separator
+
 ####################################################################
 # local builtin                                                    #
 ####################################################################

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -3638,6 +3638,9 @@ status="${status#"${status%%[![:space:]]*}"}"
 #                           ^ punctuation.definition.set.begin.regexp.shell
 #                            ^ keyword.operator.logical.regexp.shell
 #                             ^ punctuation.definition.set.begin.regexp.shell
+#                              ^ punctuation.definition.class.begin.regexp
+#                               ^^^^^^ constant.other.posix-class.regexp
+#                                     ^ punctuation.definition.set.end.regexp
 #                                     ^^ punctuation.definition.set.end.regexp.shell
 #                                       ^ keyword.operator.quantifier.regexp.shell
 status="${status#${status%%[![:space:]]*}}"
@@ -3953,6 +3956,8 @@ echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #     ^^ keyword.operator.comparison.shell
 #        ^^ meta.pattern.regexp.shell - variable.parameter
 
+echo '([^.[:space:]]+)   Class::method()' # colon not scoped as path separator
+#          ^^^^^^^^^^^^^^^^^^^^^ string.quoted.single - punctuation.separator.sequence
 
 ####################################################################
 # Bash Numeric Constants                                           #

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -1765,6 +1765,14 @@ export SOMETHING='/etc/test:/var/test'
 #                          ^ punctuation.separator.sequence
 #                                    ^ punctuation.definition.string.end
 
+export SOMETHING=/etc/test:/var/test
+# ^^^^ meta.function-call.identifier.shell support.function.export.shell
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
+#      ^^^^^^^^^ meta.variable variable.other.readwrite
+#               ^ keyword.operator.assignment
+#                ^^^^^^^^^^^^^^^^^^^ meta.string string.unquoted
+#                         ^ punctuation.separator.sequence
+
 msg="Count: ${count}"
 #         ^ meta.string string.quoted.double - punctuation.separator
 
@@ -5635,3 +5643,6 @@ else remotefilter="grep"
      # <- keyword.control.loop.end.shell
 fi
 # <- keyword.control.conditional.end.shell
+
+curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | POETRY_PREVIEW=1 python
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments - punctuation.separator


### PR DESCRIPTION
This makes it much easier to visualize e.g. setting the `PATH` env var in scripts because the `:` can be highlighted as a separate color to the rest of the string.