### PR TITLE
[Rails] Add `redirect_back_or_to` to syntax

### DIFF
--- a/Rails/Ruby (Rails).sublime-syntax
+++ b/Rails/Ruby (Rails).sublime-syntax
@@ -47,6 +47,7 @@ contexts:
         | render_without_layout
         | rescue_from
         | url_for
+        | redirect_back_or_to
         | redirect_to
         | redirect_to_path
         | redirect_to_url


### PR DESCRIPTION
Adds `redirect_back_or_to` method to the syntax.

https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to