### PR TITLE
[Git Formats] Support `.git-blame-ignore-revs` files

### DIFF
--- a/Git Formats/Git Blame Ignore Revisions.sublime-settings
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-settings
@@ -1,0 +1,6 @@
+{
+	// Ensure not to modify ignore-revisions files if set to `true` in
+	// User/Preferences.sublime-settings as everything but a SHA-1 per line
+	// will error out on versions older than Git 2.20, *including newlines*
+	"ensure_newline_at_eof_on_save": false,
+}

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -16,7 +16,7 @@ hidden_file_extensions:
   - .git-blame-ignore-revs    # ~/.git-blame-ignore-revs
 
 variables:
-  comment_char: '[#]'         # Can't use Git Common here - ';' is not allowed
+  comment_char: \#            # Can't use Git Common here - ';' is not allowed
   object_name: \b\h{40}\b
 
 contexts:

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -29,6 +29,7 @@ contexts:
       push: comment-body
 
   comment-body:
+    - meta_include_prototype: false
     - meta_scope: comment.line.git.blame.ignorerevs
     - match: \n
       pop: 1

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
 
   main:
     - include: comments
-    - include: revision
+    - include: revisions
     - include: illegal
 
   comments:
@@ -36,12 +36,12 @@ contexts:
     - match: \n
       pop: 1
 
-  revision:
+  revisions:
     - match: '{{object_name}}'
       scope: constant.other.hash.git.blame.ignorerevs
-      push: rest
+      push: expect-eol
 
-  rest:
+  expect-eol:
     - include: comments
     - include: illegal
     - include: eol-pop

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -21,17 +21,21 @@ variables:
 
 contexts:
   prototype:
-    - include: comments
+    - include: comment-start
+
+  comment-start:
+    - match: '[{{comment_char}}]'
+      scope: punctuation.definition.comment.git.blame.ignorerevs
+      push: comment-content
+
+  comment-content:
+    - meta_scope: comment.line.git.blame.ignorerevs
+    - match: \n
+      pop: 1
 
   main:
     - include: revision
     - include: illegal
-
-  comments:
-    - match: ({{comment_char}}).*\n?
-      scope: comment.line.git.blame.ignorerevs
-      captures:
-        1: punctuation.definition.comment.git.blame.ignorerevs
 
   revision:
     - match: '{{object_name}}'

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -16,15 +16,17 @@ hidden_file_extensions:
   - .git-blame-ignore-revs    # ~/.git-blame-ignore-revs
 
 variables:
-  comment_char: \#            # Can't use Git Common here - ';' is not allowed
   object_name: \b\h{40}\b
 
 contexts:
-  prototype:
+
+  main:
     - include: comments
+    - include: revision
+    - include: illegal
 
   comments:
-    - match: '[{{comment_char}}]'
+    - match: \#+
       scope: punctuation.definition.comment.git.blame.ignorerevs
       push: comment-body
 
@@ -34,21 +36,18 @@ contexts:
     - match: \n
       pop: 1
 
-  main:
-    - include: revision
-    - include: illegal
-
   revision:
     - match: '{{object_name}}'
       scope: constant.other.hash.git.blame.ignorerevs
       push: rest
 
   rest:
+    - include: comments
     - include: illegal
     - include: eol-pop
 
   illegal:
-    - match: '[^\s{{comment_char}}]+'
+    - match: '[^\s#]+'
       scope: invalid.illegal.stray-character.git.blame.ignorerevs
 
   eol-pop:

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -32,7 +32,6 @@ contexts:
       scope: comment.line.git.blame.ignorerevs
       captures:
         1: punctuation.definition.comment.git.blame.ignorerevs
-    - include: eol-pop
 
   revision:
     - match: '{{object_name}}'

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -21,14 +21,14 @@ variables:
 
 contexts:
   prototype:
-    - include: comment-start
+    - include: comments
 
-  comment-start:
+  comments:
     - match: '[{{comment_char}}]'
       scope: punctuation.definition.comment.git.blame.ignorerevs
-      push: comment-content
+      push: comment-body
 
-  comment-content:
+  comment-body:
     - meta_scope: comment.line.git.blame.ignorerevs
     - match: \n
       pop: 1

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -28,7 +28,7 @@ contexts:
     - include: illegal
 
   comments:
