### PR TITLE
[Python] Refactor syntax and update to version 2

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -841,6 +841,7 @@ contexts:
     - include: case-pattern-groups-or-tuples
     - include: case-pattern-lists
     - include: case-pattern-operators
+    - include: illegal-assignment-expressions
     - include: sequence-separators
     - include: comments
     - include: booleans
@@ -917,38 +918,52 @@ contexts:
       scope: punctuation.section.mapping.begin.python
       push: case-pattern-dictionary-body
 
-  case-pattern-dictionary-body:
-    - meta_scope: meta.mapping.python
-    - include: comments
+  case-pattern-dictionary-end:
     - match: \}
       scope: punctuation.section.mapping.end.python
       pop: 1
+
+  case-pattern-dictionary-body:
+    - meta_scope: meta.mapping.python
+    - include: case-pattern-dictionary-end
+    - include: comments
+    - include: illegal-assignment-expressions
     - match: ','
       scope: punctuation.separator.sequence.python
     - match: \*\*
       scope: keyword.operator.unpacking.mapping.python
-      push: case-pattern-dictionary-patterns
+      set: case-pattern-dictionary-unpacking
     - match: ':'
-      scope: meta.mapping.python punctuation.separator.key-value.python
-      push:
-        - case-pattern-dictionary-value
-        - allow-unpack-operators
+      scope: punctuation.separator.key-value.python
+      set: case-pattern-dictionary-expect-value
     - match: (?=\S)
-      push: case-pattern-dictionary-key
+      set: case-pattern-dictionary-key
+
+  case-pattern-dictionary-unpacking:
+    - meta_content_scope: meta.mapping.python
+    - match: (?=\s*[,:}])
+      set: case-pattern-dictionary-body
+    - include: case-pattern-expressions
 
   case-pattern-dictionary-key:
-    - clear_scopes: 1
     - meta_content_scope: meta.mapping.key.python
-    - include: case-pattern-dictionary-patterns
+    - match: (?=\s*[,:}])
+      set: case-pattern-dictionary-body
+    - include: case-pattern-expressions
+
+  case-pattern-dictionary-expect-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.mapping.python
+    - include: comments
+    - match: (?=\S)
+      set:
+        - case-pattern-dictionary-value
+        - allow-unpack-operators
 
   case-pattern-dictionary-value:
-    - clear_scopes: 1
     - meta_content_scope: meta.mapping.value.python
-    - include: case-pattern-dictionary-patterns
-
-  case-pattern-dictionary-patterns:
-    - match: (?=[,:}])
-      pop: 1
+    - match: (?=\s*[,}])
+      set: case-pattern-dictionary-body
     - include: case-pattern-expressions
 
   case-pattern-groups-or-tuples:
@@ -1622,16 +1637,16 @@ contexts:
     - include: comments
     - include: illegal-assignment-expressions
     - include: illegal-commas
+    - match: \*\*
+      scope: meta.mapping.python keyword.operator.unpacking.mapping.python
+      set: inside-dictionary-unpacking
     - match: ':'
       scope: meta.mapping.python punctuation.separator.key-value.python
       set: expect-dictionary-value
-    - match: \*\*
-      scope: meta.mapping.python keyword.operator.unpacking.mapping.python
-      set: inside-dictionary-unpacking-expression
     - match: (?=\S)
       set: inside-directory-key
 
-  inside-dictionary-unpacking-expression:
+  inside-dictionary-unpacking:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: dictionary-separator

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1761,17 +1761,15 @@ contexts:
       scope: invalid.illegal.assignment.python
     - match: <>
       scope: invalid.deprecated.operator.python
-    - match: <\=|>\=|\=\=|<|>|\!\=
-      scope: keyword.operator.comparison.python
-    - match: \+|\-|\*|\*\*|/|//|%|<<|>>|&|\||\^|~
+    - match: <<|>>|\*\*|//|[-%&*+/@^|~]
       scope: keyword.operator.arithmetic.python
+    - match: <=|>=|==|\!=|<|>
+      scope: keyword.operator.comparison.python
     - match: =(?!=)
       scope: invalid.illegal.assignment.python
     - match: \b(?:and|in|is|not|or)\b
       comment: keyword operators that evaluate to True or False
       scope: keyword.operator.logical.python
-    - match: '@'
-      scope: keyword.operator.matrix.python
     - include: sequence-separators
 
   allow-unpack-operators:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -473,12 +473,12 @@ contexts:
     - match: '{{identifier}}'
       scope: meta.import-path.python meta.import-name.python
     - match: \s*(\.) *(?={{identifier}}|$)
+      scope: meta.import-path.python
       captures:
-        0: meta.import-path.python
         1: punctuation.accessor.dot.python
     - match: \s*(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
+      scope: meta.import-path.python
       captures:
-        0: meta.import-path.python
         1: invalid.illegal.name.python
     - include: line-continuation-or-pop
     - include: else-pop

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1320,112 +1320,6 @@ contexts:
         - include: immediately-pop
     - include: immediately-pop
 
-  constants:
-    - include: booleans
-    - include: nones
-    - match: \b(?:Ellipsis|NotImplemented|__debug__)\b
-      scope: constant.language.python
-      push: illegal-assignment
-    - match: \.{3}(?!\w)
-      scope: constant.language.python
-
-  booleans:
-    - match: \b(?:True|False)\b
-      scope: constant.language.boolean.python
-      push: illegal-assignment
-
-  nones:
-    - match: \bNone\b
-      scope: constant.language.null.python
-      push: illegal-assignment
-
-  illegal-assignment:
-    - match: \:?=
-      scope: invalid.illegal.not-allowed-here.python
-      pop: true
-    - include: line-continuation-or-pop
-    - include: else-pop
-
-  numbers:
-    # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
-    # hexadecimal
-    - match: \b(0[xX])(\h*)([lL]) # py2
-      scope: meta.number.integer.hexadecimal.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-        3: constant.numeric.suffix.python
-    - match: \b(0[xX])((?:_?\h)+)
-      scope: meta.number.integer.hexadecimal.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-    # octal
-    - match: \b(0[oO]?)((?=[oO]|[0-7])[0-7]*)([lL]) # py2
-      scope: meta.number.integer.octal.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-        3: constant.numeric.suffix.python
-    - match: \b(0)([0-7]+) # py2
-      scope: meta.number.integer.octal.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-    - match: \b(0[oO])((?:_?[0-7])+)
-      scope: meta.number.integer.octal.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-    # binary
-    - match: \b(0[bB])([01]*)([lL]) # py2
-      scope: meta.number.integer.binary.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-        3: constant.numeric.suffix.python
-    - match: \b(0[bB])((?:_?[01])*)
-      scope: meta.number.integer.binary.python
-      captures:
-        1: constant.numeric.base.python
-        2: constant.numeric.value.python
-    # complex
-    - match: |-
-        (?x)
-        (
-          # 1.j, 1.1j, 1.1e1j, 1.1e-1j, 1.e1j, 1.e-1 | 1e1j, 1e-1j
-          \b{{digits}} (\.)? {{digits}}? {{exponent}}?
-          # .1j, .1e1j, .1e-1j
-          | (\.) {{digits}} {{exponent}}?
-        )
-        ([jJ])
-      scope: meta.number.imaginary.decimal.python
-      captures:
-        1: constant.numeric.value.python
-        2: punctuation.separator.decimal.python
-        3: punctuation.separator.decimal.python
-        4: constant.numeric.suffix.python
-    # floating point
-    - match: |-
-        (?x:
-          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          \b{{digits}} (?: (\.) {{digits}}? {{exponent}}? | {{exponent}} )
-          # .1, .1e1, .1e-1
-          | (\.) {{digits}} {{exponent}}?
-        )
-      scope: meta.number.float.decimal.python constant.numeric.value.python
-      captures:
-        1: punctuation.separator.decimal.python
-        2: punctuation.separator.decimal.python
-    # integer
-    - match: \b([1-9]\d*|0)([lL])\b # py2
-      scope: meta.number.integer.decimal.python
-      captures:
-        1: constant.numeric.value.python
-        2: constant.numeric.suffix.python
-    - match: \b([1-9][\d_]*|0)\b
-      scope: meta.number.integer.decimal.python constant.numeric.value.python
-
   yields:
     - match: \b(yield)(?:\s+(from))?\b
       captures:
@@ -1439,6 +1333,13 @@ contexts:
   illegal-assignment-expression:
     - match: :=
       scope: invalid.illegal.not-allowed-here.python
+
+  illegal-assignment:
+    - match: \:?=
+      scope: invalid.illegal.not-allowed-here.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: else-pop
 
   assignments:
     - include: illegal-assignment-expression
@@ -1993,6 +1894,107 @@ contexts:
     # https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
     - match: '{{magic_variables}}'
       scope: support.variable.magic.python
+
+###[ LITERALS ]###############################################################
+
+  constants:
+    - include: booleans
+    - include: nones
+    - match: \b(?:Ellipsis|NotImplemented|__debug__)\b
+      scope: constant.language.python
+      push: illegal-assignment
+    - match: \.{3}(?!\w)
+      scope: constant.language.python
+
+  booleans:
+    - match: \b(?:True|False)\b
+      scope: constant.language.boolean.python
+      push: illegal-assignment
+
+  nones:
+    - match: \bNone\b
+      scope: constant.language.null.python
+      push: illegal-assignment
+
+  numbers:
+    # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
+    # hexadecimal
+    - match: \b(0[xX])(\h*)([lL]) # py2
+      scope: meta.number.integer.hexadecimal.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+        3: constant.numeric.suffix.python
+    - match: \b(0[xX])((?:_?\h)+)
+      scope: meta.number.integer.hexadecimal.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+    # octal
+    - match: \b(0[oO]?)((?=[oO]|[0-7])[0-7]*)([lL]) # py2
+      scope: meta.number.integer.octal.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+        3: constant.numeric.suffix.python
+    - match: \b(0)([0-7]+) # py2
+      scope: meta.number.integer.octal.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+    - match: \b(0[oO])((?:_?[0-7])+)
+      scope: meta.number.integer.octal.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+    # binary
+    - match: \b(0[bB])([01]*)([lL]) # py2
+      scope: meta.number.integer.binary.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+        3: constant.numeric.suffix.python
+    - match: \b(0[bB])((?:_?[01])*)
+      scope: meta.number.integer.binary.python
+      captures:
+        1: constant.numeric.base.python
+        2: constant.numeric.value.python
+    # complex
+    - match: |-
+        (?x)
+        (
+          # 1.j, 1.1j, 1.1e1j, 1.1e-1j, 1.e1j, 1.e-1 | 1e1j, 1e-1j
+          \b{{digits}} (\.)? {{digits}}? {{exponent}}?
+          # .1j, .1e1j, .1e-1j
+          | (\.) {{digits}} {{exponent}}?
+        )
+        ([jJ])
+      scope: meta.number.imaginary.decimal.python
+      captures:
+        1: constant.numeric.value.python
+        2: punctuation.separator.decimal.python
+        3: punctuation.separator.decimal.python
+        4: constant.numeric.suffix.python
+    # floating point
+    - match: |-
+        (?x:
+          # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
+          \b{{digits}} (?: (\.) {{digits}}? {{exponent}}? | {{exponent}} )
+          # .1, .1e1, .1e-1
+          | (\.) {{digits}} {{exponent}}?
+        )
+      scope: meta.number.float.decimal.python constant.numeric.value.python
+      captures:
+        1: punctuation.separator.decimal.python
+        2: punctuation.separator.decimal.python
+    # integer
+    - match: \b([1-9]\d*|0)([lL])\b # py2
+      scope: meta.number.integer.decimal.python
+      captures:
+        1: constant.numeric.value.python
+        2: constant.numeric.suffix.python
+    - match: \b([1-9][\d_]*|0)\b
+      scope: meta.number.integer.decimal.python constant.numeric.value.python
 
 ###[ DOCSTRINGS ]#############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1268,7 +1268,6 @@ contexts:
     - include: numbers
     - include: keywords
     - include: operators
-    - include: inline-if
     - include: strings
     - include: function-calls
     - include: items
@@ -1325,9 +1324,48 @@ contexts:
       push: inside-line-continuation
     - include: immediately-pop
 
+###[ FOR EXPRESSIONS ]########################################################
+
+  for-expressions:
+    - match: \b(?:(async)\s+)?(for)\b
+      captures:
+        1: storage.modifier.async.python
+        2: keyword.control.loop.for.generator.python
+      push: for-expression-target-list
+
+  for-expression-target-list:
+    - meta_scope: meta.expression.generator.python
+    - match: \bin\b
+      scope: keyword.control.loop.for.in.python
+      pop: true
+    - match: (?=[)\]}])
+      pop: true
+    - include: comments
+    - include: illegal-name
+    - include: target-lists
+
+  target-lists:
+    - match: \(
+      scope: punctuation.section.tuple.begin.python
+      push: inside-target-list
+    - include: sequence-separators
+    - include: name
+
+  inside-target-list:
+    - meta_scope: meta.sequence.tuple.python
+    - match: \)
+      scope: punctuation.section.tuple.end.python
+      pop: true
+    - include: comments
+    - include: target-lists
+
 ###[ FLOW EXPRESSIONS ]#######################################################
 
   keywords:
+    - match: \bif\b
+      scope: keyword.control.conditional.if.python
+    - match: \belse\b
+      scope: keyword.control.conditional.else.python
     - match: \bawait\b
       scope: keyword.control.flow.await.python
     - match: \b(yield)(?:\s+(from))?\b
@@ -1381,7 +1419,7 @@ contexts:
   arguments:
     - include: argument-separators
     - include: keyword-arguments
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   argument-separators:
@@ -1521,7 +1559,7 @@ contexts:
     - match: \)
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   maybe-tuple:
@@ -1567,7 +1605,7 @@ contexts:
       scope: punctuation.section.sequence.end.python
       set: after-expression
     - include: sequence-separators
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   empty-lists:
@@ -1663,7 +1701,7 @@ contexts:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: illegal-commas
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   maybe-set:
@@ -1689,7 +1727,7 @@ contexts:
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
       push: inside-set-unpacking-expression
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
     - include: illegal-colons
 
@@ -3121,7 +3159,7 @@ contexts:
       pop: 1
     - match: \\
       scope: invalid.illegal.backslash-in-fstring.python
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   f-string-replacement-modifier:
@@ -3162,7 +3200,7 @@ contexts:
       pop: 1
     - match: \\
       scope: invalid.illegal.backslash-in-fstring.python
-    - include: inline-for
+    - include: for-expressions
     - include: expression-in-a-group
 
   f-string-replacement-regexp-modifier:
@@ -3188,48 +3226,6 @@ contexts:
     - match: \}
       scope: punctuation.section.interpolation.end.python
       pop: 2
-
-###[ INLINE EXPRESSIONS ]#####################################################
-
-  inline-for:
-    - match: \b(?:(async)\s+)?(for)\b
-      captures:
-        1: storage.modifier.async.python
-        2: keyword.control.loop.for.generator.python
-      push: inside-inline-for
-
-  inside-inline-for:
-    - meta_scope: meta.expression.generator.python
-    - match: \bin\b
-      scope: keyword.control.loop.for.in.python
-      pop: true
-    - match: (?=[)\]}])
-      pop: true
-    - include: comments
-    - include: illegal-name
-    - include: target-lists
-
-  inline-if:
-    - match: \bif\b
-      scope: keyword.control.conditional.if.python
-    - match: \belse\b
-      scope: keyword.control.conditional.else.python
-
-  target-lists:
-    - match: \(
-      scope: punctuation.section.tuple.begin.python
-      push: inside-target-list
-    - match: ','
-      scope: punctuation.separator.sequence.python
-    - include: name
-
-  inside-target-list:
-    - meta_scope: meta.sequence.tuple.python
-    - match: \)
-      scope: punctuation.section.tuple.end.python
-      pop: true
-    - include: comments
-    - include: target-lists
 
 ###[ PROTOTYPES ]#############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -176,7 +176,7 @@ contexts:
     - include: docstrings
     - include: line-statements
     - include: block-statements
-    - include: classes
+    - include: class-definitions
     - include: functions
     - include: modifiers
     - include: assignments
@@ -437,6 +437,69 @@ contexts:
     - match: \.+
       scope: meta.import-path.python keyword.control.import.relative.python
     - include: else-pop
+
+###[ CLASS DEFINITIONS ]######################################################
+
+  class-definitions:
+    - match: ^\s*(class)\b
+      captures:
+        1: keyword.declaration.class.python
+      push: class-definition-name
+
+  class-definition-name:
+    - meta_scope: meta.class.python
+    - match: (?=\()
+      set: class-definition-base-list
+    - include: illegal-names
+    - match: '{{identifier}}'
+      scope: entity.name.class.python
+    - include: class-definition-end
+
+  class-definition-base-list:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.inheritance.begin.python
+      set: inside-class-definition-base-list
+
+  inside-class-definition-base-list:
+    - meta_scope: meta.class.inheritance.python
+    - match: \)
+      scope: punctuation.section.inheritance.end.python
+      set: class-definition-end
+    - match: ':'
+      scope: invalid.illegal.no-closing-parens.python
+      pop: true
+    - match: ','
+      scope: punctuation.separator.inheritance.python
+    - include: illegal-name
+    - include: constants
+    - match: (?:({{identifier}}) *)(=)
+      captures:
+        1: variable.parameter.class-inheritance.python
+        2: keyword.operator.assignment.python
+    - match: (?={{identifier}} *\.)
+      push: qualified-base-class-name
+    - match: '{{identifier}}'
+      scope: entity.other.inherited-class.python
+    - include: expression-in-a-group
+
+  qualified-base-class-name:
+    - meta_scope: meta.path.python
+    - match: '({{identifier}}) *(\.) *'
+      captures:
+        1: variable.namespace.python
+        2: punctuation.accessor.dot.python
+    - match: '{{identifier}}'
+      scope: entity.other.inherited-class.python
+      pop: true
+    - include: immediately-pop
+
+  class-definition-end:
+    - meta_content_scope: meta.class.python
+    - match: ':'
+      scope: meta.class.python punctuation.section.class.begin.python
+      pop: true
+    - include: line-continuation-or-pop
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -1215,59 +1278,6 @@ contexts:
     - match: ^(?!\s*[#*])
       pop: true
 
-  classes:
-    - match: '^\s*(class)\b'
-      captures:
-        1: keyword.declaration.class.python
-      push:
-        - meta_scope: meta.class.python
-        - include: line-continuation-or-pop
-        - match: ':'
-          scope: punctuation.section.class.begin.python
-          pop: true
-        - match: "(?={{identifier}})"
-          push:
-            - meta_content_scope: entity.name.class.python
-            - include: entity-name-class
-            - include: immediately-pop
-        - match: \(
-          scope: punctuation.section.inheritance.begin.python
-          set:
-            - meta_scope: meta.class.inheritance.python
-            - match: \)
-              scope: punctuation.section.inheritance.end.python
-              set:
-                - include: line-continuation-or-pop
-                - match: ':'
-                  scope: meta.class.python punctuation.section.class.begin.python
-                  pop: true
-                - include: else-pop
-            - match: ':'
-              scope: invalid.illegal.no-closing-parens.python
-              pop: true
-            - match: ','
-              scope: punctuation.separator.inheritance.python
-            - include: illegal-name
-            - include: constants
-            - match: (?:({{identifier}}) *)(=)
-              captures:
-                1: variable.parameter.class-inheritance.python
-                2: keyword.operator.assignment.python
-            - match: (?={{identifier}} *\.)
-              push:
-                - meta_scope: meta.path.python
-                - match: '({{identifier}}) *(\.) *'
-                  captures:
-                    1: variable.namespace.python
-                    2: punctuation.accessor.dot.python
-                - match: '{{identifier}}'
-                  scope: entity.other.inherited-class.python
-                  pop: true
-                - include: immediately-pop
-            - match: '{{identifier}}'
-              scope: entity.other.inherited-class.python
-            - include: expression-in-a-group
-
   functions:
     - match: '^\s*(?:(async)\s+)?(def)\b'
       captures:
@@ -1836,10 +1846,6 @@ contexts:
     - include: magic-function-names
     - include: magic-variable-names
     - include: illegal-names
-
-  entity-name-class:
-    - include: illegal-names
-    - include: generic-names
 
   entity-name-function:
     - include: magic-function-names

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -149,7 +149,7 @@ variables:
     | issubclass | iter | len | locals | map | max | min | next | oct | open
     | ord | pow | property | range | repr | reversed | round | setattr | sorted
     | staticmethod | sum | super | type | vars | zip
-      # Python 2 functions
+    # Python 2 functions
     | apply | cmp | coerce | execfile | intern | raw_input | reduce | reload
     | unichr | xrange
     # Python 3 functions
@@ -165,6 +165,73 @@ variables:
     # Python 2 types prone to conflicts
     # | buffer | file
     )\b
+
+  magic_functions: |-
+    (?x: \b__(?:
+    # unary operators
+    invert | neg | pos | abs
+    # binary operators
+    | add | and | contains | div | divmod | floordiv | lshift | mod | mul | or
+    | pow | rshift | sub | truediv | xor
+    # right-hand binary operators
+    | radd | rand | rdiv | rdivmod | rfloordiv | rlshift | rmod | rmul | ror
+    | rpow | rrshift | rsub | rtruediv | rxor
+    # in-place operator assignments
+    | iadd | iand | idiv | ifloordiv | ilshift | imod | imul | ior | ipow
+    | irshift | isub | itruediv | ixor
+    # comparisons
+    | eq | ge | gt | le | lt | ne
+    | cmp | rcmp  # py2
+    # primary coercion
+    | bool | str
+    | nonzero | unicode  # py2
+    # number coercion (converts something to a number)
+    | bytes | complex | float | index | int | round
+    | long  # py2
+    # other "coercion"
+    | format | len | length_hint | hash | repr | reversed
+    | coerce | hex | oct  # py2
+    | fspath
+    # iterator (and 'await')
+    | iter | next
+    | aiter | anext
+    | await
+    # attribute and item access
+    | delattr | delitem | delslice
+    | getattr | getattribute | getitem | getslice
+    | setattr | setitem | setslice
+    | dir | missing
+    # context manager
+    | enter | exit
+    | aenter | aexit
+    # other class magic
+    | call | del | init | new | init_subclass
+    | instancecheck | subclasscheck
+    # pickling
+    | getnewargs | getnewargs_ex | getstate | setstate | reduce | reduce_ex
+    # descriptors
+    | delete | get | set | set_name
+    # class-specific
+    | subclasses
+    # dataclasses (PEP 557)
+    | post_init
+    # for typing core support (PEP 560)
+    | class_getitem | mro_entries
+    )__\b )
+
+  magic_variables: |-
+    (?x: \b__(?:
+    # generic object
+    class | dict | doc | module | name
+    # module-specific / global
+    | all | file | package
+    # functions & methods
+    | annotations | closure | code | defaults | func | globals | kwdefaults | self | qualname
+    # classes (attributes)
+    | bases | prepare | slots | metaclass | mro
+    # Python 2
+    | members | methods
+    )__\b )
 
 contexts:
   main:
@@ -1884,59 +1951,10 @@ contexts:
       pop: true
 
   magic-function-names:
+    # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
     # https://docs.python.org/2/reference/datamodel.html
     # https://docs.python.org/3/reference/datamodel.html
-    - match: |-
-        (?x)\b__(?:
-          # unary operators
-          invert|neg|pos|abs|
-          # binary operators
-          add|and|div|divmod|floordiv|lshift|mod|mul|or|pow|rshift|sub|truediv|xor|
-          contains|
-          # right-hand binary operators
-          radd|rand|rdiv|rdivmod|rfloordiv|rlshift|rmod|rmul|ror|rpow|rrshift|rsub|rtruediv|rxor|
-          # in-place operator assignments
-          iadd|iand|idiv|ifloordiv|ilshift|imod|imul|ior|ipow|irshift|isub|itruediv|ixor|
-          # comparisons
-          eq|ge|gt|le|lt|ne|
-          cmp|rcmp| # py2
-          # primary coercion
-          bool|str|
-          nonzero|unicode| # py2
-          # number coercion (converts something to a number)
-          bytes|complex|float|index|int|round|
-          long| # py2
-          # other "coercion"
-          format|len|length_hint|hash|repr|reversed|
-          coerce|hex|oct| # py2
-          fspath|
-          # iterator (and 'await')
-          iter|next|
-          aiter|anext|
-          await|
-          # attribute and item access
-          delattr|delitem|delslice|
-          getattr|getattribute|getitem|getslice|
-          setattr|setitem|setslice|
-          dir|missing|
-          # context manager
-          enter|exit|
-          aenter|aexit|
-          # other class magic
-          call|del|init|new|init_subclass|
-          instancecheck|subclasscheck|
-          # pickling
-          getnewargs|getnewargs_ex|getstate|setstate|reduce|reduce_ex|
-          # descriptors
-          delete|get|set|set_name|
-          # class-specific
-          subclasses|
-          # dataclasses (PEP 557)
-          post_init|
-          # for typing core support (PEP 560)
-          class_getitem|mro_entries
-        )__\b
-      comment: these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
+    - match: '{{magic_functions}}'
       scope: support.function.magic.python
 
   magic-variable-names:
@@ -1944,19 +1962,7 @@ contexts:
     # https://docs.python.org/3/library/inspect.html#types-and-members
     # https://docs.python.org/3/reference/datamodel.html#object.__slots__
     # https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
-    - match: |-
-        (?x)\b__(?:
-          # generic object
-          class|dict|doc|module|name|
-          # module-specific / global
-          all|file|package|
-          # functions & methods
-          annotations|closure|code|defaults|func|globals|kwdefaults|self|qualname|
-          # classes (attributes)
-          bases|prepare|slots|metaclass|mro|
-          # Python 2
-          members|methods
-        )__\b
+    - match: '{{magic_variables}}'
       scope: support.variable.magic.python
 
 ###[ DOCSTRINGS ]#############################################################

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -615,6 +615,7 @@ contexts:
         - match: '='
           scope: keyword.operator.assignment.python
           set: function-parameter-default-value
+    - include: illegal-assignment-expressions
     - match: (?=:)
       set:
         - meta_include_prototype: false
@@ -641,14 +642,14 @@ contexts:
       set: inside-function-parameter-list
     - match: \bNone\b
       scope: constant.language.null.python
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
     - match: (?=[,)])
       set: inside-function-parameter-list
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
   function-parameter-tuples:
@@ -697,7 +698,6 @@ contexts:
 
   function-return-type:
     - meta_content_scope: meta.function.annotation.return.python
-    - include: illegal-assignment-expression
     - include: function-definition-end
     - include: expression-in-a-statement
 
@@ -708,6 +708,7 @@ contexts:
       pop: true
 
   function-definition-end:
+    - include: illegal-assignment-expressions
     - match: ':'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: true
@@ -716,7 +717,7 @@ contexts:
 ###[ ASSIGNMENT STATEMENTS ]##################################################
 
   assignment-statements:
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - match: ':'
       scope: punctuation.separator.annotation.variable.python
       push: variable-annotation
@@ -728,7 +729,7 @@ contexts:
       push: assignment-statement-value
 
   assignment-statement-value:
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - include: expression-in-a-statement
     - include: line-continuation-or-pop
 
@@ -738,7 +739,7 @@ contexts:
       pop: 1
     - match: \bNone\b
       scope: constant.language.null.python
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
 ###[ CASE STATEMENTS ]########################################################
@@ -1295,7 +1296,7 @@ contexts:
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
-    - include: assignment-expression
+    - include: assignment-expressions
 
   expression-in-a-group:  # Always include this last!
     # Differs from expression-in-a-statement in that:
@@ -1304,7 +1305,7 @@ contexts:
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
-    - include: assignment-expression
+    - include: assignment-expressions
     - match: '(\.) *(?={{identifier}})'
       captures:
         1: punctuation.accessor.dot.python
@@ -1399,7 +1400,7 @@ contexts:
       scope: variable.parameter.python
 
   keyword-argument-value:
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - match: (?=[,:)])
       pop: true
     - include: expression-in-a-group
@@ -1474,7 +1475,7 @@ contexts:
 
   lambda-body:
     - meta_scope: meta.function.inline.body.python
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     # We don't know whether we are within a grouped
     # or line-statement context at this point.
     # If we're in a group, the underlying context will take over
@@ -1611,7 +1612,7 @@ contexts:
     - meta_scope: meta.mapping.python
     - include: dictionary-end
     - include: comments
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - include: illegal-commas
     - match: ':'
       scope: punctuation.separator.key-value.python
@@ -1733,24 +1734,24 @@ contexts:
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
-    - include: illegal-assignment-expression
+    - include: illegal-assignment-expressions
     - match: ':'
       scope: punctuation.separator.slice.python
     - include: expression-in-a-group
 
 ###[ OPERATORS ]##############################################################
 
-  assignment-expression:
+  assignment-expressions:
     - match: :=
       scope: keyword.operator.assignment.inline.python
 
-  illegal-assignment-expression:
+  illegal-assignment-expressions:
     - match: :=
-      scope: invalid.illegal.not-allowed-here.python
+      scope: invalid.illegal.assignment.python
 
   illegal-assignment:
     - match: \:?=
-      scope: invalid.illegal.not-allowed-here.python
+      scope: invalid.illegal.assignment.python
       pop: true
     - include: line-continuation-or-pop
     - include: else-pop

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1266,10 +1266,8 @@ contexts:
     - include: comments
     - include: constants
     - include: numbers
-    - include: yields
+    - include: keywords
     - include: operators
-    - match: \bawait\b
-      scope: keyword.other.await.python
     - include: inline-if
     - include: strings
     - include: function-calls
@@ -1327,7 +1325,11 @@ contexts:
       push: inside-line-continuation
     - include: immediately-pop
 
-  yields:
+###[ FLOW EXPRESSIONS ]#######################################################
+
+  keywords:
+    - match: \bawait\b
+      scope: keyword.control.flow.await.python
     - match: \b(yield)(?:\s+(from))?\b
       captures:
         1: keyword.control.flow.yield.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1026,7 +1026,7 @@ contexts:
     - match: elif\b
       scope: keyword.control.conditional.elseif.python
       push: elif-statement-condition
-    - match: (else)\b(?:\s*(:))?
+    - match: (else)(?:\s*(:)|\b)
       scope: meta.statement.conditional.else.python
       captures:
         1: keyword.control.conditional.else.python
@@ -1051,12 +1051,12 @@ contexts:
 ###[ EXCEPTION STATEMENTS ]###################################################
 
   exception-statements:
-    - match: (try)\b(?:\s*(:))?
+    - match: (try)(?:\s*(:)|\b)
       scope: meta.statement.exception.try.python
       captures:
         1: keyword.control.exception.try.python
         2: punctuation.section.block.exception.try.python
-    - match: (finally)\b(?:\s*(:))?
+    - match: (finally)(?:\s*(:)|\b)
       scope: meta.statement.exception.finally.python
       captures:
         1: keyword.control.exception.finally.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2151,6 +2151,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: string-prototype
 
   triple-double-quoted-raw-b-strings:
     # Triple-quoted raw string, bytes, will use regex
@@ -2165,8 +2166,10 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - match: ''
-      embed: scope:source.regexp.python
-      escape: (?=""")
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: string-prototype
 
   triple-double-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
@@ -2180,6 +2183,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: string-prototype
     - include: f-string-replacements
 
   triple-double-quoted-raw-f-strings:
@@ -2198,6 +2202,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
+        - include: string-prototype
         - include: f-string-replacements-regexp
 
   triple-double-quoted-plain-raw-u-strings:
@@ -2212,6 +2217,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: string-prototype
     - include: escaped-unicode-chars
 
   triple-double-quoted-raw-u-strings:
@@ -2242,6 +2248,7 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-double-quoted-string-pop
+        - include: string-prototype
         - include: escaped-unicode-chars
         - include: string-placeholders
         - include: string-replacements
@@ -2254,6 +2261,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
+        - include: string-prototype
         - include: escaped-unicode-chars
 
   triple-double-quoted-b-strings:
@@ -2268,6 +2276,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-chars
     - include: string-placeholders
@@ -2285,6 +2294,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
@@ -2329,6 +2339,7 @@ contexts:
         - include: triple-double-quoted-plain-u-string-content
 
   triple-double-quoted-plain-u-string-content:
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2373,6 +2384,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: string-prototype
 
   double-quoted-raw-b-strings:
     # Single-line raw string, bytes, treated as regex
@@ -2387,8 +2399,10 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - match: ''
-      embed: scope:source.regexp.python
-      escape: (?="|\n)
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: string-prototype
 
   double-quoted-plain-raw-f-strings:
     # Single-line raw f-string
@@ -2402,6 +2416,7 @@ contexts:
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - meta_include_prototype: false
     - include: double-quoted-string-end
+    - include: string-prototype
     - include: f-string-replacements
 
   double-quoted-raw-f-strings:
@@ -2420,6 +2435,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
+        - include: string-prototype
         - include: f-string-replacements-regexp
 
   double-quoted-plain-raw-u-strings:
@@ -2434,6 +2450,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: string-prototype
 
   double-quoted-raw-u-strings:
     - match: ([uU]?r)(")
@@ -2464,6 +2481,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
+        - include: string-prototype
 
   double-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
@@ -2473,6 +2491,7 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: double-quoted-string-pop
+        - include: string-prototype
         - include: string-placeholders
         - include: string-replacements
 
@@ -2488,6 +2507,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: string-prototype
     - include: escaped-chars
     - include: string-placeholders
     - include: string-replacements
@@ -2504,6 +2524,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: string-prototype
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2547,6 +2568,7 @@ contexts:
         - include: double-quoted-u-string-content
 
   double-quoted-u-string-content:
+    - include: string-prototype
     - include: escaped-unicode-chars
     - include: escaped-chars
     - include: string-placeholders
@@ -2586,6 +2608,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: string-prototype
 
   triple-single-quoted-raw-b-strings:
     # Triple-quoted raw string, bytes, will use regex
@@ -2600,8 +2623,10 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - match: ''
-      embed: scope:source.regexp.python
-      escape: (?=''')
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: string-prototype
 
   triple-single-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
@@ -2615,6 +2640,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: string-prototype
     - include: f-string-replacements
 
   triple-single-quoted-raw-f-strings:
@@ -2633,6 +2659,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
+        - include: string-prototype
         - include: f-string-replacements-regexp
 
   triple-single-quoted-plain-raw-u-strings:
@@ -2647,6 +2674,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: string-prototype
 
   triple-single-quoted-raw-u-strings:
     # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
@@ -2676,6 +2704,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
+        - include: string-prototype
         - include: escaped-unicode-chars
 
   triple-single-quoted-sql-raw-u-string-body:
@@ -2686,6 +2715,7 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-single-quoted-string-pop
+        - include: string-prototype
         - include: escaped-unicode-chars
         - include: escaped-chars
         - include: string-placeholders
@@ -2703,6 +2733,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-chars
     - include: string-placeholders
@@ -2720,6 +2751,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
@@ -2764,6 +2796,7 @@ contexts:
         - include: triple-single-quoted-u-string-content
 
   triple-single-quoted-u-string-content:
+    - include: string-prototype
     - include: string-continuations
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2808,6 +2841,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: string-prototype
 
   single-quoted-raw-b-strings:
     # Single-line raw string, bytes, treated as regex
@@ -2825,6 +2859,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
+        - include: string-prototype
 
   single-quoted-plain-raw-u-strings:
     # Single-line capital R raw string, unicode or not, no syntax embedding
@@ -2838,6 +2873,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: string-prototype
 
   single-quoted-raw-u-strings:
     - match: ([uU]?r)(')
@@ -2868,6 +2904,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
+        - include: string-prototype
 
   single-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
@@ -2877,6 +2914,7 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: single-quoted-string-pop
+        - include: string-prototype
         - include: string-placeholders
         - include: string-replacements
 
@@ -2892,6 +2930,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: string-prototype
     - include: f-string-replacements
 
   single-quoted-raw-f-strings:
@@ -2910,6 +2949,7 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
+        - include: string-prototype
         - include: f-string-replacements-regexp
 
   single-quoted-b-strings:
@@ -2924,6 +2964,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: string-prototype
     - include: escaped-chars
     - include: string-placeholders
     - include: string-replacements
@@ -2940,6 +2981,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: string-prototype
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
     - include: escaped-chars
@@ -2983,6 +3025,7 @@ contexts:
         - include: single-quoted-u-string-content
 
   single-quoted-u-string-content:
+    - include: string-prototype
     - include: escaped-unicode-chars
     - include: escaped-chars
     - include: string-placeholders
@@ -3201,6 +3244,10 @@ contexts:
     - match: \}
       scope: punctuation.section.interpolation.end.python
       pop: 2
+
+  # for use by inheriting syntaxes to easily inject string interpolation
+  # in any kind of quoted or unquoted string
+  string-prototype: []
 
 ###[ PROTOTYPES ]#############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -277,6 +277,7 @@ contexts:
 
   # Always include these last and only one at a time!
   expression-as-a-statement:
+    - include: line-continuations
     - include: illegal-assignment-expressions
     - include: lambdas
     - include: expressions-common
@@ -296,6 +297,7 @@ contexts:
     # Differs from expression-in-a-statement in that:
     # - no assignment expressions allowed
     # - accessor and lambda matching continues into the next line
+    - include: line-continuations
     - include: illegal-assignment-expressions
     - include: lambda-in-groups
     - include: expressions-common
@@ -306,6 +308,7 @@ contexts:
     # Differs from expression-in-a-statement in that:
     # - accessor and lambda matching continues into the next line
     - include: for-expressions
+    - include: line-continuations
     - include: assignment-expressions
     - include: lambda-in-groups
     - include: expressions-common
@@ -324,7 +327,6 @@ contexts:
     - include: operators
     - include: function-calls
     - include: items
-    - include: line-continuation
     - include: illegal-stray-brackets
     - include: illegal-stray-braces
     - include: illegal-stray-parens
@@ -672,7 +674,7 @@ contexts:
       set: function-parameter-annotation
     - include: function-parameter-tuples
     - include: parameter-names
-    - include: line-continuation
+    - include: line-continuations
     - include: illegal-assignment-expressions
 
   function-parameter-expect-comma:
@@ -719,7 +721,7 @@ contexts:
     - match: '{{colon}}'
       push: function-parameter-illegal-default-value
     - include: parameter-names
-    - include: line-continuation
+    - include: line-continuations
     - include: illegal-assignment-expressions
 
   function-parameter-illegal-annotation:
@@ -767,9 +769,9 @@ contexts:
       push: assignment-statement-value
 
   assignment-statement-value:
+    - include: line-continuation-or-pop
     - include: illegal-assignment-expressions
     - include: expression-in-a-statement
-    - include: line-continuation-or-pop
 
   variable-annotation:
     - meta_scope: meta.variable.annotation.python
@@ -819,6 +821,7 @@ contexts:
     - meta_content_scope: meta.statement.conditional.case.guard.python
     - include: case-statement-end
     - include: case-statement-fail
+    - include: line-continuations
     - include: expression-in-a-statement
 
   case-statement-pattern:
@@ -848,7 +851,7 @@ contexts:
     - include: illegal-stray-brackets
     - include: illegal-stray-braces
     - include: illegal-stray-parens
-    - include: line-continuation
+    - include: line-continuations
 
   case-pattern-capture-targets:
     - match: as\b
@@ -869,7 +872,7 @@ contexts:
 
   case-pattern-class-wrapper:
     - meta_scope: meta.function-call.python meta.qualified-name.python
-    - include: line-continuation
+    - include: line-continuations
     - match: (?:({{illegal_names}})|({{builtin_types}})|({{identifier}}))\s*(?=\()
       captures:
         1: invalid.illegal.name.python
@@ -1134,7 +1137,7 @@ contexts:
     # fail if match is directly followed by `:` or end of statement
     - match: (?=$|#|;|:)
       fail: match-statements
-    - include: line-continuation
+    - include: line-continuations
     - include: allow-unpack-operators
 
   match-statement-body:
@@ -1142,6 +1145,7 @@ contexts:
     - match: (?=$|#|;)
       fail: match-statements
     - include: match-statement-end
+    - include: line-continuations
     - include: expression-in-a-statement
 
   match-statement-end:
@@ -1275,7 +1279,7 @@ contexts:
     - include: with-statement-tuple-else-fail
 
   with-statement-tuple-else-fail:
-    - include: line-continuation
+    - include: line-continuations
     - match: (?=\S|$)
       fail: with-statement-tuple
 
@@ -1515,6 +1519,7 @@ contexts:
     # at the end of the line.
     - match: (?=[,:)}\]])|$
       pop: 1
+    - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
 ###[ GENERATORS GROUPS TUBLES ]###############################################
@@ -3361,11 +3366,11 @@ contexts:
       pop: 1
 
   line-continuation-or-pop:
-    - include: line-continuation
+    - include: line-continuations
     - match: (?=\s*(?:\n|;|#))
       pop: 1
 
-  line-continuation:
+  line-continuations:
     - match: (\\)\s*$
       captures:
         1: punctuation.separator.continuation.line.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -38,8 +38,8 @@ first_line_match: |-
 variables:
   # We support unicode here because Python 3 is the future
   identifier_continue: '[[:alnum:]_]'
-  identifier: '\b[[:alpha:]_]{{identifier_continue}}*\b'
-  identifier_constant: '\b(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
+  identifier: '[[:alpha:]_]{{identifier_continue}}*\b'
+  identifier_constant: '(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
   digits: (?:\d+(?:_\d+)*)
   exponent: (?:[eE][-+]?{{digits}})
   path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
@@ -73,7 +73,7 @@ variables:
     ) \s )
 
   builtin_exceptions: |-
-    \b(?x:
+    (?x:
       ArithmeticError
     | AssertionError
     | AttributeError
@@ -145,7 +145,7 @@ variables:
     )\b
 
   builtin_functions: |-
-    \b(?x:
+    (?x:
       __import__ | all | abs | any | ascii | bin | callable | chr | classmethod
     | compile | delattr | dir | divmod | enumerate | eval | filter | format
     | getattr | globals | hasattr | hash | help | hex | id | input | isinstance
@@ -160,7 +160,7 @@ variables:
     )\b
 
   builtin_types: |-
-    \b(?x:
+    (?x:
       bool | bytearray | bytes | complex | dict | float | frozenset | int
     | list | memoryview | object | set | slice | str | tuple
     # Python 2 types
@@ -170,7 +170,7 @@ variables:
     )\b
 
   magic_functions: |-
-    (?x: \b__(?:
+    (?x: __(?:
     # unary operators
     invert | neg | pos | abs
     # binary operators
@@ -223,7 +223,7 @@ variables:
     )__\b )
 
   magic_variables: |-
-    (?x: \b__(?:
+    (?x: __(?:
     # generic object
     class | dict | doc | module | name
     # module-specific / global
@@ -424,12 +424,12 @@ contexts:
 ###[ IMPORT STATEMENTS ]######################################################
 
   import-statements:
-    - match: \bimport\b
+    - match: import\b
       scope: keyword.control.import.python
       push:
         - imports-import-body
         - expect-absolute-import
-    - match: \bfrom\b
+    - match: from\b
       scope: keyword.control.import.from.python
       push:
         - imports-from-body
@@ -449,9 +449,9 @@ contexts:
     - meta_scope: meta.statement.import.python
     - meta_content_scope: meta.import-source.python
     - include: line-continuation-or-pop
-    - match: (?=\bas\b)
+    - match: (?=as\b)
       set: imports-from-import-names
-    - match: (?=\bimport\b)
+    - match: (?=import\b)
       set: imports-from-import
     - match: '{{illegal_names}}\b'
       scope: meta.import-path.python invalid.illegal.name.python
@@ -469,7 +469,7 @@ contexts:
 
   imports-from-import:
     - meta_include_prototype: false
-    - match: import
+    - match: import\b
       scope: keyword.control.import.python
       set: imports-from-import-body
 
@@ -501,7 +501,7 @@ contexts:
     - include: import-illegal-names-inlist
 
   imports-as-inlist:
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.import.as.python
       push: imports-as-body-inlist
 
@@ -523,7 +523,7 @@ contexts:
     - include: import-illegal-names
 
   imports-as:
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.import.as.python
       push: imports-as-body
 
@@ -696,7 +696,7 @@ contexts:
     - meta_scope: meta.function.parameters.annotation.python
     - match: (?=[,)=])
       set: inside-function-parameter-list
-    - match: \bNone\b
+    - match: None\b
       scope: constant.language.null.python
     - include: expression-in-a-group
 
@@ -790,7 +790,7 @@ contexts:
     - meta_scope: meta.variable.annotation.python
     - match: (?=$|=|#|;)
       pop: 1
-    - match: \bNone\b
+    - match: None\b
       scope: constant.language.null.python
     - include: expression-in-a-group
 
@@ -798,7 +798,7 @@ contexts:
 
   case-statements:
     # https://www.python.org/dev/peps/pep-0634
-    - match: (?=\bcase\b)
+    - match: (?=case\b)
       branch_point: case-statements
       branch:
         - case-statement
@@ -838,7 +838,7 @@ contexts:
 
   case-statement-pattern:
     - meta_content_scope: meta.statement.conditional.case.patterns.python
-    - match: (?=\bif\b)
+    - match: (?=if\b)
       set: case-statement-guard
     - include: case-statement-end
     - include: case-statement-fail
@@ -865,7 +865,7 @@ contexts:
     - include: line-continuation
 
   case-pattern-capture-targets:
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.conditional.case.as.python
       push: case-pattern-capture-target
 
@@ -1015,13 +1015,13 @@ contexts:
 ###[ CONDITIONAL STATEMENTS ]#################################################
 
   conditional-statements:
-    - match: \bif\b
+    - match: if\b
       scope: keyword.control.conditional.if.python
       push: if-statement-condition
-    - match: \belif\b
+    - match: elif\b
       scope: keyword.control.conditional.elseif.python
       push: elif-statement-condition
-    - match: \b(else)\b(?:\s*(:))?
+    - match: (else)\b(?:\s*(:))?
       scope: meta.statement.conditional.else.python
       captures:
         1: keyword.control.conditional.else.python
@@ -1046,17 +1046,17 @@ contexts:
 ###[ EXCEPTION STATEMENTS ]###################################################
 
   exception-statements:
-    - match: \b(try)\b(?:\s*(:))?
+    - match: (try)\b(?:\s*(:))?
       scope: meta.statement.exception.try.python
       captures:
         1: keyword.control.exception.try.python
         2: punctuation.section.block.exception.try.python
-    - match: \b(finally)\b(?:\s*(:))?
+    - match: (finally)\b(?:\s*(:))?
       scope: meta.statement.exception.finally.python
       captures:
         1: keyword.control.exception.finally.python
         2: punctuation.section.block.exception.finally.python
-    - match: \bexcept\b
+    - match: except\b
       scope: keyword.control.exception.catch.python
       push: except-statement-exception-list
 
@@ -1065,7 +1065,7 @@ contexts:
     - match: ':(?!=)'
       scope: punctuation.section.block.exception.catch.python
       pop: true
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.exception.catch.as.python
       set: except-statement-as
     - include: line-continuation-or-pop
@@ -1082,7 +1082,7 @@ contexts:
 ###[ FOR STATEMENTS ]#########################################################
 
   for-statements:
-    - match: \b(?:(async)\s+)?(for)\b
+    - match: (?:(async)\s+)?(for)\b
       captures:
         1: storage.modifier.async.python
         2: keyword.control.loop.for.python
@@ -1093,7 +1093,7 @@ contexts:
     - match: ':(?!=)'
       scope: invalid.illegal.missing-in.python
       pop: true
-    - match: \bin\b
+    - match: in\b
       scope: keyword.control.loop.for.in.python
       set: for-statement-in
     - include: line-continuation-or-pop
@@ -1110,7 +1110,7 @@ contexts:
 ###[ MATCH STATEMENTS ]#######################################################
 
   match-statements:
-    - match: (?=\bmatch\b)
+    - match: (?=match\b)
       branch_point: match-statements
       branch:
         - match-statement
@@ -1173,10 +1173,10 @@ contexts:
 ###[ MODIFIER STATEMENTS ]####################################################
 
   modifier-statements:
-    - match: \bglobal\b
+    - match: global\b
       scope: storage.modifier.global.python
       push: modifier-statement-body
-    - match: \bnonlocal\b
+    - match: nonlocal\b
       scope: storage.modifier.nonlocal.python
       push: modifier-statement-body
 
@@ -1192,7 +1192,7 @@ contexts:
 ###[ WHILE STATEMENTS ]#######################################################
 
   while-statements:
-    - match: \bwhile\b
+    - match: while\b
       scope: keyword.control.loop.while.python
       push: while-statement-condition
 
@@ -1207,7 +1207,7 @@ contexts:
 ###[ WITH STATEMENTS ]########################################################
 
   with-statements:
-    - match: \b(?:(async)\s+)?(with)\b
+    - match: (?:(async)\s+)?(with)\b
       captures:
         1: storage.modifier.async.python
         2: keyword.control.flow.with.python
@@ -1221,7 +1221,7 @@ contexts:
     - match: ':(?!=)'
       scope: punctuation.section.block.with.python
       pop: true
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.flow.with.as.python
       push: with-statement-plain-as
     - include: line-continuation-or-pop
@@ -1248,7 +1248,7 @@ contexts:
     - match: \)
       scope: punctuation.section.sequence.end.python
       pop: 1
-    - match: \bas\b
+    - match: as\b
       scope: keyword.control.flow.with.as.python
       push: with-statement-tuple-as
     - include: expression-in-a-sequence
@@ -1275,23 +1275,23 @@ contexts:
 ###[ FLOW STATEMENTS ]########################################################
 
   flow-statements:
-    - match: \bassert\b
+    - match: assert\b
       scope: keyword.control.flow.assert.python
-    - match: \breturn\b
+    - match: return\b
       scope: keyword.control.flow.return.python
-    - match: \bbreak\b
+    - match: break\b
       scope: keyword.control.flow.break.python
-    - match: \bcontinue\b
+    - match: continue\b
       scope: keyword.control.flow.continue.python
-    - match: \bpass\b
+    - match: pass\b
       scope: keyword.control.flow.pass.python
-    - match: \braise\b
+    - match: raise\b
       scope: keyword.control.flow.raise.python
       push: raise-statement-body
 
   raise-statement-body:
     - meta_scope: meta.statement.raise.python
-    - match: \bfrom\b
+    - match: from\b
       scope: keyword.control.flow.raise.from.python
       set: raise-statement-from
     - include: line-continuation-or-pop
@@ -1305,17 +1305,17 @@ contexts:
 ###[ OTHER STATEMENTS ]#######################################################
 
   other-statements:
-    - match: \bdel\b
+    - match: del\b
       scope: keyword.other.del.python
-    - match: \bexec\b(?! *($|[,.()\]}]))
+    - match: exec\b(?! *($|[,.()\]}]))
       scope: keyword.other.exec.python
-    - match: \bprint\b(?! *([,.()\]}]))
+    - match: print\b(?! *([,.()\]}]))
       scope: keyword.other.print.python
 
 ###[ FOR EXPRESSIONS ]########################################################
 
   for-expressions:
-    - match: \b(?:(async)\s+)?(for)\b
+    - match: (?:(async)\s+)?(for)\b
       captures:
         1: storage.modifier.async.python
         2: keyword.control.loop.for.generator.python
@@ -1323,7 +1323,7 @@ contexts:
 
   for-expression-target-list:
     - meta_scope: meta.expression.generator.python
-    - match: \bin\b
+    - match: in\b
       scope: keyword.control.loop.for.in.python
       pop: true
     - match: (?=[)\]}])
@@ -1350,13 +1350,13 @@ contexts:
 ###[ FLOW EXPRESSIONS ]#######################################################
 
   keywords:
-    - match: \bif\b
+    - match: if\b
       scope: keyword.control.conditional.if.python
-    - match: \belse\b
+    - match: else\b
       scope: keyword.control.conditional.else.python
-    - match: \bawait\b
+    - match: await\b
       scope: keyword.control.flow.await.python
-    - match: \b(yield)(?:\s+(from))?\b
+    - match: (yield)(?:\s+(from))?\b
       captures:
         1: keyword.control.flow.yield.python
         2: keyword.control.flow.yield-from.python
@@ -1437,7 +1437,7 @@ contexts:
     # A lambda keyword within a group may be part of a generator expression
     # Hence pop contexts off stack if `for` keyword is matched in order to
     # not scope it invalid.
-    - match: \blambda(?=\s|:|$)
+    - match: lambda(?=\s|:|$)
       scope:
         meta.function.inline.python
         storage.type.function.inline.python
@@ -1467,7 +1467,7 @@ contexts:
       pop: true
 
   lambdas:
-    - match: \blambda(?=\s|:|$)
+    - match: lambda(?=\s|:|$)
       scope:
         meta.function.inline.python
         storage.type.function.inline.python
@@ -1557,7 +1557,7 @@ contexts:
     - match: \)
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - match: (?=\bfor\b)
+    - match: (?=for\b)
       fail: generators-groups-and-tuples
     - include: expression-in-a-sequence
 
@@ -1786,7 +1786,7 @@ contexts:
       scope: keyword.operator.comparison.python
     - match: =(?!=)
       scope: invalid.illegal.assignment.python
-    - match: \b(?:and|in|is|not|or)\b
+    - match: (?:and|in|is|not|or)\b
       comment: keyword operators that evaluate to True or False
       scope: keyword.operator.logical.python
     - include: sequence-separators
@@ -1919,16 +1919,16 @@ contexts:
       pop: true
 
   illegal-names:
-    - match: \b{{illegal_names}}\b
+    - match: '{{illegal_names}}\b'
       scope: invalid.illegal.name.python
 
   illegal-name:
-    - match: \b{{illegal_names}}\b
+    - match: '{{illegal_names}}\b'
       scope: invalid.illegal.name.python
       pop: true
 
   class-variables:
-    - match: \b(?:self|cls)\b
+    - match: (?:self|cls)\b
       scope: variable.language.python
 
   wildcard-variables:
@@ -1960,71 +1960,74 @@ contexts:
   constants:
     - include: booleans
     - include: nones
-    - match: \b(?:Ellipsis|NotImplemented|__debug__)\b
+    - match: (?:Ellipsis|NotImplemented|__debug__)\b
       scope: constant.language.python
       push: illegal-assignment
     - match: \.{3}(?!\w)
       scope: constant.language.python
 
   booleans:
-    - match: \b(?:True|False)\b
+    - match: (?:True|False)\b
       scope: constant.language.boolean.python
       push: illegal-assignment
 
   nones:
-    - match: \bNone\b
+    - match: None\b
       scope: constant.language.null.python
       push: illegal-assignment
 
   numbers:
     # https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
     # hexadecimal
-    - match: \b(0[xX])(\h*)([lL]) # py2
+    - match: (0[xX])(\h*)([lL]) # py2
       scope: meta.number.integer.hexadecimal.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
         3: constant.numeric.suffix.python
-    - match: \b(0[xX])((?:_?\h)+)
+    - match: (0[xX])((?:_?\h)+)
       scope: meta.number.integer.hexadecimal.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
     # octal
-    - match: \b(0[oO]?)((?=[oO]|[0-7])[0-7]*)([lL]) # py2
+    - match: (0[oO]?)((?=[oO]|[0-7])[0-7]*)([lL]) # py2
       scope: meta.number.integer.octal.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
         3: constant.numeric.suffix.python
-    - match: \b(0)([0-7]+) # py2
+    - match: (0)([0-7]+)(\d*) # py2
       scope: meta.number.integer.octal.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
-    - match: \b(0[oO])((?:_?[0-7])+)
+        3: invalid.illegal.digit.python
+    - match: (0[oO])((?:_?[0-7])+)(\d*)
       scope: meta.number.integer.octal.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
+        3: invalid.illegal.digit.python
     # binary
-    - match: \b(0[bB])([01]*)([lL]) # py2
+    - match: (0[bB])([01]*)([lL]) # py2
       scope: meta.number.integer.binary.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
         3: constant.numeric.suffix.python
-    - match: \b(0[bB])((?:_?[01])*)
+    - match: (0[bB])((?:_?[01])*)(\d*)
       scope: meta.number.integer.binary.python
       captures:
         1: constant.numeric.base.python
         2: constant.numeric.value.python
+        3: invalid.illegal.digit.python
     # complex
     - match: |-
         (?x)
         (
           # 1.j, 1.1j, 1.1e1j, 1.1e-1j, 1.e1j, 1.e-1 | 1e1j, 1e-1j
-          \b{{digits}} (\.)? {{digits}}? {{exponent}}?
+          {{digits}} (\.)? {{digits}}? {{exponent}}?
           # .1j, .1e1j, .1e-1j
           | (\.) {{digits}} {{exponent}}?
         )
@@ -2039,7 +2042,7 @@ contexts:
     - match: |-
         (?x:
           # 1., 1.1, 1.1e1, 1.1e-1, 1.e1, 1.e-1 | 1e1, 1e-1
-          \b{{digits}} (?: (\.) {{digits}}? {{exponent}}? | {{exponent}} )
+          {{digits}} (?: (\.) {{digits}}? {{exponent}}? | {{exponent}} )
           # .1, .1e1, .1e-1
           | (\.) {{digits}} {{exponent}}?
         )
@@ -2048,13 +2051,15 @@ contexts:
         1: punctuation.separator.decimal.python
         2: punctuation.separator.decimal.python
     # integer
-    - match: \b([1-9]\d*|0)([lL])\b # py2
+    - match: ([1-9]\d*|0)([lL])\b # py2
       scope: meta.number.integer.decimal.python
       captures:
         1: constant.numeric.value.python
         2: constant.numeric.suffix.python
-    - match: \b([1-9][\d_]*|0)\b
+    - match: (?:(0?)[1-9][\d_]*|0)
       scope: meta.number.integer.decimal.python constant.numeric.value.python
+      captures:
+        1: invalid.illegal.digits.python
 
 ###[ DOCSTRINGS ]#############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -272,6 +272,7 @@ contexts:
 
   # Always include these last and only one at a time!
   expression-as-a-statement:
+    - include: illegal-assignment-expressions
     - include: lambdas
     - include: expressions-common
     - include: qualified-name
@@ -280,20 +281,31 @@ contexts:
     # Differs from expression-as-a-statement in that:
     # - invalid-name matches will pop the current context
     # - assignment expressions
+    - include: assignment-expressions
     - include: lambdas
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
-    - include: assignment-expressions
 
   expression-in-a-group:  # Always include this last!
     # Differs from expression-in-a-statement in that:
-    # - accessor matching continues into the next line
+    # - no assignment expressions allowed
+    # - accessor and lambda matching continues into the next line
+    - include: illegal-assignment-expressions
     - include: lambda-in-groups
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
+
+  expression-in-a-sequence:  # Always include this last!
+    # Differs from expression-in-a-statement in that:
+    # - accessor and lambda matching continues into the next line
+    - include: for-expressions
     - include: assignment-expressions
+    - include: lambda-in-groups
+    - include: expressions-common
+    - include: illegal-name
+    - include: qualified-name
 
   expressions-common:
     - include: dictionaries-and-sets
@@ -686,14 +698,12 @@ contexts:
       set: inside-function-parameter-list
     - match: \bNone\b
       scope: constant.language.null.python
-    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
     - match: (?=[,)])
       set: inside-function-parameter-list
-    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
   function-parameter-tuples:
@@ -761,8 +771,7 @@ contexts:
 ###[ ASSIGNMENT STATEMENTS ]##################################################
 
   assignment-statements:
-    - include: illegal-assignment-expressions
-    - match: ':'
+    - match: ':(?!=)'
       scope: punctuation.separator.annotation.variable.python
       push: variable-annotation
     - match: '{{augmented_assignment_operators}}'
@@ -783,7 +792,6 @@ contexts:
       pop: 1
     - match: \bNone\b
       scope: constant.language.null.python
-    - include: illegal-assignment-expressions
     - include: expression-in-a-group
 
 ###[ CASE STATEMENTS ]########################################################
@@ -1243,7 +1251,7 @@ contexts:
     - match: \bas\b
       scope: keyword.control.flow.with.as.python
       push: with-statement-tuple-as
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   with-statement-tuple-as:
     - include: comments
@@ -1399,8 +1407,7 @@ contexts:
   arguments:
     - include: argument-separators
     - include: keyword-arguments
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   argument-separators:
     - match: ','
@@ -1420,8 +1427,7 @@ contexts:
       scope: variable.parameter.python
 
   keyword-argument-value:
-    - include: illegal-assignment-expressions
-    - match: (?=[,:)])
+    - match: (?=[,)]|:(?!=))
       pop: true
     - include: expression-in-a-group
 
@@ -1527,7 +1533,7 @@ contexts:
       set: after-expression
     - match: (?=,|\bfor\b)
       fail: generators-groups-and-tuples
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   maybe-generator:
     - match: \(
@@ -1539,8 +1545,7 @@ contexts:
     - match: \)
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   maybe-tuple:
     - match: \(
@@ -1554,8 +1559,7 @@ contexts:
       set: after-expression
     - match: (?=\bfor\b)
       fail: generators-groups-and-tuples
-    - include: sequence-separators
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   empty-tuples:
     - match: (\()\s*(\))
@@ -1584,9 +1588,7 @@ contexts:
     - match: \]
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - include: sequence-separators
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   empty-lists:
     - match: (\[)\s*(\])
@@ -1681,8 +1683,7 @@ contexts:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: illegal-commas
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   maybe-set:
     - match: \{
@@ -1707,8 +1708,7 @@ contexts:
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
       push: inside-set-unpacking-expression
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
     - include: illegal-colons
 
   inside-set-unpacking-expression:
@@ -1754,8 +1754,7 @@ contexts:
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
-    - include: illegal-assignment-expressions
-    - match: ':'
+    - match: ':(?!=)'
       scope: punctuation.separator.slice.python
     - include: expression-in-a-group
 
@@ -3139,8 +3138,7 @@ contexts:
       pop: 1
     - match: \\
       scope: invalid.illegal.backslash-in-fstring.python
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   f-string-replacement-modifier:
     - include: f-string-replacement-end
@@ -3180,8 +3178,7 @@ contexts:
       pop: 1
     - match: \\
       scope: invalid.illegal.backslash-in-fstring.python
-    - include: for-expressions
-    - include: expression-in-a-group
+    - include: expression-in-a-sequence
 
   f-string-replacement-regexp-modifier:
     - include: f-string-replacement-end

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2255,6 +2255,20 @@ contexts:
     - match: (?=\S)
       set: triple-double-quoted-regexp-raw-u-string-body
 
+  triple-double-quoted-regexp-raw-u-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: triple-double-quoted-regexp-raw-u-string-content
+
+  triple-double-quoted-regexp-raw-u-string-content:
+    - include: string-prototype
+    - include: escaped-unicode-chars
+
   triple-double-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
@@ -2270,20 +2284,6 @@ contexts:
     - include: escaped-unicode-chars
     - include: string-placeholders
     - include: string-replacements
-
-  triple-double-quoted-regexp-raw-u-string-body:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.python string.quoted.double.block.python
-    - include: triple-double-quoted-string-end
-    - match: ''
-      push: scope:source.regexp.python
-      with_prototype:
-        - include: triple-double-quoted-string-pop
-        - include: triple-double-quoted-regexp-raw-u-string-content
-
-  triple-double-quoted-regexp-raw-u-string-content:
-    - include: string-prototype
-    - include: escaped-unicode-chars
 
   triple-double-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1830,7 +1830,6 @@ contexts:
     - match: =
       scope: invalid.illegal.assignment.python
     - match: (?:and|in|is|not|or)\b
-      comment: keyword operators that evaluate to True or False
       scope: keyword.operator.logical.python
     - include: sequence-separators
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1662,66 +1662,74 @@ contexts:
       scope: punctuation.section.mapping.begin.python
       set: inside-dictionary
 
-  inside-dictionary:
-    - meta_scope: meta.mapping.python
+  dictionary-end:
     - match: \}
       scope: punctuation.section.mapping.end.python
       set: after-expression
-    - include: illegal-assignment-expression
-    - match: ':'
-      scope: punctuation.separator.key-value.python
-      set: inside-directory-value
-    - match: ','
-      scope: invalid.illegal.expected-colon.python
-    - match: \*\*
-      scope: keyword.operator.unpacking.mapping.python
-      push: inside-dictionary-unpacking-expression
-    - include: comments
-    - match: (?=\S)
-      push: inside-directory-key
 
-  inside-dictionary-unpacking-expression:
-    - match: (?=\})
-      pop: true
-    - match: ','
-      scope: punctuation.separator.sequence.python
-      pop: true
-    - include: expression-in-a-group
-
-  inside-directory-key:
-    - clear_scopes: 1
-    - meta_scope: meta.mapping.key.python
-    - match: \s*(?=\}|,|:)
-      pop: true
-    - include: expression-in-a-group
-
-  inside-directory-value:
-    - meta_content_scope: meta.mapping.python
-    - match: \}
-      scope: punctuation.section.mapping.end.python
-      set: after-expression
+  dictionary-separator:
     - match: (?=,)
       set:
-        # clear meta scope from this match, because 'inside-directory' has it in meta_scope
+        - meta_include_prototype: false
         - match: ','
           scope: punctuation.separator.sequence.python
           set: inside-dictionary
-    - match: (?=(?:async|for)\b)
-      push:
-        - match: (?=\})
-          pop: true
-        - match: ','
-          scope: invalid.illegal.unexpected-comma.python
-        - include: inline-for
-        - include: expression-in-a-group
+
+  inside-dictionary:
+    - meta_scope: meta.mapping.python
+    - include: dictionary-end
     - include: comments
+    - include: illegal-assignment-expression
+    - include: illegal-commas
+    - match: ':'
+      scope: punctuation.separator.key-value.python
+      set: expect-dictionary-value
+    - match: \*\*
+      scope: keyword.operator.unpacking.mapping.python
+      set: inside-dictionary-unpacking-expression
     - match: (?=\S)
-      push:
-        - clear_scopes: 1
-        - meta_content_scope: meta.mapping.value.python
-        - match: (?=\s*(\}|,|(?:async|for)\b))
-          pop: true
-        - include: expression-in-a-group
+      set: inside-directory-key
+
+  inside-dictionary-unpacking-expression:
+    - meta_content_scope: meta.mapping.python
+    - include: dictionary-end
+    - include: dictionary-separator
+    - include: expression-in-a-group
+
+  inside-directory-key:
+    - meta_scope: meta.mapping.key.python
+    - match: (?=\s*[,:}])
+      set: inside-dictionary
+    - include: expression-in-a-group
+
+  expect-dictionary-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.mapping.python
+    - include: dictionary-end
+    - include: dictionary-separator
+    - match: (?=\S)
+      set: inside-directory-value
+
+  inside-directory-value:
+    - meta_content_scope: meta.mapping.value.python
+    - match: (?=\s*[,}])
+      set: after-dictionary-value
+    - match: (?=\s*(?:async|for)\b)
+      set: inside-dictionary-generator
+    - include: expression-in-a-group
+
+  after-dictionary-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.mapping.python
+    - include: dictionary-end
+    - include: dictionary-separator
+
+  inside-dictionary-generator:
+    - meta_content_scope: meta.mapping.python
+    - include: dictionary-end
+    - include: illegal-commas
+    - include: inline-for
+    - include: expression-in-a-group
 
   maybe-set:
     - match: \{
@@ -1763,6 +1771,10 @@ contexts:
         1: punctuation.section.mapping.begin.python
         2: punctuation.section.mapping.end.python
       push: after-expression
+
+  illegal-commas:
+    - match: ','
+      scope: invalid.illegal.unexpected-comma.python
 
   illegal-stray-braces:
     - match: \}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1290,7 +1290,7 @@ contexts:
     - match: '\s*(\()'
       captures:
         1: punctuation.section.arguments.begin.python
-      push: [function-call-arguments, allow-unpack-operators]
+      push: [inside-function-call-argument-list, allow-unpack-operators]
     # item access
     - match: '\s*(\[)'
       captures:
@@ -1417,17 +1417,18 @@ contexts:
               scope: punctuation.separator.slice.python
             - include: expression-in-a-group
 
+###[ FUNCTION CALLS ]#########################################################
+
   function-calls:
-    - match: '(?=(\.\s*)?{{path}}\s*\()'
-      push: [function-call-wrapper, qualified-name-until-leaf]
+    - match: (?=(\.\s*)?{{path}}\s*\()
+      push:
+        - function-call-wrapper
+        - qualified-name-until-leaf
 
   function-call-wrapper:
     - meta_scope: meta.function-call.python
     - match: (?=\()  # need to remove meta.function-call.python from opening parens
-      set:
-        - match: \(
-          scope: punctuation.section.arguments.begin.python
-          set: [after-expression, function-call-arguments, allow-unpack-operators]
+      set: function-call-argument-list
     - match: (\.)\s*(?={{identifier}})
       captures:
         1: punctuation.accessor.dot.python
@@ -1444,16 +1445,24 @@ contexts:
         - include: generic-names
         - include: immediately-pop
 
-  function-call-arguments:
+  function-call-argument-list:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.arguments.begin.python
+      set:
+        - inside-function-call-argument-list
+        - allow-unpack-operators
+
+  inside-function-call-argument-list:
     - meta_scope: meta.function-call.arguments.python
     - match: \)
       scope: punctuation.section.arguments.end.python
-      pop: true
+      set: after-expression
     - include: arguments
 
   arguments:
-    - include: keyword-arguments
     - include: argument-separators
+    - include: keyword-arguments
     - include: inline-for
     - include: expression-in-a-group
 
@@ -1463,18 +1472,22 @@ contexts:
       push: allow-unpack-operators
 
   keyword-arguments:
-    - match: '(?={{identifier}}\s*=(?!=))'
-      push:
-        - match: '='
-          scope: keyword.operator.assignment.python
-          set:
-            - include: illegal-assignment-expression
-            - match: (?=[,):])
-              pop: true
-            - include: expression-in-a-group
-        - include: illegal-names
-        - match: '{{identifier}}'
-          scope: variable.parameter.python
+    - match: (?={{identifier}}\s*=(?!=))
+      push: keyword-argument-name
+
+  keyword-argument-name:
+    - match: =
+      scope: keyword.operator.assignment.python
+      set: keyword-argument-value
+    - include: illegal-names
+    - match: '{{identifier}}'
+      scope: variable.parameter.python
+
+  keyword-argument-value:
+    - include: illegal-assignment-expression
+    - match: (?=[,:)])
+      pop: true
+    - include: expression-in-a-group
 
 ###[ LAMBDAS ]################################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -245,7 +245,6 @@ contexts:
     - include: block-statements
     - include: class-definitions
     - include: function-definitions
-    - include: modifiers
     - include: assignments
     - match: ;
       scope: punctuation.terminator.statement.python
@@ -263,6 +262,7 @@ contexts:
   line-statements:
     - include: decorators
     - include: import-statements
+    - include: modifier-statements
     - include: flow-statements
     - include: other-statements
 
@@ -1087,6 +1087,25 @@ contexts:
         - qualified-name-until-leaf
     - include: generic-name
 
+###[ MODIFIER STATEMENTS ]####################################################
+
+  modifier-statements:
+    - match: \bglobal\b
+      scope: storage.modifier.global.python
+      push: modifier-statement-body
+    - match: \bnonlocal\b
+      scope: storage.modifier.nonlocal.python
+      push: modifier-statement-body
+
+  modifier-statement-body:
+    - meta_scope: meta.statement.modifier.python
+    - include: line-continuation-or-pop
+    - include: name
+    - match: ','
+      scope: punctuation.separator.storage-list.python
+    - match: \S+
+      scope: invalid.illegal.name.storage.python
+
 ###[ WHILE STATEMENTS ]#######################################################
 
   while-statements:
@@ -1406,19 +1425,6 @@ contexts:
         2: constant.numeric.suffix.python
     - match: \b([1-9][\d_]*|0)\b
       scope: meta.number.integer.decimal.python constant.numeric.value.python
-
-  modifiers:
-    - match: \b(?:(global)|(nonlocal))\b
-      captures:
-        1: storage.modifier.global.python
-        2: storage.modifier.nonlocal.python
-      push:
-        - include: line-continuation-or-pop
-        - match: ','
-          scope: punctuation.separator.storage-list.python
-        - include: name
-        - match: \S+
-          scope: invalid.illegal.name.storage.python
 
   yields:
     - match: \b(yield)(?:\s+(from))?\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2430,11 +2430,11 @@ contexts:
     - match: (R[fF]|[fF]R)(")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push: double-quoted-plain-raw-f-string-body
 
   double-quoted-plain-raw-f-string-body:
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - meta_content_scope: meta.string.python string.quoted.double.python
     - meta_include_prototype: false
     - include: double-quoted-string-end
     - include: double-quoted-plain-raw-f-string-content
@@ -2556,12 +2556,12 @@ contexts:
     - match: ([fF])(")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push: double-quoted-f-string-body
 
   double-quoted-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - include: double-quoted-f-string-content
 
@@ -2681,12 +2681,12 @@ contexts:
     - match: ([fF]R|R[fF])(''')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push: triple-single-quoted-plain-raw-f-string-body
 
   triple-single-quoted-plain-raw-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - include: triple-single-quoted-plain-raw-f-string-content
 
@@ -2699,12 +2699,12 @@ contexts:
     - match: ([fF]r|r[fF])(''')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push: triple-single-quoted-raw-f-string-body
 
   triple-single-quoted-raw-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - match: ''
       push: scope:source.regexp.python
@@ -2809,12 +2809,12 @@ contexts:
     - match: ([fF])(''')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
       push: triple-single-quoted-f-string-body
 
   triple-single-quoted-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - include: triple-single-quoted-f-string-content
 
@@ -3006,12 +3006,12 @@ contexts:
     - match: ([fF]R|R[fF])(')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push: single-quoted-plain-raw-f-string-body
 
   single-quoted-plain-raw-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
     - include: single-quoted-plain-raw-f-string-content
 
@@ -3024,12 +3024,12 @@ contexts:
     - match: ([fF]r|r[fF])(')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push: single-quoted-raw-f-string-body
 
   single-quoted-raw-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
     - match: ''
       push: scope:source.regexp.python
@@ -3066,12 +3066,12 @@ contexts:
     - match: ([fF])(')
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
       push: single-quoted-f-string-body
 
   single-quoted-f-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
     - include: single-quoted-f-string-content
 
@@ -3305,7 +3305,7 @@ contexts:
     # Same as f-string-replacement, but with clear_scopes: true
     - clear_scopes: true
     - meta_include_prototype: false
-    - meta_scope: source.python meta.string.interpolated.python meta.interpolation.python
+    - meta_scope: source.python meta.string.python meta.interpolation.python
     - include: immediately-pop
 
   f-string-replacement-regexp-expression:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2419,13 +2419,14 @@ contexts:
     - match: '"'
       scope: meta.string.python string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
-    - include: illegal-string-end
+    - match: \n
+      scope: meta.string.python string.quoted.double.python invalid.illegal.unclosed-string.python
+      set: after-expression
     - include: string-continuations
 
   double-quoted-string-pop:
     - match: (?="|\n)
       pop: 1
-    - include: illegal-string-end
     - include: string-continuations
 
   double-quoted-plain-raw-b-strings:
@@ -2929,13 +2930,14 @@ contexts:
     - match: "'"
       scope: meta.string.python string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
-    - include: illegal-string-end
+    - match: \n
+      scope: meta.string.python string.quoted.single.python invalid.illegal.unclosed-string.python
+      set: after-expression
     - include: string-continuations
 
   single-quoted-string-pop:
     - match: (?='|\n)
       pop: 1
-    - include: illegal-string-end
     - include: string-continuations
 
   single-quoted-plain-raw-b-strings:
@@ -3168,11 +3170,6 @@ contexts:
     - include: string-replacements
 
 ###[ STRING CONTENTS ]########################################################
-
-  illegal-string-end:
-    - match: \n
-      scope: invalid.illegal.unclosed-string.python
-      set: after-expression
 
   string-continuations:
     - match: \\$

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1756,8 +1756,7 @@ contexts:
       push: inside-set-unpacking-expression
     - include: inline-for
     - include: expression-in-a-group
-    - match: ':'
-      scope: invalid.illegal.colon-inside-set.python
+    - include: illegal-colons
 
   inside-set-unpacking-expression:
     - match: (?=[,}])
@@ -1771,6 +1770,10 @@ contexts:
         1: punctuation.section.mapping.begin.python
         2: punctuation.section.mapping.end.python
       push: after-expression
+
+  illegal-colons:
+    - match: ':'
+      scope: invalid.illegal.unexpected-colon.python
 
   illegal-commas:
     - match: ','

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1253,7 +1253,7 @@ contexts:
 
   # Always include these last and only one at a time!
   expression-as-a-statement:
-    - include: lambda
+    - include: lambdas
     - include: expressions-common
     - include: qualified-name
 
@@ -1261,7 +1261,7 @@ contexts:
     # Differs from expression-as-a-statement in that:
     # - invalid-name matches will pop the current context
     # - assignment expressions
-    - include: lambda
+    - include: lambdas
     - include: expressions-common
     - include: illegal-name
     - include: qualified-name
@@ -1476,6 +1476,8 @@ contexts:
         - match: '{{identifier}}'
           scope: variable.parameter.python
 
+###[ LAMBDAS ]################################################################
+
   lambda-in-groups:
     # A lambda keyword within a group may be part of a generator expression
     # Hence pop contexts off stack if `for` keyword is matched in order to
@@ -1485,7 +1487,9 @@ contexts:
         meta.function.inline.python
         storage.type.function.inline.python
         keyword.declaration.function.inline.python
-      push: [lambda-in-group-parameters, allow-unpack-operators]
+      push:
+        - lambda-in-group-parameters
+        - allow-unpack-operators
 
   lambda-in-group-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
@@ -1507,13 +1511,15 @@ contexts:
     - match: (?=for\b)
       pop: true
 
-  lambda:
+  lambdas:
     - match: \blambda(?=\s|:|$)
       scope:
         meta.function.inline.python
         storage.type.function.inline.python
         keyword.declaration.function.inline.python
-      push: [lambda-parameters, allow-unpack-operators]
+      push:
+        - lambda-parameters
+        - allow-unpack-operators
 
   lambda-parameters:
     - meta_content_scope: meta.function.inline.parameters.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -172,23 +172,6 @@ contexts:
     - match: ''
       push: [statements, shebang]
 
-  shebang:
-    - meta_include_prototype: false
-    - match: ^\#!
-      scope: punctuation.definition.comment.python
-      set: shebang-body
-    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Python is embedded.
-      pop: true
-
-  shebang-body:
-    - meta_include_prototype: false
-    - meta_scope: comment.line.shebang.python
-    # Note: Keep sync with first_line_match!
-    - match: \bpython(?:\d(?:\.\d+)?)?\b
-      scope: constant.language.shebang.python
-    - match: \n
-      pop: true
-
   statements:
     - include: docstrings
     - include: line-statements
@@ -215,6 +198,35 @@ contexts:
     - include: import-statements
     - include: flow-statements
     - include: other-statements
+
+###[ COMMENTS ]###############################################################
+
+  comments:
+    - match: \#
+      scope: punctuation.definition.comment.python
+      push: comment-body
+
+  comment-body:
+    - meta_scope: comment.line.number-sign.python
+    - match: \n
+      pop: true
+
+  shebang:
+    - meta_include_prototype: false
+    - match: ^\#!
+      scope: punctuation.definition.comment.python
+      set: shebang-body
+    - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Python is embedded.
+      pop: true
+
+  shebang-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.shebang.python
+    # Note: Keep sync with first_line_match!
+    - match: python(?:\d(?:\.\d+)?)?\b
+      scope: constant.language.shebang.python
+    - match: \n
+      pop: true
 
 ###[ DECORATORS ]#############################################################
 
@@ -1028,14 +1040,6 @@ contexts:
           pop: true
     - match: ''
       pop: true
-
-  comments:
-    - match: "#"
-      scope: punctuation.definition.comment.python
-      push:
-        - meta_scope: comment.line.number-sign.python
-        - match: \n
-          pop: true
 
   constants:
     - include: booleans

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1955,47 +1955,974 @@ contexts:
         )__\b
       scope: support.variable.magic.python
 
-  docstrings:
-    - match: ^\s*(?=(?i)(ur|ru|u|r)?("""|'''))
-      push:
-      - match: (?i)(u)?("""|''')
-        captures:
-          1: storage.type.string.python
-          2: punctuation.definition.comment.begin.python
-        set:
-          - meta_scope: comment.block.documentation.python
-          - include: escaped-unicode-char
-          - include: escaped-char
-          - match: '\2'
-            scope: punctuation.definition.comment.end.python
-            pop: true
-      - match: (?i)(u?ru?)("""|''')
-        captures:
-          1: storage.type.string.python
-          2: punctuation.definition.comment.begin.python
-        set:
-          - meta_scope: comment.block.documentation.python
-          - match: '\2'
-            scope: punctuation.definition.comment.end.python
-            pop: true
+###[ DOCSTRINGS ]#############################################################
 
-  escaped-char:
-    - match: '(\\x\h{2})|(\\[0-7]{1,3})|(\\[\\"''abfnrtv])'
+  docstrings:
+    - match: ^\s*(?i)(u)?("""|''')
       captures:
-        1: constant.character.escape.hex.python
-        2: constant.character.escape.octal.python
-        3: constant.character.escape.python
+        1: storage.type.string.python
+        2: punctuation.definition.comment.begin.python
+      push: inside-docstring
+    - match: ^\s*(?i)(ur|ru?)("""|''')
+      captures:
+        1: storage.type.string.python
+        2: punctuation.definition.comment.begin.python
+      push: inside-raw-docstring
+
+  inside-docstring:
+    - meta_scope: comment.block.documentation.python
+    - match: \2
+      scope: punctuation.definition.comment.end.python
+      pop: true
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+
+  inside-raw-docstring:
+    - meta_scope: comment.block.documentation.python
+    - match: \2
+      scope: punctuation.definition.comment.end.python
+      pop: true
+
+###[ STRINGS ]################################################################
+
+  strings:
+    # triple-quoted versions must be matched first
+    - include: triple-double-quoted-strings
+    - include: double-quoted-strings
+    - include: triple-single-quoted-strings
+    - include: single-quoted-strings
+
+###[ TRIPLE DOUBLE QUOTED STRINGS ]###########################################
+
+  triple-double-quoted-strings:
+    - include: triple-double-quoted-plain-raw-b-strings
+    - include: triple-double-quoted-raw-b-strings
+    - include: triple-double-quoted-plain-raw-f-strings
+    - include: triple-double-quoted-raw-f-strings
+    - include: triple-double-quoted-plain-raw-u-strings
+    - include: triple-double-quoted-raw-u-strings
+    - include: triple-double-quoted-b-strings
+    - include: triple-double-quoted-f-strings
+    - include: triple-double-quoted-u-strings
+
+  triple-double-quoted-string-end:
+    - match: '"""'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+
+  triple-double-quoted-string-pop:
+    - match: (?=""")
+      pop: true
+
+  triple-double-quoted-plain-raw-b-strings:
+    # Triple-quoted capital R raw string, bytes, no syntax embedding
+    - match: ([bB]R|R[bB])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-plain-raw-b-string
+
+  inside-triple-double-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+
+  triple-double-quoted-raw-b-strings:
+    # Triple-quoted raw string, bytes, will use regex
+    - match: ([bB]r|r[bB])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-raw-b-string
+
+  inside-triple-double-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?=""")
+
+  triple-double-quoted-plain-raw-f-strings:
+    # Triple-quoted raw f-string
+    - match: ([fF]R|R[fF])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-plain-raw-f-string
+
+  inside-triple-double-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: f-string-replacements
+
+  triple-double-quoted-raw-f-strings:
+    # Triple-quoted raw f-string, treated as regex
+    - match: ([fF]r|r[fF])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-raw-f-string
+
+  inside-triple-double-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: f-string-replacements-regexp
+
+  triple-double-quoted-plain-raw-u-strings:
+    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-plain-raw-u-string
+
+  inside-triple-double-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: escaped-unicode-chars
+
+  triple-double-quoted-raw-u-strings:
+    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
+    - match: ([uU]?r)(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-raw-u-string
+
+  inside-triple-double-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-raw-u-string-syntax
+
+  triple-double-quoted-raw-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-double-quoted-sql-raw-u-string
+    - match: (?=\S)
+      set: inside-triple-double-quoted-regexp-raw-u-string
+
+  inside-triple-double-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"""'
+      scope: string.quoted.double.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: escaped-unicode-chars
+        - include: string-placeholders
+        - include: string-replacements
+
+  inside-triple-double-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - match: '"""'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: escaped-unicode-chars
+
+  triple-double-quoted-b-strings:
+    # Triple-quoted string, bytes, no syntax embedding
+    - match: ([bB])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-b-string
+
+  inside-triple-double-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: string-continuations
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+  triple-double-quoted-f-strings:
+    # Triple-quoted f-string
+    - match: ([fF])(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-f-string
+
+  inside-triple-double-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: string-continuations
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
+
+  triple-double-quoted-u-strings:
+    # Triple-quoted string, unicode or not, will detect SQL
+    - match: ([uU]?)(""")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+      push: inside-triple-double-quoted-u-string
+
+  inside-triple-double-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: string-continuations
+    - include: triple-double-quoted-u-string-syntax
+
+  triple-double-quoted-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-double-quoted-sql-u-strings
+    - match: (?=\S)
+      set: inside-double-quoted-plain-u-block-string
+
+  inside-double-quoted-plain-u-block-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-plain-u-string-content
+
+  inside-triple-double-quoted-sql-u-strings:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"""'
+      scope: string.quoted.double.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: triple-double-quoted-plain-u-string-content
+
+  triple-double-quoted-plain-u-string-content:
+    - include: string-continuations
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+###[ DOUBLE QUOTED STRINGS ]##################################################
+
+  double-quoted-strings:
+    - include: double-quoted-plain-raw-b-strings
+    - include: double-quoted-raw-b-strings
+    - include: double-quoted-plain-raw-f-strings
+    - include: double-quoted-raw-f-strings
+    - include: double-quoted-plain-raw-u-strings
+    - include: double-quoted-raw-u-strings
+    - include: double-quoted-b-strings
+    - include: double-quoted-f-strings
+    - include: double-quoted-u-strings
+
+  double-quoted-string-end:
+    - match: '"'
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+
+  double-quoted-string-pop:
+    - match: (?="|\n)
+      pop: true
+    - include: illegal-string-end
+    - include: string-continuations
+
+  double-quoted-plain-raw-b-strings:
+    # Single-line capital R raw string, bytes, no syntax embedding
+    - match: ([bB]R|R[bB])(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-plain-raw-b-string
+
+  inside-double-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+
+  double-quoted-raw-b-strings:
+    # Single-line raw string, bytes, treated as regex
+    - match: ([bB]r|r[bB])(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-raw-b-string
+
+  inside-double-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?="|\n)
+
+  double-quoted-plain-raw-f-strings:
+    # Single-line raw f-string
+    - match: (R[fF]|[fF]R)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-plain-raw-f-string
+
+  inside-double-quoted-plain-raw-f-string:
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - meta_include_prototype: false
+    - include: double-quoted-string-end
+    - include: f-string-replacements
+
+  double-quoted-raw-f-strings:
+    # Single-line raw f-string, treated as regex
+    - match: (r[fF]|[fF]r)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-raw-f-string
+
+  inside-double-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: f-string-replacements-regexp
+
+  double-quoted-plain-raw-u-strings:
+    # Single-line capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-plain-raw-u-string
+
+  inside-double-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+
+  double-quoted-raw-u-strings:
+    - match: ([uU]?r)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-raw-u-string
+
+  inside-double-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: double-quoted-string-end
+    - include: double-quoted-raw-u-string-syntax
+
+  double-quoted-raw-u-string-syntax:
+    # Single-line raw string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-double-quoted-sql-raw-u-string
+    # Single-line raw string, unicode or not, treated as regex
+    - match: (?=\S)
+      set: inside-double-quoted-regexp-raw-u-string
+
+  inside-double-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: double-quoted-string-pop
+
+  inside-double-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"'
+      scope: string.quoted.double.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: string-placeholders
+        - include: string-replacements
+
+  double-quoted-b-strings:
+    # Single-line string, bytes
+    - match: ([bB])(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-b-string
+
+  inside-double-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+  double-quoted-f-strings:
+    # Single-line f-string
+    - match: ([fF])(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-f-string
+
+  inside-double-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
+
+  double-quoted-u-strings:
+    - match: ([uU]?)(")
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+      push: inside-double-quoted-u-string
+
+  inside-double-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: double-quoted-string-end
+    - include: double-quoted-u-string-syntax
+
+  double-quoted-u-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-double-quoted-sql-u-string
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: inside-double-quoted-plain-u-string
+
+  inside-double-quoted-plain-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
+    - include: double-quoted-u-string-content
+
+  inside-double-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: '"'
+      scope: string.quoted.double.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: double-quoted-u-string-content
+
+  double-quoted-u-string-content:
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+###[ TRIPLE SINGLE QUOTED STRINGS ]###########################################
+
+  triple-single-quoted-strings:
+    - include: triple-single-quoted-plain-raw-b-strings
+    - include: triple-single-quoted-raw-b-strings
+    - include: triple-single-quoted-plain-raw-f-strings
+    - include: triple-single-quoted-raw-f-strings
+    - include: triple-single-quoted-plain-raw-u-strings
+    - include: triple-single-quoted-raw-u-strings
+    - include: triple-single-quoted-b-strings
+    - include: triple-single-quoted-f-strings
+    - include: triple-single-quoted-u-strings
+
+  triple-single-quoted-string-end:
+    - match: "'''"
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+
+  triple-single-quoted-string-pop:
+    - match: (?=''')
+      pop: true
+
+  triple-single-quoted-plain-raw-b-strings:
+    # Triple-quoted capital R raw string, bytes, no syntax embedding
+    - match: ([bB]R|R[bB])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-plain-raw-b-string
+
+  inside-triple-single-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+
+  triple-single-quoted-raw-b-strings:
+    # Triple-quoted raw string, bytes, will use regex
+    - match: ([bB]r|r[bB])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-raw-b-string
+
+  inside-triple-single-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      embed: scope:source.regexp.python
+      escape: (?=''')
+
+  triple-single-quoted-plain-raw-f-strings:
+    # Triple-quoted raw f-string
+    - match: ([fF]R|R[fF])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-plain-raw-f-string
+
+  inside-triple-single-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: f-string-replacements
+
+  triple-single-quoted-raw-f-strings:
+    # Triple-quoted raw f-string, treated as regex
+    - match: ([fF]r|r[fF])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-raw-f-string
+
+  inside-triple-single-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: f-string-replacements-regexp
+
+  triple-single-quoted-plain-raw-u-strings:
+    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-plain-raw-u-string
+
+  inside-triple-single-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+
+  triple-single-quoted-raw-u-strings:
+    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
+    - match: ([uU]?r)(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-raw-u-string
+
+  inside-triple-single-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-raw-u-string-syntax
+
+  triple-single-quoted-raw-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-single-quoted-sql-raw-u-string
+    - match: (?=\S)
+      set: inside-triple-single-quoted-regexp-raw-u-string
+
+  inside-triple-single-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: escaped-unicode-chars
+
+  inside-triple-single-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'''"
+      scope: string.quoted.single.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: escaped-unicode-chars
+        - include: escaped-chars
+        - include: string-placeholders
+        - include: string-replacements
+
+  triple-single-quoted-b-strings:
+    # Triple-quoted string, bytes, no syntax embedding
+    - match: ([bB])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-b-string
+
+  inside-triple-single-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: string-continuations
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+  triple-single-quoted-f-strings:
+    # Triple-quoted f-string
+    - match: ([fF])(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-f-string
+
+  inside-triple-single-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: string-continuations
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
+
+  triple-single-quoted-u-strings:
+    # Triple-quoted string, unicode or not, will detect SQL
+    - match: ([uU]?)(''')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+      push: inside-triple-single-quoted-u-string
+
+  inside-triple-single-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: string-continuations
+    - include: triple-single-quoted-u-string-syntax
+
+  triple-single-quoted-u-string-syntax:
+    - match: (?={{sql_indicator}})
+      set: inside-triple-single-quoted-sql-u-string
+    - match: (?=\S)
+      set: inside-single-quoted-plain-u-block-string
+
+  inside-single-quoted-plain-u-block-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-u-string-content
+
+  inside-triple-single-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'''"
+      scope: string.quoted.single.block.python punctuation.definition.string.end.python
+      set: after-expression
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: triple-single-quoted-u-string-content
+
+  triple-single-quoted-u-string-content:
+    - include: string-continuations
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+###[ SINGLE QUOTED STRINGS ]##################################################
+
+  single-quoted-strings:
+    - include: single-quoted-plain-raw-b-strings
+    - include: single-quoted-raw-b-strings
+    - include: single-quoted-plain-raw-f-strings
+    - include: single-quoted-raw-f-strings
+    - include: single-quoted-plain-raw-u-strings
+    - include: single-quoted-raw-u-strings
+    - include: single-quoted-b-strings
+    - include: single-quoted-f-strings
+    - include: single-quoted-u-strings
+
+  single-quoted-string-end:
+    - match: "'"
+      scope: punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+
+  single-quoted-string-pop:
+    - match: (?='|\n)
+      pop: true
+    - include: illegal-string-end
+    - include: string-continuations
+
+  single-quoted-plain-raw-b-strings:
+    # Single-line capital R raw string, bytes, no syntax embedding
+    - match: ([bB]R|R[bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-plain-raw-b-string
+
+  inside-single-quoted-plain-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+
+  single-quoted-raw-b-strings:
+    # Single-line raw string, bytes, treated as regex
+    - match: ([bB]r|r[bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-raw-b-string
+
+  inside-single-quoted-raw-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+
+  single-quoted-plain-raw-u-strings:
+    # Single-line capital R raw string, unicode or not, no syntax embedding
+    - match: ([uU]?R)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-plain-raw-u-string
+
+  inside-single-quoted-plain-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+
+  single-quoted-raw-u-strings:
+    - match: ([uU]?r)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-raw-u-string
+
+  inside-single-quoted-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-raw-u-string-syntax
+
+  single-quoted-raw-u-string-syntax:
+    # Single-line raw string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-single-quoted-sql-raw-u-string
+    # Single-line raw string, unicode or not, treated as regex
+    - match: (?=\S)
+      set: inside-single-quoted-regexp-raw-u-string
+
+  inside-single-quoted-regexp-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+
+  inside-single-quoted-sql-raw-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'"
+      scope: string.quoted.single.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: string-placeholders
+        - include: string-replacements
+
+  single-quoted-plain-raw-f-strings:
+    # Single-line raw f-string
+    - match: ([fF]R|R[fF])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-plain-raw-f-string
+
+  inside-single-quoted-plain-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: f-string-replacements
+
+  single-quoted-raw-f-strings:
+    # Single-line raw f-string, treated as regex
+    - match: ([fF]r|r[fF])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-raw-f-string
+
+  inside-single-quoted-raw-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.regexp.python
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: f-string-replacements-regexp
+
+  single-quoted-b-strings:
+    # Single-line string, bytes
+    - match: ([bB])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-b-string
+
+  inside-single-quoted-b-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+  single-quoted-f-strings:
+    # Single-line f-string
+    - match: ([fF])(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-f-string
+
+  inside-single-quoted-f-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: escaped-f-string-braces
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: f-string-replacements
+
+  single-quoted-u-strings:
+    - match: ([uU]?)(')
+      captures:
+        1: storage.type.string.python
+        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+      push: inside-single-quoted-u-string
+
+  inside-single-quoted-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-u-string-syntax
+
+  single-quoted-u-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: inside-single-quoted-sql-u-string
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: inside-single-quoted-plain-u-string
+
+  inside-single-quoted-plain-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
+    - include: single-quoted-u-string-content
+
+  inside-single-quoted-sql-u-string:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - match: "'"
+      scope: string.quoted.single.python punctuation.definition.string.end.python
+      set: after-expression
+    - include: illegal-string-end
+    - include: string-continuations
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: single-quoted-u-string-content
+
+  single-quoted-u-string-content:
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+    - include: string-placeholders
+    - include: string-replacements
+
+###[ STRING CONTENTS ]########################################################
+
+  illegal-string-end:
+    - match: \n
+      scope: invalid.illegal.unclosed-string.python
+      set: after-expression
+
+  string-continuations:
+    - match: \\$
+      scope: punctuation.separator.continuation.line.python
+      push:
+        - meta_include_prototype: false
+        - match: ^
+          pop: 1
+
+  escaped-chars:
+    - match: \\x\h{2}
+      scope: constant.character.escape.hex.python
+    - match: \\[0-7]{1,3}
+      scope: constant.character.escape.octal.python
+    - match: \\[\\"'abfnrtv]
+      scope: constant.character.escape.python
     - match: \\.  # deprecated in 3.6 and will eventually be a syntax error
       scope: invalid.deprecated.character.escape.python
 
-  escaped-unicode-char:
-    - match: '(\\U\h{8})|(\\u\h{4})|(\\N\{[-a-zA-Z ]+\})'
-      captures:
-        1: constant.character.escape.unicode.16-bit-hex.python
-        2: constant.character.escape.unicode.32-bit-hex.python
-        3: constant.character.escape.unicode.name.python
+  escaped-unicode-chars:
+    - match: \\U\h{8}
+      scope: constant.character.escape.unicode.16-bit-hex.python
+    - match: \\u\h{4}
+      scope: constant.character.escape.unicode.32-bit-hex.python
+    - match: \\N\{[-a-zA-Z ]+\}
+      scope: constant.character.escape.unicode.name.python
 
-  escaped-fstring-escape:
+  escaped-f-string-braces:
     # special-case the '\{{' sequence because it has higher priority than the deprecated '\{'
     - match: (\\)(\{\{|\}\})
       scope: constant.character.escape.backslash.regexp
@@ -2003,19 +2930,7 @@ contexts:
         1: invalid.deprecated.character.escape.python
         2: constant.character.escape.python
 
-  line-continuation-inside-string:
-    - match: (\\)$\n?
-      captures:
-        1: punctuation.separator.continuation.line.python
-    - match: \n
-      scope: invalid.illegal.unclosed-string.python
-      set: after-expression
-
-  line-continuation-inside-block-string:
-    - match: \\$
-      scope: punctuation.separator.continuation.line.python
-
-  constant-placeholder:
+  string-placeholders:
     - match: |- # printf style
         (?x)
         %
@@ -2034,11 +2949,10 @@ contexts:
         2: variable.other.placeholder.python
     - match: '{{strftime_spec}}'
       scope: constant.other.placeholder.python
-    - match: '\{\{|\}\}'
-      scope: constant.character.escape.python
-    - include: formatting-syntax
 
-  formatting-syntax:
+  string-replacements:
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
     # https://docs.python.org/3.6/library/string.html#formatstrings
     # Technically allows almost every character for the key,
     # but those are rarely used if ever.
@@ -2059,70 +2973,57 @@ contexts:
         4: meta.format-spec.python constant.other.format-spec.python
         5: punctuation.definition.placeholder.end.python
     - match: (?=\{[^{}"']+\{[^"']*\})  # complex (nested) form
-      branch_point: formatting-syntax-branch
+      branch_point: string-replacement
       branch:
-        - formatting-syntax-complex
-        - formatting-syntax-fallback
+        - string-replacement
+        - string-replacement-fallback
 
-  formatting-syntax-fallback:
-    - match: \{
-      scope: meta.debug.formatting-syntax-fallback.python
-      pop: true
-
-  formatting-syntax-complex:
+  string-replacement:
     - match: \{
       scope: punctuation.definition.placeholder.begin.python
-      set:
-        - meta_scope: constant.other.placeholder.python
-        - match: \}
-          scope: punctuation.definition.placeholder.end.python
-          pop: true
-        # TODO could match numeric indices or everything else as a key
-        # and also [] indexing
-        - match: '![ars]'
-          scope: storage.modifier.conversion.python
-        - match: ':'
-          scope: punctuation.separator.format-spec.python
-          push:
-            - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
-            - match: (?=\})
-              pop: true
-            - match: (?=\{)
-              push: formatting-syntax-complex
-        - match: '[{"''\n]'
-          fail: formatting-syntax-branch
+      set: inside-string-replacement
 
-  f-string-content:
+  inside-string-replacement:
+    - meta_scope: constant.other.placeholder.python
+    - match: \}
+      scope: punctuation.definition.placeholder.end.python
+      pop: true
+    # TODO could match numeric indices or everything else as a key
+    # and also [] indexing
+    - match: '![ars]'
+      scope: storage.modifier.conversion.python
+    - match: ':'
+      scope: punctuation.separator.format-spec.python
+      push: inside-string-replacement-formatspec
+    - match: '[{"''\n]'
+      fail: string-replacement
+
+  inside-string-replacement-formatspec:
+    - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
+    - match: (?=\})
+      pop: true
+    - match: (?=\{)
+      push: string-replacement
+
+  string-replacement-fallback:
+    - match: \{
+      scope: meta.debug.string-replacement-fallback.python
+      pop: true
+
+  f-string-replacements:
     # https://www.python.org/dev/peps/pep-0498/
     # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
     - match: \{\{|\}\}
       scope: constant.character.escape.python
     - match: \{\s*\}
       scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements
-    - include: illegal-stray-braces
-
-  f-string-content-with-regex:
-    # Same as f-string-content, but will reset the entire scope stack
-    # and has an additional match.
-    - match: \\(\{\{|\}\})
-      scope: constant.character.escape.backslash.regexp
-      captures:
-        1: constant.character.escape.python
-    - match: \{\{|\}\}
-      scope: constant.character.escape.python
-    - match: \{\s*\}
-      scope: invalid.illegal.empty-expression.python
-    - include: f-string-replacements-reset
-    - include: illegal-stray-braces
-
-  f-string-replacements:
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-meta
         - f-string-replacement-modifier
         - f-string-replacement-expression
+    - include: illegal-stray-braces
 
   f-string-replacement-meta:
     - clear_scopes: 1
@@ -2146,15 +3047,26 @@ contexts:
     - match: =
       scope: storage.modifier.debug.python
 
-  f-string-replacements-reset:
+  f-string-replacements-regexp:
+    # Same as f-string-replacements, but will reset the entire scope stack
+    # and has an additional match.
+    - match: \\(\{\{|\}\})
+      scope: constant.character.escape.backslash.regexp
+      captures:
+        1: constant.character.escape.python
+    - match: \{\{|\}\}
+      scope: constant.character.escape.python
+    - match: \{\s*\}
+      scope: invalid.illegal.empty-expression.python
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
-        - f-string-replacement-reset-meta
-        - f-string-replacement-reset-modifier
-        - f-string-replacement-reset-expression
+        - f-string-replacement-regexp-meta
+        - f-string-replacement-regexp-modifier
+        - f-string-replacement-regexp-expression
+    - include: illegal-stray-braces
 
-  f-string-replacement-reset-meta:
+  f-string-replacement-regexp-meta:
     # Same as f-string-replacement, but with clear_scopes: true
     - clear_scopes: true
     - meta_include_prototype: false
@@ -2162,7 +3074,7 @@ contexts:
     - match: ''
       pop: 1
 
-  f-string-replacement-reset-expression:
+  f-string-replacement-regexp-expression:
     - meta_content_scope: source.python.embedded
     - match: (?=![^=]|:|\})
       pop: 1
@@ -2171,7 +3083,7 @@ contexts:
     - include: inline-for
     - include: expression-in-a-group
 
-  f-string-replacement-reset-modifier:
+  f-string-replacement-regexp-modifier:
     - include: f-string-replacement-end
     - include: f-string-replacement-common
 
@@ -2188,662 +3100,14 @@ contexts:
     # basically any character is valid and matching {{format_spec}} is useless.
     # - match: '{{format_spec}}'
     - include: f-string-replacement-end
-    - include: f-string-content
+    - include: f-string-replacements
 
   f-string-replacement-end:
     - match: \}
       scope: punctuation.section.interpolation.end.python
       pop: 2
 
-  string-quoted-double-block:
-    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
-    # Triple-quoted capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
-    - match: '([uU]?r)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: '"""'
-              scope: string.quoted.double.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: escaped-unicode-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.double.block.python
-            - match: '"""'
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.regexp.python
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: escaped-unicode-char
-    # Triple-quoted raw string, bytes, will use regex
-    - match: '([bB]r|r[bB])(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?=""")
-    # Triple-quoted raw f-string
-    - match: ([fF]R|R[fF])(""")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: f-string-content
-    # Triple-quoted raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(""")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=""")'
-              pop: true
-            - include: f-string-content-with-regex
-    # Triple-quoted f-string
-    - match: ([fF])(""")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: f-string-content
-    # Triple-quoted string, unicode or not, will detect SQL
-    - match: '([uU]?)(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: '"""'
-              scope: string.quoted.double.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: '(?=""")'
-                  pop: true
-                - include: line-continuation-inside-block-string
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.double.block.python
-            - match: '"""'
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - include: line-continuation-inside-block-string
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: constant-placeholder
-    # Triple-quoted string, bytes, no syntax embedding
-    - match: '([bB])(""")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.block.python
-        - match: '"""'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-char
-        - include: constant-placeholder
-
-  string-quoted-double:
-    # Single-line capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?r)(")(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: '"'
-          scope: string.quoted.double.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: constant-placeholder
-            - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, treated as regex
-    - match: '([uU]?r)(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-    # Single-line raw string, bytes, treated as regex
-    - match: '([bB]r|r[bB])(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?="|\n)
-    # Single-line raw f-string
-    - match: (R[fF]|[fF]R)(")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line raw f-string, treated as regex
-    - match: (r[fF]|[fF]r)(")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-            - include: f-string-content-with-regex
-    # Single-line f-string
-    - match: ([fF])(")
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?)(")(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: '"'
-          scope: string.quoted.double.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?="|\n)'
-              pop: true
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line string, unicode or not
-    - match: '([uU]?)(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-    # Single-line string, bytes
-    - match: '([bB])(")'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.double.python
-        - match: '"'
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-
-  string-quoted-single-block:
-    # Triple-quoted capital R raw string, unicode or not, no syntax embedding
-    - match: ([uU]?R)(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-    # Triple-quoted capital R raw string, bytes, no syntax embedding
-    - match: ([bB]R|R[bB])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-    # Triple-quoted raw string, unicode or not, will detect SQL, otherwise regex
-    - match: ([uU]?r)(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: "'''"
-              scope: string.quoted.single.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.single.block.python
-            - match: "'''"
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.regexp.python
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: escaped-unicode-char
-    # Triple-quoted raw string, bytes, will use regex
-    - match: ([bB]r|r[bB])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          embed: scope:source.regexp.python
-          escape: (?=''')
-    # Triple-quoted raw f-string
-    - match: ([fF]R|R[fF])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: f-string-content
-    # Triple-quoted raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: (?=''')
-              pop: true
-            - include: f-string-content-with-regex
-    # Triple-quoted f-string
-    - match: ([fF])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: f-string-content
-    # Triple-quoted string, unicode or not, will detect SQL
-    - match: ([uU]?)(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: '(?={{sql_indicator}})'
-          set:
-            - meta_scope: meta.string.python
-            - match: "'''"
-              scope: string.quoted.single.block.python punctuation.definition.string.end.python
-              set: after-expression
-            - match: ''
-              push: scope:source.sql
-              with_prototype:
-                - match: (?=''')
-                  pop: true
-                - include: line-continuation-inside-block-string
-                - include: escaped-unicode-char
-                - include: escaped-char
-                - include: constant-placeholder
-        - match: '(?=\S)'
-          set:
-            - meta_scope: meta.string.python string.quoted.single.block.python
-            - match: "'''"
-              scope: punctuation.definition.string.end.python
-              set: after-expression
-            - include: line-continuation-inside-block-string
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: constant-placeholder
-    # Triple-quoted string, bytes, no syntax embedding
-    - match: ([bB])(''')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.block.python
-        - match: "'''"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-block-string
-        - include: escaped-char
-        - include: constant-placeholder
-
-  string-quoted-single:
-    # Single-line capital R raw string, unicode or not, no syntax embedding
-    - match: '([uU]?R)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line capital R raw string, bytes, no syntax embedding
-    - match: '([bB]R|R[bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-    # Single-line raw string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?r)('')(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: "'"
-          scope: string.quoted.single.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line raw string, unicode or not, treated as regex
-    - match: '([uU]?r)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-    # Single-line raw string, bytes, treated as regex
-    - match: '([bB]r|r[bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: line-continuation-inside-string
-    # Single-line raw f-string
-    - match: ([fF]R|R[fF])(')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.regexp.python
-          with_prototype:
-            - match: (?='|\n)
-              pop: true
-            - include: line-continuation-inside-string
-            - include: f-string-content-with-regex
-    # Single-line f-string
-    - match: ([fF])(')
-      captures:
-        1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-fstring-escape
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: f-string-content
-    # Single-line string, unicode or not, starting with a SQL keyword
-    - match: '([uU]?)('')(?={{sql_indicator}})'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python
-        - match: "'"
-          scope: string.quoted.single.python punctuation.definition.string.end.python
-          set: after-expression
-        - include: line-continuation-inside-string
-        - match: ''
-          push: scope:source.sql
-          with_prototype:
-            - match: '(?=''|\n)'
-              pop: true
-            - include: escaped-unicode-char
-            - include: escaped-char
-            - include: line-continuation-inside-string
-            - include: constant-placeholder
-    # Single-line string, unicode or not
-    - match: '([uU]?)('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-unicode-char
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-    # Single-line string, bytes
-    - match: '([bB])('')'
-      captures:
-        1: storage.type.string.python
-        2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push:
-        - meta_content_scope: meta.string.python string.quoted.single.python
-        - match: "'"
-          scope: punctuation.definition.string.end.python
-          set: after-expression
-        - include: escaped-char
-        - include: line-continuation-inside-string
-        - include: constant-placeholder
-
-  strings:
-    # block versions must be matched first
-    - include: string-quoted-double-block
-    - include: string-quoted-double
-    - include: string-quoted-single-block
-    - include: string-quoted-single
+###[ INLINE EXPRESSIONS ]#####################################################
 
   inline-for:
     - match: \b(?:(async)\s+)?(for)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -385,12 +385,12 @@ contexts:
       captures:
         1: punctuation.accessor.dot.python
       set:
-        - meta_scope: meta.qualified-name.python
+        - meta_scope: meta.path.python
         - meta_content_scope: variable.annotation.python
         - include: dotted-name-content
     - match: ''
       set:
-        - meta_scope: meta.qualified-name.python variable.annotation.python
+        - meta_scope: variable.annotation.python
         - include: name-content
 
   decorator-function-call-wrapper:
@@ -405,12 +405,12 @@ contexts:
       captures:
         1: punctuation.accessor.dot.python
       push:
-        - meta_scope: meta.qualified-name.python
+        - meta_scope: meta.path.python
         - meta_content_scope: variable.annotation.function.python
         - include: dotted-name-content
     - match: ''
       push:
-        - meta_scope: meta.qualified-name.python variable.annotation.function.python
+        - meta_scope: meta.path.python variable.annotation.function.python
         - include: name-specials
         - include: generic-names
         - include: immediately-pop
@@ -867,20 +867,32 @@ contexts:
   case-pattern-classes:
     - match: (?=(\.\s*)?{{path}}\s*\()
       push:
+        - case-pattern-class-arguments-begin
         - case-pattern-class-wrapper
         - qualified-name-until-leaf
 
   case-pattern-class-wrapper:
-    - meta_scope: meta.function-call.python meta.qualified-name.python
-    - include: line-continuations
-    - match: (?:({{illegal_names}})|({{builtin_types}})|({{identifier}}))\s*(?=\()
+    - match: (\.)\s*
+      scope: meta.path.python
       captures:
-        1: invalid.illegal.name.python
-        2: support.type.python
-        3: storage.type.class.python
-      set: case-pattern-class-arguments-begin
-    - match: \.
-      scope: punctuation.accessor.dot.python
+        1: punctuation.accessor.dot.python
+      set: qualified-case-pattern-class-name
+    - match: ''
+      set: unqualified-case-pattern-class-name
+
+  qualified-case-pattern-class-name:
+    - meta_content_scope: meta.function-call.identifier.python meta.path.python
+    - include: builtin-types
+    - include: illegal-names
+    - include: class-names
+    - include: immediately-pop
+
+  unqualified-case-pattern-class-name:
+    - meta_scope: meta.function-call.identifier.python
+    - include: builtin-types
+    - include: illegal-names
+    - include: class-names
+    - include: immediately-pop
 
   case-pattern-class-arguments-begin:
     - meta_include_prototype: false
@@ -1177,6 +1189,7 @@ contexts:
     # start a structural match pattern statement.
     - match: (?={{path}}\s*\()
       set:
+        - function-call-argument-list
         - function-call-wrapper
         - qualified-name-until-leaf
     - include: generic-name
@@ -1377,25 +1390,31 @@ contexts:
   function-calls:
     - match: (?=(\.\s*)?{{path}}\s*\()
       push:
+        - function-call-argument-list
         - function-call-wrapper
         - qualified-name-until-leaf
 
   function-call-wrapper:
-    - meta_content_scope: meta.function-call.python
-    - include: function-call-argument-list
-    - match: (\.)\s*(?={{identifier}})
+    - match: (\.)\s*
+      scope: meta.path.python
       captures:
         1: punctuation.accessor.dot.python
-      push:
-        - meta_scope: meta.qualified-name.python
-        - meta_content_scope: variable.function.python
-        - include: dotted-name-content
-    - match: (?={{identifier}})
-      push:
-        - meta_scope: meta.qualified-name.python variable.function.python
-        - include: name-specials
-        - include: generic-names
-        - include: immediately-pop
+      set: qualified-function-call-name
+    - match: ''
+      set: unqualified-function-call-name
+
+  qualified-function-call-name:
+    - meta_content_scope: meta.function-call.identifier.python meta.path.python
+    - include: dotted-name-specials
+    - include: constant-names
+    - include: function-names
+    - include: immediately-pop
+
+  unqualified-function-call-name:
+    - meta_scope: meta.function-call.identifier.python
+    - include: name-specials
+    - include: function-names
+    - include: immediately-pop
 
   function-call-argument-list:
     - meta_include_prototype: false
@@ -1856,7 +1875,7 @@ contexts:
       scope: punctuation.accessor.dot.python
 
   qualified-name-content:
-    - meta_scope: meta.qualified-name.python
+    - meta_scope: meta.path.python
     - include: name
     - include: dotted-name
     - include: immediately-pop
@@ -1865,7 +1884,7 @@ contexts:
     # Push this together with another context to match a qualified name
     # until the last non-special identifier (if any).
     # This allows the leaf to be scoped individually.
-    - meta_scope: meta.qualified-name.python
+    - meta_scope: meta.path.python
     # If a line continuation follows, this may or may not be the last leaf (most likley not though)
     - match: (?={{identifier}}\s*(\.|\\))
       push: name-content
@@ -1920,9 +1939,17 @@ contexts:
     - match: '{{magic_variables}}'
       scope: support.variable.magic.python
 
+  class-names:
+    - match: '{{identifier}}'
+      scope: support.class.python
+
   constant-names:
     - match: '{{identifier_constant}}'
       scope: variable.other.constant.python
+
+  function-names:
+    - match: '{{identifier}}'
+      scope: variable.function.python
 
   generic-names:
     - match: '{{identifier}}'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -257,15 +257,13 @@ contexts:
         - meta_content_scope: variable.annotation.python
         - include: dotted-name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
     - match: ''
       set:
         - meta_scope: meta.qualified-name.python variable.annotation.python
         - include: name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
 
   decorator-function-call-wrapper:
     - meta_scope: meta.annotation.function.python
@@ -283,15 +281,13 @@ contexts:
         - meta_content_scope: variable.annotation.function.python
         - include: dotted-name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
     - match: ''
       push:
         - meta_scope: meta.qualified-name.python variable.annotation.function.python
         - include: name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
 
   decorator-function-call-arguments:
     - clear_scopes: 1
@@ -344,8 +340,7 @@ contexts:
       captures:
         0: meta.import-path.python
         1: invalid.illegal.name.python
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
   imports-from-import:
     - meta_include_prototype: false
@@ -389,8 +384,7 @@ contexts:
     - match: (?={{identifier}})
       set: name-content
     - include: import-illegal-names-inlist
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
   import-illegal-names-inlist:
     - match: '[^\s,)]+'
@@ -413,8 +407,7 @@ contexts:
     - match: (?={{identifier}})
       set: name-content
     - include: import-illegal-names
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
   import-illegal-names:
     - match: '[^\s,]+'
@@ -437,15 +430,13 @@ contexts:
     - include: line-continuation-or-pop
     - match: \.+
       scope: invalid.illegal.unexpected-relative-import.python
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
   maybe-relative-import:
     - include: line-continuation-or-pop
     - match: \.+
       scope: meta.import-path.python keyword.control.import.relative.python
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -526,8 +517,7 @@ contexts:
     - include: wildcard-variable
     - include: illegal-name
     - include: generic-name
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
 
   case-pattern-classes:
     - match: (?=(\.\s*)?{{path}}\s*\()
@@ -1001,8 +991,7 @@ contexts:
         - include: magic-variable-names
         - include: illegal-names
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
 
   after-expression:
     # direct function call
@@ -1036,10 +1025,8 @@ contexts:
         - include: magic-variable-names
         - include: illegal-names
         - include: generic-names
-        - match: ''
-          pop: true
-    - match: ''
-      pop: true
+        - include: immediately-pop
+    - include: immediately-pop
 
   constants:
     - include: booleans
@@ -1224,8 +1211,7 @@ contexts:
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
       pop: true
-    - match: (?=\S)
-      pop: true
+    - include: else-pop
     - match: ^(?!\s*[#*])
       pop: true
 
@@ -1243,8 +1229,7 @@ contexts:
           push:
             - meta_content_scope: entity.name.class.python
             - include: entity-name-class
-            - match: ''
-              pop: true
+            - include: immediately-pop
         - match: \(
           scope: punctuation.section.inheritance.begin.python
           set:
@@ -1256,8 +1241,7 @@ contexts:
                 - match: ':'
                   scope: meta.class.python punctuation.section.class.begin.python
                   pop: true
-                - match: (?=\S)
-                  pop: true
+                - include: else-pop
             - match: ':'
               scope: invalid.illegal.no-closing-parens.python
               pop: true
@@ -1279,8 +1263,7 @@ contexts:
                 - match: '{{identifier}}'
                   scope: entity.other.inherited-class.python
                   pop: true
-                - match: ''
-                  pop: true
+                - include: immediately-pop
             - match: '{{identifier}}'
               scope: entity.other.inherited-class.python
             - include: expression-in-a-group
@@ -1300,8 +1283,7 @@ contexts:
           push:
             - meta_content_scope: entity.name.function.python
             - include: entity-name-function
-            - match: ''
-              pop: true
+            - include: immediately-pop
         - match: '(?=\()'
           set:
             - match: \(
@@ -1447,15 +1429,13 @@ contexts:
         - meta_content_scope: variable.function.python
         - include: dotted-name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
     - match: (?={{identifier}})
       push:
         - meta_scope: meta.qualified-name.python variable.function.python
         - include: name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
 
   function-call-arguments:
     - meta_scope: meta.function-call.arguments.python
@@ -1792,8 +1772,7 @@ contexts:
     - match: '{{identifier_constant}}'
       scope: variable.other.constant.python
     - include: generic-names
-    - match: ''
-      pop: true
+    - include: immediately-pop
 
   dotted-name:
     - match: \s*(\.)\s*(?={{identifier}})
@@ -1806,8 +1785,7 @@ contexts:
     - match: '{{identifier_constant}}'
       scope: variable.other.constant.python
     - include: generic-names
-    - match: ''
-      pop: true
+    - include: immediately-pop
 
   qualified-name:
     - match: (?={{path}})
@@ -1819,8 +1797,7 @@ contexts:
     - meta_scope: meta.qualified-name.python
     - include: name
     - include: dotted-name
-    - match: ''
-      pop: true
+    - include: immediately-pop
 
   qualified-name-until-leaf:
     # Push this together with another context to match a qualified name
@@ -1832,16 +1809,14 @@ contexts:
       push:
         - include: name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
     - match: (\.)\s*(?={{identifier}}\s*(\.|\\))
       captures:
         1: punctuation.accessor.dot.python
       push:
         - include: dotted-name-specials
         - include: generic-names
-        - match: ''
-          pop: true
+        - include: immediately-pop
     - match: \.(?!\s*{{identifier}})  # don't match last dot
       scope: punctuation.accessor.dot.python
     - match: (?=\S|$)
@@ -1900,27 +1875,6 @@ contexts:
   wildcard-variable:
     - match: _(?!{{identifier_continue}})
       scope: variable.language.anonymous.python
-      pop: true
-
-  line-continuation:
-    - match: (\\)(.*)$\n?
-      captures:
-        1: punctuation.separator.continuation.line.python
-        2: invalid.illegal.unexpected-text.python
-    # make sure to resume parsing at next line
-      push:
-        # This prevents strings after a continuation from being a docstring
-        - include: strings
-        - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
-          pop: true
-
-  line-continuation-or-pop:
-    - include: line-continuation
-    - match: (?=\s*($|;|#))
-      pop: true
-
-  else-pop:
-    - match: (?=\S)
       pop: true
 
   magic-function-names:
@@ -3073,8 +3027,7 @@ contexts:
     - clear_scopes: 1
     - meta_include_prototype: false
     - meta_scope: meta.interpolation.python
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   f-string-replacement-expression:
     - meta_content_scope: source.python.embedded
@@ -3115,8 +3068,7 @@ contexts:
     - clear_scopes: true
     - meta_include_prototype: false
     - meta_scope: source.python meta.string.interpolated.python meta.interpolation.python
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   f-string-replacement-regexp-expression:
     - meta_content_scope: source.python.embedded
@@ -3192,3 +3144,33 @@ contexts:
       pop: true
     - include: comments
     - include: target-lists
+
+###[ PROTOTYPES ]#############################################################
+
+  else-pop:
+    - match: (?=\S)
+      pop: 1
+
+  immediately-pop:
+    - match: ''
+      pop: 1
+
+  line-continuation-or-pop:
+    - include: line-continuation
+    - match: (?=\s*(\n|;|#))
+      pop: true
+
+  line-continuation:
+    - match: (\\)(.*)$\n?
+      captures:
+        1: punctuation.separator.continuation.line.python
+        2: invalid.illegal.unexpected-text.python
+    # make sure to resume parsing at next line
+      push: inside-line-continuation
+
+  inside-line-continuation:
+    - meta_include_prototype: false
+    # This prevents strings after a continuation from being a docstring
+    - include: strings
+    - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
+      pop: true

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -61,6 +61,8 @@ variables:
   augmented_assignment_operators: |-
     (?x: >>= | <<= | \*\*= | //= | \+= | -= | \*= | /= | %= | @= | &= | \|= | \^= )
 
+  colon: ':(?!=)'
+
   sql_indicator: |-
     (?x: \s* (?:
     # dml statements
@@ -592,7 +594,7 @@ contexts:
     - match: \)
       scope: punctuation.section.inheritance.end.python
       set: class-definition-end
-    - match: ':'
+    - match: '{{colon}}'
       scope: invalid.illegal.no-closing-parens.python
       pop: 1
     - match: ','
@@ -622,7 +624,7 @@ contexts:
 
   class-definition-end:
     - meta_content_scope: meta.class.python
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.class.python punctuation.section.class.begin.python
       pop: 1
     - include: line-continuation-or-pop
@@ -669,13 +671,13 @@ contexts:
     - match: '='
       scope: keyword.operator.assignment.python
       set: function-parameter-default-value
-    - include: illegal-assignment-expressions
-    - match: ':'
+    - match: '{{colon}}'
       scope: punctuation.separator.annotation.parameter.python
       set: function-parameter-annotation
     - include: function-parameter-tuples
     - include: parameter-names
     - include: line-continuation
+    - include: illegal-assignment-expressions
 
   function-parameter-expect-comma:
     - meta_include_prototype: false
@@ -718,10 +720,11 @@ contexts:
     - match: '='
       push: function-parameter-illegal-annotation
     # python 2 does not support type annotations
-    - match: ':'
+    - match: '{{colon}}'
       push: function-parameter-illegal-default-value
     - include: parameter-names
     - include: line-continuation
+    - include: illegal-assignment-expressions
 
   function-parameter-illegal-annotation:
     - meta_include_prototype: false
@@ -748,16 +751,16 @@ contexts:
     - include: expression-in-a-statement
 
   function-definition-end:
-    - include: illegal-assignment-expressions
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: 1
+    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
 
 ###[ ASSIGNMENT STATEMENTS ]##################################################
 
   assignment-statements:
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.separator.annotation.variable.python
       push: variable-annotation
     - match: '{{augmented_assignment_operators}}'
@@ -806,7 +809,7 @@ contexts:
     - include: allow-unpack-operators
 
   case-statement-end:
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope:
         meta.statement.conditional.case.python
         punctuation.section.block.conditional.case.python
@@ -934,7 +937,7 @@ contexts:
     - match: \*\*
       scope: keyword.operator.unpacking.mapping.python
       set: case-pattern-dictionary-unpacking
-    - match: ':'
+    - match: '{{colon}}'
       scope: punctuation.separator.key-value.python
       set: case-pattern-dictionary-value
     - match: (?=\S)
@@ -1035,7 +1038,7 @@ contexts:
 
   if-statement-condition:
     - meta_scope: meta.statement.conditional.if.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.conditional.if.python
       pop: 1
     - include: line-continuation-or-pop
@@ -1043,7 +1046,7 @@ contexts:
 
   elif-statement-condition:
     - meta_scope: meta.statement.conditional.elseif.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.conditional.elseif.python
       pop: 1
     - include: line-continuation-or-pop
@@ -1068,20 +1071,22 @@ contexts:
 
   except-statement-exception-list:
     - meta_scope: meta.statement.exception.catch.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.exception.catch.python
       pop: 1
     - match: as\b
       scope: keyword.control.exception.catch.as.python
       set: except-statement-as
+    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
     - include: target-lists
 
   except-statement-as:
     - meta_content_scope: meta.statement.exception.catch.python
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
       pop: 1
+    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
     - include: name
 
@@ -1096,7 +1101,7 @@ contexts:
 
   for-statement-target-list:
     - meta_scope: meta.statement.loop.for.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: invalid.illegal.missing-in.python
       pop: 1
     - match: in\b
@@ -1107,7 +1112,7 @@ contexts:
 
   for-statement-in:
     - meta_content_scope: meta.statement.loop.for.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
       pop: 1
     - include: line-continuation-or-pop
@@ -1144,7 +1149,7 @@ contexts:
     - include: expression-in-a-statement
 
   match-statement-end:
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.conditional.match.python
       set: maybe-first-case-statement
 
@@ -1204,7 +1209,7 @@ contexts:
 
   while-statement-condition:
     - meta_scope: meta.statement.loop.while.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.loop.while.python
       pop: 1
     - include: line-continuation-or-pop
@@ -1224,7 +1229,7 @@ contexts:
 
   with-statement-plain:
     - meta_scope: meta.statement.with.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.section.block.with.python
       pop: 1
     - match: as\b
@@ -1268,7 +1273,7 @@ contexts:
 
   with-statement-tuple-end:
     - meta_content_scope: meta.statement.with.python
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: meta.statement.with.python punctuation.section.block.with.python
       pop: 1
     - include: with-statement-tuple-else-fail
@@ -1453,7 +1458,7 @@ contexts:
 
   lambda-in-group-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.function.inline.python punctuation.section.function.begin.python
       set:
         - meta_include_prototype: false
@@ -1483,7 +1488,7 @@ contexts:
 
   lambda-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.function.inline.python punctuation.section.function.begin.python
       set:
         - meta_include_prototype: false
@@ -1502,6 +1507,7 @@ contexts:
         - allow-unpack-operators
     - include: function-parameter-tuples
     - include: parameter-names
+    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
     - match: \S
       scope: invalid.illegal.expected-parameter.python
@@ -1643,7 +1649,7 @@ contexts:
     - match: \*\*
       scope: meta.mapping.python keyword.operator.unpacking.mapping.python
       set: dictionary-unpacking-body
-    - match: ':'
+    - match: '{{colon}}'
       scope: meta.mapping.python punctuation.separator.key-value.python
       set: dictionary-value
     - match: (?=\S)
@@ -1729,7 +1735,7 @@ contexts:
       push: after-expression
 
   illegal-colons:
-    - match: ':'
+    - match: '{{colon}}'
       scope: invalid.illegal.unexpected-colon.python
 
   illegal-commas:
@@ -1758,7 +1764,7 @@ contexts:
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
-    - match: ':(?!=)'
+    - match: '{{colon}}'
       scope: punctuation.separator.slice.python
     - include: expression-in-a-group
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -334,7 +334,7 @@ contexts:
   comment-body:
     - meta_scope: comment.line.number-sign.python
     - match: \n
-      pop: true
+      pop: 1
 
   shebang:
     - meta_include_prototype: false
@@ -342,7 +342,7 @@ contexts:
       scope: punctuation.definition.comment.python
       set: shebang-body
     - match: ^|(?=\S)  # Note: Ensure to highlight shebang if Python is embedded.
-      pop: true
+      pop: 1
 
   shebang-body:
     - meta_include_prototype: false
@@ -351,7 +351,7 @@ contexts:
     - match: python(?:\d(?:\.\d+)?)?\b
       scope: constant.language.shebang.python
     - match: \n
-      pop: true
+      pop: 1
 
 ###[ DECORATORS ]#############################################################
 
@@ -371,7 +371,7 @@ contexts:
       scope: punctuation.definition.annotation.python
     - match: \S
       scope: invalid.illegal.character.python
-      pop: true
+      pop: 1
 
   decorator-wrapper:
     - match: (\.)\s*
@@ -394,7 +394,7 @@ contexts:
     - meta_scope: meta.annotation.function.python
     - match: \)
       scope: punctuation.section.arguments.end.python
-      pop: true
+      pop: 1
     - match: \(
       scope: meta.annotation.function.python punctuation.section.arguments.begin.python
       push: [decorator-function-call-arguments, allow-unpack-operators]
@@ -418,7 +418,7 @@ contexts:
     - clear_scopes: 1
     - meta_content_scope: meta.annotation.arguments.python
     - match: (?=\))
-      pop: true
+      pop: 1
     - include: arguments
 
 ###[ IMPORT STATEMENTS ]######################################################
@@ -494,7 +494,7 @@ contexts:
     - meta_scope: meta.statement.import.python meta.import-list.python
     - match: \)
       scope: punctuation.section.import-list.end.python
-      pop: true
+      pop: 1
     - include: comments
     - include: imports-as-inlist
     - include: import-names
@@ -545,9 +545,9 @@ contexts:
 
   expect-import-end:
     - match: $
-      pop: true
+      pop: 1
     - match: (?=#)
-      pop: true
+      pop: 1
     - match: '[^\s#]+'
       scope: invalid.illegal.unexpected-import.python
 
@@ -593,7 +593,7 @@ contexts:
       set: class-definition-end
     - match: ':'
       scope: invalid.illegal.no-closing-parens.python
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.inheritance.python
     - include: illegal-name
@@ -616,14 +616,14 @@ contexts:
         2: punctuation.accessor.dot.python
     - match: '{{identifier}}'
       scope: entity.other.inherited-class.python
-      pop: true
+      pop: 1
     - include: immediately-pop
 
   class-definition-end:
     - meta_content_scope: meta.class.python
     - match: ':'
       scope: meta.class.python punctuation.section.class.begin.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
 
 ###[ FUNCTION DEFINITIONS ]###################################################
@@ -688,7 +688,7 @@ contexts:
     - meta_include_prototype: false
     - include: comments
     - match: (?=[,)])
-      pop: true
+      pop: 1
     - match: '[^\s,)]+'
       scope: invalid.illegal.expected-comma.python
 
@@ -736,13 +736,13 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: invalid.illegal.default-value.python
     - match: (?=[,)=])
-      pop: true
+      pop: 1
 
   function-parameter-illegal-default-value:
     - meta_include_prototype: false
     - meta_scope: invalid.illegal.annotation.python
     - match: (?=[,)=])
-      pop: true
+      pop: 1
 
   function-after-parameters:
     - meta_content_scope: meta.function.python
@@ -759,13 +759,13 @@ contexts:
     - meta_include_prototype: false
     - match: ->
       scope: punctuation.separator.annotation.return.python
-      pop: true
+      pop: 1
 
   function-definition-end:
     - include: illegal-assignment-expressions
     - match: ':'
       scope: meta.function.python punctuation.section.function.begin.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
 
 ###[ ASSIGNMENT STATEMENTS ]##################################################
@@ -824,7 +824,7 @@ contexts:
       scope:
         meta.statement.conditional.case.python
         punctuation.section.block.conditional.case.python
-      pop: true
+      pop: 1
 
   case-statement-fail:
     - match: (?=$|#|;)
@@ -905,7 +905,7 @@ contexts:
     - meta_scope: meta.function-call.arguments.python
     - match: \)
       scope: punctuation.section.arguments.end.python
-      pop: true
+      pop: 1
     - match: (?:({{illegal_names}})|({{identifier}}))\s*(=)
       captures:
         1: invalid.illegal.name.python
@@ -932,7 +932,7 @@ contexts:
     - include: comments
     - match: \}
       scope: punctuation.section.mapping.end.python
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.sequence.python
     - match: \*\*
@@ -958,7 +958,7 @@ contexts:
 
   case-pattern-dictionary-patterns:
     - match: (?=[,:}])
-      pop: true
+      pop: 1
     - include: case-pattern-expressions
 
   case-pattern-groups-or-tuples:
@@ -978,7 +978,7 @@ contexts:
     - meta_scope: meta.group.python
     - match: \)
       scope: punctuation.section.group.end.python
-      pop: true
+      pop: 1
     - match: (?=,)
       fail: case-pattern-groups-or-tuples
     - include: case-pattern-expressions
@@ -995,7 +995,7 @@ contexts:
     - meta_scope: meta.sequence.list.python
     - match: \]
       scope: punctuation.section.sequence.end.python
-      pop: true
+      pop: 1
     - include: case-pattern-expressions
 
   case-pattern-tuple:
@@ -1009,7 +1009,7 @@ contexts:
     - meta_scope: meta.sequence.tuple.python
     - match: \)
       scope: punctuation.section.sequence.end.python
-      pop: true
+      pop: 1
     - include: case-pattern-expressions
 
 ###[ CONDITIONAL STATEMENTS ]#################################################
@@ -1031,7 +1031,7 @@ contexts:
     - meta_scope: meta.statement.conditional.if.python
     - match: ':(?!=)'
       scope: punctuation.section.block.conditional.if.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
@@ -1039,7 +1039,7 @@ contexts:
     - meta_scope: meta.statement.conditional.elseif.python
     - match: ':(?!=)'
       scope: punctuation.section.block.conditional.elseif.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
@@ -1064,7 +1064,7 @@ contexts:
     - meta_scope: meta.statement.exception.catch.python
     - match: ':(?!=)'
       scope: punctuation.section.block.exception.catch.python
-      pop: true
+      pop: 1
     - match: as\b
       scope: keyword.control.exception.catch.as.python
       set: except-statement-as
@@ -1075,7 +1075,7 @@ contexts:
     - meta_content_scope: meta.statement.exception.catch.python
     - match: ':'
       scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: name
 
@@ -1092,7 +1092,7 @@ contexts:
     - meta_scope: meta.statement.loop.for.python
     - match: ':(?!=)'
       scope: invalid.illegal.missing-in.python
-      pop: true
+      pop: 1
     - match: in\b
       scope: keyword.control.loop.for.in.python
       set: for-statement-in
@@ -1103,7 +1103,7 @@ contexts:
     - meta_content_scope: meta.statement.loop.for.python
     - match: ':(?!=)'
       scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
@@ -1200,7 +1200,7 @@ contexts:
     - meta_scope: meta.statement.loop.while.python
     - match: ':(?!=)'
       scope: punctuation.section.block.loop.while.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
@@ -1220,7 +1220,7 @@ contexts:
     - meta_scope: meta.statement.with.python
     - match: ':(?!=)'
       scope: punctuation.section.block.with.python
-      pop: true
+      pop: 1
     - match: as\b
       scope: keyword.control.flow.with.as.python
       push: with-statement-plain-as
@@ -1264,7 +1264,7 @@ contexts:
     - meta_content_scope: meta.statement.with.python
     - match: ':(?!=)'
       scope: meta.statement.with.python punctuation.section.block.with.python
-      pop: true
+      pop: 1
     - include: with-statement-tuple-else-fail
 
   with-statement-tuple-else-fail:
@@ -1325,9 +1325,9 @@ contexts:
     - meta_scope: meta.expression.generator.python
     - match: in\b
       scope: keyword.control.loop.for.in.python
-      pop: true
+      pop: 1
     - match: (?=[)\]}])
-      pop: true
+      pop: 1
     - include: comments
     - include: illegal-name
     - include: target-lists
@@ -1343,7 +1343,7 @@ contexts:
     - meta_scope: meta.sequence.tuple.python
     - match: \)
       scope: punctuation.section.tuple.end.python
-      pop: true
+      pop: 1
     - include: comments
     - include: target-lists
 
@@ -1428,7 +1428,7 @@ contexts:
 
   keyword-argument-value:
     - match: (?=[,)]|:(?!=))
-      pop: true
+      pop: 1
     - include: expression-in-a-group
 
 ###[ LAMBDAS ]################################################################
@@ -1464,7 +1464,7 @@ contexts:
 
   lambda-in-group-end:
     - match: (?=for\b)
-      pop: true
+      pop: 1
 
   lambdas:
     - match: lambda(?=\s|:|$)
@@ -1507,7 +1507,7 @@ contexts:
     # If we're in a group, the underlying context will take over
     # at the end of the line.
     - match: (?=[,:)}\]])|$
-      pop: true
+      pop: 1
     - include: expression-in-a-statement
 
 ###[ GENERATORS GROUPS TUBLES ]###############################################
@@ -1713,7 +1713,7 @@ contexts:
 
   inside-set-unpacking-expression:
     - match: (?=[,}])
-      pop: true
+      pop: 1
     - include: expression-in-a-group
 
   empty-dictionaries:
@@ -1771,7 +1771,7 @@ contexts:
   illegal-assignment:
     - match: \:?=
       scope: invalid.illegal.assignment.python
-      pop: true
+      pop: 1
     - include: line-continuation-or-pop
     - include: else-pop
 
@@ -1796,16 +1796,16 @@ contexts:
     - include: comments
     - match: \*{3,}
       scope: invalid.illegal.syntax.python
-      pop: true
+      pop: 1
     - match: \*\*
       scope: keyword.operator.unpacking.mapping.python
-      pop: true
+      pop: 1
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
-      pop: true
+      pop: 1
     - include: else-pop
     - match: ^(?!\s*[#*])
-      pop: true
+      pop: 1
 
   sequence-separators:
     - match: ','
@@ -1887,7 +1887,7 @@ contexts:
     - match: \.(?!\s*{{identifier}})  # don't match last dot
       scope: punctuation.accessor.dot.python
     - match: (?=\S|$)
-      pop: true
+      pop: 1
 
   name-specials:
     - include: builtin-functions
@@ -1916,7 +1916,7 @@ contexts:
   generic-name:
     - match: '{{identifier}}'
       scope: meta.generic-name.python
-      pop: true
+      pop: 1
 
   illegal-names:
     - match: '{{illegal_names}}\b'
@@ -1925,7 +1925,7 @@ contexts:
   illegal-name:
     - match: '{{illegal_names}}\b'
       scope: invalid.illegal.name.python
-      pop: true
+      pop: 1
 
   class-variables:
     - match: (?:self|cls)\b
@@ -1938,7 +1938,7 @@ contexts:
   wildcard-variable:
     - match: _(?!{{identifier_continue}})
       scope: variable.language.anonymous.python
-      pop: true
+      pop: 1
 
   magic-function-names:
     # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
@@ -2079,7 +2079,7 @@ contexts:
     - meta_scope: comment.block.documentation.python
     - match: \2
       scope: punctuation.definition.comment.end.python
-      pop: true
+      pop: 1
     - include: escaped-unicode-chars
     - include: escaped-chars
 
@@ -2087,7 +2087,7 @@ contexts:
     - meta_scope: comment.block.documentation.python
     - match: \2
       scope: punctuation.definition.comment.end.python
-      pop: true
+      pop: 1
 
 ###[ STRINGS ]################################################################
 
@@ -2118,7 +2118,7 @@ contexts:
 
   triple-double-quoted-string-pop:
     - match: (?=""")
-      pop: true
+      pop: 1
 
   triple-double-quoted-plain-raw-b-strings:
     # Triple-quoted capital R raw string, bytes, no syntax embedding
@@ -2344,7 +2344,7 @@ contexts:
 
   double-quoted-string-pop:
     - match: (?="|\n)
-      pop: true
+      pop: 1
     - include: illegal-string-end
     - include: string-continuations
 
@@ -2567,7 +2567,7 @@ contexts:
 
   triple-single-quoted-string-pop:
     - match: (?=''')
-      pop: true
+      pop: 1
 
   triple-single-quoted-plain-raw-b-strings:
     # Triple-quoted capital R raw string, bytes, no syntax embedding
@@ -2791,7 +2791,7 @@ contexts:
 
   single-quoted-string-pop:
     - match: (?='|\n)
-      pop: true
+      pop: 1
     - include: illegal-string-end
     - include: string-continuations
 
@@ -3093,7 +3093,7 @@ contexts:
     - meta_scope: constant.other.placeholder.python
     - match: \}
       scope: punctuation.definition.placeholder.end.python
-      pop: true
+      pop: 1
     # TODO could match numeric indices or everything else as a key
     # and also [] indexing
     - match: '![ars]'
@@ -3107,14 +3107,14 @@ contexts:
   inside-string-replacement-formatspec:
     - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
     - match: (?=\})
-      pop: true
+      pop: 1
     - match: (?=\{)
       push: string-replacement
 
   string-replacement-fallback:
     - match: \{
       scope: meta.debug.string-replacement-fallback.python
-      pop: true
+      pop: 1
 
   f-string-replacements:
     # https://www.python.org/dev/peps/pep-0498/
@@ -3233,7 +3233,7 @@ contexts:
   line-continuation-or-pop:
     - include: line-continuation
     - match: (?=\s*(?:\n|;|#))
-      pop: true
+      pop: 1
 
   line-continuation:
     - match: (\\)\s*$
@@ -3246,4 +3246,4 @@ contexts:
     # This prevents strings after a continuation from being a docstring
     - include: strings
     - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
-      pop: true
+      pop: 1

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -246,8 +246,7 @@ contexts:
     - include: class-definitions
     - include: function-definitions
     - include: assignments
-    - match: ;
-      scope: punctuation.terminator.statement.python
+    - include: statement-terminators
     - include: expression-as-a-statement
 
   block-statements:
@@ -1302,75 +1301,6 @@ contexts:
         1: keyword.control.flow.yield.python
         2: keyword.control.flow.yield-from.python
 
-  assignment-expression:
-    - match: :=
-      scope: keyword.operator.assignment.inline.python
-
-  illegal-assignment-expression:
-    - match: :=
-      scope: invalid.illegal.not-allowed-here.python
-
-  illegal-assignment:
-    - match: \:?=
-      scope: invalid.illegal.not-allowed-here.python
-      pop: true
-    - include: line-continuation-or-pop
-    - include: else-pop
-
-  assignments:
-    - include: illegal-assignment-expression
-    - match: ':'
-      scope: punctuation.separator.annotation.variable.python
-      push: variable-annotation
-    - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
-      scope: keyword.operator.assignment.augmented.python
-    - match: '=(?!=)'
-      scope: keyword.operator.assignment.python
-
-  variable-annotation:
-    - meta_scope: meta.variable.annotation.python
-    - match: (?=$|=|#|;)
-      pop: 1
-    - match: \bNone\b
-      scope: constant.language.null.python
-    - include: illegal-assignment-expression
-    - include: expression-in-a-group
-
-  operators:
-    - match: <>
-      scope: invalid.deprecated.operator.python
-    - match: <\=|>\=|\=\=|<|>|\!\=
-      scope: keyword.operator.comparison.python
-    - match: \+|\-|\*|\*\*|/|//|%|<<|>>|&|\||\^|~
-      scope: keyword.operator.arithmetic.python
-    - match: \b(and|in|is|not|or)\b
-      comment: keyword operators that evaluate to True or False
-      scope: keyword.operator.logical.python
-    - match: '@'
-      scope: keyword.operator.matrix.python
-    - include: sequence-separators
-
-  sequence-separators:
-    - match: ','
-      scope: punctuation.separator.sequence.python
-      push: allow-unpack-operators
-
-  allow-unpack-operators:
-    # Match unpacking operators, if present
-    - include: comments
-    - match: \*{3,}
-      scope: invalid.illegal.syntax.python
-      pop: true
-    - match: \*\*
-      scope: keyword.operator.unpacking.mapping.python
-      pop: true
-    - match: \*
-      scope: keyword.operator.unpacking.sequence.python
-      pop: true
-    - include: else-pop
-    - match: ^(?!\s*[#*])
-      pop: true
-
 ###[ FUNCTION CALLS ]#########################################################
 
   function-calls:
@@ -1778,6 +1708,81 @@ contexts:
     - match: ':'
       scope: punctuation.separator.slice.python
     - include: expression-in-a-group
+
+###[ OPERATORS ]##############################################################
+
+  assignment-expression:
+    - match: :=
+      scope: keyword.operator.assignment.inline.python
+
+  illegal-assignment-expression:
+    - match: :=
+      scope: invalid.illegal.not-allowed-here.python
+
+  illegal-assignment:
+    - match: \:?=
+      scope: invalid.illegal.not-allowed-here.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: else-pop
+
+  assignments:
+    - include: illegal-assignment-expression
+    - match: ':'
+      scope: punctuation.separator.annotation.variable.python
+      push: variable-annotation
+    - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
+      scope: keyword.operator.assignment.augmented.python
+    - match: '=(?!=)'
+      scope: keyword.operator.assignment.python
+
+  variable-annotation:
+    - meta_scope: meta.variable.annotation.python
+    - match: (?=$|=|#|;)
+      pop: 1
+    - match: \bNone\b
+      scope: constant.language.null.python
+    - include: illegal-assignment-expression
+    - include: expression-in-a-group
+
+  operators:
+    - match: <>
+      scope: invalid.deprecated.operator.python
+    - match: <\=|>\=|\=\=|<|>|\!\=
+      scope: keyword.operator.comparison.python
+    - match: \+|\-|\*|\*\*|/|//|%|<<|>>|&|\||\^|~
+      scope: keyword.operator.arithmetic.python
+    - match: \b(?:and|in|is|not|or)\b
+      comment: keyword operators that evaluate to True or False
+      scope: keyword.operator.logical.python
+    - match: '@'
+      scope: keyword.operator.matrix.python
+    - include: sequence-separators
+
+  allow-unpack-operators:
+    # Match unpacking operators, if present
+    - include: comments
+    - match: \*{3,}
+      scope: invalid.illegal.syntax.python
+      pop: true
+    - match: \*\*
+      scope: keyword.operator.unpacking.mapping.python
+      pop: true
+    - match: \*
+      scope: keyword.operator.unpacking.sequence.python
+      pop: true
+    - include: else-pop
+    - match: ^(?!\s*[#*])
+      pop: true
+
+  sequence-separators:
+    - match: ','
+      scope: punctuation.separator.sequence.python
+      push: allow-unpack-operators
+
+  statement-terminators:
+    - match: ;
+      scope: punctuation.terminator.statement.python
 
 ###[ IDENTIFIERS ]############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -211,44 +211,14 @@ contexts:
     - include: with-statements
 
   line-statements:
-    - include: imports
     - include: decorators
-    - match: \braise\b
-      scope: keyword.control.flow.raise.python
-      push: raise-statement-body
-    - match: \bassert\b
-      scope: keyword.control.flow.assert.python
-    - match: \bdel\b
-      scope: keyword.other.del.python
-    - match: \bprint\b(?! *([,.()\]}]))
-      scope: keyword.other.print.python
-    - match: \bexec\b(?! *($|[,.()\]}]))
-      scope: keyword.other.exec.python
-    - match: \breturn\b
-      scope: keyword.control.flow.return.python
-    - match: \bbreak\b
-      scope: keyword.control.flow.break.python
-    - match: \bcontinue\b
-      scope: keyword.control.flow.continue.python
-    - match: \bpass\b
-      scope: keyword.control.flow.pass.python
-
-  raise-statement-body:
-    - meta_scope: meta.statement.raise.python
-    - match: \bfrom\b
-      scope: keyword.control.flow.raise.from.python
-      set: raise-statement-from
-    - include: line-continuation-or-pop
-    - include: expression-in-a-statement
-
-  raise-statement-from:
-    - meta_content_scope: meta.statement.raise.python
-    - include: line-continuation-or-pop
-    - include: expression-in-a-statement
+    - include: import-statements
+    - include: flow-statements
+    - include: other-statements
 
 ###[ IMPORT STATEMENTS ]######################################################
 
-  imports:
+  import-statements:
     - match: \bimport\b
       scope: keyword.control.import.python
       push:
@@ -852,6 +822,46 @@ contexts:
     - include: line-continuation
     - match: (?=\S|$)
       fail: with-statement-tuple
+
+###[ FLOW STATEMENTS ]########################################################
+
+  flow-statements:
+    - match: \bassert\b
+      scope: keyword.control.flow.assert.python
+    - match: \breturn\b
+      scope: keyword.control.flow.return.python
+    - match: \bbreak\b
+      scope: keyword.control.flow.break.python
+    - match: \bcontinue\b
+      scope: keyword.control.flow.continue.python
+    - match: \bpass\b
+      scope: keyword.control.flow.pass.python
+    - match: \braise\b
+      scope: keyword.control.flow.raise.python
+      push: raise-statement-body
+
+  raise-statement-body:
+    - meta_scope: meta.statement.raise.python
+    - match: \bfrom\b
+      scope: keyword.control.flow.raise.from.python
+      set: raise-statement-from
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
+  raise-statement-from:
+    - meta_content_scope: meta.statement.raise.python
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
+###[ OTHER STATEMENTS ]#######################################################
+
+  other-statements:
+    - match: \bdel\b
+      scope: keyword.other.del.python
+    - match: \bexec\b(?! *($|[,.()\]}]))
+      scope: keyword.other.exec.python
+    - match: \bprint\b(?! *([,.()\]}]))
+      scope: keyword.other.print.python
 
 ###[ EXPRESSIONS ]############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -363,64 +363,79 @@ contexts:
 ###[ DECORATORS ]#############################################################
 
   decorators:
-    - match: ^\s*(?=@)
+    - match: ^\s*(@)
+      captures:
+        1: meta.annotation.python punctuation.definition.annotation.python
       push: decorator-body
 
   decorator-body:
-    # Due to line continuations, we don't know whether this is a "function call" yet
     - meta_content_scope: meta.annotation.python
     - include: line-continuation-or-pop
-    - match: (?=\.?\s*{{path}}\s*\() # now we do
-      set: [after-expression, decorator-function-call-wrapper, qualified-name-until-leaf]
-    - match: (?=\.?\s*{{path}})
-      push: [decorator-wrapper, qualified-name-until-leaf]
-    - match: '@'
-      scope: punctuation.definition.annotation.python
-    - match: \S
-      scope: invalid.illegal.character.python
-      pop: 1
+    - include: assignment-expressions
+    - include: lambdas
+    - include: dictionaries-and-sets
+    - include: generators-groups-and-tuples
+    - include: lists
+    - include: constants
+    - include: numbers
+    - include: strings
+    - include: keywords
+    - include: operators
+    - include: decorator-function-calls
+    - include: decorator-variables
+    - include: illegal-stray-brackets
+    - include: illegal-stray-braces
+    - include: illegal-stray-parens
 
-  decorator-wrapper:
+  decorator-function-calls:
+    - match: (?=(?:\.\s*)?{{path}}\s*\() # now we do
+      push:
+        - function-call-argument-list
+        - decorator-function-call-name
+        - qualified-name-until-leaf
+
+  decorator-function-call-name:
+    - meta_content_scope: meta.function-call.identifier.python
     - match: (\.)\s*
       captures:
         1: punctuation.accessor.dot.python
-      set:
-        - meta_scope: meta.path.python
-        - meta_content_scope: variable.annotation.python
-        - include: dotted-name-content
+      set: qualified-decorator-function-call-name
     - match: ''
-      set:
-        - meta_scope: variable.annotation.python
-        - include: name-content
+      set: unqualified-decorator-function-call-name
 
-  decorator-function-call-wrapper:
-    - meta_scope: meta.annotation.function.python
-    - match: \)
-      scope: punctuation.section.arguments.end.python
-      pop: 1
-    - match: \(
-      scope: meta.annotation.function.python punctuation.section.arguments.begin.python
-      push: [decorator-function-call-arguments, allow-unpack-operators]
+  qualified-decorator-function-call-name:
+    - meta_scope: meta.function-call.identifier.python meta.path.python
+    - include: unqualified-decorator-variable-name
+
+  unqualified-decorator-function-call-name:
+    - meta_scope: meta.function-call.identifier.python
+    - include: unqualified-decorator-variable-name
+
+  decorator-variables:
+    - match: (?=(?:\.\s*)?{{identifier}})
+      push:
+        - after-expression
+        - decorator-variable-name
+        - qualified-name-until-leaf
+
+  decorator-variable-name:
     - match: (\.)\s*
       captures:
         1: punctuation.accessor.dot.python
-      push:
-        - meta_scope: meta.path.python
-        - meta_content_scope: variable.annotation.function.python
-        - include: dotted-name-content
+      set: qualified-decorator-variable-name
     - match: ''
-      push:
-        - meta_scope: meta.path.python variable.annotation.function.python
-        - include: name-specials
-        - include: generic-names
-        - include: immediately-pop
+      set: unqualified-decorator-variable-name
 
-  decorator-function-call-arguments:
-    - clear_scopes: 1
-    - meta_content_scope: meta.annotation.arguments.python
-    - match: (?=\))
+  qualified-decorator-variable-name:
+    - meta_scope: meta.path.python
+    - include: unqualified-decorator-variable-name
+
+  unqualified-decorator-variable-name:
+    - include: illegal-name
+    - match: '{{identifier}}'
+      scope: variable.annotation.python
       pop: 1
-    - include: arguments
+    - include: immediately-pop
 
 ###[ IMPORT STATEMENTS ]######################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1242,7 +1242,7 @@ contexts:
     - include: inline-if
     - include: strings
     - include: function-calls
-    - include: item-access
+    - include: items
     - include: lists
     - include: dictionaries-and-sets
     - include: generators-groups-and-tuples
@@ -1286,38 +1286,14 @@ contexts:
         - include: immediately-pop
 
   after-expression:
-    # direct function call
-    - match: '\s*(\()'
+    - match: \s*(?=\()
+      set: function-call-argument-list
+    - match: \s*(?=\[)
+      set: item-access
+    - match: \s*(\\)\s*$
       captures:
-        1: punctuation.section.arguments.begin.python
-      push: [inside-function-call-argument-list, allow-unpack-operators]
-    # item access
-    - match: '\s*(\[)'
-      captures:
-        1: meta.item-access.python punctuation.section.brackets.begin.python
-      push:
-        - meta_content_scope: meta.item-access.arguments.python
-        - match: \]
-          scope: meta.item-access.python punctuation.section.brackets.end.python
-          pop: true
-        - include: illegal-assignment-expression
-        - match: ':'
-          scope: punctuation.separator.slice.python
-        - include: expression-in-a-group
-    # indirect function call following attribute access
-    - match: (?={{illegal_names}})
-      pop: true
-    - include: function-calls
-    # arbitrary attribute access
-    - match: '\s*(\.)'
-      captures:
-        1: punctuation.accessor.dot.python
-      push:
-        - include: magic-function-names
-        - include: magic-variable-names
-        - include: illegal-names
-        - include: generic-names
-        - include: immediately-pop
+        1: punctuation.separator.continuation.line.python
+      push: inside-line-continuation
     - include: immediately-pop
 
   yields:
@@ -1394,28 +1370,6 @@ contexts:
     - include: else-pop
     - match: ^(?!\s*[#*])
       pop: true
-
-  item-access:
-    - match: '(?={{path}}\s*\[)'
-      push:
-        - match: \]
-          scope: meta.item-access.python punctuation.section.brackets.end.python
-          set: after-expression
-        - match: '(?={{path}}\s*\[)'
-          push:
-            - meta_content_scope: meta.item-access.python
-            - match: '(?=\s*\[)'
-              pop: true
-            - include: qualified-name
-        - match: \[
-          scope: meta.item-access.python punctuation.section.brackets.begin.python
-          push:
-            - meta_content_scope: meta.item-access.arguments.python
-            - match: '(?=\])'
-              pop: true
-            - match: ':'
-              scope: punctuation.separator.slice.python
-            - include: expression-in-a-group
 
 ###[ FUNCTION CALLS ]#########################################################
 
@@ -1802,6 +1756,29 @@ contexts:
     - match: \}
       scope: invalid.illegal.stray.python
 
+###[ ITEM ACCESS ]############################################################
+
+  items:
+    - match: (?={{path}}\s*\[)
+      push:
+        - item-access
+        - qualified-name-content
+
+  item-access:
+    - match: \[
+      scope: meta.item-access.python punctuation.section.brackets.begin.python
+      set: inside-maybe-item-access
+
+  inside-maybe-item-access:
+    - meta_content_scope: meta.item-access.python
+    - match: \]
+      scope: punctuation.section.brackets.end.python
+      set: after-expression
+    - include: illegal-assignment-expression
+    - match: ':'
+      scope: punctuation.separator.slice.python
+    - include: expression-in-a-group
+
 ###[ IDENTIFIERS ]############################################################
 
   builtin-exceptions:
@@ -1914,7 +1891,7 @@ contexts:
       pop: true
 
   class-variables:
-    - match: \b(self|cls)\b
+    - match: \b(?:self|cls)\b
       scope: variable.language.python
 
   wildcard-variables:
@@ -3246,15 +3223,13 @@ contexts:
 
   line-continuation-or-pop:
     - include: line-continuation
-    - match: (?=\s*(\n|;|#))
+    - match: (?=\s*(?:\n|;|#))
       pop: true
 
   line-continuation:
-    - match: (\\)(.*)$\n?
+    - match: (\\)\s*$
       captures:
         1: punctuation.separator.continuation.line.python
-        2: invalid.illegal.unexpected-text.python
-    # make sure to resume parsing at next line
       push: inside-line-continuation
 
   inside-line-continuation:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: Python
 scope: source.python
+version: 2
 
 file_extensions:
   - py
@@ -448,11 +449,10 @@ contexts:
   imports-from-body:
     - meta_scope: meta.statement.import.python
     - meta_content_scope: meta.import-source.python
-    - include: line-continuation-or-pop
-    - match: (?=as\b)
+    - include: imports-from-import
+    - match: as\b
+      scope: keyword.control.import.as.python
       set: imports-from-import-names
-    - match: (?=import\b)
-      set: imports-from-import
     - match: '{{illegal_names}}\b'
       scope: meta.import-path.python invalid.illegal.name.python
     - match: '{{identifier}}'
@@ -465,6 +465,7 @@ contexts:
       captures:
         0: meta.import-path.python
         1: invalid.illegal.name.python
+    - include: line-continuation-or-pop
     - include: else-pop
 
   imports-from-import:
@@ -630,15 +631,15 @@ contexts:
 
   function-definitions:
     - match: ^\s*(?:(async)\s+)?(def)\b
+      scope: meta.function.python
       captures:
         1: keyword.declaration.async.python
         2: keyword.declaration.function.python
       push: function-definition-name
 
   function-definition-name:
-    - meta_scope: meta.function.python
-    - match: (?=\()
-      set: function-parameter-list
+    - meta_content_scope: meta.function.python
+    - include: function-parameter-list
     - include: illegal-names
     - match: '{{magic_functions}}'
       scope: entity.name.function.python support.function.magic.python
@@ -649,15 +650,15 @@ contexts:
   function-parameter-list:
     - meta_include_prototype: false
     - match: \(
-      scope: punctuation.section.parameters.begin.python
+      scope: meta.function.parameters.python punctuation.section.parameters.begin.python
       set:
         - inside-function-parameter-list
         - allow-unpack-operators
 
   inside-function-parameter-list:
-    - meta_scope: meta.function.parameters.python
+    - meta_content_scope: meta.function.parameters.python
     - match: \)
-      scope: punctuation.section.parameters.end.python
+      scope: meta.function.parameters.python punctuation.section.parameters.end.python
       set: function-after-parameters
     - match: ','
       scope: punctuation.separator.parameters.python
@@ -665,19 +666,13 @@ contexts:
     - match: /
       scope: storage.modifier.positional-args-only.python
       push: function-parameter-expect-comma
-    - match: (?==)
-      set:
-        - meta_include_prototype: false
-        - match: '='
-          scope: keyword.operator.assignment.python
-          set: function-parameter-default-value
+    - match: '='
+      scope: keyword.operator.assignment.python
+      set: function-parameter-default-value
     - include: illegal-assignment-expressions
-    - match: (?=:)
-      set:
-        - meta_include_prototype: false
-        - match: ':'
-          scope: punctuation.separator.annotation.parameter.python
-          set: function-parameter-annotation
+    - match: ':'
+      scope: punctuation.separator.annotation.parameter.python
+      set: function-parameter-annotation
     - include: function-parameter-tuples
     - include: illegal-names
     - match: '{{identifier}}'
@@ -746,20 +741,15 @@ contexts:
 
   function-after-parameters:
     - meta_content_scope: meta.function.python
-    - match: (?=->)
-      set: [function-return-type, function-return-type-separator]
+    - match: ->
+      scope: meta.function.annotation.return.python punctuation.separator.annotation.return.python
+      set: function-return-type
     - include: function-definition-end
 
   function-return-type:
     - meta_content_scope: meta.function.annotation.return.python
     - include: function-definition-end
     - include: expression-in-a-statement
-
-  function-return-type-separator:
-    - meta_include_prototype: false
-    - match: ->
-      scope: punctuation.separator.annotation.return.python
-      pop: 1
 
   function-definition-end:
     - include: illegal-assignment-expressions
@@ -1370,9 +1360,8 @@ contexts:
         - qualified-name-until-leaf
 
   function-call-wrapper:
-    - meta_scope: meta.function-call.python
-    - match: (?=\()  # need to remove meta.function-call.python from opening parens
-      set: function-call-argument-list
+    - meta_content_scope: meta.function-call.python
+    - include: function-call-argument-list
     - match: (\.)\s*(?={{identifier}})
       captures:
         1: punctuation.accessor.dot.python
@@ -1449,7 +1438,7 @@ contexts:
   lambda-in-group-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
     - match: ':'
-      scope: punctuation.section.function.begin.python
+      scope: meta.function.inline.python punctuation.section.function.begin.python
       set:
         - meta_include_prototype: false
         - match: ''
@@ -1479,7 +1468,7 @@ contexts:
   lambda-parameters:
     - meta_content_scope: meta.function.inline.parameters.python
     - match: ':'
-      scope: punctuation.section.function.begin.python
+      scope: meta.function.inline.python punctuation.section.function.begin.python
       set:
         - meta_include_prototype: false
         - match: ''
@@ -1614,33 +1603,30 @@ contexts:
 
   maybe-dictionary:
     - match: \{
-      scope: punctuation.section.mapping.begin.python
+      scope: meta.mapping.python punctuation.section.mapping.begin.python
       set: inside-dictionary
 
   dictionary-end:
     - match: \}
-      scope: punctuation.section.mapping.end.python
+      scope: meta.mapping.python punctuation.section.mapping.end.python
       set: after-expression
 
   dictionary-separator:
-    - match: (?=,)
-      set:
-        - meta_include_prototype: false
-        - match: ','
-          scope: punctuation.separator.sequence.python
-          set: inside-dictionary
+    - match: ','
+      scope: meta.mapping.python punctuation.separator.sequence.python
+      set: inside-dictionary
 
   inside-dictionary:
-    - meta_scope: meta.mapping.python
+    - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: comments
     - include: illegal-assignment-expressions
     - include: illegal-commas
     - match: ':'
-      scope: punctuation.separator.key-value.python
+      scope: meta.mapping.python punctuation.separator.key-value.python
       set: expect-dictionary-value
     - match: \*\*
-      scope: keyword.operator.unpacking.mapping.python
+      scope: meta.mapping.python keyword.operator.unpacking.mapping.python
       set: inside-dictionary-unpacking-expression
     - match: (?=\S)
       set: inside-directory-key
@@ -1746,11 +1732,11 @@ contexts:
 
   item-access:
     - match: \[
-      scope: meta.item-access.python punctuation.section.brackets.begin.python
+      scope: punctuation.section.brackets.begin.python
       set: inside-maybe-item-access
 
   inside-maybe-item-access:
-    - meta_content_scope: meta.item-access.python
+    - meta_scope: meta.item-access.python
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
@@ -2113,7 +2099,9 @@ contexts:
 
   triple-double-quoted-string-end:
     - match: '"""'
-      scope: punctuation.definition.string.end.python
+      scope:
+        meta.string.python string.quoted.double.block.python
+        punctuation.definition.string.end.python
       set: after-expression
 
   triple-double-quoted-string-pop:
@@ -2154,12 +2142,12 @@ contexts:
     - match: ([fF]R|R[fF])(""")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push: inside-triple-double-quoted-plain-raw-f-string
 
   inside-triple-double-quoted-plain-raw-f-string:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - include: f-string-replacements
 
@@ -2168,12 +2156,12 @@ contexts:
     - match: ([fF]r|r[fF])(""")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push: inside-triple-double-quoted-raw-f-string
 
   inside-triple-double-quoted-raw-f-string:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - match: ''
       push: scope:source.regexp.python
@@ -2218,9 +2206,7 @@ contexts:
   inside-triple-double-quoted-sql-raw-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: '"""'
-      scope: string.quoted.double.block.python punctuation.definition.string.end.python
-      set: after-expression
+    - include: triple-double-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2232,9 +2218,7 @@ contexts:
   inside-triple-double-quoted-regexp-raw-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
-    - match: '"""'
-      scope: punctuation.definition.string.end.python
-      set: after-expression
+    - include: triple-double-quoted-string-end
     - match: ''
       push: scope:source.regexp.python
       with_prototype:
@@ -2263,12 +2247,12 @@ contexts:
     - match: ([fF])(""")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.block.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
       push: inside-triple-double-quoted-f-string
 
   inside-triple-double-quoted-f-string:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.block.python
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - include: string-continuations
     - include: escaped-f-string-braces
@@ -2306,9 +2290,7 @@ contexts:
   inside-triple-double-quoted-sql-u-strings:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: '"""'
-      scope: string.quoted.double.block.python punctuation.definition.string.end.python
-      set: after-expression
+    - include: triple-double-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2337,7 +2319,7 @@ contexts:
 
   double-quoted-string-end:
     - match: '"'
-      scope: punctuation.definition.string.end.python
+      scope: meta.string.python string.quoted.double.python punctuation.definition.string.end.python
       set: after-expression
     - include: illegal-string-end
     - include: string-continuations
@@ -2396,12 +2378,12 @@ contexts:
     - match: (r[fF]|[fF]r)(")
       captures:
         1: storage.type.string.python
-        2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
+        2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
       push: inside-double-quoted-raw-f-string
 
   inside-double-quoted-raw-f-string:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
+    - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - match: ''
       push: scope:source.regexp.python
@@ -2455,11 +2437,7 @@ contexts:
   inside-double-quoted-sql-raw-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: '"'
-      scope: string.quoted.double.python punctuation.definition.string.end.python
-      set: after-expression
-    - include: illegal-string-end
-    - include: string-continuations
+    - include: double-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2530,11 +2508,7 @@ contexts:
   inside-double-quoted-sql-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: '"'
-      scope: string.quoted.double.python punctuation.definition.string.end.python
-      set: after-expression
-    - include: illegal-string-end
-    - include: string-continuations
+    - include: double-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2562,7 +2536,7 @@ contexts:
 
   triple-single-quoted-string-end:
     - match: "'''"
-      scope: punctuation.definition.string.end.python
+      scope: meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python
       set: after-expression
 
   triple-single-quoted-string-pop:
@@ -2676,9 +2650,7 @@ contexts:
   inside-triple-single-quoted-sql-raw-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: "'''"
-      scope: string.quoted.single.block.python punctuation.definition.string.end.python
-      set: after-expression
+    - include: triple-single-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2753,9 +2725,7 @@ contexts:
   inside-triple-single-quoted-sql-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: "'''"
-      scope: string.quoted.single.block.python punctuation.definition.string.end.python
-      set: after-expression
+    - include: triple-single-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2784,7 +2754,7 @@ contexts:
 
   single-quoted-string-end:
     - match: "'"
-      scope: punctuation.definition.string.end.python
+      scope: meta.string.python string.quoted.single.python punctuation.definition.string.end.python
       set: after-expression
     - include: illegal-string-end
     - include: string-continuations
@@ -2871,11 +2841,7 @@ contexts:
   inside-single-quoted-sql-raw-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: "'"
-      scope: string.quoted.single.python punctuation.definition.string.end.python
-      set: after-expression
-    - include: illegal-string-end
-    - include: string-continuations
+    - include: single-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:
@@ -2978,11 +2944,7 @@ contexts:
   inside-single-quoted-sql-u-string:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
-    - match: "'"
-      scope: string.quoted.single.python punctuation.definition.string.end.python
-      set: after-expression
-    - include: illegal-string-end
-    - include: string-continuations
+    - include: single-quoted-string-end
     - match: ''
       push: scope:source.sql
       with_prototype:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -236,6 +236,8 @@ variables:
     | members | methods
     )__\b )
 
+##############################################################################
+
 contexts:
   main:
     - meta_include_prototype: false
@@ -267,6 +269,48 @@ contexts:
     - include: modifier-statements
     - include: flow-statements
     - include: other-statements
+
+  # Always include these last and only one at a time!
+  expression-as-a-statement:
+    - include: lambdas
+    - include: expressions-common
+    - include: qualified-name
+
+  expression-in-a-statement:
+    # Differs from expression-as-a-statement in that:
+    # - invalid-name matches will pop the current context
+    # - assignment expressions
+    - include: lambdas
+    - include: expressions-common
+    - include: illegal-name
+    - include: qualified-name
+    - include: assignment-expressions
+
+  expression-in-a-group:  # Always include this last!
+    # Differs from expression-in-a-statement in that:
+    # - accessor matching continues into the next line
+    - include: lambda-in-groups
+    - include: expressions-common
+    - include: illegal-name
+    - include: qualified-name
+    - include: assignment-expressions
+
+  expressions-common:
+    - include: dictionaries-and-sets
+    - include: generators-groups-and-tuples
+    - include: lists
+    - include: comments
+    - include: constants
+    - include: numbers
+    - include: strings
+    - include: keywords
+    - include: operators
+    - include: function-calls
+    - include: items
+    - include: line-continuation
+    - include: illegal-stray-brackets
+    - include: illegal-stray-braces
+    - include: illegal-stray-parens
 
 ###[ COMMENTS ]###############################################################
 
@@ -1259,61 +1303,6 @@ contexts:
       scope: keyword.other.exec.python
     - match: \bprint\b(?! *([,.()\]}]))
       scope: keyword.other.print.python
-
-###[ EXPRESSIONS ]############################################################
-
-  expressions-common:
-    - include: comments
-    - include: constants
-    - include: numbers
-    - include: keywords
-    - include: operators
-    - include: strings
-    - include: function-calls
-    - include: items
-    - include: lists
-    - include: dictionaries-and-sets
-    - include: generators-groups-and-tuples
-    - include: illegal-stray-brackets
-    - include: illegal-stray-braces
-    - include: illegal-stray-parens
-    - include: line-continuation
-
-  # Always include these last and only one at a time!
-  expression-as-a-statement:
-    - include: lambdas
-    - include: expressions-common
-    - include: qualified-name
-
-  expression-in-a-statement:
-    # Differs from expression-as-a-statement in that:
-    # - invalid-name matches will pop the current context
-    # - assignment expressions
-    - include: lambdas
-    - include: expressions-common
-    - include: illegal-name
-    - include: qualified-name
-    - include: assignment-expressions
-
-  expression-in-a-group:  # Always include this last!
-    # Differs from expression-in-a-statement in that:
-    # - accessor matching continues into the next line
-    - include: lambda-in-groups
-    - include: expressions-common
-    - include: illegal-name
-    - include: qualified-name
-    - include: assignment-expressions
-
-  after-expression:
-    - match: \s*(?=\()
-      set: function-call-argument-list
-    - match: \s*(?=\[)
-      set: item-access
-    - match: \s*(\\)\s*$
-      captures:
-        1: punctuation.separator.continuation.line.python
-      push: inside-line-continuation
-    - include: immediately-pop
 
 ###[ FOR EXPRESSIONS ]########################################################
 
@@ -3219,6 +3208,17 @@ contexts:
       pop: 2
 
 ###[ PROTOTYPES ]#############################################################
+
+  after-expression:
+    - match: \s*(?=\()
+      set: function-call-argument-list
+    - match: \s*(?=\[)
+      set: item-access
+    - match: \s*(\\)\s*$
+      captures:
+        1: punctuation.separator.continuation.line.python
+      push: inside-line-continuation
+    - include: immediately-pop
 
   else-pop:
     - match: (?=\S)

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2151,6 +2151,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-plain-raw-b-string-content
+
+  triple-double-quoted-plain-raw-b-string-content:
     - include: string-prototype
 
   triple-double-quoted-raw-b-strings:
@@ -2169,7 +2172,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: string-prototype
+        - include: triple-double-quoted-raw-b-string-content
+
+  triple-double-quoted-raw-b-string-content:
+    - include: string-prototype
 
   triple-double-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
@@ -2183,6 +2189,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-plain-raw-f-string-content
+
+  triple-double-quoted-plain-raw-f-string-content:
     - include: string-prototype
     - include: f-string-replacements
 
@@ -2202,8 +2211,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: string-prototype
-        - include: f-string-replacements-regexp
+        - include: triple-double-quoted-raw-f-string-content
+
+  triple-double-quoted-raw-f-string-content:
+    - include: string-prototype
+    - include: f-string-replacements-regexp
 
   triple-double-quoted-plain-raw-u-strings:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -2217,6 +2229,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-plain-raw-u-string-content
+
+  triple-double-quoted-plain-raw-u-string-content:
     - include: string-prototype
     - include: escaped-unicode-chars
 
@@ -2248,10 +2263,13 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: string-prototype
-        - include: escaped-unicode-chars
-        - include: string-placeholders
-        - include: string-replacements
+        - include: triple-double-quoted-sql-raw-u-string-content
+
+  triple-double-quoted-sql-raw-u-string-content:
+    - include: string-prototype
+    - include: escaped-unicode-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   triple-double-quoted-regexp-raw-u-string-body:
     - meta_include_prototype: false
@@ -2261,8 +2279,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: string-prototype
-        - include: escaped-unicode-chars
+        - include: triple-double-quoted-regexp-raw-u-string-content
+
+  triple-double-quoted-regexp-raw-u-string-content:
+    - include: string-prototype
+    - include: escaped-unicode-chars
 
   triple-double-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding
@@ -2276,6 +2297,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-b-string-content
+
+  triple-double-quoted-b-string-content:
     - include: string-prototype
     - include: string-continuations
     - include: escaped-chars
@@ -2294,6 +2318,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-f-string-content
+
+  triple-double-quoted-f-string-content:
     - include: string-prototype
     - include: string-continuations
     - include: escaped-f-string-braces
@@ -2326,7 +2353,7 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
-    - include: triple-double-quoted-plain-u-string-content
+    - include: triple-double-quoted-u-string-content
 
   triple-double-quoted-sql-u-strings-body:
     - meta_include_prototype: false
@@ -2336,9 +2363,9 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-double-quoted-string-pop
-        - include: triple-double-quoted-plain-u-string-content
+        - include: triple-double-quoted-u-string-content
 
-  triple-double-quoted-plain-u-string-content:
+  triple-double-quoted-u-string-content:
     - include: string-prototype
     - include: string-continuations
     - include: escaped-unicode-chars
@@ -2384,6 +2411,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: double-quoted-plain-raw-b-string-content
+
+  double-quoted-plain-raw-b-string-content:
     - include: string-prototype
 
   double-quoted-raw-b-strings:
@@ -2402,7 +2432,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
-        - include: string-prototype
+        - include: double-quoted-raw-b-string-content
+
+  double-quoted-raw-b-string-content:
+    - include: string-prototype
 
   double-quoted-plain-raw-f-strings:
     # Single-line raw f-string
@@ -2416,6 +2449,9 @@ contexts:
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - meta_include_prototype: false
     - include: double-quoted-string-end
+    - include: double-quoted-plain-raw-f-string-content
+
+  double-quoted-plain-raw-f-string-content:
     - include: string-prototype
     - include: f-string-replacements
 
@@ -2435,8 +2471,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
-        - include: string-prototype
-        - include: f-string-replacements-regexp
+        - include: double-quoted-raw-f-string-content
+
+  double-quoted-raw-f-string-content:
+    - include: string-prototype
+    - include: f-string-replacements-regexp
 
   double-quoted-plain-raw-u-strings:
     # Single-line capital R raw string, unicode or not, no syntax embedding
@@ -2450,6 +2489,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: double-quoted-plain-raw-u-string-content
+
+  double-quoted-plain-raw-u-string-content:
     - include: string-prototype
 
   double-quoted-raw-u-strings:
@@ -2481,7 +2523,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: double-quoted-string-pop
-        - include: string-prototype
+        - include: double-quoted-regexp-raw-u-string-content
+
+  double-quoted-regexp-raw-u-string-content:
+    - include: string-prototype
 
   double-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
@@ -2491,9 +2536,12 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: double-quoted-string-pop
-        - include: string-prototype
-        - include: string-placeholders
-        - include: string-replacements
+        - include: double-quoted-sql-raw-u-string-content
+
+  double-quoted-sql-raw-u-string-content:
+    - include: string-prototype
+    - include: string-placeholders
+    - include: string-replacements
 
   double-quoted-b-strings:
     # Single-line string, bytes
@@ -2507,6 +2555,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: double-quoted-b-string-content
+
+  double-quoted-b-string-content:
     - include: string-prototype
     - include: escaped-chars
     - include: string-placeholders
@@ -2524,6 +2575,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: double-quoted-f-string-content
+
+  double-quoted-f-string-content:
     - include: string-prototype
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars
@@ -2608,6 +2662,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-plain-raw-b-string-content
+
+  triple-single-quoted-plain-raw-b-string-content:
     - include: string-prototype
 
   triple-single-quoted-raw-b-strings:
@@ -2626,7 +2683,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: string-prototype
+        - include: triple-single-quoted-raw-b-string-content
+
+  triple-single-quoted-raw-b-string-content:
+    - include: string-prototype
 
   triple-single-quoted-plain-raw-f-strings:
     # Triple-quoted raw f-string
@@ -2640,6 +2700,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-plain-raw-f-string-content
+
+  triple-single-quoted-plain-raw-f-string-content:
     - include: string-prototype
     - include: f-string-replacements
 
@@ -2659,8 +2722,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: string-prototype
-        - include: f-string-replacements-regexp
+        - include: triple-single-quoted-raw-f-string-content
+
+  triple-single-quoted-raw-f-string-content:
+    - include: string-prototype
+    - include: f-string-replacements-regexp
 
   triple-single-quoted-plain-raw-u-strings:
     # Triple-quoted capital R raw string, unicode or not, no syntax embedding
@@ -2674,6 +2740,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-plain-raw-u-string-content
+
+  triple-single-quoted-plain-raw-u-string-content:
     - include: string-prototype
 
   triple-single-quoted-raw-u-strings:
@@ -2704,8 +2773,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: string-prototype
-        - include: escaped-unicode-chars
+        - include: triple-single-quoted-regexp-raw-u-string-content
+
+  triple-single-quoted-regexp-raw-u-string-content:
+    - include: string-prototype
+    - include: escaped-unicode-chars
 
   triple-single-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
@@ -2715,11 +2787,13 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: triple-single-quoted-string-pop
-        - include: string-prototype
-        - include: escaped-unicode-chars
-        - include: escaped-chars
-        - include: string-placeholders
-        - include: string-replacements
+        - include: triple-single-quoted-sql-raw-u-string-content
+
+  triple-single-quoted-sql-raw-u-string-content:
+    - include: string-prototype
+    - include: escaped-unicode-chars
+    - include: string-placeholders
+    - include: string-replacements
 
   triple-single-quoted-b-strings:
     # Triple-quoted string, bytes, no syntax embedding
@@ -2733,6 +2807,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-b-string-content
+
+  triple-single-quoted-b-string-content:
     - include: string-prototype
     - include: string-continuations
     - include: escaped-chars
@@ -2751,6 +2828,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-f-string-content
+
+  triple-single-quoted-f-string-content:
     - include: string-prototype
     - include: string-continuations
     - include: escaped-f-string-braces
@@ -2841,6 +2921,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-plain-raw-b-string-content
+
+  single-quoted-plain-raw-b-string-content:
     - include: string-prototype
 
   single-quoted-raw-b-strings:
@@ -2859,7 +2942,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
-        - include: string-prototype
+        - include: single-quoted-raw-b-string-content
+
+  single-quoted-raw-b-string-content:
+    - include: string-prototype
 
   single-quoted-plain-raw-u-strings:
     # Single-line capital R raw string, unicode or not, no syntax embedding
@@ -2873,6 +2959,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-plain-raw-u-string-content
+
+  single-quoted-plain-raw-u-string-content:
     - include: string-prototype
 
   single-quoted-raw-u-strings:
@@ -2904,7 +2993,10 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
-        - include: string-prototype
+        - include: single-quoted-regexp-raw-u-string-content
+
+  single-quoted-regexp-raw-u-string-content:
+    - include: string-prototype
 
   single-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
@@ -2914,9 +3006,12 @@ contexts:
       push: scope:source.sql
       with_prototype:
         - include: single-quoted-string-pop
-        - include: string-prototype
-        - include: string-placeholders
-        - include: string-replacements
+        - include: single-quoted-sql-raw-u-string-content
+
+  single-quoted-sql-raw-u-string-content:
+    - include: string-prototype
+    - include: string-placeholders
+    - include: string-replacements
 
   single-quoted-plain-raw-f-strings:
     # Single-line raw f-string
@@ -2930,6 +3025,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-plain-raw-f-string-content
+
+  single-quoted-plain-raw-f-string-content:
     - include: string-prototype
     - include: f-string-replacements
 
@@ -2949,8 +3047,11 @@ contexts:
       push: scope:source.regexp.python
       with_prototype:
         - include: single-quoted-string-pop
-        - include: string-prototype
-        - include: f-string-replacements-regexp
+        - include: single-quoted-raw-f-string-content
+
+  single-quoted-raw-f-string-content:
+    - include: string-prototype
+    - include: f-string-replacements-regexp
 
   single-quoted-b-strings:
     # Single-line string, bytes
@@ -2964,6 +3065,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-b-string-content
+
+  single-quoted-b-string-content:
     - include: string-prototype
     - include: escaped-chars
     - include: string-placeholders
@@ -2981,6 +3085,9 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-f-string-content
+
+  single-quoted-f-string-content:
     - include: string-prototype
     - include: escaped-f-string-braces
     - include: escaped-unicode-chars

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1549,6 +1549,8 @@ contexts:
       pop: true
     - include: expression-in-a-statement
 
+###[ GENERATORS GROUPS TUBLES ]###############################################
+
   generators-groups-and-tuples:
     - include: empty-tuples
     - match: (?=\()
@@ -1610,20 +1612,26 @@ contexts:
         2: punctuation.section.sequence.end.python
       push: after-expression
 
+  illegal-stray-parens:
+    - match: \)
+      scope: invalid.illegal.stray.python
+
+###[ LISTS ]##################################################################
+
   lists:
     - include: empty-lists
     - match: \[
       scope: punctuation.section.sequence.begin.python
-      push: [inside-list, allow-unpack-operators]
+      push:
+        - inside-list
+        - allow-unpack-operators
 
   inside-list:
     - meta_scope: meta.sequence.list.python
     - match: \]
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - match: ','
-      scope: punctuation.separator.sequence.python
-      push: allow-unpack-operators
+    - include: sequence-separators
     - include: inline-for
     - include: expression-in-a-group
 
@@ -1634,6 +1642,12 @@ contexts:
         1: punctuation.section.sequence.begin.python
         2: punctuation.section.sequence.end.python
       push: after-expression
+
+  illegal-stray-brackets:
+    - match: \]
+      scope: invalid.illegal.stray.python
+
+###[ DICTIONARIES AND SETS ]##################################################
 
   dictionaries-and-sets:
     - include: empty-dictionaries
@@ -1661,21 +1675,25 @@ contexts:
       scope: invalid.illegal.expected-colon.python
     - match: \*\*
       scope: keyword.operator.unpacking.mapping.python
-      push:
-        - match: (?=\})
-          pop: true
-        - match: ','
-          scope: punctuation.separator.sequence.python
-          pop: true
-        - include: expression-in-a-group
+      push: inside-dictionary-unpacking-expression
     - include: comments
     - match: (?=\S)
-      push:
-        - clear_scopes: 1
-        - meta_scope: meta.mapping.key.python
-        - match: \s*(?=\}|,|:)
-          pop: true
-        - include: expression-in-a-group
+      push: inside-directory-key
+
+  inside-dictionary-unpacking-expression:
+    - match: (?=\})
+      pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.python
+      pop: true
+    - include: expression-in-a-group
+
+  inside-directory-key:
+    - clear_scopes: 1
+    - meta_scope: meta.mapping.key.python
+    - match: \s*(?=\}|,|:)
+      pop: true
+    - include: expression-in-a-group
 
   inside-directory-value:
     - meta_content_scope: meta.mapping.python
@@ -1727,16 +1745,16 @@ contexts:
       scope: punctuation.separator.set.python
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
-      push:
-        - match: (?=\})
-          pop: true
-        - match: (?=,)
-          pop: true
-        - include: expression-in-a-group
+      push: inside-set-unpacking-expression
     - include: inline-for
     - include: expression-in-a-group
     - match: ':'
       scope: invalid.illegal.colon-inside-set.python
+
+  inside-set-unpacking-expression:
+    - match: (?=[,}])
+      pop: true
+    - include: expression-in-a-group
 
   empty-dictionaries:
     - match: (\{)\s*(\})
@@ -1746,17 +1764,11 @@ contexts:
         2: punctuation.section.mapping.end.python
       push: after-expression
 
-  illegal-stray-parens:
-    - match: \)
-      scope: invalid.illegal.stray.python
-
-  illegal-stray-brackets:
-    - match: \]
-      scope: invalid.illegal.stray.python
-
   illegal-stray-braces:
     - match: \}
       scope: invalid.illegal.stray.python
+
+###[ IDENTIFIERS ]############################################################
 
   builtin-exceptions:
     - match: '{{builtin_exceptions}}'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -504,9 +504,9 @@ contexts:
   imports-as-inlist:
     - match: as\b
       scope: keyword.control.import.as.python
-      push: imports-as-body-inlist
+      push: imports-as-inlist-body
 
-  imports-as-body-inlist:
+  imports-as-inlist-body:
     - match: (?={{identifier}})
       set: name-content
     - include: import-illegal-names-inlist
@@ -585,9 +585,9 @@ contexts:
     - meta_include_prototype: false
     - match: \(
       scope: punctuation.section.inheritance.begin.python
-      set: inside-class-definition-base-list
+      set: class-definition-base-list-body
 
-  inside-class-definition-base-list:
+  class-definition-base-list-body:
     - meta_scope: meta.class.inheritance.python
     - match: \)
       scope: punctuation.section.inheritance.end.python
@@ -652,10 +652,10 @@ contexts:
     - match: \(
       scope: meta.function.parameters.python punctuation.section.parameters.begin.python
       set:
-        - inside-function-parameter-list
+        - function-parameter-list-body
         - allow-unpack-operators
 
-  inside-function-parameter-list:
+  function-parameter-list-body:
     - meta_content_scope: meta.function.parameters.python
     - match: \)
       scope: meta.function.parameters.python punctuation.section.parameters.end.python
@@ -690,7 +690,7 @@ contexts:
   function-parameter-annotation:
     - meta_scope: meta.function.parameters.annotation.python
     - match: (?=[,)=])
-      set: inside-function-parameter-list
+      set: function-parameter-list-body
     - match: None\b
       scope: constant.language.null.python
     - include: expression-in-a-group
@@ -698,7 +698,7 @@ contexts:
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
     - match: (?=[,)])
-      set: inside-function-parameter-list
+      set: function-parameter-list-body
     - include: expression-in-a-group
 
   function-parameter-tuples:
@@ -706,9 +706,9 @@ contexts:
     # removed from python 3 since PEP-3113
     - match: \(
       scope: punctuation.section.group.begin.python
-      push: inside-function-parameter-tuple
+      push: function-parameter-tuple-body
 
-  inside-function-parameter-tuple:
+  function-parameter-tuple-body:
     - meta_scope: meta.group.python
     - match: \)
       scope: punctuation.section.group.end.python
@@ -935,7 +935,7 @@ contexts:
       set: case-pattern-dictionary-unpacking
     - match: ':'
       scope: punctuation.separator.key-value.python
-      set: case-pattern-dictionary-expect-value
+      set: case-pattern-dictionary-value
     - match: (?=\S)
       set: case-pattern-dictionary-key
 
@@ -951,16 +951,16 @@ contexts:
       set: case-pattern-dictionary-body
     - include: case-pattern-expressions
 
-  case-pattern-dictionary-expect-value:
+  case-pattern-dictionary-value:
     - meta_include_prototype: false
     - meta_content_scope: meta.mapping.python
     - include: comments
     - match: (?=\S)
       set:
-        - case-pattern-dictionary-value
+        - case-pattern-dictionary-value-body
         - allow-unpack-operators
 
-  case-pattern-dictionary-value:
+  case-pattern-dictionary-value-body:
     - meta_content_scope: meta.mapping.value.python
     - match: (?=\s*[,}])
       set: case-pattern-dictionary-body
@@ -1145,9 +1145,9 @@ contexts:
   match-statement-end:
     - match: ':(?!=)'
       scope: punctuation.section.block.conditional.match.python
-      set: expect-first-case-statement
+      set: maybe-first-case-statement
 
-  expect-first-case-statement:
+  maybe-first-case-statement:
     # Disable detentation of first case statement by special indentation rule.
     # see: https://github.com/sublimehq/Packages/issues/3456
     - match: case\b
@@ -1340,11 +1340,11 @@ contexts:
   target-lists:
     - match: \(
       scope: punctuation.section.tuple.begin.python
-      push: inside-target-list
+      push: target-list-body
     - include: sequence-separators
     - include: name
 
-  inside-target-list:
+  target-list-body:
     - meta_scope: meta.sequence.tuple.python
     - match: \)
       scope: punctuation.section.tuple.end.python
@@ -1398,10 +1398,10 @@ contexts:
     - match: \(
       scope: punctuation.section.arguments.begin.python
       set:
-        - inside-function-call-argument-list
+        - function-call-argument-list-body
         - allow-unpack-operators
 
-  inside-function-call-argument-list:
+  function-call-argument-list-body:
     - meta_scope: meta.function-call.arguments.python
     - match: \)
       scope: punctuation.section.arguments.end.python
@@ -1528,9 +1528,9 @@ contexts:
   maybe-group:
     - match: \(
       scope: punctuation.section.group.begin.python
-      set: inside-group
+      set: group-body
 
-  inside-group:
+  group-body:
     - meta_scope: meta.group.python
     - match: \)
       scope: punctuation.section.group.end.python
@@ -1542,9 +1542,9 @@ contexts:
   maybe-generator:
     - match: \(
       scope: punctuation.section.sequence.begin.python
-      set: inside-generator
+      set: generator-body
 
-  inside-generator:
+  generator-body:
     - meta_scope: meta.sequence.generator.python
     - match: \)
       scope: punctuation.section.sequence.end.python
@@ -1554,9 +1554,9 @@ contexts:
   maybe-tuple:
     - match: \(
       scope: punctuation.section.sequence.begin.python
-      set: inside-tuple
+      set: tuple-body
 
-  inside-tuple:
+  tuple-body:
     - meta_scope: meta.sequence.tuple.python
     - match: \)
       scope: punctuation.section.sequence.end.python
@@ -1584,10 +1584,10 @@ contexts:
     - match: \[
       scope: punctuation.section.sequence.begin.python
       push:
-        - inside-list
+        - list-body
         - allow-unpack-operators
 
-  inside-list:
+  list-body:
     - meta_scope: meta.sequence.list.python
     - match: \]
       scope: punctuation.section.sequence.end.python
@@ -1619,7 +1619,7 @@ contexts:
   maybe-dictionary:
     - match: \{
       scope: meta.mapping.python punctuation.section.mapping.begin.python
-      set: inside-dictionary
+      set: dictionary-body
 
   dictionary-end:
     - match: \}
@@ -1629,9 +1629,9 @@ contexts:
   dictionary-separator:
     - match: ','
       scope: meta.mapping.python punctuation.separator.sequence.python
-      set: inside-dictionary
+      set: dictionary-body
 
-  inside-dictionary:
+  dictionary-body:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: comments
@@ -1639,39 +1639,39 @@ contexts:
     - include: illegal-commas
     - match: \*\*
       scope: meta.mapping.python keyword.operator.unpacking.mapping.python
-      set: inside-dictionary-unpacking
+      set: dictionary-unpacking-body
     - match: ':'
       scope: meta.mapping.python punctuation.separator.key-value.python
-      set: expect-dictionary-value
+      set: dictionary-value
     - match: (?=\S)
-      set: inside-directory-key
+      set: directory-key-body
 
-  inside-dictionary-unpacking:
+  dictionary-unpacking-body:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: dictionary-separator
     - include: expression-in-a-group
 
-  inside-directory-key:
+  directory-key-body:
     - meta_scope: meta.mapping.key.python
     - match: (?=\s*[,:}])
-      set: inside-dictionary
+      set: dictionary-body
     - include: expression-in-a-group
 
-  expect-dictionary-value:
+  dictionary-value:
     - meta_include_prototype: false
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: dictionary-separator
     - match: (?=\S)
-      set: inside-directory-value
+      set: directory-value-body
 
-  inside-directory-value:
+  directory-value-body:
     - meta_content_scope: meta.mapping.value.python
     - match: (?=\s*[,}])
       set: after-dictionary-value
     - match: (?=\s*(?:async|for)\b)
-      set: inside-dictionary-generator
+      set: dictionary-generator-body
     - include: expression-in-a-group
 
   after-dictionary-value:
@@ -1680,7 +1680,7 @@ contexts:
     - include: dictionary-end
     - include: dictionary-separator
 
-  inside-dictionary-generator:
+  dictionary-generator-body:
     - meta_content_scope: meta.mapping.python
     - include: dictionary-end
     - include: illegal-commas
@@ -1689,17 +1689,17 @@ contexts:
   maybe-set:
     - match: \{
       scope: punctuation.section.set.begin.python
-      set: maybe-inside-set
+      set: maybe-set-body
 
-  maybe-inside-set:
+  maybe-set-body:
     - meta_scope: meta.set.python
     - match: (?=,|:=)
-      set: inside-set
+      set: set-body
     - match: (?=:|\*\*)
       fail: dictionaries-and-sets
-    - include: inside-set
+    - include: set-body
 
-  inside-set:
+  set-body:
     - meta_scope: meta.set.python
     - match: \}
       scope: punctuation.section.set.end.python
@@ -1708,11 +1708,11 @@ contexts:
       scope: punctuation.separator.set.python
     - match: \*
       scope: keyword.operator.unpacking.sequence.python
-      push: inside-set-unpacking-expression
+      push: set-unpacking-expression-body
     - include: expression-in-a-sequence
     - include: illegal-colons
 
-  inside-set-unpacking-expression:
+  set-unpacking-expression-body:
     - match: (?=[,}])
       pop: 1
     - include: expression-in-a-group
@@ -1748,9 +1748,9 @@ contexts:
   item-access:
     - match: \[
       scope: punctuation.section.brackets.begin.python
-      set: inside-maybe-item-access
+      set: maybe-item-access-body
 
-  inside-maybe-item-access:
+  maybe-item-access-body:
     - meta_scope: meta.item-access.python
     - match: \]
       scope: punctuation.section.brackets.end.python
@@ -2069,14 +2069,14 @@ contexts:
       captures:
         1: storage.type.string.python
         2: punctuation.definition.comment.begin.python
-      push: inside-docstring
+      push: docstring-body
     - match: ^\s*(?i)(ur|ru?)("""|''')
       captures:
         1: storage.type.string.python
         2: punctuation.definition.comment.begin.python
-      push: inside-raw-docstring
+      push: raw-docstring-body
 
-  inside-docstring:
+  docstring-body:
     - meta_scope: comment.block.documentation.python
     - match: \2
       scope: punctuation.definition.comment.end.python
@@ -2084,7 +2084,7 @@ contexts:
     - include: escaped-unicode-chars
     - include: escaped-chars
 
-  inside-raw-docstring:
+  raw-docstring-body:
     - meta_scope: comment.block.documentation.python
     - match: \2
       scope: punctuation.definition.comment.end.python
@@ -2129,9 +2129,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-plain-raw-b-string
+      push: triple-double-quoted-plain-raw-b-string-body
 
-  inside-triple-double-quoted-plain-raw-b-string:
+  triple-double-quoted-plain-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2142,9 +2142,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-raw-b-string
+      push: triple-double-quoted-raw-b-string-body
 
-  inside-triple-double-quoted-raw-b-string:
+  triple-double-quoted-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2158,9 +2158,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-plain-raw-f-string
+      push: triple-double-quoted-plain-raw-f-string-body
 
-  inside-triple-double-quoted-plain-raw-f-string:
+  triple-double-quoted-plain-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2172,9 +2172,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-raw-f-string
+      push: triple-double-quoted-raw-f-string-body
 
-  inside-triple-double-quoted-raw-f-string:
+  triple-double-quoted-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2190,9 +2190,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-plain-raw-u-string
+      push: triple-double-quoted-plain-raw-u-string-body
 
-  inside-triple-double-quoted-plain-raw-u-string:
+  triple-double-quoted-plain-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2204,9 +2204,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-raw-u-string
+      push: triple-double-quoted-raw-u-string-body
 
-  inside-triple-double-quoted-raw-u-string:
+  triple-double-quoted-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2214,11 +2214,11 @@ contexts:
 
   triple-double-quoted-raw-u-string-syntax:
     - match: (?={{sql_indicator}})
-      set: inside-triple-double-quoted-sql-raw-u-string
+      set: triple-double-quoted-sql-raw-u-string-body
     - match: (?=\S)
-      set: inside-triple-double-quoted-regexp-raw-u-string
+      set: triple-double-quoted-regexp-raw-u-string-body
 
-  inside-triple-double-quoted-sql-raw-u-string:
+  triple-double-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: triple-double-quoted-string-end
@@ -2230,7 +2230,7 @@ contexts:
         - include: string-placeholders
         - include: string-replacements
 
-  inside-triple-double-quoted-regexp-raw-u-string:
+  triple-double-quoted-regexp-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2246,9 +2246,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-b-string
+      push: triple-double-quoted-b-string-body
 
-  inside-triple-double-quoted-b-string:
+  triple-double-quoted-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2263,9 +2263,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-f-string
+      push: triple-double-quoted-f-string-body
 
-  inside-triple-double-quoted-f-string:
+  triple-double-quoted-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2281,9 +2281,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
-      push: inside-triple-double-quoted-u-string
+      push: triple-double-quoted-u-string-body
 
-  inside-triple-double-quoted-u-string:
+  triple-double-quoted-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
@@ -2292,17 +2292,17 @@ contexts:
 
   triple-double-quoted-u-string-syntax:
     - match: (?={{sql_indicator}})
-      set: inside-triple-double-quoted-sql-u-strings
+      set: triple-double-quoted-sql-u-strings-body
     - match: (?=\S)
-      set: inside-double-quoted-plain-u-block-string
+      set: double-quoted-plain-u-block-string-body
 
-  inside-double-quoted-plain-u-block-string:
+  double-quoted-plain-u-block-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
     - include: triple-double-quoted-plain-u-string-content
 
-  inside-triple-double-quoted-sql-u-strings:
+  triple-double-quoted-sql-u-strings-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: triple-double-quoted-string-end
@@ -2351,9 +2351,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-plain-raw-b-string
+      push: double-quoted-plain-raw-b-string-body
 
-  inside-double-quoted-plain-raw-b-string:
+  double-quoted-plain-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2364,9 +2364,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-raw-b-string
+      push: double-quoted-raw-b-string-body
 
-  inside-double-quoted-raw-b-string:
+  double-quoted-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2380,9 +2380,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-plain-raw-f-string
+      push: double-quoted-plain-raw-f-string-body
 
-  inside-double-quoted-plain-raw-f-string:
+  double-quoted-plain-raw-f-string-body:
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - meta_include_prototype: false
     - include: double-quoted-string-end
@@ -2394,9 +2394,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-raw-f-string
+      push: double-quoted-raw-f-string-body
 
-  inside-double-quoted-raw-f-string:
+  double-quoted-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2412,9 +2412,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-plain-raw-u-string
+      push: double-quoted-plain-raw-u-string-body
 
-  inside-double-quoted-plain-raw-u-string:
+  double-quoted-plain-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2424,9 +2424,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-raw-u-string
+      push: double-quoted-raw-u-string-body
 
-  inside-double-quoted-raw-u-string:
+  double-quoted-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: double-quoted-string-end
@@ -2435,12 +2435,12 @@ contexts:
   double-quoted-raw-u-string-syntax:
     # Single-line raw string, unicode or not, starting with a SQL keyword
     - match: (?={{sql_indicator}})
-      set: inside-double-quoted-sql-raw-u-string
+      set: double-quoted-sql-raw-u-string-body
     # Single-line raw string, unicode or not, treated as regex
     - match: (?=\S)
-      set: inside-double-quoted-regexp-raw-u-string
+      set: double-quoted-regexp-raw-u-string-body
 
-  inside-double-quoted-regexp-raw-u-string:
+  double-quoted-regexp-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2449,7 +2449,7 @@ contexts:
       with_prototype:
         - include: double-quoted-string-pop
 
-  inside-double-quoted-sql-raw-u-string:
+  double-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: double-quoted-string-end
@@ -2466,9 +2466,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-b-string
+      push: double-quoted-b-string-body
 
-  inside-double-quoted-b-string:
+  double-quoted-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2482,9 +2482,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-f-string
+      push: double-quoted-f-string-body
 
-  inside-double-quoted-f-string:
+  double-quoted-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.double.python
     - include: double-quoted-string-end
@@ -2498,9 +2498,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
-      push: inside-double-quoted-u-string
+      push: double-quoted-u-string-body
 
-  inside-double-quoted-u-string:
+  double-quoted-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: double-quoted-string-end
@@ -2509,18 +2509,18 @@ contexts:
   double-quoted-u-string-syntax:
     # Single-line string, unicode or not, starting with a SQL keyword
     - match: (?={{sql_indicator}})
-      set: inside-double-quoted-sql-u-string
+      set: double-quoted-sql-u-string-body
     # Single-line string, unicode or not
     - match: (?=\S)
-      set: inside-double-quoted-plain-u-string
+      set: double-quoted-plain-u-string-body
 
-  inside-double-quoted-plain-u-string:
+  double-quoted-plain-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - include: double-quoted-u-string-content
 
-  inside-double-quoted-sql-u-string:
+  double-quoted-sql-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: double-quoted-string-end
@@ -2564,9 +2564,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-plain-raw-b-string
+      push: triple-single-quoted-plain-raw-b-string-body
 
-  inside-triple-single-quoted-plain-raw-b-string:
+  triple-single-quoted-plain-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2577,9 +2577,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-raw-b-string
+      push: triple-single-quoted-raw-b-string-body
 
-  inside-triple-single-quoted-raw-b-string:
+  triple-single-quoted-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2593,9 +2593,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-plain-raw-f-string
+      push: triple-single-quoted-plain-raw-f-string-body
 
-  inside-triple-single-quoted-plain-raw-f-string:
+  triple-single-quoted-plain-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2607,9 +2607,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-raw-f-string
+      push: triple-single-quoted-raw-f-string-body
 
-  inside-triple-single-quoted-raw-f-string:
+  triple-single-quoted-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2625,9 +2625,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-plain-raw-u-string
+      push: triple-single-quoted-plain-raw-u-string-body
 
-  inside-triple-single-quoted-plain-raw-u-string:
+  triple-single-quoted-plain-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2638,9 +2638,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-raw-u-string
+      push: triple-single-quoted-raw-u-string-body
 
-  inside-triple-single-quoted-raw-u-string:
+  triple-single-quoted-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2648,11 +2648,11 @@ contexts:
 
   triple-single-quoted-raw-u-string-syntax:
     - match: (?={{sql_indicator}})
-      set: inside-triple-single-quoted-sql-raw-u-string
+      set: triple-single-quoted-sql-raw-u-string-body
     - match: (?=\S)
-      set: inside-triple-single-quoted-regexp-raw-u-string
+      set: triple-single-quoted-regexp-raw-u-string-body
 
-  inside-triple-single-quoted-regexp-raw-u-string:
+  triple-single-quoted-regexp-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2662,7 +2662,7 @@ contexts:
         - include: triple-single-quoted-string-pop
         - include: escaped-unicode-chars
 
-  inside-triple-single-quoted-sql-raw-u-string:
+  triple-single-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: triple-single-quoted-string-end
@@ -2681,9 +2681,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-b-string
+      push: triple-single-quoted-b-string-body
 
-  inside-triple-single-quoted-b-string:
+  triple-single-quoted-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2698,9 +2698,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-f-string
+      push: triple-single-quoted-f-string-body
 
-  inside-triple-single-quoted-f-string:
+  triple-single-quoted-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2716,9 +2716,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
-      push: inside-triple-single-quoted-u-string
+      push: triple-single-quoted-u-string-body
 
-  inside-triple-single-quoted-u-string:
+  triple-single-quoted-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
@@ -2727,17 +2727,17 @@ contexts:
 
   triple-single-quoted-u-string-syntax:
     - match: (?={{sql_indicator}})
-      set: inside-triple-single-quoted-sql-u-string
+      set: triple-single-quoted-sql-u-string-body
     - match: (?=\S)
-      set: inside-single-quoted-plain-u-block-string
+      set: single-quoted-plain-u-block-string-body
 
-  inside-single-quoted-plain-u-block-string:
+  single-quoted-plain-u-block-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
     - include: triple-single-quoted-u-string-content
 
-  inside-triple-single-quoted-sql-u-string:
+  triple-single-quoted-sql-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: triple-single-quoted-string-end
@@ -2786,9 +2786,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-plain-raw-b-string
+      push: single-quoted-plain-raw-b-string-body
 
-  inside-single-quoted-plain-raw-b-string:
+  single-quoted-plain-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2799,9 +2799,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-raw-b-string
+      push: single-quoted-raw-b-string-body
 
-  inside-single-quoted-raw-b-string:
+  single-quoted-raw-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2816,9 +2816,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-plain-raw-u-string
+      push: single-quoted-plain-raw-u-string-body
 
-  inside-single-quoted-plain-raw-u-string:
+  single-quoted-plain-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2828,9 +2828,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-raw-u-string
+      push: single-quoted-raw-u-string-body
 
-  inside-single-quoted-raw-u-string:
+  single-quoted-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2839,12 +2839,12 @@ contexts:
   single-quoted-raw-u-string-syntax:
     # Single-line raw string, unicode or not, starting with a SQL keyword
     - match: (?={{sql_indicator}})
-      set: inside-single-quoted-sql-raw-u-string
+      set: single-quoted-sql-raw-u-string-body
     # Single-line raw string, unicode or not, treated as regex
     - match: (?=\S)
-      set: inside-single-quoted-regexp-raw-u-string
+      set: single-quoted-regexp-raw-u-string-body
 
-  inside-single-quoted-regexp-raw-u-string:
+  single-quoted-regexp-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2853,7 +2853,7 @@ contexts:
       with_prototype:
         - include: single-quoted-string-pop
 
-  inside-single-quoted-sql-raw-u-string:
+  single-quoted-sql-raw-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: single-quoted-string-end
@@ -2870,9 +2870,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-plain-raw-f-string
+      push: single-quoted-plain-raw-f-string-body
 
-  inside-single-quoted-plain-raw-f-string:
+  single-quoted-plain-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2884,9 +2884,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-raw-f-string
+      push: single-quoted-raw-f-string-body
 
-  inside-single-quoted-raw-f-string:
+  single-quoted-raw-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2902,9 +2902,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-b-string
+      push: single-quoted-b-string-body
 
-  inside-single-quoted-b-string:
+  single-quoted-b-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2918,9 +2918,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.interpolated.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-f-string
+      push: single-quoted-f-string-body
 
-  inside-single-quoted-f-string:
+  single-quoted-f-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.interpolated.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2934,9 +2934,9 @@ contexts:
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
-      push: inside-single-quoted-u-string
+      push: single-quoted-u-string-body
 
-  inside-single-quoted-u-string:
+  single-quoted-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
@@ -2945,18 +2945,18 @@ contexts:
   single-quoted-u-string-syntax:
     # Single-line string, unicode or not, starting with a SQL keyword
     - match: (?={{sql_indicator}})
-      set: inside-single-quoted-sql-u-string
+      set: single-quoted-sql-u-string-body
     # Single-line string, unicode or not
     - match: (?=\S)
-      set: inside-single-quoted-plain-u-string
+      set: single-quoted-plain-u-string-body
 
-  inside-single-quoted-plain-u-string:
+  single-quoted-plain-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
     - include: single-quoted-u-string-content
 
-  inside-single-quoted-sql-u-string:
+  single-quoted-sql-u-string-body:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python
     - include: single-quoted-string-end
@@ -3064,9 +3064,9 @@ contexts:
   string-replacement:
     - match: \{
       scope: punctuation.definition.placeholder.begin.python
-      set: inside-string-replacement
+      set: string-replacement-body
 
-  inside-string-replacement:
+  string-replacement-body:
     - meta_scope: constant.other.placeholder.python
     - match: \}
       scope: punctuation.definition.placeholder.end.python
@@ -3077,11 +3077,11 @@ contexts:
       scope: storage.modifier.conversion.python
     - match: ':'
       scope: punctuation.separator.format-spec.python
-      push: inside-string-replacement-formatspec
+      push: string-replacement-formatspec-body
     - match: '[{"''\n]'
       fail: string-replacement
 
-  inside-string-replacement-formatspec:
+  string-replacement-formatspec-body:
     - meta_content_scope: meta.format-spec.python constant.other.format-spec.python
     - match: (?=\})
       pop: 1
@@ -3196,7 +3196,7 @@ contexts:
     - match: \s*(\\)\s*$
       captures:
         1: punctuation.separator.continuation.line.python
-      push: inside-line-continuation
+      push: line-continuation-body
     - include: immediately-pop
 
   else-pop:
@@ -3216,9 +3216,9 @@ contexts:
     - match: (\\)\s*$
       captures:
         1: punctuation.separator.continuation.line.python
-      push: inside-line-continuation
+      push: line-continuation-body
 
-  inside-line-continuation:
+  line-continuation-body:
     - meta_include_prototype: false
     # This prevents strings after a continuation from being a docstring
     - include: strings

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -61,6 +61,8 @@ variables:
   augmented_assignment_operators: |-
     (?x: >>= | <<= | \*\*= | //= | \+= | -= | \*= | /= | %= | @= | &= | \|= | \^= )
 
+  assignment_operator: '=(?!=)'
+
   colon: ':(?!=)'
 
   sql_indicator: |-
@@ -601,7 +603,7 @@ contexts:
       scope: punctuation.separator.inheritance.python
     - include: illegal-name
     - include: constants
-    - match: (?:({{identifier}}) *)(=)
+    - match: ({{identifier}})\s*({{assignment_operator}})
       captures:
         1: variable.parameter.class-inheritance.python
         2: keyword.operator.assignment.python
@@ -668,7 +670,7 @@ contexts:
     - match: /
       scope: storage.modifier.positional-args-only.python
       push: function-parameter-expect-comma
-    - match: '='
+    - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
       set: function-parameter-default-value
     - match: '{{colon}}'
@@ -717,7 +719,7 @@ contexts:
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
     # default values should follow the argument
-    - match: '='
+    - match: '{{assignment_operator}}'
       push: function-parameter-illegal-annotation
     # python 2 does not support type annotations
     - match: '{{colon}}'
@@ -766,7 +768,7 @@ contexts:
     - match: '{{augmented_assignment_operators}}'
       scope: keyword.operator.assignment.augmented.python
       push: assignment-statement-value
-    - match: =(?!=)
+    - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
       push: assignment-statement-value
 
@@ -901,11 +903,11 @@ contexts:
     - include: case-pattern-expressions
 
   case-pattern-keyword-arguments:
-    - match: (?={{identifier}}\s*=(?!=))
+    - match: (?={{identifier}}\s*{{assignment_operator}})
       push: case-pattern-keyword-argument-name
 
   case-pattern-keyword-argument-name:
-    - match: =
+    - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
       set: allow-unpack-operators
     - include: parameter-names
@@ -1425,11 +1427,11 @@ contexts:
       push: allow-unpack-operators
 
   keyword-arguments:
-    - match: (?={{identifier}}\s*=(?!=))
+    - match: (?={{identifier}}\s*{{assignment_operator}})
       push: keyword-argument-name
 
   keyword-argument-name:
-    - match: =
+    - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
       set:
         - keyword-argument-value
@@ -1500,7 +1502,7 @@ contexts:
     - match: ','
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
-    - match: '='
+    - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
       push:
         - keyword-argument-value
@@ -1794,7 +1796,7 @@ contexts:
       scope: keyword.operator.arithmetic.python
     - match: <=|>=|==|\!=|<|>
       scope: keyword.operator.comparison.python
-    - match: =(?!=)
+    - match: =
       scope: invalid.illegal.assignment.python
     - match: (?:and|in|is|not|or)\b
       comment: keyword operators that evaluate to True or False

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1303,15 +1303,6 @@ contexts:
     - include: illegal-name
     - include: qualified-name
     - include: assignment-expressions
-    - match: '(\.) *(?={{identifier}})'
-      captures:
-        1: punctuation.accessor.dot.python
-      push:
-        - include: magic-function-names
-        - include: magic-variable-names
-        - include: illegal-names
-        - include: generic-names
-        - include: immediately-pop
 
   after-expression:
     - match: \s*(?=\()

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -674,9 +674,7 @@ contexts:
       scope: punctuation.separator.annotation.parameter.python
       set: function-parameter-annotation
     - include: function-parameter-tuples
-    - include: illegal-names
-    - match: '{{identifier}}'
-      scope: variable.parameter.python
+    - include: parameter-names
     - include: line-continuation
 
   function-parameter-expect-comma:
@@ -722,9 +720,7 @@ contexts:
     # python 2 does not support type annotations
     - match: ':'
       push: function-parameter-illegal-default-value
-    - include: illegal-names
-    - match: '{{identifier}}'
-      scope: variable.parameter.python
+    - include: parameter-names
     - include: line-continuation
 
   function-parameter-illegal-annotation:
@@ -897,14 +893,19 @@ contexts:
     - match: \)
       scope: punctuation.section.arguments.end.python
       pop: 1
-    - match: (?:({{illegal_names}})|({{identifier}}))\s*(=)
-      captures:
-        1: invalid.illegal.name.python
-        2: variable.parameter.python
-        3: keyword.operator.assignment.python
-      push: allow-unpack-operators
     - include: argument-separators
+    - include: case-pattern-keyword-arguments
     - include: case-pattern-expressions
+
+  case-pattern-keyword-arguments:
+    - match: (?={{identifier}}\s*=(?!=))
+      push: case-pattern-keyword-argument-name
+
+  case-pattern-keyword-argument-name:
+    - match: =
+      scope: keyword.operator.assignment.python
+      set: allow-unpack-operators
+    - include: parameter-names
 
   case-pattern-operators:
     - match: '[-+]'
@@ -1425,10 +1426,10 @@ contexts:
   keyword-argument-name:
     - match: =
       scope: keyword.operator.assignment.python
-      set: keyword-argument-value
-    - include: illegal-names
-    - match: '{{identifier}}'
-      scope: variable.parameter.python
+      set:
+        - keyword-argument-value
+        - allow-unpack-operators
+    - include: parameter-names
 
   keyword-argument-value:
     - match: (?=[,)]|:(?!=))
@@ -1494,12 +1495,14 @@ contexts:
     - match: ','
       scope: punctuation.separator.parameters.python
       push: allow-unpack-operators
-    - include: line-continuation-or-pop
-    - include: keyword-arguments
+    - match: '='
+      scope: keyword.operator.assignment.python
+      push:
+        - keyword-argument-value
+        - allow-unpack-operators
     - include: function-parameter-tuples
-    - include: illegal-names
-    - match: '{{identifier}}'
-      scope: variable.parameter.python
+    - include: parameter-names
+    - include: line-continuation-or-pop
     - match: \S
       scope: invalid.illegal.expected-parameter.python
 
@@ -1931,6 +1934,11 @@ contexts:
   class-variables:
     - match: (?:self|cls)\b
       scope: variable.language.python
+
+  parameter-names:
+    - include: illegal-names
+    - match: '{{identifier}}'
+      scope: variable.parameter.python
 
   wildcard-variables:
     - match: _(?!{{identifier_continue}})

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -385,15 +385,11 @@ contexts:
       set:
         - meta_scope: meta.qualified-name.python
         - meta_content_scope: variable.annotation.python
-        - include: dotted-name-specials
-        - include: generic-names
-        - include: immediately-pop
+        - include: dotted-name-content
     - match: ''
       set:
         - meta_scope: meta.qualified-name.python variable.annotation.python
-        - include: name-specials
-        - include: generic-names
-        - include: immediately-pop
+        - include: name-content
 
   decorator-function-call-wrapper:
     - meta_scope: meta.annotation.function.python
@@ -409,9 +405,7 @@ contexts:
       push:
         - meta_scope: meta.qualified-name.python
         - meta_content_scope: variable.annotation.function.python
-        - include: dotted-name-specials
-        - include: generic-names
-        - include: immediately-pop
+        - include: dotted-name-content
     - match: ''
       push:
         - meta_scope: meta.qualified-name.python variable.annotation.function.python
@@ -1391,9 +1385,7 @@ contexts:
       push:
         - meta_scope: meta.qualified-name.python
         - meta_content_scope: variable.function.python
-        - include: dotted-name-specials
-        - include: generic-names
-        - include: immediately-pop
+        - include: dotted-name-content
     - match: (?={{identifier}})
       push:
         - meta_scope: meta.qualified-name.python variable.function.python
@@ -1830,26 +1822,13 @@ contexts:
 
 ###[ IDENTIFIERS ]############################################################
 
-  builtin-exceptions:
-    - match: '{{builtin_exceptions}}'
-      scope: support.type.exception.python
-
-  builtin-functions:
-    - match: '{{builtin_functions}}'
-      scope: support.function.builtin.python
-
-  builtin-types:
-    - match: '{{builtin_types}}'
-      scope: support.type.python
-
   name:
     - match: (?={{identifier}})
       push: name-content
 
   name-content:
     - include: name-specials
-    - match: '{{identifier_constant}}'
-      scope: variable.other.constant.python
+    - include: constant-names
     - include: generic-names
     - include: immediately-pop
 
@@ -1861,8 +1840,7 @@ contexts:
 
   dotted-name-content:
     - include: dotted-name-specials
-    - match: '{{identifier_constant}}'
-      scope: variable.other.constant.python
+    - include: constant-names
     - include: generic-names
     - include: immediately-pop
 
@@ -1885,41 +1863,61 @@ contexts:
     - meta_scope: meta.qualified-name.python
     # If a line continuation follows, this may or may not be the last leaf (most likley not though)
     - match: (?={{identifier}}\s*(\.|\\))
-      push:
-        - include: name-specials
-        - include: generic-names
-        - include: immediately-pop
+      push: name-content
     - match: (\.)\s*(?={{identifier}}\s*(\.|\\))
       captures:
         1: punctuation.accessor.dot.python
-      push:
-        - include: dotted-name-specials
-        - include: generic-names
-        - include: immediately-pop
+      push: dotted-name-content
     - match: \.(?!\s*{{identifier}})  # don't match last dot
       scope: punctuation.accessor.dot.python
     - match: (?=\S|$)
       pop: 1
 
   name-specials:
+    - include: builtin-exceptions
     - include: builtin-functions
     - include: builtin-types
-    - include: builtin-exceptions
-    - include: illegal-names
-    - include: magic-function-names
-    - include: magic-variable-names
+    - include: magic-functions
+    - include: magic-variables
     - include: class-variables
     - include: wildcard-variables
+    - include: illegal-names
 
   dotted-name-specials:
-    - include: magic-function-names
-    - include: magic-variable-names
+    - include: magic-functions
+    - include: magic-variables
     - include: illegal-names
 
-  entity-name-function:
-    - include: magic-function-names
-    - include: illegal-names
-    - include: generic-names
+  builtin-exceptions:
+    - match: '{{builtin_exceptions}}'
+      scope: support.type.exception.python
+
+  builtin-functions:
+    - match: '{{builtin_functions}}'
+      scope: support.function.builtin.python
+
+  builtin-types:
+    - match: '{{builtin_types}}'
+      scope: support.type.python
+
+  magic-functions:
+    # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
+    # https://docs.python.org/2/reference/datamodel.html
+    # https://docs.python.org/3/reference/datamodel.html
+    - match: '{{magic_functions}}'
+      scope: support.function.magic.python
+
+  magic-variables:
+    # magic variables which a class/module/object may have.
+    # https://docs.python.org/3/library/inspect.html#types-and-members
+    # https://docs.python.org/3/reference/datamodel.html#object.__slots__
+    # https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
+    - match: '{{magic_variables}}'
+      scope: support.variable.magic.python
+
+  constant-names:
+    - match: '{{identifier_constant}}'
+      scope: variable.other.constant.python
 
   generic-names:
     - match: '{{identifier}}'
@@ -1956,21 +1954,6 @@ contexts:
     - match: _(?!{{identifier_continue}})
       scope: variable.language.anonymous.python
       pop: 1
-
-  magic-function-names:
-    # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
-    # https://docs.python.org/2/reference/datamodel.html
-    # https://docs.python.org/3/reference/datamodel.html
-    - match: '{{magic_functions}}'
-      scope: support.function.magic.python
-
-  magic-variable-names:
-    # magic variables which a class/module/object may have.
-    # https://docs.python.org/3/library/inspect.html#types-and-members
-    # https://docs.python.org/3/reference/datamodel.html#object.__slots__
-    # https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
-    - match: '{{magic_variables}}'
-      scope: support.variable.magic.python
 
 ###[ LITERALS ]###############################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -201,6 +201,15 @@ contexts:
       scope: punctuation.terminator.statement.python
     - include: expression-as-a-statement
 
+  block-statements:
+    - include: case-statements
+    - include: conditional-statements
+    - include: exception-statements
+    - include: for-statements
+    - include: match-statements
+    - include: while-statements
+    - include: with-statements
+
   line-statements:
     - include: imports
     - include: decorators
@@ -237,7 +246,7 @@ contexts:
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
 
-###[ IMPORTS ]################################################################
+###[ IMPORT STATEMENTS ]######################################################
 
   imports:
     - match: \bimport\b
@@ -383,97 +392,6 @@ contexts:
       scope: meta.import-path.python keyword.control.import.relative.python
     - match: (?=\S)
       pop: true
-
-###[ STATEMENTS ]#############################################################
-
-  block-statements:
-    # async for ... in ...:
-    - match: \b(async +)?(for)\b
-      captures:
-        1: storage.modifier.async.python
-        2: keyword.control.loop.for.python
-      push:
-        - meta_scope: meta.statement.loop.for.python
-        - include: line-continuation-or-pop
-        - match: \bin\b
-          scope: keyword.control.loop.for.in.python
-          set:
-            - meta_content_scope: meta.statement.loop.for.python
-            - include: line-continuation-or-pop
-            - match: ':(?!=)'
-              scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
-              pop: true
-            - include: expression-in-a-statement
-        - match: ':(?!=)'
-          scope: invalid.illegal.missing-in.python
-          pop: true
-        - include: target-lists
-    # async with ... as ...:
-    - include: with-statements
-    # except ... as ...:
-    - match: \bexcept\b
-      scope: keyword.control.exception.catch.python
-      push:
-        - meta_scope: meta.statement.exception.catch.python
-        - include: line-continuation-or-pop
-        - match: ':(?!=)'
-          scope: punctuation.section.block.exception.catch.python
-          pop: true
-        - match: '\bas\b'
-          scope: keyword.control.exception.catch.as.python
-          set:
-            - meta_content_scope: meta.statement.exception.catch.python
-            - include: line-continuation-or-pop
-            - match: ':'
-              scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
-              pop: true
-            - include: name
-        - include: target-lists
-    - match: \bif\b
-      scope: keyword.control.conditional.if.python
-      push:
-        - meta_scope: meta.statement.conditional.if.python
-        - include: line-continuation-or-pop
-        - match: ':(?!=)'
-          scope: punctuation.section.block.conditional.if.python
-          pop: true
-        - include: expression-in-a-statement
-    - match: \bwhile\b
-      scope: keyword.control.loop.while.python
-      push:
-        - meta_scope: meta.statement.loop.while.python
-        - include: line-continuation-or-pop
-        - match: ':(?!=)'
-          scope: punctuation.section.block.loop.while.python
-          pop: true
-        - include: expression-in-a-statement
-    - match: \b(else)\b(?:\s*(:))?
-      scope: meta.statement.conditional.else.python
-      captures:
-        1: keyword.control.conditional.else.python
-        2: punctuation.section.block.conditional.else.python
-    - match: \b(try)\b(?:\s*(:))?
-      scope: meta.statement.exception.try.python
-      captures:
-        1: keyword.control.exception.try.python
-        2: punctuation.section.block.exception.try.python
-    - match: \b(finally)\b(?:\s*(:))?
-      scope: meta.statement.exception.finally.python
-      captures:
-        1: keyword.control.exception.finally.python
-        2: punctuation.section.block.exception.finally.python
-    - match: \belif\b
-      scope: keyword.control.conditional.elseif.python
-      push:
-        - meta_scope: meta.statement.conditional.elseif.python
-        - match: ':(?!=)'
-          scope: punctuation.section.block.conditional.elseif.python
-          pop: true
-        - match: $\n?
-          pop: true
-        - include: expression-in-a-statement
-    - include: case-statements
-    - include: match-statements
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -694,6 +612,101 @@ contexts:
       pop: true
     - include: case-pattern-expressions
 
+###[ CONDITIONAL STATEMENTS ]#################################################
+
+  conditional-statements:
+    - match: \bif\b
+      scope: keyword.control.conditional.if.python
+      push: if-statement-condition
+    - match: \belif\b
+      scope: keyword.control.conditional.elseif.python
+      push: elif-statement-condition
+    - match: \b(else)\b(?:\s*(:))?
+      scope: meta.statement.conditional.else.python
+      captures:
+        1: keyword.control.conditional.else.python
+        2: punctuation.section.block.conditional.else.python
+
+  if-statement-condition:
+    - meta_scope: meta.statement.conditional.if.python
+    - match: ':(?!=)'
+      scope: punctuation.section.block.conditional.if.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
+  elif-statement-condition:
+    - meta_scope: meta.statement.conditional.elseif.python
+    - match: ':(?!=)'
+      scope: punctuation.section.block.conditional.elseif.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
+###[ EXCEPTION STATEMENTS ]###################################################
+
+  exception-statements:
+    - match: \b(try)\b(?:\s*(:))?
+      scope: meta.statement.exception.try.python
+      captures:
+        1: keyword.control.exception.try.python
+        2: punctuation.section.block.exception.try.python
+    - match: \b(finally)\b(?:\s*(:))?
+      scope: meta.statement.exception.finally.python
+      captures:
+        1: keyword.control.exception.finally.python
+        2: punctuation.section.block.exception.finally.python
+    - match: \bexcept\b
+      scope: keyword.control.exception.catch.python
+      push: except-statement-exception-list
+
+  except-statement-exception-list:
+    - meta_scope: meta.statement.exception.catch.python
+    - match: ':(?!=)'
+      scope: punctuation.section.block.exception.catch.python
+      pop: true
+    - match: \bas\b
+      scope: keyword.control.exception.catch.as.python
+      set: except-statement-as
+    - include: line-continuation-or-pop
+    - include: target-lists
+
+  except-statement-as:
+    - meta_content_scope: meta.statement.exception.catch.python
+    - match: ':'
+      scope: meta.statement.exception.catch.python punctuation.section.block.exception.catch.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: name
+
+###[ FOR STATEMENTS ]#########################################################
+
+  for-statements:
+    - match: \b(?:(async)\s+)?(for)\b
+      captures:
+        1: storage.modifier.async.python
+        2: keyword.control.loop.for.python
+      push: for-statement-target-list
+
+  for-statement-target-list:
+    - meta_scope: meta.statement.loop.for.python
+    - match: ':(?!=)'
+      scope: invalid.illegal.missing-in.python
+      pop: true
+    - match: \bin\b
+      scope: keyword.control.loop.for.in.python
+      set: for-statement-in
+    - include: line-continuation-or-pop
+    - include: target-lists
+
+  for-statement-in:
+    - meta_content_scope: meta.statement.loop.for.python
+    - match: ':(?!=)'
+      scope: meta.statement.loop.for.python punctuation.section.block.loop.for.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
 ###[ MATCH STATEMENTS ]#######################################################
 
   match-statements:
@@ -757,10 +770,25 @@ contexts:
         - qualified-name-until-leaf
     - include: generic-name
 
+###[ WHILE STATEMENTS ]#######################################################
+
+  while-statements:
+    - match: \bwhile\b
+      scope: keyword.control.loop.while.python
+      push: while-statement-condition
+
+  while-statement-condition:
+    - meta_scope: meta.statement.loop.while.python
+    - match: ':(?!=)'
+      scope: punctuation.section.block.loop.while.python
+      pop: true
+    - include: line-continuation-or-pop
+    - include: expression-in-a-statement
+
 ###[ WITH STATEMENTS ]########################################################
 
   with-statements:
-    - match: \b(?:(async) +)?(with)\b
+    - match: \b(?:(async)\s+)?(with)\b
       captures:
         1: storage.modifier.async.python
         2: keyword.control.flow.with.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -216,6 +216,78 @@ contexts:
     - include: flow-statements
     - include: other-statements
 
+###[ DECORATORS ]#############################################################
+
+  decorators:
+    - match: ^\s*(?=@)
+      push: decorator-body
+
+  decorator-body:
+    # Due to line continuations, we don't know whether this is a "function call" yet
+    - meta_content_scope: meta.annotation.python
+    - include: line-continuation-or-pop
+    - match: (?=\.?\s*{{path}}\s*\() # now we do
+      set: [after-expression, decorator-function-call-wrapper, qualified-name-until-leaf]
+    - match: (?=\.?\s*{{path}})
+      push: [decorator-wrapper, qualified-name-until-leaf]
+    - match: '@'
+      scope: punctuation.definition.annotation.python
+    - match: \S
+      scope: invalid.illegal.character.python
+      pop: true
+
+  decorator-wrapper:
+    - match: (\.)\s*
+      captures:
+        1: punctuation.accessor.dot.python
+      set:
+        - meta_scope: meta.qualified-name.python
+        - meta_content_scope: variable.annotation.python
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: ''
+      set:
+        - meta_scope: meta.qualified-name.python variable.annotation.python
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+
+  decorator-function-call-wrapper:
+    - meta_scope: meta.annotation.function.python
+    - match: \)
+      scope: punctuation.section.arguments.end.python
+      pop: true
+    - match: \(
+      scope: meta.annotation.function.python punctuation.section.arguments.begin.python
+      push: [decorator-function-call-arguments, allow-unpack-operators]
+    - match: (\.)\s*
+      captures:
+        1: punctuation.accessor.dot.python
+      push:
+        - meta_scope: meta.qualified-name.python
+        - meta_content_scope: variable.annotation.function.python
+        - include: dotted-name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+    - match: ''
+      push:
+        - meta_scope: meta.qualified-name.python variable.annotation.function.python
+        - include: name-specials
+        - include: generic-names
+        - match: ''
+          pop: true
+
+  decorator-function-call-arguments:
+    - clear_scopes: 1
+    - meta_content_scope: meta.annotation.arguments.python
+    - match: (?=\))
+      pop: true
+    - include: arguments
+
 ###[ IMPORT STATEMENTS ]######################################################
 
   import-statements:
@@ -1329,76 +1401,6 @@ contexts:
       scope: meta.function.python punctuation.section.function.begin.python
       pop: true
     - include: line-continuation-or-pop
-
-  decorators:
-    - match: ^\s*(?=@)
-      push:
-        # Due to line continuations, we don't know whether this is a "function call" yet
-        - meta_content_scope: meta.annotation.python
-        - match: '@'
-          scope: punctuation.definition.annotation.python
-        - match: $
-          pop: true
-        - include: line-continuation-or-pop
-        - match: (?=\.?\s*{{path}}\s*\() # now we do
-          set: [after-expression, decorator-function-call-wrapper, qualified-name-until-leaf]
-        - match: (?=\.?\s*{{path}})
-          push: [decorator-wrapper, qualified-name-until-leaf]
-        - match: \S
-          scope: invalid.illegal.character.python
-          pop: true
-
-  decorator-wrapper:
-    - match: (\.)\s*
-      captures:
-        1: punctuation.accessor.dot.python
-      set:
-        - meta_scope: meta.qualified-name.python
-        - meta_content_scope: variable.annotation.python
-        - include: dotted-name-specials
-        - include: generic-names
-        - match: ''
-          pop: true
-    - match: ''
-      set:
-        - meta_scope: meta.qualified-name.python variable.annotation.python
-        - include: name-specials
-        - include: generic-names
-        - match: ''
-          pop: true
-
-  decorator-function-call-wrapper:
-    - meta_scope: meta.annotation.function.python
-    - match: \)
-      scope: punctuation.section.arguments.end.python
-      pop: true
-    - match: \(
-      scope: meta.annotation.function.python punctuation.section.arguments.begin.python
-      push: [decorator-function-call-arguments, allow-unpack-operators]
-    - match: (\.)\s*
-      captures:
-        1: punctuation.accessor.dot.python
-      push:
-        - meta_scope: meta.qualified-name.python
-        - meta_content_scope: variable.annotation.function.python
-        - include: dotted-name-specials
-        - include: generic-names
-        - match: ''
-          pop: true
-    - match: ''
-      push:
-        - meta_scope: meta.qualified-name.python variable.annotation.function.python
-        - include: name-specials
-        - include: generic-names
-        - match: ''
-          pop: true
-
-  decorator-function-call-arguments:
-    - clear_scopes: 1
-    - meta_content_scope: meta.annotation.arguments.python
-    - match: (?=\))
-      pop: true
-    - include: arguments
 
   item-access:
     - match: '(?={{path}}\s*\[)'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2159,9 +2159,7 @@ contexts:
 
   triple-double-quoted-string-end:
     - match: '"""'
-      scope:
-        meta.string.python string.quoted.double.block.python
-        punctuation.definition.string.end.python
+      scope: meta.string.python string.quoted.double.block.python punctuation.definition.string.end.python
       set: after-expression
 
   triple-double-quoted-string-pop:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -472,11 +472,11 @@ contexts:
       scope: meta.import-path.python invalid.illegal.name.python
     - match: '{{identifier}}'
       scope: meta.import-path.python meta.import-name.python
-    - match: \s*(\.) *(?={{identifier}}|$)
+    - match: \s*(\.)\s*(?={{identifier}}|$)
       scope: meta.import-path.python
       captures:
         1: punctuation.accessor.dot.python
-    - match: \s*(\. *\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
+    - match: \s*(\.\s*\S+) # matches and consumes the remainder of "abc.123" or "abc.+"
       scope: meta.import-path.python
       captures:
         1: invalid.illegal.name.python
@@ -618,7 +618,7 @@ contexts:
       captures:
         1: variable.parameter.class-inheritance.python
         2: keyword.operator.assignment.python
-    - match: (?={{identifier}} *\.)
+    - match: (?={{identifier}}\s*\.)
       push: qualified-base-class-name
     - match: '{{identifier}}'
       scope: entity.other.inherited-class.python
@@ -626,7 +626,7 @@ contexts:
 
   qualified-base-class-name:
     - meta_scope: meta.path.python
-    - match: '({{identifier}}) *(\.) *'
+    - match: '({{identifier}})\s*(\.)\s*'
       captures:
         1: variable.namespace.python
         2: punctuation.accessor.dot.python
@@ -1346,9 +1346,9 @@ contexts:
   other-statements:
     - match: del\b
       scope: keyword.other.del.python
-    - match: exec\b(?! *($|[,.()\]}]))
+    - match: exec\b(?!\s*($|[,.()\]}]))
       scope: keyword.other.exec.python
-    - match: print\b(?! *([,.()\]}]))
+    - match: print\b(?!\s*([,.()\]}]))
       scope: keyword.other.print.python
 
 ###[ FOR EXPRESSIONS ]########################################################

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -244,7 +244,7 @@ contexts:
     - include: line-statements
     - include: block-statements
     - include: class-definitions
-    - include: functions
+    - include: function-definitions
     - include: modifiers
     - include: assignments
     - match: ;
@@ -565,6 +565,149 @@ contexts:
     - meta_content_scope: meta.class.python
     - match: ':'
       scope: meta.class.python punctuation.section.class.begin.python
+      pop: true
+    - include: line-continuation-or-pop
+
+###[ FUNCTION DEFINITIONS ]###################################################
+
+  function-definitions:
+    - match: ^\s*(?:(async)\s+)?(def)\b
+      captures:
+        1: keyword.declaration.async.python
+        2: keyword.declaration.function.python
+      push: function-definition-name
+
+  function-definition-name:
+    - meta_scope: meta.function.python
+    - match: (?=\()
+      set: function-parameter-list
+    - include: illegal-names
+    - match: '{{magic_functions}}'
+      scope: entity.name.function.python support.function.magic.python
+    - match: '{{identifier}}'
+      scope: entity.name.function.python
+    - include: function-definition-end
+
+  function-parameter-list:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.parameters.begin.python
+      set:
+        - inside-function-parameter-list
+        - allow-unpack-operators
+
+  inside-function-parameter-list:
+    - meta_scope: meta.function.parameters.python
+    - match: \)
+      scope: punctuation.section.parameters.end.python
+      set: function-after-parameters
+    - match: ','
+      scope: punctuation.separator.parameters.python
+      push: allow-unpack-operators
+    - match: /
+      scope: storage.modifier.positional-args-only.python
+      push: function-parameter-expect-comma
+    - match: (?==)
+      set:
+        - meta_include_prototype: false
+        - match: '='
+          scope: keyword.operator.assignment.python
+          set: function-parameter-default-value
+    - match: (?=:)
+      set:
+        - meta_include_prototype: false
+        - match: ':'
+          scope: punctuation.separator.annotation.parameter.python
+          set: function-parameter-annotation
+    - include: function-parameter-tuples
+    - include: illegal-names
+    - match: '{{identifier}}'
+      scope: variable.parameter.python
+    - include: line-continuation
+
+  function-parameter-expect-comma:
+    - meta_include_prototype: false
+    - include: comments
+    - match: (?=[,)])
+      pop: true
+    - match: '[^\s,)]+'
+      scope: invalid.illegal.expected-comma.python
+
+  function-parameter-annotation:
+    - meta_scope: meta.function.parameters.annotation.python
+    - match: (?=[,)=])
+      set: inside-function-parameter-list
+    - match: \bNone\b
+      scope: constant.language.null.python
+    - include: illegal-assignment-expression
+    - include: expression-in-a-group
+
+  function-parameter-default-value:
+    - meta_scope: meta.function.parameters.default-value.python
+    - match: (?=[,)])
+      set: inside-function-parameter-list
+    - include: illegal-assignment-expression
+    - include: expression-in-a-group
+
+  function-parameter-tuples:
+    # python 2 style tuple arguments
+    # removed from python 3 since PEP-3113
+    - match: \(
+      scope: punctuation.section.group.begin.python
+      push: inside-function-parameter-tuple
+
+  inside-function-parameter-tuple:
+    - meta_scope: meta.group.python
+    - match: \)
+      scope: punctuation.section.group.end.python
+      set: after-expression
+    - match: ','
+      scope: punctuation.separator.parameters.python
+      push: allow-unpack-operators
+    # default values should follow the argument
+    - match: '='
+      push: function-parameter-illegal-annotation
+    # python 2 does not support type annotations
+    - match: ':'
+      push: function-parameter-illegal-default-value
+    - include: illegal-names
+    - match: '{{identifier}}'
+      scope: variable.parameter.python
+    - include: line-continuation
+
+  function-parameter-illegal-annotation:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.default-value.python
+    - match: (?=[,)=])
+      pop: true
+
+  function-parameter-illegal-default-value:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.annotation.python
+    - match: (?=[,)=])
+      pop: true
+
+  function-after-parameters:
+    - meta_content_scope: meta.function.python
+    - match: (?=->)
+      set: [function-return-type, function-return-type-separator]
+    - include: function-definition-end
+
+  function-return-type:
+    - meta_content_scope: meta.function.annotation.return.python
+    - include: illegal-assignment-expression
+    - include: function-definition-end
+    - include: expression-in-a-statement
+
+  function-return-type-separator:
+    - meta_include_prototype: false
+    - match: ->
+      scope: punctuation.separator.annotation.return.python
+      pop: true
+
+  function-definition-end:
+    - match: ':'
+      scope: meta.function.python punctuation.section.function.begin.python
       pop: true
     - include: line-continuation-or-pop
 
@@ -1345,126 +1488,6 @@ contexts:
     - match: ^(?!\s*[#*])
       pop: true
 
-  functions:
-    - match: '^\s*(?:(async)\s+)?(def)\b'
-      captures:
-        1: keyword.declaration.async.python
-        2: keyword.declaration.function.python
-      push:
-        - meta_scope: meta.function.python
-        - include: line-continuation-or-pop
-        - match: ':'
-          scope: punctuation.section.function.begin.python
-          pop: true
-        - match: "(?={{identifier}})"
-          push:
-            - meta_content_scope: entity.name.function.python
-            - include: entity-name-function
-            - include: immediately-pop
-        - match: '(?=\()'
-          set:
-            - match: \(
-              scope: meta.function.parameters.python punctuation.section.parameters.begin.python
-              set: [function-parameters, allow-unpack-operators]
-
-  function-parameters:
-    - meta_content_scope: meta.function.parameters.python
-    - match: \)
-      scope: punctuation.section.parameters.end.python
-      set: function-after-parameters
-    - include: comments
-    - match: ','
-      scope: punctuation.separator.parameters.python
-      push: allow-unpack-operators
-    - match: /
-      scope: storage.modifier.positional-args-only.python
-      push:
-        - match: (?=[,)])
-          pop: true
-        - match: \S
-          scope: invalid.illegal.expected-comma.python
-    - match: '(?==)'
-      set:
-        - match: '='
-          scope: keyword.operator.assignment.python
-          set:
-            - meta_scope: meta.function.parameters.default-value.python
-            - match: '(?=[,)])'
-              set: [function-parameters, allow-unpack-operators]
-            - include: illegal-assignment-expression
-            - include: expression-in-a-group
-    - match: '(?=:)'
-      set:
-        - match: ':'
-          scope: punctuation.separator.annotation.parameter.python
-          set:
-            - meta_scope: meta.function.parameters.annotation.python
-            - match: '(?=[,)=])'
-              set: function-parameters
-            - match: \bNone\b
-              scope: constant.language.null.python
-            - include: illegal-assignment-expression
-            - include: expression-in-a-group
-    - include: function-parameters-tuple
-    - include: illegal-names
-    - match: '{{identifier}}'
-      scope: variable.parameter.python
-    - include: line-continuation
-
-  function-parameters-tuple:
-    # python 2 style tuple arguments
-    # removed from python 3 since PEP-3113
-    - match: \(
-      scope: punctuation.section.group.begin.python
-      push:
-        - meta_scope: meta.group.python
-        - match: \)
-          scope: punctuation.section.group.end.python
-          set: after-expression
-        - include: comments
-        - match: ','
-          scope: punctuation.separator.parameters.python
-          push: allow-unpack-operators
-        # default values should follow the argument
-        - match: '='
-          push:
-            - meta_scope: invalid.illegal.default-value.python
-            - match: '(?=[,)=])'
-              pop: true
-        # python 2 does not support type annotations
-        - match: '(?=:)'
-          push:
-            - meta_scope: invalid.illegal.annotation.python
-            - match: '(?=[,)=])'
-              pop: true
-        - include: illegal-names
-        - match: '{{identifier}}'
-          scope: variable.parameter.python
-        - include: line-continuation
-
-  function-after-parameters:
-    - meta_content_scope: meta.function.python
-    - match: (?=->)
-      set: [function-return-type, function-return-type-separator]
-    - include: function-terminator
-
-  function-return-type:
-    - meta_content_scope: meta.function.annotation.return.python
-    - include: illegal-assignment-expression
-    - include: function-terminator
-    - include: expression-in-a-statement
-
-  function-return-type-separator:
-    - match: ->
-      scope: punctuation.separator.annotation.return.python
-      pop: true
-
-  function-terminator:
-    - match: ':'
-      scope: meta.function.python punctuation.section.function.begin.python
-      pop: true
-    - include: line-continuation-or-pop
-
   item-access:
     - match: '(?={{path}}\s*\[)'
       push:
@@ -1601,7 +1624,7 @@ contexts:
       push: allow-unpack-operators
     - include: line-continuation-or-pop
     - include: keyword-arguments
-    - include: function-parameters-tuple
+    - include: function-parameter-tuples
     - include: illegal-names
     - match: '{{identifier}}'
       scope: variable.parameter.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2110,30 +2110,82 @@ contexts:
 ###[ DOCSTRINGS ]#############################################################
 
   docstrings:
-    - match: ^\s*(?i)(u)?("""|''')
-      captures:
-        1: storage.type.string.python
-        2: punctuation.definition.comment.begin.python
-      push: docstring-body
-    - match: ^\s*(?i)(ur|ru?)("""|''')
-      captures:
-        1: storage.type.string.python
-        2: punctuation.definition.comment.begin.python
-      push: raw-docstring-body
+    - include: double-quoted-docstrings
+    - include: single-quoted-docstrings
 
-  docstring-body:
-    - meta_scope: comment.block.documentation.python
-    - match: \2
-      scope: punctuation.definition.comment.end.python
+  double-quoted-docstrings:
+    - match: ^\s*(?i)(u)?(""")
+      captures:
+        1: storage.type.string.python
+        2: comment.block.documentation.python punctuation.definition.comment.begin.python
+      push:
+        - double-quoted-docstring-summery
+        - else-pop
+    - match: ^\s*(?i)(ur|ru?)(""")
+      captures:
+        1: storage.type.string.python
+        2: comment.block.documentation.python punctuation.definition.comment.begin.python
+      push:
+        - double-quoted-docstring-summery
+        - else-pop
+
+  double-quoted-docstring-summery:
+    - meta_content_scope: comment.block.documentation.summary.python
+    - match: $
+      set: double-quoted-docstring-body
+    - include: double-quoted-docstring-end
+
+  double-quoted-docstring-end:
+    - match: '"""'
+      scope: comment.block.documentation.python punctuation.definition.comment.end.python
       pop: 1
+
+  double-quoted-docstring-body:
+    - meta_content_scope: comment.block.documentation.python
+    - include: double-quoted-docstring-end
     - include: escaped-unicode-chars
     - include: escaped-chars
 
-  raw-docstring-body:
-    - meta_scope: comment.block.documentation.python
-    - match: \2
-      scope: punctuation.definition.comment.end.python
+  double-quoted-raw-docstring-body:
+    - meta_content_scope: comment.block.documentation.python
+    - include: double-quoted-docstring-end
+
+  single-quoted-docstrings:
+    - match: ^\s*(?i)(u)?(''')
+      captures:
+        1: storage.type.string.python
+        2: comment.block.documentation.python punctuation.definition.comment.begin.python
+      push:
+        - single-quoted-docstring-summery
+        - else-pop
+    - match: ^\s*(?i)(ur|ru?)(''')
+      captures:
+        1: storage.type.string.python
+        2: comment.block.documentation.python punctuation.definition.comment.begin.python
+      push:
+        - single-quoted-docstring-summery
+        - else-pop
+
+  single-quoted-docstring-end:
+    - match: "'''"
+      scope: comment.block.documentation.python punctuation.definition.comment.end.python
       pop: 1
+
+  single-quoted-docstring-summery:
+    - meta_content_scope: comment.block.documentation.summary.python
+    - match: $
+      set: single-quoted-docstring-body
+    - include: single-quoted-docstring-end
+
+  single-quoted-docstring-body:
+    - meta_content_scope: comment.block.documentation.python
+    - include: single-quoted-docstring-end
+    - include: escaped-unicode-chars
+    - include: escaped-chars
+
+  single-quoted-raw-docstring-body:
+    - meta_content_scope: comment.block.documentation.python
+    - include: single-quoted-docstring-end
 
 ###[ STRINGS ]################################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -57,6 +57,9 @@ variables:
     )
   strftime_spec: '(?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))'
 
+  augmented_assignment_operators: |-
+    (?x: >>= | <<= | \*\*= | //= | \+= | -= | \*= | /= | %= | @= | &= | \|= | \^= )
+
   sql_indicator: |-
     (?x: \s* (?:
     # dml statements
@@ -245,7 +248,6 @@ contexts:
     - include: block-statements
     - include: class-definitions
     - include: function-definitions
-    - include: assignments
     - include: statement-terminators
     - include: expression-as-a-statement
 
@@ -260,6 +262,7 @@ contexts:
 
   line-statements:
     - include: decorators
+    - include: assignment-statements
     - include: import-statements
     - include: modifier-statements
     - include: flow-statements
@@ -709,6 +712,34 @@ contexts:
       scope: meta.function.python punctuation.section.function.begin.python
       pop: true
     - include: line-continuation-or-pop
+
+###[ ASSIGNMENT STATEMENTS ]##################################################
+
+  assignment-statements:
+    - include: illegal-assignment-expression
+    - match: ':'
+      scope: punctuation.separator.annotation.variable.python
+      push: variable-annotation
+    - match: '{{augmented_assignment_operators}}'
+      scope: keyword.operator.assignment.augmented.python
+      push: assignment-statement-value
+    - match: =(?!=)
+      scope: keyword.operator.assignment.python
+      push: assignment-statement-value
+
+  assignment-statement-value:
+    - include: illegal-assignment-expression
+    - include: expression-in-a-statement
+    - include: line-continuation-or-pop
+
+  variable-annotation:
+    - meta_scope: meta.variable.annotation.python
+    - match: (?=$|=|#|;)
+      pop: 1
+    - match: \bNone\b
+      scope: constant.language.null.python
+    - include: illegal-assignment-expression
+    - include: expression-in-a-group
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -1504,8 +1535,6 @@ contexts:
       fail: generators-groups-and-tuples
     - include: sequence-separators
     - include: expression-in-a-group
-    - match: '='
-      scope: invalid.illegal.unexpected-assignment-in-tuple.python
 
   empty-tuples:
     - match: (\()\s*(\))
@@ -1726,32 +1755,17 @@ contexts:
     - include: line-continuation-or-pop
     - include: else-pop
 
-  assignments:
-    - include: illegal-assignment-expression
-    - match: ':'
-      scope: punctuation.separator.annotation.variable.python
-      push: variable-annotation
-    - match: \+=|-=|\*=|/=|//=|%=|@=|&=|\|=|\^=|>>=|<<=|\*\*=
-      scope: keyword.operator.assignment.augmented.python
-    - match: '=(?!=)'
-      scope: keyword.operator.assignment.python
-
-  variable-annotation:
-    - meta_scope: meta.variable.annotation.python
-    - match: (?=$|=|#|;)
-      pop: 1
-    - match: \bNone\b
-      scope: constant.language.null.python
-    - include: illegal-assignment-expression
-    - include: expression-in-a-group
-
   operators:
+    - match: '{{augmented_assignment_operators}}'
+      scope: invalid.illegal.assignment.python
     - match: <>
       scope: invalid.deprecated.operator.python
     - match: <\=|>\=|\=\=|<|>|\!\=
       scope: keyword.operator.comparison.python
     - match: \+|\-|\*|\*\*|/|//|%|<<|>>|&|\||\^|~
       scope: keyword.operator.arithmetic.python
+    - match: =(?!=)
+      scope: invalid.illegal.assignment.python
     - match: \b(?:and|in|is|not|or)\b
       comment: keyword operators that evaluate to True or False
       scope: keyword.operator.logical.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1775,7 +1775,7 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                                      ^^^^^ constant.language.boolean.python
 #                                           ^ punctuation.separator.inheritance.python
 #                                             ^^^^ constant.language.boolean.python
-#                                                 ^ invalid.illegal.not-allowed-here.python
+#                                                 ^ invalid.illegal.assignment.python
 #                                                  ^^^^^ constant.language.boolean.python
 
 
@@ -2629,24 +2629,24 @@ class Starship:
 ##################
 
 True = False
-#    ^ invalid.illegal.not-allowed-here.python
+#    ^ invalid.illegal.assignment.python
 
 False = True
-#     ^ invalid.illegal.not-allowed-here.python
+#     ^ invalid.illegal.assignment.python
 
 None = True
-#    ^ invalid.illegal.not-allowed-here.python
+#    ^ invalid.illegal.assignment.python
 
 # Examples from https://www.python.org/dev/peps/pep-0572/
 
 y := f(x)
-# ^^ invalid.illegal.not-allowed-here.python
+# ^^ invalid.illegal.assignment.python
 
 (y := f(x))
 #  ^^ keyword.operator.assignment.inline.python
 
 y0 = y1 := f(x)
-#       ^^ invalid.illegal.not-allowed-here.python
+#       ^^ invalid.illegal.assignment.python
 
 y0 = (y1 := f(x))
 #        ^^ keyword.operator.assignment.inline.python
@@ -2694,18 +2694,24 @@ if any(len(longline := line) >= 100 for line in lines):
 
 # These are all invalid. We could let linters handle them,
 # but these weren't hard to implement.
-def foo(x: y:=f(x)) -> a:=None: pass
-#           ^^ invalid.illegal.not-allowed-here.python
-#                       ^^ invalid.illegal.not-allowed-here.python
+def foo(x: y:=f(x), y:=foo, (a:=b)) -> a:=None: pass
+#           ^^ invalid.illegal.assignment.python
+#                    ^^ invalid.illegal.assignment.python
+#                             ^ invalid.illegal.annotation.python
+#                              ^^ invalid.illegal.default-value.python
+#                                       ^^ invalid.illegal.assignment.python
+def bar() := :
+#         ^^ invalid.illegal.assignment.python
+#            ^ punctuation.section.function.begin.python
 foo(x = y := f(x), y=x:=2)
-#         ^^ invalid.illegal.not-allowed-here.python
-#                     ^^ invalid.illegal.not-allowed-here.python
+#         ^^ invalid.illegal.assignment.python
+#                     ^^ invalid.illegal.assignment.python
 [1][x:=0]
-#    ^^ invalid.illegal.not-allowed-here.python
+#    ^^ invalid.illegal.assignment.python
 def foo(answer = p := 42):  pass
-#                  ^^ invalid.illegal.not-allowed-here.python
+#                  ^^ invalid.illegal.assignment.python
 (lambda: x := 1)
-#          ^^ invalid.illegal.not-allowed-here.python
+#          ^^ invalid.illegal.assignment.python
 
 
 # <- - meta

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2707,6 +2707,21 @@ y0 = y1 := f(x)
 y0 = (y1 := f(x))
 #        ^^ keyword.operator.assignment.inline.python
 
+y0 = (y1 := f1(x), y2 := f2(x))
+#        ^^ keyword.operator.assignment.inline.python
+#                     ^^ keyword.operator.assignment.inline.python
+
+y0 = (y := f(x) for y, x in values)
+#       ^^ keyword.operator.assignment.inline.python
+
+y0 = [y1 := f1(x), y2 := f2(x)]
+#        ^^ keyword.operator.assignment.inline.python
+#                     ^^ keyword.operator.assignment.inline.python
+
+y0 = {y1 := f1(x), y2 := f2(x)}
+#        ^^ keyword.operator.assignment.inline.python
+#                     ^^ keyword.operator.assignment.inline.python
+
 foo(x=(y := f(x)))
 #        ^^ keyword.operator.assignment.inline.python
 
@@ -2750,22 +2765,40 @@ if any(len(longline := line) >= 100 for line in lines):
 
 # These are all invalid. We could let linters handle them,
 # but these weren't hard to implement.
+
+def foo := :
+#       ^^ invalid.illegal.assignment.python
+#          ^ punctuation.section.function.begin.python
+
+def foo() := :
+#         ^^ invalid.illegal.assignment.python
+#            ^ punctuation.section.function.begin.python
+
+def foo(x = y := 42): pass
+#             ^^ invalid.illegal.assignment.python
+
 def foo(x: y:=f(x), y:=foo, (a:=b)) -> a:=None: pass
 #           ^^ invalid.illegal.assignment.python
 #                    ^^ invalid.illegal.assignment.python
 #                             ^ invalid.illegal.annotation.python
 #                              ^^ invalid.illegal.default-value.python
 #                                       ^^ invalid.illegal.assignment.python
-def bar() := :
-#         ^^ invalid.illegal.assignment.python
-#            ^ punctuation.section.function.begin.python
+
 foo(x = y := f(x), y=x:=2)
 #         ^^ invalid.illegal.assignment.python
 #                     ^^ invalid.illegal.assignment.python
+
+{k1: y1 := f(x)}
+#       ^^ invalid.illegal.assignment.python
+
+foo[x:=0]
+#    ^^ invalid.illegal.assignment.python
+
 [1][x:=0]
 #    ^^ invalid.illegal.assignment.python
-def foo(answer = p := 42):  pass
-#                  ^^ invalid.illegal.assignment.python
+
+lambda: x := 1
+
 (lambda: x := 1)
 #          ^^ invalid.illegal.assignment.python
 

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -260,11 +260,11 @@ import a as .b, .b
 #               ^ invalid.illegal.unexpected-relative-import.python
 #                ^ meta.generic-name.python
 import a.b as c, a.e as f
-#      ^^^ meta.qualified-name.python
+#      ^^^ meta.path.python
 #          ^^ keyword.control.import.as.python
 #             ^ meta.generic-name.python
 #              ^ punctuation.separator.import-list.python
-#                ^^^ meta.qualified-name.python
+#                ^^^ meta.path.python
 #                    ^^ keyword.control.import.as.python
 #                       ^ meta.generic-name.python
 from a import b as c, d as  # comment
@@ -307,7 +307,7 @@ from importlib import import_module
 ##################
 
 identifier
-#^^^^^^^^^ meta.qualified-name meta.generic-name
+#^^^^^^^^^ meta.path meta.generic-name
 
 class
 #^^^^ keyword.declaration.class.python
@@ -319,7 +319,7 @@ async
 #^^^^ - invalid.illegal.name
 
 __all__
-#^^^^^^ meta.qualified-name support.variable.magic - meta.generic-name
+#^^^^^^ meta.path support.variable.magic - meta.generic-name
 __file__
 #^^^^^^^ support.variable.magic
 __missing__
@@ -344,7 +344,7 @@ open.open.open.
 #            ^^^^^^^^^ constant.language.python
 
 CONSTANT._13_
-#^^^^^^^ meta.qualified-name.python variable.other.constant.python
+#^^^^^^^ meta.path.python variable.other.constant.python
 #        ^^^^ - variable.other.constant
 
  _A_B A1
@@ -352,10 +352,10 @@ CONSTANT._13_
 #     ^^ - variable.other.constant
 
 some.NO
-#    ^^ meta.qualified-name.python variable.other.constant.python
+#    ^^ meta.path.python variable.other.constant.python
 
 NO_SWEAT NO AA1
-# <- meta.qualified-name.python variable.other.constant.python
+# <- meta.path.python variable.other.constant.python
 #        ^^ variable.other.constant
 #           ^^^ variable.other.constant
 
@@ -369,35 +369,52 @@ _ self
 ##################
 
 identifier()
-#^^^^^^^^^^^ meta.function-call
-#^^^^^^^^^ meta.qualified-name variable.function
+# <- meta.function-call.identifier.python variable.function.python
+#^^^^^^^^^ meta.function-call.identifier.python
+#         ^^ meta.function-call.arguments.python
+#^^^^^^^^^ variable.function.python
 #         ^ punctuation.section.arguments.begin
 #          ^ punctuation.section.arguments.end
 
 IDENTIFIER()
-#^^^^^^^^^ meta.qualified-name variable.function - variable.other.constant
+# <- meta.function-call.identifier.python variable.function.python
+#^^^^^^^^^ meta.function-call.identifier.python
+#         ^^ meta.function-call.arguments.python
+#^^^^^^^^^ variable.function.python
+#         ^ punctuation.section.arguments.begin
+#          ^ punctuation.section.arguments.end
 
 dotted.
+# <- meta.path.python - meta.function-call
+#^^^^^^^ - meta.function-call
 #     ^ punctuation.accessor.dot
 
 dotted .
+# <- meta.path.python - meta.function-call
+#^^^^^^^^ - meta.function-call
 #      ^ punctuation.accessor.dot
 
 dotted . identifier(12, True)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call - meta.function-call meta.function-call
-#                  ^^^^^^^^^^ meta.function-call.arguments
-#^^^^^^^^^^^^^^^^^^ meta.qualified-name
-#^^^^^^ - variable.function
+# <- meta.path.python - meta.function-call
+#^^^^^^^^ - meta.function-call
+#        ^^^^^^^^^^ meta.function-call.identifier.python - meta.function-call meta.function-call
+#                  ^^^^^^^^^^ meta.function-call.arguments.python - meta.function-call meta.function-call
+#^^^^^^^^^^^^^^^^^^ meta.path
+#^^^^^^^^ - variable.function
 #      ^ punctuation.accessor.dot
 #        ^^^^^^^^^^ variable.function
 
 open.__new__(12, \
-#^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+# <- - meta.function-call
+#^^^^ - meta.function-call
+#    ^^^^^^^ meta.function-call.identifier.python
+#           ^^^^^^^ meta.function-call.arguments.python
 #^^^ support.function.builtin
 #   ^ punctuation.accessor.dot
-#    ^^^^^^^ variable.function support.function.magic
+#    ^^^^^^^ support.function.magic
 #                ^ punctuation.separator.continuation.line.python
              True)
+#           ^^^^^^ meta.function-call.arguments.python
 
 iter()
 #^^^ support.function.builtin
@@ -414,8 +431,15 @@ TypeError()
 #^^^^^^^^ support.type.exception
 #
 module.TypeError()
-#^^^^^^^^^^^^^^^ meta.function-call
+# <- - meta.function-call
+#^^^^^^ - meta.function-call
+#      ^^^^^^^^^ meta.function-call.identifier.python
+#               ^^ meta.function-call.arguments.python
+#^^^^^^^^^^^^^^^ meta.path.python
+#     ^ punctuation.accessor.dot.python
 #      ^^^^^^^^^ variable.function - support
+#               ^ punctuation.section.arguments.begin.python
+#                ^ punctuation.section.arguments.end.python
 
 open.open.open()
 #^^^ support.function.builtin
@@ -609,18 +633,22 @@ def _():
 ##################
 
 myobj.method().attribute
-#^^^^^^^^^^^^^ meta.function-call
+#^^^^^ - meta.function-call
+#     ^^^^^^^^ meta.function-call
+#             ^^^^^^^^^^ - meta.function-call
 #    ^ punctuation.accessor.dot
 #     ^^^^^^ variable.function
 #             ^ punctuation.accessor.dot
 
 'foo'. upper()
-#    ^^^^^^^^^ meta.function-call
+#^^^^^^ - meta.function-call
+#      ^^^^^^^ meta.function-call
 #    ^ punctuation.accessor.dot
 #      ^^^^^ variable.function
 
 'foo'.and()
-#    ^^^^^^ meta.function-call
+#^^^^^ - meta.function-call
+#     ^^^^^ meta.function-call
 #    ^ punctuation.accessor.dot
 #     ^^^ invalid.illegal.name.python
 
@@ -682,7 +710,8 @@ range(20)[10:2:-2]
 #       ^ punctuation.accessor.dot.python
 
 "string".upper()
-#       ^^^^^^^^ meta.function-call
+#^^^^^^^^ - meta.function-call
+#        ^^^^^^^ meta.function-call
 #       ^ punctuation.accessor.dot.python
 
 (i for i in range(10))[5]
@@ -712,7 +741,8 @@ range(20)[10:2:-2]
 #               ^ punctuation.accessor.dot.python
 
 {True: False}.get(True)
-#            ^^^^^^^^^^ meta.function-call
+#^^^^^^^^^^^^^ - meta.function-call
+#             ^^^^^^^^^ meta.function-call
 #            ^ punctuation.accessor.dot.python
 
 1[12]
@@ -803,7 +833,7 @@ def _():
     with (folder / "file.txt").open() as x:
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
 #        ^^^^^^^^^^^^^^^^^^^^^ meta.group.python
-#                             ^^^^^ meta.function-call.python meta.qualified-name.python
+#                              ^^^^ meta.function-call.identifier.python meta.path.python
 #                                  ^^ meta.function-call.arguments.python
 #   ^^^^ keyword.control.flow.with.python
 #        ^ punctuation.section.group.begin.python
@@ -823,8 +853,8 @@ def _():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
 #        ^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
 #         ^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python meta.group.python - meta.sequence meta.sequence
-#                              ^^^^^^^^^^^^^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
-#                               ^^^^ meta.function-call.python
+#                               ^^^^^^^^^^^^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
+#                               ^^^^ meta.function-call.identifier.python
 #                                   ^^ meta.function-call.arguments.python
 #                                           ^ - meta.sequence
 #   ^^^^ keyword.control.flow.with.python
@@ -834,7 +864,7 @@ def _():
 #                 ^ keyword.operator.arithmetic.python
 #                   ^^^^^^^^^^ meta.string.python string.quoted.double.python
 #                             ^ punctuation.section.group.end.python
-#                              ^ meta.function-call.python punctuation.accessor.dot.python
+#                              ^ punctuation.accessor.dot.python
 #                               ^^^^ variable.function.python - support
 #                                   ^ punctuation.section.arguments.begin.python
 #                                    ^ punctuation.section.arguments.end.python
@@ -860,7 +890,7 @@ def _():
 #                  ^ keyword.operator.arithmetic.python
 #                    ^^^^^^^^^^ meta.string.python string.quoted.double.python
 #                              ^ punctuation.section.group.end.python
-#                               ^ meta.function-call.python punctuation.accessor.dot.python
+#                               ^ punctuation.accessor.dot.python
 #                                ^^^^ variable.function.python - support
 #                                    ^ punctuation.section.arguments.begin.python
 #                                     ^ punctuation.section.arguments.end.python
@@ -1064,12 +1094,12 @@ def _():
     match expr
 #   ^^^^^^^^^^ - meta.statement.conditional
 #   ^^^^^ meta.generic-name.python
-#         ^^^^ meta.qualified-name.python meta.generic-name.python
+#         ^^^^ meta.path.python meta.generic-name.python
 
     match expr:
 #   ^^^^^^^^^^^ meta.statement.conditional.match.python
 #   ^^^^^ keyword.control.conditional.match.python
-#         ^^^^ meta.qualified-name.python meta.generic-name.python
+#         ^^^^ meta.path.python meta.generic-name.python
 #             ^ punctuation.section.block.conditional.match.python
 
     match(expr,)
@@ -1082,7 +1112,7 @@ def _():
 #        ^^^^^^^ meta.statement.conditional.match.python meta.sequence.tuple.python
 #               ^ meta.statement.conditional.match.python - meta.sequence
 #   ^^^^^ keyword.control.conditional.match.python
-#         ^^^^ meta.qualified-name.python meta.generic-name.python
+#         ^^^^ meta.path.python meta.generic-name.python
 #             ^ punctuation.separator.sequence.python
 #              ^ punctuation.section.sequence.end.python
 #               ^ punctuation.section.block.conditional.match.python
@@ -1091,15 +1121,15 @@ def _():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.match.python
 #   ^^^^^ keyword.control.conditional.match.python
 #         ^ keyword.operator.unpacking.sequence.python
-#          ^^^^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#          ^^^^^^^^^^ meta.path.python meta.generic-name.python
 #                    ^ punctuation.separator.sequence.python
-#                      ^^^^^ meta.qualified-name.python meta.generic-name.python
+#                      ^^^^^ meta.path.python meta.generic-name.python
 #                           ^ punctuation.section.block.conditional.match.python
 
     match http_code:
 #   ^^^^^^^^^^^^^^^^ meta.statement.conditional.match.python
 #   ^^^^^ keyword.control.conditional.match.python
-#         ^^^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#         ^^^^^^^^^ meta.path.python meta.generic-name.python
 #                  ^ punctuation.section.block.conditional.match.python
     case "200":
 #   ^^^^^^^^^^^^ meta.disable-dedentation.python
@@ -1270,11 +1300,11 @@ def _():
 #                                                                             ^ meta.statement.conditional.case.python - meta.set
 #   ^^^^ keyword.control.conditional.case.python
 #        ^ punctuation.section.mapping.begin.python
-#          ^^^^^ meta.qualified-name.python meta.generic-name.python
+#          ^^^^^ meta.path.python meta.generic-name.python
 #                ^ punctuation.separator.key-value.python
 #                  ^^^^^^^ string.quoted.single.python
 #                          ^ punctuation.separator.sequence.python
-#                            ^^^^^^^ meta.qualified-name.python
+#                            ^^^^^^^ meta.path.python
 #                                   ^ punctuation.separator.key-value.python
 #                                     ^^^ constant.numeric.value.python
 #                                        ^ punctuation.separator.sequence.python
@@ -1311,7 +1341,7 @@ def _():
     case int():
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #           ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #             ^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
@@ -1323,7 +1353,7 @@ def _():
     case else():
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #            ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #              ^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
@@ -1335,12 +1365,12 @@ def _():
     case name(*pattern, *expr):
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #            ^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                             ^ meta.statement.conditional.case.python - meta.function-call
 #                              ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^^ storage.type.class.python
+#        ^^^^ support.class.python
 #            ^ punctuation.section.arguments.begin.python
 #             ^ keyword.operator.unpacking.sequence.python
 #              ^^^^^^^ meta.generic-name.python
@@ -1353,35 +1383,35 @@ def _():
     case name(key = pattern):
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#        ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #            ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                           ^ meta.statement.conditional.case.python - meta.function-call
 #                            ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^^ storage.type.class.python
+#        ^^^^ support.class.python
 #            ^ punctuation.section.arguments.begin.python
 #             ^^^ variable.parameter.python
 #                 ^ keyword.operator.assignment.python
-#                   ^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                   ^^^^^^^ meta.path.python meta.generic-name.python
 #                          ^ punctuation.section.arguments.end.python
 #                           ^ punctuation.section.block.conditional.case.python
 
     case path.name(key = pattern):
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
-#       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#       ^^^^^^ meta.statement.conditional.case.patterns.python - meta.function-call
+#             ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #                 ^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                                ^ meta.statement.conditional.case.python - meta.function-call
 #                                 ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^^^^^^^ meta.qualified-name.python
+#        ^^^^^^^^^ meta.path.python
 #        ^^^^ meta.generic-name.python
 #            ^ punctuation.accessor.dot.python
-#             ^^^^ storage.type.class.python
+#             ^^^^ support.class.python
 #                 ^ punctuation.section.arguments.begin.python
 #                  ^^^ variable.parameter.python
 #                      ^ keyword.operator.assignment.python
-#                        ^^^^^^^ meta.qualified-name.python meta.generic-name.python
+#                        ^^^^^^^ meta.path.python meta.generic-name.python
 #                               ^ punctuation.section.arguments.end.python
 #                                ^ punctuation.section.block.conditional.case.python
 
@@ -1389,10 +1419,10 @@ def _():
         . \
         name(key = pattern):
 #   ^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python
-#       ^^^^ meta.function-call.python meta.qualified-name.python
+#       ^^^^ meta.function-call.identifier.python
 #           ^^^^^^^^^^^^^^^ meta.function-call.arguments.python
 #                          ^ meta.statement.conditional.case.python
-#       ^^^^ storage.type.class.python
+#       ^^^^ support.class.python
 #           ^ punctuation.section.arguments.begin.python
 #            ^^^ variable.parameter.python
 #                ^ keyword.operator.assignment.python
@@ -1404,15 +1434,15 @@ def _():
 #  ^ - meta.statement
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
-#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#        ^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #           ^^ meta.statement.conditional.case.patterns.python  meta.function-call.arguments.python
 #             ^^ meta.statement.conditional.case.patterns.python - meta.function-call
-#               ^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#               ^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #                      ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python - meta.group
 #                               ^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python meta.group.python
 #                                        ^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python - meta.group
 #                                                          ^^ meta.statement.conditional.case.patterns.python - meta.function-call
-#                                                            ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.python
+#                                                            ^^^^ meta.statement.conditional.case.patterns.python meta.function-call.identifier.python
 #                                                                ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #                                                                  ^ meta.statement.conditional.case.patterns.python - meta.function-call
 #                                                                   ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.function-call
@@ -1423,7 +1453,7 @@ def _():
 #           ^ punctuation.section.arguments.begin.python
 #            ^ punctuation.section.arguments.end.python
 #             ^ punctuation.separator.sequence.python
-#               ^^^^^^^ storage.type.class.python
+#               ^^^^^^^ support.class.python
 #                      ^ punctuation.section.arguments.begin.python
 #                       ^^^^^^^ variable.parameter.python
 #                              ^ keyword.operator.assignment.python
@@ -1480,7 +1510,7 @@ def _():
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
 #       ^ punctuation.separator.annotation.variable.python
-#         ^^^ meta.qualified-name.python support.type.python
+#         ^^^ meta.path.python support.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1489,13 +1519,13 @@ def _():
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.variable.python
-#     ^^^ meta.qualified-name.python support.type.python
+#     ^^^ meta.path.python support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
     match = re.match(r"^.*$")
 #   ^^^^^ meta.generic-name.python - keyword
-#              ^^^^^ meta.function-call.python variable.function.python
+#              ^^^^^ meta.function-call.identifier.python variable.function.python
     if match:
 #      ^^^^^ meta.generic-name.python - keyword
         g = match.group(1)
@@ -1512,7 +1542,7 @@ def _():
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.annotation.variable.python
-#          ^^^ meta.qualified-name.python support.type.python
+#          ^^^ meta.path.python support.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1521,7 +1551,7 @@ def _():
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.variable.python
-#     ^^^ meta.qualified-name.python support.type.python
+#     ^^^ meta.path.python support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1846,7 +1876,7 @@ class Unterminated(Inherited:
 @ normal . decorator
 # <- meta.annotation punctuation.definition.annotation
 #^^^^^^^^^^^^^^^^^^^ meta.annotation
-# ^^^^^^^^^^^^^^^^^^ meta.qualified-name
+# ^^^^^^^^^^^^^^^^^^ meta.path
 # ^^^^^^ meta.generic-name - variable.annotation
 #          ^^^^^^^^^ variable.annotation
 #        ^ punctuation.accessor.dot - variable
@@ -1859,7 +1889,7 @@ class Class():
 #                    ^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.arguments
 #   ^ punctuation.definition.annotation
 #    ^^^^^^^^^^^^^^^^ meta.annotation.function
-#    ^^^^^^^^^^^^^^^ meta.qualified-name
+#    ^^^^^^^^^^^^^^^ meta.path
 #    ^^^^^^^^^ meta.generic-name - variable.annotation
 #             ^ punctuation.accessor.dot
 #              ^^^^^ variable.annotation.function meta.generic-name
@@ -1884,7 +1914,7 @@ class Class():
     @deco #comment
 #^^^ - meta.annotation
 #   ^^^^^ meta.annotation
-#    ^^^^ meta.qualified-name variable.annotation
+#    ^^^^ variable.annotation
 #        ^^ - meta.annotation
 #         ^^^^^^^^ comment
 
@@ -1917,7 +1947,7 @@ class Class():
 #         ^^^^^ variable.annotation.function
 
     @ deco \
-#     ^^^^ meta.qualified-name meta.generic-name - variable.annotation
+#     ^^^^ meta.path meta.generic-name - variable.annotation
 #          ^ punctuation.separator.continuation.line
 
     @deco \
@@ -2001,7 +2031,7 @@ mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
 #              ^ punctuation.separator.key-value
 #                ^^^^ meta.mapping.value.python constant.language
 #                    ^ punctuation.separator.sequence.python
-#                      ^^^^ meta.mapping.key.python meta.qualified-name
+#                      ^^^^ meta.mapping.key.python meta.path
 #                          ^ punctuation.separator.key-value.python
 #                            ^^^^^^^^^^^^^^^^ meta.sequence.tuple
 #                            ^ punctuation.section.sequence.begin
@@ -2280,7 +2310,7 @@ d = {**d, **dict()}
 #   ^^^^^^^^^^^^^^^ meta.mapping.python
 #    ^^^ - meta.mapping.key
 #    ^^ keyword.operator.unpacking.mapping.python
-#      ^ meta.qualified-name.python
+#      ^ meta.path.python
 #       ^ punctuation.separator.sequence.python
 #         ^^^^^^^^ - meta.mapping.key
 #         ^^ keyword.operator.unpacking.mapping.python
@@ -2289,7 +2319,7 @@ d = {**d, **dict()}
 s = {*d, *set()}
 #   ^^^^^^^^^^^^ meta.set.python
 #    ^ keyword.operator.unpacking.sequence.python
-#     ^ meta.qualified-name.python
+#     ^ meta.path.python
 #      ^ punctuation.separator.set.python
 #        ^ keyword.operator.unpacking.sequence.python
 #         ^^^ support.type.python
@@ -2678,14 +2708,14 @@ foo.bar(baz., True)
 primes: List[int] = []
 #     ^ punctuation.separator.annotation.variable.python
 #     ^^^^^^^^^^^^ meta.variable.annotation.python
-#       ^^^^ meta.qualified-name.python
+#       ^^^^ meta.path.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.variable.python
 #      ^^^^^^^ meta.variable.annotation.python
 #             ^^^^^^^ comment
-#        ^^^ meta.qualified-name.python
+#        ^^^ meta.path.python
 
 foo: str | None = None
 #  ^^^^^^^^^^^^^ meta.variable.annotation.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1460,6 +1460,7 @@ def _():
 
 def abc():
     global from, for, variable, .
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.modifier.python
 #   ^^^^^^ storage.modifier.global
 #          ^^^^ invalid.illegal.name
 #                ^^^ invalid.illegal.name

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2510,8 +2510,64 @@ foo ^= bar ^= baz
 #   ^^ keyword.operator.assignment.augmented.python
 #          ^^ invalid.illegal.assignment.python
 
-matrix @ multiplication
-#      ^ keyword.operator.matrix.python
+# arithmetic operators
+
+  << >> ** * // / - + & % | ~ ^ @
+# ^^ keyword.operator.arithmetic.python
+#   ^ - keyword
+#    ^^ keyword.operator.arithmetic.python
+#      ^ - keyword
+#       ^^ keyword.operator.arithmetic.python
+#         ^ - keyword
+#          ^ keyword.operator.arithmetic.python
+#           ^ - keyword
+#            ^^ keyword.operator.arithmetic.python
+#              ^ - keyword
+#               ^ keyword.operator.arithmetic.python
+#                ^ - keyword
+#                 ^ keyword.operator.arithmetic.python
+#                  ^ - keyword
+#                   ^ keyword.operator.arithmetic.python
+#                    ^ - keyword
+#                     ^ keyword.operator.arithmetic.python
+#                      ^ - keyword
+#                       ^ keyword.operator.arithmetic.python
+#                        ^ - keyword
+#                         ^ keyword.operator.arithmetic.python
+#                          ^ - keyword
+#                           ^ keyword.operator.arithmetic.python
+#                            ^ - keyword
+#                             ^ keyword.operator.arithmetic.python
+#                              ^ - keyword
+#                               ^ keyword.operator.arithmetic.python
+#                                ^ - keyword
+
+# comparison operators
+
+  <= >= == != < > <>
+# ^^ keyword.operator.comparison.python
+#   ^ - keyword
+#    ^^ keyword.operator.comparison.python
+#      ^ - keyword
+#       ^^ keyword.operator.comparison.python
+#         ^ - keyword
+#          ^^ keyword.operator.comparison.python
+#            ^ - keyword
+#             ^ keyword.operator.comparison.python
+#              ^ - keyword
+#               ^ keyword.operator.comparison.python
+#                ^ - keyword
+#                 ^^ invalid.deprecated.operator.python
+
+# locical keywords
+
+  and in is not or
+# ^^^ keyword.operator.logical.python
+#     ^^ keyword.operator.logical.python
+#        ^^ keyword.operator.logical.python
+#           ^^^ keyword.operator.logical.python
+#               ^^ keyword.operator.logical.python
+
 
 ##################
 # Context "Fail Early"

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -939,7 +939,7 @@ def _():
 #                                ^^ keyword.control.flow.with.as
 #                                    ^ punctuation.section.block.with
         await something()
-#       ^^^^^ keyword.other.await
+#       ^^^^^ keyword.control.flow.await
 
     assert foo == bar
 #   ^^^^^^ keyword.control.flow.assert.python
@@ -2207,7 +2207,7 @@ _ = [m
 result = [i async for i in aiter() if i % 2]
 #           ^^^^^ storage.modifier.async
 result = [await fun() for fun in funcs]
-#         ^^^^^ keyword.other.await.python
+#         ^^^^^ keyword.control.flow.await.python
 
 foo, bar = get_vars()
 #  ^ punctuation.separator.sequence.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2839,8 +2839,7 @@ def foo(x = y := 42): pass
 def foo(x: y:=f(x), y:=foo, (a:=b)) -> a:=None: pass
 #           ^^ invalid.illegal.assignment.python
 #                    ^^ invalid.illegal.assignment.python
-#                             ^ invalid.illegal.annotation.python
-#                              ^^ invalid.illegal.default-value.python
+#                             ^^ invalid.illegal.assignment.python
 #                                       ^^ invalid.illegal.assignment.python
 
 foo(x = y := f(x), y=x:=2)

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1978,7 +1978,7 @@ myset = {"key", True, key2, [-1], {}:1}
 #                             ^ constant.numeric
 #                               ^ punctuation.separator.set
 #                                 ^^ meta.mapping.empty.python
-#                                   ^ invalid.illegal.colon-inside-set.python
+#                                   ^ invalid.illegal.unexpected-colon.python
 #                                     ^ punctuation.section.set.end.python
 
 myset = {a := 1, b := 2}
@@ -1995,7 +1995,7 @@ myset = {a := 1, b := 2}
 # <- meta.set.python punctuation.section.set.begin.python
 #^^^^^^^^^^ meta.set.python
 #  ^^ keyword.operator.assignment.inline.python
-#      ^ invalid.illegal.colon-inside-set.python
+#      ^ invalid.illegal.unexpected-colon.python
 #         ^ punctuation.section.set.end.python
 
 {1, b := 2}
@@ -2026,7 +2026,7 @@ more_complex_set = {
     *{1}, 2: 2}
 #   ^ meta.set.python
 #       ^ meta.set.python punctuation.separator.set.python
-#          ^ meta.set.python invalid.illegal.colon-inside-set.python
+#          ^ meta.set.python invalid.illegal.unexpected-colon.python
 
 generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.generator.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -475,9 +475,11 @@ def _():
 
     {key: lambda x, y: 10}
 #   ^ punctuation.section.mapping.begin
-#         ^^^^^^^^^^^^^^^ meta.function.inline
+#         ^^^^^^ meta.function.inline.python
+#               ^^^^^ meta.function.inline.parameters.python
+#                    ^ meta.function.inline.python
+#                     ^^^ meta.function.inline.body.python
 #         ^^^^^^ keyword.declaration.function.inline.python
-#                ^^^^^ meta.function.inline.parameters
 #                ^ variable.parameter
 #                 ^ punctuation.separator.parameters
 #                   ^ variable.parameter
@@ -486,9 +488,11 @@ def _():
 
     {lambda x, y: 10}
 #   ^ punctuation.section.set.begin
-#    ^^^^^^^^^^^^^^^ meta.function.inline
+#    ^^^^^^ meta.function.inline.python
+#          ^^^^^ meta.function.inline.parameters.python
+#               ^ meta.function.inline.python
+#                ^^^ meta.function.inline.body.python
 #    ^^^^^^ keyword.declaration.function.inline.python
-#           ^^^^^ meta.function.inline.parameters
 #           ^ variable.parameter
 #            ^ punctuation.separator.parameters
 #              ^ variable.parameter
@@ -497,9 +501,11 @@ def _():
 
     [lambda x, y: 10]
 #   ^ punctuation.section.sequence.begin
-#    ^^^^^^^^^^^^^^^ meta.function.inline
+#    ^^^^^^ meta.function.inline.python
+#          ^^^^^ meta.function.inline.parameters.python
+#               ^ meta.function.inline.python
+#                ^^^ meta.function.inline.body.python
 #    ^^^^^^ keyword.declaration.function.inline.python
-#           ^^^^^ meta.function.inline.parameters
 #           ^ variable.parameter
 #            ^ punctuation.separator.parameters
 #              ^ variable.parameter
@@ -531,7 +537,8 @@ def _():
     lambda *a, **kwa, ab*, * *: (a, kwa)
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function.inline meta.function.inline
 #   ^^^^^^ meta.function.inline.python
-#         ^^^^^^^^^^^^^^^^^^^^^ meta.function.inline.parameters.python
+#         ^^^^^^^^^^^^^^^^^^^^ meta.function.inline.parameters.python
+#                             ^ meta.function.inline.python
 #                              ^^^^^^^^^ meta.function.inline.body.python
 #          ^ keyword.operator.unpacking.sequence.python
 #           ^ variable.parameter.python
@@ -546,8 +553,9 @@ def _():
     lambda (x, y): 0
 #   ^^^^^^^^^^^^^^^^ - meta.function.inline meta.function.inline
 #   ^^^^^^ meta.function.inline.python
-#         ^^^^^^^^ meta.function.inline.parameters.python
-#          ^^^^^^ meta.group.python
+#         ^ meta.function.inline.parameters.python - meta.group
+#          ^^^^^^ meta.function.inline.parameters.python meta.group.python
+#                ^ meta.function.inline.python
 #                 ^^ meta.function.inline.body.python
 #          ^ punctuation.section.group.begin.python
 #           ^ variable.parameter.python
@@ -1503,7 +1511,7 @@ def abc():
 #                               ^ invalid.illegal.name.storage
 
 def my_func # comment
-#^^^^^^^^^^ meta.function.python
+#^^^^^^^^^^ meta.function.python - meta.function meta.function
 #          ^^^^^^^^^^^ - meta.function
 #   ^^^^^^^ entity.name.function.python
 #           ^^^^^^^^^ comment.line.number-sign.python
@@ -1519,6 +1527,7 @@ def my_func() # comment
 #             ^^^^^^^^^ comment.line.number-sign.python
 
 def my_func(): # comment
+#^^^^^^^^^^^^^ - meta.function meta.function
 #^^^^^^^^^^ meta.function.python
 #          ^^ meta.function.parameters.python
 #            ^ meta.function.python
@@ -1549,6 +1558,7 @@ def my_func(param1, # Multi-line function definition
 
 
 def func(from='me'):
+#^^^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function
 #        ^^^^ invalid.illegal.name
     pass
 
@@ -2136,7 +2146,7 @@ dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
 list_ = [lambda: 1 for i in range(10)]
 #       ^ meta.sequence.list.python - meta.function
 #        ^^^^^^ meta.sequence.list.python meta.function.inline.python
-#              ^ meta.sequence.list.python meta.function.inline.parameters.python
+#              ^ meta.sequence.list.python meta.function.inline.python
 #               ^^^ meta.sequence.list.python meta.function.inline.body.python
 #                  ^^^^^^^^^^^^^^^^^^^ meta.sequence.list.python - meta.function
 #                                     ^ - meta.sequence
@@ -2156,7 +2166,7 @@ list_ = [lambda: 1 for i in range(10)]
 generator_ = (lambda: 1 for i in range(10))
 #            ^ meta.sequence.generator.python - meta.function
 #             ^^^^^^ meta.sequence.generator.python meta.function.inline.python
-#                   ^ meta.sequence.generator.python meta.function.inline.parameters.python
+#                   ^ meta.sequence.generator.python meta.function.inline.python
 #                    ^^^ meta.sequence.generator.python meta.function.inline.body.python
 #                       ^^^^^^^^^^^^^^^^^^^ meta.sequence.generator.python - meta.function
 #                                          ^ - meta.sequence
@@ -2176,7 +2186,7 @@ generator_ = (lambda: 1 for i in range(10))
 set_ = {lambda: 1 for i in range(10)}
 #      ^ meta.set.python - meta.function
 #       ^^^^^^ meta.set.python meta.function.inline.python
-#             ^ meta.set.python meta.function.inline.parameters.python
+#             ^ meta.set.python meta.function.inline.python
 #              ^^^ meta.set.python meta.function.inline.body.python
 #                 ^^^^^^^^^^^^^^^^^^^ meta.set.python - meta.function
 #                                    ^ - meta.set

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1242,45 +1242,62 @@ def _():
 #                     ^^^^ constant.language.boolean.python
 #                         ^ punctuation.section.block.conditional.case.python
 
-    case {s_key: 'value', num.key: 100, **pattern} if foo in {'foo', 'bar'}:
+    case { s_key : 'value' , num.key: 100, **pattern} if foo in {'foo', 'bar'}:
 #   ^^^^ meta.statement.conditional.case.python - meta.mapping
 #       ^ meta.statement.conditional.case.patterns.python - meta.mapping
-#        ^ meta.statement.conditional.case.patterns.python meta.mapping.python
-#         ^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
-#              ^ meta.statement.conditional.case.patterns.python meta.mapping.python
-#               ^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
-#                       ^^ meta.statement.conditional.case.patterns.python meta.mapping.python
-#                         ^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
-#                                ^ meta.statement.conditional.case.patterns.python meta.mapping.python
-#                                 ^^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
-#                                     ^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
-#                                                 ^ meta.statement.conditional.case.patterns.python - meta.mapping
-#                                                  ^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.set
-#                                                            ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python meta.set.python
-#                                                                          ^ meta.statement.conditional.case.python - meta.set
+#        ^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#          ^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
+#               ^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                  ^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
+#                         ^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                            ^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.key.python
+#                                   ^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                                     ^^^ meta.statement.conditional.case.patterns.python meta.mapping.value.python
+#                                        ^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#                                                    ^ meta.statement.conditional.case.patterns.python - meta.mapping
+#                                                     ^^^^^^^^^^ meta.statement.conditional.case.guard.python - meta.set
+#                                                               ^^^^^^^^^^^^^^ meta.statement.conditional.case.guard.python meta.set.python
+#                                                                             ^ meta.statement.conditional.case.python - meta.set
 #   ^^^^ keyword.control.conditional.case.python
 #        ^ punctuation.section.mapping.begin.python
-#         ^^^^^ meta.qualified-name.python meta.generic-name.python
-#              ^ punctuation.separator.key-value.python
-#                ^^^^^^^ string.quoted.single.python
-#                       ^ punctuation.separator.sequence.python
-#                         ^^^^^^^ meta.qualified-name.python
-#                                ^ punctuation.separator.key-value.python
-#                                  ^^^ constant.numeric.value.python
-#                                     ^ punctuation.separator.sequence.python
-#                                       ^^ keyword.operator.unpacking.mapping.python
-#                                         ^^^^^^^ meta.generic-name.python
-#                                                ^ punctuation.section.mapping.end.python
-#                                                  ^^ keyword.control.conditional.if.python
-#                                                     ^^^ meta.generic-name.python
-#                                                         ^^ keyword.operator.logical.python
-#                                                            ^ punctuation.section.set.begin.python
-#                                                             ^^^^^ string.quoted.single.python
-#                                                                  ^ punctuation.separator.set.python
-#                                                                    ^^^^^ string.quoted.single.python
-#                                                                         ^ punctuation.section.set.end.python
-#                                                                          ^ punctuation.section.block.conditional.case.python
+#          ^^^^^ meta.qualified-name.python meta.generic-name.python
+#                ^ punctuation.separator.key-value.python
+#                  ^^^^^^^ string.quoted.single.python
+#                          ^ punctuation.separator.sequence.python
+#                            ^^^^^^^ meta.qualified-name.python
+#                                   ^ punctuation.separator.key-value.python
+#                                     ^^^ constant.numeric.value.python
+#                                        ^ punctuation.separator.sequence.python
+#                                          ^^ keyword.operator.unpacking.mapping.python
+#                                            ^^^^^^^ meta.generic-name.python
+#                                                   ^ punctuation.section.mapping.end.python
+#                                                     ^^ keyword.control.conditional.if.python
+#                                                        ^^^ meta.generic-name.python
+#                                                            ^^ keyword.operator.logical.python
+#                                                               ^ punctuation.section.set.begin.python
+#                                                                ^^^^^ string.quoted.single.python
+#                                                                     ^ punctuation.separator.set.python
+#                                                                       ^^^^^ string.quoted.single.python
+#                                                                            ^ punctuation.section.set.end.python
+#                                                                             ^ punctuation.section.block.conditional.case.python
 
+    case {
+        'key'    # comment
+#      ^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python
+#      ^ meta.mapping.python
+#       ^^^^^ meta.mapping.key.python meta.string.python string.quoted.single.python
+#            ^^^^^^^^^^^^^^ meta.mapping.key.python
+        :        # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+        'value'  # comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.patterns.python
+# ^^^^^^ meta.mapping.python
+#       ^^^^^^^ meta.mapping.value.python meta.string.python string.quoted.single.python
+#              ^^^^^^^^^^^^ meta.mapping.value.python
+    }:
+# ^^^ meta.statement.conditional.case.patterns.python meta.mapping.python
+#    ^ meta.statement.conditional.case.python punctuation.section.block.conditional.case.python
+#
     case int():
 #   ^^^^ meta.statement.conditional.case.python - meta.function-call
 #       ^ meta.statement.conditional.case.patterns.python - meta.function-call
@@ -2822,6 +2839,10 @@ foo(x = y := f(x), y=x:=2)
 
 {k1: y1 := f(x)}
 #       ^^ invalid.illegal.assignment.python
+
+case {k1: y1 := f(x), k1 := f(x)}:
+#            ^^ invalid.illegal.assignment.python
+#                        ^^ invalid.illegal.assignment.python
 
 foo[x:=0]
 #    ^^ invalid.illegal.assignment.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1938,15 +1938,33 @@ mydict = {"key": True, key2: (1, 2, [-1, -2]), ,}
 #                                      ^ punctuation.separator.sequence
 #                                           ^ punctuation.section.sequence.end
 #                                            ^ punctuation.separator.sequence.python
-#                                              ^ invalid.illegal.expected-colon.python
+#                                              ^ invalid.illegal.unexpected-comma.python
 #                                               ^ punctuation.section.mapping.end - meta.mapping.key
 
 mydict = { 'a' : xform, 'b' : form, 'c' : frm }
 #                                 ^ meta.mapping.python punctuation.separator.sequence.python
 #                                       ^ punctuation.separator.key-value.python
 
+mydict = { a : b for b in { 'foo', 'bar', 'baz' } }
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.mapping meta.mapping
+#        ^^ meta.mapping.python
+#          ^ meta.mapping.key.python
+#           ^^^ meta.mapping.python
+#              ^ meta.mapping.value.python - meta.set
+#               ^^^^^^^^^^ meta.mapping.python - meta.set
+#                         ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python meta.set.python
+#                                                ^^ meta.mapping.python - meta.set
+#                ^^^ keyword.control.loop.for.generator.python
+
 mydict = { a : b async for b in range(1, 2) }
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.mapping meta.mapping
+#        ^^ meta.mapping.python
+#          ^ meta.mapping.key.python
+#           ^^^ meta.mapping.python
+#              ^ meta.mapping.value.python
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
 #                ^^^^^ storage.modifier.async.python
+#                      ^^^ keyword.control.loop.for.generator.python
 
 myset = {"key", True, key2, [-1], {}:1}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set
@@ -2027,10 +2045,11 @@ set_ = {i for i in range(100)}
 #               ^^ keyword.control.loop.for.in
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
+#       ^ meta.mapping.python
 #        ^ meta.mapping.key.python
-#         ^^^^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.key.python
+#         ^^ meta.mapping.python - meta.mapping.key - meta.mapping.value
 #           ^ meta.mapping.value.python
-#            ^^^^^^^^^^^^^^^^^^^^^ - meta.mapping.value
+#            ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
 #             ^^^^^^^^ meta.expression.generator
 #             ^^^ keyword.control.loop.for.generator
 #                   ^^ keyword.control.loop.for.in

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1493,14 +1493,21 @@ def my_func(): # comment
 #              ^^^^^^^^^ comment.line.number-sign.python
 
 def my_func(param1, # Multi-line function definition
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
+#^^^^^^^^^^ meta.function.python
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.python
 #                 ^ punctuation.separator.parameters
-#                   ^ comment.line.number-sign
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign
     # This is defaulted
 #   ^ comment.line.number-sign
     param2='#1' \
+#  ^^^^^^^^^^^^^^^ meta.function.parameters - meta.function meta.function
 #               ^ punctuation.separator.continuation.line.python
-):
-# <- punctuation.section.parameters.end
+) :
+# <- meta.function.parameters.python punctuation.section.parameters.end
+#^^ meta.function.python - meta.function meta.function
+#  ^ - meta.function
+# ^ punctuation.section.function.begin.python
     print('Hi!')
 
 
@@ -1508,10 +1515,11 @@ def func(from='me'):
 #        ^^^^ invalid.illegal.name
     pass
 
-def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int:
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
-#                                                                                                  ^^^^^^ meta.function.annotation.return
+def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int :
+#^^^^^^^^^^^^^^^^^^^ meta.function.python - meta.function meta.function
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters - meta.function meta.function
+#                                                                                                  ^^^^^^^ meta.function.annotation.return.python - meta.function meta.function
+#                                                                                                         ^ meta.function.python - meta.function meta.function
 #                   ^ - meta.function meta.function.parameters
 #                    ^^^^^^ variable.parameter
 #                          ^^^^^ meta.function.parameters.annotation
@@ -1538,7 +1546,7 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 #                                                                                                ^ punctuation.section.parameters.end
 #                                                                                                  ^^ punctuation.separator.annotation
 #                                                                                                     ^^^ support.type
-#                                                                                                        ^ punctuation.section.function.begin
+#                                                                                                         ^ punctuation.section.function.begin
 
 def type_annotations_line_continuation_without_terminator() \
       -> int

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -2,22 +2,28 @@
 # <- source.python comment.line.number-sign punctuation.definition.comment
 
 r"""This is a syntax test file.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
-#^^^ punctuation.definition.comment.begin
-# <- storage.type.string
+# <- storage.type.string - comment
+#^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
 
 And this right here, where we're writing in, is a docstring.
+# <- comment.block.documentation.python
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.python
 """
+# <- comment.block.documentation.python punctuation.definition.comment.end.python
 
 ur"""Raw docstring \"""
-# <- storage.type.string.python
-# ^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.python
-#                   ^^^ punctuation.definition.comment.end.python
+# <- storage.type.string.python - comment
+# ^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#    ^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
+#                   ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
 
 """Normal docstring \""""
-# ^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.python
-#                   ^^ constant.character.escape.python
-#                     ^^^ punctuation.definition.comment.end.python
+# <- comment.block.documentation.python punctuation.definition.comment.begin.python
+#^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#  ^^^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
+#                    ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
+#                       ^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
 
 debug = False
 """

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -473,6 +473,16 @@ def _():
 #             ^ punctuation.section.function.begin
 #               ^^^^ invalid.illegal.name.python
 
+    c = lambda x, y=0: x + y
+#       ^^^^^^ meta.function.inline.python
+#             ^^^^^^^ meta.function.inline.parameters.python
+#                    ^ meta.function.inline.python
+#                     ^^^^^^ meta.function.inline.body.python
+#       ^^^^^^ storage.type.function.inline keyword.declaration.function.inline.python
+#              ^ meta.function.inline.parameters.python variable.parameter.python
+#                    ^ punctuation.section.function.begin
+#                        ^ keyword.operator.arithmetic.python
+
     {key: lambda x, y: 10}
 #   ^ punctuation.section.mapping.begin
 #         ^^^^^^ meta.function.inline.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1675,9 +1675,9 @@ def name(p1, p2, /): pass
 ##################
 
 class MyClass():
-#^^^^^^^^^^^^^^^ meta.class
-#            ^^ meta.class.inheritance
-#              ^ punctuation.section.class.begin
+#^^^^^^^^^^^^ meta.class.python - meta.class meta.class
+#            ^^ meta.class.inheritance.python - meta.class meta.class
+#              ^ meta.class.python - meta.class meta.class punctuation.section.class.begin
     def my_func(self, param1, # Multi-line function definition
 #                             ^ comment.line.number-sign
         # This is defaulted

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -807,12 +807,12 @@ def _():
 #                                  ^^ meta.function-call.arguments.python
 #   ^^^^ keyword.control.flow.with.python
 #        ^ punctuation.section.group.begin.python
-#         ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#         ^^^^^^ meta.generic-name.python
 #                ^ keyword.operator.arithmetic.python
 #                  ^^^^^^^^^^ meta.string.python string.quoted.double.python
 #                            ^ punctuation.section.group.end.python
 #                             ^ punctuation.accessor.dot.python
-#                              ^^^^ variable.function.python
+#                              ^^^^ variable.function.python - support
 #                                  ^ punctuation.section.arguments.begin.python
 #                                   ^ punctuation.section.arguments.end.python
 #                                     ^^ keyword.control.flow.with.as.python
@@ -824,18 +824,18 @@ def _():
 #        ^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
 #         ^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python meta.group.python - meta.sequence meta.sequence
 #                              ^^^^^^^^^^^^^ meta.sequence.tuple.python - meta.sequence meta.sequence - meta.sequence meta.group
-#                               ^^^^ meta.function-call.python meta.qualified-name.python
+#                               ^^^^ meta.function-call.python
 #                                   ^^ meta.function-call.arguments.python
 #                                           ^ - meta.sequence
 #   ^^^^ keyword.control.flow.with.python
 #        ^ punctuation.section.sequence.begin.python
 #         ^ punctuation.section.group.begin.python
-#          ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#          ^^^^^^ meta.generic-name.python
 #                 ^ keyword.operator.arithmetic.python
 #                   ^^^^^^^^^^ meta.string.python string.quoted.double.python
 #                             ^ punctuation.section.group.end.python
-#                              ^ meta.function-call.python meta.qualified-name.python punctuation.accessor.dot.python
-#                               ^^^^ meta.qualified-name.python variable.function.python
+#                              ^ meta.function-call.python punctuation.accessor.dot.python
+#                               ^^^^ variable.function.python - support
 #                                   ^ punctuation.section.arguments.begin.python
 #                                    ^ punctuation.section.arguments.end.python
 #                                      ^^ keyword.control.flow.with.as.python
@@ -856,16 +856,16 @@ def _():
 #   ^^^^ keyword.control.flow.with.python
 #        ^ punctuation.section.group.begin.python
 #         ^^ punctuation.section.group.begin.python
-#           ^^^^^^ meta.qualified-name.python meta.generic-name.python
+#           ^^^^^^ meta.generic-name.python
 #                  ^ keyword.operator.arithmetic.python
 #                    ^^^^^^^^^^ meta.string.python string.quoted.double.python
 #                              ^ punctuation.section.group.end.python
-#                               ^ meta.function-call.python meta.qualified-name.python punctuation.accessor.dot.python
-#                                ^^^^ variable.function.python
+#                               ^ meta.function-call.python punctuation.accessor.dot.python
+#                                ^^^^ variable.function.python - support
 #                                    ^ punctuation.section.arguments.begin.python
 #                                     ^ punctuation.section.arguments.end.python
 #                                       ^^ invalid.illegal.name.python
-#                                          ^ meta.qualified-name.python meta.generic-name.python
+#                                          ^ meta.generic-name.python
 #                                           ^ punctuation.section.group.end.python
 #                                            ^ invalid.illegal.stray.python
 #                                             ^ punctuation.section.block.with.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -294,6 +294,13 @@ import .str
 import str
 #      ^^^ support.type.python
 
+from importlib import import_module
+# <- meta.statement.import.python keyword.control.import.from.python
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.import.python
+#^^^ keyword.control.import.from.python
+#    ^^^^^^^^^ - keyword
+#              ^^^^^^ keyword.control.import.python
+#                     ^^^^^^^^^^^^^ - keyword
 
 ##################
 # Identifiers
@@ -2406,10 +2413,12 @@ unintuitive = 0B101 + 0O101 + 10l
 
 illegal = 1LL << 08 | 0b010203 | 0xAbraCadabra
 #           ^ - meta.number - constant.numeric
-#                 ^ - meta.number - constant.numeric
+#                ^^ meta.number.integer.decimal.python constant.numeric.value.python
+#                ^ invalid.illegal.digits.python
 #                     ^^ meta.number.integer.binary.python constant.numeric.base.python
 #                       ^^^ meta.number.integer.binary.python constant.numeric.value.python
-#                          ^^^^^^ - meta.number - constant.numeric
+#                          ^^^ invalid.illegal.digit.python
+#                             ^^^ - meta.number - constant.numeric
 #                                ^^ meta.number.integer.hexadecimal.python constant.numeric.base.python
 #                                  ^^ meta.number.integer.hexadecimal.python constant.numeric.value.python
 #                                    ^^^^^^^^^ - meta.number- constant.numeric
@@ -2445,7 +2454,20 @@ flags = 0b_0011_1111_0100_1110 | 0b_1 & 0b_0_
 octoct = 0o_2 ^ 0o_
 #        ^^ meta.number.integer.octal.python constant.numeric.base.python
 #          ^^ meta.number.integer.octal.python constant.numeric.value.python
-#               ^^^ - constant
+#               ^ meta.number.integer.decimal.python constant.numeric.value.python
+#                ^^ - constant
+
+if 5in range(10):
+#^^^^^^^^^^^^^^^ meta.statement.conditional.if.python
+#  ^ meta.number.integer.decimal.python constant.numeric.value.python
+#   ^^ keyword.operator.logical.python
+
+   5if 0else 6
+#  ^ meta.number.integer.decimal.python constant.numeric.value.python
+#   ^^ keyword.control.conditional.if.python
+#      ^ meta.number.integer.decimal.python constant.numeric.value.python
+#       ^^^^ keyword.control.conditional.else.python
+
 
 ##################
 # Operators

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1918,8 +1918,8 @@ tuple_expression = ()and()
 
 not_a_tuple = (a = 2, b += 3)
 #             ^^^^^^^^^^^^^^^ meta.sequence
-#                ^ invalid.illegal.unexpected-assignment-in-tuple - keyword
-#                        ^ invalid.illegal.unexpected-assignment-in-tuple - keyword
+#                ^ invalid.illegal.assignment.python
+#                       ^^ invalid.illegal.assignment.python
 
 just_a_group = (1)
 #              ^^^ meta.group.python
@@ -2457,16 +2457,61 @@ foo = bar()
 #   ^ keyword.operator.assignment.python
 foo == bar()
 #   ^^ keyword.operator.comparison.python
-#
-foo <<= bar
+
+foo <<= bar <<= baz
 #   ^^^ keyword.operator.assignment.augmented.python
+#           ^^^ invalid.illegal.assignment.python
+
+foo >>= bar >>= baz
+#   ^^^ keyword.operator.assignment.augmented.python
+#           ^^^ invalid.illegal.assignment.python
+
+foo **= bar **= baz
+#   ^^^ keyword.operator.assignment.augmented.python
+#           ^^^ invalid.illegal.assignment.python
+
+foo *= bar *= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo //= bar //= baz
+#   ^^^ keyword.operator.assignment.augmented.python
+#           ^^^ invalid.illegal.assignment.python
+
+foo /= bar /= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo += bar += baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo -= bar -= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo %= bar %= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo @= bar @= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo &= bar &= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo |= bar |= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
+
+foo ^= bar ^= baz
+#   ^^ keyword.operator.assignment.augmented.python
+#          ^^ invalid.illegal.assignment.python
 
 matrix @ multiplication
 #      ^ keyword.operator.matrix.python
-
-a @= b
-# ^^ keyword.operator.assignment.augmented.python
-
 
 ##################
 # Context "Fail Early"

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -456,6 +456,10 @@ def _():
 #     ^^ keyword.control.conditional.if
 #          ^^^^ keyword.control.conditional.else
 
+    a[0] if b[1] else c[3]
+#        ^^ keyword.control.conditional.if
+#                ^^^^ keyword.control.conditional.else
+
     c = lambda: pass
 #       ^^^^^^^^^^^^ meta.function.inline
 #       ^^^^^^ storage.type.function.inline keyword.declaration.function.inline.python
@@ -605,28 +609,49 @@ func()(1, 2)
 #^^^^^^^^^^^ - meta.function-call meta.function-call
 
 myobj[1](True)
-#^^^^^^^ meta.item-access
-#    ^ punctuation.section.brackets.begin - meta.item-access.arguments
-#     ^ meta.item-access.arguments
-#      ^ punctuation.section.brackets.end - meta.item-access.arguments
-#       ^^^^^^ meta.function-call
+#^^^^ - meta.item-access
+#    ^ punctuation.section.brackets.begin.python
+#    ^^^ meta.item-access.python
+#      ^ punctuation.section.brackets.end.python
+#       ^^^^^^ meta.function-call.arguments.python
 
 myobj[1][2](0)
-#^^^^^^^^^^ meta.item-access
-#    ^ punctuation.section.brackets.begin - meta.item-access.arguments
-#     ^ meta.item-access.arguments
-#      ^ punctuation.section.brackets.end - meta.item-access.arguments
-#       ^ punctuation.section.brackets.begin - meta.item-access.arguments
-#        ^ meta.item-access.arguments
-#         ^ punctuation.section.brackets.end - meta.item-access.arguments
-#          ^^^ meta.function-call
+#^^^^ - meta.item-access
+#    ^ punctuation.section.brackets.begin.python
+#    ^^^^^^ meta.item-access.python
+#      ^ punctuation.section.brackets.end.python
+#       ^ punctuation.section.brackets.begin.python
+#         ^ punctuation.section.brackets.end.python
+#          ^^^ meta.function-call.arguments.python
+
+a[0].b[1].d[2](e[3])[f[g[4].h[5]]]
+# <- - meta.item-access
+#^^^ meta.item-access.python
+#   ^^ - meta.item-access
+#     ^^^ meta.item-access.python
+#        ^^ - meta.item-access
+#          ^^^ meta.item-access.python
+#             ^^ - meta.item-access
+#               ^^^ meta.item-access.python
+#                  ^ - meta.item-access
+#                   ^^ meta.item-access.python - meta.item-access meta.item-access
+#                     ^^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
+#                       ^^^ meta.item-access.python meta.item-access.python meta.item-access.python
+#                          ^^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
+#                            ^^^ meta.item-access.python meta.item-access.python meta.item-access.python
+#                               ^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
+#                                ^ meta.item-access.python - meta.item-access meta.item-access
+#                                 ^ - meta.item-access
+
+self[5] = 0
+#   ^^^ meta.item-access.python
 
 range(20)[10:2:-2]
 #           ^ punctuation.separator.slice
 #             ^ punctuation.separator.slice
 
 "string"[12]
-#       ^^^^ meta.item-access - meta.structure
+#       ^^^^ meta.item-access - meta.sequence
 
 "string".
 #       ^ punctuation.accessor.dot.python
@@ -636,11 +661,15 @@ range(20)[10:2:-2]
 #       ^ punctuation.accessor.dot.python
 
 (i for i in range(10))[5]
-#                     ^^^ meta.item-access - meta.structure
+#                     ^^^ meta.item-access - meta.sequence
 
 [1, 2, 3][2]
 #^^^^^^^^ meta.sequence
-#        ^^^ meta.item-access - meta.structure
+#        ^^^ meta.item-access - meta.sequence
+
+[1, 2, 3] \
+    [2]
+#   ^^^ meta.item-access - meta.sequence
 
 [a.b., a., .][2]
 #^^^^^^^^^^^^ meta.sequence
@@ -648,7 +677,7 @@ range(20)[10:2:-2]
 #   ^ punctuation.accessor.dot.python
 #       ^ punctuation.accessor.dot.python
 #          ^ punctuation.accessor.dot.python
-#            ^^^ meta.item-access - meta.structure
+#            ^^^ meta.item-access - meta.sequence
 
 {foo.: bar.baz.}.
 #   ^ punctuation.accessor.dot.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -125,8 +125,7 @@ from collections.abc import Iterable
 from a.b.c.
 #^^^ meta.statement.import.python - meta.import-source - meta.import-path
 #   ^ meta.statement.import.python meta.import-source.python - meta.import-path
-#    ^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
-#          ^ - meta.statement
+#    ^^^^^^^ meta.statement.import.python meta.import-source.python meta.import-path.python
 #     ^ punctuation.accessor.dot.python
 #       ^ punctuation.accessor.dot.python
 #         ^ punctuation.accessor.dot.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1853,7 +1853,6 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                                                  ^^^^^ constant.language.boolean.python
 
 
-
 class MyClass:
     def foo():
         return None
@@ -1867,6 +1866,15 @@ class MyClass:
 class Unterminated(Inherited:
 # <- meta.class.python keyword.declaration.class.python
 #                           ^ invalid.illegal
+
+
+class AClass:
+    # `def` immediately after a line-continued string within a class
+    x =  "Type help() for interactive help, " \
+         "or help(object) for help about object."
+    def __call__(self, *args, **kwds):
+#   ^^^ - invalid.illegal
+        pass
 
 
 ##################
@@ -1885,22 +1893,21 @@ class Class():
 
     @functools.wraps(method, 12, kwarg=None)# comment
 #^^^ - meta.annotation
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation - meta.annotation meta.annotation
-#                    ^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.arguments
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.python
+#    ^^^^^^^^^^^^^^^ meta.function-call.identifier.python meta.path.python
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.python
 #   ^ punctuation.definition.annotation
-#    ^^^^^^^^^^^^^^^^ meta.annotation.function
-#    ^^^^^^^^^^^^^^^ meta.path
 #    ^^^^^^^^^ meta.generic-name - variable.annotation
 #             ^ punctuation.accessor.dot
-#              ^^^^^ variable.annotation.function meta.generic-name
+#              ^^^^^ variable.annotation.python
 #                   ^ punctuation.section.arguments.begin
 #                          ^ punctuation.separator.arguments
 #                            ^^ constant.numeric
+#                              ^ punctuation.separator.arguments
 #                                ^^^^^ variable.parameter
 #                                     ^ keyword.operator
 #                                      ^^^^ constant.language
-#                              ^ punctuation.separator.arguments
-#                                          ^ meta.annotation.function punctuation.section.arguments.end
+#                                          ^ punctuation.section.arguments.end
 #                                           ^^^^^^^^^ comment - meta.annotation
     def wrapper(self):
         return self.__class__(method)
@@ -1920,7 +1927,7 @@ class Class():
 
     @staticmethod
 #   ^^^^^^^^^^^^^ meta.annotation
-#    ^^^^^^^^^^^^ variable.annotation support.function.builtin
+#    ^^^^^^^^^^^^ variable.annotation - support
 #                ^ - meta.annotation
 
     @not_a.staticmethod
@@ -1930,11 +1937,27 @@ class Class():
 
     @not_a.__init__()
 #   ^^^^^^^^^^^^^^^ meta.annotation
-#          ^^^^^^^^ variable.annotation support.function.magic
 #         ^ punctuation.accessor.dot
+#          ^^^^^^^^ variable.annotation.python - support
 
     @deco[4]
-#        ^ invalid.illegal.character
+#        ^^^ meta.item-access.python
+#        ^ punctuation.section.brackets.begin.python
+#         ^ meta.number.integer.decimal.python constant.numeric.value.python
+#          ^ punctuation.section.brackets.end.python
+
+    @deco[4].foo.bar
+#   ^^^^^^^^^^^^^^^^ meta.annotation.python
+#   ^ punctuation.definition.annotation.python
+#    ^^^^ variable.annotation.python
+#        ^^^ meta.item-access.python
+#        ^ punctuation.section.brackets.begin.python
+#         ^ meta.number.integer.decimal.python constant.numeric.value.python
+#          ^ punctuation.section.brackets.end.python
+#           ^ punctuation.accessor.dot.python
+#            ^^^ meta.generic-name.python
+#               ^ punctuation.accessor.dot.python
+#                ^^^ variable.annotation.python
 
     @deco \
         . rator
@@ -1943,8 +1966,9 @@ class Class():
 
     @ deco \
         . rator()
-#       ^^^^^^^^^ meta.annotation.function
-#         ^^^^^ variable.annotation.function
+#       ^^^^^^^ meta.annotation.python meta.function-call.identifier.python meta.path.python
+#              ^^ meta.annotation.python meta.function-call.arguments.python
+#         ^^^^^ variable.annotation
 
     @ deco \
 #     ^^^^ meta.path meta.generic-name - variable.annotation
@@ -1953,17 +1977,59 @@ class Class():
     @deco \
 
     def f(): pass
-#   ^^^ keyword.declaration.function.python - meta.decorator
+#   ^^^ keyword.declaration.function.python - meta.decorator - invalid
 
+    @(y := _)
+#  ^ - meta.annotation
+#   ^ meta.annotation.python punctuation.definition.annotation.python
+#    ^^^^^^^^ meta.annotation.python meta.group.python
+#            ^ - meta.annotation
+#    ^ punctuation.section.group.begin.python
+#     ^ meta.generic-name.python
+#       ^^ keyword.operator.assignment.inline.python
+#          ^ variable.language.anonymous.python
+#           ^ punctuation.section.group.end.python
 
-class AClass:
-    # `def` immediately after a line-continued string within a class
-    x =  "Type help() for interactive help, " \
-         "or help(object) for help about object."
-    def __call__(self, *args, **kwds):
-#   ^^^ - invalid.illegal
-        pass
+    @z := _
+#  ^ - meta.annotation
+#   ^^^^^^^ meta.annotation.python
+#          ^ - meta.annotation
+#   ^ punctuation.definition.annotation.python
+#    ^ variable.annotation.python
+#      ^^ keyword.operator.assignment.inline.python
+#         ^ variable.annotation.python
 
+    @[k for k in buttons()].clicked
+#   ^ meta.annotation.python punctuation.definition.annotation.python
+#    ^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.python meta.sequence.list.python
+#                          ^^^^^^^^ meta.annotation.python meta.path.python
+#    ^ punctuation.section.sequence.begin.python
+#     ^ meta.generic-name.python
+#       ^^^ keyword.control.loop.for.generator.python
+#           ^ meta.generic-name.python
+#             ^^ keyword.control.loop.for.in.python
+#                ^^^^^^^ meta.function-call.identifier.python variable.function.python
+#                       ^^ meta.function-call.arguments.python
+#                         ^ punctuation.section.sequence.end.python
+#                          ^ punctuation.accessor.dot.python
+#                           ^^^^^^^ variable.annotation.python
+#
+
+    @(k for k in buttons()).clicked
+#   ^ meta.annotation.python punctuation.definition.annotation.python
+#    ^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.python meta.sequence.generator.python
+#                          ^^^^^^^^ meta.annotation.python meta.path.python
+#    ^ punctuation.section.sequence.begin.python
+#     ^ meta.generic-name.python
+#       ^^^ keyword.control.loop.for.generator.python
+#           ^ meta.generic-name.python
+#             ^^ keyword.control.loop.for.in.python
+#                ^^^^^^^ meta.function-call.identifier.python variable.function.python
+#                       ^^ meta.function-call.arguments.python
+#                         ^ punctuation.section.sequence.end.python
+#                          ^ punctuation.accessor.dot.python
+#                           ^^^^^^^ variable.annotation.python
+#
 
 ##################
 # Collection literals and generators

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -425,12 +425,12 @@ datetime.strftime(datetime.now(), '%Y%V%uT')
 #              ^^^^^^ constant.other.placeholder.python
 #                 ^^ constant.other.format-spec.python
 '{0:%Y}-{0:%m
-# ^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^^^^^ meta.string.python string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
 #      ^^^^ - constant.other.placeholder.python
 #            ^ invalid.illegal.unclosed-string.python
 '{0:%Y}-{0:%
-# ^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^^^^ meta.string.python string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
 #      ^^^^^ - constant.other.placeholder.python
 #           ^ invalid.illegal.unclosed-string.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -640,20 +640,20 @@ f"string"
 
  RF"""string"""
 #^^ storage.type.string - string
-#  ^^^^^^^^^^^^ meta.string.interpolated string.quoted.double.block
+#  ^^^^^^^^^^^^ meta.string string.quoted.double.block
 
 F'''string'''
 # <- storage.type.string
-#^^^^^^^^^^^^ meta.string.interpolated string.quoted.single.block
-#^ meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.begin.python
-#         ^ meta.string.interpolated.python string.quoted.single.block.python punctuation.definition.string.end.python
+#^^^^^^^^^^^^ meta.string string.quoted.single.block
+#^ meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+#         ^ meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python
 
     f"{size:.2f}"
-#    ^ meta.string.interpolated.python - meta.interpolation
-#     ^^^^^ meta.string.interpolated.python meta.interpolation.python - meta.format-spec
-#          ^^^^ meta.string.interpolated.python meta.interpolation.python meta.format-spec.python - meta.format-spec meta.format-spec
-#              ^ meta.string.interpolated.python meta.interpolation.python - meta.format-spec
-#               ^ meta.string.interpolated.python string.quoted.double.python - meta.interpolation
+#    ^ meta.string.python - meta.interpolation
+#     ^^^^^ meta.string.python meta.interpolation.python - meta.format-spec
+#          ^^^^ meta.string.python meta.interpolation.python meta.format-spec.python - meta.format-spec meta.format-spec
+#              ^ meta.string.python meta.interpolation.python - meta.format-spec
+#               ^ meta.string.python string.quoted.double.python - meta.interpolation
 #    ^ punctuation.definition.string.begin.python
 #     ^ punctuation.section.interpolation.begin.python
 #      ^^^^ meta.qualified-name.python meta.generic-name.python
@@ -664,7 +664,7 @@ F'''string'''
 
  rf'string'
 #^^ storage.type.string - string
-#  ^^^^^^^^ meta.string.interpolated string.quoted.single
+#  ^^^^^^^^ meta.string string.quoted.single
 
 rf'\r\n' f'\r\n' Rf'\r\n'
 #  ^^^^ source.regexp constant.character.escape.regexp
@@ -677,10 +677,10 @@ rf"\r\n" f"\r\n" Rf'\r\n'
 #                   ^^^^ - constant
 
 expr = fr"^\s*({label}|{notlabel})"
-#         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated.python
-#         ^ meta.string.interpolated.python string.quoted.double.python source.regexp.python keyword.control.anchor.regexp
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python
+#         ^ meta.string.python string.quoted.double.python source.regexp.python keyword.control.anchor.regexp
 #             ^ source.regexp.python meta.group.regexp punctuation.section.group.begin.regexp
-#              ^^^^^^^ source.python meta.string.interpolated.python meta.interpolation.python
+#              ^^^^^^^ source.python meta.string.python meta.interpolation.python
 #               ^^^^^ source.python.embedded meta.qualified-name.python meta.generic-name.python
 #                                ^ source.regexp.python meta.group.regexp punctuation.section.group.end.regexp
 
@@ -756,7 +756,7 @@ f"\{{{x}\}} test"
 #    ^ punctuation.section.interpolation.begin.python
 
 f"{something}"
-#^^^^^^^^^^^^ meta.string.interpolated
+#^^^^^^^^^^^^ meta.string
 # <- storage.type.string
 #^ punctuation.definition.string.begin
 # ^ punctuation.section.interpolation.begin
@@ -766,7 +766,7 @@ f"{something}"
 #              ^ source - meta, string, source source
 
 f"{True!a:02f}"
-#^^^^^^^^^^^^^^ meta.string.interpolated
+#^^^^^^^^^^^^^^ meta.string
 # ^ - source source.python.embedded
 #  ^^^^ source source.python.embedded constant.language
 #      ^^^^^^^ - source source.python.embedded
@@ -797,13 +797,13 @@ f"result: {value:{width}.{precision}}\n"
 #                                   ^^^ - meta.interpolation.python meta.interpolation.python
 rf"{value:{width!s:d}}"
 # <- storage.type.string.python - string
-# ^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+# ^^^^^^^^^^^^^^^^^^^^^ meta.string
 #          ^^^^^ source source.python.embedded
 #               ^^ storage.modifier.conversion
 #                 ^^ constant.other.format-spec
 
 F""" {} {\} }
-#^^^^^^^^^^^ meta.string.interpolated
+#^^^^^^^^^^^ meta.string
 #^^^ punctuation.definition.string.begin
 #    ^^ invalid.illegal.empty-expression
 #        ^ invalid.illegal.backslash-in-fstring
@@ -831,24 +831,24 @@ f'{x=!s:*^20}'
 f'{"Σ"=}'
 #     ^ storage.modifier.debug.python
 f'{"Σ"= }'
-# ^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
-#  ^^^ meta.string.interpolated.python meta.interpolation.python source.python.embedded
-#     ^^^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
+# ^ meta.string.python meta.interpolation.python - source.python.embedded
+#  ^^^ meta.string.python meta.interpolation.python source.python.embedded
+#     ^^^ meta.string.python meta.interpolation.python - source.python.embedded
 #     ^ storage.modifier.debug.python
 f'{"Σ" =}'
-# ^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
-#  ^^^ meta.string.interpolated.python meta.interpolation.python source.python.embedded
-#     ^^^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
+# ^ meta.string.python meta.interpolation.python - source.python.embedded
+#  ^^^ meta.string.python meta.interpolation.python source.python.embedded
+#     ^^^ meta.string.python meta.interpolation.python - source.python.embedded
 #      ^ storage.modifier.debug.python
 f'{"Σ" = }'
-# ^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
-#  ^^^ meta.string.interpolated.python meta.interpolation.python source.python.embedded
-#     ^^^^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
+# ^ meta.string.python meta.interpolation.python - source.python.embedded
+#  ^^^ meta.string.python meta.interpolation.python source.python.embedded
+#     ^^^^ meta.string.python meta.interpolation.python - source.python.embedded
 #      ^ storage.modifier.debug.python
 f'{"Σ" = !s}'
-# ^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
-#  ^^^ meta.string.interpolated.python meta.interpolation.python source.python.embedded
-#     ^^^^^^ meta.string.interpolated.python meta.interpolation.python - source.python.embedded
+# ^ meta.string.python meta.interpolation.python - source.python.embedded
+#  ^^^ meta.string.python meta.interpolation.python source.python.embedded
+#     ^^^^^^ meta.string.python meta.interpolation.python - source.python.embedded
 #      ^ storage.modifier.debug.python
 #        ^^ storage.modifier.conversion.python
 f'{0==1}'
@@ -869,7 +869,7 @@ f" {
 
 f'   \
  {1 + 2!a:02f}'
-#^^^^^^^^^^^^^^ meta.string.interpolated
+#^^^^^^^^^^^^^^ meta.string
 # ^^^^^ source source.python.embedded
 
 f"{d for d in range(10)}"  # yes, this doesn't make sense

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -430,7 +430,7 @@ datetime.strftime(datetime.now(), '%Y%V%uT')
 #      ^^^^ - constant.other.placeholder.python
 #            ^ invalid.illegal.unclosed-string.python
 '{0:%Y}-{0:%
-# ^^^^^^^^^^^ string.quoted.single.python
+# ^^^^^^^^^^ string.quoted.single.python
 # ^^^^^ constant.other.placeholder.python
 #      ^^^^^ - constant.other.placeholder.python
 #           ^ invalid.illegal.unclosed-string.python

--- a/Python/syntax_test_python_strings.py
+++ b/Python/syntax_test_python_strings.py
@@ -656,7 +656,7 @@ F'''string'''
 #               ^ meta.string.python string.quoted.double.python - meta.interpolation
 #    ^ punctuation.definition.string.begin.python
 #     ^ punctuation.section.interpolation.begin.python
-#      ^^^^ meta.qualified-name.python meta.generic-name.python
+#      ^^^^ meta.path.python meta.generic-name.python
 #          ^^^^ constant.other.format-spec.python
 #          ^ punctuation.separator.format-spec.python
 #              ^ punctuation.section.interpolation.end.python
@@ -681,7 +681,7 @@ expr = fr"^\s*({label}|{notlabel})"
 #         ^ meta.string.python string.quoted.double.python source.regexp.python keyword.control.anchor.regexp
 #             ^ source.regexp.python meta.group.regexp punctuation.section.group.begin.regexp
 #              ^^^^^^^ source.python meta.string.python meta.interpolation.python
-#               ^^^^^ source.python.embedded meta.qualified-name.python meta.generic-name.python
+#               ^^^^^ source.python.embedded meta.path.python meta.generic-name.python
 #                                ^ source.regexp.python meta.group.regexp punctuation.section.group.end.regexp
 
 line = re.sub(rf" ?\{{\\i.?\}}({x})\{{\\i.?\}}", r"\1", line)


### PR DESCRIPTION
Fixes #2763
Fixes #2796

This PR...

1. mostely reorganizes/reorders existing syntaxes to apply a common top-down scheme of grouped contexts, which has proven to help improving maintainability of syntaxes
2. applies a common naming scheme to all contexts (several PRs have caused a mix of different schemes)
3. updates the syntax to sublime-syntax version 2
4. fixes various overlapping or missing meta scopes
5. ensures to apply ligatures correctly to all kinds of operators by re-ordering related patterns
6. fixes some edge cases with regards to expression assignment operators