### PR TITLE
[Batch File] Improve batch file matching

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -9,10 +9,14 @@ file_extensions:
   - bat
   - cmd
 
+hidden_file_extensions:
+  - .bat
+  - .cmd
+
 first_line_match: |-
   (?xi:
-    ^ \s* (?:\:|rem) .*? -\*- .*? \bbat\b .*? -\*-  # editorconfig
-  | ^ \s* @echo\s+(?:on|off)\b
+    ^ [@\s]* (?:\:|rem) .*? -\*- .*? \b(?:bat|cmd)\b .*? -\*-  # editorconfig
+  | ^ [@\s]* (?:if \s+ \S .*? =?=? .*? \S \s+)? [@(\s]* echo \s+ (?:on|off|=) \b
   )
 
 ###############################################################################


### PR DESCRIPTION
This PR aims to improve batch file (i.e. `cmd.exe` script) matching by:

  - adding `.bat` and `.cmd` to the list of valid file extensions (dotfile scripts e.g. `%USERPROFILE%\.{bat,cmd}` invoked via `{HKLM,HKCU}\Software\Microsoft\Command Processor\AutoRun`);
  - enhancing `first_line_match` in order for it to match most of the common first line patterns in batch files, specifically "ifdebugecho" (`@if "%DEBUG%"=="" @echo off`) and its variants.

Catches all of the following:

  - `@echo off`
  - `@if "%DEBUG%"=="" echo off`
  - `@if "%DEBUG_BATCH_ECHO:"=%"=="on" (echo on)`
  - `if not defined DEBUG @echo off`
  - `if 0==1: echo =r"""...`
  - `if "%~n0"=="" (@echo off) else (@goto :EOF)`

There are more, but the goal is not to be perfect.