-    - match: ({{comment_char}}).*
+    - match: ({{comment_char}}).*\n?
       scope: comment.line.git.blame.ignorerevs
       captures:
         1: punctuation.definition.comment.git.blame.ignorerevs

--- a/Git Formats/Git Blame Ignore Revisions.sublime-syntax
+++ b/Git Formats/Git Blame Ignore Revisions.sublime-syntax
@@ -1,0 +1,52 @@
+%YAML 1.2
+---
+# Syntax based on documentation here:
+# https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+# (refers to https://git-scm.com/docs/git-fsck#Documentation/git-fsck.txt-fsckskipList)
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+name: Git Blame Ignore Revisions
+scope: text.git.blame.ignorerevs
+version: 2
+
+file_extensions:
+  - git-blame-ignore-revs     # *.git-blame-ignore-revs
+
+hidden_file_extensions:
+  - .git-blame-ignore-revs    # ~/.git-blame-ignore-revs
+
+variables:
+  comment_char: '[#]'         # Can't use Git Common here - ';' is not allowed
+  object_name: \b\h{40}\b
+
+contexts:
+  prototype:
+    - include: comments
+
+  main:
+    - include: revision
+    - include: illegal
+
+  comments:
+    - match: ({{comment_char}}).*
+      scope: comment.line.git.blame.ignorerevs
+      captures:
+        1: punctuation.definition.comment.git.blame.ignorerevs
+    - include: eol-pop
+
+  revision:
+    - match: '{{object_name}}'
+      scope: constant.other.hash.git.blame.ignorerevs
+      push: rest
+
+  rest:
+    - include: illegal
+    - include: eol-pop
+
+  illegal:
+    - match: '[^\s{{comment_char}}]+'
+      scope: invalid.illegal.stray-character.git.blame.ignorerevs
+
+  eol-pop:
+    - match: $
+      pop: 1

--- a/Git Formats/tests/syntax_test_git_blame_ignore_revs
+++ b/Git Formats/tests/syntax_test_git_blame_ignore_revs
@@ -11,9 +11,12 @@
 1e142ae87ead6c3cc0684842957b482cc9061c9d ;( :^) #
 # <- constant.other.hash.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                       ^ - constant - invalid
 #                                        ^^ invalid.illegal.stray-character.git.blame.ignorerevs
 #                                           ^^^ invalid.illegal.stray-character.git.blame.ignorerevs
-#                                               ^ comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+#                                              ^ - comment - invalid
+#                                               ^^ comment.line.git.blame.ignorerevs
+#                                               ^ punctuation.definition.comment.git.blame.ignorerevs
 
 # Trim trailing whitespace in README
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
@@ -21,16 +24,20 @@
 9ed036cf8c7b6d6866fbafadb7954ebcffa6d22c # TODO: rewrite history
 # <- constant.other.hash.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                       ^ - constant - comment
 #                                        ^ punctuation.definition.comment.git.blame.ignorerevs
 #                                        ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
 
 the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi
 # <- invalid.illegal.stray-character.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                             ^ - constant - invalid
 #                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                                                      ^ - constant - invalid
 #                                                                       ^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                                                                         ^ - constant - invalid
 #                                                                          ^ punctuation.definition.comment.git.blame.ignorerevs
-#                                                                          ^^^^ comment.line.git.blame.ignorerevs
+#                                                                          ^^^^^ comment.line.git.blame.ignorerevs
 
 # Migrate to black
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
@@ -38,7 +45,7 @@ the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi
 264b2c9c72691c5937b80e84e061c52dd2d8861a 950d9a0751d79b92d78ea44344ce3e3c5b3948f9## 1 per line please
 # <- constant.other.hash.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                       ^ - constant - invalid
 #                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
-#                                                                                ^ punctuation.definition.comment.git.blame.ignorerevs
-#                                                                                 ^ - punctuation.definition.comment.git.blame.ignorerevs
-#                                                                                ^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+#                                                                                ^^ punctuation.definition.comment.git.blame.ignorerevs
+#                                                                                ^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs

--- a/Git Formats/tests/syntax_test_git_blame_ignore_revs
+++ b/Git Formats/tests/syntax_test_git_blame_ignore_revs
@@ -35,9 +35,10 @@ the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi
 # Migrate to black
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
-264b2c9c72691c5937b80e84e061c52dd2d8861a 950d9a0751d79b92d78ea44344ce3e3c5b3948f9# one per line please
+264b2c9c72691c5937b80e84e061c52dd2d8861a 950d9a0751d79b92d78ea44344ce3e3c5b3948f9## 1 per line please
 # <- constant.other.hash.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
 #                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
 #                                                                                ^ punctuation.definition.comment.git.blame.ignorerevs
