### PR TITLE
Kill $1.begin(), $1.end() snippet

### DIFF
--- a/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
+++ b/C++/Snippets/$1.begin()-$1.end()-(beginend).sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-	<description>$1.begin(), $1.end()</description>
-	<content><![CDATA[${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}begin(), ${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}end()]]></content>
-	<tabTrigger>beginend</tabTrigger>
-	<scope>(source.c++ | source.objc++) - meta.preprocessor.include - comment - string</scope>
-</snippet>


### PR DESCRIPTION
The correct spelling that actually works in the general case is `std::begin($1), std::end($1)`, but that was axed in #3713: kill this too