### PR TITLE
[HTML] Add support for `text/babel` MIME-type

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -40,11 +40,14 @@ variables:
   javascript_mime_type: |-
     (?xi:
       (?:
+      # default JS MIME types
       # https://mimesniff.spec.whatwg.org/#javascript-mime-type
         (?:application|text)/(?:x-)?(?:java|ecma)script
       | text/javascript1\.[0-5]
       | text/jscript
       | text/livescript
+      # non-standard JS MIME types
+      | text/babel
       )
       {{mime_type_parameters}}?
     )

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -92,6 +92,11 @@
         ##  ^^^^^^^^^ meta.tag.script.end.html - source.js.embedded.html
         ##           ^ - meta.tag
 
+        <script type="text/babel">var foo</script>
+        ## ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
+        ##                        ^^^^^^^ source.js.embedded.html
+        ##                               ^^^^^^^^^ meta.tag.script.end.html
+
         <script type="text/javascript"> <!--
         ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value - source
         ##      ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value - source


### PR DESCRIPTION
This commit adds `text/babel` to the list of supported MIME types to enable JavaScript highlighting within <script type="text/babel"> tags.

see: https://github.com/vuejs/vue-syntax-highlight/issues/218

Other templating syntaxes may be effected as well, so fixing it in default HTML might help all of them.