### PR TITLE
[HTML] Sync known html tag names with CSS

### DIFF
--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1209,7 +1209,7 @@ test = "hello%>
        '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
             %><li><%= item %></li><%
                     '^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp
-           '  ^ meta.tag.inline.any.html punctuation.definition.tag.begin.html
+           '  ^ punctuation.definition.tag.begin.html
            '      ^^^ punctuation.section.embedded.begin.inside-block.asp
            '               ^^ punctuation.section.embedded.end.inside-block.asp
         Next

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -101,8 +101,8 @@ variables:
   # Note: Sections are sorted by expected frequency.
   html_tags:  |-
     (?x:
-      {{html_inline_tags}}
-    | {{html_text_tags}}
+      {{html_text_semantic_tags}}
+    | {{html_text_content_tags}}
     | {{html_section_tags}}
     | {{html_table_tags}}
     | {{html_embedded_tags}}
@@ -113,80 +113,77 @@ variables:
     | {{html_web_tags}}
     | {{html_markup_tags}}
     | {{html_header_tags}}
-    | {{html_root_tags}}
-    | {{html_deprecated_tags}}
+    | {{html_structure_tags}}
+    | {{html_deprecated_block_tags}}
+    | {{html_deprecated_inline_tags}}
     )
 
-  html_root_tags: |-
-    \b(?xi: html | body ){{break}}
+  # Aggregates structural root notes from
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#sectioning_root
+  html_structure_tags: |-
+    (?xi: html | head | body ){{break}}
 
+  # Note: <head> is moved to `html_structure_tags`
   html_header_tags: |-
-    \b(?xi: base | head | link | meta | script | style | title ){{break}}
+    (?xi: base | link | meta | script | style | title ){{break}}
 
   html_section_tags: |-
-    \b(?xi:
-      address | article | aside | footer | header | h1 | h2 | h3 | h4 | h5 | h6
-    | hgroup | main | nav | section
-    ){{break}}
+    (?xi: address | article | aside | footer | header | h[1-6] | hgroup | main
+    | nav | section ){{break}}
 
-  html_text_tags: |-
-    \b(?xi:
-      blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
-    | ol | p | pre | ul
-    ){{break}}
+  html_text_content_tags: |-
+    (?xi: blockquote | cite | dd | dt | dl | div | figcaption | figure | hr
+    | li | ol | p | pre | ul ){{break}}
 
-  html_inline_tags: |-
-    \b(?xi:
-      a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
-    | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
-    | sub | sup | u | var | wbr
-    ){{break}}
+  html_text_semantic_tags: |-
+    (?xi: a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i
+    | kbd | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span
+    | strong | sub | sup | u | var | wbr ){{break}}
 
   html_media_tags: |-
-    \b(?xi: area | audio | source | img | map | track | video ){{break}}
+    (?xi: area | audio | source | img | map | track | video ){{break}}
 
   html_embedded_tags: |-
-    \b(?xi: embed | iframe | object | param | picture | source ){{break}}
+    (?xi: embed | iframe | object | param | picture | source ){{break}}
 
   html_script_tags: |-
