### PR TITLE
[JavaScript] More precise component tag scope

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -175,7 +175,7 @@ contexts:
 
   jsx-tag-name-component:
     - match: '{{jsx_identifier}}'
-      scope: entity.name.tag.js
+      scope: entity.name.tag.component.js
       pop: 1
     - include: else-pop
 

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -99,15 +99,19 @@
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
 //  ^^^^^^^^^^^^^ meta.tag
 //   ^^^^^^^^^^^ meta.tag.name - entity.name.tag.native
+//   ^^^ entity.name.tag.component
 //      ^ punctuation.accessor
+//       ^^^ entity.name.tag.component
 //          ^ punctuation.accessor
-//           ^^^ entity.name.tag
+//           ^^^ entity.name.tag.component
 //               ^^^^^^ - meta.tag
 //                     ^^^^^^^^^^^^^^ meta.tag
 //                       ^^^^^^^^^^^ meta.tag.name - entity.name.tag.native
+//                       ^^^ entity.name.tag.component
 //                          ^ punctuation.accessor
+//                           ^^^ entity.name.tag.component
 //                              ^ punctuation.accessor
-//                               ^^^ entity.name.tag
+//                               ^^^ entity.name.tag.component
 
     <foo>Hello!<bar/>World!</foo>;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx


### PR DESCRIPTION
This commit scopes JSX component tags `entity.name.tag.component` as counterpart for `entity.name.tag.native`. 

It may help color schemes to target component tags more easily.