### PR TITLE
Syntax higlight for .CJS files as JAVASCRIPT

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -8,6 +8,7 @@ version: 2
 file_extensions:
   - js
   - mjs
+  - cjs
   - htc
 
 first_line_match: |-


### PR DESCRIPTION
.cjs files are CommonJS files and should be syntax highlighted as Javascript. The .cjs extension is being used to discern between .mjs (ES6 modules) and .cjs (commonJS) files. The traditional .js doesn't give this information.