### PR TITLE
[Erlang] Remove obsolete query keyword

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -807,13 +807,6 @@ contexts:
         - meta_scope: meta.block.erlang
         - include: expr-control-flow-end
         - include: expr-control-body
-    # https://www.erlang.org/doc/reference_manual/...?
-    - match: query{{ident_break}}
-      scope: keyword.control.flow.query.erlang
-      push:
-        - meta_scope: meta.query.erlang
-        - include: expr-control-flow-end
-        - include: expr-control-body
     # https://www.erlang.org/doc/reference_manual/expressions.html#guard-sequences
     - match: when{{ident_break}}
       scope: keyword.control.conditional.when.erlang


### PR DESCRIPTION
Fixes #2401

This PR proposes to remove the obsolete keyword `query` from Erlang syntax, as it has been deprecated in 2007 and removed from Erlang-OTP in 2012.

The atom `query` can be used as normal variable/constant in any context, these days.

The last attempt to do so (see: #2409) was rejected because of backward compatibility concerns.

With inheritance it is however trivial to create a syntax, which re-adds the keyword if needed.

We can leave it to end-users or provide an _Erlang (Legacy).sublime-syntax_ with following code, to maintain backward compatibility for those who need it.

```yaml
%YAML 1.2
---
# https://www.erlang.org/doc/reference_manual
# https://www.sublimetext.com/docs/syntax.html
name: Erlang (Legacy)
scope: source.erlang
version: 2

extends: Erlang.sublime-syntax

contexts:
  expr-control:
    - meta_prepend: true
    # https://www.erlang.org/doc/reference_manual/...?
    - match: query{{ident_break}}
      scope: keyword.control.flow.query.erlang
      push:
        - meta_scope: meta.query.erlang
        - include: expr-control-flow-end
        - include: expr-control-body
```