### PR TITLE
[TypeScript] Implement satisfies operator

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -716,7 +716,7 @@ contexts:
     - match: '!(?![.=])'
       scope: keyword.operator.type.js
 
-    - match: (?:satisfies|as){{identifier_break}}
+    - match: as{{identifier_break}}
       scope: keyword.operator.type.js
       push:
         - match: const{{identifier_break}}
@@ -728,6 +728,14 @@ contexts:
             - ts-type-expression-end
             - ts-type-expression-end-no-line-terminator
             - ts-type-expression-begin
+
+    - match: satisfies{{identifier_break}}
+      scope: keyword.operator.type.js
+      push:
+        - ts-type-meta
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
 
   ts-type-annotation:
     - match: ':'

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -716,7 +716,7 @@ contexts:
     - match: '!(?![.=])'
       scope: keyword.operator.type.js
 
-    - match: as{{identifier_break}}
+    - match: (?:satisfies|as){{identifier_break}}
       scope: keyword.operator.type.js
       push:
         - match: const{{identifier_break}}

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -716,6 +716,10 @@ x as boolean;
 //^^ keyword.operator.type
 //   ^^^^^^^ meta.type support.type.primitive.boolean
 
+x satisfies boolean;
+//^^^^^^^^^ keyword.operator.type
+//          ^^^^^^^ meta.type support.type.primitive.boolean
+
 x as const;
 //^^ keyword.operator.type
 //   ^^^^^ storage.modifier.const


### PR DESCRIPTION
Implement the `satisfies` operator from TypeScript 4.9.

This implementation does allow `x satisfies const`. I don't think that's valid, but there's no spec, so who's to say? (My usual answer is “AST Explorer”, but it doesn't seem to have updated to 4.9 yet.) Either way, it shouldn't do any harm.