### PR TITLE
[JSON] Add Apache Avro files to JSON extensions

### DIFF
--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -21,6 +21,7 @@ file_extensions:
   - sublime-workspace
   - ipynb
   - gltf
+  - avsc
 
 hidden_file_extensions:
   - Pipfile.lock


### PR DESCRIPTION
Apache Avro is written in a subset of JSON, and the existing JSON sublime-syntax works well for this. It would be nice to have this default to JSON syntax.

https://avro.apache.org/docs/1.11.1/specification/#schema-declaration