### PR TITLE
[Makefile] fix scoping of shell interpolation

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -10,6 +10,7 @@
 # All number references refer to the "Make manual" (see link above).
 name: Makefile
 scope: source.makefile
+version: 2
 
 file_extensions:
   - mk
@@ -604,33 +605,53 @@ contexts:
   variable-sub-common:
     - match: ':'
       scope: punctuation.definition.substitution.makefile
+      set: variable-substitution-reference
+    - include: highlight-percentage-sign
+    - include: variable-substitutions
+
+  variable-substitution-reference:
+    - match: '[)}]'
+      scope: keyword.other.block.end.makefile
+      pop: true
     - match: =
-      scope: punctuation.definition.assignment.makefile
+      scope: keyword.operator.assignment.makefile
     - include: highlight-percentage-sign
     - include: variable-substitutions
 
   variable-substitutions:
     - include: function-invocations
-    - match: \$\$?\(
+    - match: \$\(
       scope: keyword.other.block.begin.makefile
       push:
-        - meta_scope: variable.parameter.makefile
+        - meta_scope: meta.interpolation.makefile
+        - meta_content_scope: variable.parameter.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
-    - match: \$\$?{
+    - match: \${
       scope: keyword.other.block.begin.makefile
       push:
-        - meta_scope: variable.parameter.makefile
+        - meta_scope: meta.interpolation.makefile
+        - meta_content_scope: variable.parameter.makefile
         - match: \}
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
     - match: \$\$?[@%<?^+|*]
       scope: variable.language.automatic.makefile
-    - match: \$\$
+    - match: \$(?=\$[{\w])
       scope: constant.character.escape.makefile
+      push:
+        - include: scope:source.shell.bash#expansions-parameter
+        - match: ''
+          pop: true
+    - match: \$(?=\$\()
+      scope: constant.character.escape.makefile
+      push:
+        - include: scope:source.shell.embedded.makefile#expansions-command
+        - match: ''
+          pop: true
     - match: (\$)[[:alpha:]]
       captures:
         0: variable.parameter.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -137,7 +137,7 @@ contexts:
         - meta_scope: meta.string.makefile string.quoted.single.makefile
         - match: "'"
           scope: punctuation.definition.string.end.makefile
-          pop: true
+          pop: 1
         - include: escape-literals
         - include: line-continuation
         - include: variable-substitutions
@@ -147,7 +147,7 @@ contexts:
         - meta_scope: meta.string.makefile string.quoted.double.makefile
         - match: '"'
           scope: punctuation.definition.string.end.makefile
-          pop: true
+          pop: 1
         - include: escape-literals
         - include: line-continuation
         - include: variable-substitutions
@@ -156,7 +156,7 @@ contexts:
       push:
         - match: \)
           scope: punctuation.section.group.end.makefile
-          pop: true
+          pop: 1
         - include: variable-substitutions
         - match: \,
           scope: punctuation.separator.makefile
@@ -266,7 +266,7 @@ contexts:
     - match: ^(?=\t([-@]{1,2})?)
       set: recipe-with-tabs
     - match: ^
-      pop: true
+      pop: 1
 
   recipe-inline:
     - meta_content_scope: meta.function.body.makefile source.shell.embedded.makefile
@@ -288,7 +288,7 @@ contexts:
         2: constant.language.makefile
     - include: recipe-common
     - match: ^(?![ ]+)
-      pop: true
+      pop: 1
 
   recipe-with-tabs:
     - meta_content_scope: meta.function.body.makefile
@@ -302,7 +302,7 @@ contexts:
         2: constant.language.makefile
     - include: recipe-common
     - match: ^(?!\t)
-      pop: true
+      pop: 1
 
   recipe-common:
     - include: control-flow
@@ -324,11 +324,11 @@ contexts:
       # make sure to resume parsing at next line
       push:
         - match: (?=\S|^\s*$)
-          pop: true
+          pop: 1
 
   pop-on-line-end:
     - match: $
-      pop: true
+      pop: 1
 
   continuation-or-pop-on-line-end:
     - include: line-continuation
@@ -342,7 +342,7 @@ contexts:
         - meta_scope: meta.string.makefile string.quoted.single.makefile
         - match: "'"
           scope: punctuation.definition.string.end.makefile
-          pop: true
+          pop: 1
         - include: escape-literals
         - include: line-continuation
         - include: variable-substitutions
@@ -353,7 +353,7 @@ contexts:
         - meta_scope: meta.string.makefile string.quoted.double.makefile
         - match: '"'
           scope: punctuation.definition.string.end.makefile
-          pop: true
+          pop: 1
         - include: escape-literals
         - include: line-continuation
         - include: variable-substitutions
@@ -388,13 +388,13 @@ contexts:
     - include: line-continuation
     - match: \\\\
     - match: \n
-      pop: true
+      pop: 1
 
   inside-function-call:
     - meta_content_scope: meta.function-call.arguments.makefile
     - match: \)
       scope: keyword.other.block.end.makefile
-      pop: true
+      pop: 1
     - match: \(
       push: textual-parenthesis-balancer
     - match: \,
@@ -451,7 +451,7 @@ contexts:
         - meta_content_scope: meta.function-call.arguments.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
-          pop: true
+          pop: 1
         - match: \(
           push: textual-parenthesis-balancer
         - match: \,
@@ -505,7 +505,7 @@ contexts:
         - meta_content_scope: source.shell.embedded.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
-          pop: true
+          pop: 1
         - include: shell-content
 
   variable-definitions:
@@ -545,13 +545,13 @@ contexts:
 
   textual-parenthesis-balancer:
     - match: \)
-      pop: true
+      pop: 1
     - include: variable-substitutions
 
   eat-whitespace-then-pop:
     - clear_scopes: 1
     - match: \s*
-      pop: true
+      pop: 1
 
   value-maybe-shellscript:
     - match: ((?:bash|sh|zsh)\s+-c\s+)(['"`])
@@ -594,13 +594,13 @@ contexts:
     - match: ^\s*(endef)\b
       captures:
         1: keyword.control.makefile
-      pop: true
+      pop: 1
     # keep in balance with nested define statements
     # see: https://github.com/sublimehq/Packages/issues/1998
     - match: ^\s*define\b
       push:
         - match: ^\s*endef\b
-          pop: true
+          pop: 1
 
   variable-sub-common:
     - include: highlight-percentage-sign
@@ -610,14 +610,14 @@ contexts:
     - meta_scope: meta.interpolation.makefile
     - match: \)
       scope: keyword.other.block.end.makefile
-      pop: true
+      pop: 1
     - include: variable-substitution-reference-common
 
   variable-substitution-reference-inside-brace:
     - meta_scope: meta.interpolation.makefile
     - match: \}
       scope: keyword.other.block.end.makefile
-      pop: true
+      pop: 1
     - include: variable-substitution-reference-common
 
   variable-substitution-reference-common:
@@ -635,7 +635,7 @@ contexts:
         - meta_content_scope: variable.parameter.makefile
         - match: \)
           scope: keyword.other.block.end.makefile
-          pop: true
+          pop: 1
         - include: variable-sub-common
         - match: ':'
           scope: punctuation.definition.substitution.makefile
@@ -647,7 +647,7 @@ contexts:
         - meta_content_scope: variable.parameter.makefile
         - match: \}
           scope: keyword.other.block.end.makefile
-          pop: true
+          pop: 1
         - include: variable-sub-common
         - match: ':'
           scope: punctuation.definition.substitution.makefile
@@ -659,13 +659,13 @@ contexts:
       push:
         - include: scope:source.shell.bash#expansions-parameter
         - match: ''
-          pop: true
+          pop: 1
     - match: \$(?=\$\()
       scope: constant.character.escape.makefile
       push:
         - include: scope:source.shell.embedded.makefile#expansions-command
         - match: ''
-          pop: true
+          pop: 1
     - match: (\$)[[:alpha:]]
       captures:
         0: variable.parameter.makefile

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -603,16 +603,24 @@ contexts:
           pop: true
 
   variable-sub-common:
-    - match: ':'
-      scope: punctuation.definition.substitution.makefile
-      set: variable-substitution-reference
     - include: highlight-percentage-sign
     - include: variable-substitutions
 
-  variable-substitution-reference:
-    - match: '[)}]'
+  variable-substitution-reference-inside-paren:
+    - meta_scope: meta.interpolation.makefile
+    - match: \)
       scope: keyword.other.block.end.makefile
       pop: true
+    - include: variable-substitution-reference-common
+
+  variable-substitution-reference-inside-brace:
+    - meta_scope: meta.interpolation.makefile
+    - match: \}
+      scope: keyword.other.block.end.makefile
+      pop: true
+    - include: variable-substitution-reference-common
+
+  variable-substitution-reference-common:
     - match: =
       scope: keyword.operator.assignment.makefile
     - include: highlight-percentage-sign
@@ -629,6 +637,9 @@ contexts:
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
+        - match: ':'
+          scope: punctuation.definition.substitution.makefile
+          set: variable-substitution-reference-inside-paren
     - match: \${
       scope: keyword.other.block.begin.makefile
       push:
@@ -638,6 +649,9 @@ contexts:
           scope: keyword.other.block.end.makefile
           pop: true
         - include: variable-sub-common
+        - match: ':'
+          scope: punctuation.definition.substitution.makefile
+          set: variable-substitution-reference-inside-brace
     - match: \$\$?[@%<?^+|*]
       scope: variable.language.automatic.makefile
     - match: \$(?=\$[{\w])

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -55,8 +55,9 @@ bar := $(foo:.o=.c)
 # <- variable
 #   ^^ keyword
 #      ^^ keyword.other.block.begin
-#           ^ punctuation
-#              ^ punctuation
+#        ^^^ variable.parameter
+#           ^ punctuation.definition.substitution
+#              ^ keyword.operator.assignment
 #                 ^ keyword.other.block.end
 bar := $(foo:%.o=%.c)
 # <- variable
@@ -65,7 +66,7 @@ bar := $(foo:%.o=%.c)
 #      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
-#               ^ punctuation
+#               ^ keyword.operator
 #                ^ variable.language
 #                   ^ keyword.other.block.end
 
@@ -76,7 +77,7 @@ bar := ${foo:%.o=%.c}
 #      ^^ keyword.other.block.begin
 #           ^ punctuation
 #            ^ variable.language
-#               ^ punctuation
+#               ^ keyword.operator
 #                ^ variable.language
 #                   ^ keyword.other.block.end
 
@@ -206,8 +207,8 @@ override \
 
 override \
 	define foo
-# ^^^^^ keyword.control.makefile
-#       ^^^^ variable.other.makefile
+	#^^^^^ keyword.control.makefile
+	#      ^^^ variable.other.makefile
 endef
 # <- keyword.control.makefile
 
@@ -251,9 +252,9 @@ lib/%.o: CFLAGS := -fPIC -g
 ifeq ($(shell test -r $(MAKEFILE_PATH)Makefile.Defs; echo $$?), 0)
 # <- keyword.control
 #       ^ support.function
-#                     ^^ variable.parameter keyword.other.block.begin
+#                     ^^ keyword.other.block.begin
 #                       ^^^^^^^^^^^^^ variable.parameter
-#                                    ^ variable.parameter keyword.other.block.end
+#                                    ^ keyword.other.block.end
 #                                                         ^^^ variable.language.automatic
     include $(MAKEFILE_PATH)Makefile.Defs
     # <- keyword.control
@@ -320,22 +321,23 @@ foo: qux
 sources := $($(a1)_objects:.o=.c)
 # ^ variable
 #       ^^ keyword.operator
-#          ^^ string variable keyword.other.block.begin
-#            ^^ string variable variable keyword.other.block.begin
+#          ^^ string keyword.other.block.begin
+#            ^^ string variable keyword.other.block.begin
 #              ^^ string variable variable
-#                ^ string variable variable keyword.other.block.end
+#                ^ meta.interpolation meta.interpolation keyword.other.block.end
 #                 ^^^^^^^^ string variable
-#                         ^ string variable punctuation.definition
-#                          ^^ string variable
-#                            ^ string variable punctuation.definition
-#                             ^^ string variable
-#                               ^ string variable keyword.other.block.end
+#                         ^ string punctuation.definition
+#                          ^^ string
+#                            ^ string keyword.operator
+#                             ^^ string
+#                               ^ string keyword.other.block.end
 
 .build/vernum: ../meta/version
     sed -i.bak 's/.*automatically updated.*/version = "$(VER)" # automatically updated/' setup.py
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded meta.function-call
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single - comment
-#                                                      ^^^^^^ variable.parameter.makefile
+#                                                      ^^^^^^ meta.interpolation
+#                                                        ^^^ variable.parameter.makefile
 
 CC=g++
 #<- variable.other
@@ -350,8 +352,8 @@ OBJECTS=$(SOURCES:.cpp=.o)
 #<- variable.other
 #      ^ keyword.operator.assignment
 #       ^^ string.unquoted keyword.other.block.begin
-#                ^ string.unquoted variable.parameter punctuation.definition.substitution
-#                     ^ string.unquoted variable.parameter punctuation.definition
+#                ^ string.unquoted punctuation.definition.substitution
+#                     ^ string.unquoted keyword.operator.assignment
 #                        ^ string.unquoted keyword.other.block.end
 EXECUTABLE=hello
 
@@ -368,12 +370,12 @@ lib: foo.o bar.o lose.o win.o
 all: $(SOURCES) $(EXECUTABLE)
 #<- entity.name.function
 #  ^ keyword.operator.assignment
-#    ^^ variable.parameter keyword.other.block.begin
+#    ^^ keyword.other.block.begin
 #      ^^^^^^^ variable.parameter
-#             ^ variable.parameter keyword.other.block.end
-#               ^^ variable.parameter keyword.other.block.begin
+#             ^ keyword.other.block.end
+#               ^^ keyword.other.block.begin
 #                 ^^^^^^^^^^ variable.parameter
-#                           ^ variable.parameter keyword.other.block.end
+#                           ^ keyword.other.block.end
 
 export FOO=foo
 # ^ keyword.control
@@ -453,7 +455,7 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 #                                                                ^ punctuation.separator
 #                                                                 ^^ keyword.other.block.begin
 #                                                                   ^^^^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter
-#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments variable.parameter keyword.other.block.end
+#                                                                       ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
 #                                                                        ^ meta.function-call.arguments meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
 #                                                                         ^ meta.function-call.arguments meta.function-call.arguments keyword.other.block.end
 #                                                                          ^ meta.function-call.arguments keyword.other.block.end
@@ -466,9 +468,9 @@ LS := $(call pathsearch,ls)
 
 sinclude $(MAKEFILE_PATH)Makefile.Defs
 # <- keyword.control.import
-#        ^ string.unquoted variable.parameter keyword.other.block.begin
+#        ^ string.unquoted keyword.other.block.begin
 #          ^ string.unquoted variable.parameter
-#                       ^ string.unquoted variable.parameter keyword.other.block.end
+#                       ^ string.unquoted keyword.other.block.end
 
 
 CC=g++
@@ -569,7 +571,7 @@ a_percentage_%_sign := $(SOME_C%MPLEX:SUBSTITUTI%N)
 #            ^ variable.other - variable.language
 #                              ^ string.unquoted variable.parameter variable.language
 #                                    ^ punctuation
-#                                               ^ string.unquoted variable.parameter variable.language
+#                                               ^ string.unquoted variable.language
 
 %.cpp: %.o
 # <- meta.function entity.name.function variable.language
@@ -665,7 +667,8 @@ $(a:b=c) : d
 	#                    ^^ meta.function.body variable.language.automatic
 
 $(X:a=b) : w ;
-# <- meta.function entity.name.function variable.parameter keyword.other.block.begin
+# <- meta.function entity.name.function keyword.other.block.begin
+# ^ variable.parameter
 #        ^ keyword.operator
 #          ^ meta.function.arguments string.unquoted
 #           ^ - string.unquoted
@@ -840,7 +843,7 @@ revision.tex: $(VCSTURD)
     /bin/echo '\newcommand{\Revision}'"{$(subst _,\_,$(REVISION))}" > $@
     #           ^ - invalid.illegal
     #                                     ^ meta.function-call.makefile
-    #                                                ^^ meta.function.body meta.function-call.arguments variable.parameter
+    #                                                  ^^ meta.function.body meta.function-call.arguments variable.parameter
 AUXFILES += revision.aux
 endif
 
@@ -988,26 +991,55 @@ html:
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile - source.shell source.shell
 #   ^^^^^^^^^^ meta.function-call.identifier.shell
 #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#              ^^^^^^^^^^^ variable.parameter.makefile
+#                ^^^^^^^^ variable.parameter.makefile
 #                          ^^ variable.parameter.option.shell
-#                             ^^^^^^^^^^^ variable.parameter.makefile
+#                               ^^^^^^^^^ variable.parameter.makefile
 #                                          ^^ variable.parameter.option.shell
-#                                             ^^^^^^^^^^^ variable.parameter.makefile
-#                                                         ^^^^^^^^^^^^^^ variable.parameter.makefile
+#                                               ^^^^^^^^ variable.parameter.makefile
+#                                                           ^^^^^^^^^^^ variable.parameter.makefile
 
 shell_string_interpolation:
     var1="double nquoted $(string) value"
-    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.quoted.double.shell
-    #                    ^^^^^^^^^ variable.parameter.makefile
+    #    ^^^^^^^^^^^^^^^^ string.quoted.double.shell
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell
+    #                    ^^^^^^^^^ meta.interpolation
     #                    ^^ keyword.other.block.begin.makefile
+    #                      ^^^^^^ variable.parameter.makefile
     #                            ^ keyword.other.block.end.makefile
+    #                             ^^^^^^^ string.quoted.double.shell
     var1='single nquoted $(string) value'
-    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.quoted.single.shell
-    #                    ^^^^^^^^^ variable.parameter.makefile
+    #    ^^^^^^^^^^^^^^^^ string.quoted.single.shell
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell
+    #                    ^^^^^^^^^ meta.interpolation
     #                    ^^ keyword.other.block.begin.makefile
+    #                      ^^^^^^ variable.parameter.makefile
     #                            ^ keyword.other.block.end.makefile
+    #                             ^^^^^^^ string.quoted.single.shell
     var1=unquoted\ $(string)\ value
-    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell string.unquoted.shell
-    #              ^^^^^^^^^ variable.parameter.makefile
+    #    ^^^^^^^^^^ string.unquoted.shell
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.makefile source.shell.embedded.makefile meta.string.shell
+    #              ^^^^^^^^^ meta.interpolation
     #              ^^ keyword.other.block.begin.makefile
+    #                ^^^^^^ variable.parameter.makefile
     #                      ^ keyword.other.block.end.makefile
+    #                       ^^^^^^^ string.unquoted.shell
+
+# https://www.gnu.org/software/make/manual/html_node/Errors.html
+clean:
+	-rm -f *.o
+	# <- constant.language.makefile
+	#^^ variable.function.shell
+
+foo:
+	echo $$foo
+	#    ^ constant.character.escape.makefile
+	#     ^ punctuation.definition.variable.shell
+	#     ^^^^ variable.other.readwrite.shell
+	foo $$(echo $$PATH)
+	#   ^ constant.character.escape.makefile
+	#    ^ punctuation
+	#     ^ punctuation.section.interpolation.begin.shell
+	#      ^^^^ support.function.echo.shell
+	#           ^ constant.character.escape.makefile
+	#            ^ punctuation.definition.variable.shell
+	#            ^^^^^ variable.other.readwrite.shell

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -1043,3 +1043,10 @@ foo:
 	#           ^ constant.character.escape.makefile
 	#            ^ punctuation.definition.variable.shell
 	#            ^^^^^ variable.other.readwrite.shell
+
+	test "$$abc" = "$$def"
+	# ^ support.function.test.shell
+	#    ^^^^^^^ string.quoted.double.shell
+	#     ^ constant.character.escape.makefile
+	#      ^ punctuation.definition.variable.shell
+	#       ^^^ variable.other.readwrite.shell


### PR DESCRIPTION
- Makefile variable substitutions were all `variable.parameter` - i.e. the punctuation and substitution, not just the variable name, which made everything one color
- text inside an escaped $ followed by an open paren was also treated as `variable.parameter` instead of correctly being highlighted as Shell script