### PR TITLE
[TypeScript] Implement catch type annotations

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -86,6 +86,27 @@ contexts:
         - ts-namespace-name
     - include: else-pop
 
+  conditional:
+    - meta_prepend: true
+    - match: catch{{identifier_break}}
+      scope: keyword.control.exception.catch.js
+      set:
+        - catch-meta
+        - block-scope
+        - ts-expect-catch-parens
+
+  ts-expect-catch-parens:
+    - match: \(
+      scope: punctuation.section.group.begin.js
+      set:
+        - - meta_scope: meta.group.js
+          - match: \)
+            scope: punctuation.section.group.end.js
+            pop: 1
+        - ts-type-annotation
+        - expression
+    - include: else-pop
+
   parenthesized-expression:
     - match: \(
       scope: punctuation.section.group.begin.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1354,3 +1354,13 @@ const f = (x): (y) => 42 => z;
 //                       ^^ keyword.declaration.function.arrow
 //                          ^ meta.block variable.other.readwrite
 //                           ^ punctuation.terminator.statement
+
+try {} catch (e: any) {}
+//     ^^^^^^^^^^^^^^^^^ meta.catch
+//     ^^^^^ keyword.control.exception.catch
+//           ^^^^^^^^ meta.group
+//            ^ variable.other.readwrite
+//             ^ punctuation.separator.type
+//              ^^^^ meta.type
+//               ^^^ support.type.any
+//                    ^^ meta.block


### PR DESCRIPTION
Fix #3702.

This is a TypeScript 4.0 feature that just never got implemented.