### PR TITLE
[Batch File] Fix escaped characters in quoted arguments

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -687,7 +687,7 @@ contexts:
       pop: 1
     - match: $
       pop: 2
-    - match: '%%|\^[\W&&\S]'
+    - match: '%%'
       scope: constant.character.escape.dosbatch
     - include: variable-interpolations
 
@@ -1653,7 +1653,7 @@ contexts:
     - include: quoted-eol-pop
 
   escaped-characters:
-    - match: '%%|\^\^!|\^.'
+    - match: '%%|\^.'
       scope: constant.character.escape.dosbatch
 
 ###[ INTERPOLATIONS ]#########################################################

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1815,6 +1815,7 @@ put arg1 arg2
 ::      ^^^^^^^^^^^^^^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch - punctuation
 ::       ^^ constant.character.escape.dosbatch
 ::         ^^^^^^^^^^^^^^^^ - constant.character
+
    ECHO cd = @( ^
    for %%^^^^ in ("") do @for /f "delims=" %%a in (^^""$*%%~^^"^") do @( ^
 :: ^^^^ - constant

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1780,7 +1780,8 @@ put arg1 arg2
    ECHO %% ^^! ^& ^| ^( ^)
 ::      ^^^^^^^^^^^^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch
 ::      ^^ constant.character.escape.dosbatch
-::         ^^^ constant.character.escape.dosbatch
+::         ^^ constant.character.escape.dosbatch
+::           ^ - constant.character
 ::             ^^ constant.character.escape.dosbatch
 ::                ^^ constant.character.escape.dosbatch
 ::                   ^^ constant.character.escape.dosbatch
@@ -1813,12 +1814,21 @@ put arg1 arg2
    ECHO "%% ^^! ^& ^| ^( ^)"
 ::      ^^^^^^^^^^^^^^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch - punctuation
 ::       ^^ constant.character.escape.dosbatch
-::          ^^ constant.character.escape.dosbatch
-::              ^^ constant.character.escape.dosbatch
-::                 ^^ constant.character.escape.dosbatch
-::                    ^^ constant.character.escape.dosbatch
-::                       ^^ constant.character.escape.dosbatch
-
+::         ^^^^^^^^^^^^^^^^ - constant.character
+   ECHO cd = @( ^
+   for %%^^^^ in ("") do @for /f "delims=" %%a in (^^""$*%%~^^"^") do @( ^
+:: ^^^^ - constant
+::     ^^^^^^ constant.character.escape.dosbatch
+::           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant
+::                                         ^^ constant.character.escape.dosbatch
+::                                           ^^^^^^ - constant
+::                                                 ^^ constant.character.escape.dosbatch
+::                                                   ^^^^ - constant
+::                                                       ^^ constant.character.escape.dosbatch
+::                                                         ^ - constant
+::                                                          ^^ constant.character.escape.dosbatch
+::                                                            ^^^^^^^^^^^^ - constant
+::                                                                       ^ punctuation.separator.continuation.line.dosbatch
 
 :::: [ ECHO variables ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This PR fixes following issues with escape sequences:

1. The `^` does not have special meaning within quoted arguments. 

2. The `^^` sequence in unquoted arguments denotes a literal `^`.
   
   `^^!` is not a escape sequence, but only the first 2 chars are.

Many thank's for reporting to: @mataha