### PR TITLE
[JavaScript] fix indentation for case/default blocks

### DIFF
--- a/JavaScript/Indentation Rules.tmPreferences
+++ b/JavaScript/Indentation Rules.tmPreferences
@@ -12,10 +12,6 @@
 			(?:
 			# dedent closing braces
 			  \}
-			# detent `case ... :`
-			| case\b
-			# detent `default:`
-			| default\b
 			)
 		]]></string>
 
@@ -27,10 +23,6 @@
 			# indent after opening braces (may be followed by whitespace or comments)
 			# but exclude lines such as `extern "C" {`
 			  .* \{ (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
-			# indent after `case ... :`
-			| case\b
-			# indent after `default:`
-			| default\b
 			)
 		]]></string>
 

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -548,52 +548,52 @@ function testIfElseIndentationWithBracesAndComment(v) {
 
 function testSwitchCaseIndentation(v) {
     switch (s) {
-    case
-    case:
-    case break
-    case: break
-    case "(": break
-    case ")": break;
-    case ":": break;
-    case ";": break;
-    case
+        case
+        case:
+        case break
+        case: break
+        case "(": break
+        case ")": break;
+        case ":": break;
+        case ";": break;
+        case
         break;
-    case:
+        case:
         break;
-    case ":"
+        case ":"
         break;
-    case ':':
+        case ':':
         break;
-    case NestedIfStatement:
+        case NestedIfStatement:
         if (s.endsWith() = '(')
             return;
         break;
-    case NestedSwitchCase:
+        case NestedSwitchCase:
         switch (v) {
-        case 0: break;
-        case 2:
+            case 0: break;
+            case 2:
             break;
         }
         break;
-    case NestedSwitchCaseBlock:
+        case NestedSwitchCaseBlock:
         {
             switch (v) {
-            case 0: break;
-            case 2:
+                case 0: break;
+                case 2:
                 break;
             }
             break;
         }
-    case NestedSwitchCaseBlock2:
+        case NestedSwitchCaseBlock2:
         {
             switch (v) {
-            case 0: break;
-            case 2:
+                case 0: break;
+                case 2:
                 break;
             }
         }
         break;
-    default:
+        default:
         break;
     }
 }


### PR DESCRIPTION
In JavaScript, it is a universal convention that `case` labels are indented one level beyond the containing switch - see e.g. the behavior of [Prettier](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBnA7gSxmAFgAgAooBXAGzIEp9gAdKMAQ1TnwEYl798AjAJziMA1gG56TFvgBMnBs1YBmJDS68BwsVAC+9HVBAAaEBAAOMTNFTJQjPnwjoACrYRWUjMukYBPK0f6MYEJwMADKjAC2cAAymFBwyABmHiz+fIHBYSaBcQDmyDB8JHBGcBE8cAAmlVXRjFC5JIy5cABiEHwRjDDmDcggjCQwEIYguDARZADquNhwqNlgcKGu2JgAbtje-WCofiBxLHwwjum5XUkpJSAAVqgAHqF5ZHAAiiQQ8JdkqSDZfEd+jxGBUyKMTHw4jApphKjBcMgABwABiMEIgLCm6RM-Qh8zgfHWCSMAEcPvBTqY3ANUABaeJVKqjARkzACU7NC5IZI-a4sCKYApFPnPOAAQR6kJ4QzgjgJsXi31+qFF70+CW5VyMMBBMLhCKQUm16UwZDyAGEIBEuSB5gBWUYkFgAFRBbh5v3WxQAklAarBQmBIWYxX7QjBvC8lXAtFogA), the de-facto standard formatter, as well as other formatters like [deno fmt](https://www.peterbartha.com/deno-playground#code=M4dwlgLgxgFgBACgHYFcA2aCUcDeAoOOKAQ2AFM4BGALgMLgCMAnM4gawG46Ty4AmWoR4UAzNVx1CzVpzoBfPAqA). This PR changes the formatting to match that convention (partially reverting https://github.com/sublimehq/Packages/pull/3213).

In an ideal world, the rule would be written to say that the line following a `case:`/`default:` should be indented only if it's not itself another `case:` or `default:`. But I don't think that's feasible given how these rules appear to work, so instead this always indents. That works correctly at least for the (considerable) subset of users who always put the contents of `case`/`default` blocks within braces.