### PR TITLE
[Python] Add support for type comments and annotations

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -939,9 +939,9 @@ contexts:
     - include: function-definition-end
 
   function-return-type:
-    - meta_content_scope: meta.function.annotation.return.python
+    - meta_content_scope: meta.function.annotation.return.python meta.type.python
     - include: function-definition-end
-    - include: expression-in-a-statement
+    - include: type-hint-expressions
 
   function-definition-end:
     - match: '{{colon}}'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -336,7 +336,9 @@ contexts:
   comments:
     - match: \#
       scope: punctuation.definition.comment.python
-      push: comment-body
+      push:
+        - comment-body
+        - type-hint
 
   comment-body:
     - meta_scope: comment.line.number-sign.python
@@ -359,6 +361,152 @@ contexts:
       scope: constant.language.shebang.python
     - match: \n
       pop: 1
+
+###[ TYPE HINTS ]#############################################################
+
+  type-hint:
+    # 1st type hint may be of any type
+    - match: (type)(:)
+      captures:
+        1: keyword.other.type.python
+        2: punctuation.separator.type.python
+      set: type-hint-any
+    - include: else-pop
+    - include: eol-pop
+
+  type-hint-any:
+    - meta_scope: meta.type.python
+    - include: type-hint-end
+    - match: ignore\b
+      scope: keyword.other.ignore.python
+      set:
+        - type-hint-type
+        - type-hint-error-list
+    - match: (?=\S)
+      set:
+        - type-hint-ignore
+        - type-hint-begin
+
+  type-hint-ignore:
+    # 2nd type hint may only be a `type: ignore`
+    # As it isn't a real start of a comment `#` is not scoped punctuation.
+    - match: \s*\#\s*((type)(:)\s*(ignore\b))
+      captures:
+        1: meta.type.python
+        2: keyword.other.type.python
+        3: punctuation.separator.type.python
+        4: keyword.other.ignore.python
+      set: type-hint-error-list
+    - include: immediately-pop
+
+  type-hint-type:
+    # 2nd type hint must not be a `type: ignore`
+    # As it isn't a real start of a comment `#` is not scoped punctuation.
+    - match: \s*\#\s*((type)(:)(?!\s*ignore\b))
+      captures:
+        1: meta.type.python
+        2: keyword.other.type.python
+        3: punctuation.separator.type.python
+      set: type-hint-begin
+    - include: immediately-pop
+
+  type-hint-error-list:
+    - meta_content_scope: meta.type.python
+    - match: \[
+      scope: punctuation.section.sequence.begin.python
+      set: type-hint-error-list-body
+    - include: type-hint-end
+
+  type-hint-error-list-body:
+    - meta_scope: meta.type.python meta.sequence.list.python
+    - match: \]
+      scope: punctuation.section.sequence.end.python
+      pop: 1
+    - include: type-hint-end
+    - include: sequence-separators
+    - match: \b[[:alpha:]_-][[:alnum:]_-]+\b
+      scope: constant.other.error-code.python
+
+  type-hint-begin:
+    - meta_content_scope: meta.type.python
+    - match: \(
+      scope: punctuation.section.parameters.begin.python
+      set: type-hint-function-parameter-list-body
+    - match: (?=\S)
+      set: type-hint-body
+
+  type-hint-function-parameter-list-body:
+    - meta_scope: meta.type.function.parameters.python
+    - match: \)
+      scope: punctuation.section.parameters.end.python
+      set: type-hint-function-return-type
+    - include: type-hint-body
+
+  type-hint-function-return-type:
+    - meta_content_scope: meta.type.function.python
+    - match: ->
+      scope: punctuation.separator.return-type.python
+      set: type-hint-function-return-type-body
+    - include: type-hint-end
+
+  type-hint-function-return-type-body:
+    - meta_scope: meta.type.function.return-type.python
+    - include: type-hint-body
+
+  type-hint-body:
+    - meta_scope: meta.type.python
+    - include: type-hint-end
+    - include: type-hint-expressions
+
+  type-hint-end:
+    - match: (?=\s*[\n#):;=\]}])
+      pop: 1
+
+  type-hint-expressions:
+    - include: type-hint-brackets
+    - include: type-hint-groups
+    - include: type-separators
+    - include: type-constants
+    - include: double-quoted-strings
+    - include: single-quoted-strings
+    - include: builtin-exceptions
+    - include: builtin-types
+    - include: illegal-function-calls
+    - include: illegal-name
+    - include: qualified-name
+
+  type-hint-brackets:
+    - match: \[
+      scope: punctuation.section.brackets.begin.python
+      push: type-hint-brackets-body
+
+  type-hint-brackets-body:
+    - meta_scope: meta.brackets.python
+    - match: \]
+      scope: punctuation.section.brackets.end.python
+      pop: 1
+    - include: type-hint-body
+
+  type-hint-groups:
+    - match: \(
+      scope: invalid.illegal.parens.begin.python
+      push: type-hint-groups-body
+
+  type-hint-groups-body:
+    - match: \)
+      scope: invalid.illegal.parens.end.python
+      pop: 1
+    - include: type-hint-body
+
+  type-constants:
+    - match: None\b
+      scope: constant.language.null.python
+    - include: constants
+
+  type-separators:
+    - match: \|
+      scope: punctuation.separator.type.union.python
+    - include: sequence-separators
 
 ###[ DECORATORS ]#############################################################
 
@@ -1503,6 +1651,16 @@ contexts:
     - match: (?=[,)]|:(?!=))
       pop: 1
     - include: expression-in-a-group
+
+  illegal-function-calls:
+    - match: (?:\.\s*)?{{path}}\s*\(
+      push: illegal-function-call-arguments
+
+  illegal-function-call-arguments:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.function.python
+    - match: \)
+      pop: 1
 
 ###[ LAMBDAS ]################################################################
 
@@ -3506,6 +3664,10 @@ contexts:
 
   else-pop:
     - match: (?=\S)
+      pop: 1
+
+  eol-pop:
+    - match: $
       pop: 1
 
   immediately-pop:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -3745,5 +3745,6 @@ contexts:
     - meta_include_prototype: false
     # This prevents strings after a continuation from being a docstring
     - include: strings
-    - match: (?=\S|^(?!\s*[[:alpha:]]*['"]))
+    - include: else-pop
+    - match: ^(?!\s*[[:alpha:]]*['"])
       pop: 1

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -418,7 +418,7 @@ contexts:
     - include: type-hint-end
 
   type-hint-error-list-body:
-    - meta_scope: meta.type.python meta.sequence.list.python
+    - meta_scope: meta.type.python meta.sequence.list.errors.python
     - match: \]
       scope: punctuation.section.sequence.end.python
       pop: 1
@@ -463,8 +463,8 @@ contexts:
       pop: 1
 
   type-hint-expressions:
-    - include: type-hint-brackets
     - include: type-hint-groups
+    - include: type-hint-lists
     - include: type-separators
     - include: type-constants
     - include: double-quoted-strings
@@ -475,18 +475,6 @@ contexts:
     - include: illegal-name
     - include: qualified-name
 
-  type-hint-brackets:
-    - match: \[
-      scope: punctuation.section.brackets.begin.python
-      push: type-hint-brackets-body
-
-  type-hint-brackets-body:
-    - meta_scope: meta.brackets.python
-    - match: \]
-      scope: punctuation.section.brackets.end.python
-      pop: 1
-    - include: type-hint-body
-
   type-hint-groups:
     - match: \(
       scope: invalid.illegal.parens.begin.python
@@ -495,6 +483,18 @@ contexts:
   type-hint-groups-body:
     - match: \)
       scope: invalid.illegal.parens.end.python
+      pop: 1
+    - include: type-hint-body
+
+  type-hint-lists:
+    - match: \[
+      scope: punctuation.section.sequence.begin.python
+      push: type-hint-list-body
+
+  type-hint-list-body:
+    - meta_scope: meta.sequence.list.members.python
+    - match: \]
+      scope: punctuation.section.sequence.end.python
       pop: 1
     - include: type-hint-body
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -878,16 +878,16 @@ contexts:
       scope: invalid.illegal.expected-comma.python
 
   function-parameter-annotation:
-    - meta_scope: meta.function.parameters.annotation.python
+    - meta_scope: meta.function.parameters.annotation.python meta.type.python
     - match: (?=[,)=])
       set: function-parameter-list-body
-    - match: None\b
-      scope: constant.language.null.python
-    - include: expression-in-a-group
+    - include: line-continuations
+    - include: illegal-assignment-expressions
+    - include: type-hint-expressions
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
-    - match: (?=[,)])
+    - match: (?=[,)=])
       set: function-parameter-list-body
     - include: expression-in-a-group
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -174,6 +174,32 @@ variables:
     # | buffer | file
     )\b
 
+  typing_types: |-
+    (?x:
+    # Super-special typing primitives.
+      Annotated | Any | Callable | ClassVar | Concatenate | Final | ForwardRef
+    | Generic | Literal | Optional | ParamSpec | Protocol | Tuple | Type
+    | TypeVar | TypeVarTuple | Union
+    # ABCs (from collections.abc).
+    | AbstractSet | ByteString | Container | ContextManager | Hashable | ItemsView
+    | Iterable | Iterator | KeysView | Mapping | MappingView | MutableMapping
+    | MutableSequence | MutableSet | Sequence | Sized | ValuesView | Awaitable
+    | AsyncIterator | AsyncIterable | Coroutine | Collection | AsyncGenerator
+    | AsyncContextManager
+    # Structural checks, a.k.a. protocols.
+    | Reversible | SupportsAbs | SupportsBytes | SupportsComplex | SupportsFloat
+    | SupportsIndex | SupportsInt | SupportsRound
+    # Concrete collection types.
+    | ChainMap | Counter | Deque | Dict | DefaultDict | List | OrderedDict
+    | Set | FrozenSet | NamedTuple | TypedDict | Generator
+    # Other concrete types.
+    | BinaryIO | IO | Match | Pattern | TextIO
+    # One-off things.
+    | AnyStr | LiteralString | Never | NewType | NoReturn | NotRequired
+    | ParamSpecArgs | ParamSpecKwargs | Required | Self | Text | TypeAlias
+    | TypeGuard | Unpack
+    )\b
+
   magic_functions: |-
     (?x: __(?:
     # unary operators
@@ -2150,6 +2176,8 @@ contexts:
   builtin-types:
     - match: '{{builtin_types}}'
       scope: support.type.python
+    - match: '{{typing_types}}'
+      scope: support.class.typing.python
 
   magic-functions:
     # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2151,7 +2151,7 @@ contexts:
 
   builtin-exceptions:
     - match: '{{builtin_exceptions}}'
-      scope: support.type.exception.python
+      scope: support.class.exception.python
 
   builtin-functions:
     - match: '{{builtin_functions}}'

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -968,12 +968,9 @@ contexts:
     - include: expression-in-a-statement
 
   variable-annotation:
-    - meta_scope: meta.variable.annotation.python
-    - match: (?=$|=|#|;)
-      pop: 1
-    - match: None\b
-      scope: constant.language.null.python
-    - include: expression-in-a-group
+    - meta_scope: meta.type.python
+    - include: line-continuations
+    - include: type-hint-body
 
 ###[ CASE STATEMENTS ]########################################################
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -913,6 +913,10 @@ contexts:
       branch:
         - function-parameter-annotation-continue
         - function-parameter-annotation-end
+    - include: function-parameter-annotation-content
+
+  function-parameter-annotation-content:
+    # Note: maybe type-hint expressions
     - include: type-constants
     - include: expression-in-a-group
 
@@ -997,6 +1001,10 @@ contexts:
         2: meta.function.python punctuation.section.function.begin.python
       pop: 1
     - include: line-continuation-or-pop
+    - include: function-return-type-content
+
+  function-return-type-content:
+    # Note: maybe type-hint expressions
     - include: illegal-assignment-expressions
     - include: type-constants
     - include: expression-in-a-statement
@@ -1035,9 +1043,12 @@ contexts:
     - meta_content_scope: meta.type.python
     - match: (?=\s*[\n#):;=\]}])
       pop: 1
-    - include: type-constants
-    - include: type-separators
     - include: line-continuations
+    - include: variable-annotation-content
+
+  variable-annotation-content:
+    # Note: maybe type-hint expressions
+    - include: type-constants
     - include: expression-in-a-statement
 
 ###[ CASE STATEMENTS ]########################################################

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -903,9 +903,29 @@ contexts:
     - meta_content_scope: meta.type.python
     - match: \s*(?=[,)=])
       set: function-parameter-list-body
+    # Scope newline `meta.type` only, if type continues on next line.
+    # Note: This is required to workaround ST's line blindness.
+    - match: (?=\s*\n)
+      branch_point: function-parameter-annotation-end
+      branch:
+        - function-parameter-annotation-continue
+        - function-parameter-annotation-end
     - include: type-constants
     - include: type-separators
     - include: expression-in-a-group
+
+  function-parameter-annotation-continue:
+    - meta_include_prototype: false
+    - match: \s*(?=[,)=])
+      fail: function-parameter-annotation-end
+    - include: comments
+    - include: else-pop
+
+  function-parameter-annotation-end:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2
+      push: function-parameter-list-body
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -878,8 +878,16 @@ contexts:
       scope: invalid.illegal.expected-comma.python
 
   function-parameter-annotation:
-    - meta_scope: meta.function.parameters.type.python meta.type.python
-    - match: (?=[,)=])
+    - meta_include_prototype: false
+    - meta_scope: meta.function.parameters.type.python
+    - include: line-continuations
+    - match: (?=\S)
+      set: function-parameter-annotation-body
+
+  function-parameter-annotation-body:
+    - meta_scope: meta.function.parameters.type.python
+    - meta_content_scope: meta.type.python
+    - match: \s*(?=[,)=])
       set: function-parameter-list-body
     - include: line-continuations
     - include: illegal-assignment-expressions
@@ -934,21 +942,34 @@ contexts:
   function-after-parameters:
     - meta_content_scope: meta.function.python
     - match: ->
-      scope: meta.function.return-type.python punctuation.separator.return-type.python
+      scope: punctuation.separator.return-type.python
       set: function-return-type
     - include: function-definition-end
 
   function-return-type:
+    - meta_include_prototype: false
+    - meta_scope: meta.function.return-type.python
+    - include: line-continuation-or-pop
+    - match: (?=\S)
+      set: function-return-type-body
+
+  function-return-type-body:
     - meta_content_scope: meta.function.return-type.python meta.type.python
-    - include: function-definition-end
+    - match: (\s*)({{colon}})
+      captures:
+        1: meta.function.return-type.python
+        2: meta.function.python punctuation.section.function.begin.python
+      pop: 1
+    - include: line-continuation-or-pop
+    - include: illegal-assignment-expressions
     - include: type-hint-expressions
 
   function-definition-end:
     - match: '{{colon}}'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: 1
-    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
+    - include: illegal-assignment-expressions
 
 ###[ ASSIGNMENT STATEMENTS ]##################################################
 
@@ -968,7 +989,13 @@ contexts:
     - include: expression-in-a-statement
 
   variable-annotation:
-    - meta_scope: meta.type.python
+    - meta_include_prototype: false
+    - include: line-continuation-or-pop
+    - match: (?=\S)
+      set: variable-annotation-body
+
+  variable-annotation-body:
+    - meta_content_scope: meta.type.python
     - include: line-continuations
     - include: type-hint-body
 
@@ -3686,5 +3713,5 @@ contexts:
     - meta_include_prototype: false
     # This prevents strings after a continuation from being a docstring
     - include: strings
-    - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
+    - match: (?=\S|^(?!\s*[[:alpha:]]*['"]))
       pop: 1

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -514,12 +514,15 @@ contexts:
     - include: type-hint-body
 
   type-constants:
+    # Note: Enables `None = None` in type hints.
     - match: None\b
       scope: constant.language.null.python
 
   type-separators:
+    # Note: Scoped as normal arithmetic operator for consistency reasons with
+    #       type-hints in annotations, which share syntax with normal expressions
     - match: \|
-      scope: keyword.operator.logical.union.python
+      scope: keyword.operator.arithmetic.python
     - include: sequence-separators
 
 ###[ DECORATORS ]#############################################################
@@ -911,7 +914,6 @@ contexts:
         - function-parameter-annotation-continue
         - function-parameter-annotation-end
     - include: type-constants
-    - include: type-separators
     - include: expression-in-a-group
 
   function-parameter-annotation-continue:
@@ -997,7 +999,6 @@ contexts:
     - include: line-continuation-or-pop
     - include: illegal-assignment-expressions
     - include: type-constants
-    - include: type-separators
     - include: expression-in-a-statement
 
   function-definition-end:

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -519,7 +519,7 @@ contexts:
 
   type-separators:
     - match: \|
-      scope: punctuation.separator.type.union.python
+      scope: keyword.operator.logical.union.python
     - include: sequence-separators
 
 ###[ DECORATORS ]#############################################################

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -833,7 +833,7 @@ contexts:
       scope: keyword.operator.assignment.python
       set: function-parameter-default-value
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.parameter.python
+      scope: punctuation.separator.type.python
       set: function-parameter-annotation
     - include: comments
     - include: function-parameter-tuples
@@ -878,7 +878,7 @@ contexts:
       scope: invalid.illegal.expected-comma.python
 
   function-parameter-annotation:
-    - meta_scope: meta.function.parameters.annotation.python meta.type.python
+    - meta_scope: meta.function.parameters.type.python meta.type.python
     - match: (?=[,)=])
       set: function-parameter-list-body
     - include: line-continuations
@@ -934,12 +934,12 @@ contexts:
   function-after-parameters:
     - meta_content_scope: meta.function.python
     - match: ->
-      scope: meta.function.annotation.return.python punctuation.separator.annotation.return.python
+      scope: meta.function.return-type.python punctuation.separator.return-type.python
       set: function-return-type
     - include: function-definition-end
 
   function-return-type:
-    - meta_content_scope: meta.function.annotation.return.python meta.type.python
+    - meta_content_scope: meta.function.return-type.python meta.type.python
     - include: function-definition-end
     - include: type-hint-expressions
 
@@ -954,7 +954,7 @@ contexts:
 
   assignment-statements:
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.variable.python
+      scope: punctuation.separator.type.python
       push: variable-annotation
     - match: '{{augmented_assignment_operators}}'
       scope: keyword.operator.assignment.augmented.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2159,7 +2159,7 @@ contexts:
 
   builtin-types:
     - match: '{{builtin_types}}'
-      scope: support.type.python
+      scope: storage.type.python
     - match: '{{typing_types}}'
       scope: support.class.typing.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2179,7 +2179,7 @@ contexts:
 
   builtin-types:
     - match: '{{builtin_types}}'
-      scope: storage.type.python
+      scope: support.type.python
     - match: '{{typing_types}}'
       scope: support.class.typing.python
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -485,49 +485,37 @@ contexts:
     - include: type-hint-expressions
 
   type-hint-end:
-    - match: (?=\s*[\n#):;=\]}])
+    - match: (?=\s*[\n#])
       pop: 1
 
   type-hint-expressions:
-    - include: type-hint-groups
     - include: type-hint-lists
     - include: type-separators
     - include: type-constants
+    - include: constants
     - include: double-quoted-strings
     - include: single-quoted-strings
     - include: builtin-exceptions
     - include: builtin-types
-    - include: illegal-function-calls
-    - include: illegal-name
     - include: qualified-name
-
-  type-hint-groups:
-    - match: \(
-      scope: invalid.illegal.parens.begin.python
-      push: type-hint-groups-body
-
-  type-hint-groups-body:
-    - match: \)
-      scope: invalid.illegal.parens.end.python
-      pop: 1
-    - include: type-hint-body
 
   type-hint-lists:
     - match: \[
-      scope: punctuation.section.sequence.begin.python
+      scope: punctuation.section.brackets.begin.python
       push: type-hint-list-body
 
   type-hint-list-body:
-    - meta_scope: meta.sequence.list.members.python
+    # As annotations contain normal expressions use a generic `meta.brackets`
+    # for sake of consistent scoping/highlighting.
+    - meta_scope: meta.brackets.python
     - match: \]
-      scope: punctuation.section.sequence.end.python
+      scope: punctuation.section.brackets.end.python
       pop: 1
     - include: type-hint-body
 
   type-constants:
     - match: None\b
       scope: constant.language.null.python
-    - include: constants
 
   type-separators:
     - match: \|
@@ -859,7 +847,7 @@ contexts:
       scope: keyword.operator.assignment.python
       set: function-parameter-default-value
     - match: '{{colon}}'
-      scope: punctuation.separator.type.python
+      scope: punctuation.separator.annotation.python
       set: function-parameter-annotation
     - include: comments
     - include: function-parameter-tuples
@@ -905,19 +893,19 @@ contexts:
 
   function-parameter-annotation:
     - meta_include_prototype: false
-    - meta_scope: meta.function.parameters.type.python
+    - meta_scope: meta.function.parameters.annotation.python
     - include: line-continuations
     - match: (?=\S)
       set: function-parameter-annotation-body
 
   function-parameter-annotation-body:
-    - meta_scope: meta.function.parameters.type.python
+    - meta_scope: meta.function.parameters.annotation.python
     - meta_content_scope: meta.type.python
     - match: \s*(?=[,)=])
       set: function-parameter-list-body
-    - include: line-continuations
-    - include: illegal-assignment-expressions
-    - include: type-hint-expressions
+    - include: type-constants
+    - include: type-separators
+    - include: expression-in-a-group
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
@@ -988,7 +976,9 @@ contexts:
       pop: 1
     - include: line-continuation-or-pop
     - include: illegal-assignment-expressions
-    - include: type-hint-expressions
+    - include: type-constants
+    - include: type-separators
+    - include: expression-in-a-statement
 
   function-definition-end:
     - match: '{{colon}}'
@@ -1001,7 +991,7 @@ contexts:
 
   assignment-statements:
     - match: '{{colon}}'
-      scope: punctuation.separator.type.python
+      scope: punctuation.separator.annotation.python
       push: variable-annotation
     - match: '{{augmented_assignment_operators}}'
       scope: keyword.operator.assignment.augmented.python
@@ -1022,8 +1012,12 @@ contexts:
 
   variable-annotation-body:
     - meta_content_scope: meta.type.python
+    - match: (?=\s*[\n#):;=\]}])
+      pop: 1
+    - include: type-constants
+    - include: type-separators
     - include: line-continuations
-    - include: type-hint-body
+    - include: expression-in-a-statement
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -1702,16 +1696,6 @@ contexts:
       pop: 1
     - include: expression-in-a-group
 
-  illegal-function-calls:
-    - match: (?:\.\s*)?{{path}}\s*\(
-      push: illegal-function-call-arguments
-
-  illegal-function-call-arguments:
-    - meta_include_prototype: false
-    - meta_scope: invalid.illegal.function.python
-    - match: \)
-      pop: 1
-
 ###[ LAMBDAS ]################################################################
 
   lambda-in-groups:
@@ -2032,7 +2016,7 @@ contexts:
       set: maybe-item-access-body
 
   maybe-item-access-body:
-    - meta_scope: meta.item-access.python
+    - meta_scope: meta.brackets.python
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
@@ -3728,7 +3712,7 @@ contexts:
 
   line-continuation-or-pop:
     - include: line-continuations
-    - match: (?=\s*(?:\n|;|#))
+    - match: (?=\s*[\n;#])
       pop: 1
 
   line-continuations:

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -390,7 +390,7 @@ __bool__ abc.__nonzero__
 #            ^^^^^^^^^^^ support.function.magic
 
 TypeError module.TypeError
-#^^^^^^^^ support.type.exception
+#^^^^^^^^ support.class.exception
 #                ^^^^^^^^^ - support
 
 open.open.open.
@@ -489,7 +489,7 @@ anext()
 
 
 TypeError()
-#^^^^^^^^ support.type.exception
+#^^^^^^^^ support.class.exception
 #
 module.TypeError()
 # <- - meta.function-call
@@ -1069,7 +1069,7 @@ def _():
     except Exception as x:
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch.python - meta.statement.exception.catch.python meta.statement.exception.catch.python
 #   ^^^^^^ keyword.control.exception.catch.python
-#          ^^^^^^^^^ support.type.exception.python
+#          ^^^^^^^^^ support.class.exception.python
 #                    ^^ keyword.control.exception.catch.as.python
 #                       ^ meta.generic-name.python
 #                        ^ punctuation.section.block.exception.catch.python
@@ -2602,14 +2602,14 @@ class Cls:
 except Exception:
 #^^^^^^^^^^^^^^^^ meta.statement.exception.catch
 #^^^^^ keyword.control.exception.catch
-#      ^^^^^^^^^ support.type.exception
+#      ^^^^^^^^^ support.class.exception
 #               ^ punctuation.section.block
 except (KeyError, NameError) as e:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch
 #^^^^^ keyword.control.exception.catch
-#       ^^^^^^^^ support.type.exception
+#       ^^^^^^^^ support.class.exception
 #               ^ punctuation.separator.sequence
-#                 ^^^^^^^^^ support.type.exception
+#                 ^^^^^^^^^ support.class.exception
 #                            ^^ keyword.control.exception.catch.as
 #                                ^ punctuation.section.block
 except \
@@ -2634,7 +2634,7 @@ raise Ellipsis
 raise KeyError() from z
 #^^^^^^^^^^^^^^^^^^^^^^ meta.statement.raise - meta.statement.raise meta.statement.raise
 #^^^^ keyword.control.flow.raise
-#     ^^^^^^^^ support.type.exception
+#     ^^^^^^^^ support.class.exception
 #                ^^^^ keyword.control.flow.raise.from
 
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1571,7 +1571,7 @@ def _():
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
 #       ^ punctuation.separator.annotation.variable.python
-#         ^^^ meta.path.python support.type.python
+#         ^^^ support.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1580,7 +1580,7 @@ def _():
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.variable.python
-#     ^^^ meta.path.python support.type.python
+#     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1603,7 +1603,7 @@ def _():
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.annotation.variable.python
-#          ^^^ meta.path.python support.type.python
+#          ^^^ support.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1612,7 +1612,7 @@ def _():
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.variable.python
-#     ^^^ meta.path.python support.type.python
+#     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -2923,65 +2923,78 @@ foo.bar(baz., True)
 
 primes: List[int] = []
 #     ^ punctuation.separator.annotation.variable.python
-#     ^^^^^^^^^^^^ meta.variable.annotation.python
+#     ^^^^^^^^^^^ meta.type.python
+#                ^^^^^^ - meta.type
 #       ^^^^ meta.path.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.variable.python
-#      ^^^^^^^ meta.variable.annotation.python
+#      ^^^^^ meta.type.python
+#           ^^ - meta.type - comment
 #             ^^^^^^^ comment
-#        ^^^ meta.path.python
+#        ^^^ support.type.python
 
 foo: str | None = None
-#  ^^^^^^^^^^^^^ meta.variable.annotation.python
-#               ^^^^^^^ - meta.variable
+#  ^^^^^^^^^^^^ meta.type.python
+#              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.variable.python
 #    ^^^ support.type.python
-#        ^ keyword.operator.arithmetic.python
+#        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^^ constant.language.null.python
 
 bar: str | None = 'b'
-#  ^^^^^^^^^^^^^ meta.variable.annotation.python
-#               ^^^^^^ - meta.variable
+#  ^^^^^^^^^^^^ meta.type.python
+#              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.variable.python
 #    ^^^ support.type.python
-#        ^ keyword.operator.arithmetic.python
+#        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^ string.quoted.single.python
 
 foo: \
-#  ^^^ meta.variable.annotation.python
+#  ^^^ meta.type.python
 foo: \
     bar = zoo
-# <- meta.variable.annotation.python
-#^^^^^^^ meta.variable.annotation.python
+# <- meta.type.python
+#^^^^^^ meta.type.python
+#      ^^^^^^^ - meta.type
 #       ^ keyword.operator.assignment
 
 zoo: \
-#  ^^^ meta.variable.annotation.python
+#  ^^^ meta.type.python
 zoo: \
     loo \
-# <- meta.variable.annotation.python
-#^^^^^^^^^ meta.variable.annotation.python
+# <- meta.type.python
+#^^^^^^^^^ meta.type.python
 zoo: \
     loo \
     = too
-# <- meta.variable.annotation.python
-#^^^ meta.variable.annotation.python
+# <- meta.type.python
+#^^^ meta.type.python
 #   ^ keyword.operator.assignment
 
 foo: int; print("foo")
 #       ^ punctuation.terminator.statement.python
-#       ^^^^^^^^^^^^^^ - meta.variable.annotation.python
+#       ^^^^^^^^^^^^^^ - meta.type.python
+
+foo: (int, float) # illegal parens
+#   ^^^^^^^^^^^^^ meta.type.python - meta.group
+#    ^ invalid.illegal.parens.begin.python
+#     ^^^ support.type.python
+#        ^ punctuation.separator.sequence.python
+#          ^^^^^ support.type.python
+#               ^ invalid.illegal.parens.end.python
+#                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
 
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.annotation.variable.python
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.variable.annotation.python
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python
+#                                  ^^^^^^ - meta.type
 #                                   ^ keyword.operator.assignment
 
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2965,10 +2965,10 @@ primes: List[int] = []
 #     ^ punctuation.separator.type.python
 #     ^^ - meta.type
 #       ^^^^ meta.type.python meta.generic-name.python
-#           ^^^^^ meta.type.python meta.brackets.python
-#           ^ punctuation.section.brackets.begin.python
+#           ^^^^^ meta.type.python meta.sequence.list.members.python
+#           ^ punctuation.section.sequence.begin.python
 #            ^^^ support.type.python
-#               ^ punctuation.section.brackets.end.python
+#               ^ punctuation.section.sequence.end.python
 #                ^^^^^^ - meta.type
 #                 ^ keyword.operator.assignment
 
@@ -3098,7 +3098,7 @@ value = 3  # type: ignore[error-code-1, 4noint][error] # foo
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #          ^^ comment.line.number-sign.python - meta.type
 #            ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                        ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.python
+#                        ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.errors.python
 #                                              ^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
 #                  ^^^^^^ keyword.other.ignore.python
 #                        ^ punctuation.section.sequence.begin.python
@@ -3106,7 +3106,7 @@ value = 3  # type: ignore[error-code-1, 4noint][error] # foo
 #                                     ^ punctuation.separator.sequence.python
 #                                       ^^^^^^ - constant
 #                                             ^ punctuation.section.sequence.end.python
-#                                              ^^^^^^^ - meta.sequence - meta.brackets - meta.item-access
+#                                              ^^^^^^^ - meta.sequence - meta.sequence - meta.item-access
 
 primes = 5  # type: ignore  # type: str  # technically ok but weird
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
@@ -3139,9 +3139,9 @@ primes = 5  # type: str  # type: str  # invalid
 dct = {}  # type: Dict[str, (int, float)] # illegal parens
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
-#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
-#                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
-#                     ^ punctuation.section.brackets.begin.python
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
+#                     ^ punctuation.section.sequence.begin.python
 #                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^ invalid.illegal.parens.begin.python
@@ -3149,40 +3149,40 @@ dct = {}  # type: Dict[str, (int, float)] # illegal parens
 #                               ^ punctuation.separator.sequence.python
 #                                 ^^^^^ support.type.python
 #                                      ^ invalid.illegal.parens.end.python
-#                                       ^ punctuation.section.brackets.end.python
+#                                       ^ punctuation.section.sequence.end.python
 
 dct = {}  # type: Dict[str, str | int]
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
-#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
-#                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
-#                     ^ punctuation.section.brackets.begin.python
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
+#                     ^ punctuation.section.sequence.begin.python
 #                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^^^ support.type.python
 #                               ^ punctuation.separator.type.union.python
 #                                 ^^^ support.type.python
-#                                    ^ punctuation.section.brackets.end.python
+#                                    ^ punctuation.section.sequence.end.python
 
 lst = []  # type: List[Dict[Any, ...]] # comment
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
-#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
-#                     ^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.brackets meta.brackets
-#                          ^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python meta.brackets.python
-#                                    ^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.brackets meta.brackets
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                     ^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python - meta.sequence meta.sequence
+#                          ^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python meta.sequence.list.members.python
+#                                    ^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python - meta.sequence meta.sequence
 #                                     ^^^^^^^^^^^ comment.line.number-sign.python - meta.type
 #         ^ punctuation.definition.comment.python
 #           ^^^^ keyword.other.type.python
 #               ^ punctuation.separator.type.python
 #                 ^^^^ meta.generic-name.python
-#                     ^ punctuation.section.brackets.begin
+#                     ^ punctuation.section.sequence.begin
 #                      ^^^^ meta.generic-name.python
-#                          ^ punctuation.section.brackets.begin.python
+#                          ^ punctuation.section.sequence.begin.python
 #                           ^^^ meta.generic-name.python
 #                              ^ punctuation.separator.sequence.python
 #                                ^^^ constant.language.python
-#                                   ^^ punctuation.section.brackets.end.python
+#                                   ^^ punctuation.section.sequence.end.python
 
 # incomplete list
 lst = []  # type: List[ # type: ignore
@@ -3242,21 +3242,21 @@ def function(a, b, *c, **d):
 #                 ^^^ support.type.python
 #                    ^ punctuation.separator.sequence.python
 #                      ^^^^ meta.path.python meta.generic-name.python
-#                          ^^^^^ meta.brackets.python
-#                          ^ punctuation.section.brackets.begin.python
+#                          ^^^^^ meta.sequence.list.members.python
+#                          ^ punctuation.section.sequence.begin.python
 #                           ^^^ support.type.python
-#                              ^ punctuation.section.brackets.end.python
+#                              ^ punctuation.section.sequence.end.python
 #                               ^ punctuation.separator.sequence.python
 #                                 ^^^^ support.type.python
 #                                     ^ punctuation.section.parameters.end.python
 #                                       ^^ punctuation.separator.return-type.python
 #                                          ^^^^ meta.path.python meta.generic-name.python
-#                                              ^^^^^^^^^^ meta.brackets.python
-#                                              ^ punctuation.section.brackets.begin.python
+#                                              ^^^^^^^^^^ meta.sequence.list.members.python
+#                                              ^ punctuation.section.sequence.begin.python
 #                                               ^^^ support.type.python
 #                                                  ^ punctuation.separator.sequence.python
 #                                                    ^^^ support.type.python
-#                                                       ^ punctuation.section.brackets.end.python
+#                                                       ^ punctuation.section.sequence.end.python
 
 class TypeCommentTest:
     member = []  # type: List[dict]

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1570,7 +1570,7 @@ def _():
 
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
-#       ^ punctuation.separator.annotation.variable.python
+#       ^ punctuation.separator.type.python
 #         ^^^ support.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1579,7 +1579,7 @@ def _():
 #   ^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
-#   ^ punctuation.separator.annotation.variable.python
+#   ^ punctuation.separator.type.python
 #     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1602,7 +1602,7 @@ def _():
 
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
-#        ^ punctuation.separator.annotation.variable.python
+#        ^ punctuation.separator.type.python
 #          ^^^ support.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1611,7 +1611,7 @@ def _():
 #   ^^^^^ meta.generic-name.python - keyword
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
-#   ^ punctuation.separator.annotation.variable.python
+#   ^ punctuation.separator.type.python
 #     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1705,29 +1705,29 @@ def func(from='me'):
 def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int :
 #^^^^^^^^^^^^^^^^^^^ meta.function.python - meta.function meta.function
 #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters - meta.function meta.function
-#                                                                                                  ^^^^^^^ meta.function.annotation.return.python - meta.function meta.function
+#                                                                                                  ^^^^^^^ meta.function.return-type.python - meta.function meta.function
 #                                                                                                         ^ meta.function.python - meta.function meta.function
 #                   ^ - meta.function meta.function.parameters
 #                    ^^^^^^ variable.parameter
-#                          ^^^^^ meta.function.parameters.annotation
-#                          ^ punctuation.separator.annotation
+#                          ^^^^^ meta.function.parameters.type
+#                          ^ punctuation.separator.type
 #                            ^^^ support.type
 #                               ^ punctuation.separator.parameters
 #                                 ^^^^^^ variable.parameter
-#                                       ^ punctuation.separator.annotation
+#                                       ^ punctuation.separator.type
 #                                               ^ punctuation.separator.parameters
 #                                                 ^^^^^^ variable.parameter
-#                                                       ^ punctuation.separator.annotation
+#                                                       ^ punctuation.separator.type
 #                                                         ^^^^^^^^^ invalid.illegal.function.python
 #                                                                  ^ punctuation.separator.parameters
 #                                                                    ^^^^^^ variable.parameter
-#                                                                          ^ punctuation.separator.annotation
+#                                                                          ^ punctuation.separator.type
 #                                                                            ^^^^^^^^ string.quoted.double
 #                                                                                     ^^^^^^^^^^^ meta.function.parameters.default-value
 #                                                                                     ^ keyword.operator.assignment
 #                                                                                       ^^^^^^^^^ string.quoted.double
 #                                                                                                ^ punctuation.section.parameters.end
-#                                                                                                  ^^ punctuation.separator.annotation
+#                                                                                                  ^^ punctuation.separator.return-type.python
 #                                                                                                     ^^^ support.type
 #                                                                                                         ^ punctuation.section.function.begin
 
@@ -1736,8 +1736,8 @@ def type_annotations_line_continuation_without_terminator() \
 #^^^^^^^^^^^ - meta.function meta.function
 #           ^ - meta.function
 #^^^^^ meta.function.python
-#     ^^^^^^ meta.function.annotation.return
-#     ^^ punctuation.separator.annotation
+#     ^^^^^^ meta.function.return-type
+#     ^^ punctuation.separator.return-type.python
 #        ^^^ support.type
     pass
 
@@ -1746,8 +1746,8 @@ def type_annotations_line_continuation_without_terminator_but_comment() \
 #^^^^^^^^^^^ - meta.function meta.function
 #           ^^^^^^^^^^ - meta.function
 #^^^^^ meta.function.python
-#     ^^^^^^ meta.function.annotation.return
-#     ^^ punctuation.separator.annotation
+#     ^^^^^^ meta.function.return-type
+#     ^^ punctuation.separator.return-type.python
 #        ^^^ support.type
     pass
 
@@ -1755,9 +1755,9 @@ def type_annotations_line_continuation() \
       -> int:
 #^^^^^^^^^^^^ - meta.function meta.function
 #^^^^^ meta.function.python
-#     ^^^^^^ meta.function.annotation.return
+#     ^^^^^^ meta.function.return-type
 #           ^ meta.function.python
-#     ^^ punctuation.separator.annotation
+#     ^^ punctuation.separator.return-type.python
 #        ^^^ support.type
 #           ^ punctuation.section.function.begin
     pass
@@ -1765,7 +1765,7 @@ def type_annotations_line_continuation() \
 def type_annotations_line_continuation() \
       -> \
       int:
-#^^^^^^^^ meta.function.annotation.return
+#^^^^^^^^ meta.function.return-type
 #        ^ meta.function.python
 #     ^^^ support.type
 #        ^ punctuation.section.function.begin
@@ -1775,13 +1775,13 @@ def type_annotations_line_continuation() \
       -> \
       int \
       :
-#^^^^^ meta.function.annotation.return
+#^^^^^ meta.function.return-type
 #     ^ meta.function.python punctuation.section.function.begin.python
     pass
 
 def type_annotation_with_defaults(foo: str | None = None)
-#                                    ^^^^^^^^^^^^^ meta.function.parameters.annotation.python - meta.function.parameters.default-value
-#                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
+#                                    ^^^^^^^^^^^^^ meta.function.parameters.type.python - meta.function.parameters.default-value
+#                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.type
 #                                      ^^^ support.type.python
 #                                          ^ punctuation.separator.type.union.python
 #                                            ^^^^ constant.language.null.python
@@ -1917,7 +1917,7 @@ def func(
     baz: str,
 #  ^^^^^^^^^^^ meta.function.parameters
 #   ^^^ variable.parameter.python
-#      ^ punctuation.separator.annotation.parameter.python
+#      ^ punctuation.separator.type
 #        ^^^ support.type.python
 #           ^ punctuation.separator.parameters.python
 ): pass
@@ -2876,7 +2876,7 @@ foo ^= bar ^= baz
 
 # Pop contexts gracefully
 def func(unclosed, parameters: if else
-#                            ^^^^ meta.function.parameters.annotation.python
+#                            ^^^^ meta.function.parameters.type.python
 #                                ^^^^^^ - meta.function
 #                              ^^ invalid.illegal.name.python
 #                                 ^^^^ keyword.control.conditional.else.python
@@ -2927,14 +2927,14 @@ foo.bar(baz., True)
 ##################
 
 primes: List[int] = []
-#     ^ punctuation.separator.annotation.variable.python
+#     ^ punctuation.separator.type.python
 #     ^^^^^^^^^^^ meta.type.python
 #                ^^^^^^ - meta.type
 #       ^^^^ meta.path.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
-#      ^ punctuation.separator.annotation.variable.python
+#      ^ punctuation.separator.type.python
 #      ^^^^^ meta.type.python
 #           ^^ - meta.type - comment
 #             ^^^^^^^ comment
@@ -2943,7 +2943,7 @@ captain: str  # Note: no initial value!
 foo: str | None = None
 #  ^^^^^^^^^^^^ meta.type.python
 #              ^^^^^^^^ - meta.type
-#  ^ punctuation.separator.annotation.variable.python
+#  ^ punctuation.separator.type.python
 #    ^^^ support.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
@@ -2953,7 +2953,7 @@ foo: str | None = None
 bar: str | None = 'b'
 #  ^^^^^^^^^^^^ meta.type.python
 #              ^^^^^^^ - meta.type
-#  ^ punctuation.separator.annotation.variable.python
+#  ^ punctuation.separator.type.python
 #    ^^^ support.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
@@ -2997,7 +2997,7 @@ foo: (int, float) # illegal parens
 
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
-#        ^ punctuation.separator.annotation.variable.python
+#        ^ punctuation.separator.type.python
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python
 #                                  ^^^^^^ - meta.type
 #                                   ^ keyword.operator.assignment

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1720,7 +1720,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                                       ^ punctuation.separator.annotation
 #                                         ^^^^^^^^^^^^^ meta.type.python
 #                                         ^^^^^^ meta.path.python meta.generic-name.python
-#                                                ^ punctuation.separator.type.union.python
+#                                                ^ keyword.operator.logical.union.python
 #                                                  ^^^^ constant.language.null.python
 #                                                       ^ punctuation.separator.parameters
 #                                                         ^^^^^^ variable.parameter
@@ -1821,7 +1821,7 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                                ^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
 #                                      ^^^ storage.type.python
-#                                          ^ punctuation.separator.type.union.python
+#                                          ^ keyword.operator.logical.union.python
 #                                            ^^^^ constant.language.null.python
 #                                                 ^ keyword.operator.assignment.python
 #                                                   ^^^^ constant.language.null.python
@@ -2991,7 +2991,7 @@ foo: str | None = None
 #              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
 #    ^^^ storage.type.python
-#        ^ punctuation.separator.type.union.python
+#        ^ keyword.operator.logical.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^^ constant.language.null.python
@@ -3002,7 +3002,7 @@ bar: str | None = 'b'
 #              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
 #    ^^^ storage.type.python
-#        ^ punctuation.separator.type.union.python
+#        ^ keyword.operator.logical.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^ string.quoted.single.python
@@ -3172,7 +3172,7 @@ dct = {}  # type: Dict[str, str | int]
 #                      ^^^ storage.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^^^ storage.type.python
-#                               ^ punctuation.separator.type.union.python
+#                               ^ keyword.operator.logical.union.python
 #                                 ^^^ storage.type.python
 #                                    ^ punctuation.section.brackets.end.python
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1826,6 +1826,15 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                                 ^ keyword.operator.assignment.python
 #                                                   ^^^^ constant.language.null.python
 
+def last_type_annotation(
+    foo: str | None
+#   ^^^ meta.function.parameters.python
+#      ^^ meta.function.parameters.annotation.python - meta.type
+#        ^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python
+#                  ^ meta.function.parameters.python - meta.type
+): pass
+# <- meta.function.parameters.python punctuation.section.parameters.end.python
+
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                  ^^^^^^^^ meta.function.parameters - meta.function meta.function

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -345,15 +345,15 @@ from unicode.__init__ . 123 import unicode as unicode
 #           ^ punctuation.accessor.dot.python
 #            ^^^^^^^^ meta.import-name.python - support
 #                     ^^^^^ invalid.illegal.name.python
-#                                  ^^^^^^^ storage.type.python
-#                                             ^^^^^^^ storage.type.python
+#                                  ^^^^^^^ support.type.python
+#                                             ^^^^^^^ support.type.python
 
 import .str
 #      ^ invalid.illegal.unexpected-relative-import.python
-#       ^^^ storage.type.python
+#       ^^^ support.type.python
 
 import str
-#      ^^^ storage.type.python
+#      ^^^ support.type.python
 
 from importlib import import_module
 # <- meta.statement.import.python keyword.control.import.from.python
@@ -1406,7 +1406,7 @@ def _():
 #           ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #             ^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^ storage.type.python
+#        ^^^ support.type.python
 #           ^ punctuation.section.arguments.begin.python
 #            ^ punctuation.section.arguments.end.python
 #             ^ punctuation.section.block.conditional.case.python
@@ -1510,7 +1510,7 @@ def _():
 #                                                                                 ^ meta.statement.conditional.case.python
 #                                                                                  ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^ storage.type.python
+#        ^^^ support.type.python
 #           ^ punctuation.section.arguments.begin.python
 #            ^ punctuation.section.arguments.end.python
 #             ^ punctuation.separator.sequence.python
@@ -1571,7 +1571,7 @@ def _():
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
 #       ^ punctuation.separator.annotation.python
-#         ^^^ storage.type.python
+#         ^^^ support.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1580,7 +1580,7 @@ def _():
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.python
-#     ^^^ storage.type.python
+#     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1603,7 +1603,7 @@ def _():
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.annotation.python
-#          ^^^ storage.type.python
+#          ^^^ support.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1612,7 +1612,7 @@ def _():
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.python
-#     ^^^ storage.type.python
+#     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1714,7 +1714,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                    ^^^^^^ variable.parameter
 #                          ^^^^^ meta.function.parameters.annotation
 #                          ^ punctuation.separator.annotation
-#                            ^^^ meta.type.python storage.type.python
+#                            ^^^ meta.type.python support.type.python
 #                               ^ punctuation.separator.parameters
 #                                 ^^^^^^ variable.parameter
 #                                       ^ punctuation.separator.annotation
@@ -1738,7 +1738,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                                                                                               ^^^^^^^^^ string.quoted.double
 #                                                                                                        ^ punctuation.section.parameters.end
 #                                                                                                          ^^ punctuation.separator.return-type.python
-#                                                                                                             ^^^ storage.type
+#                                                                                                             ^^^ support.type
 #                                                                                                                 ^ punctuation.section.function.begin
 
 def type_annotations_arrow_only() ->
@@ -1761,7 +1761,7 @@ def type_annotations_without_terminator_followd_by_comment() -> int # comment
 #                                                               ^^^ meta.function.return-type.python meta.type.python
 #                                                                  ^^^^^^^^^^^ - meta.function - meta.type
 #                                                            ^^ punctuation.separator.return-type.python
-#                                                               ^^^ storage.type.python
+#                                                               ^^^ support.type.python
     pass
 # <- - meta.function - meta.type
 #   ^^^^ keyword.control.flow.pass.python
@@ -1773,7 +1773,7 @@ def type_annotations_line_continuation_without_terminator() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type storage.type
+#        ^^^ meta.type support.type
     pass
 
 def type_annotations_line_continuation_without_terminator_but_comment() \
@@ -1783,7 +1783,7 @@ def type_annotations_line_continuation_without_terminator_but_comment() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type storage.type
+#        ^^^ meta.type support.type
     pass
 
 def type_annotations_line_continuation() \
@@ -1793,7 +1793,7 @@ def type_annotations_line_continuation() \
 #     ^^^^^^ meta.function.return-type
 #           ^ meta.function.python
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type storage.type
+#        ^^^ meta.type support.type
 #           ^ punctuation.section.function.begin
     pass
 
@@ -1802,7 +1802,7 @@ def type_annotations_line_continuation() \
       int:
 # <- meta.function.return-type.python - meta.type
 #^^^^^ meta.function.return-type.python - meta.type
-#     ^^^ meta.function.return-type.python meta.type.python storage.type.python
+#     ^^^ meta.function.return-type.python meta.type.python support.type.python
 #        ^ meta.function.python punctuation.section.function.begin.python
     pass
 
@@ -1820,7 +1820,7 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                      ^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python - meta.function.parameters.default-value
 #                                                ^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
-#                                      ^^^ storage.type.python
+#                                      ^^^ support.type.python
 #                                          ^ keyword.operator.logical.union.python
 #                                            ^^^^ constant.language.null.python
 #                                                 ^ keyword.operator.assignment.python
@@ -1965,7 +1965,7 @@ def func(
 #  ^^^^^^^^^^^ meta.function.parameters
 #   ^^^ variable.parameter.python
 #      ^ punctuation.separator.annotation
-#        ^^^ storage.type.python
+#        ^^^ support.type.python
 #           ^ punctuation.separator.parameters.python
 ): pass
 
@@ -2232,7 +2232,7 @@ mytuple = ("this", 'is', 4, tuple)
 #                      ^ punctuation.separator.sequence
 #                        ^ constant.numeric
 #                         ^ punctuation.separator.sequence
-#                           ^^^^^ storage.type
+#                           ^^^^^ support.type
 #                                ^ punctuation.section.sequence.end
 
 also_a_tuple = ()[-1]
@@ -2544,7 +2544,7 @@ foo, bar = get_vars()
 t = (*tuple(), *[1, 2], 3*1)
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
 #    ^ keyword.operator.arithmetic.python
-#     ^^^^^ storage.type.python
+#     ^^^^^ support.type.python
 #              ^ keyword.operator.unpacking.sequence.python
 #                        ^ keyword.operator.arithmetic.python
 
@@ -2568,7 +2568,7 @@ d = {**d, **dict()}
 #       ^ punctuation.separator.sequence.python
 #         ^^^^^^^^ - meta.mapping.key
 #         ^^ keyword.operator.unpacking.mapping.python
-#           ^^^^ storage.type.python
+#           ^^^^ support.type.python
 
 s = {*d, *set()}
 #   ^^^^^^^^^^^^ meta.set.python
@@ -2576,7 +2576,7 @@ s = {*d, *set()}
 #     ^ meta.path.python
 #      ^ punctuation.separator.set.python
 #        ^ keyword.operator.unpacking.sequence.python
-#         ^^^ storage.type.python
+#         ^^^ support.type.python
 
 generator = (
     i
@@ -2973,7 +2973,7 @@ primes: List[int] = []
 #       ^^^^ meta.type.python support.class.typing.python
 #           ^^^^^ meta.type.python meta.brackets.python
 #           ^ punctuation.section.brackets.begin.python
-#            ^^^ storage.type.python
+#            ^^^ support.type.python
 #               ^ punctuation.section.brackets.end.python
 #                ^^^^^^ - meta.type
 #                 ^ keyword.operator.assignment
@@ -2981,7 +2981,7 @@ primes: List[int] = []
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.python
 #      ^^ - meta.type
-#        ^^^ meta.type.python storage.type.python
+#        ^^^ meta.type.python support.type.python
 #           ^^ - meta.type - comment
 #             ^^^^^^^ comment
 
@@ -2990,7 +2990,7 @@ foo: str | None = None
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
-#    ^^^ storage.type.python
+#    ^^^ support.type.python
 #        ^ keyword.operator.logical.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
@@ -3001,7 +3001,7 @@ bar: str | None = 'b'
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
-#    ^^^ storage.type.python
+#    ^^^ support.type.python
 #        ^ keyword.operator.logical.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
@@ -3009,7 +3009,7 @@ bar: str | None = 'b'
 
 foo: int := 0
 #  ^ punctuation.separator.annotation.python
-#    ^^^ meta.type.python meta.path.python storage.type.python
+#    ^^^ meta.type.python meta.path.python support.type.python
 #       ^^^^^^ - meta.type
 #        ^^ invalid.illegal.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -3071,9 +3071,9 @@ foo: (int, float) # illegal type, but python likes them
 #    ^^^^^^^^^^^^ meta.type.python meta.sequence.tuple.python
 #                ^^^^^^^^^^^^^^^^^^ - meta.type
 #    ^ punctuation.section.sequence.begin.python
-#     ^^^ storage.type.python
+#     ^^^ support.type.python
 #        ^ punctuation.separator.sequence.python
-#          ^^^^^ storage.type.python
+#          ^^^^^ support.type.python
 #               ^ punctuation.section.sequence.end.python
 #                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
 
@@ -3133,7 +3133,7 @@ primes = 5  # type: ignore  # type: str  # technically ok but weird
 #                   ^^^^^^ keyword.other.ignore.python
 #                             ^^^^ keyword.other.type.python
 #                                 ^ punctuation.separator.type.python
-#                                   ^^^ storage.type.python
+#                                   ^^^ support.type.python
 
 primes = 5  # type: str  # type: ignore  # typical
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
@@ -3154,12 +3154,12 @@ dct = {}  # type: Dict[str, (int, float)] # illegal parens
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
 #                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
 #                     ^ punctuation.section.brackets.begin.python
-#                      ^^^ storage.type.python
+#                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^ - punctuation
-#                            ^^^ storage.type.python
+#                            ^^^ support.type.python
 #                               ^ punctuation.separator.sequence.python
-#                                 ^^^^^ storage.type.python
+#                                 ^^^^^ support.type.python
 #                                      ^ - punctuation
 #                                       ^ punctuation.section.brackets.end.python
 
@@ -3169,11 +3169,11 @@ dct = {}  # type: Dict[str, str | int]
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
 #                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
 #                     ^ punctuation.section.brackets.begin.python
-#                      ^^^ storage.type.python
+#                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
-#                           ^^^ storage.type.python
+#                           ^^^ support.type.python
 #                               ^ keyword.operator.logical.union.python
-#                                 ^^^ storage.type.python
+#                                 ^^^ support.type.python
 #                                    ^ punctuation.section.brackets.end.python
 
 lst = []  # type: List[Dict[Any, ...]] # comment
@@ -3234,9 +3234,9 @@ for a, b in lst: # type: str, int
 #                  ^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
 #                  ^^^^ keyword.other.type.python
 #                      ^ punctuation.separator.type.python
-#                        ^^^ storage.type.python
+#                        ^^^ support.type.python
 #                           ^ punctuation.separator.sequence.python
-#                             ^^^ storage.type.python
+#                             ^^^ support.type.python
 
 # Python 2.7 function annotations.
 def function(a, b, *c, **d):
@@ -3249,25 +3249,25 @@ def function(a, b, *c, **d):
 #                                       ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.function.return-type.python
 #                                                        ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
 #           ^ punctuation.section.parameters.begin.python
-#            ^^^ storage.type.python
+#            ^^^ support.type.python
 #               ^ punctuation.separator.sequence.python
-#                 ^^^ storage.type.python
+#                 ^^^ support.type.python
 #                    ^ punctuation.separator.sequence.python
 #                      ^^^^ support.class.typing.python
 #                          ^^^^^ meta.brackets.python
 #                          ^ punctuation.section.brackets.begin.python
-#                           ^^^ storage.type.python
+#                           ^^^ support.type.python
 #                              ^ punctuation.section.brackets.end.python
 #                               ^ punctuation.separator.sequence.python
-#                                 ^^^^ storage.type.python
+#                                 ^^^^ support.type.python
 #                                     ^ punctuation.section.parameters.end.python
 #                                       ^^ punctuation.separator.return-type.python
 #                                          ^^^^ support.class.typing.python
 #                                              ^^^^^^^^^^ meta.brackets.python
 #                                              ^ punctuation.section.brackets.begin.python
-#                                               ^^^ storage.type.python
+#                                               ^^^ support.type.python
 #                                                  ^ punctuation.separator.sequence.python
-#                                                    ^^^ storage.type.python
+#                                                    ^^^ support.type.python
 #                                                       ^ punctuation.section.brackets.end.python
 
 class TypeCommentTest:
@@ -3279,7 +3279,7 @@ class TypeCommentTest:
 #                        ^^^^ support.class.typing.python
 #                            ^^^^^^ meta.brackets.python
 #                            ^ punctuation.section.brackets.begin.python
-#                             ^^^^ storage.type.python
+#                             ^^^^ support.type.python
 #                                 ^ punctuation.section.brackets.end.python
 
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1718,11 +1718,7 @@ def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "st
 #                                               ^ punctuation.separator.parameters
 #                                                 ^^^^^^ variable.parameter
 #                                                       ^ punctuation.separator.annotation
-#                                                         ^^^^^^^^^ meta.function-call
-#                                                            ^ punctuation.section.arguments.begin
-#                                                             ^ constant.numeric
-#                                                                ^ constant.numeric
-#                                                                 ^ punctuation.section.arguments.end
+#                                                         ^^^^^^^^^ invalid.illegal.function.python
 #                                                                  ^ punctuation.separator.parameters
 #                                                                    ^^^^^^ variable.parameter
 #                                                                          ^ punctuation.separator.annotation
@@ -1787,7 +1783,7 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                    ^^^^^^^^^^^^^ meta.function.parameters.annotation.python - meta.function.parameters.default-value
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
 #                                      ^^^ support.type.python
-#                                          ^ keyword.operator.arithmetic.python
+#                                          ^ punctuation.separator.type.union.python
 #                                            ^^^^ constant.language.null.python
 #                                                 ^ keyword.operator.assignment.python
 #                                                   ^^^^ constant.language.null.python
@@ -2880,8 +2876,17 @@ foo ^= bar ^= baz
 
 # Pop contexts gracefully
 def func(unclosed, parameters: if else
+#                            ^^^^ meta.function.parameters.annotation.python
+#                                ^^^^^^ - meta.function
+#                              ^^ invalid.illegal.name.python
+#                                 ^^^^ keyword.control.conditional.else.python
     pass
-#   ^^^^ invalid.illegal.name
+#   ^^^^ keyword.control.flow.pass.python
+
+# Pop contexts gracefully
+def func(unclosed, parameters: if else
+    pass
+#   ^^^^ keyword.control.flow.pass.python
 
 # The following function should be matched as normal
 # despite the above definition not being closed correctly

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1702,34 +1702,66 @@ def func(from='me'):
 #        ^^^^ invalid.illegal.name
     pass
 
-def type_annotations(param1: int, param2: MyType, param3: max(2, 3), param4: "string" = "default") -> int :
+def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), param4: "string" = "default") -> int :
 #^^^^^^^^^^^^^^^^^^^ meta.function.python - meta.function meta.function
-#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters - meta.function meta.function
-#                                                                                                  ^^^^^^^ meta.function.return-type.python - meta.function meta.function
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters - meta.function meta.function
 #                                                                                                         ^ meta.function.python - meta.function meta.function
+#                                                                                                          ^^^ meta.function.return-type.python - meta.type - meta.function meta.function
+#                                                                                                             ^^^ meta.function.return-type.python meta.type.python - meta.function meta.function
+#                                                                                                                ^ meta.function.return-type.python - meta.type - meta.function meta.function
+#                                                                                                                 ^ meta.function.python - meta.function meta.function
 #                   ^ - meta.function meta.function.parameters
 #                    ^^^^^^ variable.parameter
 #                          ^^^^^ meta.function.parameters.type
 #                          ^ punctuation.separator.type
-#                            ^^^ support.type
+#                            ^^^ meta.type.python support.type.python
 #                               ^ punctuation.separator.parameters
 #                                 ^^^^^^ variable.parameter
 #                                       ^ punctuation.separator.type
-#                                               ^ punctuation.separator.parameters
-#                                                 ^^^^^^ variable.parameter
-#                                                       ^ punctuation.separator.type
-#                                                         ^^^^^^^^^ invalid.illegal.function.python
-#                                                                  ^ punctuation.separator.parameters
-#                                                                    ^^^^^^ variable.parameter
-#                                                                          ^ punctuation.separator.type
-#                                                                            ^^^^^^^^ string.quoted.double
-#                                                                                     ^^^^^^^^^^^ meta.function.parameters.default-value
-#                                                                                     ^ keyword.operator.assignment
-#                                                                                       ^^^^^^^^^ string.quoted.double
-#                                                                                                ^ punctuation.section.parameters.end
-#                                                                                                  ^^ punctuation.separator.return-type.python
-#                                                                                                     ^^^ support.type
-#                                                                                                         ^ punctuation.section.function.begin
+#                                         ^^^^^^^^^^^^^ meta.type.python
+#                                         ^^^^^^ meta.path.python meta.generic-name.python
+#                                                ^ punctuation.separator.type.union.python
+#                                                  ^^^^ constant.language.null.python
+#                                                       ^ punctuation.separator.parameters
+#                                                         ^^^^^^ variable.parameter
+#                                                               ^ punctuation.separator.type
+#                                                                 ^^^^^^^^^ meta.type.python invalid.illegal.function.python
+#                                                                          ^ punctuation.separator.parameters
+#                                                                            ^^^^^^ variable.parameter
+#                                                                                  ^ punctuation.separator.type
+#                                                                                    ^^^^^^^^ meta.type.python meta.string.python string.quoted.double.python
+#                                                                                             ^^^^^^^^^^^ meta.function.parameters.default-value
+#                                                                                             ^ keyword.operator.assignment
+#                                                                                               ^^^^^^^^^ string.quoted.double
+#                                                                                                        ^ punctuation.section.parameters.end
+#                                                                                                          ^^ punctuation.separator.return-type.python
+#                                                                                                             ^^^ support.type
+#                                                                                                                 ^ punctuation.section.function.begin
+
+def type_annotations_arrow_only() ->
+    pass
+# <- - meta.function - meta.type
+#   ^^^^ keyword.control.flow.pass.python
+
+def type_annotations_without_terminator() -> int
+    pass
+# <- - meta.function - meta.type
+#   ^^^^ keyword.control.flow.pass.python
+
+def type_annotations_terminated_by_keyword() -> int if
+    pass
+# <- - meta.function - meta.type
+#   ^^^^ keyword.control.flow.pass.python
+
+def type_annotations_without_terminator_followd_by_comment() -> int # comment
+#                                                            ^^^ meta.function.return-type.python - meta.type
+#                                                               ^^^ meta.function.return-type.python meta.type.python
+#                                                                  ^^^^^^^^^^^ - meta.function - meta.type
+#                                                            ^^ punctuation.separator.return-type.python
+#                                                               ^^^ support.type.python
+    pass
+# <- - meta.function - meta.type
+#   ^^^^ keyword.control.flow.pass.python
 
 def type_annotations_line_continuation_without_terminator() \
       -> int
@@ -1738,7 +1770,7 @@ def type_annotations_line_continuation_without_terminator() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ support.type
+#        ^^^ meta.type support.type
     pass
 
 def type_annotations_line_continuation_without_terminator_but_comment() \
@@ -1748,7 +1780,7 @@ def type_annotations_line_continuation_without_terminator_but_comment() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ support.type
+#        ^^^ meta.type support.type
     pass
 
 def type_annotations_line_continuation() \
@@ -1758,29 +1790,32 @@ def type_annotations_line_continuation() \
 #     ^^^^^^ meta.function.return-type
 #           ^ meta.function.python
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ support.type
+#        ^^^ meta.type support.type
 #           ^ punctuation.section.function.begin
     pass
 
 def type_annotations_line_continuation() \
       -> \
       int:
-#^^^^^^^^ meta.function.return-type
-#        ^ meta.function.python
-#     ^^^ support.type
-#        ^ punctuation.section.function.begin
+# <- meta.function.return-type.python - meta.type
+#^^^^^ meta.function.return-type.python - meta.type
+#     ^^^ meta.function.return-type.python meta.type.python support.type.python
+#        ^ meta.function.python punctuation.section.function.begin.python
     pass
 
 def type_annotations_line_continuation() \
       -> \
       int \
       :
-#^^^^^ meta.function.return-type
+# <- meta.function.return-type.python - meta.type
+#^^^^^ meta.function.return-type.python - meta.type
 #     ^ meta.function.python punctuation.section.function.begin.python
     pass
 
 def type_annotation_with_defaults(foo: str | None = None)
-#                                    ^^^^^^^^^^^^^ meta.function.parameters.type.python - meta.function.parameters.default-value
+#                                    ^^ meta.function.parameters.type.python - meta.function.parameters.default-value - meta.type
+#                                      ^^^^^^^^^^ meta.function.parameters.type.python meta.type.python - meta.function.parameters.default-value
+#                                                ^ meta.function.parameters.type.python - meta.function.parameters.default-value - meta.type
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.type
 #                                      ^^^ support.type.python
 #                                          ^ punctuation.separator.type.union.python
@@ -2928,20 +2963,26 @@ foo.bar(baz., True)
 
 primes: List[int] = []
 #     ^ punctuation.separator.type.python
-#     ^^^^^^^^^^^ meta.type.python
+#     ^^ - meta.type
+#       ^^^^ meta.type.python meta.generic-name.python
+#           ^^^^^ meta.type.python meta.brackets.python
+#           ^ punctuation.section.brackets.begin.python
+#            ^^^ support.type.python
+#               ^ punctuation.section.brackets.end.python
 #                ^^^^^^ - meta.type
-#       ^^^^ meta.path.python
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.type.python
-#      ^^^^^ meta.type.python
+#      ^^ - meta.type
+#        ^^^ meta.type.python support.type.python
 #           ^^ - meta.type - comment
 #             ^^^^^^^ comment
 #        ^^^ support.type.python
 
 foo: str | None = None
-#  ^^^^^^^^^^^^ meta.type.python
+#  ^^ - meta.type
+#    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.type.python
 #    ^^^ support.type.python
@@ -2951,7 +2992,8 @@ foo: str | None = None
 #                 ^^^^ constant.language.null.python
 
 bar: str | None = 'b'
-#  ^^^^^^^^^^^^ meta.type.python
+#  ^^ - meta.type
+#    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.type.python
 #    ^^^ support.type.python
@@ -2960,34 +3002,62 @@ bar: str | None = 'b'
 #               ^ keyword.operator.assignment.python
 #                 ^^^ string.quoted.single.python
 
+foo:
+    bar = baz
+# <- - meta.type
+#^^^^^^^^^^^^^ - meta.type
+#   ^^^ meta.generic-name.python
+#       ^ keyword.operator.assignment.python
+#         ^^^ meta.generic-name.python
+
 foo: \
-#  ^^^ meta.type.python
+#  ^^^^ - meta.type
 foo: \
-    bar = zoo
-# <- meta.type.python
-#^^^^^^ meta.type.python
+    bar = baz
+# <- - meta.type
+#^^^ - meta.type
+#   ^^^ meta.type.python
 #      ^^^^^^^ - meta.type
 #       ^ keyword.operator.assignment
 
-zoo: \
-#  ^^^ meta.type.python
-zoo: \
-    loo \
-# <- meta.type.python
-#^^^^^^^^^ meta.type.python
-zoo: \
-    loo \
-    = too
-# <- meta.type.python
-#^^^ meta.type.python
+foo: \
+#  ^^^^ - meta.type
+foo: \
+    bar \
+# <- - meta.type
+#^^^ - meta.type
+#   ^^^^^^ meta.type.python
+foo: \
+    bar \
+    = baz
+# <- - meta.type
+#^^^^^^^^^ - meta.type
 #   ^ keyword.operator.assignment
 
-foo: int; print("foo")
-#       ^ punctuation.terminator.statement.python
-#       ^^^^^^^^^^^^^^ - meta.type.python
+foo: bar \
+    .baz = zoo
+# <- meta.type.python
+#^^^^^^^ meta.type.python
+#       ^^^^^^^ - meta.type
+
+foo: bar \
+    .baz
+    zoo
+# <- - meta.type
+#^^^^^^^ - meta.type
+
+foo: int ; print("foo")
+# <- - meta.type
+#^^^^ - meta.type
+#    ^^^ meta.type.python
+#       ^^^^^^^^^^^^^^^^ - meta.type
+#        ^ punctuation.terminator.statement.python
 
 foo: (int, float) # illegal parens
-#   ^^^^^^^^^^^^^ meta.type.python - meta.group
+# <- - meta.type
+#^^^^ - meta.type
+#    ^^^^^^^^^^^^ meta.type.python - meta.group
+#                ^^^^^^^^^^^^^^^^^^ - meta.type
 #    ^ invalid.illegal.parens.begin.python
 #     ^^^ support.type.python
 #        ^ punctuation.separator.sequence.python
@@ -2998,7 +3068,8 @@ foo: (int, float) # illegal parens
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
 #        ^ punctuation.separator.type.python
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python
+#        ^^ - meta.type
+#          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python
 #                                  ^^^^^^ - meta.type
 #                                   ^ keyword.operator.assignment
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2986,6 +2986,203 @@ class Starship:
 
 
 ##################
+# Type comments - type: ignore must be by itself.
+##################
+
+value = 3  # type: # type: # rest
+#          ^^ comment.line.number-sign.python - meta.type
+#            ^^^^^ comment.line.number-sign.python meta.type.python
+#                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+
+# This is not a type-ignore comment.
+value = 3  # type: ignore_class_starting_with_ignore
+#          ^^ comment.line.number-sign.python - meta.type
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.type meta.type
+#                                                   ^ comment.line.number-sign.python - meta.type
+#          ^ punctuation.definition.comment.python
+#            ^^^^ keyword.other.type.python
+#                ^ punctuation.separator.type.python
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic-name.python
+
+# Mypy ignore extension
+value = 3  # type: ignore[error-code-1, 4noint][error] # foo
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#          ^^ comment.line.number-sign.python - meta.type
+#            ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                        ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.python
+#                                              ^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+#                  ^^^^^^ keyword.other.ignore.python
+#                        ^ punctuation.section.sequence.begin.python
+#                         ^^^^^^^^^^^^ constant.other.error-code
+#                                     ^ punctuation.separator.sequence.python
+#                                       ^^^^^^ - constant
+#                                             ^ punctuation.section.sequence.end.python
+#                                              ^^^^^^^ - meta.sequence - meta.brackets - meta.item-access
+
+primes = 5  # type: ignore  # type: str  # technically ok but weird
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#           ^^ comment.line.number-sign.python - meta.type
+#             ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                         ^^^^ comment.line.number-sign.python - meta.type
+#                             ^^^^^^^^^ comment.line.number-sign.python meta.type.python
+#                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+#           ^ punctuation.definition.comment.python
+#             ^^^^ keyword.other.type.python
+#                 ^ punctuation.separator.type.python
+#                   ^^^^^^ keyword.other.ignore.python
+#                             ^^^^ keyword.other.type.python
+#                                 ^ punctuation.separator.type.python
+#                                   ^^^ support.type.python
+
+primes = 5  # type: str  # type: ignore  # typical
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#           ^^ comment.line.number-sign.python - meta.type
+#             ^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                      ^^^^ comment.line.number-sign.python - meta.type
+#                          ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+#                                      ^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+
+primes = 5  # type: str  # type: str  # invalid
+#           ^^ comment.line.number-sign.python - meta.type
+#             ^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                      ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+
+dct = {}  # type: Dict[str, (int, float)] # illegal parens
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#         ^^ comment.line.number-sign.python - meta.type
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
+#                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
+#                     ^ punctuation.section.brackets.begin.python
+#                      ^^^ support.type.python
+#                         ^ punctuation.separator.sequence.python
+#                           ^ invalid.illegal.parens.begin.python
+#                            ^^^ support.type.python
+#                               ^ punctuation.separator.sequence.python
+#                                 ^^^^^ support.type.python
+#                                      ^ invalid.illegal.parens.end.python
+#                                       ^ punctuation.section.brackets.end.python
+
+dct = {}  # type: Dict[str, str | int]
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#         ^^ comment.line.number-sign.python - meta.type
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
+#                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
+#                     ^ punctuation.section.brackets.begin.python
+#                      ^^^ support.type.python
+#                         ^ punctuation.separator.sequence.python
+#                           ^^^ support.type.python
+#                               ^ punctuation.separator.type.union.python
+#                                 ^^^ support.type.python
+#                                    ^ punctuation.section.brackets.end.python
+
+lst = []  # type: List[Dict[Any, ...]] # comment
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#         ^^ comment.line.number-sign.python - meta.type
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.brackets
+#                     ^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.brackets meta.brackets
+#                          ^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python meta.brackets.python
+#                                    ^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.brackets meta.brackets
+#                                     ^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+#         ^ punctuation.definition.comment.python
+#           ^^^^ keyword.other.type.python
+#               ^ punctuation.separator.type.python
+#                 ^^^^ meta.generic-name.python
+#                     ^ punctuation.section.brackets.begin
+#                      ^^^^ meta.generic-name.python
+#                          ^ punctuation.section.brackets.begin.python
+#                           ^^^ meta.generic-name.python
+#                              ^ punctuation.separator.sequence.python
+#                                ^^^ constant.language.python
+#                                   ^^ punctuation.section.brackets.end.python
+
+# incomplete list
+lst = []  # type: List[ # type: ignore
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#         ^^ comment.line.number-sign.python - meta.type
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                     ^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python punctuation.section.sequence.begin.python
+#                      ^^^ comment.line.number-sign.python - meta.type
+#                         ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+
+
+# incomplete list and illegal group
+lst = []  # type: List[( # type: ignore
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#         ^^ comment.line.number-sign.python - meta.type
+#           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
+#                     ^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
+#                       ^^^ comment.line.number-sign.python - meta.type
+#                          ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+
+view = None  # type: sublime.View
+#            ^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#            ^^ comment.line.number-sign.python - meta.type
+#              ^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+#                                ^ comment.line.number-sign.python - meta.type
+#            ^ punctuation.definition.comment.python
+#              ^^^^ keyword.other.type.python
+#                  ^ punctuation.separator.type.python
+#                    ^^^^^^^^^^^^ meta.path.python
+#                    ^^^^^^^ meta.generic-name.python
+#                           ^ punctuation.accessor.dot.python
+#                            ^^^^ meta.generic-name.python
+
+for a, b in lst: # type: str, int
+#                ^^^^^^^^^^^^^^^^ - meta.type meta.type
+#                ^^ comment.line.number-sign.python - meta.type
+#                  ^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+#                  ^^^^ keyword.other.type.python
+#                      ^ punctuation.separator.type.python
+#                        ^^^ support.type.python
+#                           ^ punctuation.separator.sequence.python
+#                             ^^^ support.type.python
+
+# Python 2.7 function annotations.
+def function(a, b, *c, **d):
+    # type: (int, str, List[str], bool) -> Dict[str, str] # type: noncomment
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
+#   ^^ comment.line.number-sign.python - meta.type
+#     ^^^^^^ comment.line.number-sign.python meta.type.python
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.function.parameters.python
+#                                      ^ comment.line.number-sign.python meta.type.function.python
+#                                       ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.function.return-type.python
+#                                                        ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
+#           ^ punctuation.section.parameters.begin.python
+#            ^^^ support.type.python
+#               ^ punctuation.separator.sequence.python
+#                 ^^^ support.type.python
+#                    ^ punctuation.separator.sequence.python
+#                      ^^^^ meta.path.python meta.generic-name.python
+#                          ^^^^^ meta.brackets.python
+#                          ^ punctuation.section.brackets.begin.python
+#                           ^^^ support.type.python
+#                              ^ punctuation.section.brackets.end.python
+#                               ^ punctuation.separator.sequence.python
+#                                 ^^^^ support.type.python
+#                                     ^ punctuation.section.parameters.end.python
+#                                       ^^ punctuation.separator.return-type.python
+#                                          ^^^^ meta.path.python meta.generic-name.python
+#                                              ^^^^^^^^^^ meta.brackets.python
+#                                              ^ punctuation.section.brackets.begin.python
+#                                               ^^^ support.type.python
+#                                                  ^ punctuation.separator.sequence.python
+#                                                    ^^^ support.type.python
+#                                                       ^ punctuation.section.brackets.end.python
+
+class TypeCommentTest:
+    member = []  # type: List[dict]
+#                ^^ comment.line.number-sign.python - meta.type
+#                  ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
+#                  ^^^^ keyword.other.type.python
+#                      ^ punctuation.separator.type.python
+#                        ^^^^ meta.path.python meta.generic-name.python
+#                            ^^^^^^ meta.sequence.list.members.python
+#                            ^ punctuation.section.sequence.begin.python
+#                             ^^^^ support.type.python
+#                                 ^ punctuation.section.sequence.end.python
+
+
+##################
 # Assignment Expressions
 ##################
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2978,7 +2978,6 @@ captain: str  # Note: no initial value!
 #        ^^^ meta.type.python support.type.python
 #           ^^ - meta.type - comment
 #             ^^^^^^^ comment
-#        ^^^ support.type.python
 
 foo: str | None = None
 #  ^^ - meta.type

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2964,7 +2964,7 @@ foo.bar(baz., True)
 primes: List[int] = []
 #     ^ punctuation.separator.type.python
 #     ^^ - meta.type
-#       ^^^^ meta.type.python meta.generic-name.python
+#       ^^^^ meta.type.python support.class.typing.python
 #           ^^^^^ meta.type.python meta.sequence.list.members.python
 #           ^ punctuation.section.sequence.begin.python
 #            ^^^ support.type.python
@@ -3175,11 +3175,11 @@ lst = []  # type: List[Dict[Any, ...]] # comment
 #         ^ punctuation.definition.comment.python
 #           ^^^^ keyword.other.type.python
 #               ^ punctuation.separator.type.python
-#                 ^^^^ meta.generic-name.python
+#                 ^^^^ support.class.typing.python
 #                     ^ punctuation.section.sequence.begin
-#                      ^^^^ meta.generic-name.python
+#                      ^^^^ support.class.typing.python
 #                          ^ punctuation.section.sequence.begin.python
-#                           ^^^ meta.generic-name.python
+#                           ^^^ support.class.typing.python
 #                              ^ punctuation.separator.sequence.python
 #                                ^^^ constant.language.python
 #                                   ^^ punctuation.section.sequence.end.python
@@ -3241,7 +3241,7 @@ def function(a, b, *c, **d):
 #               ^ punctuation.separator.sequence.python
 #                 ^^^ support.type.python
 #                    ^ punctuation.separator.sequence.python
-#                      ^^^^ meta.path.python meta.generic-name.python
+#                      ^^^^ support.class.typing.python
 #                          ^^^^^ meta.sequence.list.members.python
 #                          ^ punctuation.section.sequence.begin.python
 #                           ^^^ support.type.python
@@ -3250,7 +3250,7 @@ def function(a, b, *c, **d):
 #                                 ^^^^ support.type.python
 #                                     ^ punctuation.section.parameters.end.python
 #                                       ^^ punctuation.separator.return-type.python
-#                                          ^^^^ meta.path.python meta.generic-name.python
+#                                          ^^^^ support.class.typing.python
 #                                              ^^^^^^^^^^ meta.sequence.list.members.python
 #                                              ^ punctuation.section.sequence.begin.python
 #                                               ^^^ support.type.python
@@ -3264,7 +3264,7 @@ class TypeCommentTest:
 #                  ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
 #                  ^^^^ keyword.other.type.python
 #                      ^ punctuation.separator.type.python
-#                        ^^^^ meta.path.python meta.generic-name.python
+#                        ^^^^ support.class.typing.python
 #                            ^^^^^^ meta.sequence.list.members.python
 #                            ^ punctuation.section.sequence.begin.python
 #                             ^^^^ support.type.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -345,15 +345,15 @@ from unicode.__init__ . 123 import unicode as unicode
 #           ^ punctuation.accessor.dot.python
 #            ^^^^^^^^ meta.import-name.python - support
 #                     ^^^^^ invalid.illegal.name.python
-#                                  ^^^^^^^ support.type.python
-#                                             ^^^^^^^ support.type.python
+#                                  ^^^^^^^ storage.type.python
+#                                             ^^^^^^^ storage.type.python
 
 import .str
 #      ^ invalid.illegal.unexpected-relative-import.python
-#       ^^^ support.type.python
+#       ^^^ storage.type.python
 
 import str
-#      ^^^ support.type.python
+#      ^^^ storage.type.python
 
 from importlib import import_module
 # <- meta.statement.import.python keyword.control.import.from.python
@@ -1406,7 +1406,7 @@ def _():
 #           ^^ meta.statement.conditional.case.patterns.python meta.function-call.arguments.python
 #             ^ meta.statement.conditional.case.python - meta.function-call
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^ support.type.python
+#        ^^^ storage.type.python
 #           ^ punctuation.section.arguments.begin.python
 #            ^ punctuation.section.arguments.end.python
 #             ^ punctuation.section.block.conditional.case.python
@@ -1510,7 +1510,7 @@ def _():
 #                                                                                 ^ meta.statement.conditional.case.python
 #                                                                                  ^ - meta.statement
 #   ^^^^ keyword.control.conditional.case.python
-#        ^^^ support.type.python
+#        ^^^ storage.type.python
 #           ^ punctuation.section.arguments.begin.python
 #            ^ punctuation.section.arguments.end.python
 #             ^ punctuation.separator.sequence.python
@@ -1571,7 +1571,7 @@ def _():
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
 #       ^ punctuation.separator.annotation.python
-#         ^^^ support.type.python
+#         ^^^ storage.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1580,7 +1580,7 @@ def _():
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.python
-#     ^^^ support.type.python
+#     ^^^ storage.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1603,7 +1603,7 @@ def _():
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.annotation.python
-#          ^^^ support.type.python
+#          ^^^ storage.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1612,7 +1612,7 @@ def _():
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
 #   ^ punctuation.separator.annotation.python
-#     ^^^ support.type.python
+#     ^^^ storage.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
@@ -1714,7 +1714,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                    ^^^^^^ variable.parameter
 #                          ^^^^^ meta.function.parameters.annotation
 #                          ^ punctuation.separator.annotation
-#                            ^^^ meta.type.python support.type.python
+#                            ^^^ meta.type.python storage.type.python
 #                               ^ punctuation.separator.parameters
 #                                 ^^^^^^ variable.parameter
 #                                       ^ punctuation.separator.annotation
@@ -1738,7 +1738,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                                                                                               ^^^^^^^^^ string.quoted.double
 #                                                                                                        ^ punctuation.section.parameters.end
 #                                                                                                          ^^ punctuation.separator.return-type.python
-#                                                                                                             ^^^ support.type
+#                                                                                                             ^^^ storage.type
 #                                                                                                                 ^ punctuation.section.function.begin
 
 def type_annotations_arrow_only() ->
@@ -1761,7 +1761,7 @@ def type_annotations_without_terminator_followd_by_comment() -> int # comment
 #                                                               ^^^ meta.function.return-type.python meta.type.python
 #                                                                  ^^^^^^^^^^^ - meta.function - meta.type
 #                                                            ^^ punctuation.separator.return-type.python
-#                                                               ^^^ support.type.python
+#                                                               ^^^ storage.type.python
     pass
 # <- - meta.function - meta.type
 #   ^^^^ keyword.control.flow.pass.python
@@ -1773,7 +1773,7 @@ def type_annotations_line_continuation_without_terminator() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type support.type
+#        ^^^ meta.type storage.type
     pass
 
 def type_annotations_line_continuation_without_terminator_but_comment() \
@@ -1783,7 +1783,7 @@ def type_annotations_line_continuation_without_terminator_but_comment() \
 #^^^^^ meta.function.python
 #     ^^^^^^ meta.function.return-type
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type support.type
+#        ^^^ meta.type storage.type
     pass
 
 def type_annotations_line_continuation() \
@@ -1793,7 +1793,7 @@ def type_annotations_line_continuation() \
 #     ^^^^^^ meta.function.return-type
 #           ^ meta.function.python
 #     ^^ punctuation.separator.return-type.python
-#        ^^^ meta.type support.type
+#        ^^^ meta.type storage.type
 #           ^ punctuation.section.function.begin
     pass
 
@@ -1802,7 +1802,7 @@ def type_annotations_line_continuation() \
       int:
 # <- meta.function.return-type.python - meta.type
 #^^^^^ meta.function.return-type.python - meta.type
-#     ^^^ meta.function.return-type.python meta.type.python support.type.python
+#     ^^^ meta.function.return-type.python meta.type.python storage.type.python
 #        ^ meta.function.python punctuation.section.function.begin.python
     pass
 
@@ -1820,7 +1820,7 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                      ^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python - meta.function.parameters.default-value
 #                                                ^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
-#                                      ^^^ support.type.python
+#                                      ^^^ storage.type.python
 #                                          ^ punctuation.separator.type.union.python
 #                                            ^^^^ constant.language.null.python
 #                                                 ^ keyword.operator.assignment.python
@@ -1956,7 +1956,7 @@ def func(
 #  ^^^^^^^^^^^ meta.function.parameters
 #   ^^^ variable.parameter.python
 #      ^ punctuation.separator.annotation
-#        ^^^ support.type.python
+#        ^^^ storage.type.python
 #           ^ punctuation.separator.parameters.python
 ): pass
 
@@ -2223,7 +2223,7 @@ mytuple = ("this", 'is', 4, tuple)
 #                      ^ punctuation.separator.sequence
 #                        ^ constant.numeric
 #                         ^ punctuation.separator.sequence
-#                           ^^^^^ support.type
+#                           ^^^^^ storage.type
 #                                ^ punctuation.section.sequence.end
 
 also_a_tuple = ()[-1]
@@ -2535,7 +2535,7 @@ foo, bar = get_vars()
 t = (*tuple(), *[1, 2], 3*1)
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
 #    ^ keyword.operator.arithmetic.python
-#     ^^^^^ support.type.python
+#     ^^^^^ storage.type.python
 #              ^ keyword.operator.unpacking.sequence.python
 #                        ^ keyword.operator.arithmetic.python
 
@@ -2559,7 +2559,7 @@ d = {**d, **dict()}
 #       ^ punctuation.separator.sequence.python
 #         ^^^^^^^^ - meta.mapping.key
 #         ^^ keyword.operator.unpacking.mapping.python
-#           ^^^^ support.type.python
+#           ^^^^ storage.type.python
 
 s = {*d, *set()}
 #   ^^^^^^^^^^^^ meta.set.python
@@ -2567,7 +2567,7 @@ s = {*d, *set()}
 #     ^ meta.path.python
 #      ^ punctuation.separator.set.python
 #        ^ keyword.operator.unpacking.sequence.python
-#         ^^^ support.type.python
+#         ^^^ storage.type.python
 
 generator = (
     i
@@ -2964,7 +2964,7 @@ primes: List[int] = []
 #       ^^^^ meta.type.python support.class.typing.python
 #           ^^^^^ meta.type.python meta.brackets.python
 #           ^ punctuation.section.brackets.begin.python
-#            ^^^ support.type.python
+#            ^^^ storage.type.python
 #               ^ punctuation.section.brackets.end.python
 #                ^^^^^^ - meta.type
 #                 ^ keyword.operator.assignment
@@ -2972,7 +2972,7 @@ primes: List[int] = []
 captain: str  # Note: no initial value!
 #      ^ punctuation.separator.annotation.python
 #      ^^ - meta.type
-#        ^^^ meta.type.python support.type.python
+#        ^^^ meta.type.python storage.type.python
 #           ^^ - meta.type - comment
 #             ^^^^^^^ comment
 
@@ -2981,7 +2981,7 @@ foo: str | None = None
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
-#    ^^^ support.type.python
+#    ^^^ storage.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
@@ -2992,7 +2992,7 @@ bar: str | None = 'b'
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
-#    ^^^ support.type.python
+#    ^^^ storage.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
@@ -3000,7 +3000,7 @@ bar: str | None = 'b'
 
 foo: int := 0
 #  ^ punctuation.separator.annotation.python
-#    ^^^ meta.type.python meta.path.python support.type.python
+#    ^^^ meta.type.python meta.path.python storage.type.python
 #       ^^^^^^ - meta.type
 #        ^^ invalid.illegal.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -3062,9 +3062,9 @@ foo: (int, float) # illegal type, but python likes them
 #    ^^^^^^^^^^^^ meta.type.python meta.sequence.tuple.python
 #                ^^^^^^^^^^^^^^^^^^ - meta.type
 #    ^ punctuation.section.sequence.begin.python
-#     ^^^ support.type.python
+#     ^^^ storage.type.python
 #        ^ punctuation.separator.sequence.python
-#          ^^^^^ support.type.python
+#          ^^^^^ storage.type.python
 #               ^ punctuation.section.sequence.end.python
 #                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
 
@@ -3124,7 +3124,7 @@ primes = 5  # type: ignore  # type: str  # technically ok but weird
 #                   ^^^^^^ keyword.other.ignore.python
 #                             ^^^^ keyword.other.type.python
 #                                 ^ punctuation.separator.type.python
-#                                   ^^^ support.type.python
+#                                   ^^^ storage.type.python
 
 primes = 5  # type: str  # type: ignore  # typical
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
@@ -3145,12 +3145,12 @@ dct = {}  # type: Dict[str, (int, float)] # illegal parens
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
 #                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
 #                     ^ punctuation.section.brackets.begin.python
-#                      ^^^ support.type.python
+#                      ^^^ storage.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^ - punctuation
-#                            ^^^ support.type.python
+#                            ^^^ storage.type.python
 #                               ^ punctuation.separator.sequence.python
-#                                 ^^^^^ support.type.python
+#                                 ^^^^^ storage.type.python
 #                                      ^ - punctuation
 #                                       ^ punctuation.section.brackets.end.python
 
@@ -3160,11 +3160,11 @@ dct = {}  # type: Dict[str, str | int]
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
 #                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
 #                     ^ punctuation.section.brackets.begin.python
-#                      ^^^ support.type.python
+#                      ^^^ storage.type.python
 #                         ^ punctuation.separator.sequence.python
-#                           ^^^ support.type.python
+#                           ^^^ storage.type.python
 #                               ^ punctuation.separator.type.union.python
-#                                 ^^^ support.type.python
+#                                 ^^^ storage.type.python
 #                                    ^ punctuation.section.brackets.end.python
 
 lst = []  # type: List[Dict[Any, ...]] # comment
@@ -3225,9 +3225,9 @@ for a, b in lst: # type: str, int
 #                  ^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
 #                  ^^^^ keyword.other.type.python
 #                      ^ punctuation.separator.type.python
-#                        ^^^ support.type.python
+#                        ^^^ storage.type.python
 #                           ^ punctuation.separator.sequence.python
-#                             ^^^ support.type.python
+#                             ^^^ storage.type.python
 
 # Python 2.7 function annotations.
 def function(a, b, *c, **d):
@@ -3240,25 +3240,25 @@ def function(a, b, *c, **d):
 #                                       ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.function.return-type.python
 #                                                        ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python - meta.type
 #           ^ punctuation.section.parameters.begin.python
-#            ^^^ support.type.python
+#            ^^^ storage.type.python
 #               ^ punctuation.separator.sequence.python
-#                 ^^^ support.type.python
+#                 ^^^ storage.type.python
 #                    ^ punctuation.separator.sequence.python
 #                      ^^^^ support.class.typing.python
 #                          ^^^^^ meta.brackets.python
 #                          ^ punctuation.section.brackets.begin.python
-#                           ^^^ support.type.python
+#                           ^^^ storage.type.python
 #                              ^ punctuation.section.brackets.end.python
 #                               ^ punctuation.separator.sequence.python
-#                                 ^^^^ support.type.python
+#                                 ^^^^ storage.type.python
 #                                     ^ punctuation.section.parameters.end.python
 #                                       ^^ punctuation.separator.return-type.python
 #                                          ^^^^ support.class.typing.python
 #                                              ^^^^^^^^^^ meta.brackets.python
 #                                              ^ punctuation.section.brackets.begin.python
-#                                               ^^^ support.type.python
+#                                               ^^^ storage.type.python
 #                                                  ^ punctuation.separator.sequence.python
-#                                                    ^^^ support.type.python
+#                                                    ^^^ storage.type.python
 #                                                       ^ punctuation.section.brackets.end.python
 
 class TypeCommentTest:
@@ -3270,7 +3270,7 @@ class TypeCommentTest:
 #                        ^^^^ support.class.typing.python
 #                            ^^^^^^ meta.brackets.python
 #                            ^ punctuation.section.brackets.begin.python
-#                             ^^^^ support.type.python
+#                             ^^^^ storage.type.python
 #                                 ^ punctuation.section.brackets.end.python
 
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -723,49 +723,49 @@ func()(1, 2)
 #^^^^^^^^^^^ - meta.function-call meta.function-call
 
 myobj[1](True)
-#^^^^ - meta.item-access
+#^^^^ - meta.brackets
 #    ^ punctuation.section.brackets.begin.python
-#    ^^^ meta.item-access.python
+#    ^^^ meta.brackets.python
 #      ^ punctuation.section.brackets.end.python
 #       ^^^^^^ meta.function-call.arguments.python
 
 myobj[1][2](0)
-#^^^^ - meta.item-access
+#^^^^ - meta.brackets
 #    ^ punctuation.section.brackets.begin.python
-#    ^^^^^^ meta.item-access.python
+#    ^^^^^^ meta.brackets.python
 #      ^ punctuation.section.brackets.end.python
 #       ^ punctuation.section.brackets.begin.python
 #         ^ punctuation.section.brackets.end.python
 #          ^^^ meta.function-call.arguments.python
 
 a[0].b[1].d[2](e[3])[f[g[4].h[5]]]
-# <- - meta.item-access
-#^^^ meta.item-access.python
-#   ^^ - meta.item-access
-#     ^^^ meta.item-access.python
-#        ^^ - meta.item-access
-#          ^^^ meta.item-access.python
-#             ^^ - meta.item-access
-#               ^^^ meta.item-access.python
-#                  ^ - meta.item-access
-#                   ^^ meta.item-access.python - meta.item-access meta.item-access
-#                     ^^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
-#                       ^^^ meta.item-access.python meta.item-access.python meta.item-access.python
-#                          ^^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
-#                            ^^^ meta.item-access.python meta.item-access.python meta.item-access.python
-#                               ^ meta.item-access.python meta.item-access.python - meta.item-access meta.item-access meta.item-access
-#                                ^ meta.item-access.python - meta.item-access meta.item-access
-#                                 ^ - meta.item-access
+# <- - meta.brackets
+#^^^ meta.brackets.python
+#   ^^ - meta.brackets
+#     ^^^ meta.brackets.python
+#        ^^ - meta.brackets
+#          ^^^ meta.brackets.python
+#             ^^ - meta.brackets
+#               ^^^ meta.brackets.python
+#                  ^ - meta.brackets
+#                   ^^ meta.brackets.python - meta.brackets meta.brackets
+#                     ^^ meta.brackets.python meta.brackets.python - meta.brackets meta.brackets meta.brackets
+#                       ^^^ meta.brackets.python meta.brackets.python meta.brackets.python
+#                          ^^ meta.brackets.python meta.brackets.python - meta.brackets meta.brackets meta.brackets
+#                            ^^^ meta.brackets.python meta.brackets.python meta.brackets.python
+#                               ^ meta.brackets.python meta.brackets.python - meta.brackets meta.brackets meta.brackets
+#                                ^ meta.brackets.python - meta.brackets meta.brackets
+#                                 ^ - meta.brackets
 
 self[5] = 0
-#   ^^^ meta.item-access.python
+#   ^^^ meta.brackets.python
 
 range(20)[10:2:-2]
 #           ^ punctuation.separator.slice
 #             ^ punctuation.separator.slice
 
 "string"[12]
-#       ^^^^ meta.item-access - meta.sequence
+#       ^^^^ meta.brackets - meta.sequence
 
 "string".
 #       ^ punctuation.accessor.dot.python
@@ -776,15 +776,15 @@ range(20)[10:2:-2]
 #       ^ punctuation.accessor.dot.python
 
 (i for i in range(10))[5]
-#                     ^^^ meta.item-access - meta.sequence
+#                     ^^^ meta.brackets - meta.sequence
 
 [1, 2, 3][2]
 #^^^^^^^^ meta.sequence
-#        ^^^ meta.item-access - meta.sequence
+#        ^^^ meta.brackets - meta.sequence
 
 [1, 2, 3] \
     [2]
-#   ^^^ meta.item-access - meta.sequence
+#   ^^^ meta.brackets - meta.sequence
 
 [a.b., a., .][2]
 #^^^^^^^^^^^^ meta.sequence
@@ -792,7 +792,7 @@ range(20)[10:2:-2]
 #   ^ punctuation.accessor.dot.python
 #       ^ punctuation.accessor.dot.python
 #          ^ punctuation.accessor.dot.python
-#            ^^^ meta.item-access - meta.sequence
+#            ^^^ meta.brackets - meta.sequence
 
 {foo.: bar.baz.}.
 #   ^ punctuation.accessor.dot.python
@@ -807,7 +807,7 @@ range(20)[10:2:-2]
 #            ^ punctuation.accessor.dot.python
 
 1[12]
-#^^^^ - meta.item-access
+#^^^^ - meta.brackets
 
 
 ##################
@@ -1570,7 +1570,7 @@ def _():
 
     case: int = 0
 #   ^^^^ meta.generic-name.python - keyword
-#       ^ punctuation.separator.type.python
+#       ^ punctuation.separator.annotation.python
 #         ^^^ support.type.python
 #             ^ keyword.operator.assignment.python
 #               ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1579,7 +1579,7 @@ def _():
 #   ^^^^ meta.generic-name.python - keyword
 #        ^ punctuation.separator.continuation.line.python
     : int = 0
-#   ^ punctuation.separator.type.python
+#   ^ punctuation.separator.annotation.python
 #     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1602,7 +1602,7 @@ def _():
 
     match: int = 0
 #   ^^^^^ meta.generic-name.python - keyword
-#        ^ punctuation.separator.type.python
+#        ^ punctuation.separator.annotation.python
 #          ^^^ support.type.python
 #              ^ keyword.operator.assignment.python
 #                ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1611,7 +1611,7 @@ def _():
 #   ^^^^^ meta.generic-name.python - keyword
 #         ^ punctuation.separator.continuation.line.python
     : int = 0
-#   ^ punctuation.separator.type.python
+#   ^ punctuation.separator.annotation.python
 #     ^^^ support.type.python
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
@@ -1712,23 +1712,26 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                                                                                                                 ^ meta.function.python - meta.function meta.function
 #                   ^ - meta.function meta.function.parameters
 #                    ^^^^^^ variable.parameter
-#                          ^^^^^ meta.function.parameters.type
-#                          ^ punctuation.separator.type
+#                          ^^^^^ meta.function.parameters.annotation
+#                          ^ punctuation.separator.annotation
 #                            ^^^ meta.type.python support.type.python
 #                               ^ punctuation.separator.parameters
 #                                 ^^^^^^ variable.parameter
-#                                       ^ punctuation.separator.type
+#                                       ^ punctuation.separator.annotation
 #                                         ^^^^^^^^^^^^^ meta.type.python
 #                                         ^^^^^^ meta.path.python meta.generic-name.python
 #                                                ^ punctuation.separator.type.union.python
 #                                                  ^^^^ constant.language.null.python
 #                                                       ^ punctuation.separator.parameters
 #                                                         ^^^^^^ variable.parameter
-#                                                               ^ punctuation.separator.type
-#                                                                 ^^^^^^^^^ meta.type.python invalid.illegal.function.python
-#                                                                          ^ punctuation.separator.parameters
+#                                                               ^ punctuation.separator.annotation
+#                                                                 ^^^^^^^^^ meta.function-call
+#                                                                    ^ punctuation.section.arguments.begin
+#                                                                     ^ constant.numeric
+#                                                                        ^ constant.numeric
+#                                                                         ^ punctuation.section.arguments.end
 #                                                                            ^^^^^^ variable.parameter
-#                                                                                  ^ punctuation.separator.type
+#                                                                                  ^ punctuation.separator.annotation
 #                                                                                    ^^^^^^^^ meta.type.python meta.string.python string.quoted.double.python
 #                                                                                             ^^^^^^^^^^^ meta.function.parameters.default-value
 #                                                                                             ^ keyword.operator.assignment
@@ -1813,10 +1816,10 @@ def type_annotations_line_continuation() \
     pass
 
 def type_annotation_with_defaults(foo: str | None = None)
-#                                    ^^ meta.function.parameters.type.python - meta.function.parameters.default-value - meta.type
-#                                      ^^^^^^^^^^ meta.function.parameters.type.python meta.type.python - meta.function.parameters.default-value
-#                                                ^ meta.function.parameters.type.python - meta.function.parameters.default-value - meta.type
-#                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.type
+#                                    ^^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
+#                                      ^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python - meta.function.parameters.default-value
+#                                                ^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
+#                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
 #                                      ^^^ support.type.python
 #                                          ^ punctuation.separator.type.union.python
 #                                            ^^^^ constant.language.null.python
@@ -1952,7 +1955,7 @@ def func(
     baz: str,
 #  ^^^^^^^^^^^ meta.function.parameters
 #   ^^^ variable.parameter.python
-#      ^ punctuation.separator.type
+#      ^ punctuation.separator.annotation
 #        ^^^ support.type.python
 #           ^ punctuation.separator.parameters.python
 ): pass
@@ -2117,7 +2120,7 @@ class Class():
 #          ^^^^^^^^ variable.annotation.python - support
 
     @deco[4]
-#        ^^^ meta.item-access.python
+#        ^^^ meta.brackets.python
 #        ^ punctuation.section.brackets.begin.python
 #         ^ meta.number.integer.decimal.python constant.numeric.value.python
 #          ^ punctuation.section.brackets.end.python
@@ -2126,7 +2129,7 @@ class Class():
 #   ^^^^^^^^^^^^^^^^ meta.annotation.python
 #   ^ punctuation.definition.annotation.python
 #    ^^^^ variable.annotation.python
-#        ^^^ meta.item-access.python
+#        ^^^ meta.brackets.python
 #        ^ punctuation.section.brackets.begin.python
 #         ^ meta.number.integer.decimal.python constant.numeric.value.python
 #          ^ punctuation.section.brackets.end.python
@@ -2225,7 +2228,7 @@ mytuple = ("this", 'is', 4, tuple)
 
 also_a_tuple = ()[-1]
 #              ^^ meta.sequence.tuple.empty.python
-#                ^^^^ meta.item-access
+#                ^^^^ meta.brackets
 
 tuple_expression = ()and()
 #                  ^^ meta.sequence.tuple.empty.python
@@ -2911,17 +2914,11 @@ foo ^= bar ^= baz
 
 # Pop contexts gracefully
 def func(unclosed, parameters: if else
-#                            ^^^^ meta.function.parameters.type.python
-#                                ^^^^^^ - meta.function
-#                              ^^ invalid.illegal.name.python
+#                            ^^^^^^^^^^ meta.function.parameters.annotation.python
+#                              ^^ keyword.control.conditional.if.python
 #                                 ^^^^ keyword.control.conditional.else.python
     pass
-#   ^^^^ keyword.control.flow.pass.python
-
-# Pop contexts gracefully
-def func(unclosed, parameters: if else
-    pass
-#   ^^^^ keyword.control.flow.pass.python
+#   ^^^^ invalid.illegal.name.python
 
 # The following function should be matched as normal
 # despite the above definition not being closed correctly
@@ -2962,18 +2959,18 @@ foo.bar(baz., True)
 ##################
 
 primes: List[int] = []
-#     ^ punctuation.separator.type.python
+#     ^ punctuation.separator.annotation.python
 #     ^^ - meta.type
 #       ^^^^ meta.type.python support.class.typing.python
-#           ^^^^^ meta.type.python meta.sequence.list.members.python
-#           ^ punctuation.section.sequence.begin.python
+#           ^^^^^ meta.type.python meta.brackets.python
+#           ^ punctuation.section.brackets.begin.python
 #            ^^^ support.type.python
-#               ^ punctuation.section.sequence.end.python
+#               ^ punctuation.section.brackets.end.python
 #                ^^^^^^ - meta.type
 #                 ^ keyword.operator.assignment
 
 captain: str  # Note: no initial value!
-#      ^ punctuation.separator.type.python
+#      ^ punctuation.separator.annotation.python
 #      ^^ - meta.type
 #        ^^^ meta.type.python support.type.python
 #           ^^ - meta.type - comment
@@ -2983,7 +2980,7 @@ foo: str | None = None
 #  ^^ - meta.type
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^^ - meta.type
-#  ^ punctuation.separator.type.python
+#  ^ punctuation.separator.annotation.python
 #    ^^^ support.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
@@ -2994,12 +2991,19 @@ bar: str | None = 'b'
 #  ^^ - meta.type
 #    ^^^^^^^^^^ meta.type.python
 #              ^^^^^^^ - meta.type
-#  ^ punctuation.separator.type.python
+#  ^ punctuation.separator.annotation.python
 #    ^^^ support.type.python
 #        ^ punctuation.separator.type.union.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^ string.quoted.single.python
+
+foo: int := 0
+#  ^ punctuation.separator.annotation.python
+#    ^^^ meta.type.python meta.path.python support.type.python
+#       ^^^^^^ - meta.type
+#        ^^ invalid.illegal.assignment.python
+#           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
 foo:
     bar = baz
@@ -3052,21 +3056,21 @@ foo: int ; print("foo")
 #       ^^^^^^^^^^^^^^^^ - meta.type
 #        ^ punctuation.terminator.statement.python
 
-foo: (int, float) # illegal parens
+foo: (int, float) # illegal type, but python likes them
 # <- - meta.type
 #^^^^ - meta.type
-#    ^^^^^^^^^^^^ meta.type.python - meta.group
+#    ^^^^^^^^^^^^ meta.type.python meta.sequence.tuple.python
 #                ^^^^^^^^^^^^^^^^^^ - meta.type
-#    ^ invalid.illegal.parens.begin.python
+#    ^ punctuation.section.sequence.begin.python
 #     ^^^ support.type.python
 #        ^ punctuation.separator.sequence.python
 #          ^^^^^ support.type.python
-#               ^ invalid.illegal.parens.end.python
+#               ^ punctuation.section.sequence.end.python
 #                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
 
 class Starship:
     stats: ClassVar[Dict[str, int]] = {}
-#        ^ punctuation.separator.type.python
+#        ^ punctuation.separator.annotation.python
 #        ^^ - meta.type
 #          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python
 #                                  ^^^^^^ - meta.type
@@ -3105,7 +3109,7 @@ value = 3  # type: ignore[error-code-1, 4noint][error] # foo
 #                                     ^ punctuation.separator.sequence.python
 #                                       ^^^^^^ - constant
 #                                             ^ punctuation.section.sequence.end.python
-#                                              ^^^^^^^ - meta.sequence - meta.sequence - meta.item-access
+#                                              ^^^^^^^ - meta.sequence - meta.sequence - meta.brackets
 
 primes = 5  # type: ignore  # type: str  # technically ok but weird
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
@@ -3139,56 +3143,56 @@ dct = {}  # type: Dict[str, (int, float)] # illegal parens
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
-#                     ^ punctuation.section.sequence.begin.python
+#                     ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
+#                     ^ punctuation.section.brackets.begin.python
 #                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
-#                           ^ invalid.illegal.parens.begin.python
+#                           ^ - punctuation
 #                            ^^^ support.type.python
 #                               ^ punctuation.separator.sequence.python
 #                                 ^^^^^ support.type.python
-#                                      ^ invalid.illegal.parens.end.python
-#                                       ^ punctuation.section.sequence.end.python
+#                                      ^ - punctuation
+#                                       ^ punctuation.section.brackets.end.python
 
 dct = {}  # type: Dict[str, str | int]
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
-#                     ^ punctuation.section.sequence.begin.python
+#                     ^^^^^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python
+#                     ^ punctuation.section.brackets.begin.python
 #                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^^^ support.type.python
 #                               ^ punctuation.separator.type.union.python
 #                                 ^^^ support.type.python
-#                                    ^ punctuation.section.sequence.end.python
+#                                    ^ punctuation.section.brackets.end.python
 
 lst = []  # type: List[Dict[Any, ...]] # comment
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                     ^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python - meta.sequence meta.sequence
-#                          ^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python meta.sequence.list.members.python
-#                                    ^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python - meta.sequence meta.sequence
+#                     ^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.sequence meta.sequence
+#                          ^^^^^^^^^^ comment.line.number-sign.python meta.type.python meta.brackets.python meta.brackets.python
+#                                    ^ comment.line.number-sign.python meta.type.python meta.brackets.python - meta.sequence meta.sequence
 #                                     ^^^^^^^^^^^ comment.line.number-sign.python - meta.type
 #         ^ punctuation.definition.comment.python
 #           ^^^^ keyword.other.type.python
 #               ^ punctuation.separator.type.python
 #                 ^^^^ support.class.typing.python
-#                     ^ punctuation.section.sequence.begin
+#                     ^ punctuation.section.brackets.begin
 #                      ^^^^ support.class.typing.python
-#                          ^ punctuation.section.sequence.begin.python
+#                          ^ punctuation.section.brackets.begin.python
 #                           ^^^ support.class.typing.python
 #                              ^ punctuation.separator.sequence.python
 #                                ^^^ constant.language.python
-#                                   ^^ punctuation.section.sequence.end.python
+#                                   ^^ punctuation.section.brackets.end.python
 
 # incomplete list
 lst = []  # type: List[ # type: ignore
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                     ^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python punctuation.section.sequence.begin.python
+#                     ^ comment.line.number-sign.python meta.type.python meta.brackets.python punctuation.section.brackets.begin.python
 #                      ^^^ comment.line.number-sign.python - meta.type
 #                         ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
 
@@ -3198,7 +3202,7 @@ lst = []  # type: List[( # type: ignore
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.type meta.type
 #         ^^ comment.line.number-sign.python - meta.type
 #           ^^^^^^^^^^ comment.line.number-sign.python meta.type.python - meta.sequence
-#                     ^^ comment.line.number-sign.python meta.type.python meta.sequence.list.members.python
+#                     ^^ comment.line.number-sign.python meta.type.python meta.brackets.python
 #                       ^^^ comment.line.number-sign.python - meta.type
 #                          ^^^^^^^^^^^^ comment.line.number-sign.python meta.type.python
 
@@ -3241,21 +3245,21 @@ def function(a, b, *c, **d):
 #                 ^^^ support.type.python
 #                    ^ punctuation.separator.sequence.python
 #                      ^^^^ support.class.typing.python
-#                          ^^^^^ meta.sequence.list.members.python
-#                          ^ punctuation.section.sequence.begin.python
+#                          ^^^^^ meta.brackets.python
+#                          ^ punctuation.section.brackets.begin.python
 #                           ^^^ support.type.python
-#                              ^ punctuation.section.sequence.end.python
+#                              ^ punctuation.section.brackets.end.python
 #                               ^ punctuation.separator.sequence.python
 #                                 ^^^^ support.type.python
 #                                     ^ punctuation.section.parameters.end.python
 #                                       ^^ punctuation.separator.return-type.python
 #                                          ^^^^ support.class.typing.python
-#                                              ^^^^^^^^^^ meta.sequence.list.members.python
-#                                              ^ punctuation.section.sequence.begin.python
+#                                              ^^^^^^^^^^ meta.brackets.python
+#                                              ^ punctuation.section.brackets.begin.python
 #                                               ^^^ support.type.python
 #                                                  ^ punctuation.separator.sequence.python
 #                                                    ^^^ support.type.python
-#                                                       ^ punctuation.section.sequence.end.python
+#                                                       ^ punctuation.section.brackets.end.python
 
 class TypeCommentTest:
     member = []  # type: List[dict]
@@ -3264,10 +3268,10 @@ class TypeCommentTest:
 #                  ^^^^ keyword.other.type.python
 #                      ^ punctuation.separator.type.python
 #                        ^^^^ support.class.typing.python
-#                            ^^^^^^ meta.sequence.list.members.python
-#                            ^ punctuation.section.sequence.begin.python
+#                            ^^^^^^ meta.brackets.python
+#                            ^ punctuation.section.brackets.begin.python
 #                             ^^^^ support.type.python
-#                                 ^ punctuation.section.sequence.end.python
+#                                 ^ punctuation.section.brackets.end.python
 
 
 ##################

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1720,7 +1720,7 @@ def type_annotations(param1: int, param2: MyType | None , param3: max(2, 3), par
 #                                       ^ punctuation.separator.annotation
 #                                         ^^^^^^^^^^^^^ meta.type.python
 #                                         ^^^^^^ meta.path.python meta.generic-name.python
-#                                                ^ keyword.operator.logical.union.python
+#                                                ^ keyword.operator.arithmetic.python
 #                                                  ^^^^ constant.language.null.python
 #                                                       ^ punctuation.separator.parameters
 #                                                         ^^^^^^ variable.parameter
@@ -1821,7 +1821,7 @@ def type_annotation_with_defaults(foo: str | None = None)
 #                                                ^ meta.function.parameters.annotation.python - meta.function.parameters.default-value - meta.type
 #                                                 ^^^^^^ meta.function.parameters.default-value.python - meta.function.parameters.annotation
 #                                      ^^^ support.type.python
-#                                          ^ keyword.operator.logical.union.python
+#                                          ^ keyword.operator.arithmetic.python
 #                                            ^^^^ constant.language.null.python
 #                                                 ^ keyword.operator.assignment.python
 #                                                   ^^^^ constant.language.null.python
@@ -2991,7 +2991,7 @@ foo: str | None = None
 #              ^^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
 #    ^^^ support.type.python
-#        ^ keyword.operator.logical.union.python
+#        ^ keyword.operator.arithmetic.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^^ constant.language.null.python
@@ -3002,10 +3002,35 @@ bar: str | None = 'b'
 #              ^^^^^^^ - meta.type
 #  ^ punctuation.separator.annotation.python
 #    ^^^ support.type.python
-#        ^ keyword.operator.logical.union.python
+#        ^ keyword.operator.arithmetic.python
 #          ^^^^ constant.language.null.python
 #               ^ keyword.operator.assignment.python
 #                 ^^^ string.quoted.single.python
+
+bar: (str | None) = 'b'
+#  ^^ - meta.type
+#    ^^^^^^^^^^^^ meta.type.python meta.group.python
+#                ^^^^^^^ - meta.type
+#  ^ punctuation.separator.annotation.python
+#     ^^^ support.type.python
+#         ^ keyword.operator.arithmetic.python
+#           ^^^^ constant.language.null.python
+#                 ^ keyword.operator.assignment.python
+#                   ^^^ string.quoted.single.python
+
+bar: list[str | None] = 'b'
+#  ^^ - meta.type
+#    ^^^^ meta.type.python meta.path.python support.type.python
+#        ^^^^^^^^^^^^ meta.type.python meta.brackets.python
+#                    ^^^^^^^ - meta.type
+#  ^ punctuation.separator.annotation.python
+#        ^ punctuation.section.brackets.begin.python
+#         ^^^ support.type.python
+#             ^ keyword.operator.arithmetic.python
+#               ^^^^ constant.language.null.python
+#                   ^ punctuation.section.brackets.end.python
+#                     ^ keyword.operator.assignment.python
+#                       ^^^ string.quoted.single.python
 
 foo: int := 0
 #  ^ punctuation.separator.annotation.python
@@ -3172,7 +3197,7 @@ dct = {}  # type: Dict[str, str | int]
 #                      ^^^ support.type.python
 #                         ^ punctuation.separator.sequence.python
 #                           ^^^ support.type.python
-#                               ^ keyword.operator.logical.union.python
+#                               ^ keyword.operator.arithmetic.python
 #                                 ^^^ support.type.python
 #                                    ^ punctuation.section.brackets.end.python
 

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -199,7 +199,10 @@ query = \
                 select 1)
             ELSE NULL
         ) as result
-    """
+    """ + test
+#   ^^^ meta.string.python string.quoted.double.block.python punctuation.definition.string.end.python
+#       ^ keyword.operator.arithmetic.python
+#         ^^^^ meta.path.python meta.generic-name.python
 
 query = \
     r"""


### PR DESCRIPTION
Supersedes #1925

This PR proposes to add dedicated contexts for type hints.

It provides highlighting for type comments including feedback from #1925.

Existing type annotations are refactored to ~~make use of `type-expressions` and~~ follow a common scope naming scheme for type hints. It is inspired by PHP, TS and TSX, which use `meta.type` to scope type hint expressions.

Known type classes from typing module are scoped as `support.class.typing`.

