### PR TITLE
[CSS] Fix translate function arguments highlighting

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -2309,7 +2309,7 @@ contexts:
             - include: scalar-constants
 
     # transform functions with comma separated <number> or <percentage> types
-    # scale() scale3d()
+    # scale(), scale3d()
     - match: \b(?i:scale(?:3d)?)(?=\()
       scope: meta.function-call.identifier.css support.function.transform.css
       push:

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1405,8 +1405,7 @@ contexts:
 
   counter-property-value-content:
     - include: global-constants
-    - match: (?i:none){{break}}
-      scope: constant.language.null.css
+    - include: none-constants
     - match: '{{ident}}'
       scope: entity.other.counter-name.css
     - include: property-value-content
@@ -2295,8 +2294,8 @@ contexts:
   # https://www.w3.org/TR/css-transforms-1/#transform-functions
   transform-functions:
     # transform functions with comma separated <number> types
-    # matrix(), scale(), matrix3d(), scale3d()
-    - match: \b(?i:matrix3d|scale3d|matrix|scale)(?=\()
+    # matrix(), matrix3d()
+    - match: \b(?i:matrix(?:3d)?)(?=\()
       scope: meta.function-call.identifier.css support.function.transform.css
       push:
         - meta_include_prototype: false
@@ -2309,9 +2308,9 @@ contexts:
             - include: calc-functions
             - include: scalar-constants
 
-    # transform functions with comma separated <number> or <length> types
-    # translate(), translate3d()
-    - match: \b(?i:translate(3d)?)(?=\()
+    # transform functions with comma separated <number> or <percentage> types
+    # scale() scale3d()
+    - match: \b(?i:scale(?:3d)?)(?=\()
       scope: meta.function-call.identifier.css support.function.transform.css
       push:
         - meta_include_prototype: false
@@ -2323,10 +2322,25 @@ contexts:
             - include: comma-delimiters
             - include: calc-functions
             - include: percentage-constants
-            - include: length-constants
             - include: scalar-constants
 
-    # transform functions with a single <number> or <length> type
+    # transform functions with comma separated <length> or <percentage> types
+    # translate(), translate3d()
+    - match: \b(?i:translate(?:3d)?)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+    # transform functions with a single <length> or <percentage> type
     # translateX(), translateY()
     - match: \b(?i:translate[XY])(?=\()
       scope: meta.function-call.identifier.css support.function.transform.css
@@ -2338,9 +2352,8 @@ contexts:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: calc-functions
-            - include: percentage-constants
             - include: length-constants
-            - include: scalar-constants
+            - include: percentage-constants
 
     # transform functions with a single <angle> type
     # rotate(), skewX(), skewY(), rotateX(), rotateY(), rotateZ()
@@ -2384,6 +2397,7 @@ contexts:
             - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
+            - include: none-constants
 
     # transform functions with a comma separated <number> or <angle> types
     # rotate3d()
@@ -2412,7 +2426,6 @@ contexts:
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
-            - include: comma-delimiters
             - include: calc-functions
             - include: scalar-constants
 
@@ -2672,6 +2685,10 @@ contexts:
   grid-constants:
     - match: \b(?i:auto|max-content|min-content){{break}}
       scope: support.constant.property-value.css
+
+  none-constants:
+    - match: (?i:none){{break}}
+      scope: constant.language.null.css
 
   other-constants:
     - match: '{{ident}}'

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2858,86 +2858,131 @@
 }
 
 .test-transform-functions {
-    top: rotate(0);
-/*       ^^^^^^ support.function.transform.css */
-/*              ^ meta.number.integer.decimal.css constant.numeric.value.css */
 
-    top: rotate(1)
-/*       ^^^^^^ support.function.transform.css */
-/*              ^ - meta.number.integer.decimal.css constant.numeric.value.css */
-
-    top: rotate3d(-1, 2deg);
-/*       ^^^^^^^^ support.function.transform.css */
-/*                ^ meta.number.integer.decimal.css keyword.operator.arithmetic.css */
-/*                 ^ meta.number.integer.decimal.css constant.numeric.value.css */
+    transform: matrix(1%, 10.5);
+/*             ^^^^^^ support.function.transform.css */
 /*                    ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                     ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                     ^ - constant.numeric.suffix */
+/*                      ^ punctuation.separator.sequence.css */
+/*                        ^^^^ meta.number.float.decimal.css constant.numeric.value.css */
 
-    top: matrix3d(1, 0);
-/*       ^^^^^^^^ support.function.transform.css */
-/*                ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                 ^ punctuation.separator.sequence.css */
-/*                   ^ meta.number.integer.decimal.css constant.numeric.value.css */
-
-    top: translate3d(1, 2px, 3%);
-/*       ^^^^^^^^^^^ support.function.transform.css */
-/*                   ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                    ^ punctuation.separator.sequence.css */
+    transform: matrix3d(1, 0, 0.2);
+/*             ^^^^^^^^ support.function.transform.css */
 /*                      ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                       ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
-/*                           ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                            ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                       ^ punctuation.separator.sequence.css */
+/*                         ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                          ^ punctuation.separator.sequence.css */
+/*                            ^^^ meta.number.float.decimal.css constant.numeric.value.css */
 
-    top: translateY(2px);
-/*       ^^^^^^^^^^ support.function.transform.css */
-/*                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                   ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+    transform: perspective(none);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^^^^ constant.language.null.css */
 
-    top: translateX(1%);
-/*       ^^^^^^^^^^ support.function.transform */
-/*                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                   ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+    transform: perspective(0);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^ meta.number.integer.decimal.css constant.numeric.value.css */
 
-    top: translateZ(0);
-/*       ^^^^^^^^^^ support.function.transform */
-/*                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
+    transform: perspective(17px);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                           ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 
-    top: skewY(1deg);
-/*       ^^^^^ support.function.transform.css */
-/*             ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*              ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+    transform: perspective(17rem);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                           ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 
-    top: skew(1deg, 2turn);
-/*       ^^^^ support.function.transform.css */
-/*            ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*             ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
-/*                ^ punctuation.separator.sequence.css */
-/*                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                   ^^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+    transform: perspective(6.5cm);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^^^ meta.number.float.decimal.css constant.numeric.value.css */
+/*                            ^^ meta.number.float.decimal.css constant.numeric.suffix.css */
 
-    top: perspective(17px);
-/*       ^^^^^^^^^^^ support.function.transform.css */
-/*                   ^^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                     ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+    transform: rotate(0);
+/*             ^^^^^^ support.function.transform.css */
+/*                    ^ meta.number.integer.decimal.css constant.numeric.value.css */
 
-    top: scaleY(2);
-/*       ^^^^^^ support.function.transform.css */
-/*              ^ meta.number.integer.decimal.css constant.numeric.value.css */
+    transform: rotate(1);
+/*             ^^^^^^ support.function.transform.css */
+/*                    ^ - meta.number.integer.decimal.css constant.numeric.value.css */
 
-    top: skewY(1rad) rotate(1turn);
-/*       ^^^^^ support.function.transform.css */
-/*             ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*              ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
-/*                   ^^^^^^ support.function.transform.css */
+    transform: rotate3d(-1, 0, 0, 2deg);
+/*             ^^^^^^^^ support.function.transform.css */
+/*                      ^ meta.number.integer.decimal.css keyword.operator.arithmetic.css */
+/*                       ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                        ^ punctuation.separator.sequence.css */
 /*                          ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                           ^^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                           ^ punctuation.separator.sequence.css */
+/*                             ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                              ^ punctuation.separator.sequence.css */
+/*                                ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                                 ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    transform: scaleY(2,);
+/*             ^^^^^^ support.function.transform.css */
+/*                    ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                     ^ - punctuation */
+
+    transform: skew(1deg, 2turn);
+/*             ^^^^ support.function.transform.css */
+/*                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                   ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                      ^ punctuation.separator.sequence.css */
+/*                        ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                         ^^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    transform: skewX(1.5deg);
+/*             ^^^^^ support.function.transform.css */
+/*                   ^^^ meta.number.float.decimal.css constant.numeric.value.css */
+/*                      ^^^ meta.number.float.decimal.css constant.numeric.suffix.css */
+
+    transform: skewY(1deg,);
+/*             ^^^^^ support.function.transform.css */
+/*                   ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                    ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                       ^ - punctuation */
+
+    transform: skewY(1rad) rotate(1turn);
+/*             ^^^^^ support.function.transform.css */
+/*                   ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                    ^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                         ^^^^^^ support.function.transform.css */
+/*                                ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                                 ^^^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 
     transform: translate(var(--center), 0) scale(var(--ripple-scale), 1);
 /*             ^^^^^^^^^ support.function.transform */
 /*                       ^^^ support.function.var */
 /*                           ^^^^^^^^ variable.other.custom-property.css */
+/*                                    ^ punctuation.separator.sequence.css */
 /*                                      ^ meta.number.integer.decimal.css constant.numeric.value.css */
-/*                                               ^^^ support.function.var */
+/*                                         ^^^^^ support.function.transform.css */
+/*                                               ^^^ support.function.var.css */
+/*                                                   ^^^^^^^^^^^^^^ variable.other.custom-property.css */
+/*                                                                  ^ punctuation.separator.sequence.css */
+/*                                                                    ^ meta.number.integer.decimal.css constant.numeric.value.css */
+
+    transform: translate3d(0, 2px, 3%);
+/*             ^^^^^^^^^^^ support.function.transform.css */
+/*                         ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                          ^ punctuation.separator.sequence.css */
+/*                            ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                             ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+/*                                 ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                                  ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    transform: translateX(1%);
+/*             ^^^^^^^^^^ support.function.transform */
+/*                        ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                         ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    transform: translateY(2px);
+/*             ^^^^^^^^^^ support.function.transform.css */
+/*                        ^ meta.number.integer.decimal.css constant.numeric.value.css */
+/*                         ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
+
+    transform: translateZ(0);
+/*             ^^^^^^^^^^ support.function.transform */
+/*                        ^ meta.number.integer.decimal.css constant.numeric.value.css */
 }
 
 .test-timing-functions {


### PR DESCRIPTION
This commit...

1. fixes `none` constant highlighting in `perspective()` functions
2. removes `<percentage>` from `matrix()` and `matrix3d()`
3. removes `<numbers>` from `translateX()` and `translateY()`
4. removes `<comma>` from `scaleX()`, ... .

5. adds and sorts transform related test cases.

Note: 

This commit intents to fix behavior/highlighting with existing accuracy/complexity/granularity.

The decision to simplify those contexts by more lazy highlighting may/should be part of a future change.