-    \b(?xi: canvas | noscript | script ){{break}}
+    (?xi: canvas | noscript (?# | script ) ){{break}}
 
   html_markup_tags: |-
-    \b(?xi: del | ins ){{break}}
+    (?xi: del | ins ){{break}}
 
   html_table_tags: |-
-    \b(?xi:
-        caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
-    ){{break}}
+    (?xi: caption | col | colgroup | table | tbody | tr | td | tfoot
+    | th | thead ){{break}}
 
   html_forms_tags: |-
-    \b(?xi:
-      button | datalist | option | fieldset | label | form | input | legend
-    | meter | optgroup | select | output | progress | textarea
-    ){{break}}
+    (?xi: button | datalist | fieldset | form |  input | label | legend | meter
+    | optgroup | option | output | progress | select | textarea ){{break}}
 
   html_interactive_tags: |-
-    \b(?xi: details | dialog | menu | summary ){{break}}
+    (?xi: details | dialog | menu | summary ){{break}}
 
   html_web_tags: |-
-    \b(?xi: slot | template ){{break}}
+    (?xi: slot | template ){{break}}
 
-  html_deprecated_tags: |-
-    \b(?xi:
-      acronym | applet | basefont | bgsound | big | blink | center | command
-    | content | dir | element | font | frame | frameset | image | isindex
-    | keygen | listing | marquee | menuitem | multicol | nextid | nobr
-    | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
-    ){{break}}
+  html_deprecated_block_tags: |-
+    (?xi: applet | bgsound | content | dir | element | frame | frameset
+    | marquee | noembed | noframes | plaintext | xmp ){{break}}
+
+  html_deprecated_inline_tags: |-
+    (?xi: acronym | basefont | big | blink | center | command | font | image
+    | keygen | menuitem | nobr | param | rb | rtc | shadow | spacer | strike
+    | tt ){{break}}
 
   # SVG tag names
   # maintained from previous CSS.sublime-syntax
   svg_tags: |-
-    \b(?xi:
-      circle | clipPath | defs | ellipse | eventsource | filter | foreignObject
-    | g | glyph | glyphRef | line | linearGradient | marker | mask | path
-    | pattern | polygon | polyline | radialGradient | rect | stop | svg
-    | switch | symbol | text | textPath | tref | tspan | use
+    (?xi: circle | clipPath | defs | ellipse | eventsource | filter
+    | foreignObject | g | glyph | glyphRef | line | linearGradient | marker
+    | mask | path | pattern | polygon | polyline | radialGradient | rect | stop
+    | svg | switch | symbol | text | textPath | tref | tspan | use
     # custom element like tags reserved for SVG/MathML
     | annotation-xml | color-profile | missing-glyph
     | font-face(?: -src | -uri | -format | -name )?

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -19,20 +19,88 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 ###############################################################################
 
 variables:
-  block_tag_name: |-
-    (?ix:
-      address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
-    ){{tag_name_break}}
+  # HTML tags
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  # Note: Sections are sorted by expected frequency.
 
-  inline_tag_name: |-
-    (?ix:
-      abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
-    ){{tag_name_break}}
+  html_block_tags: |-
+    (?x:
+      {{html_text_content_tags}}
+    | {{html_section_tags}}
+    | {{html_embedded_tags}}
+    | {{html_web_tags}}
+    | {{html_header_tags}}
+    | {{html_deprecated_block_tags}}
+    )
 
-  form_tag_name: |-
-    (?ix:
-      button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
-    ){{tag_name_break}}
+  html_inline_tags: |-
+    (?x:
+      {{html_text_semantic_tags}}
+    | {{html_markup_tags}}
+    | {{html_media_tags}}
+    | {{html_interactive_tags}}
+    | {{html_script_tags}}
+    | {{html_deprecated_inline_tags}}
+    )
+
+  # Aggregates structural root notes from
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#main_root
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#document_metadata
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element#sectioning_root
+  html_structure_tags: |-
+    (?xi: html | head | body ){{tag_name_break}}
+
+  # Note: <head> is moved to `html_structure_tags`
+  html_header_tags: |-
+    (?xi: base | link | meta | (?# script | style | ) title ){{tag_name_break}}
+
+  html_section_tags: |-
+    (?xi: address | article | aside | footer | header | h[1-6] | hgroup | main
+    | nav | section ){{tag_name_break}}
+
+  html_text_content_tags: |-
+    (?xi: blockquote | cite | dd | dt | dl | div | figcaption | figure | hr
+    | li | ol | p | pre | ul ){{tag_name_break}}
+
+  html_text_semantic_tags: |-
+    (?xi: a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i
+    | kbd | mark | q | ruby | rp | rt | s | samp | small | span | strong | sub
+    | sup | u | var | wbr ){{tag_name_break}}
+
+  html_media_tags: |-
+    (?xi: area | audio | img | map | track | video ){{tag_name_break}}
+
+  html_embedded_tags: |-
+    (?xi: embed | iframe | object | param | picture | source ){{tag_name_break}}
+
+  html_script_tags: |-
+    (?xi: canvas | noscript (?# | script ) ){{tag_name_break}}
+
+  html_markup_tags: |-
+    (?xi: del | ins ){{tag_name_break}}
+
+  html_table_tags: |-
+    (?xi: caption | col | colgroup | table | tbody | tr | td | tfoot
+    | th | thead ){{tag_name_break}}
+
+  html_forms_tags: |-
+    (?xi: button | datalist | (?# fieldset | form | ) input | label | legend | meter
+    | optgroup | option | output | progress | select | textarea ){{tag_name_break}}
+
+  html_interactive_tags: |-
+    (?xi: details | dialog | menu | summary ){{tag_name_break}}
+
+  html_web_tags: |-
+    (?xi: slot | template ){{tag_name_break}}
+
+  html_deprecated_block_tags: |-
+    (?xi: applet | bgsound | content | dir | element | frame | frameset
+    | marquee | noembed | noframes | plaintext | xmp ){{tag_name_break}}
+
+  html_deprecated_inline_tags: |-
+    (?xi: acronym | basefont | big | blink | center | command | font | image
+    | keygen | menuitem | nobr | param | rb | rtc | shadow | spacer | strike
+    | tt ){{tag_name_break}}
 
   html_mime_type: |-
     (?xi: text/html {{mime_type_parameters}}? )
@@ -58,7 +126,7 @@ variables:
   # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
   json_mime_type: |-
-     (?xi: (?i:application/|text/|[[:ascii:]]+\+)json {{mime_type_parameters}}? )
+     (?xi: (?: application/ | text/ | [[:ascii:]]+\+ ) json {{mime_type_parameters}}? )
 
   # A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings
   # limited to HTTP quoted-string token code points. It is initially empty.
@@ -98,8 +166,7 @@ variables:
     )
 
   event_attribute_names: |-
-    (?xi:
-      onabort | onautocomplete | onautocompleteerror | onauxclick | onblur
+    (?xi: onabort | onautocomplete | onautocompleteerror | onauxclick | onblur
     | oncancel | oncanplay | oncanplaythrough | onchange | onclick | onclose
     | oncontextmenu | oncopy | oncuechange | ondblclick | ondrag | ondragend
     | ondragenter | ondragexit | ondragleave | ondragover | ondragstart | ondrop
@@ -127,78 +194,72 @@ contexts:
   tag-html:
     - include: script-tag
     - include: style-tag
-    - match: (</?)((?i:body|head|html){{tag_name_break}})
+    - match: (</?)({{html_structure_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.structure.any.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.structure.any.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</?)({{block_tag_name}})
+      push: structure-tag-content
+    - match: (</?)({{html_block_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.block.any.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</?)((?i:hr){{tag_name_break}})
+      push: block-any-tag-content
+    - match: (</?)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.block.any.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.block.any.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
+        2: entity.name.tag.inline.any.html
+      push: inline-any-tag-content
     - match: (</?)((?i:form|fieldset){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.form.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.block.form.html
-        - include: tag-end
-        - include: tag-attributes
-    - match: (</?)({{inline_tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.any.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.inline.any.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)({{form_tag_name}})
+      push: block-forms-tag-content
+    - match: (</?)({{html_forms_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.inline.form.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)((?i:a){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.inline.a.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.inline.a.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
-    - match: (</?)((?i:col|colgroup|table|tbody|td|tfoot|th|thead|tr){{tag_name_break}})
+      push: inline-forms-tag-content
+    - match: (</?)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html
-      push:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.inline.table.html
-        - include: tag-end-maybe-self-closing
-        - include: tag-attributes
+      push: table-tag-content
+
+  structure-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.structure.any.html
+    - include: tag-end
+    - include: tag-attributes
+
+  block-any-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.block.any.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  block-forms-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.block.form.html
+    - include: tag-end
+    - include: tag-attributes
+
+  inline-any-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.inline.any.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  inline-forms-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.inline.form.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  table-tag-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.inline.table.html
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
 
 ###[ OTHER TAG ]##############################################################
 

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -872,6 +872,18 @@ class="foo"></div>
         ##                                           ^ - punctuation.definition.tag.end.html
         ##                                            ^^ meta.tag.other.html punctuation.definition.tag.end.html
 
+        <slot name=""></slot>
+        ## <- meta.tag.block.any.html punctuation.definition.tag.begin.html
+        ##^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html
+        ##^^^ entity.name.tag.block.any.html
+        ##    ^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
+        ##        ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+        ##         ^^ meta.attribute-with-value.html meta.string.html string.quoted.double.html
+        ##           ^ punctuation.definition.tag.end.html
+        ##            ^^ punctuation.definition.tag.begin.html
+        ##              ^^^^ entity.name.tag.block.any.html
+        ##                  ^ punctuation.definition.tag.end.html
+
         <body·other attrib=1/>
         ## ^^^^^^^^ entity.name.tag.other.html
         ##          ^^^^^^ entity.other.attribute-name.html

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -5748,7 +5748,7 @@ blah*
 | ^ punctuation.definition.raw.begin.markdown
 |      ^ punctuation.definition.raw.end.markdown
 |        ^ - punctuation
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html 
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html 
 
 - list item
 
@@ -6018,7 +6018,7 @@ foo
 ## https://spec.commonmark.org/0.30/#example-344
 
 <a href="`">`
-| ^^^^^^^^^^ meta.tag.inline.a
+| ^^^^^^^^^^ meta.tag.inline.any
 |           ^^ - meta.tag - markup.raw - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-345

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -124,13 +124,13 @@
 #                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation - source
 
 <a onclick="run(<% @ruby %>, 'var<% @ruby %>e')" style="font: <% @ruby_font %>, 'font_<% @name %>';">text</a>
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html meta.attribute-with-value.event.html meta.string.html
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.event.html meta.string.html
 #           ^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #               ^^^^^^^^^^^ meta.interpolation.html meta.embedded.rails
 #                          ^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #                                ^^^^^^^^^^^ meta.interpolation.html meta.string.js meta.interpolation.rails meta.embedded.rails
 #                                           ^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
-#                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html meta.attribute-with-value.style.html meta.string.html
+#                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html meta.attribute-with-value.style.html meta.string.html
 #                                                       ^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded
 #                                                             ^^^^^^^^^^^^^^^^ meta.interpolation.html meta.embedded.rails
 #                                                                             ^^^^^^^^ meta.interpolation.html - meta.interpolation meta.interpolation - meta.embedded


### PR DESCRIPTION
This PR proposes to apply tag name variables from CSS.sublime-syntax to HTML.sublime-syntax to get both syntaxes inline. Some html5 tags such as `del`, `ins`, `slot` etc. have been missing.

Variables are grouped into `html_block_tags` and `html_inline_tags` to maintain current scoping (`meta.tag.[structure|block|inline]`) of HTML.

> The main purpose of those variables is to better keep track of possible changes on MDN.

A dedicated named context is created for each kind of tag content in case an inheriting syntax wants to replace or extend one of them.

Dedicated pattern for `<a...>` tags is removed as it doesn't push into any special context nor is the scope used in completions or snippets.

#### CSS

Variable names and formatting is adjusted in CSS. Word boundary checks are removed as tag names appear in selectors only, which already maintain word boundaries of "unknown" tags/classes/ids.

#### Notes

1. Beyond `a` tag and some new html5 tags, syntax highlighting is not effected.
2. Parsing performance is unchanged.