-#                                                                                ^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+#                                                                                 ^ - punctuation.definition.comment.git.blame.ignorerevs
+#                                                                                ^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs

--- a/Git Formats/tests/syntax_test_git_blame_ignore_revs
+++ b/Git Formats/tests/syntax_test_git_blame_ignore_revs
@@ -1,14 +1,19 @@
 # SYNTAX TEST "Git Blame Ignore Revisions.sublime-syntax"
 # <- text.git.blame.ignorerevs comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
 
+# Standalone comment
+# <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+
 # Convert CRLF to LF in source files
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
-1e142ae87ead6c3cc0684842957b482cc9061c9d ;( :^)
+1e142ae87ead6c3cc0684842957b482cc9061c9d ;( :^) #
 # <- constant.other.hash.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
 #                                        ^^ invalid.illegal.stray-character.git.blame.ignorerevs
 #                                           ^^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                                               ^ comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
 
 # Trim trailing whitespace in README
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
@@ -19,13 +24,13 @@
 #                                        ^ punctuation.definition.comment.git.blame.ignorerevs
 #                                        ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
 
-the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi!
+the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi
 # <- invalid.illegal.stray-character.git.blame.ignorerevs
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
 #                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
 #                                                                       ^^ invalid.illegal.stray-character.git.blame.ignorerevs
 #                                                                          ^ punctuation.definition.comment.git.blame.ignorerevs
-#                                                                          ^^^^^ comment.line.git.blame.ignorerevs
+#                                                                          ^^^^ comment.line.git.blame.ignorerevs
 
 # Migrate to black
 # <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs

--- a/Git Formats/tests/syntax_test_git_blame_ignore_revs
+++ b/Git Formats/tests/syntax_test_git_blame_ignore_revs
@@ -1,0 +1,38 @@
+# SYNTAX TEST "Git Blame Ignore Revisions.sublime-syntax"
+# <- text.git.blame.ignorerevs comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+
+# Convert CRLF to LF in source files
+# <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+1e142ae87ead6c3cc0684842957b482cc9061c9d ;( :^)
+# <- constant.other.hash.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                        ^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                                           ^^^ invalid.illegal.stray-character.git.blame.ignorerevs
+
+# Trim trailing whitespace in README
+# <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+9ed036cf8c7b6d6866fbafadb7954ebcffa6d22c # TODO: rewrite history
+# <- constant.other.hash.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                        ^ punctuation.definition.comment.git.blame.ignorerevs
+#                                        ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+
+the-best-thing-we've-ever-done 3897d1b4465ae8f45c62b2da88cf90033764226c 13 # Hi!
+# <- invalid.illegal.stray-character.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                                                       ^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                                                                          ^ punctuation.definition.comment.git.blame.ignorerevs
+#                                                                          ^^^^^ comment.line.git.blame.ignorerevs
+
+# Migrate to black
+# <- comment.line.git.blame.ignorerevs punctuation.definition.comment.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs
+264b2c9c72691c5937b80e84e061c52dd2d8861a 950d9a0751d79b92d78ea44344ce3e3c5b3948f9# one per line please
+# <- constant.other.hash.git.blame.ignorerevs
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.other.hash.git.blame.ignorerevs
+#                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.stray-character.git.blame.ignorerevs
+#                                                                                ^ punctuation.definition.comment.git.blame.ignorerevs
+#                                                                                ^^^^^^^^^^^^^^^^^^^^^ comment.line.git.blame.ignorerevs


### PR DESCRIPTION
Git Blame Ignore Revisions file consists of a list of object names (i.e. one unabbreviated SHA-1 per line) that should be excluded from the blame view using git's `git blame --ignore-revs-file <file>` command or, on GitHub, by committing a `.git-blame-ignore-revs` file to the root directory of a repository. Versions of git 2.20 and higher permit comments (`#`), empty lines and trailing/leading whitespace; older versions error on everything but a SHA-1 per line.

I believe the syntax of these files is simple enough to warrant including support for them in the default package without placing much (to be honest, any) potential maintenance burden.

Included syntax tests take an average of 0.3ms over 10 runs here.