### PR TITLE
[Python] Add support for named-only-parameters operators

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -668,7 +668,7 @@ contexts:
       scope: meta.function.parameters.python punctuation.section.parameters.begin.python
       set:
         - function-parameter-list-body
-        - allow-unpack-operators
+        - function-parameter-allow-unpack-operators
 
   function-parameter-list-body:
     - meta_content_scope: meta.function.parameters.python
@@ -677,7 +677,7 @@ contexts:
       set: function-after-parameters
     - match: ','
       scope: punctuation.separator.parameters.python
-      push: allow-unpack-operators
+      push: function-parameter-allow-unpack-operators
     - match: /
       scope: storage.modifier.positional-args-only.python
       push: function-parameter-expect-comma
@@ -692,6 +692,34 @@ contexts:
     - include: parameter-names
     - include: line-continuations
     - include: illegal-assignment-expressions
+
+  function-parameter-allow-unpack-operators:
+    - match: (?=\*(?!\*))
+      branch_point: unpack-or-separator
+      branch:
+        - function-parameter-unpack-operator
+        - function-parameter-named-only-operator
+    - include: allow-unpack-operators
+
+  function-parameter-named-only-operator:
+    - meta_include_prototype: false
+    - match: \*
+      scope: storage.modifier.named-args-only.python
+      pop: 2
+
+  function-parameter-unpack-operator:
+    - meta_include_prototype: false
+    - match: \*
+      scope: keyword.operator.unpacking.sequence.python
+      set: function-parameter-unpack-operator-check
+
+  function-parameter-unpack-operator-check:
+    - meta_include_prototype: false
+    - include: comments
+    - match: (?=,)
+      fail: unpack-or-separator
+    - match: ^(?!\s*([#,]|$))|(?=\S)
+      pop: 2
 
   function-parameter-expect-comma:
     - meta_include_prototype: false
@@ -720,7 +748,9 @@ contexts:
     # removed from python 3 since PEP-3113
     - match: \(
       scope: punctuation.section.group.begin.python
-      push: function-parameter-tuple-body
+      push:
+        - function-parameter-tuple-body
+        - allow-unpack-operators
 
   function-parameter-tuple-body:
     - meta_scope: meta.group.python
@@ -1847,7 +1877,7 @@ contexts:
       scope: keyword.operator.unpacking.sequence.python
       pop: 1
     - include: else-pop
-    - match: ^(?!\s*[#*])
+    - match: ^(?!\s*([#*]|$))
       pop: 1
 
   sequence-separators:

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -1800,6 +1800,14 @@ async def coroutine(param1):
 #         ^ entity.name.function
    pass
 
+def func(*): pass
+#       ^^^ meta.function.parameters.python
+#        ^ keyword.operator.unpacking.sequence.python
+
+def func(p1, p2, *): pass
+#                ^ keyword.operator.unpacking.sequence.python
+#                 ^ punctuation.section.parameters.end.python
+
 def func(*args, other_arg=2**10, **kwargs):
 #        ^ keyword.operator.unpacking.sequence.python
 #                          ^^ keyword.operator.arithmetic.python
@@ -1813,6 +1821,29 @@ def func(
 #              ^^ keyword.operator.arithmetic
     **kwargs
 #   ^^ keyword.operator.unpacking.mapping
+):
+    pass
+
+def func(
+
+    *
+#   ^ keyword.operator.unpacking.sequence.python
+
+    args,
+#   ^^^^ variable.parameter.python
+
+    other_arg
+    = 2
+
+    **
+#   ^^ keyword.operator.arithmetic.python
+    10,
+
+    **
+#   ^^ keyword.operator.unpacking.mapping.python
+
+    kwargs
+#   ^^^^^^ variable.parameter.python
 ):
     pass
 
@@ -1840,29 +1871,60 @@ def func(args, (x, y)=(0,0)):
 #                          ^ punctuation.section.parameters.end.python
     pass
 
-def foo(arg: int = 0, (x: float, y=20) = (0.0, "default")):
-#                     ^^^^^^^^^^^^^^^^ meta.group.python
-#                                     ^^^ - meta.group.python
-#                                        ^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
-#                     ^ punctuation.section.group.begin.python
-#                      ^ variable.parameter.python
-#                       ^^^^^^^ invalid.illegal.annotation.python
-#                              ^ punctuation.separator.parameters.python
-#                                ^ variable.parameter.python
-#                                 ^^^ invalid.illegal.default-value.python
-#                                    ^ punctuation.section.group.end.python
-#                                      ^ keyword.operator.assignment.python
-#                                        ^ punctuation.section.sequence.begin.python
-#                                                       ^ punctuation.section.sequence.end.python
+def func(arg: int = 0, (x: float, y=20) = (0.0, "default")):
+#                      ^^^^^^^^^^^^^^^^ meta.group.python
+#                                      ^^^ - meta.group.python
+#                                         ^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
+#                      ^ punctuation.section.group.begin.python
+#                       ^ variable.parameter.python
+#                        ^^^^^^^ invalid.illegal.annotation.python
+#                               ^ punctuation.separator.parameters.python
+#                                 ^ variable.parameter.python
+#                                  ^^^ invalid.illegal.default-value.python
+#                                     ^ punctuation.section.group.end.python
+#                                       ^ keyword.operator.assignment.python
+#                                         ^ punctuation.section.sequence.begin.python
+#                                                        ^ punctuation.section.sequence.end.python
     pass
 
-def name(p1, p2=None, /, p_or_kw=None, *, kw): pass
+def func(p1, p2=None, /, p_or_kw=None, *, kw): pass
 #                     ^ storage.modifier.positional-args-only.python
 #                      ^ punctuation.separator.parameters.python
-#                                      ^ keyword.operator.unpacking.sequence.python
-def name(p1, p2, /): pass
+#                                    ^ punctuation.separator.parameters.python
+#                                      ^ storage.modifier.named-args-only.python
+#                                       ^ punctuation.separator.parameters.python
+
+def func(p1, p2, /): pass
 #                ^ storage.modifier.positional-args-only.python
 #                 ^ punctuation.section.parameters.end.python
+
+def func(p1, p2, *,): pass
+#                ^ storage.modifier.named-args-only.python
+#                 ^ punctuation.separator.parameters.python
+#                  ^ punctuation.section.parameters.end.python
+
+def func(*,): pass
+#       ^^^^ meta.function.parameters.python
+#        ^ storage.modifier.named-args-only.python
+
+def func(
+    bar: str,
+
+    *
+#  ^^^ meta.function.parameters.python
+#   ^ storage.modifier.named-args-only.python
+
+    ,
+#  ^^^ meta.function.parameters.python
+#   ^ punctuation.separator.parameters.python
+
+    baz: str,
+#  ^^^^^^^^^^^ meta.function.parameters
+#   ^^^ variable.parameter.python
+#      ^ punctuation.separator.annotation.parameter.python
+#        ^^^ support.type.python
+#           ^ punctuation.separator.parameters.python
+): pass
 
 
 ##################


### PR DESCRIPTION
Fixes #3711

This commit...

1. fixes an issue with unpack operators not being matched in case they are followed by an empty line.

2. scopes single asterisk parameter in function signatures as named-parameters only storage modifier, which is the counter-part of `/` being scoped as positional-only parameters.