### PR TITLE
[ASP] Fix ASP tag highlighting in CSS/JS

### DIFF
--- a/ASP/Embeddings/CSS (for ASP).sublime-syntax
+++ b/ASP/Embeddings/CSS (for ASP).sublime-syntax
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+###############################################################################
+# This intermediate syntax is used by `HTML (ASP).sublime-syntax`
+#
+# It powers VBScript highlighting within ASP tags in embedded CSS.
+#
+#   <script>
+#     <%! ... %>
+#     <%= ... %>
+#     <%  ... %>
+#   </script>
+#
+# The primary task is to add `asp-tags` context to CSS's
+# prototype to match all the <% %> tags.
+###############################################################################
+
+scope: source.css.embedded.asp
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: HTML (ASP).sublime-syntax#asp-tags
+
+  string-content:
+    - meta_prepend: true
+    - include: HTML (ASP).sublime-syntax#asp-interpolations

--- a/ASP/Embeddings/JavaScript (for ASP).sublime-syntax
+++ b/ASP/Embeddings/JavaScript (for ASP).sublime-syntax
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+###############################################################################
+# This intermediate syntax is used by `HTML (ASP).sublime-syntax`
+#
+# It powers VBScript highlighting within ASP tags in embedded JavaScript.
+#
+#   <script>
+#     <%! ... %>
+#     <%= ... %>
+#     <%  ... %>
+#   </script>
+#
+# The primary task is to add `asp-tags` context to JavaScript's
+# prototype to match all the <% %> tags.
+###############################################################################
+
+scope: source.js.embedded.asp
+version: 2
+hidden: true
+
+extends: Packages/JavaScript/JavaScript.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: HTML (ASP).sublime-syntax#asp-tags
+
+  string-content:
+    - meta_prepend: true
+    - include: HTML (ASP).sublime-syntax#asp-interpolations

--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -34,6 +34,60 @@ contexts:
     - meta_prepend: true
     - include: asp-interpolations
 
+  tag-event-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.embedded.asp
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.js.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.embedded.asp
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.js.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-style-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.asp#rule-list-body
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.css.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.asp#rule-list-body
+      embed_scope:
+        meta.string.html meta.interpolation.html
+        source.css.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
   tag-attribute-value-content:
     - meta_prepend: true
     - include: asp-interpolations
@@ -96,6 +150,33 @@ contexts:
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
 
+  script-javascript-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.embedded.asp
+      embed_scope: meta.tag.sgml.cdata.html source.js.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.embedded.asp
+      embed_scope: source.js.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.js.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.js.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   script-vbscript:
     - meta_scope: meta.tag.script.begin.html
     - include: script-common
@@ -118,16 +199,45 @@ contexts:
         3: source.asp.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+###[ STYLE TAGS ]#############################################################
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.asp
+      embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.asp
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
 ###[ ASP TAGS ]###############################################################
 
   asp-tags:
     - match: <%
-      scope: punctuation.section.embedded.begin.asp
+      scope: meta.embedded.asp punctuation.section.embedded.begin.asp
       push: asp-tag-content
 
   asp-interpolations:
     - match: <%
-      scope: punctuation.section.embedded.begin.asp
+      scope: meta.embedded.asp punctuation.section.embedded.begin.asp
       push: [asp-tag-clear-scope, asp-tag-content]
 
   asp-tag-clear-scope:
@@ -136,6 +246,7 @@ contexts:
     - include: immediately-pop
 
   asp-tag-content:
+    - meta_content_scope: meta.embedded.asp
     - match: \@ # https://msdn.microsoft.com/en-us/library/ms525579%28v=vs.90%29.aspx
       set: asp-directive
     - match: =
@@ -145,6 +256,7 @@ contexts:
       set: asp-statements
 
   asp-directive:
+    - meta_scope: meta.embedded.asp
     - match: \@?\s*\b((?i:ENABLESESSIONSTATE|LANGUAGE|LCID|TRANSACTION))\b
       captures:
         1: constant.language.processing-directive.asp
@@ -158,12 +270,14 @@ contexts:
     - include: asp-end
 
   asp-expression:
+    - meta_scope: meta.embedded.asp
     - meta_content_scope: source.asp.embedded.html
     - include: asp-end
     - include: Packages/ASP/ASP.sublime-syntax#expression
       apply_prototype: true
 
   asp-statements:
+    - meta_scope: meta.embedded.asp
     - meta_content_scope: source.asp.embedded.html
     - include: asp-end
     - include: Packages/ASP/ASP.sublime-syntax

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -53,6 +53,16 @@
     '                        ^^^ comment.block.html punctuation.definition.comment.end.html
     '
 
+    <script> var i = <%=value%>; </script>
+    '  ^^^^^ meta.tag - source
+    '       ^^^^^^^^^^^^^^^^^^^^^ source.js.embedded.html
+    '                ^^^^^^^^^^ meta.embedded.asp
+    '                ^^^ punctuation.section.embedded.begin.asp
+    '                   ^^^^^ source.asp.embedded.html variable.other.asp
+    '                        ^^ punctuation.section.embedded.end.asp
+    '                            ^^^^^^^^^ meta.tag - source
+    '
+
     <script>
 
 ' <- source.js.embedded.html
@@ -167,6 +177,22 @@
     '                                     ^ - meta.tag - comment - source
     '                                      ^^^^^^^^ meta.tag - comment - source
 
+    <style>.<%=selector%> { <%=attr%>: <%=value%>; }</style>
+    '^^^^^^ meta.tag.style.begin.html
+    '      ^^^^^^^^^^^^^^^ source.css.embedded.html - meta.property-list - meta.block
+    '                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css
+    '                                               ^^^^^^^^ meta.tag.style.end.html
+    '      ^ meta.selector.css entity.other.attribute-name.class.css punctuation.definition.entity.css
+    '       ^^^^^^^^^^^^^ meta.selector.css entity.other.attribute-name.class.css meta.embedded.asp
+    '       ^^^ punctuation.section.embedded.begin.asp
+    '          ^^^^^^^^ source.asp.embedded.html variable.other.asp
+    '                  ^^ punctuation.section.embedded.end.asp
+    '                     ^ punctuation.section.block.begin.css
+    '                       ^^^^^^^^^ meta.embedded.asp
+    '                                ^ punctuation.separator.key-value.css
+    '                                  ^^^^^^^^^^ meta.property-value.css meta.embedded.asp
+    '                                            ^ punctuation.terminator.rule.css
+    '                                              ^ punctuation.section.block.end.css
     <style>
 
 ' <- source.css.embedded.html


### PR DESCRIPTION
Fixes https://forum.sublimetext.com/t/syntax-highlighting-in-classic-asp-doesnt-work-at-all/67203/3

This commit applies common strategy of supporting template tags in embedded CSS/JS to HTML (ASP).