### PR TITLE
[JavaScript] Catch variable should be a binding pattern

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -776,7 +776,7 @@ contexts:
       set:
         - catch-meta
         - block-scope
-        - expect-parenthesized-expression
+        - catch-binding
 
   expect-parenthesized-expression:
     - include: parenthesized-expression
@@ -922,6 +922,20 @@ contexts:
       scope: keyword.control.loop.while.js
       set: parenthesized-expression
     - include: else-pop
+
+  catch-binding:
+    - match: \(
+      scope: punctuation.section.group.begin.js
+      set:
+        - catch-binding-end
+        - variable-binding-pattern
+    - include: else-pop
+
+  catch-binding-end:
+    - meta_scope: meta.group.js
+    - match: \)
+      scope: punctuation.section.group.end.js
+      pop: 1
 
   decorator:
     - match: '@'

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -336,7 +336,8 @@ try {
 // <- meta.block
 //^^^^^^^^^^^^ meta.catch
 //^^^^^ keyword.control.exception.catch
-//       ^ meta.group
+//      ^^^ meta.group
+//       ^ meta.binding.name variable.other.readwrite
 //          ^ meta.block
     foobar = 0
 //  ^^^^^^^^^^ meta.catch meta.block

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1354,3 +1354,13 @@ const f = (x): (y) => 42 => z;
 //                       ^^ keyword.declaration.function.arrow
 //                          ^ meta.block variable.other.readwrite
 //                           ^ punctuation.terminator.statement
+
+try {} catch (e: any) {}
+//     ^^^^^^^^^^^^^^^^^ meta.catch
+//     ^^^^^ keyword.control.exception.catch
+//           ^^^^^^^^ meta.group
+//            ^ variable.other.readwrite
+//             ^ punctuation.separator.type
+//              ^^^^ meta.type
+//               ^^^ support.type.any
+//                    ^^ meta.block


### PR DESCRIPTION
Fix #3702. Supersedes #3703.

The original `catch` implementation used `parenthesized-expression` for the catch variable binging. This was technically incorrect, but it should be very hard to notice — even if you used a destructuring pattern, it would be highlighted as an object literal and look more or less correct.

However, in TypeScript this caused a problem. To begin with, it wouldn't highlight any type annotation on the catch variable. But also, in TypeScript the `parenthesized-expression` specifically looks for a type annotation and fails the `arrow-function` branch. This is especially bad here because the catch binding doesn't actually branch on `arrow-function`, so if the catch block is in an arrow function it will fail that outer arrow function and probably break highlighting in a weird way.

This is fixed by writing a context specifically for the catch binding that then uses the `variable-binding-pattern` context. As a bonus, this already supports type annotations, so no change to the TypeScript syntax is needed.