### PR TITLE
[TypeScript] Fix bug in arrow function type parameters

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -707,6 +707,11 @@ contexts:
     - match: \>
       scope: punctuation.definition.assertion.end.js
       pop: 1
+    - match: (?=\S) # Cover ts-type-parameter-list-head
+      push:
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
 
   ts-old-type-assertion-check:
     - match: (?=\()

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1255,6 +1255,14 @@ const f = <T,>(): U => {};
 //                ^ support.class
 //                  ^^ keyword.declaration.function.arrow
 
+const f = <T, U = V<any>>() => {};
+//        ^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//        ^^^^^^^^^^^^^^^ meta.generic
+//                       ^^ meta.function.parameters
+//                         ^^^^^^ meta.function
+//                          ^^ keyword.declaration.function.arrow
+//                             ^^ meta.block
+
     a != b;
 //    ^^ keyword.operator.comparison
 


### PR DESCRIPTION
Reported in https://github.com/Thom1729/Sublime-JS-Custom/issues/138.

In non-TSX TypeScript, a `<` at the beginning of an expression is either an old-style type assertion or an arrow function with type parameters. In ambiguous cases (and good golly are there ambiguous cases), I'm pretty sure it's always an arrow function. (I would check the spec, if there was one.) In the syntax definition, this is implemented by trying to parse an old-style type assertion, then reusing the regular parenthesized expression code, which will detect an arrow function and fail to the appropriate branch.

This was failing in cases like `<T = U<V>>() => {}`. The reason for this is that the old-type type assertion code didn't know how to parse the default, and eventually it got to the first `>` and ended the assertion. This put the whole thing in a bad state, and it wouldn't find the arrow telling it to backtrack. The result was that the type parameter list was highlighted very wrong. I imagine that this could result in arbitrarily bad highlighting in some cases.

The fix was to broaden the old-style assertion syntax to handle code that was actually type parameter lists. It doesn't have to handle it *correctly*, just not get lost when angle brackets appear. This fix should work for any valid code.