### PR TITLE
[Go] support language hints for backtick strings

### DIFF
--- a/Go/Go (Embedded Backtick String).sublime-syntax
+++ b/Go/Go (Embedded Backtick String).sublime-syntax
@@ -1,0 +1,63 @@
+%YAML 1.2
+---
+name: Go (Embedded Backtick String)
+scope: source.go.embedded-backtick-string
+version: 2
+extends: Packages/Go/Go.sublime-syntax
+hidden: true
+
+contexts:
+  # https://www.jetbrains.com/help/go/using-language-injections.html#use-language-injection-comments
+  inside-comment-magic-language-injection-language-after-language-identifier:
+    - meta_content_scope: comment.line.double-slash.go
+    # TODO: support prefix and suffix
+    - match: $\n?
+      set:
+        - main
+        - consume-comments-at-beginning-of-line
+
+  pop-at-bol:
+    - match: ^
+      pop: true
+
+  main:
+    - meta_prepend: true
+    - match: $\n?
+      pop: true
+
+  consume-comments-at-beginning-of-line:
+    - include: match-comments
+    - match: ^\s*(?=/[/*])
+    - include: pop-at-bol
+
+  match-raw-string:
+    - match: '`'
+      scope: punctuation.definition.string.begin.go
+      embed: embedded-language
+      escape: '`'
+      escape_captures:
+        0: punctuation.definition.string.end.go
+
+  embedded-language:
+    - meta_include_prototype: false
+
+  match-parens:
+    - meta_prepend: true
+    - match: (?=\))
+      pop: true
+
+  match-brackets:
+    - meta_prepend: true
+    - match: (?=\])
+      pop: true
+
+  match-braces:
+    - meta_prepend: true
+    - match: (?=\})
+      pop: true
+
+  match-backtick-string-formatting:
+    - include: match-template-string
+    - match: \%%
+      scope: constant.character.escape.go
+    - include: match-fmt

--- a/Go/Go (Embedded JSON).sublime-syntax
+++ b/Go/Go (Embedded JSON).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+name: Go (Embedded JSON)
+scope: source.go.embedded-backtick-string.json
+version: 2
+extends: Packages/Go/Go (Embedded Backtick String).sublime-syntax
+hidden: true
+
+contexts:
+  embedded-language:
+    - match: ''
+      embed: scope:source.json
+      embed_scope: source.json.embedded.go
+      escape: (?!)

--- a/Go/Go (Embedded Regex).sublime-syntax
+++ b/Go/Go (Embedded Regex).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+name: Go (Embedded Regex)
+scope: source.go.embedded-backtick-string.regexp
+version: 2
+extends: Packages/Go/Go (Embedded Backtick String).sublime-syntax
+hidden: true
+
+contexts:
+  embedded-language:
+    - match: ''
+      embed: scope:source.regexp
+      embed_scope: source.regexp.embedded.go
+      escape: (?!)

--- a/Go/Go (Embedded SQL).sublime-syntax
+++ b/Go/Go (Embedded SQL).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+name: Go (Embedded SQL)
+scope: source.go.embedded-backtick-string.sql
+version: 2
+extends: Packages/Go/Go (Embedded Backtick String).sublime-syntax
+hidden: true
+
+contexts:
+  embedded-language:
+    - match: ''
+      embed: scope:source.sql
+      embed_scope: source.sql.embedded.go
+      escape: (?!)

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -160,6 +160,7 @@ contexts:
     - include: match-comment-magic-general
     - include: match-comment-magic-line-renum
     - include: match-comment-magic-line-extern
+    - include: match-comment-magic-language-injection
 
   # Go has magic comments in the form of:
   #
@@ -221,6 +222,29 @@ contexts:
         3: meta.variable.function.go
         4: meta.punctuation.separator.space.go
         5: meta.annotation.parameters.go
+
+  match-comment-magic-language-injection:
+    - match: (//)\s*(language)\s*(=)\s*
+      captures:
+        0: meta.annotation.identifier.go
+        1: punctuation.definition.comment.go
+        2: support.other.go
+        3: keyword.operator.assignment.go
+      push: match-comment-magic-language-injection-language-id
+
+  match-comment-magic-language-injection-language-id:
+    - meta_scope: comment.line.double-slash.go
+    - match: (?i)sql\b
+      scope: meta.annotation.parameters.go constant.language.go
+      set: scope:source.go.embedded-backtick-string.sql#inside-comment-magic-language-injection-language-after-language-identifier
+    - match: (?i)json\b
+      scope: meta.annotation.parameters.go constant.language.go
+      set: scope:source.go.embedded-backtick-string.json#inside-comment-magic-language-injection-language-after-language-identifier
+    - match: (?i)regexp\b
+      scope: meta.annotation.parameters.go constant.language.go
+      set: scope:source.go.embedded-backtick-string.regexp#inside-comment-magic-language-injection-language-after-language-identifier
+    - match: $
+      pop: true
 
   pop-line-annotation:
     - meta_scope: comment.line.double-slash.go

--- a/Go/SQL (Embedded Go Backtick String Formatting).sublime-syntax
+++ b/Go/SQL (Embedded Go Backtick String Formatting).sublime-syntax
@@ -1,0 +1,12 @@
+%YAML 1.2
+---
+name: SQL inside Go backtick string
+scope: source.sql.go-embedded-backtick-string
+version: 2
+extends: Packages/SQL/SQL.sublime-syntax
+hidden: true
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.go.embedded-backtick-string#match-backtick-string-formatting


### PR DESCRIPTION
It's very common in Go code to see ["language injection comments" as popularized by JetBrains' GoLand](https://www.jetbrains.com/help/go/using-language-injections.html#use-language-injection-comments).

The idea is that a comment will give a language hint as to what type of code is embedded in the following backtick string, for syntax highlighting and completions purposes. i.e. `// language=sql`

This PR adds such support to Sublime, for embedded SQL, JSON and regular expressions. These are the main embedded languages I've come across.