### PR TITLE
[CSS] Exclude trailing newline from folding regions

### DIFF
--- a/CSS/Fold.tmPreferences
+++ b/CSS/Fold.tmPreferences
@@ -12,6 +12,8 @@
                 <string>punctuation.section.block.begin</string>
                 <key>end</key>
                 <string>punctuation.section.block.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
This commit makes closing brackets to directly follow a folded region instead of keeping them at the beginning of the next line.

The explicit rule is required as default behavior of ST has recently changed.

see also: #3686