### PR TITLE
[Matlab] Cancel completions after keywords at EOL

### DIFF
--- a/Matlab/Completion Rules.tmPreferences
+++ b/Matlab/Completion Rules.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.matlab</string>
+    <key>settings</key>
+    <dict>
+        <key>cancelCompletion</key>
+        <string>^.*\b(?:arguments|break|case|catch|classdef|continue|else|elseif|end|enumeration|events|for|function|global|if|methods|otherwise|parfor|persistent|properties|return|spmd|switch|try|while)$</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This allows to press the <kbd>Enter</kbd> key in order to insert a linebreak after a keyword at the end of the line, without accidentally inserting the 2nd best completion match (see #3648). It should improve the behavior while typing, if the default value for the `"auto_complete_commit_on_tab"` setting is used.

If I didn't miss anything, the keywords which could in practice appear at EOL are `arguments`, `break`, `catch`, `continue`, `else`, `end`, `enumeration`, `events`, `methods`, `otherwise`, `properties`, `return`, `spmd`, `try`.
But I think it doesn't hurt to also close the completion popup after other keywords.