### PR TITLE
[meta] Refactor syntax test CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   run_syntax_tests:
-    name: Test on ${{ matrix.sublime-channel }} Build
+    name: Test on ${{ matrix.sublime-channel }} build
     runs-on: ubuntu-latest
     timeout-minutes: 15 # default is 6 hours!
     continue-on-error: ${{ matrix.optional }}
@@ -48,26 +48,28 @@ jobs:
           # latest dev build
           # https://www.sublimetext.com/dev
           - sublime-channel: dev
-            sublime-build: 4147
+            sublime-build: latest
             optional: false
 
     steps:
 
       # https://github.com/actions/checkout
-      - name: Git checkout
+      - name: Checkout Packages
         uses: actions/checkout@v3
+        with:
+          path: st_syntax_tests/Data/Packages
 
-      - name: Get binary for Build ${{ matrix.sublime-build }} (${{ matrix.sublime-channel }})
+      - name: Get binary for ${{ matrix.sublime-channel }} build ${{ matrix.sublime-build }}
         run: |
-          wget -O st_syntax_tests.tar.xz https://download.sublimetext.com/st_syntax_tests_build_${{ matrix.sublime-build }}_x64.tar.xz
+          if [[ "${{ matrix.sublime-build }}" == "latest" ]]; then
+            wget -O st_syntax_tests.tar.xz https://download.sublimetext.com/latest/dev/linux/x64/syntax_tests
+          else
+            wget -O st_syntax_tests.tar.xz https://download.sublimetext.com/st_syntax_tests_build_${{ matrix.sublime-build }}_x64.tar.xz
+          fi
           tar xf st_syntax_tests.tar.xz
-          mv st_syntax_tests/* ./
-          rm -R st_syntax_tests st_syntax_tests.tar.xz
-
-      - name: 'Move root dirs into "Data/Packages/" subdir'
-        run: |
-          mkdir -p Data/Packages/
-          find . -maxdepth 1 -mindepth 1 -type d -not -name 'Data' -exec mv '{}' Data/Packages/ ';'
+          rm st_syntax_tests.tar.xz
 
       - name: Run syntax tests
-        run: ./syntax_tests
+        run: |
+          cd st_syntax_tests
+          ./syntax_tests


### PR DESCRIPTION
This commit...

1. avoids moving files around by checking out syntax repository into a directory the test runner is directly extracted to afterwards.
2. uses new "latest" url to reduce maintenance effort after each dev build being released.