### PR TITLE
[C++] Add std::begin($1), std::end($1) snippet

### DIFF
--- a/C++/Snippets/stdbegin($1)-stdend($1)-(beginend).sublime-snippet
+++ b/C++/Snippets/stdbegin($1)-stdend($1)-(beginend).sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<description>std::begin($1), std::end($1)</description>
+	<content><![CDATA[std::begin(${1:v}${1/^.*?(-)?(>)?$/(?2::)/}), std::end(${1:v}${1/^.*?(-)?(>)?$/(?2::)/})]]></content>
+	<tabTrigger>beginend</tabTrigger>
+	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
+</snippet>


### PR DESCRIPTION
Ideally I'd also love to kill the weird current `$1.begin(), $1.end()` which definitionally doesn't really work, but I think I can just do that locally maybe.