### PR TITLE
[JSON] Tweak folding rules

### DIFF
--- a/JSON/Fold.tmPreferences
+++ b/JSON/Fold.tmPreferences
@@ -14,12 +14,16 @@
                 <string>punctuation.section.sequence.begin</string>
                 <key>end</key>
                 <string>punctuation.section.sequence.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.mapping.begin</string>
                 <key>end</key>
                 <string>punctuation.section.mapping.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
This commit makes closing brackets to directly follow a folded region instead of keeping them at the beginning of the next line.

The explicit rule is required as default behavior of ST has recently changed.