### PR TITLE
[Go] Scope struct tags as annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: ci
 on:
   push:
     branches:
-      - '*'
+      - 'master'
+      - 'develop/**'
     tags-ignore:
       - '*'
     paths:
@@ -15,7 +16,8 @@ on:
       - '.github/workflows/ci.yml'
   pull_request:
     branches:
-      - '*'
+      - 'master'
+      - 'develop/**'
     paths:
       - '**/syntax_test_*'
       - '**/*.hidden-tmLanguage'

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -1266,20 +1266,22 @@ contexts:
 
   match-struct-tag-annotation:
     - match: '`'
-      scope: punctuation.definition.string.begin.go punctuation.definition.annotation.begin.go
+      scope: punctuation.definition.annotation.begin.go
       push: match-struct-tag-annotation-inner
 
   match-struct-tag-annotation-inner:
     - meta_include_prototype: false
-    - meta_scope: meta.annotation.go string.quoted.backtick.go
+    - meta_scope: meta.annotation.go
     - match: '`'
-      scope: punctuation.definition.string.end.go punctuation.definition.annotation.end.go
+      scope: punctuation.definition.annotation.end.go
       pop: 1
     - match: (\w+)(:)
       captures:
         1: meta.annotation.identifier.go variable.annotation.go
         2: meta.annotation.go punctuation.separator.key-value.go
       push: match-struct-tag-annotation-value
