### PR TITLE
[JavaScript] Fix syntax engine deadlock

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -226,11 +226,6 @@ contexts:
     - match: ''
       pop: 1
 
-  immediately-pop-2:
-    - meta_include_prototype: false
-    - match: ''
-      pop: 2
-
   comma-separator:
     - match: ','
       scope: punctuation.separator.comma.js
@@ -663,7 +658,7 @@ contexts:
       branch_point: expression-statement-continuation
       branch:
         - expression-statement-continuation
-        - immediately-pop-2
+        - expression-statement-pop
     - include: expression-end
 
   expression-statement-continuation:
@@ -678,6 +673,16 @@ contexts:
       pop: true
     - match: (?=\S)
       fail: expression-statement-continuation
+
+  expression-statement-pop:
+    # Consume only comments (ignore patterns from inheriting syntaxes) and
+    # pop `expression-statement-end` at the same text point the previous branch
+    # fails at in order to prevent ST's syntax engine to lock up.
+    # see: https://github.com/sublimehq/sublime_text/issues/5853
+    - meta_include_prototype: false
+    - include: comments
+    - match: (?=\S)
+      pop: 2
 
   restricted-production:
     - meta_include_prototype: false
@@ -948,15 +953,28 @@ contexts:
       branch_point: decorator-expression-continuation
       branch:
         - decorator-expression-continuation
-        - immediately-pop-2
+        - decorator-expression-pop
 
     - include: else-pop
 
   decorator-expression-continuation:
     - match: (?=[.`(])
-      pop: true
+      pop: 1
     - match: (?=\S)
       fail: decorator-expression-continuation
+
+  decorator-expression-pop:
+    # Consume only comments (ignore patterns from inheriting syntaxes)
+    # and clear `meta.annotation` scope so it looks like the comment not being
+    # part of the annotation anymore.
+    # Pop `decorator-expression-end` at the same text point the previous branch
+    # fails at in order to prevent ST's syntax engine to lock up.
+    # see: https://github.com/sublimehq/sublime_text/issues/5853
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - include: comments
+    - match: (?=\S)
+      pop: 2
 
   decorator-expression-begin:
     - include: decorator-name

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -222,6 +222,10 @@ contexts:
     - match: (?=\S)
       pop: 1
 
+  else-pop-2:
+    - match: (?=\S)
+      pop: 2
+
   immediately-pop:
     - match: ''
       pop: 1
@@ -682,8 +686,7 @@ contexts:
     # see: https://github.com/sublimehq/sublime_text/issues/5853
     - meta_include_prototype: false
     - include: comments
-    - match: (?=\S)
-      pop: 2
+    - include: else-pop-2
 
   restricted-production:
     - meta_include_prototype: false
@@ -974,8 +977,7 @@ contexts:
     - clear_scopes: 1
     - meta_include_prototype: false
     - include: comments
-    - match: (?=\S)
-      pop: 2
+    - include: else-pop-2
 
   decorator-expression-begin:
     - include: decorator-name

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -38,8 +38,8 @@ variables:
 
   block_comment_contents: (?:(?:[^*]|\*(?!/))*)
   block_comment: (?:/\*{{block_comment_contents}}\*/)
-  nothing: (?x:(?:\s|{{block_comment}})*)
-  line_ending_ahead: (?={{nothing}}(?:/\*{{block_comment_contents}})?$)
+  nothing: (?:(?:\s|{{block_comment}})*)
+  line_ending_ahead: (?={{nothing}}(?:/\*{{block_comment_contents}}|//.*)?$)
 
   # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
   reserved_word: |-

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -665,12 +665,13 @@ contexts:
     - match: (?=\+\+|--)
       fail: expression-statement-continuation
     - match: |-
-        (?x:(?=
-          != |
-          [-+*/%><=&|^\[(;,.:?] |
-          (?:in|instanceof){{identifier_break}}
-        ))
-      pop: true
+        (?x)
+        (?=
+          !=
+        | [-+*/%><=&|^\[(;,.:?]
+        | (?:in|instanceof){{identifier_break}}
+        )
+      pop: 1
     - match: (?=\S)
       fail: expression-statement-continuation
 

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -760,6 +760,14 @@ class MyClass extends TheirClass {
 //        ^ - meta.annotation
     bar() {}
 
+    @foo // comment
+//  ^^^^ meta.annotation - comment
+//      ^ - comment - meta.annotation.js
+//       ^^^^^^^^^^^ comment.line - meta.annotation
+    bar() {}
+//^^ - meta.annotation
+//  ^^^^^^^^ meta.function - meta.annotation
+
     @foo /* comment
 //  ^^^^ meta.annotation - comment
 //      ^ - comment - meta.annotation.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -760,6 +760,38 @@ class MyClass extends TheirClass {
 //        ^ - meta.annotation
     bar() {}
 
+    @foo /* comment
+//  ^^^^ meta.annotation - comment
+//      ^ - comment - meta.annotation.js
+//       ^^^^^^^^^^^ comment.block.js - meta.annotation
+    */bar() {}
+//^^^^ comment.block.js - meta.annotation
+//    ^^^^^^^^ meta.function - meta.annotation
+
+    @foo /* block */ /* comment
+//  ^^^^ meta.annotation - comment
+//      ^ - comment - meta.annotation.js
+//       ^^^^^^^^^^^^^^^^^^^^^^^  - meta.annotation
+//       ^^^^^^^^^^^ comment.block.js
+//                   ^^^^^^^^^^^ comment.block.js
+    bar() {}
+//  ^^^^^^^^^ comment.block.js
+    */bar() {}
+//^^^^ comment.block.js - meta.annotation
+//    ^^^^^^^^ meta.function - meta.annotation
+
+    @foo /* block */ /* comment
+//  ^^^^^ meta.annotation.js - comment
+//       ^^^^^^^^^^^ meta.annotation.js comment.block.js
+//                  ^ meta.annotation.js - comment
+//                   ^^^^^^^^^^^ meta.annotation.js comment.block.js
+    bar() {}
+//  ^^^^^^^^^meta.annotation.js comment.block.js
+    */ . bar baz() {}
+//^^^^ meta.annotation.js comment.block.js
+//    ^^^^^^ meta.annotation.js - comment
+//           ^^^^^^^^ meta.function - meta.annotation
+
     static ['foo']() {}
 //         ^^^^^^^^^^^^ meta.function
 


### PR DESCRIPTION
Works around: https://github.com/sublimehq/sublime_text/issues/5813 and https://github.com/sublimehq/sublime_text/issues/5853

### Problem

ST locks up on certain text manipulation operations, which seem to cause syntax engine to bring into an invalid state causing a deadlock or infinite loop.

The two related branch points are used to peak into the next line to decide whether the current context's expression continues. If not the current context is to be popped off stack (immediately).

"Immediately" is what causes ST to lock up, on certain text manipulations if the context/branch is nested in another branch.

### Solution

This PR works around this bug by popping the fallback branch at the same text point as the main branch failed at, using the same pattern to pop. As a result tokens which are matched by `{{line_ending_ahead}}` need to be consumed by the fallback context. In that case these are comments. A possible meta scope needs to be cleared and prototypes from possible inheriting syntaxes are to be skipped.

Note: Also make sure line comments pop annotations early.