### PR TITLE
[C#] support raw string literals

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1266,6 +1266,8 @@ contexts:
     - include: type_no_space
 
   line_of_code_in:
+    - match: (?=\bvar\b)
+      pop: true
     - include: lambdas
     - include: line_of_code_in_no_semicolon
     - match: ';'
@@ -1300,18 +1302,6 @@ contexts:
     - match: '='
       scope: keyword.operator.assignment.cs
     - include: literals
-    # interpolated strings
-    - match: '\$"'
-      scope: punctuation.definition.string.begin.cs
-      push: format_string
-    # multi-line strings
-    - match: '@"'
-      scope: punctuation.definition.string.begin.cs
-      push: long_string
-    # interpolated multi-line strings
-    - match: '(@\$|\$@)"'
-      scope: punctuation.definition.string.begin.cs
-      push: long_format_string
     - match: '({{name}})(?={{generic_declaration}}\()\s*(<)'
       captures:
         1: variable.function.cs
@@ -1688,10 +1678,53 @@ contexts:
       captures:
         1: constant.numeric.value.cs
         2: constant.numeric.suffix.cs
-    # strings
+    - include: strings
+
+  strings:
+    - match: '("""+)'
+      scope: punctuation.definition.string.begin.cs
+      push: raw_string_literal
     - match: '"'
       scope: punctuation.definition.string.begin.cs
       push: string
+    # interpolated strings
+    - match: '\$("""+)'
+      scope: punctuation.definition.string.begin.cs
+      push: raw_format_string
+    - match: '\$\$("""+)'
+      scope: punctuation.definition.string.begin.cs
+      push: raw_format_string_2
+    - match: '@\$("""+)'
+      scope: punctuation.definition.string.begin.cs
+      push: raw_format_string_literal
+    - match: '@\$\$("""+)'
+      scope: punctuation.definition.string.begin.cs
+      push: raw_format_string_literal_2
+    - match: '\$"'
+      scope: punctuation.definition.string.begin.cs
+      push: format_string
+    # multi-line strings
+    - match: '@"'
+      scope: punctuation.definition.string.begin.cs
+      push: long_string
+    # interpolated multi-line strings
+    - match: '(@\$|\$@)"'
+      scope: punctuation.definition.string.begin.cs
+      push: long_format_string
+
+  raw_string_literal:
+    - meta_include_prototype: false
+    - meta_scope: string.quoted.triple.cs
+    - include: string_escaped
+    - match: '\1'
+      scope: punctuation.definition.string.end.cs
+      pop: true
+    - include: string_placeholders
+    - match: '(\{)(\d+)'
+      captures:
+        1: punctuation.definition.placeholder.begin.cs
+        2: meta.number.integer.decimal.cs constant.numeric.value.cs
+      push: string_placeholder
 
   string:
     - meta_include_prototype: false
@@ -1724,13 +1757,83 @@ contexts:
         - meta_scope: meta.string.interpolated.cs
         - meta_content_scope: source.cs
         - clear_scopes: 2
-        - match: $
-          pop: true
         - include: string_placeholder_format
         - include: string_interpolation
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
+
+  raw_format_string:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
+    - match: '\1'
+      scope: punctuation.definition.string.end.cs
+      pop: true
+    - include: string_escaped
+    - include: string_placeholder_escape
+    - match: \{
+      scope: punctuation.section.interpolation.begin.cs
+      push:
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
+        - clear_scopes: 2
+        - include: string_placeholder_format
+        - include: string_interpolation
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
+      pop: true
+
+  raw_format_string_literal:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
+    - match: '\1'
+      scope: punctuation.definition.string.end.cs
+      pop: true
+    - include: string_placeholder_escape
+    - match: \{
+      scope: punctuation.section.interpolation.begin.cs
+      push:
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
+        - clear_scopes: 2
+        - include: string_placeholder_format
+        - include: string_interpolation
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
+      pop: true
+
+  raw_format_string_2:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
+    - match: '\1'
+      scope: punctuation.definition.string.end.cs
+      pop: true
+    - include: string_escaped
+    - include: string_placeholder_escape
+    - match: \{\{
+      scope: punctuation.section.interpolation.begin.cs
+      push:
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
+        - clear_scopes: 2
+        - include: string_placeholder_format
+        - include: string_interpolation_2
+
+  raw_format_string_literal_2:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
+    - match: '\1'
+      scope: punctuation.definition.string.end.cs
+      pop: true
+    - include: string_placeholder_escape
+    - match: \{
+      scope: punctuation.section.interpolation.begin.cs
+      push:
+        - meta_scope: meta.string.interpolated.cs
+        - meta_content_scope: source.cs
+        - clear_scopes: 2
+        - include: string_placeholder_format
+        - include: string_interpolation_2
 
   long_format_string:
     - meta_include_prototype: false
@@ -1786,12 +1889,15 @@ contexts:
     - match: '[^"}]+'
       scope: invalid.illegal.unexpected-character-in-placeholder.cs
 
-  string_placeholder_format:
+  string_placeholder_format_before_colon:
     - match: '\s*(?:(,)\s*((-?)\d+)\s*)?'
       captures:
         1: punctuation.separator.arguments.cs
         2: meta.number.integer.decimal.cs constant.numeric.value.cs
         3: keyword.operator.arithmetic.cs
+
+  string_placeholder_format:
+    - include: string_placeholder_format_before_colon
     - match: ':(?=")'
       scope: invalid.illegal.unclosed-string-placeholder.cs
       pop: true
@@ -1810,11 +1916,7 @@ contexts:
           scope: invalid.illegal.unescaped-placeholder.cs
 
   long_string_placeholder_format:
-    - match: '\s*(?:(,)\s*((-?)\d+)\s*)?'
-      captures:
-        1: punctuation.separator.arguments.cs
-        2: meta.number.integer.decimal.cs constant.numeric.value.cs
-        3: keyword.operator.arithmetic.cs
+    - include: string_placeholder_format_before_colon
     - match: ':(?="(?!"))'
       scope: invalid.illegal.unclosed-string-placeholder.cs
       pop: true
@@ -1836,6 +1938,12 @@ contexts:
 
   string_interpolation:
     - match: '\}'
+      scope: punctuation.section.interpolation.end.cs
+      pop: true
+    - include: line_of_code_in
+
+  string_interpolation_2:
+    - match: '\}\}'
       scope: punctuation.section.interpolation.end.cs
       pop: true
     - include: line_of_code_in

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -1,0 +1,101 @@
+/// SYNTAX TEST "Packages/C#/C#.sublime-syntax"
+
+// https://learn.microsoft.com/en-gb/dotnet/csharp/whats-new/csharp-11#raw-string-literals
+
+string longMessage = """
+///                  ^^^ string.quoted.triple punctuation.definition.string.begin
+    This is a long message.
+    It has several lines.
+        Some are indented
+                more than others.
+    Some should start at the first column.
+    Some have "quoted text" in them.
+/// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple - punctuation
+    """;
+/// ^^^ string.quoted.triple punctuation.definition.string.end
+
+longMessage = """""
+This raw string literal has four """", count them: """" four!
+embedded quote characters in a sequence. That's why it starts and ends
+with five double quotes.
+
+You could extend this example with as many embedded quotes as needed for your text.
+"""""
+// - no semi-colon on the line above
+
+var location = $$"""
+/// <- storage.type.variable
+/// ^^^^^^^^ variable.other
+///            ^^^^^ meta.string.interpolated string.quoted.triple punctuation.definition.string.begin
+   You are at {{{Longitude}}, {{Latitude}}}
+///           ^^ meta.string.interpolated string.quoted.triple constant.character.escape
+///             ^ - constant
+///                       ^^ meta.string.interpolated string.quoted.triple constant.character.escape
+///                           ^^ meta.string.interpolated string.quoted.triple constant.character.escape
+///                                     ^^ meta.string.interpolated string.quoted.triple constant.character.escape
+///                                       ^ - constant
+   """;
+
+var pointMessage = $"""The point "{X}, {Y}" is {Math.Sqrt(X * X + Y * Y)} from the origin""";
+///                ^^^^ meta.string.interpolated string.quoted.triple punctuation.definition.string.begin
+///                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+///                               ^ punctuation.section.interpolation.begin
+///                                ^ variable.other
+///                                 ^ punctuation.section.interpolation.end
+///                                    ^ punctuation.section.interpolation.begin
+///                                     ^ variable.other
+///                                      ^ punctuation.section.interpolation.end
+///                                                                                         ^ punctuation.terminator.statement - meta.string
+
+nint intptr = IntPtr.Zero;
+/// <- storage.type
+
+public static void M(string myString)
+{
+    ArgumentNullException.ThrowIfNull(myString);
+    // method
+}
+
+// https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/tokens/interpolated
+/* Beginning with C# 11, the interpolated expressions can include newlines. The text between
+   the { and } must be valid C#, therefore it can include newlines that improve readability.
+   The following example shows how newlines can improve the readability of an expression
+   involving pattern matching:
+*/
+string message = $"The usage policy for {safetyScore} is {
+    safetyScore switch
+///             ^^^^^^ meta.string.interpolated source keyword.control.flow
+    {
+        > 90 => "Unlimited usage",
+        > 80 => "General usage, with daily safety check",
+        > 70 => "Issues must be addressed within 1 week",
+        > 50 => "Issues must be addressed within 1 day",
+        _ => "Issues must be addressed before continued use",
+    }
+    }";
+/// ^ meta.string.interpolated punctuation.section.interpolation.end
+///  ^ meta.string.interpolated string.quoted.double punctuation.definition.string.end
+///   ^ punctuation.terminator.statement
+
+string name = "Horace";
+int age = 34;
+Console.WriteLine($"He asked, \"Is your name {name}?\", but didn't wait for a reply :-{{");
+///                           ^^ meta.function-call meta.group meta.string.interpolated string.quoted.double constant.character.escape
+Console.WriteLine($"{name} is {age} year{(age == 1 ? "" : "s")} old.");
+///                                                     ^ keyword.operator.ternary
+// Expected output is:
+// He asked, "Is your name Horace?", but didn't wait for a reply :-{
+// Horace is 34 years old.
+
+string s2 = @$"He said, ""This is the last \u0063hance\x0021""";
+///         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated string.quoted.double.raw
+///         ^^^ punctuation.definition.string.begin
+///                     ^^ constant.character.escape
+///                                        ^^^^^^^^^^^^^^^^^ - constant
+
+
+string s2 = @$$"""He said, ""This is the last \u0063hance\x0021""";
+///         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated string.quoted.triple
+///         ^^^^^^ punctuation.definition.string.begin
+///                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant
+///                                                            ^^^ punctuation.definition.string.end

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -98,8 +98,9 @@ string long_interpolation = $@"
 
 string unclosed_interpolation = $"inner {
 ///                                     ^ punctuation.section.interpolation.begin.cs
-///                                      ^ invalid.illegal.unclosed-string.cs
-
+///                                      ^ - invalid.illegal.unclosed-string.cs
+5}"
+;
 /// <- - string
 
 string unclosed_interpolation = $"inner {2}


### PR DESCRIPTION
C#11 supports triple quoted strings using double quotes i.e. `"""`. It also handles interpolation inside them if they begin with one or more dollar signs. Each additional dollar sign represents that an extra curly brace should be used to denote the interpolation start/end markers. An `@` before the dollar signs/quotes represents the string will be literal, i.e. `\n` wouldn't be expanded.

This is therefore going to be quite tricky to handle all cases, and what I have in this PR is mainly a bare minimum prototype which ideally needs some clean up but I don't have time for it now.

C#11 also removes the requirement for interpolations to be single-line only.
