### PR TITLE
[HTML] Fix attribute value highlighting if name is absent

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -274,6 +274,11 @@ contexts:
 ###[ GENERIC ATTRIBUTE ]######################################################
 
   tag-generic-attribute:
+    - match: =
+      scope: punctuation.separator.key-value.html
+      push:
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
     - match: '{{attribute_name_start}}'
       push:
         - tag-generic-attribute-meta

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -930,6 +930,15 @@ class="foo"></div>
         ##                      ^^^^^^^^^ meta.string.html string.unquoted.html
         ##                                ^^ punctuation.definition.tag.end.html
 
+
+        <A{{template}} ={{value}} />
+        ## ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+        ## ^^^^^^^^^^^ entity.name.tag.other.html
+        ##             ^^^^^^^^^^ meta.attribute-with-value.html
+        ##             ^ punctuation.separator.key-value.html
+        ##              ^^^^^^^^^ meta.string.html string.unquoted.html
+        ##                        ^^ punctuation.definition.tag.end.html
+
         <!-- Note: Templating syntaxes must handle the following cases on their own! -->
 
         <{{template}} {{attr}}={{value}} />


### PR DESCRIPTION
This commit makes sure to scope attribute values correctly, even if attribute name is missing.

It helps maintaining correct syntax highlighting in incomplete code scenarios or if attribute name has been consumed by a `prototype` pattern of an inheriting syntax.

see: https://github.com/Medalink/laravel-blade/issues/196