### PR TITLE
[Python] Fix raw docstring highlighting

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2122,7 +2122,7 @@ contexts:
       captures:
         1: storage.type.string.python
         2: comment.block.documentation.python punctuation.definition.comment.begin.python
-      push: maybe-double-quoted-docstring-summery
+      push: maybe-double-quoted-raw-docstring-summery
 
   maybe-double-quoted-docstring-summery:
     - meta_content_scope: comment.block.documentation.python
@@ -2147,6 +2147,18 @@ contexts:
     - include: escaped-unicode-chars
     - include: escaped-chars
 
+  maybe-double-quoted-raw-docstring-summery:
+    - meta_content_scope: comment.block.documentation.python
+    - include: double-quoted-docstring-end
+    - match: (?=\S)
+      set: double-quoted-raw-docstring-summery
+
+  double-quoted-raw-docstring-summery:
+    - meta_content_scope: comment.block.documentation.summary.python
+    - match: $
+      set: double-quoted-raw-docstring-body
+    - include: double-quoted-docstring-end
+
   double-quoted-raw-docstring-body:
     - meta_content_scope: comment.block.documentation.python
     - include: double-quoted-docstring-end
@@ -2156,21 +2168,23 @@ contexts:
       captures:
         1: storage.type.string.python
         2: comment.block.documentation.python punctuation.definition.comment.begin.python
-      push:
-        - single-quoted-docstring-summery
-        - else-pop
+      push: maybe-single-quoted-docstring-summery
     - match: ^\s*(?i)(ur|ru?)(''')
       captures:
         1: storage.type.string.python
         2: comment.block.documentation.python punctuation.definition.comment.begin.python
-      push:
-        - single-quoted-docstring-summery
-        - else-pop
+      push: maybe-single-quoted-raw-docstring-summery
 
   single-quoted-docstring-end:
     - match: "'''"
       scope: comment.block.documentation.python punctuation.definition.comment.end.python
       pop: 1
+
+  maybe-single-quoted-docstring-summery:
+    - meta_content_scope: comment.block.documentation.python
+    - include: single-quoted-docstring-end
+    - match: (?=\S)
+      set: single-quoted-docstring-summery
 
   single-quoted-docstring-summery:
     - meta_content_scope: comment.block.documentation.summary.python
@@ -2183,6 +2197,18 @@ contexts:
     - include: single-quoted-docstring-end
     - include: escaped-unicode-chars
     - include: escaped-chars
+
+  maybe-single-quoted-raw-docstring-summery:
+    - meta_content_scope: comment.block.documentation.python
+    - include: single-quoted-docstring-end
+    - match: (?=\S)
+      set: single-quoted-raw-docstring-summery
+
+  single-quoted-raw-docstring-summery:
+    - meta_content_scope: comment.block.documentation.summary.python
+    - match: $
+      set: single-quoted-raw-docstring-body
+    - include: single-quoted-docstring-end
 
   single-quoted-raw-docstring-body:
     - meta_content_scope: comment.block.documentation.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -18,6 +18,11 @@ ur"""Raw docstring \"""
 #    ^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
 #                   ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
 
+R"""
+C:\Users
+# ^^ - constant.character - invalid
+"""
+
 """Normal docstring \""""
 # <- comment.block.documentation.python punctuation.definition.comment.begin.python
 #^^ comment.block.documentation.python punctuation.definition.comment.begin.python
@@ -41,6 +46,46 @@ debug = False
 This is a variable docstring, as supported by sphinx and epydoc
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
 """
+
+r'''This is a syntax test file.
+# <- storage.type.string - comment
+#^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
+
+And this right here, where we're writing in, is a docstring.
+# <- comment.block.documentation.python
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.python
+'''
+# <- comment.block.documentation.python punctuation.definition.comment.end.python
+
+ur'''Raw docstring \'''
+# <- storage.type.string.python - comment
+# ^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#    ^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
+#                   ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
+
+R'''
+C:\Users
+# ^^ - constant.character - invalid
+'''
+
+'''Normal docstring \'''"
+# <- comment.block.documentation.python punctuation.definition.comment.begin.python
+#^^ comment.block.documentation.python punctuation.definition.comment.begin.python
+#  ^^^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
+#                    ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
+#                       ^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+
+'''
+#^^^ comment.block.documentation.python
+docstring starting on the second line
+'''
+
+'''
+docstring starting on the second line
+# <- comment.block.documentation.summary.python
+#^^^ comment.block.documentation.summary.python
+'''
 
 
 ##################


### PR DESCRIPTION
Fixes #3682

This commit ...

1. fixes an issue with raw docstrings using the same context as normal docstrings.
2. adjusts context architecture of single quoted docstrings to the one of double quoted ones, to start summary line scope at the first non- whitespace character.