+    - match: (\w+)(?=[\s`])
+      scope: meta.annotation.identifier.go variable.annotation.go
 
   match-struct-tag-annotation-value:
     - match: '"'

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -660,9 +660,9 @@ contexts:
   match-interpreted-string:
     - match: '"'
       scope: punctuation.definition.string.begin.go
-      push: inside-interpreted-string
+      push: match-interpreted-string-inner
 
-  inside-interpreted-string:
+  match-interpreted-string-inner:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.go
     - match: '"'
@@ -1259,36 +1259,39 @@ contexts:
       scope: variable.other.member.declaration.go
       push: pop-struct-field-meta
 
-    - include: struct-tag-annotation
+    - include: match-struct-tag-annotation
     - include: match-semicolon
     - include: match-comma
     - include: match-operators
 
-  struct-tag-annotation:
+  match-struct-tag-annotation:
     - match: '`'
       scope: punctuation.definition.string.begin.go punctuation.definition.annotation.begin.go
+      push: match-struct-tag-annotation-inner
+
+  match-struct-tag-annotation-inner:
+    - meta_include_prototype: false
+    - meta_scope: meta.annotation.go string.quoted.backtick.go
+    - match: '`'
+      scope: punctuation.definition.string.end.go punctuation.definition.annotation.end.go
+      pop: 1
+    - match: (\w+)(:)
+      captures:
+        1: meta.annotation.identifier.go variable.annotation.go
+        2: meta.annotation.go punctuation.separator.key-value.go
+      push: match-struct-tag-annotation-value
+
+  match-struct-tag-annotation-value:
+    - match: '"'
+      scope: punctuation.definition.string.begin.go
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.backtick.go meta.annotation.go
-        - match: '`'
-          scope: punctuation.definition.string.end.go punctuation.definition.annotation.end.go
-          pop: 1
-        - match: (\w+)(:)
-          captures:
-            1: meta.annotation.identifier.go variable.annotation.go
-            2: meta.annotation.go punctuation.separator.key-value.go
-          push:
-            - clear_scopes: 1
-            - match: '"'
-              scope: punctuation.definition.string.begin.go
-              push:
-                - meta_include_prototype: false
-                - meta_scope: string.quoted.double.go meta.annotation.parameters.go
-                - include: inside-interpreted-string
-                - match: ','
-                  scope: punctuation.separator.sequence.go
-            - match: ''
-              pop: true
+        - meta_scope: meta.annotation.parameters.go string.quoted.double.go
+        - include: match-interpreted-string-inner
+        - match: ','
+          scope: punctuation.separator.sequence.go
+    - match: ''
+      pop: true
 
   pop-struct-field-meta:
     - include: pop-before-brace-end

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -660,18 +660,20 @@ contexts:
   match-interpreted-string:
     - match: '"'
       scope: punctuation.definition.string.begin.go
-      push:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.double.go
-        - match: '"'
-          scope: punctuation.definition.string.end.go
-          pop: 1
-        - include: match-template-string
-        - match: '{{char_escape}}'
-          scope: constant.character.escape.go
-        - match: \%%
-          scope: constant.character.escape.go
-        - include: match-fmt
+      push: inside-interpreted-string
+
+  inside-interpreted-string:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.double.go
+    - match: '"'
+      scope: punctuation.definition.string.end.go
+      pop: 1
+    - include: match-template-string
+    - match: '{{char_escape}}'
+      scope: constant.character.escape.go
+    - match: \%%
+      scope: constant.character.escape.go
+    - include: match-fmt
 
   match-template-string:
    - match: '{{(?=.*}})'
@@ -1257,7 +1259,36 @@ contexts:
       scope: variable.other.member.declaration.go
       push: pop-struct-field-meta
 
-    - include: match-any
+    - include: struct-tag-annotation
+    - include: match-semicolon
+    - include: match-comma
+    - include: match-operators
+
+  struct-tag-annotation:
+    - match: '`'
+      scope: punctuation.definition.string.begin.go punctuation.definition.annotation.begin.go
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.backtick.go meta.annotation.go
+        - match: '`'
+          scope: punctuation.definition.string.end.go punctuation.definition.annotation.end.go
+          pop: 1
+        - match: (\w+)(:)
+          captures:
+            1: meta.annotation.identifier.go variable.annotation.go
+            2: meta.annotation.go punctuation.separator.key-value.go
+          push:
+            - clear_scopes: 1
+            - match: '"'
+              scope: punctuation.definition.string.begin.go
+              push:
+                - meta_include_prototype: false
+                - meta_scope: string.quoted.double.go meta.annotation.parameters.go
+                - include: inside-interpreted-string
+                - match: ','
+                  scope: punctuation.separator.sequence.go
+            - match: ''
+              pop: true
 
   pop-struct-field-meta:
     - include: pop-before-brace-end

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1542,7 +1542,7 @@ by accident, but if necessary, such support could be sacrificed.
         field typ `json:"field,omitempty" xml:"name"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.backtick.go meta.annotation
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation string.quoted.backtick.go
 //                 ^^^^ meta.annotation.identifier variable.annotation
 //                     ^ punctuation.separator.key-value
 //                      ^^^^^^^^^^^^^^^^^ meta.annotation.parameters
@@ -1552,7 +1552,7 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.definition.string.end
 //                                        ^^^ meta.annotation.identifier variable.annotation
 //                                           ^ punctuation.separator.key-value
-//                                            ^^^^^^ string.quoted.double meta.annotation.parameters
+//                                            ^^^^^^ meta.annotation.parameters string.quoted.double
 //                                            ^ punctuation.definition.string.begin
 //                                                 ^ punctuation.definition.string.end
 //                                                  ^ punctuation.definition.string.end punctuation.definition.annotation.end

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1539,10 +1539,23 @@ by accident, but if necessary, such support could be sacrificed.
 
     struct {
 //  ^^^^^^ keyword.declaration.struct.go
-        field typ `json:"field"`
+        field typ `json:"field,omitempty" xml:"name"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
-//                ^^^^^^^^^^^^^^ meta.type.go string.quoted.backtick.go
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.backtick.go meta.annotation
+//                 ^^^^ meta.annotation.identifier variable.annotation
+//                     ^ punctuation.separator.key-value
+//                      ^^^^^^^^^^^^^^^^^ meta.annotation.parameters
+//                      ^^^^^^^^^^^^^^^^^ string.quoted.double
+//                      ^ punctuation.definition.string.begin
+//                            ^ punctuation.separator.sequence
+//                                      ^ punctuation.definition.string.end
+//                                        ^^^ meta.annotation.identifier variable.annotation
+//                                           ^ punctuation.separator.key-value
+//                                            ^^^^^^ string.quoted.double meta.annotation.parameters
+//                                            ^ punctuation.definition.string.begin
+//                                                 ^ punctuation.definition.string.end
+//                                                  ^ punctuation.definition.string.end punctuation.definition.annotation.end
         field /**/ typ /**/ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^^ meta.type.go comment.block.go

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -1542,7 +1542,8 @@ by accident, but if necessary, such support could be sacrificed.
         field typ `json:"field,omitempty" xml:"name"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^ meta.type.go storage.type.go
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation string.quoted.backtick.go
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
+//                ^ punctuation.definition.annotation.begin
 //                 ^^^^ meta.annotation.identifier variable.annotation
 //                     ^ punctuation.separator.key-value
 //                      ^^^^^^^^^^^^^^^^^ meta.annotation.parameters
@@ -1555,20 +1556,20 @@ by accident, but if necessary, such support could be sacrificed.
 //                                            ^^^^^^ meta.annotation.parameters string.quoted.double
 //                                            ^ punctuation.definition.string.begin
 //                                                 ^ punctuation.definition.string.end
-//                                                  ^ punctuation.definition.string.end punctuation.definition.annotation.end
+//                                                  ^ punctuation.definition.annotation.end
         field /**/ typ /**/ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^^ meta.type.go comment.block.go
 //                 ^^^ meta.type.go storage.type.go
 //                     ^^^^ meta.type.go comment.block.go
-//                          ^^^^^^^^^^^^^^ meta.type.go string.quoted.backtick.go
+//                          ^^^^^^^^^^^^^^ meta.type.go meta.annotation
         typ       `json:"-"`
 //      ^^^ meta.type.go entity.other.inherited-class.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.backtick.go
+//                ^^^^^^^^^^ meta.type.go meta.annotation
         typ /**/  `json:"-"`
 //      ^^^ meta.type.go entity.other.inherited-class.go
 //          ^^^^ meta.type.go comment.block.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.backtick.go
+//                ^^^^^^^^^^ meta.type.go meta.annotation
         typ
 //      ^^^ meta.type.go entity.other.inherited-class.go
 
@@ -1798,9 +1799,9 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                           ^ punctuation.section.braces.end.go
 
     struct{ embed[typ] `tag`; }
@@ -1811,9 +1812,9 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                          ^ punctuation.terminator.go
 //                            ^ punctuation.section.braces.end.go
 
@@ -1855,9 +1856,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                    ^ punctuation.terminator.go
 //                      ^^^^^ variable.other.member.declaration.go
 //                            ^^^ storage.type.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                      ^ punctuation.section.braces.end.go
 
     struct{ embed[typ]; field typ `tag`; }
@@ -1871,9 +1872,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                    ^ punctuation.terminator.go
 //                      ^^^^^ variable.other.member.declaration.go
 //                            ^^^ storage.type.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^ punctuation.section.braces.end.go
 
@@ -1885,9 +1886,9 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
@@ -1901,9 +1902,9 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
@@ -1918,15 +1919,15 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                            ^ punctuation.section.braces.end.go
 
     struct{ embed[typ] `tag`; field typ `tag`; }
@@ -1937,15 +1938,15 @@ by accident, but if necessary, such support could be sacrificed.
 //               ^ punctuation.section.brackets.begin.go
 //                ^^^ variable.other.type.go
 //                   ^ punctuation.section.brackets.end.go
-//                     ^^^^^ string.quoted.backtick.go
-//                     ^ punctuation.definition.string.begin.go
-//                         ^ punctuation.definition.string.end.go
+//                     ^^^^^ meta.annotation
+//                     ^ punctuation.definition.annotation.begin.go
+//                         ^ punctuation.definition.annotation.end.go
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^ punctuation.section.braces.end.go
 
@@ -1984,9 +1985,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                 ^ punctuation.section.braces.end.go
 
     struct{ ident.embed[typ] `tag`; }
@@ -1999,9 +2000,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^ punctuation.section.braces.end.go
 
@@ -2049,9 +2050,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                            ^ punctuation.section.braces.end.go
 
     struct{ ident.embed[typ]; field typ `tag`; }
@@ -2067,9 +2068,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.terminator.go
 //                            ^^^^^ variable.other.member.declaration.go
 //                                  ^^^ storage.type.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^ punctuation.section.braces.end.go
 
@@ -2083,9 +2084,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
@@ -2101,9 +2102,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
@@ -2120,15 +2121,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                  ^ punctuation.section.braces.end.go
 
     struct{ ident.embed[typ] `tag`; field typ `tag`; }
@@ -2141,15 +2142,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                     ^ punctuation.section.brackets.begin.go
 //                      ^^^ variable.other.type.go
 //                         ^ punctuation.section.brackets.end.go
-//                           ^^^^^ string.quoted.backtick.go
-//                           ^ punctuation.definition.string.begin.go
-//                               ^ punctuation.definition.string.end.go
+//                           ^^^^^ meta.annotation
+//                           ^ punctuation.definition.annotation.begin.go
+//                               ^ punctuation.definition.annotation.end.go
 //                                ^ punctuation.terminator.go
 //                                  ^^^^^ variable.other.member.declaration.go
 //                                        ^^^ storage.type.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^ punctuation.section.braces.end.go
 
@@ -2191,9 +2192,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                      ^ punctuation.section.braces.end.go
 
     struct{ field typ; embed[typ] `tag`; }
@@ -2207,9 +2208,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^ punctuation.section.braces.end.go
 
@@ -2260,9 +2261,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                               ^ punctuation.terminator.go
 //                                 ^^^^^ variable.other.member.declaration.go
 //                                       ^^^ storage.type.go
-//                                           ^^^^^ string.quoted.backtick.go
-//                                           ^ punctuation.definition.string.begin.go
-//                                               ^ punctuation.definition.string.end.go
+//                                           ^^^^^ meta.annotation
+//                                           ^ punctuation.definition.annotation.begin.go
+//                                               ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.section.braces.end.go
 
     struct{ field typ; embed[typ]; field typ `tag`; }
@@ -2279,9 +2280,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                               ^ punctuation.terminator.go
 //                                 ^^^^^ variable.other.member.declaration.go
 //                                       ^^^ storage.type.go
-//                                           ^^^^^ string.quoted.backtick.go
-//                                           ^ punctuation.definition.string.begin.go
-//                                               ^ punctuation.definition.string.end.go
+//                                           ^^^^^ meta.annotation
+//                                           ^ punctuation.definition.annotation.begin.go
+//                                               ^ punctuation.definition.annotation.end.go
 //                                                ^ punctuation.terminator.go
 //                                                  ^ punctuation.section.braces.end.go
 
@@ -2296,9 +2297,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
@@ -2315,9 +2316,10 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                 ^^^ meta.annotation.identifier variable.annotation
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
@@ -2335,15 +2337,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.backtick.go
-//                                                 ^ punctuation.definition.string.begin.go
-//                                                     ^ punctuation.definition.string.end.go
+//                                                 ^^^^^ meta.annotation
+//                                                 ^ punctuation.definition.annotation.begin.go
+//                                                     ^ punctuation.definition.annotation.end.go
 //                                                       ^ punctuation.section.braces.end.go
 
     struct{ field typ; embed[typ] `tag`; field typ `tag`; }
@@ -2357,15 +2359,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                          ^ punctuation.section.brackets.begin.go
 //                           ^^^ variable.other.type.go
 //                              ^ punctuation.section.brackets.end.go
-//                                ^^^^^ string.quoted.backtick.go
-//                                ^ punctuation.definition.string.begin.go
-//                                    ^ punctuation.definition.string.end.go
+//                                ^^^^^ meta.annotation
+//                                ^ punctuation.definition.annotation.begin.go
+//                                    ^ punctuation.definition.annotation.end.go
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.backtick.go
-//                                                 ^ punctuation.definition.string.begin.go
-//                                                     ^ punctuation.definition.string.end.go
+//                                                 ^^^^^ meta.annotation
+//                                                 ^ punctuation.definition.annotation.begin.go
+//                                                     ^ punctuation.definition.annotation.end.go
 //                                                      ^ punctuation.terminator.go
 //                                                        ^ punctuation.section.braces.end.go
 
@@ -2375,9 +2377,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2391,9 +2393,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2408,17 +2410,17 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                            ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; embed[typ] `tag`; }
@@ -2427,17 +2429,17 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^ punctuation.section.braces.end.go
 
@@ -2447,9 +2449,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2466,9 +2468,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2486,9 +2488,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2497,9 +2499,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.backtick.go
-//                                                 ^ punctuation.definition.string.begin.go
-//                                                     ^ punctuation.definition.string.end.go
+//                                                 ^^^^^ meta.annotation
+//                                                 ^ punctuation.definition.annotation.begin.go
+//                                                     ^ punctuation.definition.annotation.end.go
 //                                                       ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; embed[typ]; field typ `tag`; }
@@ -2508,9 +2510,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
@@ -2519,9 +2521,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                     ^ punctuation.terminator.go
 //                                       ^^^^^ variable.other.member.declaration.go
 //                                             ^^^ storage.type.go
-//                                                 ^^^^^ string.quoted.backtick.go
-//                                                 ^ punctuation.definition.string.begin.go
-//                                                     ^ punctuation.definition.string.end.go
+//                                                 ^^^^^ meta.annotation
+//                                                 ^ punctuation.definition.annotation.begin.go
+//                                                     ^ punctuation.definition.annotation.end.go
 //                                                      ^ punctuation.terminator.go
 //                                                        ^ punctuation.section.braces.end.go
 
@@ -2531,17 +2533,17 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
@@ -2553,17 +2555,17 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
@@ -2576,23 +2578,23 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.backtick.go
-//                                                       ^ punctuation.definition.string.begin.go
-//                                                           ^ punctuation.definition.string.end.go
+//                                                       ^^^^^ meta.annotation
+//                                                       ^ punctuation.definition.annotation.begin.go
+//                                                           ^ punctuation.definition.annotation.end.go
 //                                                             ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; embed[typ] `tag`; field typ `tag`; }
@@ -2601,23 +2603,23 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ entity.other.inherited-class.go
 //                                ^ punctuation.section.brackets.begin.go
 //                                 ^^^ variable.other.type.go
 //                                    ^ punctuation.section.brackets.end.go
-//                                      ^^^^^ string.quoted.backtick.go
-//                                      ^ punctuation.definition.string.begin.go
-//                                          ^ punctuation.definition.string.end.go
+//                                      ^^^^^ meta.annotation
+//                                      ^ punctuation.definition.annotation.begin.go
+//                                          ^ punctuation.definition.annotation.end.go
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.backtick.go
-//                                                       ^ punctuation.definition.string.begin.go
-//                                                           ^ punctuation.definition.string.end.go
+//                                                       ^^^^^ meta.annotation
+//                                                       ^ punctuation.definition.annotation.begin.go
+//                                                           ^ punctuation.definition.annotation.end.go
 //                                                            ^ punctuation.terminator.go
 //                                                              ^ punctuation.section.braces.end.go
 
@@ -2627,9 +2629,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2645,9 +2647,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2664,9 +2666,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2674,9 +2676,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                  ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; ident.embed[typ] `tag`; }
@@ -2685,9 +2687,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2695,9 +2697,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^ punctuation.section.braces.end.go
 
@@ -2707,9 +2709,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2728,9 +2730,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2750,9 +2752,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2763,9 +2765,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.backtick.go
-//                                                       ^ punctuation.definition.string.begin.go
-//                                                           ^ punctuation.definition.string.end.go
+//                                                       ^^^^^ meta.annotation
+//                                                       ^ punctuation.definition.annotation.begin.go
+//                                                           ^ punctuation.definition.annotation.end.go
 //                                                             ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; ident.embed[typ]; field typ `tag`; }
@@ -2774,9 +2776,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2787,9 +2789,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                           ^ punctuation.terminator.go
 //                                             ^^^^^ variable.other.member.declaration.go
 //                                                   ^^^ storage.type.go
-//                                                       ^^^^^ string.quoted.backtick.go
-//                                                       ^ punctuation.definition.string.begin.go
-//                                                           ^ punctuation.definition.string.end.go
+//                                                       ^^^^^ meta.annotation
+//                                                       ^ punctuation.definition.annotation.begin.go
+//                                                           ^ punctuation.definition.annotation.end.go
 //                                                            ^ punctuation.terminator.go
 //                                                              ^ punctuation.section.braces.end.go
 
@@ -2799,9 +2801,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2809,9 +2811,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
@@ -2823,9 +2825,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2833,9 +2835,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
@@ -2848,9 +2850,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2858,15 +2860,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
-//                                                             ^^^^^ string.quoted.backtick.go
-//                                                             ^ punctuation.definition.string.begin.go
-//                                                                 ^ punctuation.definition.string.end.go
+//                                                             ^^^^^ meta.annotation
+//                                                             ^ punctuation.definition.annotation.begin.go
+//                                                                 ^ punctuation.definition.annotation.end.go
 //                                                                   ^ punctuation.section.braces.end.go
 
     struct{ field typ `tag`; ident.embed[typ] `tag`; field typ `tag`; }
@@ -2875,9 +2877,9 @@ by accident, but if necessary, such support could be sacrificed.
 //        ^ punctuation.section.braces.begin.go
 //          ^^^^^ variable.other.member.declaration.go
 //                ^^^ storage.type.go
-//                    ^^^^^ string.quoted.backtick.go
-//                    ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                    ^^^^^ meta.annotation
+//                    ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
 //                         ^ punctuation.terminator.go
 //                           ^^^^^ variable.other.go
 //                                ^ punctuation.accessor.dot.go
@@ -2885,15 +2887,15 @@ by accident, but if necessary, such support could be sacrificed.
 //                                      ^ punctuation.section.brackets.begin.go
 //                                       ^^^ variable.other.type.go
 //                                          ^ punctuation.section.brackets.end.go
-//                                            ^^^^^ string.quoted.backtick.go
-//                                            ^ punctuation.definition.string.begin.go
-//                                                ^ punctuation.definition.string.end.go
+//                                            ^^^^^ meta.annotation
+//                                            ^ punctuation.definition.annotation.begin.go
+//                                                ^ punctuation.definition.annotation.end.go
 //                                                 ^ punctuation.terminator.go
 //                                                   ^^^^^ variable.other.member.declaration.go
 //                                                         ^^^ storage.type.go
-//                                                             ^^^^^ string.quoted.backtick.go
-//                                                             ^ punctuation.definition.string.begin.go
-//                                                                 ^ punctuation.definition.string.end.go
+//                                                             ^^^^^ meta.annotation
+//                                                             ^ punctuation.definition.annotation.begin.go
+//                                                                 ^ punctuation.definition.annotation.end.go
 //                                                                  ^ punctuation.terminator.go
 //                                                                    ^ punctuation.section.braces.end.go
 
@@ -2920,9 +2922,9 @@ by accident, but if necessary, such support could be sacrificed.
 //           ^ punctuation.section.brackets.begin.go
 //            ^^^ variable.other.type.go
 //               ^ punctuation.section.brackets.end.go
-//                 ^^ string.quoted.backtick.go
-//                 ^ punctuation.definition.string.begin.go
-//                  ^ punctuation.definition.string.end.go
+//                 ^^ meta.annotation
+//                 ^ punctuation.definition.annotation.begin.go
+//                  ^ punctuation.definition.annotation.end.go
         embed /**/ [typ]
 //^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
 //      ^^^^^ entity.other.inherited-class.go
@@ -2941,9 +2943,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                 ^ punctuation.section.brackets.begin.go
 //                  ^^^ variable.other.type.go
 //                     ^ punctuation.section.brackets.end.go
-//                       ^^ string.quoted.backtick.go
-//                       ^ punctuation.definition.string.begin.go
-//                        ^ punctuation.definition.string.end.go
+//                       ^^ meta.annotation
+//                       ^ punctuation.definition.annotation.begin.go
+//                        ^ punctuation.definition.annotation.end.go
         embed /**/ [typ] /**/
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
 //      ^^^^^ entity.other.inherited-class.go
@@ -2968,9 +2970,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                       ^^^^ comment.block.go
 //                       ^^ punctuation.definition.comment.begin.go
 //                         ^^ punctuation.definition.comment.end.go
-//                            ^^ string.quoted.backtick.go
-//                            ^ punctuation.definition.string.begin.go
-//                             ^ punctuation.definition.string.end.go
+//                            ^^ meta.annotation
+//                            ^ punctuation.definition.annotation.begin.go
+//                             ^ punctuation.definition.annotation.end.go
         embed /**/ [typ] ; field typ
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.go
 //      ^^^^^ entity.other.inherited-class.go
@@ -3010,9 +3012,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                       ^^^^ comment.block.go
 //                       ^^ punctuation.definition.comment.begin.go
 //                         ^^ punctuation.definition.comment.end.go
-//                            ^^ string.quoted.backtick.go
-//                            ^ punctuation.definition.string.begin.go
-//                             ^ punctuation.definition.string.end.go
+//                            ^^ meta.annotation
+//                            ^ punctuation.definition.annotation.begin.go
+//                             ^ punctuation.definition.annotation.end.go
 //                              ^ punctuation.terminator.go
 //                                ^^^^^ variable.other.member.declaration.go
 //                                      ^^^ storage.type.go
@@ -3054,9 +3056,9 @@ by accident, but if necessary, such support could be sacrificed.
 //                        ^^ punctuation.definition.comment.begin.go
 //                          ^^ punctuation.definition.comment.end.go
 //                             ^^^ storage.type.go
-//                                 ^^^^^ string.quoted.backtick.go
-//                                 ^ punctuation.definition.string.begin.go
-//                                     ^ punctuation.definition.string.end.go
+//                                 ^^^^^ meta.annotation
+//                                 ^ punctuation.definition.annotation.begin.go
+//                                     ^ punctuation.definition.annotation.end.go
     }
 //^^^ meta.type.go
 //  ^ punctuation.section.braces.end.go


### PR DESCRIPTION
Scope Golang's [struct tags](https://pkg.go.dev/reflect#StructTag) as annotations.
Further reading:
- https://www.digitalocean.com/community/tutorials/how-to-use-struct-tags-in-go
- https://stackoverflow.com/a/30889373/4473405

~~I have kept the original `string.quoted.backtick` scoping as well for backwards compatibility with users whom might prefer these to stay highlighted as before.~~