### PR TITLE
[CSS] Fix duplicate meta.selector scope in pseudo classes

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1236,7 +1236,7 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
-            - include: selectors
+            - include: selector-content
 
   # Functional Pseudo Classes with generic arguments
   pseudo-class-function-with-generic-args:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2274,6 +2274,13 @@
 .test-attribute-selectors-flags[a="" i] {}
 /*                                   ^ keyword.other.flag.css */
 
+.test-attribute-selectors:not( [title="identifier"] ) {}
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.css - meta.group */
+/*                           ^^ meta.selector.css meta.function-call.arguments.css meta.group.css - meta.brackets */
+/*                             ^^^^^^^^^^^^^^^^^^^^ meta.selector.css meta.group.css meta.attribute-selector.css meta.brackets.css - meta.selector meta.selector */
+/*                                                 ^^ meta.selector.css meta.function-call.arguments.css meta.group.css - meta.brackets */
+/*                                                   ^ meta.selector.css - meta.group */
+
    *.test-universal-selector {}
 /* ^ variable.language.wildcard.asterisk.css */
 


### PR DESCRIPTION
This commit introduces a tiny optimization to avoid duplicate `meta.selector` scope in pseudo classes such as `:not( ... )`.