### PR TITLE
[Matlab] Add heuristic to pop function context for not-nested functions without end keyword

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -749,6 +749,10 @@ contexts:
     - match: \bend\b
       scope: keyword.declaration.function.end.matlab
       pop: 1
+    # Heuristic to pop context when another `function` keyword appears directly at the start of a line, which is
+    # unlikely to indicate a nested function (the `end` keyword is sometimes optional).
+    - match: ^(?=function\b)
+      pop: 1
     - include: function-declarations
     - include: keywords
     - include: expressions

--- a/Matlab/syntax_test_matlab.matlab
+++ b/Matlab/syntax_test_matlab.matlab
@@ -1040,3 +1040,12 @@ X = inf(n)
 
 X = nan(n)
 %   ^^^ support.function.builtin.matlab
+
+
+%---------------------------------------------
+% Pop function context if another function appears at the start of a line
+
+function myFunction(x)
+
+function notNestedFunction(x)
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function - meta.function meta.function


### PR DESCRIPTION
This PR proposes to add a heuristic to pop the `meta.function` scope when another `function` keyword appears at the start of a line, which unlikely indicates a nested function.

### Rationale

When I rewrote the Matlab syntax (#2650), I added the `meta.function` scope to a function body, beginning with the `function` keyword to the corresponding `end` keyword (inclusive). Similar to e.g. Python, Matlab supports [nested functions](https://www.mathworks.com/help/matlab/matlab_prog/nested-functions.html), and as you would expect, the `meta.function` scope gets stacked in that case.

But unlike Python, Matlab is not sensitive to whitespace/indentation, and especially it is also relatively common to *not* indent the function body (with nested function being an exception, but afaik it's not required to indent them).

This could be an example of nested functions (uncommon indentation):
```matlab
function parent
disp('This is the parent function')
nestedfx

function nestedfx
disp('This is the nested function')
end

end
```

Noticeably, the `end` statement is not required for functions in general, only under certain conditions which are described at https://www.mathworks.com/help/matlab/matlab_prog/create-functions-in-files.html#bvf7wat (with nested functions being one example):

![docs](https://user-images.githubusercontent.com/6579999/216787991-a5824fda-be20-4a61-a007-2b1ec1488151.png)

(Note that "local" function are *not* "nested" functions)

So the following are separate, independent local functions (not nested):
```matlab
function func1
disp('This is function 1')

function func2
disp('This is function 2')
```

As I described under point 2) in https://github.com/sublimehq/Packages/pull/2650#issuecomment-770401880, the latter example currently leads to an accumulation of stacked `meta.function` scopes. I wrote in that comment that "it has no implications for syntax highlighting", but actually I see now that it becomes problematic if you have hundreds of such functions in a single file, because ST stops syntax highlighting at some level when too many contexts are on the stack.

<details><summary>Screenshot (click to expand)</summary>

![matlab](https://user-images.githubusercontent.com/6579999/216788005-4d2d9bc2-4184-411c-95ca-733ca33ad802.png)

</details>

Therefore I think now that it would be better to pop `meta.function` when another `function` keyword appears at the start of a line. This means, that in the first code example from above, the second `end` keyword would not be recognized, but that example is a constructed edge-case and I think it's unlikely to happen in practice.
I don't think that branching in the syntax could be helpful here, because
> the highlighting engine will not rewind more than 128 lines when a `fail` occurs