### PR TITLE
[ShellScript] Add APKBUILD to list of filenames

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -32,6 +32,7 @@ hidden_file_extensions:
   - .zprofile
   - .zshenv
   - .zshrc
+  - APKBUILD  # https://wiki.alpinelinux.org/wiki/APKBUILD_Reference
   - PKGBUILD  # https://jlk.fjfi.cvut.cz/arch/manpages/man/PKGBUILD.5
   - ebuild
   - eclass


### PR DESCRIPTION
Much like `PKGBUILD`s, `APKBUILD`s are essentially shell scripts.