### PR TITLE
[HTML] Exclude prototype from tag content

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -246,14 +246,15 @@ contexts:
         - tag-html-name
 
   tag-html-name:
-      - meta_content_scope: entity.name.tag.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
   tag-html-content:
-      - meta_scope: meta.tag.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
 
 ###[ ATTRIBUTES ]#############################################################
 
@@ -293,6 +294,7 @@ contexts:
     - include: immediately-pop
 
   tag-generic-attribute-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-generic-attribute-value

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -129,6 +129,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.any.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.structure.any.html
         - include: tag-end
         - include: tag-attributes
@@ -137,6 +138,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.block.any.html
         - include: tag-end
         - include: tag-attributes
@@ -145,6 +147,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.block.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
@@ -153,6 +156,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.form.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.block.form.html
         - include: tag-end
         - include: tag-attributes
@@ -161,6 +165,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.any.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
@@ -169,6 +174,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.form.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
@@ -177,6 +183,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.a.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.a.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
@@ -185,6 +192,7 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html
       push:
+        - meta_include_prototype: false
         - meta_scope: meta.tag.inline.table.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
@@ -199,14 +207,15 @@ contexts:
         - tag-other-name
 
   tag-other-name:
-      - meta_content_scope: entity.name.tag.other.html
-      - match: '{{tag_name_break}}'
-        pop: 1
+    - meta_content_scope: entity.name.tag.other.html
+    - match: '{{tag_name_break}}'
+      pop: 1
 
   tag-other-content:
-      - meta_scope: meta.tag.other.html
-      - include: tag-end-maybe-self-closing
-      - include: tag-attributes
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.other.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
 
 ###[ SCRIPT TAG ]#############################################################
 
@@ -230,10 +239,12 @@ contexts:
       set: script-close-tag-content
 
   script-close-tag-content:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.script.end.html
     - include: tag-end
 
   script-javascript:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
     - match: '>'
@@ -268,6 +279,7 @@ contexts:
         4: comment.block.html punctuation.definition.comment.end.html
 
   script-json:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
     - match: '>'
@@ -302,6 +314,7 @@ contexts:
         4: comment.block.html punctuation.definition.comment.end.html
 
   script-html:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
     - include: tag-end
@@ -324,6 +337,7 @@ contexts:
       set: script-type-attribute-assignment
 
   script-type-attribute-assignment:
+    - meta_include_prototype: false
     - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
     - match: =
       scope: punctuation.separator.key-value.html
@@ -390,10 +404,12 @@ contexts:
       set: style-close-tag-content
 
   style-close-tag-content:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.style.end.html
     - include: tag-end
 
   style-css:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
@@ -428,6 +444,7 @@ contexts:
         4: comment.block.html punctuation.definition.comment.end.html
 
   style-other:
+    - meta_include_prototype: false
     - meta_scope: meta.tag.style.begin.html
     - include: style-common
     - match: '>'
@@ -445,6 +462,7 @@ contexts:
       set: style-type-attribute-assignment
 
   style-type-attribute-assignment:
+    - meta_include_prototype: false
     - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
     - match: =
       scope: punctuation.separator.key-value.html
@@ -519,6 +537,7 @@ contexts:
     - include: immediately-pop
 
   tag-class-attribute-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-class-attribute-value
@@ -585,6 +604,7 @@ contexts:
     - include: immediately-pop
 
   tag-event-attribute-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-event-attribute-value
@@ -622,6 +642,7 @@ contexts:
     - include: immediately-pop
 
   tag-href-attributes-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-href-attribute-value
@@ -692,6 +713,7 @@ contexts:
     - include: immediately-pop
 
   tag-id-attribute-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-id-attribute-value
@@ -758,6 +780,7 @@ contexts:
     - include: immediately-pop
 
   tag-style-attribute-assignment:
+    - meta_include_prototype: false
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-style-attribute-value

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -246,10 +246,10 @@ contexts:
   script-javascript:
     - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-javascript-content
+    - include: script-common
 
   script-javascript-content:
     - meta_include_prototype: false
@@ -281,10 +281,10 @@ contexts:
   script-json:
     - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-json-content
+    - include: script-common
 
   script-json-content:
     - meta_include_prototype: false
@@ -316,15 +316,15 @@ contexts:
   script-html:
     - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - include: tag-end
+    - include: script-common
 
   script-other:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: script-close-tag
+    - include: script-common
 
   script-common:
     - include: script-type-attribute
@@ -411,10 +411,10 @@ contexts:
   style-css:
     - meta_include_prototype: false
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-css-content
+    - include: style-common
 
   style-css-content:
     - meta_include_prototype: false
@@ -446,10 +446,10 @@ contexts:
   style-other:
     - meta_include_prototype: false
     - meta_scope: meta.tag.style.begin.html
-    - include: style-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
       set: style-close-tag
+    - include: style-common
 
   style-common:
     - include: style-type-attribute

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5688,6 +5688,13 @@ function embedHtml() {
 //                                                 ^^ punctuation.section.embedded.end
 //                                                             ^^ punctuation.definition.tag.end.html
 
+<tag <? echo $attr; ?> = <? echo $value; ?> >
+//^^^ meta.tag - meta.attribute-with-value
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html
+//                                         ^^ meta.tag - meta.attribute-with-value
+//   ^^^^^^^^^^^^^^^^^ meta.embedded.php
+//                     ^ punctuation.separator.key-value.html
+//                       ^^^^^^^^^^^^^^^^^^ meta.string.html meta.embedded.php
 
 <div class="test <?= $foo ?>"></div>
 //   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html


### PR DESCRIPTION
This PR excludes `prototype` from all tag related contexts, which
are not intended to be extended in a generic manner.

If an inheriting syntax wants to add more attribute types, it should do
so by explicitly extending `tag-attributes` context.

Rational
--------

An inheriting syntax is expected to use `prototype` context to inject
patterns which customize scoping of tag attribute names and values.

Therefore `generic-attribute-name` is designed to push a separate
context on stack, which can include patterns from `prototype`.

Same is true for most attribute values, except those which embed an
external syntax.

This expectation however has not been met until this commit, because
`prototype` context was directly prepended to each tag content context.
Hence those never matched within attribute name contexts.

---

This change enables combination of Laravel Blade with AlpineJS, both using `@directives` (e.g. `@click` vs. `@if`).

![grafik](https://user-images.githubusercontent.com/16542113/211167952-103d80b1-6a64-487f-99ca-df1c700b3400.png)
