### PR TITLE
[Markdown] Add language separator for fenced code blocks

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -141,7 +141,7 @@ variables:
     (?x:             # first word of an infostring is used as language specifier
       (
         [[:alpha:]]  # starts with a letter to make sure not to hit any attribute annotation
-        [^`\s]*      # optionally followed by any nonwhitespace character (except backticks)
+        [^\s:;`]*    # optionally followed by any nonwhitespace character (except backticks)
       )
     )
   fenced_code_block_trailing_infostring_characters: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -149,7 +149,7 @@ variables:
       (
         \s*          # any whitespace, or ..
       |
-        \s[^`]*      # any characters (except backticks), separated by whitespace ...
+        [\s:][^`]*   # any characters (except backticks), separated by whitespace or colon ...
       )
       $\n?           # ... until EOL
     )

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -149,7 +149,7 @@ variables:
       (
         \s*          # any whitespace, or ..
       |
-        [\s:][^`]*   # any characters (except backticks), separated by whitespace or colon ...
+        [\s:;][^`]*  # any characters (except backticks), separated by colon, semicolon or whitespace ...
       )
       $\n?           # ... until EOL
     )

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -2032,8 +2032,17 @@ declare type foo = 'bar'
 |^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.jsx.markdown-gfm
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name.markdown
+|     ^ - constant
 
 | <- markup.raw.code-fence.jsx.markdown-gfm source.jsx
+```
+
+```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|^^ punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^^^^^^ constant.other.language-name.markdown
+|           ^ - constant
 ```
 
 ```R%&?! weired language name

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -2028,6 +2028,14 @@ declare type foo = 'bar'
 | <- meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
+```jsx:file.jsx
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.jsx.markdown-gfm
+|^^ punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^ constant.other.language-name.markdown
+
+| <- markup.raw.code-fence.jsx.markdown-gfm source.jsx
+```
+
 ```R%&?! weired language name
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
 |  ^^^^^ constant.other.language-name.markdown


### PR DESCRIPTION
This commit adds `:` as valid language name terminator.

The following code block

~~~md
```jsx:file.jsx
import Router from 'next/router'

function MyComponent() {
	const [show, setShow] = useState(false)

	useEffect(() => {
    console.log(2)
	}, [])

	return <>...</>
}
~~~

renders as:

```jsx:file.jsx
import Router from 'next/router'

function MyComponent() {
	const [show, setShow] = useState(false)

	useEffect(() => {
    console.log(2)
	}, [])

	return <>...</>
}
```

see: https://github.com/withastro/astro/blob/main/examples/with-markdown-plugins/src/pages/index.md

Note: CommonMark writes the "first word" is used as language identifier, so there may be more valid separator chars.