### PR TITLE
[Markdown] Fix html tag higlighting in ATX headings

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -868,6 +868,7 @@ contexts:
     - include: images
     - include: literals
     - include: links
+    - include: markups
 
 ###[ LEAF BLOCKS: SETEXT HEADINGS OR PARAGRAPH ]##############################
 

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -1052,6 +1052,11 @@ this must not be bold italic***
 |      ^^^ - entity.name.section
 |       ^^ punctuation.definition.heading.end.markdown
 
+# Headding <u>with</u> tag
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown
+|          ^^^ meta.tag
+|                 ^^^^ meta.tag
 
 # TEST: SETEXT HEADINGS #######################################################
 


### PR DESCRIPTION
This commit adds a missing include to `atx-heading-content`, which caused html tags from not being highlighted.