### PR TITLE
[JavaScript] Fix JSX attribute meta scopes

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -102,14 +102,14 @@ contexts:
     - include: immediately-pop
 
   jsx-tag-attributes:
-    - meta_scope: meta.tag.attributes.js
+    - meta_content_scope: meta.tag.attributes.js
 
     - match: '>'
-      scope: punctuation.definition.tag.end.js
+      scope: meta.tag.js punctuation.definition.tag.end.js
       set: jsx-body
 
     - match: '/'
-      scope: punctuation.definition.tag.end.js
+      scope: meta.tag.js punctuation.definition.tag.end.js
       set: jsx-expect-tag-end
 
     - include: jsx-interpolation

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -78,12 +78,35 @@
 //^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
 
     <foo />;
-//  ^ meta.jsx.js meta.tag.js
-//   ^^^^ meta.jsx.js meta.tag.name.js
-//       ^^ meta.jsx.js meta.tag.js
-//  ^ punctuation.definition.tag.begin.js
-//   ^^^ entity.name.tag.native.js
-//       ^^ punctuation.definition.tag.end.js
+//  ^ meta.jsx meta.tag
+//   ^^^^ meta.jsx meta.tag.name
+//       ^^ meta.jsx meta.tag - meta.tag.attributes
+//  ^ punctuation.definition.tag.begin
+//   ^^^ entity.name.tag.native
+//       ^^ punctuation.definition.tag.end
+
+    <foo attr= />;
+//  ^ meta.jsx meta.tag
+//   ^^^^ meta.jsx meta.tag.name
+//       ^^^^^^ meta.jsx meta.tag.attributes
+//             ^^ meta.jsx meta.tag - meta.tag.attributes
+//  ^ punctuation.definition.tag.begin
+//   ^^^ entity.name.tag.native
+//       ^^^^ entity.other.attribute-name
+//           ^ punctuation.separator.key-value
+//             ^^ punctuation.definition.tag.end
+
+    <foo attr="val" />;
+//  ^ meta.jsx meta.tag
+//   ^^^^ meta.jsx meta.tag.name
+//       ^^^^^^^^^^^ meta.jsx meta.tag.attributes
+//                  ^^ meta.jsx meta.tag - meta.tag.attributes
+//  ^ punctuation.definition.tag.begin
+//   ^^^ entity.name.tag.native
+//       ^^^^ entity.other.attribute-name
+//           ^ punctuation.separator.key-value
+//            ^^^^^ string.quoted.double
+//                  ^^ punctuation.definition.tag.end
 
     <foo>Hello!</foo>;
 //  ^^^^^^^^^^^^^^^^^ meta.jsx

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -78,10 +78,12 @@
 //^^^^^^^^^^^^^^^^^^^^ comment.line.other.js - meta.preprocessor
 
     <foo />;
-//  ^^^^^^^ meta.jsx meta.tag
-//  ^ punctuation.definition.tag.begin
-//   ^^^ meta.tag.name entity.name.tag.native
-//       ^^ punctuation.definition.tag.end
+//  ^ meta.jsx.js meta.tag.js
+//   ^^^^ meta.jsx.js meta.tag.name.js
+//       ^^ meta.jsx.js meta.tag.js
+//  ^ punctuation.definition.tag.begin.js
+//   ^^^ entity.name.tag.native.js
+//       ^^ punctuation.definition.tag.end.js
 
     <foo>Hello!</foo>;
 //  ^^^^^^^^^^^^^^^^^ meta.jsx
@@ -283,4 +285,4 @@
 </foo>;
 
     <Class />;
-//   ^^^^^ entity.name.tag - entity.name.tag.native
+//   ^^^^^ entity.name.tag.component - entity.name.tag.native

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -238,12 +238,13 @@ if (a < b || c <= d) {}
 //    ^ punctuation.definition.generic.begin
 //     ^ support.class
 //      ^ punctuation.definition.generic.end
-//        ^^^^^^^^^ meta.tag.attributes
+//        ^^^^^^^^ meta.tag.attributes
 //        ^ entity.other.attribute-name
 //         ^ punctuation.separator.key-value
 //          ^^^^^ string.quoted.double
 //          ^ punctuation.definition.string.begin
 //              ^ punctuation.definition.string.end
+//                ^^ - meta.tag.attributes
 //                ^ punctuation.definition.tag.end
 //                 ^ meta.tag punctuation.definition.tag.end
 //                  ^ punctuation.terminator.statement


### PR DESCRIPTION
This commit fixes an issue which caused `/` in self-closing tags being scoped `meta.tag.attributes`.