### PR TITLE
[Java] Rename class scopes

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -1966,7 +1966,7 @@ contexts:
 
   receiver-unqualified-type:
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - receiver-unqualified-type-end
         - maybe-array-modifiers
@@ -1984,7 +1984,7 @@ contexts:
   receiver-qualified-type:
     - meta_scope: meta.path.java
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - receiver-qualified-type-end
         - qualified-object-type-arguments
@@ -2034,7 +2034,7 @@ contexts:
   receiver-qualified-identifier-path:
     - meta_scope: meta.path.java
     - match: '{{id}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - receiver-qualified-identifier-accessor
         - maybe-type-argument
@@ -2224,7 +2224,7 @@ contexts:
       scope: punctuation.accessor.dot.java
       set:
         - match: '{{classcase_id}}'
-          scope: storage.type.class.java
+          scope: support.class.java
           set:
             - variable-namespace-meta
             - maybe-object-type-child
@@ -2598,7 +2598,7 @@ contexts:
 
   qualified-constant-class:
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       set:
         - qualified-constant-class-accessor
         - maybe-type-argument
@@ -2652,7 +2652,7 @@ contexts:
 
   static-import-class:
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       set:
         - static-import-class-accessor
         - maybe-type-argument
@@ -2710,7 +2710,7 @@ contexts:
 
   type-import-class:
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       set:
         - type-import-class-accessor
         - maybe-type-argument
@@ -2884,7 +2884,7 @@ contexts:
   object-types:
     # Popular JDK classes, generic type variable
     - match: (?:UUID|UR[LI]|\p{Lu}){{break}}
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - maybe-object-type-child
         - maybe-array-modifiers
@@ -2894,7 +2894,7 @@ contexts:
       scope: constant.other.java
     # Classes
     - match: '{{classcase_id}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - maybe-object-type-child
         - maybe-array-modifiers
@@ -2912,7 +2912,7 @@ contexts:
       scope: constant.other.java
       pop: 1
     - match: '{{classcase_id}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       set:
         - maybe-object-type-child
         - maybe-array-modifiers
@@ -2941,7 +2941,7 @@ contexts:
 
   unqualified-object-type:
     - match: '{{id}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - unqualiefied-object-type-end
         - maybe-type-argument
@@ -2975,7 +2975,7 @@ contexts:
 
   qualified-object-type-class:
     - match: '{{identifier}}'
-      scope: storage.type.class.java
+      scope: support.class.java
       push:
         - qualified-object-type-end
         - qualified-object-type-arguments

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -671,7 +671,7 @@ import a.b.Class.*;
 //      ^ punctuation.accessor.dot.java - entity - variable
 //       ^ variable.namespace.java
 //        ^ punctuation.accessor.dot.java - entity - variable
-//         ^^^^^ storage.type.class.java
+//         ^^^^^ support.class.java
 //              ^ punctuation.accessor.dot.java - entity - variable
 //               ^ variable.language.wildcard.asterisk.java
 
@@ -682,7 +682,7 @@ import a.b.Class.SubClass;
 //      ^ punctuation.accessor.dot.java - entity - variable
 //       ^ variable.namespace.java
 //        ^ punctuation.accessor.dot.java - entity - variable
-//         ^^^^^ storage.type.class.java
+//         ^^^^^ support.class.java
 //              ^ punctuation.accessor.dot.java - entity
 //               ^^^^^^^^ entity.name.class.java
 
@@ -701,7 +701,7 @@ import
     .Class
 //^^^^^^^^^^^ meta.import.java meta.path.java
 //  ^ punctuation.accessor.dot.java - entity - variable
-//   ^^^^^ storage.type.class.java
+//   ^^^^^ support.class.java
     .
 //^^^^ meta.import.java meta.path.java
 //  ^ punctuation.accessor.dot.java - entity
@@ -732,7 +732,7 @@ import static a.b.Class.fooMethod;
 //             ^ punctuation.accessor.dot.java
 //              ^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
-//                ^^^^^ storage.type.class.java
+//                ^^^^^ support.class.java
 //                     ^ punctuation.accessor.dot.java
 //                      ^^^^^^^^^ entity.name.import.java
 //                               ^ punctuation.terminator.java
@@ -746,7 +746,7 @@ import static a.b.Class.CONSTANT ;
 //             ^ punctuation.accessor.dot.java
 //              ^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
-//                ^^^^^ storage.type.class.java
+//                ^^^^^ support.class.java
 //                     ^ punctuation.accessor.dot.java
 //                      ^^^^^^^^ entity.name.constant.java
 //                               ^ punctuation.terminator.java
@@ -767,7 +767,7 @@ import static /**/ a /**/ . /**/ b /**/ . /**/ Class /**/ . /**/ CONSTANT;
 //                                 ^^^^ comment.block.empty.java
 //                                      ^ punctuation.accessor.dot.java
 //                                        ^^^^ comment.block.empty.java
-//                                             ^^^^^ storage.type.class.java
+//                                             ^^^^^ support.class.java
 //                                                  ^^^^^^^^^^^^^ - entity - variable
 //                                                   ^^^^ comment.block.empty.java
 //                                                        ^ punctuation.accessor.dot.java
@@ -801,7 +801,7 @@ import
     /**/ Class
 //^^^^^^^^^^^^ meta.import.java meta.path.java
 //  ^^^^ comment.block.empty.java
-//       ^^^^^ storage.type.class.java
+//       ^^^^^ support.class.java
     /**/ .
 //^^^^^^^^^^^^ meta.import.java meta.path.java
 //  ^^^^ comment.block.empty.java
@@ -824,7 +824,7 @@ import static a.b.Class.*;
 //             ^ punctuation.accessor.dot.java
 //              ^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
-//                ^^^^^ storage.type.class.java
+//                ^^^^^ support.class.java
 //                     ^ punctuation.accessor.dot.java
 //                      ^ variable.language.wildcard.asterisk.java
 
@@ -834,7 +834,7 @@ import static C.d.ced
 //                   ^ - meta.import - meta.path
 //^^^^ keyword.declaration.import.java
 //     ^^^^^^ storage.modifier.java
-//            ^ storage.type.class.java
+//            ^ support.class.java
 //             ^ punctuation.accessor.dot.java
 //              ^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
@@ -1039,7 +1039,7 @@ class GenericTest<A extends Foo
 //               ^ punctuation.definition.generic.begin.java
 //                ^ variable.parameter.type.java
 //                  ^^^^^^^ storage.modifier.extends.java
-//                          ^^^ storage.type.class.java
+//                          ^^^ support.class.java
 
 class GenericTest<integer extends Foo>
 //<- meta.class.java keyword.declaration.class.java
@@ -1049,7 +1049,7 @@ class GenericTest<integer extends Foo>
 //               ^ punctuation.definition.generic.begin.java
 //                ^^^^^^^ variable.parameter.type.java
 //                        ^^^^^^^ storage.modifier.extends.java
-//                                ^^^ storage.type.class.java
+//                                ^^^ support.class.java
 //                                   ^ punctuation.definition.generic.end.java
 
 class generictest<integer extends foo>
@@ -1060,7 +1060,7 @@ class generictest<integer extends foo>
 //               ^ punctuation.definition.generic.begin.java
 //                ^^^^^^^ variable.parameter.type.java
 //                        ^^^^^^^ storage.modifier.extends.java
-//                                ^^^ storage.type.class.java
+//                                ^^^ support.class.java
 //                                   ^ punctuation.definition.generic.end.java
 
 class GenericTest<int extends Foo>
@@ -1071,7 +1071,7 @@ class GenericTest<int extends Foo>
 //               ^ punctuation.definition.generic.begin.java
 //                ^^^ invalid.illegal.unexpected-keyword.java
 //                    ^^^^^^^ storage.modifier.extends.java
-//                            ^^^ storage.type.class.java
+//                            ^^^ support.class.java
 //                               ^ punctuation.definition.generic.end.java
 
 class GenericTest<? extends Foo>
@@ -1082,7 +1082,7 @@ class GenericTest<? extends Foo>
 //               ^ punctuation.definition.generic.begin.java
 //                ^ invalid.illegal.unexpected-keyword.java
 //                  ^^^^^^^ storage.modifier.extends.java
-//                          ^^^ storage.type.class.java
+//                          ^^^ support.class.java
 //                             ^ punctuation.definition.generic.end.java
 
 class GenericTest<? extends int>
@@ -1104,7 +1104,7 @@ class GenericTest<A super Foo>
 //               ^ punctuation.definition.generic.begin.java
 //                ^ variable.parameter.type.java
 //                  ^^^^^ invalid.illegal.unexpected-keyword.java
-//                        ^^^ storage.type.class.java
+//                        ^^^ support.class.java
 //                           ^ punctuation.definition.generic.end.java
 
 class GenericTest<super Foo>
@@ -1114,7 +1114,7 @@ class GenericTest<super Foo>
 //               ^^^^^^^^^^^ meta.class.identifier.java meta.generic.declaration.java
 //               ^ punctuation.definition.generic.begin.java
 //                ^^^^^ invalid.illegal.unexpected-keyword.java
-//                      ^^^ storage.type.class.java
+//                      ^^^ support.class.java
 //                         ^ punctuation.definition.generic.end.java
 
 class GenericTest<@Anno A extends @Anno com . @Anno Foo<A, @Anno com . @Anno Bar> & @Anno Foo<? super Baz> . @Anno Bar<A extends Foo>>
@@ -1139,9 +1139,9 @@ class GenericTest<@Anno A extends @Anno com . @Anno Foo<A, @Anno com . @Anno Bar
 //                                 ^^^^ variable.annotation.java
 //                                      ^^^ variable.namespace.java
 //                                          ^ punctuation.accessor.dot.java
-//                                                  ^^^ storage.type.class.java
+//                                                  ^^^ support.class.java
 //                                                     ^ punctuation.definition.generic.begin.java
-//                                                      ^ storage.type.class.java
+//                                                      ^ support.class.java
 //                                                       ^ punctuation.separator.comma.java
 //                                                         ^ punctuation.definition.annotation.java
 //                                                          ^^^^ variable.annotation.java
@@ -1149,25 +1149,25 @@ class GenericTest<@Anno A extends @Anno com . @Anno Foo<A, @Anno com . @Anno Bar
 //                                                                   ^ punctuation.accessor.dot.java
 //                                                                     ^ punctuation.definition.annotation.java
 //                                                                      ^^^^ variable.annotation.java
-//                                                                           ^^^ storage.type.class.java
+//                                                                           ^^^ support.class.java
 //                                                                              ^ punctuation.definition.generic.end.java
 //                                                                                ^ keyword.operator.logical.java
 //                                                                                  ^ punctuation.definition.annotation.java
 //                                                                                   ^^^^ variable.annotation.java
-//                                                                                        ^^^ storage.type.class.java
+//                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
 //                                                                                            ^ variable.language.wildcard.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
-//                                                                                                    ^^^ storage.type.class.java
+//                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
 //                                                                                                         ^ punctuation.accessor.dot.java
 //                                                                                                           ^ punctuation.definition.annotation.java
 //                                                                                                            ^^^^ variable.annotation.java
-//                                                                                                                 ^^^ storage.type.class.java
+//                                                                                                                 ^^^ support.class.java
 //                                                                                                                    ^ punctuation.definition.generic.begin.java
-//                                                                                                                     ^ storage.type.class.java
+//                                                                                                                     ^ support.class.java
 //                                                                                                                       ^^^^^^^ invalid.illegal.unexpected-keyword.java
-//                                                                                                                               ^^^ storage.type.class.java
+//                                                                                                                               ^^^ support.class.java
 //                                                                                                                                  ^^ punctuation.definition.generic.end.java
 
 class generictest<@anno a extends @anno com . @anno foo<a, @anno com . @anno bar> & @anno foo<? super baz> . @anno bar<a extends foo>>
@@ -1192,9 +1192,9 @@ class generictest<@anno a extends @anno com . @anno foo<a, @anno com . @anno bar
 //                                 ^^^^ variable.annotation.java
 //                                      ^^^ variable.namespace.java
 //                                          ^ punctuation.accessor.dot.java
-//                                                  ^^^ storage.type.class.java
+//                                                  ^^^ support.class.java
 //                                                     ^ punctuation.definition.generic.begin.java
-//                                                      ^ storage.type.class.java
+//                                                      ^ support.class.java
 //                                                       ^ punctuation.separator.comma.java
 //                                                         ^ punctuation.definition.annotation.java
 //                                                          ^^^^ variable.annotation.java
@@ -1202,25 +1202,25 @@ class generictest<@anno a extends @anno com . @anno foo<a, @anno com . @anno bar
 //                                                                   ^ punctuation.accessor.dot.java
 //                                                                     ^ punctuation.definition.annotation.java
 //                                                                      ^^^^ variable.annotation.java
-//                                                                           ^^^ storage.type.class.java
+//                                                                           ^^^ support.class.java
 //                                                                              ^ punctuation.definition.generic.end.java
 //                                                                                ^ keyword.operator.logical.java
 //                                                                                  ^ punctuation.definition.annotation.java
 //                                                                                   ^^^^ variable.annotation.java
-//                                                                                        ^^^ storage.type.class.java
+//                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
 //                                                                                            ^ variable.language.wildcard.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
-//                                                                                                    ^^^ storage.type.class.java
+//                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
 //                                                                                                         ^ punctuation.accessor.dot.java
 //                                                                                                           ^ punctuation.definition.annotation.java
 //                                                                                                            ^^^^ variable.annotation.java
-//                                                                                                                 ^^^ storage.type.class.java
+//                                                                                                                 ^^^ support.class.java
 //                                                                                                                    ^ punctuation.definition.generic.begin.java
-//                                                                                                                     ^ storage.type.class.java
+//                                                                                                                     ^ support.class.java
 //                                                                                                                       ^^^^^^^ invalid.illegal.unexpected-keyword.java
-//                                                                                                                               ^^^ storage.type.class.java
+//                                                                                                                               ^^^ support.class.java
 //                                                                                                                                  ^^ punctuation.definition.generic.end.java
 
 class GenericTest<A> extends Foo<? extends A> {}
@@ -1246,7 +1246,7 @@ class GenericTest<A> extends Foo<? extends A> {}
 //                              ^ punctuation.definition.generic.begin.java
 //                               ^ variable.language.wildcard.java
 //                                 ^^^^^^^ storage.modifier.extends.java
-//                                         ^ storage.type.class.java
+//                                         ^ support.class.java
 //                                          ^ punctuation.definition.generic.end.java
 //                                           ^ - entity - keyword - storage
 //                                            ^ punctuation.section.block.begin.java
@@ -1285,15 +1285,15 @@ class GenericTest<A> extends @Anno com . @Anno Foo<@Anno ? extends @Anno SuperCl
 //                                                         ^^^^^^^ storage.modifier.extends.java
 //                                                                 ^ punctuation.definition.annotation.java
 //                                                                  ^^^^ variable.annotation.java
-//                                                                       ^^^^^^^^^^ storage.type.class.java
+//                                                                       ^^^^^^^^^^ support.class.java
 //                                                                                  ^ punctuation.accessor.dot.java
 //                                                                                    ^ punctuation.definition.annotation.java
 //                                                                                     ^^^^ variable.annotation.java
-//                                                                                          ^^^^^^^^ storage.type.class.java
+//                                                                                          ^^^^^^^^ support.class.java
 //                                                                                                   ^ keyword.operator.logical.java
 //                                                                                                     ^ punctuation.definition.annotation.java
 //                                                                                                      ^^^^ variable.annotation.java
-//                                                                                                           ^^^^^^^^^^ storage.type.class.java
+//                                                                                                           ^^^^^^^^^^ support.class.java
 //                                                                                                                     ^ punctuation.definition.generic.end.java
 //                                                                                                                      ^ punctuation.separator.comma.java
 //                                                                                                                       ^ - entity - keyword - storage - variable
@@ -1349,7 +1349,7 @@ class lowercasetest<t> implements fully.qualified.other<t> {
 //                                                ^^^^^ entity.other.inherited-class.java
 //                                                     ^^^ meta.generic.java
 //                                                     ^ punctuation.definition.generic.begin.java
-//                                                      ^ storage.type.class.java
+//                                                      ^ support.class.java
 //                                                       ^ punctuation.definition.generic.end.java
 }
 // <- punctuation.section.block.end.java
@@ -1511,7 +1511,7 @@ class AnyClass { // comment
 
       void classReferences() {
         Foo.class; // comment
-//      ^^^ storage.type.class.java
+//      ^^^ support.class.java
 //         ^ punctuation.accessor.dot.java
 //          ^^^^^ variable.language.class.java - storage.type.java
 //               ^ punctuation.terminator.java
@@ -1809,10 +1809,10 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //                                             ^^^^^^^^^^ meta.generic.java - meta.generic meta.generic
 //                                              ^ variable.language.wildcard.java
 //                                                ^^^^^ keyword.declaration.super.java
-//                                                      ^ storage.type.class.java
+//                                                      ^ support.class.java
 //                                                       ^ punctuation.definition.generic.begin.java
 //                                                       ^^^^ meta.generic.java meta.generic.java
-//                                                        ^^ storage.type.class.java
+//                                                        ^^ support.class.java
 //                                                          ^ punctuation.definition.generic.end.java
 //                                                           ^ meta.generic.java punctuation.definition.generic.end.java - meta.generic meta.generic
 //                                                             ^^^^^^^^^^ storage.modifier.implements.java
@@ -1958,7 +1958,7 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //  ^^^^^^ storage.modifier.java
 
     String image = "";
-//  ^^^^^^ storage.type.class.java
+//  ^^^^^^ support.class.java
 //         ^^^^^ variable.other.member.java
 //               ^ keyword.operator.assignment.java
 //                 ^^ string.quoted.double.java
@@ -1971,7 +1971,7 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //                     ^^^ meta.function.java - meta.function meta.function
 //  ^^^^^^^^^ entity.name.function.constructor.java
 //           ^ punctuation.section.group.begin.java
-//            ^^^^^^ storage.type.class.java
+//            ^^^^^^ support.class.java
 //                   ^ variable.parameter.java
 //                    ^ punctuation.section.group.end.java
 //                      ^ punctuation.section.block.begin.java
@@ -1999,7 +1999,7 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //                ^^^^ storage.type.void.java
 //                     ^^^^ entity.name.function.java
 //                         ^ punctuation.section.group.begin.java
-//                          ^^^^^^ storage.type.class.java
+//                          ^^^^^^ support.class.java
 //                                ^^ storage.modifier.array.java
 //                                  ^ variable.parameter.java
 //                                   ^ punctuation.section.group.end.java
@@ -2331,7 +2331,7 @@ Bar             // comment
 //                   ^ punctuation.section.group.begin.java
 //                    ^ punctuation.section.group.end.java
 //                      ^^^^^^^ storage.modifier.default.java
-//                              ^^^^^^ storage.type.class.java
+//                              ^^^^^^ support.class.java
 //                                    ^ punctuation.accessor.dot.java
 //                                     ^^^^^ variable.language.class.java - storage.type.java
 
@@ -2456,7 +2456,7 @@ record RecordTest<T>(int x, @notnull foo bar) implements Foo, Bar { }
 //                        ^ punctuation.separator.comma.java
 //                          ^ punctuation.definition.annotation.java
 //                           ^^^^^^^ variable.annotation.java
-//                                   ^^^ storage.type.class.java
+//                                   ^^^ support.class.java
 //                                       ^^^ variable.parameter.java
 //                                          ^ punctuation.section.group.end.java
 //                                            ^^^^^^^^^^ storage.modifier.implements.java
@@ -2704,13 +2704,13 @@ class FieldDeclarationTests {
 //^^^^^^^^ meta.field.modifier.java
 //        ^^^^^^^ meta.field.type.java
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 
   private string
 //^^^^^^^^ meta.field.modifier.java
 //        ^^^^^^^ meta.field.type.java
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 
   private String memberString1 = "Hello";
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.field meta.field
@@ -2721,7 +2721,7 @@ class FieldDeclarationTests {
 //                              ^^^^^^^^ meta.field.value.java
 //                                      ^ - meta.field
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 //               ^^^^^^^^^^^^^ variable.other.member.java
 //                             ^ keyword.operator.assignment.java
 //                               ^^^^^^^ string.quoted.double.java
@@ -2739,13 +2739,13 @@ class FieldDeclarationTests {
 //                                     ^^^^^^^^^^^^^^^^^^^ meta.field.value.java meta.instantiation.java - meta.annotation
 //                                                        ^ - meta.field
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 //               ^^^^^^^^^^^^^ variable.other.member.java
 //                             ^ keyword.operator.assignment.java
 //                               ^ punctuation.definition.annotation.java
 //                                ^^^^ variable.annotation.java
 //                                     ^^^ keyword.other.storage.new.java
-//                                         ^^^^^^ storage.type.class.java
+//                                         ^^^^^^ support.class.java
 //                                               ^ punctuation.section.group.begin.java
 //                                                ^^^^^^^ string.quoted.double.java
 //                                                       ^ punctuation.section.group.end.java
@@ -2762,10 +2762,10 @@ class FieldDeclarationTests {
 //                                             ^^^^^^^^^ meta.function-call.arguments.java meta.group.java
 //                                                      ^ - meta.field
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 //               ^^^^^^^^^^^^^ variable.other.member.java
 //                             ^ keyword.operator.assignment.java
-//                               ^^^^^^ storage.type.class.java
+//                               ^^^^^^ support.class.java
 //                                     ^ punctuation.accessor.dot.java
 //                                      ^^^^^^^ variable.function.java
 //                                             ^ punctuation.section.group.begin.java
@@ -2821,7 +2821,7 @@ class FieldDeclarationTests {
 //^^^^^^^ storage.modifier.java
 //        ^^^^^^ storage.modifier.java
 //               ^^^^^ storage.modifier.java
-//                     ^^^^^^ storage.type.class.java
+//                     ^^^^^^ support.class.java
 //                            ^^^^^^^^^^^^^^^^^^^^^^^ entity.name.constant.java
 //                                                    ^ keyword.operator.assignment.java
 //                                                      ^^^^^^^ string.quoted.double.java
@@ -2836,7 +2836,7 @@ class FieldDeclarationTests {
 //^^^^^^ meta.field.modifier.java
 //      ^^^^^^^^^ meta.field.type.java
 //^^^^^ storage.modifier.java
-//      ^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^ support.class.java
     MY_CONST = new MyObject(),
 //^^ meta.field.type.java
 //  ^^^^^^^^^ meta.field.identifier.java
@@ -2846,7 +2846,7 @@ class FieldDeclarationTests {
 //  ^^^^^^^^ entity.name.constant.java
 //           ^ keyword.operator.assignment.java
 //             ^^^ keyword.other.storage.new.java
-//                 ^^^^^^^^ storage.type.class.java
+//                 ^^^^^^^^ support.class.java
 //                         ^ punctuation.section.group.begin.java
 //                          ^ punctuation.section.group.end.java
 //                           ^ punctuation.separator.comma.java
@@ -2859,7 +2859,7 @@ class FieldDeclarationTests {
 //  ^^^^^^^^^^^^^^^^^ entity.name.constant
 //                    ^ keyword.operator.assignment.java
 //                      ^^^ keyword.other.storage.new.java
-//                          ^^^^^^^^ storage.type.class.java
+//                          ^^^^^^^^ support.class.java
 //                                  ^ punctuation.section.group.begin.java
 //                                   ^ punctuation.section.group.end.java
 //                                    ^ punctuation.terminator.java
@@ -2899,14 +2899,14 @@ class FieldDeclarationTests {
 //         ^ punctuation.accessor.dot.java
 //          ^ variable.namespace.java
 //           ^ punctuation.accessor.dot.java
-//            ^^^^^^^ storage.type.class.java
+//            ^^^^^^^ support.class.java
 //                    ^^^^^ variable.other.member.java
 //                          ^ keyword.operator.assignment.java
 //                            ^ variable.namespace.java
 //                             ^ punctuation.accessor.dot.java
 //                              ^ variable.namespace.java
 //                               ^ punctuation.accessor.dot.java
-//                                ^^^^^^^^^ storage.type.class.java
+//                                ^^^^^^^^^ support.class.java
 //                                         ^ punctuation.accessor.dot.java
 //                                          ^^^^^^^^^^^^^^^^^^^ constant.other.java
 //                                                             ^ punctuation.terminator.java
@@ -2932,7 +2932,7 @@ class FieldDeclarationTests {
 //                        ^^^^ comment.block.empty.java punctuation.definition.comment.java
 //                             ^ punctuation.accessor.dot.java
 //                               ^^^^ comment.block.empty.java punctuation.definition.comment.java
-//                                    ^^^^^^^ storage.type.class.java
+//                                    ^^^^^^^ support.class.java
 //                                            ^^^^ comment.block.empty.java punctuation.definition.comment.java
 //                                                 ^^^^^ variable.other.member.java
 //                                                       ^^^^ comment.block.empty.java punctuation.definition.comment.java
@@ -2942,29 +2942,29 @@ class FieldDeclarationTests {
 //                                                                    ^ punctuation.accessor.dot.java
 //                                                                     ^ variable.namespace.java
 //                                                                      ^ punctuation.accessor.dot.java
-//                                                                       ^^^^^^^^^ storage.type.class.java
+//                                                                       ^^^^^^^^^ support.class.java
 //                                                                                ^ punctuation.accessor.dot.java
 //                                                                                 ^^^^^^^^^^^^^^^^^^^ constant.other.java
 //                                                                                                    ^ punctuation.terminator.java
 
   private static final UUID SECURE_ID = UUID.randomUUID();
-//                     ^^^^ storage.type.class.java
+//                     ^^^^ support.class.java
 //                          ^^^^^^^^^ entity.name.constant
-//                                      ^^^^ storage.type.class.java
+//                                      ^^^^ support.class.java
 //                                           ^^^^^^^^^^ variable.function.java
 //                                                     ^ punctuation.section.group.begin.java
 //                                                      ^ punctuation.section.group.end.java
 //                                                       ^ punctuation.terminator.java
 
   private URI uri = new URI();
-//        ^^^ storage.type.class.java
+//        ^^^ support.class.java
 //            ^^^ variable.other.member.java
-//                      ^^^ storage.type.class.java
+//                      ^^^ support.class.java
 
   private URI URI2 = new URI();
-//        ^^^ storage.type.class.java
+//        ^^^ support.class.java
 //            ^^^^ entity.name.constant.java
-//                       ^^^ storage.type.class.java
+//                       ^^^ support.class.java
 
   byte[] byteArray;
 //^^^^^^^ meta.field.type.java
@@ -3060,7 +3060,7 @@ class FieldDeclarationTests {
 //^^^^^^^^^^^ meta.field.type.java
 //           ^^^^^^^^^^^^^^^^^ meta.field.identifier.java
 //                            ^ - meta.field
-//^^^^^^ storage.type.class.java
+//^^^^^^ support.class.java
 //      ^^^^ storage.modifier.array.java
 //           ^^^^^^^^^^^^^^^^^ variable.other.member.java
 //                            ^ punctuation.terminator.java
@@ -3080,7 +3080,7 @@ class FieldDeclarationTests {
 //                                                            ^^^^^ meta.annotation.identifier.java
 //                                                                 ^^^^^^^^^ - meta.annotation
 //         ^^^^^ storage.modifier.java
-//               ^^^^^^ storage.type.class.java
+//               ^^^^^^ support.class.java
 //                            ^^^ storage.modifier.array.java
 //                                      ^^^ storage.modifier.array.java
 //                                          ^^^^^^^^^^^^^^^^^ variable.other.member.java
@@ -3097,7 +3097,7 @@ class FieldDeclarationTests {
 //                ^^^^^^^^^^^^^^^^^^^^^^^ - meta.path
 //^^^^^^^^^ variable.namespace.java
 //         ^ punctuation.accessor.dot.java
-//          ^^^^^^ storage.type.class.java
+//          ^^^^^^ support.class.java
 //                ^^^^ storage.modifier.array.java
 //                     ^^^^^^^^^^^^^^^^^ variable.other.member.java
 //                                      ^ punctuation.terminator.java
@@ -3113,7 +3113,7 @@ class FieldDeclarationTests {
 //     ^ punctuation.accessor.dot.java
 //      ^^^^^^^^^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
-//                ^^^^^^ storage.type.class.java
+//                ^^^^^^ support.class.java
 //                      ^^^^ storage.modifier.array.java
 //                           ^^^^^^^^^^^^^^^^^ variable.other.member.java
 //                                            ^ punctuation.terminator.java
@@ -3151,7 +3151,7 @@ class FieldDeclarationTests {
 //^ punctuation.definition.annotation.java
 // ^^^^ variable.annotation.java
 //      ^^^^ comment.block.empty.java
-//           ^^^^^^ storage.type.class.java
+//           ^^^^^^ support.class.java
 //                  ^ punctuation.definition.annotation.java
 //                   ^^^^ variable.annotation.java
 //                       ^ punctuation.section.group.begin.java
@@ -3179,7 +3179,7 @@ class FieldDeclarationTests {
 //         ^ meta.field.type.java - meta.generic
 //          ^^^^^ meta.field.identifier.java
 //               ^ - meta.field
-//^^^^ storage.type.class.java
+//^^^^ support.class.java
 //    ^ punctuation.definition.generic.begin.java
 //     ^^^ invalid.illegal.unexpected-keyword.java
 //        ^ punctuation.definition.generic.end.java
@@ -3193,7 +3193,7 @@ class FieldDeclarationTests {
 //         ^ meta.field.type.java - meta.generic
 //          ^^^^^ meta.field.identifier.java
 //               ^ - meta.field
-//^^^^ storage.type.class.java
+//^^^^ support.class.java
 //    ^ punctuation.definition.generic.begin.java
 //     ^^^ invalid.illegal.unexpected-keyword.java
 //        ^ punctuation.definition.generic.end.java
@@ -3207,9 +3207,9 @@ class FieldDeclarationTests {
 //            ^ meta.field.type.java - meta.generic
 //             ^^^^^ meta.field.identifier.java
 //                  ^ - meta.field
-//^^^^ storage.type.class.java
+//^^^^ support.class.java
 //    ^ punctuation.definition.generic.begin.java
-//     ^^^^^^ storage.type.class.java
+//     ^^^^^^ support.class.java
 //           ^ punctuation.definition.generic.end.java
 //             ^^^^^ variable.other.member.java
 //                  ^ punctuation.terminator.java
@@ -3221,9 +3221,9 @@ class FieldDeclarationTests {
 //            ^ meta.field.type.java - meta.generic
 //             ^^^^^ meta.field.identifier.java
 //                  ^ - meta.field
-//^^^^ storage.type.class.java
+//^^^^ support.class.java
 //    ^ punctuation.definition.generic.begin.java
-//     ^^^^^^ storage.type.class.java
+//     ^^^^^^ support.class.java
 //           ^ punctuation.definition.generic.end.java
 //             ^^^^^ variable.other.member.java
 //                  ^ punctuation.terminator.java
@@ -3241,13 +3241,13 @@ class FieldDeclarationTests {
 //    ^ punctuation.accessor.dot.java
 //     ^^^^ variable.namespace.java
 //         ^ punctuation.accessor.dot.java
-//          ^^^^ storage.type.class.java
+//          ^^^^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
 //               ^^^^ variable.namespace.java
 //                   ^ punctuation.accessor.dot.java
 //                    ^^^ variable.namespace.java
 //                       ^ punctuation.accessor.dot.java
-//                        ^^^ storage.type.class.java
+//                        ^^^ support.class.java
 //                           ^ punctuation.definition.generic.end.java
 //                             ^^^^^ variable.other.member.java
 //                                  ^ punctuation.terminator.java
@@ -3265,13 +3265,13 @@ class FieldDeclarationTests {
 //    ^ punctuation.accessor.dot.java
 //     ^^^^ variable.namespace.java
 //         ^ punctuation.accessor.dot.java
-//          ^^^^ storage.type.class.java
+//          ^^^^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
 //               ^^^^ variable.namespace.java
 //                   ^ punctuation.accessor.dot.java
 //                    ^^^ variable.namespace.java
 //                       ^ punctuation.accessor.dot.java
-//                        ^^^ storage.type.class.java
+//                        ^^^ support.class.java
 //                           ^ punctuation.definition.generic.end.java
 //                             ^^^^^ variable.other.member.java
 //                                  ^ punctuation.terminator.java
@@ -3289,16 +3289,16 @@ class FieldDeclarationTests {
 //                                    ^ - meta.field
 //^^^^ variable.namespace.java
 //    ^ punctuation.accessor.dot.java
-//     ^^^^ storage.type.class.java
+//     ^^^^ support.class.java
 //         ^^ punctuation.definition.generic.diamond.java
 //           ^ punctuation.accessor.dot.java
-//            ^^^^ storage.type.class.java
+//            ^^^^ support.class.java
 //                ^ punctuation.definition.generic.begin.java
 //                 ^^^^ variable.namespace.java
 //                     ^ punctuation.accessor.dot.java
 //                      ^^^ variable.namespace.java
 //                         ^ punctuation.accessor.dot.java
-//                          ^^^ storage.type.class.java
+//                          ^^^ support.class.java
 //                             ^ punctuation.definition.generic.end.java
 //                               ^^^^^ variable.other.member.java
 //                                    ^ punctuation.terminator.java
@@ -3409,7 +3409,7 @@ class MethodDelcarationTests {
 //^^^^ storage.type.void.java
 //     ^^^^^^ entity.name.function.java
 //           ^ punctuation.section.group.begin.java
-//            ^^^ storage.type.class.java
+//            ^^^ support.class.java
 //                ^^^ variable.parameter.java
 //                    ^ punctuation.terminator.java
 
@@ -3438,7 +3438,7 @@ class MethodDelcarationTests {
 //                       ^ meta.function.java - meta.group - meta.block meta.block
 //                        ^^ meta.function.java meta.block.java
 //^^^^^^^ storage.modifier.java
-//        ^^^^^^ storage.type.class.java
+//        ^^^^^^ support.class.java
 //               ^^^^^^ entity.name.function.java
 //                     ^ punctuation.section.group.begin.java
 //                      ^ punctuation.section.group.end.java
@@ -3563,9 +3563,9 @@ class MethodDelcarationTests {
 //         ^^^^ storage.type.void.java
 //              ^^^^^^^^^^^^^^^^ entity.name.function.java
 //                               ^ punctuation.section.group.begin.java
-//                                ^^^^ storage.type.class.java
+//                                ^^^^ support.class.java
 //                                    ^ punctuation.definition.generic.begin.java
-//                                     ^^^^^^^^^^^^ storage.type.class.java
+//                                     ^^^^^^^^^^^^ support.class.java
 //                                                 ^ punctuation.definition.generic.end.java
 //                                                   ^^^ variable.parameter.java
 //                                                      ^ punctuation.section.group.end.java
@@ -3583,7 +3583,7 @@ class MethodDelcarationTests {
 //                                  ^ punctuation.section.group.begin.java
 //                                   ^ punctuation.definition.annotation.java
 //                                    ^^^^^^^^^^^^^^ variable.annotation.java
-//                                                   ^^^^ storage.type.class.java
+//                                                   ^^^^ support.class.java
 //                                                        ^^^^ variable.parameter.java
 //                                                            ^ punctuation.section.group.end.java
 //                                                             ^ punctuation.terminator.java
@@ -3601,9 +3601,9 @@ class MethodDelcarationTests {
 //                 ^^^^ storage.type
 //                      ^^^^^^^^^^ entity.name.function.java
 //                                ^ punctuation.section.group.begin.java
-//                                 ^^^^ storage.type.class.java
+//                                 ^^^^ support.class.java
 //                                     ^ punctuation.definition.generic.begin.java
-//                                      ^^^^^^ storage.type.class.java
+//                                      ^^^^^^ support.class.java
 //                                            ^ punctuation.definition.generic.end.java
 //                                              ^^^^ variable.parameter.java
 //                                                  ^ punctuation.section.group.end.java
@@ -3621,23 +3621,23 @@ class MethodDelcarationTests {
 //                                                                 ^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java meta.generic.java
 //                                                                                ^^^^^ meta.function.parameters.java meta.group.java - meta.generic
 //^^^^^^ storage.modifier.java
-//       ^^^^^^^^^ storage.type.class.java
+//       ^^^^^^^^^ support.class.java
 //                ^ punctuation.definition.generic.begin.java
-//                 ^^^^^ storage.type.class.java
+//                 ^^^^^ support.class.java
 //                      ^ punctuation.separator.comma.java
-//                        ^^^^ storage.type.class.java
+//                        ^^^^ support.class.java
 //                            ^ punctuation.separator.comma.java
-//                              ^^^^^^^^ storage.type.class.java
+//                              ^^^^^^^^ support.class.java
 //                                      ^ punctuation.separator.comma.java
-//                                        ^^^^^ storage.type.class.java
+//                                        ^^^^^ support.class.java
 //                                             ^ punctuation.definition.generic.end.java
 //                                               ^^^^^^^^^^^^^^ entity.name.function.java
 //                                                             ^ punctuation.section.group.begin.java
-//                                                              ^^^ storage.type.class.java
+//                                                              ^^^ support.class.java
 //                                                                 ^ punctuation.definition.generic.begin.java
-//                                                                  ^^^^ storage.type.class.java
+//                                                                  ^^^^ support.class.java
 //                                                                      ^ punctuation.separator.comma.java
-//                                                                        ^^^^^^^ storage.type.class.java
+//                                                                        ^^^^^^^ support.class.java
 //                                                                               ^ punctuation.definition.generic.end.java
 //                                                                                 ^^^ variable.parameter.java
 //                                                                                    ^ punctuation.section.group.end.java
@@ -3660,9 +3660,9 @@ class MethodDelcarationTests {
 //                               ^ punctuation.section.group.begin.java
 //                                ^ punctuation.section.group.end.java
 //                                  ^^^^^^ storage.modifier.throws.java
-//                                         ^^^^^^^^^^^ storage.type.class.java
+//                                         ^^^^^^^^^^^ support.class.java
 //                                                    ^ punctuation.definition.generic.begin.java
-//                                                     ^^^ storage.type.class.java
+//                                                     ^^^ support.class.java
 //                                                        ^ punctuation.definition.generic.end.java
 //                                                          ^ punctuation.section.block.begin.java
     throw
@@ -3677,7 +3677,7 @@ class MethodDelcarationTests {
         MyException
 //^^^^^^^^^^^^^^^^^^ meta.function.java meta.block.java
 //     ^^^^^^^^^^^^^ meta.statement.flow.throw.java meta.instantiation.java
-//      ^^^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^^^ support.class.java
         ("hello (world)");
 //^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.java meta.block.java
 //      ^^^^^^^^^^^^^^^^^ meta.statement.flow.throw.java meta.instantiation.java meta.group.java
@@ -3727,7 +3727,7 @@ class MethodDelcarationTests {
 //                               ^ punctuation.section.group.begin.java
 //                                ^ punctuation.section.group.end.java
 //                                  ^^^^^^ storage.modifier.throws.java
-//                                         ^^^^^ storage.type.class.java
+//                                         ^^^^^ support.class.java
 //                                              ^^ invalid.illegal.unexpected-modifier.java
 //                                                 ^ punctuation.section.block.begin.java
 //                                                  ^ punctuation.section.block.end.java
@@ -3750,9 +3750,9 @@ class MethodDelcarationTests {
 //                               ^ punctuation.section.group.begin.java
 //                                ^ punctuation.section.group.end.java
 //                                  ^^^^^^ storage.modifier.throws.java
-//                                         ^^^^^^^^^^^ storage.type.class.java
+//                                         ^^^^^^^^^^^ support.class.java
 //                                                    ^ punctuation.definition.generic.begin.java
-//                                                     ^^^ storage.type.class.java
+//                                                     ^^^ support.class.java
 //                                                        ^ punctuation.definition.generic.end.java
 //                                                          ^ punctuation.section.block.begin.java
 //                                                           ^ punctuation.section.block.end.java
@@ -3781,11 +3781,11 @@ class MethodDelcarationTests {
 //                                  ^^^^^^ storage.modifier.throws.java
 //                                         ^^^^ variable.namespace.java
 //                                             ^ punctuation.accessor.dot.java
-//                                              ^^^^^^^^^^^ storage.type.class.java
+//                                              ^^^^^^^^^^^ support.class.java
 //                                                         ^ punctuation.definition.generic.begin.java
 //                                                          ^^^^ variable.namespace.java
 //                                                              ^ punctuation.accessor.dot.java
-//                                                               ^^^ storage.type.class.java
+//                                                               ^^^ support.class.java
 //                                                                  ^ punctuation.definition.generic.end.java
 //                                                                    ^ punctuation.section.block.begin.java
 //                                                                     ^ punctuation.section.block.end.java
@@ -3817,7 +3817,7 @@ class MethodDelcarationTests {
   void classVarArgs(String... values) {}
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function - meta.function meta.function
 //                 ^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java
-//                  ^^^^^^ storage.type.class.java
+//                  ^^^^^^ support.class.java
 //                        ^^^ keyword.operator.variadic.java
 //                            ^^^^^^ variable.parameter.java
 
@@ -3826,7 +3826,7 @@ class MethodDelcarationTests {
 //                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java
 //                                                         ^ - meta.function.parameters.java
 //                                ^^^^^^^ invalid.illegal.unexpected-keyword.java
-//                                        ^^^^^^ storage.type.class.java
+//                                        ^^^^^^ support.class.java
 //                                              ^^^ keyword.operator.variadic.java
 //                                                  ^^^^^^ variable.parameter.java
 
@@ -3863,7 +3863,7 @@ class MethodDelcarationTests {
 //                  ^^^ storage.type.primitive.java
 //                      ^ variable.parameter.java
 //                       ^^ storage.modifier.array.java
-//                           ^^^^^^ storage.type.class.java
+//                           ^^^^^^ support.class.java
 //                                  ^ variable.parameter.java
 //                                   ^^ storage.modifier.array.java
 
@@ -3881,12 +3881,12 @@ class MethodDelcarationTests {
 
     Map<Long, Date>[] mapping,
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java - meta.function meta.function
-//  ^^^ storage.type.class.java
+//  ^^^ support.class.java
 //     ^^^^^^^^^^^^ meta.generic.java
 //     ^ punctuation.definition.generic.begin.java
-//      ^^^^ storage.type.class.java
+//      ^^^^ support.class.java
 //          ^ punctuation.separator.comma.java
-//            ^^^^ storage.type.class.java
+//            ^^^^ support.class.java
 //                ^ punctuation.definition.generic.end.java
 //                 ^^ storage.modifier.array.java
 //                    ^^^^^^^ variable.parameter.java
@@ -3917,7 +3917,7 @@ class MethodDelcarationTests {
 
     String<int,int@Anno[]>@Anno[]@Anno[]arg@Anno[]@Anno[]
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java - meta.function meta.function
-//  ^^^^^^ storage.type.class.java
+//  ^^^^^^ support.class.java
 //        ^^^^^^^^^^^^^^^^ meta.generic.java
 //        ^ punctuation.definition.generic.begin.java
 //         ^^^ invalid.illegal.unexpected-keyword.java
@@ -3957,7 +3957,7 @@ class MethodDelcarationTests {
 //    ^^^^ storage.type.void.java
 //         ^^^^^^^^^^^^^^^^^ entity.name.function.java
 //                          ^ punctuation.section.group.begin.java
-//                           ^ storage.type.class.java
+//                           ^ support.class.java
 //                             ^^^ variable.parameter.java
 //                                ^ punctuation.section.group.end.java
 //                                 ^ punctuation.terminator.java
@@ -3979,15 +3979,15 @@ class MethodDelcarationTests {
 //  ^ punctuation.definition.generic.end.java
 //    ^^^^^^ storage.modifier.java
 //           ^^^^^^ storage.modifier.java
-//                  ^^^ storage.type.class.java
+//                  ^^^ support.class.java
 //                     ^ punctuation.definition.generic.begin.java
-//                      ^ storage.type.class.java
+//                      ^ support.class.java
 //                       ^ punctuation.definition.generic.end.java
 //                         ^^^^^^^^^^^^^^^ entity.name.function.java
 //                                        ^ punctuation.section.group.begin.java
-//                                         ^^^ storage.type.class.java
+//                                         ^^^ support.class.java
 //                                            ^ punctuation.definition.generic.begin.java
-//                                             ^ storage.type.class.java
+//                                             ^ support.class.java
 //                                              ^ punctuation.definition.generic.end.java
 //                                                ^^^ variable.parameter.java
 //                                                   ^ punctuation.section.group.end.java
@@ -4009,18 +4009,18 @@ class MethodDelcarationTests {
 //^^^^^^ storage.modifier.java
 //       ^^^^^^ storage.modifier.java
 //               ^ variable.parameter.type.java
-//                  ^ storage.type.class.java
+//                  ^ support.class.java
 //                    ^^^^^^^^^^^^^^^^^ entity.name.function.java
-//                                      ^^^^^^^^^^ storage.type.class.java
+//                                      ^^^^^^^^^^ support.class.java
 //                                                ^ punctuation.definition.generic.begin.java
 //                                                 ^ variable.language.wildcard.java
 //                                                   ^^^^^^^ storage.modifier.extends.java
-//                                                           ^ storage.type.class.java
+//                                                           ^ support.class.java
 //                                                            ^ punctuation.definition.generic.end.java
 //                                                             ^ punctuation.separator.comma.java - meta.generic.java
-//                                                               ^^^^ storage.type.class.java
+//                                                               ^^^^ support.class.java
 //                                                                   ^ punctuation.definition.generic.begin.java
-//                                                                    ^ storage.type.class.java
+//                                                                    ^ support.class.java
 //                                                                     ^ punctuation.definition.generic.end.java
 //                                                                      ^ punctuation.section.group.end.java
 //                                                                        ^ punctuation.section.block.begin.java
@@ -4038,11 +4038,11 @@ class MethodDelcarationTests {
 //                 ^ punctuation.definition.generic.begin.java
 //                  ^ variable.parameter.type.java
 //                    ^^^^^^^ storage.modifier.extends.java
-//                            ^^^^^^^^^^ storage.type.class.java
+//                            ^^^^^^^^^^ support.class.java
 //                                      ^ punctuation.definition.generic.begin.java
 //                                       ^ variable.language.wildcard.java
 //                                         ^^^^^ keyword.declaration.super.java
-//                                               ^ storage.type.class.java
+//                                               ^ support.class.java
 //                                                ^^ punctuation.definition.generic.end.java
         T max(Collection<T> coll);
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function - meta.function meta.function
@@ -4051,12 +4051,12 @@ class MethodDelcarationTests {
 //        ^^^ meta.function.identifier.java
 //           ^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java
 //                               ^ - meta.function
-//      ^ storage.type.class.java
+//      ^ support.class.java
 //        ^^^ entity.name.function.java
 //           ^ punctuation.section.group.begin.java
-//            ^^^^^^^^^^ storage.type.class.java
+//            ^^^^^^^^^^ support.class.java
 //                      ^ punctuation.definition.generic.begin.java
-//                       ^ storage.type.class.java
+//                       ^ support.class.java
 //                        ^ punctuation.definition.generic.end.java
 //                          ^^^^ variable.parameter.java
 //                              ^ punctuation.section.group.end.java
@@ -4070,7 +4070,7 @@ class MethodDelcarationTests {
 //^ punctuation.definition.annotation.java
 // ^^^^^^^ variable.annotation.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^^^^ storage.type.class.java
+//         ^^^^^^ support.class.java
 //               ^ punctuation.accessor.dot.java
 //                ^^^^^ variable.language.class.java - storage.type.java
 //                     ^ punctuation.section.group.end.java
@@ -4094,7 +4094,7 @@ class MethodDelcarationTests {
 //    ^^^^^^^ storage.modifier.extends.java
       AutoCloseable
 //^^^^^^^^^^^^^^^^^^ meta.function.modifier.java meta.generic.declaration.java - meta.function meta.function
-//    ^^^^^^^^^^^^^ storage.type.class.java
+//    ^^^^^^^^^^^^^ support.class.java
     >
 //^^^^ - meta.function meta.function
 //^^^ meta.function.modifier.java meta.generic.declaration.java
@@ -4117,9 +4117,9 @@ class MethodDelcarationTests {
 //  ^ punctuation.section.group.begin.java
       SomeType<T> root
 //^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java - meta.function meta.function
-//    ^^^^^^^^ storage.type.class.java
+//    ^^^^^^^^ support.class.java
 //            ^ punctuation.definition.generic.begin.java
-//             ^ storage.type.class.java
+//             ^ support.class.java
 //              ^ punctuation.definition.generic.end.java
 //                ^^^^ variable.parameter.java
     )
@@ -4134,15 +4134,15 @@ class MethodDelcarationTests {
 //  ^^^^^^ storage.modifier.throws.java
         Exception
 //^^^^^^^^^^^^^^^^ meta.function.throws.java - meta.function meta.function
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
         , IOException,
 //^^^^^^^^^^^^^^^^^^^^^ meta.function.throws.java - meta.function meta.function
 //      ^ punctuation.separator.comma.java
-//        ^^^^^^^^^^^ storage.type.class.java
+//        ^^^^^^^^^^^ support.class.java
 //                   ^ punctuation.separator.comma.java
         SAXException
 //^^^^^^^^^^^^^^^^^^^ meta.function.throws.java - meta.function meta.function
-//      ^^^^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^^^^ support.class.java
   {
 //<- meta.function.throws.java - meta.function meta.function
 //^^ meta.function.java meta.block.java - meta.function meta.function
@@ -4159,7 +4159,7 @@ class MethodDelcarationTests {
 //^ punctuation.definition.annotation.java
 // ^^^^^^^ variable.annotation.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^^^^ storage.type.class.java
+//         ^^^^^^ support.class.java
 //               ^ punctuation.accessor.dot.java
 //                ^^^^^ variable.language.class.java - storage.type.java
 //                     ^ punctuation.section.group.end.java
@@ -4169,16 +4169,16 @@ class MethodDelcarationTests {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.identifier.java entity.name.function.java
 //                                                                                ^ meta.function.parameters.java meta.group.java punctuation.section.group.begin.java
       WITHSOMEPARAMS foo,
-//    ^ meta.function.parameters.java storage.type.class.java
+//    ^ meta.function.parameters.java support.class.java
 //                   ^ meta.function.parameters.java variable.parameter.java
       Generic<Param> bar)
-//    ^ meta.function.parameters.java storage.type.class.java
+//    ^ meta.function.parameters.java support.class.java
 //           ^^^^^^^ meta.generic.java
 //                   ^ meta.function.parameters.java variable.parameter.java
 //                      ^ punctuation.section.group.end
       throws Exception {
 //    ^ meta.function.throws.java storage.modifier.throws.java
-//           ^ meta.function.throws.java storage.type.class.java
+//           ^ meta.function.throws.java support.class.java
     return someMethod (new Function<V, V>() {
 //        ^ - meta.function-call
 //         ^^^^^^^^^^^ meta.function-call.identifier.java - meta.function-call meta.function-call
@@ -4189,9 +4189,9 @@ class MethodDelcarationTests {
 //                   ^ - variable
       @Override
       public V apply(V input) {
-//           ^ storage.type.class.java
+//           ^ support.class.java
 //                  ^^^^^^^^^ meta.function.parameters.java
-//                   ^ storage.type.class.java
+//                   ^ support.class.java
 //                     ^ variable.parameter.java
 //                            ^ meta.function
         return input;
@@ -4223,10 +4223,10 @@ class ReceiverArgTests {
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java meta.group.java - meta.function meta.function
 //^^^^^^^^^^^^^^^^ entity.name.function.constructor.java
 //                ^ punctuation.section.group.begin.java
-//                 ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                 ^^^^^^^^^^^^^^^^ support.class.java
 //                                  ^^^^ variable.parameter.this.java
 //                                      ^ punctuation.separator.comma.java
-//                                        ^ storage.type.class.java
+//                                        ^ support.class.java
 //                                          ^^^^ invalid.illegal.identifier.java
 //                                              ^ punctuation.section.group.end.java
 //                                                ^ punctuation.section.block.begin.java
@@ -4242,16 +4242,16 @@ class ReceiverArgTests {
 //^^^^ storage.type.void.java
 //     ^^^^^^ entity.name.function.java
 //           ^ punctuation.section.group.begin.java
-//            ^^^^^^^^^^^^^^^^ storage.type.class.java
+//            ^^^^^^^^^^^^^^^^ support.class.java
 //                             ^^^^ variable.parameter.this.java
 //                                 ^ punctuation.separator.comma.java
-//                                   ^ storage.type.class.java
+//                                   ^ support.class.java
 //                                     ^^^^ invalid.illegal.identifier.java
 //                                         ^ punctuation.separator.comma.java
-//                                           ^ storage.type.class.java
+//                                           ^ support.class.java
 //                                             ^^^^^ invalid.illegal.identifier.java
 //                                                  ^ punctuation.separator.comma.java
-//                                                    ^ storage.type.class.java
+//                                                    ^ support.class.java
 //                                                      ^^^ variable.parameter.java
 //                                                         ^ punctuation.section.group.end.java
 //                                                          ^^ storage.modifier.array.java
@@ -4270,7 +4270,7 @@ class ReceiverArgTests {
 //       ^^^^ storage.type.void.java
 //            ^^^^^^ entity.name.function.java
 //                  ^ punctuation.section.group.begin.java
-//                   ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^^^^^^^^^ support.class.java
 //                                    ^^^^ variable.parameter.this.java
 //                                        ^ punctuation.section.group.end.java
 //                                          ^ punctuation.section.block.begin.java
@@ -4280,13 +4280,13 @@ class ReceiverArgTests {
     A(ReceiverArgTests ReceiverArgTests.this, A ReceiverArgTests.this) {}
 //  ^ entity.name.function.constructor.java
 //   ^ punctuation.section.group.begin.java
-//    ^^^^^^^^^^^^^^^^ storage.type.class.java
+//    ^^^^^^^^^^^^^^^^ support.class.java
 //                     ^^^^^^^^^^^^^^^^^^^^^ meta.path.java
-//                     ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                     ^^^^^^^^^^^^^^^^ support.class.java
 //                                     ^ punctuation.accessor.dot.java
 //                                      ^^^^ variable.parameter.this.java
 //                                          ^ punctuation.separator.comma.java
-//                                            ^ storage.type.class.java
+//                                            ^ support.class.java
 //                                              ^^^^^^^^^^^^^^^^ variable.parameter.java
 //                                                              ^ invalid.illegal.unexpected-accessor.java
 //                                                               ^^^^ invalid.illegal.unexpected-member.java
@@ -4299,12 +4299,12 @@ class ReceiverArgTests {
 //   ^ punctuation.section.group.begin.java
         /**/ ReceiverArgTests
 //      ^^^^ comment.block.empty.java
-//           ^^^^^^^^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^^^^^^^^ support.class.java
         /**/ ReceiverArgTests
 //      ^^^^ comment.block.empty.java
 //          ^ - meta.path
 //           ^^^^^^^^^^^^^^^^^ meta.path.java
-//           ^^^^^^^^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^^^^^^^^ support.class.java
         /**/ .
 //     ^^^^^^^^ meta.path.java
 //      ^^^^ comment.block.empty.java
@@ -4323,7 +4323,7 @@ class ReceiverArgTests {
 //           ^ punctuation.separator.comma.java
         /**/  A
 //      ^^^^ comment.block.empty.java
-//            ^ storage.type.class.java - meta.path
+//            ^ support.class.java - meta.path
         /**/  ReceiverArgTests
 //      ^^^^ comment.block.empty.java
 //            ^^^^^^^^^^^^^^^^ variable.parameter.java - meta.path - support
@@ -4356,7 +4356,7 @@ class ReceiverArgTests {
 //  ^^^^ storage.type.void.java
 //       ^^^^^^ entity.name.function.java
 //             ^ punctuation.section.group.begin.java
-//              ^ storage.type.class.java
+//              ^ support.class.java
 //                ^^^^ variable.parameter.this.java
 //                    ^ punctuation.section.group.end.java
 //                      ^ punctuation.section.block.begin.java
@@ -4368,11 +4368,11 @@ class ReceiverArgTests {
       B(ReceiverArgTests.A A.this) {}
 //    ^ entity.name.function.constructor.java
 //     ^ punctuation.section.group.begin.java
-//      ^^^^^^^^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^^^^^^^^ support.class.java
 //                      ^ punctuation.accessor.dot.java
-//                       ^ storage.type.class.java
+//                       ^ support.class.java
 //                         ^^^^^^ meta.path.java
-//                         ^ storage.type.class.java
+//                         ^ support.class.java
 //                          ^ punctuation.accessor.dot.java
 //                           ^^^^ variable.parameter.this.java
 //                               ^ punctuation.section.group.end.java
@@ -4383,11 +4383,11 @@ class ReceiverArgTests {
       B(ReceiverArgTests.A A.fail) {}
 //    ^ entity.name.function.constructor.java
 //     ^ punctuation.section.group.begin.java
-//      ^^^^^^^^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^^^^^^^^ support.class.java
 //                      ^ punctuation.accessor.dot.java
-//                       ^ storage.type.class.java
+//                       ^ support.class.java
 //                         ^^^^^^ meta.path.java
-//                         ^ storage.type.class.java
+//                         ^ support.class.java
 //                          ^ punctuation.accessor.dot.java
 //                           ^^^^ invalid.illegal.identifier.java
 //                               ^ punctuation.section.group.end.java
@@ -4406,11 +4406,11 @@ class ReceiverArgTests {
 //    ^^^^ storage.type.void.java
 //         ^^^^^^ entity.name.function.java
 //               ^ punctuation.section.group.begin.java
-//                ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                ^^^^^^^^^^^^^^^^ support.class.java
 //                                ^ punctuation.accessor.dot.java
-//                                 ^ storage.type.class.java
+//                                 ^ support.class.java
 //                                  ^ punctuation.accessor.dot.java
-//                                   ^ storage.type.class.java
+//                                   ^ support.class.java
 //                                     ^^^^ variable.parameter.this.java
 //                                         ^ punctuation.section.group.end.java
 //                                           ^ punctuation.section.block.begin.java
@@ -4428,14 +4428,14 @@ class ReceiverArgTests {
 //    ^^^^ storage.type.void.java
 //         ^^^^^^ entity.name.function.java
 //               ^ punctuation.section.group.begin.java
-//                ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                ^^^^^^^^^^^^^^^^ support.class.java
 //                                ^ punctuation.accessor.dot.java
-//                                 ^ storage.type.class.java
+//                                 ^ support.class.java
 //                                  ^ punctuation.accessor.dot.java
-//                                   ^ storage.type.class.java
-//                                     ^ storage.type.class.java
+//                                   ^ support.class.java
+//                                     ^ support.class.java
 //                                      ^ punctuation.accessor.dot.java
-//                                       ^ storage.type.class.java
+//                                       ^ support.class.java
 //                                        ^ punctuation.accessor.dot.java
 //                                         ^^^^ variable.parameter.this.java
 //                                             ^ punctuation.section.group.end.java
@@ -4454,14 +4454,14 @@ class ReceiverArgTests {
 //    ^^^^ storage.type.void.java
 //         ^^^^^^ entity.name.function.java
 //               ^ punctuation.section.group.begin.java
-//                ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                ^^^^^^^^^^^^^^^^ support.class.java
 //                                ^ punctuation.accessor.dot.java
-//                                 ^ storage.type.class.java
+//                                 ^ support.class.java
 //                                  ^ punctuation.accessor.dot.java
-//                                   ^ storage.type.class.java
-//                                     ^ storage.type.class.java
+//                                   ^ support.class.java
+//                                     ^ support.class.java
 //                                      ^ punctuation.accessor.dot.java
-//                                       ^ storage.type.class.java
+//                                       ^ support.class.java
 //                                        ^ punctuation.accessor.dot.java
 //                                         ^^^^ variable.parameter.this.java
 //                                             ^ punctuation.section.group.end.java
@@ -4487,19 +4487,19 @@ class ReceiverArgTests {
 //         ^^^^^^ entity.name.function.java
 //               ^ punctuation.section.group.begin.java
 //                ^^ meta.annotation.identifier.java
-//                   ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^^^^^^^^^ support.class.java
 //                                   ^^^ meta.generic.java
 //                                       ^ punctuation.accessor.dot.java
 //                                         ^^ meta.annotation.identifier.java
-//                                            ^ storage.type.class.java
+//                                            ^ support.class.java
 //                                              ^ punctuation.accessor.dot.java
 //                                                ^^^^ meta.annotation.identifier.java
-//                                                     ^ storage.type.class.java
+//                                                     ^ support.class.java
 //                                                       ^^ meta.annotation.identifier.java
-//                                                          ^ storage.type.class.java
+//                                                          ^ support.class.java
 //                                                            ^ punctuation.accessor.dot.java
 //                                                              ^^^^ meta.annotation.identifier.java
-//                                                                   ^ storage.type.class.java
+//                                                                   ^ support.class.java
 //                                                                     ^ punctuation.accessor.dot.java
 //                                                                       ^^^^^^ meta.annotation.identifier.java
 //                                                                             ^^^^^^ meta.annotation.parameters.java meta.group.java
@@ -4723,7 +4723,7 @@ class LocalVariableDeclarationTests {
   void declareObjectTypes() {
 
     TestClass ;
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 
     testclass ;
 //  ^^^^^^^^^ variable.other.java
@@ -4731,20 +4731,20 @@ class LocalVariableDeclarationTests {
     TestClass foo
 //  ^^^^^^^^^^ meta.declaration.type.java
 //            ^^^^ meta.declaration.identifier.java
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 
     testclass foo
 //  ^^^^^^^^^^ meta.declaration.type.java
 //            ^^^^ meta.declaration.identifier.java
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 
     TestClass foo;
 //  ^^^^^^^^^^ meta.declaration.type.java
 //            ^^^ meta.declaration.identifier.java
 //               ^ - meta.declaration
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 //               ^ punctuation.terminator.java
 
@@ -4755,7 +4755,7 @@ class LocalVariableDeclarationTests {
 //               ^ meta.declaration.java
 //                ^^^^ meta.declaration.identifier.java
 //                    ^ - meta.declaration
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 //               ^ punctuation.separator.comma.java
 //                 ^^^ variable.other.java
@@ -4769,7 +4769,7 @@ class LocalVariableDeclarationTests {
 //                  ^^^^^ meta.declaration.identifier.java
 //                       ^ meta.declaration.java
 //                        ^ - meta.declaration
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 //                ^ keyword.operator.assignment.java
 //                 ^ punctuation.separator.comma.java
@@ -4788,7 +4788,7 @@ class LocalVariableDeclarationTests {
 //                         ^ meta.declaration.java
 //                          ^^^ meta.declaration.value.java
 //                             ^ - meta.declaration
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //            ^^^ variable.other.java
 //                ^ keyword.operator.assignment.java
 //                  ^ constant.numeric.value.java
@@ -4810,7 +4810,7 @@ class LocalVariableDeclarationTests {
 //                                 ^^ meta.declaration.value.java
 //                                   ^ - meta.declaration
 //  ^^^^^ storage.modifier.java
-//        ^^^^^^^^^ storage.type.class.java
+//        ^^^^^^^^^ support.class.java
 //                 ^^ storage.modifier.array.java
 //                    ^ variable.other.java
 //                      ^ keyword.operator.assignment.java
@@ -4831,7 +4831,7 @@ class LocalVariableDeclarationTests {
 //                                                                   ^ - meta.declaration
 //  ^^^^^^^ meta.annotation.identifier.java
 //          ^^^^^ storage.modifier.java
-//                ^^^^^^^^^ storage.type.class.java
+//                ^^^^^^^^^ support.class.java
 //                          ^ variable.other.java
 //                            ^^^^^ meta.annotation.identifier.java
 //                                  ^^ storage.modifier.array.java
@@ -4848,7 +4848,7 @@ class LocalVariableDeclarationTests {
 //                                                                   ^ - meta.declaration
 //  ^^^^^^^ meta.annotation.identifier.java
 //          ^^^^^ storage.modifier.java
-//                ^^^^^^^^^ storage.type.class.java
+//                ^^^^^^^^^ support.class.java
 //                          ^ variable.other.java
 //                            ^^^^^ meta.annotation.identifier.java
 //                                  ^^ storage.modifier.array.java
@@ -4864,7 +4864,7 @@ class LocalVariableDeclarationTests {
 //                       ^ - meta.declaration
 //  ^^^ variable.namespace.java
 //     ^ punctuation.accessor.dot.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //                ^^^ variable.other.java
 //                   ^ invalid.illegal.unexpected-accessor.java
 //                    ^^^ invalid.illegal.unexpected-member.java
@@ -4877,7 +4877,7 @@ class LocalVariableDeclarationTests {
 //                       ^ - meta.declaration
 //  ^^^ variable.namespace.java
 //     ^ punctuation.accessor.dot.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //                ^^^ variable.other.java
 //                   ^ invalid.illegal.unexpected-accessor.java
 //                    ^^^ invalid.illegal.unexpected-member.java
@@ -4890,11 +4890,11 @@ class LocalVariableDeclarationTests {
 //       ^ meta.declaration.value.java
 //        ^^^^^^^^^ meta.declaration.value.java meta.instantiation.java
 //                 ^ - meta.declaration - meta.instantiation
-//  ^ storage.type.class.java
+//  ^ support.class.java
 //    ^ variable.other.java
 //      ^ keyword.operator.assignment.java
 //        ^^^ keyword.other.storage.new.java
-//            ^ storage.type.class.java
+//            ^ support.class.java
 //             ^ punctuation.section.group.begin.java
 //              ^ punctuation.section.group.end.java
 //               ^ punctuation.section.block.begin.java
@@ -4911,10 +4911,10 @@ class LocalVariableDeclarationTests {
 //              ^ meta.declaration.type.java - meta.generic - meta.path
 //               ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^^^^^^^^ meta.generic.java
 //      ^ punctuation.definition.generic.begin.java
-//       ^^^^^^ storage.type.class.java
+//       ^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.end.java
 //               ^ variable.other.java
 //                ^ punctuation.terminator.java
@@ -4927,13 +4927,13 @@ class LocalVariableDeclarationTests {
 //                        ^ meta.declaration.type.java - meta.generic - meta.path
 //                         ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                          ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^^^^ variable.namespace.java
 //           ^ punctuation.accessor.dot.java
 //            ^^^^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
-//                 ^^^^^^ storage.type.class.java
+//                 ^^^^^^ support.class.java
 //                       ^ punctuation.definition.generic.end.java
 //                         ^ variable.other.java
 //                          ^ punctuation.terminator.java
@@ -4944,9 +4944,9 @@ class LocalVariableDeclarationTests {
 //           ^ meta.declaration.type.java - meta.generic - meta.path
 //            ^ meta.declaration.identifier.java - meta.generic - meta.path
 //             ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
-//       ^^^ storage.type.class.java
+//       ^^^ support.class.java
 //          ^ punctuation.definition.generic.end.java
 //            ^ variable.other.java
 //             ^ punctuation.terminator.java
@@ -4959,13 +4959,13 @@ class LocalVariableDeclarationTests {
 //                    ^ meta.declaration.type.java - meta.generic - meta.path
 //                     ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                      ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^^^^ variable.namespace.java
 //           ^ punctuation.accessor.dot.java
 //            ^^^ variable.namespace.java
 //               ^ punctuation.accessor.dot.java
-//                ^^^ storage.type.class.java
+//                ^^^ support.class.java
 //                   ^ punctuation.definition.generic.end.java
 //                     ^ variable.other.java
 //                      ^ punctuation.terminator.java
@@ -4976,7 +4976,7 @@ class LocalVariableDeclarationTests {
 //             ^ meta.declaration.type.java - meta.generic - meta.path
 //              ^ meta.declaration.identifier.java - meta.generic - meta.path
 //               ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^^^ storage.type.primitive.java
 //          ^^ storage.modifier.array.java
@@ -4992,13 +4992,13 @@ class LocalVariableDeclarationTests {
 //                          ^ meta.declaration.type.java - meta.generic - meta.path
 //                           ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                            ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^^^^ variable.namespace.java
 //           ^ punctuation.accessor.dot.java
 //            ^^^^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
-//                 ^^^^^^ storage.type.class.java
+//                 ^^^^^^ support.class.java
 //                       ^^ storage.modifier.array.java
 //                         ^ punctuation.definition.generic.end.java
 //                           ^ variable.other.java
@@ -5010,9 +5010,9 @@ class LocalVariableDeclarationTests {
 //             ^ meta.declaration.type.java - meta.generic - meta.path
 //              ^ meta.declaration.identifier.java - meta.generic - meta.path
 //               ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^^^^^^^ meta.generic.java
-//       ^^^ storage.type.class.java
+//       ^^^ support.class.java
 //          ^^ storage.modifier.array.java
 
     List<int[][]>[][] x;
@@ -5021,7 +5021,7 @@ class LocalVariableDeclarationTests {
 //               ^^^^^ meta.declaration.type.java - meta.generic - meta.path
 //                    ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                     ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^^^ storage.type.primitive.java
 //          ^^^^ storage.modifier.array.java
@@ -5036,7 +5036,7 @@ class LocalVariableDeclarationTests {
 //                     ^ meta.declaration.type.java - meta.generic - meta.path
 //                      ^ meta.declaration.identifier.java - meta.generic - meta.path
 //                       ^ - meta.declaration
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
 //       ^ variable.language.wildcard.java
 //         ^^^^^^^ storage.modifier.extends.java
@@ -5061,9 +5061,9 @@ class LocalVariableDeclarationTests {
 //            ^ punctuation.accessor.dot.java
 //              ^ punctuation.definition.annotation.java
 //               ^^^^ variable.annotation.java
-//                    ^^^^^^^^^ storage.type.class.java
+//                    ^^^^^^^^^ support.class.java
 //                             ^ punctuation.definition.generic.begin.java
-//                              ^ storage.type.class.java
+//                              ^ support.class.java
 //                               ^ punctuation.definition.generic.end.java
 //                                 ^ punctuation.definition.annotation.java
 //                                  ^^^^ variable.namespace.java
@@ -5091,9 +5091,9 @@ class LocalVariableDeclarationTests {
 //            ^ punctuation.accessor.dot.java
 //              ^ punctuation.definition.annotation.java
 //               ^^^^ variable.annotation.java
-//                    ^^^^^^^^^ storage.type.class.java
+//                    ^^^^^^^^^ support.class.java
 //                             ^ punctuation.definition.generic.begin.java
-//                              ^ storage.type.class.java
+//                              ^ support.class.java
 //                               ^ punctuation.definition.generic.end.java
 //                                 ^ punctuation.definition.annotation.java
 //                                  ^^^^ variable.namespace.java
@@ -5120,9 +5120,9 @@ class LocalVariableDeclarationTests {
 //    ^ meta.declaration.type.java - meta.generic
 //     ^^^ meta.declaration.type.java meta.generic.java
 //        ^ meta.declaration.identifier.java - meta.generic
-//    ^ storage.type.class.java
+//    ^ support.class.java
 //     ^ punctuation.definition.generic.begin.java
-//      ^ storage.type.class.java
+//      ^ support.class.java
 //       ^ punctuation.definition.generic.end.java
 //        ^ variable.other.java
 //         ^ punctuation.terminator.java
@@ -5787,7 +5787,7 @@ class SwitchStatementTests {
 //         ^^^^^^^^^^^^^^^^  meta.statement.conditional.case.label.java meta.path.java
 //                         ^ meta.statement.conditional.case.java - meta.path
 //    ^^^^ keyword.control.conditional.case.java
-//         ^^^^^^^ storage.type.class.java
+//         ^^^^^^^ support.class.java
 //                ^ punctuation.accessor.dot.java
 //                 ^^^^^^^^ constant.other.java
 //                         ^ punctuation.separator.expressions.java
@@ -5801,7 +5801,7 @@ class SwitchStatementTests {
 //            ^ punctuation.accessor.dot.java
 //             ^^^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
-//                 ^^^^^^^ storage.type.class.java
+//                 ^^^^^^^ support.class.java
 //                        ^ punctuation.accessor.dot.java
 //                         ^^^^^^^^^ constant.other.java
 
@@ -5814,7 +5814,7 @@ class SwitchStatementTests {
 //            ^ punctuation.accessor.dot.java
 //             ^^^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
-//                 ^^^^^^^ storage.type.class.java
+//                 ^^^^^^^ support.class.java
 //                        ^ punctuation.accessor.dot.java
 //                         ^^^^^^^^^ constant.other.java
 //                                  ^ punctuation.separator.expressions.java
@@ -5835,7 +5835,7 @@ class SwitchStatementTests {
 //                               ^ punctuation.accessor.dot.java
 //                                 ^ punctuation.definition.annotation.java
 //                                  ^^^^ variable.annotation.java
-//                                       ^^^^^^^ storage.type.class.java
+//                                       ^^^^^^^ support.class.java
 //                                               ^ punctuation.accessor.dot.java
 //                                                 ^ punctuation.definition.annotation.java
 //                                                  ^^^^ variable.annotation.java
@@ -5858,7 +5858,7 @@ class SwitchStatementTests {
 //                                                             ^ punctuation.accessor.dot.java
 //                                                                    ^ punctuation.definition.annotation.java
 //                                                                     ^^^^ variable.annotation.java
-//                                                                               ^^^^^^^ storage.type.class.java
+//                                                                               ^^^^^^^ support.class.java
 //                                                                                            ^ punctuation.accessor.dot.java
 //                                                                                                   ^ punctuation.definition.annotation.java
 //                                                                                                    ^^^^ variable.annotation.java
@@ -6056,7 +6056,7 @@ class SwitchExpressionsTests {
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.switch.java meta.block.java meta.statement.flow.throw.java
 //          ^^^^^ keyword.control.flow.throw.java
 //                ^^^ keyword.other.storage.new.java
-//                    ^^^^^^^^^^^^^^^^^^^^^ storage.type.class.java
+//                    ^^^^^^^^^^^^^^^^^^^^^ support.class.java
 //                                         ^ punctuation.section.group.begin.java
 //                                          ^^^^^^^^^^^^^^^ string.quoted.double.java
 //                                                          ^ keyword.operator.arithmetic.java
@@ -6077,10 +6077,10 @@ class SwitchExpressionsTests {
 //                    ^^ meta.statement.conditional.case.java
 //                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                  ^ variable.other.java
 //                    ^^ punctuation.separator.expressions.java
-//                       ^^^^^^ storage.type.class.java
+//                       ^^^^^^ support.class.java
 //                             ^ punctuation.accessor.dot.java
 //                              ^^^^^^ variable.function.java
 
@@ -6090,10 +6090,10 @@ class SwitchExpressionsTests {
 //                    ^^ meta.statement.conditional.case.java
 //                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^ storage.type.class.java
+//          ^^^^ support.class.java
 //               ^ variable.other.java
 //                    ^^ punctuation.separator.expressions.java
-//                       ^^^^^^ storage.type.class.java
+//                       ^^^^^^ support.class.java
 //                             ^ punctuation.accessor.dot.java
 //                              ^^^^^^ variable.function.java
 
@@ -6106,7 +6106,7 @@ class SwitchExpressionsTests {
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.statement.conditional.case
 //          ^^^^ constant.language.null.java
 //              ^ punctuation.separator.comma.java
-//                ^^^^^^ storage.type.class.java
+//                ^^^^^^ support.class.java
 //                       ^ variable.other.java
 //                         ^^ punctuation.separator.expressions.java
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.java
@@ -6135,7 +6135,7 @@ class SwitchExpressionsTests {
 //                       ^^ meta.statement.conditional.case.java
 //                         ^^^^^^^^^^^^^^^ - meta.statement.conditional.case
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                  ^^^^ keyword.control.conditional.when.java
 //                       ^^  punctuation.separator.expressions.java
 //                          ^^^^^^^^^^^^ string.quoted.double.java
@@ -6148,7 +6148,7 @@ class SwitchExpressionsTests {
 //                                               ^^ meta.statement.conditional.case.java
 //                                                 ^^^^^^^^^^^^ - meta.statement.conditional.case
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                  ^ variable.other.java
 //                    ^^^^ keyword.control.conditional.when.java
 //                         ^ meta.variable.identifier.java variable.other.java
@@ -6165,7 +6165,7 @@ class SwitchExpressionsTests {
 //     ^^^^^ meta.statement.conditional.case.java
 //          ^^^^^^^^^^ meta.statement.conditional.case.label.java
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                  ^ variable.other.java
           when t.isType() > WEEKEND ->
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
@@ -6181,7 +6181,7 @@ class SwitchExpressionsTests {
 //                                  ^^ punctuation.separator.expressions.java
              System.out.println("weekend");
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.function.java meta.block.java meta.statement.conditional.switch.java meta.block.java
-//           ^^^^^^ storage.type.class.java
+//           ^^^^^^ support.class.java
 //                 ^ punctuation.accessor.dot.java
 //                  ^^^ meta.variable.identifier.java variable.other.java
 //                     ^ punctuation.accessor.dot.java
@@ -6196,19 +6196,19 @@ class SwitchExpressionsTests {
 //                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.label.java
 //                                                                    ^^ meta.statement.conditional.case.java
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                  ^ variable.other.java
 //                    ^^^^ keyword.control.conditional.when.java
 //                         ^ variable.other.java
 //                           ^^ keyword.operator.comparison.java
 //                              ^^^^^^^ constant.other.java
 //                                     ^ punctuation.separator.comma.java
-//                                       ^^^^ storage.type.class.java
+//                                       ^^^^ support.class.java
 //                                            ^ variable.other.java
 //                                              ^^^^ keyword.control.conditional.when.java
 //                                                   ^ variable.other.java
 //                                                     ^^ keyword.operator.comparison.java
-//                                                        ^^^^ storage.type.class.java
+//                                                        ^^^^ support.class.java
 //                                                            ^ punctuation.accessor.dot.java
 //                                                             ^^^^^^ constant.other.java
 //                                                                    ^^ punctuation.separator.expressions.java
@@ -6221,9 +6221,9 @@ class SwitchExpressionsTests {
 //                                                                                        ^^ meta.statement.conditional.case.java
 //                                                                                          ^ - meta.statement.conditional.case
 //     ^^^^ keyword.control.conditional.case.java
-//          ^^^^^^^^ storage.type.class.java
+//          ^^^^^^^^ support.class.java
 //                  ^ punctuation.section.group.begin.java
-//                   ^^^^ storage.type.class.java
+//                   ^^^^ support.class.java
 //                       ^ punctuation.section.group.begin.java
 //                        ^^^ storage.type.primitive.java
 //                            ^ variable.other.java
@@ -6235,7 +6235,7 @@ class SwitchExpressionsTests {
 //                                          ^ variable.other.java
 //                                           ^ punctuation.section.group.end.java
 //                                            ^ punctuation.separator.comma.java
-//                                              ^^^^ storage.type.class.java
+//                                              ^^^^ support.class.java
 //                                                  ^ punctuation.section.group.begin.java
 //                                                   ^^^ storage.type.primitive.java
 //                                                       ^ variable.other.java
@@ -6617,17 +6617,17 @@ class ForStatementTests {
 //      ^ punctuation.section.group.begin.java
 //       ^^^^^ storage.modifier.java
 //             ^^^^^ meta.annotation.identifier.java
-//                   ^^^^^ storage.type.class.java
+//                   ^^^^^ support.class.java
 //                         ^^^^ variable.other.java
 //                              ^ keyword.operator.assignment.java
 //                                ^^^^ variable.other.java
 //                                     ^ keyword.operator.ternary.java
 //                                       ^^^ keyword.other.storage.new.java
-//                                           ^^^ storage.type.class.java
+//                                           ^^^ support.class.java
 //                                              ^^ punctuation.definition.generic.diamond.java
 //                                                 ^ keyword.operator.ternary.java
 //                                                   ^^^ keyword.other.storage.new.java
-//                                                       ^^^ storage.type.class.java
+//                                                       ^^^ support.class.java
 //                                                          ^ punctuation.section.brackets.begin.java
 //                                                           ^ punctuation.section.brackets.end.java
 //                                                            ^ punctuation.section.group.end.java
@@ -6655,11 +6655,11 @@ class ForStatementTests {
 //                                ^^^^ variable.other.java
 //                                     ^ keyword.operator.ternary.java
 //                                       ^^^ keyword.other.storage.new.java
-//                                           ^^^ storage.type.class.java
+//                                           ^^^ support.class.java
 //                                              ^^ punctuation.definition.generic.diamond.java
 //                                                 ^ keyword.operator.ternary.java
 //                                                   ^^^ keyword.other.storage.new.java
-//                                                       ^^^ storage.type.class.java
+//                                                       ^^^ support.class.java
 //                                                          ^ punctuation.section.brackets.begin.java
 //                                                           ^ punctuation.section.brackets.end.java
 //                                                            ^ punctuation.section.group.end.java
@@ -6902,7 +6902,7 @@ class ReturnStatementTests {
 //                      ^ - meta.statement.flow.return
 //  ^^^^^^ keyword.control.flow.return.java
 //         ^^^ keyword.other.storage.new.java
-//             ^^^^^^^ storage.type.class.java
+//             ^^^^^^^ support.class.java
 //                    ^ punctuation.section.group.begin.java
 //                     ^ punctuation.section.group.end.java
 //                      ^ punctuation.terminator.java
@@ -7006,7 +7006,7 @@ class ThrowStatementTests {
 //                     ^ - meta.statement.flow.throw
 //  ^^^^^ keyword.control.flow.throw.java
 //        ^^^ keyword.other.storage.new.java
-//            ^^^^^^^ storage.type.class.java
+//            ^^^^^^^ support.class.java
 //                   ^ punctuation.section.group.begin.java
 //                    ^ punctuation.section.group.end.java
 //                     ^ punctuation.terminator.java
@@ -7042,10 +7042,10 @@ class SynchronizedStatementTests {
 
 
   synchronized$ ;
-//^^^^^^^^^^^^^ meta.field.type.java storage.type.class.java - keyword
+//^^^^^^^^^^^^^ meta.field.type.java support.class.java - keyword
 
   $synchronized ;
-//^^^^^^^^^^^^^ meta.field.type.java storage.type.class.java - keyword
+//^^^^^^^^^^^^^ meta.field.type.java support.class.java - keyword
 
   synchronized
 //^^^^^^^^^^^^^ meta.function.modifier.java
@@ -7158,7 +7158,7 @@ class TryStatementTests {
 //  ^^^^^^^^^^^^^^^ meta.statement.exception.catch.java
 //  ^^^^^ keyword.control.exception.catch.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^ storage.type.class.java
+//         ^^^ support.class.java
 //            ^^ invalid.illegal.unexpected-modifier.java
 //               ^ variable.other.java
 //                ^ punctuation.section.group.end.java
@@ -7167,10 +7167,10 @@ class TryStatementTests {
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.exception.catch.java
 //  ^^^^^ keyword.control.exception.catch.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^ storage.type.class.java
+//         ^^^ support.class.java
 //            ^^ invalid.illegal.unexpected-modifier.java
 //               ^ punctuation.separator.pipe.java
-//                 ^^^ storage.type.class.java
+//                 ^^^ support.class.java
 //                    ^^ invalid.illegal.unexpected-modifier.java
 //                       ^ punctuation.separator.pipe.java
 //                         ^^^ invalid.illegal.unexpected-keyword.java
@@ -7233,7 +7233,7 @@ class TryStatementTests {
 //        ^^^ variable.function.java
 //                 ^^^^^ keyword.control.exception.catch.java
 //                       ^ punctuation.section.group.begin.java
-//                        ^^^^^^^^^ storage.type.class.java
+//                        ^^^^^^^^^ support.class.java
 //                                  ^ variable.other.java
 //                                   ^ punctuation.section.group.end.java
 //                                     ^ punctuation.section.block.begin.java
@@ -7260,7 +7260,7 @@ class TryStatementTests {
 //  ^ punctuation.section.block.end.java
 //    ^^^^^ keyword.control.exception.catch.java
 //          ^ punctuation.section.group.begin.java
-//           ^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^ support.class.java
 //                     ^ variable.other.java
 //                      ^ punctuation.section.group.end.java
 //                        ^ punctuation.section.block.begin.java
@@ -7323,7 +7323,7 @@ class TryStatementTests {
 //      ^ punctuation.section.group.begin.java
 //       ^^^ variable.other.java
 //           ^ keyword.operator.assignment.java
-//             ^^^ storage.type.class.java
+//             ^^^ support.class.java
 //                ^ punctuation.accessor.dot.java
 //                 ^^^ variable.function.java
 //                    ^ punctuation.section.group.begin.java
@@ -7354,7 +7354,7 @@ class TryStatementTests {
 //                        ^^ meta.statement.exception.try.java meta.block.java
 //  ^^^ keyword.control.exception.try.java
 //      ^ punctuation.section.group.begin.java
-//       ^^^ storage.type.class.java
+//       ^^^ support.class.java
 //          ^^ storage.modifier.array.java
 //             ^^^ variable.other.java
 //                ^^ storage.modifier.array.java
@@ -7371,13 +7371,13 @@ class TryStatementTests {
 //                                                 ^^ meta.statement.exception.try.java meta.block.java
 //  ^^^ keyword.control.exception.try.java
 //      ^ punctuation.section.group.begin.java
-//       ^^^^^^ storage.type.class.java
+//       ^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^^^^^^ storage.type.class.java
+//              ^^^^^^ support.class.java
 //                    ^ punctuation.definition.generic.end.java
 //                      ^^^^^ variable.other.java
 //                            ^ keyword.operator.assignment.java
-//                              ^^^^^ storage.type.class.java
+//                              ^^^^^ support.class.java
 //                                   ^ punctuation.accessor.dot.java
 //                                    ^^^^^ variable.function.java
 //                                         ^ punctuation.section.group.begin.java
@@ -7395,7 +7395,7 @@ class TryStatementTests {
 //  ^ punctuation.section.block.end.java
 //    ^^^^^ keyword.control.exception.catch.java
 //          ^ punctuation.section.group.begin.java
-//           ^^^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^^^ support.class.java
 //                       ^^^^^^ variable.other.java
 //                             ^ punctuation.section.group.end.java
 //                               ^ punctuation.section.block.begin.java
@@ -7407,7 +7407,7 @@ class TryStatementTests {
 //    ^^^^^ keyword.control.exception.catch.java
 //          ^ punctuation.section.group.begin
 //           ^^^^^ storage.modifier.java
-//                 ^^^^^^^^^^^ storage.type.class
+//                 ^^^^^^^^^^^ support.class
 //                             ^ punctuation.separator.pipe.java
 //                               ^^^ variable.namespace.java
 //                                  ^ punctuation.accessor.dot.java
@@ -7415,13 +7415,13 @@ class TryStatementTests {
 //                                      ^ punctuation.accessor.dot.java
 //                                       ^^^ variable.namespace.java
 //                                          ^ punctuation.accessor.dot.java
-//                                           ^^^ storage.type.class.java
+//                                           ^^^ support.class.java
 //                                              ^ punctuation.accessor.dot.java
-//                                               ^^^ storage.type.class.java
+//                                               ^^^ support.class.java
 //                                                   ^ punctuation.separator.pipe.java
           YourException
 //       ^^^^^^^^^^^^^^^ meta.statement.exception.catch.java meta.group.java - meta.statement.exception.catch meta.statement.exception.catch
-//        ^^^^^^^^^^^^^ storage.type.class.java
+//        ^^^^^^^^^^^^^ support.class.java
           ignore) {}
 //       ^^^^^^^ meta.statement.exception.catch.java meta.group.java - meta.statement.exception.catch meta.statement.exception.catch
 //               ^ meta.statement.exception.catch.java - meta.statement.exception.catch meta.statement.exception.catch
@@ -7437,11 +7437,11 @@ class TryStatementTests {
 //  ^^^ keyword.control.exception.try.java
 //      ^ punctuation.section.group.begin.java
 //       ^^^^^ storage.modifier.java
-//             ^^^^^^^^^^^ storage.type.class.java
+//             ^^^^^^^^^^^ support.class.java
 //                         ^^ variable.other.java
 //                            ^ keyword.operator.assignment.java
 //                              ^^^ keyword.other.storage.new.java
-//                                  ^^^^^^^^^^^^^^^ storage.type.class.java
+//                                  ^^^^^^^^^^^^^^^ support.class.java
 //                                                 ^ punctuation.section.group.begin.java
 //                                                  ^^^^ variable.other.java
 //                                                      ^ punctuation.section.brackets.begin.java
@@ -7454,11 +7454,11 @@ class TryStatementTests {
 //                                                             ^ meta.statement.exception.try.java - meta.statement.exception.try meta.statement.exception.try - meta.group
 //                                                              ^^ meta.statement.exception.try.java meta.block.java
 //       ^^^^^ storage.modifier.java
-//             ^^^^^^^^^^^^ storage.type.class.java
+//             ^^^^^^^^^^^^ support.class.java
 //                          ^^ variable.other.java
 //                             ^ keyword.operator.assignment.java
 //                               ^^^ keyword.other.storage.new.java
-//                                   ^^^^^^^^^^^^^^^^ storage.type.class.java
+//                                   ^^^^^^^^^^^^^^^^ support.class.java
 //                                                   ^ punctuation.section.group.begin.java
 //                                                    ^^^^ variable.other.java
 //                                                        ^ punctuation.section.brackets.begin.java
@@ -7479,7 +7479,7 @@ class TryStatementTests {
 //           ^^ variable.other.java
 //              ^ keyword.operator.assignment.java
 //                ^^^ keyword.other.storage.new.java
-//                    ^^^^^^^^^^^^^^ storage.type.class.java
+//                    ^^^^^^^^^^^^^^ support.class.java
         var line = in.readLine();
 //      ^^^ storage.type.variant.java
 //          ^^^^ variable.other.java
@@ -7561,7 +7561,7 @@ class MethodInvocationExpressionsTests {
 //        ^ punctuation.accessor.dot.java
 //         ^^^ meta.generic.java
 //         ^ punctuation.definition.generic.begin.java
-//          ^ storage.type.class.java
+//          ^ support.class.java
 //           ^ punctuation.definition.generic.end.java
 //            ^^^ meta.function-call.identifier.java
 //               ^^ meta.function-call.arguments.java meta.group.java
@@ -7585,7 +7585,7 @@ class MethodInvocationExpressionsTests {
 //       ^ punctuation.accessor.dot.java
 //        ^^^ meta.generic.java
 //        ^ punctuation.definition.generic.begin.java
-//         ^ storage.type.class.java
+//         ^ support.class.java
 //          ^ punctuation.definition.generic.end.java
 //           ^^^ meta.function-call.identifier.java
 //              ^^ meta.function-call.arguments.java meta.group.java
@@ -7599,7 +7599,7 @@ class MethodInvocationExpressionsTests {
 //       ^ punctuation.accessor.dot.java
 //        ^^^ meta.generic.java
 //        ^ punctuation.definition.generic.begin.java
-//         ^ storage.type.class.java
+//         ^ support.class.java
 //          ^ punctuation.definition.generic.end.java
 //            ^^^ meta.function-call.identifier.java
 //               ^^ meta.function-call.arguments.java meta.group.java
@@ -7662,7 +7662,7 @@ class MethodInvocationExpressionsTests {
 //                              ^^^^^^ meta.function-call.arguments.java meta.group.java
 //      ^^^ variable.namespace.java
 //         ^ punctuation.accessor.dot.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                 ^ punctuation.accessor.dot.java
 //                  ^^^^^^^^^^^^ variable.function.java
 //                              ^ punctuation.section.group.begin.java
@@ -7684,7 +7684,7 @@ class MethodInvocationExpressionsTests {
 //      ^ punctuation.accessor.dot.java
 //       ^^^ variable.namespace.java
 //          ^ punctuation.accessor.dot.java
-//           ^^^^^^^ storage.type.class.java
+//           ^^^^^^^ support.class.java
 //                  ^ punctuation.accessor.dot.java
 //                   ^^^^^^^^^^^^ variable.function.java
 //                               ^ punctuation.section.group.begin.java
@@ -7718,14 +7718,14 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^^^ meta.instantiation.java
 //                ^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //                ^ punctuation.terminator.java
 
     new TestClass(
 //  ^^^^^^^^^^^^^^^ meta.instantiation.java
 //               ^^ meta.group.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.section.group.begin.java
 
     new TestClass( ;
@@ -7733,7 +7733,7 @@ class InstanceCreationExpressionsTests {
 //               ^^ meta.group.java
 //                 ^^ - meta.instantiation - meta.group
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.section.group.begin.java
 //                 ^ punctuation.terminator.java
 
@@ -7742,7 +7742,7 @@ class InstanceCreationExpressionsTests {
 //               ^^^^^ meta.group.java
 //                    ^^ - meta.instantiation - meta.group
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.section.group.begin.java
 //                ^^^ variable.other.java
 //                    ^ punctuation.terminator.java
@@ -7752,7 +7752,7 @@ class InstanceCreationExpressionsTests {
 //               ^^^^^ meta.group.java
 //                    ^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.section.group.begin.java
 //                ^^^ variable.other.java
 //                   ^ punctuation.section.group.end.java
@@ -7763,7 +7763,7 @@ class InstanceCreationExpressionsTests {
 //               ^^^^^ meta.group.java
 //                    ^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.section.group.begin.java
 //                ^^^ variable.other.java
 //                   ^ punctuation.section.group.end.java
@@ -7776,7 +7776,7 @@ class InstanceCreationExpressionsTests {
 //                         ^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
 //       ^^^ variable.annotation.java
-//           ^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^ support.class.java
 //                    ^ punctuation.section.group.begin.java
 //                     ^^^ variable.other.java
 //                        ^ punctuation.section.group.end.java
@@ -7789,7 +7789,7 @@ class InstanceCreationExpressionsTests {
 //                         ^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
 //       ^^^ variable.annotation.java
-//           ^^^^^^^^^ storage.type.class.java
+//           ^^^^^^^^^ support.class.java
 //                    ^ punctuation.section.group.begin.java
 //                     ^^^ variable.other.java
 //                        ^ punctuation.section.group.end.java
@@ -7803,7 +7803,7 @@ class InstanceCreationExpressionsTests {
 //         ^ punctuation.accessor.dot.java
 //          ^^^^ variable.namespace.java
 //              ^ punctuation.accessor.dot.java
-//               ^^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^^ support.class.java
 //                        ^^^^^ meta.group.java
 //                        ^ punctuation.section.group.begin.java
 //                         ^^^ variable.other.java
@@ -7818,7 +7818,7 @@ class InstanceCreationExpressionsTests {
 //         ^ punctuation.accessor.dot.java
 //          ^^^^ variable.namespace.java
 //              ^ punctuation.accessor.dot.java
-//               ^^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^^ support.class.java
 //                        ^^^^^ meta.group.java
 //                        ^ punctuation.section.group.begin.java
 //                         ^^^ variable.other.java
@@ -7827,9 +7827,9 @@ class InstanceCreationExpressionsTests {
     new OuterClass.InnerClass();
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^^ support.class.java
 //                ^ punctuation.accessor.dot.java
-//                 ^^^^^^^^^^ storage.type.class.java
+//                 ^^^^^^^^^^ support.class.java
 
     new @Foo com . @Foo java . @Foo OuterClass . @Foo InnerClass(foo);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java
@@ -7853,11 +7853,11 @@ class InstanceCreationExpressionsTests {
 //                           ^ punctuation.accessor.dot.java
 //                             ^ punctuation.definition.annotation.java
 //                              ^^^ variable.annotation.java
-//                                  ^^^^^^^^^^ storage.type.class.java
+//                                  ^^^^^^^^^^ support.class.java
 //                                             ^ punctuation.accessor.dot.java
 //                                               ^ punctuation.definition.annotation.java
 //                                                ^^^ variable.annotation.java
-//                                                    ^^^^^^^^^^ storage.type.class.java
+//                                                    ^^^^^^^^^^ support.class.java
 //                                                              ^^^^^ meta.group.java
 //                                                              ^ punctuation.section.group.begin.java
 //                                                               ^^^ variable.other.java
@@ -7890,7 +7890,7 @@ class InstanceCreationExpressionsTests {
 //                                             ^ punctuation.accessor.dot.java
 //                                               ^ punctuation.definition.annotation.java
 //                                                ^^^ variable.annotation.java
-//                                                    ^^^^^^^^^^ storage.type.class.java
+//                                                    ^^^^^^^^^^ support.class.java
 //                                                              ^^^^^ meta.group.java
 //                                                              ^ punctuation.section.group.begin.java
 //                                                               ^^^ variable.other.java
@@ -7904,10 +7904,10 @@ class InstanceCreationExpressionsTests {
 //               ^^^^^^^^^^^^^^^ meta.instantiation.java meta.instantiation.java
 //                              ^^^^^^^ meta.instantiation.java - meta.instantiation meta.instantiation
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^ support.class.java
 //              ^ punctuation.section.group.begin.java
 //               ^^^ keyword.other.storage.new.java
-//                   ^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^ support.class.java
 //                           ^^^ meta.brackets.java
 //                              ^ punctuation.separator.comma.java
 //                                ^^^^ constant.language.boolean.java
@@ -7926,7 +7926,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java
 //  ^^^ keyword.other.storage.new.java
 //      ^^^^^^ invalid.illegal.unexpected-keyword.java
-//             ^^^^^^^^^^ storage.type.class.java
+//             ^^^^^^^^^^ support.class.java
 //                       ^ punctuation.section.group.begin.java
 //                        ^ punctuation.section.group.end.java
 //                          ^ punctuation.section.block.begin.java
@@ -7937,7 +7937,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java
 //  ^^^ keyword.other.storage.new.java
 //      ^^^^^ invalid.illegal.unexpected-keyword.java
-//            ^^^^^^^^^^ storage.type.class.java
+//            ^^^^^^^^^^ support.class.java
 //                      ^ punctuation.section.group.begin.java
 //                       ^ punctuation.section.group.end.java
 //                         ^ punctuation.section.block.begin.java
@@ -8067,7 +8067,7 @@ class InstanceCreationExpressionsTests {
 //               ^^^^^^^^^^^^^^ meta.instantiation.java meta.braces.java
 //                             ^ - meta.instantiation - meta.braces
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^ storage.type.class.java
+//      ^^^^^^ support.class.java
 //            ^ punctuation.section.brackets.begin.java
 //             ^ punctuation.section.brackets.end.java
 //               ^ punctuation.section.braces.begin.java
@@ -8081,7 +8081,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^ meta.instantiation.java - meta.braces
 //              ^^^^^^^^^^^^^^^^^ - meta.instantiation
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^ storage.type.class.java
+//      ^^^^^^ support.class.java
 //            ^ punctuation.section.brackets.begin.java
 //             ^ punctuation.section.brackets.end.java
 //                 ^ punctuation.section.block.begin.java
@@ -8096,7 +8096,7 @@ class InstanceCreationExpressionsTests {
 //              ^^^ meta.brackets
 //                 ^ - meta.instantiation - meta.brackets
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^ support.class.java
 //              ^ punctuation.section.brackets.begin.java
 //               ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                ^ punctuation.section.brackets.end.java
@@ -8107,7 +8107,7 @@ class InstanceCreationExpressionsTests {
 //              ^^^ meta.brackets
 //                 ^ - meta.instantiation - meta.brackets
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^ support.class.java
 //              ^ punctuation.section.brackets.begin.java
 //               ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                ^ punctuation.section.brackets.end.java
@@ -8118,7 +8118,7 @@ class InstanceCreationExpressionsTests {
 //              ^^^^^ meta.brackets
 //                   ^ - meta.instantiation - meta.brackets
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^ support.class.java
 //              ^ punctuation.section.brackets.begin.java
 //               ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                ^ punctuation.section.brackets.end.java
@@ -8140,7 +8140,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^ keyword.other.storage.new.java
 //      ^ punctuation.definition.annotation.java
 //       ^^^^^^^ variable.annotation.java
-//               ^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^ support.class.java
 //                        ^ punctuation.definition.annotation.java
 //                         ^^^^^ variable.annotation.java
 //                               ^ punctuation.section.brackets.begin.java
@@ -8168,7 +8168,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^ keyword.other.storage.new.java
 //      ^ punctuation.definition.annotation.java
 //       ^^^^^^^ variable.annotation.java
-//               ^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^ support.class.java
 //                        ^ punctuation.definition.annotation.java
 //                         ^^^^^ variable.annotation.java
 //                               ^ punctuation.section.brackets.begin.java
@@ -8194,7 +8194,7 @@ class InstanceCreationExpressionsTests {
 //               ^ punctuation.accessor.dot.java
 //                ^^ variable.namespace.java
 //                  ^ punctuation.accessor.dot.java
-//                   ^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^ support.class.java
 //                           ^ punctuation.section.brackets.begin.java
 //                            ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                             ^ punctuation.section.brackets.end.java
@@ -8211,7 +8211,7 @@ class InstanceCreationExpressionsTests {
 //               ^ punctuation.accessor.dot.java
 //                ^^ variable.namespace.java
 //                  ^ punctuation.accessor.dot.java
-//                   ^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^ support.class.java
 //                           ^ punctuation.section.brackets.begin.java
 //                            ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                             ^ punctuation.section.brackets.end.java
@@ -8224,7 +8224,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^^ meta.instantiation.java
 //             ^^ meta.generic.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^^ punctuation.definition.generic.diamond.java
 //               ^ punctuation.terminator.java
 
@@ -8233,7 +8233,7 @@ class InstanceCreationExpressionsTests {
 //             ^^ meta.generic.java
 //               ^^ meta.group.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^^ punctuation.definition.generic.diamond.java
 //               ^ punctuation.section.group.begin.java
 //                ^ punctuation.section.group.end.java
@@ -8244,9 +8244,9 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^ meta.generic.java
 //                   ^^ meta.group.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^^^^ storage.type.class.java
+//              ^^^^ support.class.java
 //                  ^ punctuation.definition.generic.end.java
 //                   ^ punctuation.section.group.begin.java
 //                    ^ punctuation.section.group.end.java
@@ -8259,11 +8259,11 @@ class InstanceCreationExpressionsTests {
 //                   ^ - meta.annotation
 //                         ^^ meta.group.java
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
 //              ^ punctuation.definition.annotation.java
 //               ^^^^ variable.annotation.java
-//                    ^^^^ storage.type.class.java
+//                    ^^^^ support.class.java
 //                        ^ punctuation.definition.generic.end.java
 //                         ^ punctuation.section.group.begin.java
 //                          ^ punctuation.section.group.end.java
@@ -8273,7 +8273,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^^^^^^^^^^^^^^ meta.instantiation.java
 //             ^^^ meta.generic.java
 //                ^^ meta.group.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
 //              ^ variable.language.wildcard.java
 //               ^ punctuation.definition.generic.end.java
@@ -8291,7 +8291,7 @@ class InstanceCreationExpressionsTests {
 //                            ^^ meta.group.java
 //      ^ punctuation.definition.annotation.java
 //       ^^^^ variable.annotation.java
-//            ^^^^^^^ storage.type.class.java
+//            ^^^^^^^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
@@ -8308,7 +8308,7 @@ class InstanceCreationExpressionsTests {
 //             ^ punctuation.definition.generic.begin.java
 //              ^ variable.language.wildcard.java
 //                ^^^^^^^ storage.modifier.extends.java
-//                        ^^^^ storage.type.class.java
+//                        ^^^^ support.class.java
 //                            ^ punctuation.definition.generic.end.java
 //                             ^ punctuation.section.group.begin.java
 //                              ^ punctuation.section.group.end.java
@@ -8320,7 +8320,7 @@ class InstanceCreationExpressionsTests {
 //                                               ^^ meta.instantiation.java meta.group.java
 //      ^ punctuation.definition.annotation.java
 //       ^^^^ variable.annotation.java
-//            ^^^^^^^ storage.type.class.java
+//            ^^^^^^^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
@@ -8328,7 +8328,7 @@ class InstanceCreationExpressionsTests {
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
-//                                          ^^^^ storage.type.class.java
+//                                          ^^^^ support.class.java
 //                                              ^ punctuation.definition.generic.end.java
 //                                               ^ punctuation.section.group.begin.java
 //                                                ^ punctuation.section.group.end.java
@@ -8340,7 +8340,7 @@ class InstanceCreationExpressionsTests {
 //                                               ^^ meta.instantiation.java meta.group.java
 //      ^ punctuation.definition.annotation.java
 //       ^^^^ variable.annotation.java
-//            ^^^^^^^ storage.type.class.java
+//            ^^^^^^^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
@@ -8348,7 +8348,7 @@ class InstanceCreationExpressionsTests {
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
-//                                          ^^^^ storage.type.class.java
+//                                          ^^^^ support.class.java
 //                                              ^ punctuation.definition.generic.end.java
 //                                               ^ punctuation.section.group.begin.java
 //                                                ^ punctuation.section.group.end.java
@@ -8361,9 +8361,9 @@ class InstanceCreationExpressionsTests {
 //             ^ punctuation.definition.generic.begin.java
 //              ^ variable.language.wildcard.java
 //                ^^^^^^^ storage.modifier.extends.java
-//                        ^^^^ storage.type.class.java
+//                        ^^^^ support.class.java
 //                            ^ punctuation.separator.comma.java
-//                              ^^^^^^ storage.type.class.java
+//                              ^^^^^^ support.class.java
 //                                    ^ punctuation.definition.generic.end.java
 //                                     ^ punctuation.section.group.begin.java
 //                                      ^ punctuation.section.group.end.java
@@ -8376,7 +8376,7 @@ class InstanceCreationExpressionsTests {
 //             ^ punctuation.definition.generic.begin.java
 //              ^ variable.language.wildcard.java
 //                ^^^^^ keyword.declaration.super.java
-//                      ^^^^ storage.type.class.java
+//                      ^^^^ support.class.java
 //                          ^ punctuation.definition.generic.end.java
 //                           ^ punctuation.section.group.begin.java
 //                            ^ punctuation.section.group.end.java
@@ -8419,7 +8419,7 @@ class InstanceCreationExpressionsTests {
 //                                            ^^ storage.modifier.array.java
 
     new Generic<String, int>();
-//              ^^^^^^ storage.type.class.java
+//              ^^^^^^ support.class.java
 //                      ^^^ invalid.illegal.unexpected-keyword.java
 
     new Generic<a.b.FooBar>();
@@ -8447,16 +8447,16 @@ class InstanceCreationExpressionsTests {
 //                                                    ^ meta.instantiation.java meta.braces.java - meta.instantiation meta.instantiation
 //                                                     ^ - meta.instantiation - meta.braces
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
 //             ^^^ meta.generic.java
 //                ^ punctuation.section.brackets.begin.java
 //                 ^ punctuation.section.brackets.end.java
 //                   ^ punctuation.section.braces.begin
 //                     ^^^ keyword.other.storage.new.java
-//                         ^^^^^^^ storage.type.class.java
+//                         ^^^^^^^ support.class.java
 //                                   ^ punctuation.separator.comma.java
 //                                     ^^^ keyword.other.storage.new.java
-//                                         ^^^^^^^ storage.type.class.java
+//                                         ^^^^^^^ support.class.java
 //                                                    ^ punctuation.section.braces.end
 
     new ArrayList<?>[] { new ArrayList<java.sql.Date>(), new ArrayList<Date>() }
@@ -8472,7 +8472,7 @@ class InstanceCreationExpressionsTests {
 //                                     ^^^^^^^^^^^^^ meta.path.java
 //                                                                    ^^^^^^ meta.generic.java - meta.path
 //  ^^^ keyword.other.storage.new.java
-//      ^^^^^^^^^ storage.type.class.java
+//      ^^^^^^^^^ support.class.java
 //               ^ punctuation.definition.generic.begin.java
 //                ^ variable.language.wildcard.java
 //                 ^ punctuation.definition.generic.end.java
@@ -8480,21 +8480,21 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.section.brackets.end.java
 //                     ^ punctuation.section.braces.begin.java
 //                       ^^^ keyword.other.storage.new.java
-//                           ^^^^^^^^^ storage.type.class.java
+//                           ^^^^^^^^^ support.class.java
 //                                    ^ punctuation.definition.generic.begin.java
 //                                     ^^^^ variable.namespace.java
 //                                         ^ punctuation.accessor.dot.java
 //                                          ^^^ variable.namespace.java
 //                                             ^ punctuation.accessor.dot.java
-//                                              ^^^^ storage.type.class.java
+//                                              ^^^^ support.class.java
 //                                                  ^ punctuation.definition.generic.end.java
 //                                                   ^ punctuation.section.group.begin.java
 //                                                    ^ punctuation.section.group.end.java
 //                                                     ^ punctuation.separator.comma.java
 //                                                       ^^^ keyword.other.storage.new.java
-//                                                           ^^^^^^^^^ storage.type.class.java
+//                                                           ^^^^^^^^^ support.class.java
 //                                                                    ^ punctuation.definition.generic.begin.java
-//                                                                     ^^^^ storage.type.class.java
+//                                                                     ^^^^ support.class.java
 //                                                                         ^ punctuation.definition.generic.end.java
 //                                                                          ^ punctuation.section.group.begin.java
 //                                                                           ^ punctuation.section.group.end.java
@@ -8514,7 +8514,7 @@ class InstanceCreationExpressionsTests {
 //   ^^^^^^^^^^^ meta.instantiation.java meta.path.java
 //    ^ variable.namespace.java
 //     ^ punctuation.accessor.dot.java
-//      ^^^^^^^ storage.type.class.java
+//      ^^^^^^^ support.class.java
       <
 //   ^ meta.instantiation.java meta.path.java - meta.generic
 //    ^^ meta.instantiation.java meta.path.java meta.generic.java
@@ -8530,7 +8530,7 @@ class InstanceCreationExpressionsTests {
 //     ^^^^^^^^^^^ meta.instantiation.java meta.path.java meta.generic.java meta.path.java
 //      ^ variable.namespace.java
 //       ^ punctuation.accessor.dot.java
-//        ^^^^^^^ storage.type.class.java
+//        ^^^^^^^ support.class.java
       >();
 //<- meta.instantiation.java meta.path.java meta.generic.java - meta.path meta.path
 //   ^^ meta.instantiation.java meta.path.java meta.generic.java - meta.path meta.path
@@ -8557,17 +8557,17 @@ class MethodReferenceExpressionsTests {
   void run() {
 
     System::currentTimeMillis  // static method
-//  ^^^^^^ storage.type.class.java
+//  ^^^^^^ support.class.java
 //        ^^ punctuation.accessor.double-colon.java
 //          ^^^^^^^^^^^^^^^^^ variable.function.reference.java
 
     List::size                 // inferred type arguments for generic type
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^^ punctuation.accessor.double-colon.java
 //        ^^^^ variable.function.reference.java
 
     List<String>::size         // explicit type arguments for generic type
-//  ^^^^ storage.type.class.java
+//  ^^^^ support.class.java
 //      ^^^^^^^^ meta.generic.java
 //              ^^ punctuation.accessor.double-colon.java
 //                ^^^^ variable.function.reference.java
@@ -8579,12 +8579,12 @@ class MethodReferenceExpressionsTests {
 //         ^^^^^ variable.function.reference.java
 
     T::tvarMember
-//  ^ storage.type.class.java
+//  ^ support.class.java
 //   ^^ punctuation.accessor.double-colon.java
 //     ^^^^^^^^^^ variable.function.reference.java
 
     System.out::println
-//  ^^^^^^ storage.type.class.java
+//  ^^^^^^ support.class.java
 //        ^ punctuation.accessor.dot.java
 //         ^^^ variable.other.java
 //            ^^ punctuation.accessor.double-colon.java
@@ -8611,7 +8611,7 @@ class MethodReferenceExpressionsTests {
 //          ^^^^ variable.other.java
 //              ^ punctuation.accessor.dot.java
 //               ^^^^^^^^^^ variable.function.java
-//                          ^^^^^^ storage.type.class.java
+//                          ^^^^^^ support.class.java
 //                                ^^ punctuation.accessor.double-colon.java
 //                                  ^^^^ variable.function.reference.java
 //                                        ^ keyword.operator.ternary.java
@@ -8626,45 +8626,45 @@ class MethodReferenceExpressionsTests {
 //         ^^^^^^^^ variable.function.reference.java
 
     Arrays::<String>sort       // explicit type arguments
-//  ^^^^^^ storage.type.class.java
+//  ^^^^^^ support.class.java
 //        ^^ punctuation.accessor.double-colon.java
 //          ^^^^^^^^ meta.generic.java
 //                  ^^^^ variable.function.reference.java
 
     ArrayList<String>::new     // constructor for parameterized type
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //           ^^^^^^^^ meta.generic.java
 //                   ^^ punctuation.accessor.double-colon.java
 //                     ^^^ keyword.other.storage.new.java
 
     ArrayList<String ::new     // constructor for parameterized type
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //           ^^^^^^^^ meta.generic.java
 //                   ^^ punctuation.accessor.double-colon.java
 //                     ^^^ keyword.other.storage.new.java
 
     ArrayList::new             // inferred type arguments for generic class
-//  ^^^^^^^^^ storage.type.class.java
+//  ^^^^^^^^^ support.class.java
 //           ^^ punctuation.accessor.double-colon.java
 //             ^^^ keyword.other.storage.new.java
 
     Foo::<Integer>new          // explicit type arguments for generic constructor
-//  ^^^ storage.type.class.java
+//  ^^^ support.class.java
 //     ^^ punctuation.accessor.double-colon.java
 //       ^^^^^^^^^ meta.generic.java
 //                ^^^ keyword.other.storage.new.java
 
     Bar<String>::<Integer>new  // generic class, generic constructor
-//  ^^^ storage.type.class.java
+//  ^^^ support.class.java
 //     ^^^^^^^^ meta.generic.java
 //             ^^ punctuation.accessor.double-colon.java
 //               ^^^^^^^^^ meta.generic.java
 //                        ^^^ keyword.other.storage.new.java
 
     Outer.Inner::new           // inner class constructor
-//  ^^^^^ storage.type.class.java
+//  ^^^^^ support.class.java
 //       ^ punctuation.accessor.dot.java
-//        ^^^^^ storage.type.class.java
+//        ^^^^^ support.class.java
 //             ^^ punctuation.accessor.double-colon.java
 //               ^^^ keyword.other.storage.new.java
     int[]::new                 // array creation
@@ -8704,7 +8704,7 @@ class CastExpressionsTests {
 //  ^^^^^^ meta.cast.java meta.group.java
 //        ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.section.group.end.java
 //         ^^^ variable.other.java
 
@@ -8773,7 +8773,7 @@ class CastExpressionsTests {
 //  ^ punctuation.section.group.begin.java
 //   ^^^ storage.type.primitive.java
 //      ^ punctuation.section.group.end.java
-//        ^^^^^^^^^ storage.type.class.java
+//        ^^^^^^^^^ support.class.java
 //                 ^ punctuation.terminator.java
 
     (int) new TestClass();
@@ -8784,7 +8784,7 @@ class CastExpressionsTests {
 //   ^^^ storage.type.primitive.java
 //      ^ punctuation.section.group.end.java
 //        ^^^ keyword.other.storage.new.java
-//            ^^^^^^^^^ storage.type.class.java
+//            ^^^^^^^^^ support.class.java
 //                     ^ punctuation.section.group.begin.java
 //                      ^ punctuation.section.group.end.java
 //                       ^ punctuation.terminator.java
@@ -8851,7 +8851,7 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^ meta.cast.java meta.group.java
 //             ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //            ^ punctuation.section.group.end.java
 //              ^^^ variable.other.java
 
@@ -8859,7 +8859,7 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^^^ meta.cast.java meta.group.java
 //               ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //            ^^ storage.modifier.array.java
 //              ^ punctuation.section.group.end.java
 //                ^^^ variable.other.java
@@ -8868,7 +8868,7 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^ meta.cast.java meta.group.java
 //             ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //            ^ punctuation.section.group.end.java
 //              ^^^ variable.other.java
 
@@ -8876,7 +8876,7 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^^^ meta.cast.java meta.group.java
 //               ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //            ^^ storage.modifier.array.java
 //              ^ punctuation.section.group.end.java
 //                ^^^ variable.other.java
@@ -8885,9 +8885,9 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.cast.java meta.group.java
 //                          ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //             ^ keyword.operator.logical.java
-//               ^^^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^^^ support.class.java
 //                         ^ punctuation.section.group.end.java
 //                           ^^^ variable.other.java
 
@@ -8895,9 +8895,9 @@ class CastExpressionsTests {
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.cast.java meta.group.java
 //                          ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^^^^^^ storage.type.class.java
+//   ^^^^^^^^^ support.class.java
 //             ^ keyword.operator.logical.java
-//               ^^^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^^^ support.class.java
 //                         ^ punctuation.section.group.end.java
 //                           ^^^ variable.other.java
 
@@ -8906,10 +8906,10 @@ class CastExpressionsTests {
 //                                      ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
 //   ^^^^^ meta.annotation.identifier.java
-//         ^^^^^^^^^ storage.type.class.java
+//         ^^^^^^^^^ support.class.java
 //                   ^ keyword.operator.logical.java
 //                     ^^^^^ meta.annotation.identifier.java
-//                           ^^^^^^^^^^ storage.type.class.java
+//                           ^^^^^^^^^^ support.class.java
 //                                     ^ punctuation.section.group.end.java
 //                                       ^^^ variable.other.java
   }
@@ -8919,18 +8919,18 @@ class CastExpressionsTests {
     (a < b) foo;
 //  ^^^^^^^ meta.group.java
 //  ^ punctuation.section.group.begin.java
-//   ^ storage.type.class.java
+//   ^ support.class.java
 //     ^ punctuation.definition.generic.begin.java
-//       ^ storage.type.class.java
+//       ^ support.class.java
 //        ^ punctuation.section.group.end.java
 //          ^^^ variable.other.java
 
     (a < b) ~ foo;
 //  ^^^^^^^ meta.group.java
 //  ^ punctuation.section.group.begin.java
-//   ^ storage.type.class.java
+//   ^ support.class.java
 //     ^ punctuation.definition.generic.begin.java
-//       ^ storage.type.class.java
+//       ^ support.class.java
 //        ^ punctuation.section.group.end.java
 //          ^ keyword.operator.bitwise.java
 //            ^^^ variable.other.java
@@ -8941,9 +8941,9 @@ class CastExpressionsTests {
 //          ^ meta.cast.java meta.group.java - meta.generic
 //           ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.definition.generic.begin.java
-//        ^ storage.type.class.java
+//        ^ support.class.java
 //         ^ punctuation.definition.generic.end.java
 //          ^ punctuation.section.group.end.java
 //            ^^^ variable.other.java
@@ -8954,9 +8954,9 @@ class CastExpressionsTests {
 //          ^^^ meta.cast.java meta.group.java - meta.generic
 //             ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.definition.generic.begin.java
-//        ^ storage.type.class.java
+//        ^ support.class.java
 //         ^ punctuation.definition.generic.end.java
 //          ^^ storage.modifier.array.java
 //            ^ punctuation.section.group.end.java
@@ -8968,9 +8968,9 @@ class CastExpressionsTests {
 //          ^ meta.cast.java meta.group.java - meta.generic
 //           ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.definition.generic.begin.java
-//        ^ storage.type.class.java
+//        ^ support.class.java
 //         ^ punctuation.definition.generic.end.java
 //          ^ punctuation.section.group.end.java
 //            ^^^ variable.other.java
@@ -8981,9 +8981,9 @@ class CastExpressionsTests {
 //          ^^^ meta.cast.java meta.group.java - meta.generic
 //             ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.definition.generic.begin.java
-//        ^ storage.type.class.java
+//        ^ support.class.java
 //         ^ punctuation.definition.generic.end.java
 //          ^^ storage.modifier.array.java
 //            ^ punctuation.section.group.end.java
@@ -8992,18 +8992,18 @@ class CastExpressionsTests {
     (list<t>[] & OtherList<T> & None) foo;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.cast.java meta.group.java
 //  ^ punctuation.section.group.begin.java
-//   ^^^^ storage.type.class.java
+//   ^^^^ support.class.java
 //       ^ punctuation.definition.generic.begin.java
-//        ^ storage.type.class.java
+//        ^ support.class.java
 //         ^ punctuation.definition.generic.end.java
 //          ^^ storage.modifier.array.java
 //             ^ keyword.operator.logical.java
-//               ^^^^^^^^^ storage.type.class.java
+//               ^^^^^^^^^ support.class.java
 //                        ^ punctuation.definition.generic.begin.java
-//                         ^ storage.type.class.java
+//                         ^ support.class.java
 //                          ^ punctuation.definition.generic.end.java
 //                            ^ keyword.operator.logical.java
-//                              ^^^^ storage.type.class.java
+//                              ^^^^ support.class.java
 //                                  ^ punctuation.section.group.end.java
 //                                    ^^^ variable.other.java
 
@@ -9014,7 +9014,7 @@ class CastExpressionsTests {
 //       ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
 //   ^ punctuation.definition.generic.begin.java
-//    ^ storage.type.class.java
+//    ^ support.class.java
 //     ^ punctuation.definition.generic.end.java
 //      ^ punctuation.section.group.end.java
 //        ^^^ variable.other.java
@@ -9026,7 +9026,7 @@ class CastExpressionsTests {
 //         ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
 //   ^ punctuation.definition.generic.begin.java
-//    ^ storage.type.class.java
+//    ^ support.class.java
 //     ^ punctuation.definition.generic.end.java
 //      ^^ storage.modifier.array.java
 //        ^ punctuation.section.group.end.java
@@ -9039,7 +9039,7 @@ class CastExpressionsTests {
 //       ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
 //   ^ punctuation.definition.generic.begin.java
-//    ^ storage.type.class.java
+//    ^ support.class.java
 //     ^ punctuation.definition.generic.end.java
 //      ^ punctuation.section.group.end.java
 //        ^^^ variable.other.java
@@ -9051,7 +9051,7 @@ class CastExpressionsTests {
 //         ^^^^ - meta.cast - meta.group
 //  ^ punctuation.section.group.begin.java
 //   ^ punctuation.definition.generic.begin.java
-//    ^ storage.type.class.java
+//    ^ support.class.java
 //     ^ punctuation.definition.generic.end.java
 //      ^^ storage.modifier.array.java
 //        ^ punctuation.section.group.end.java
@@ -9192,14 +9192,14 @@ class TypeComparisonExpressionsTests {
     a instanceof b
 //    ^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//               ^ storage.type.class.java
+//               ^ support.class.java
 
     a instanceof b.c
 //    ^^^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //               ^ variable.namespace.java
 //                ^ punctuation.accessor.dot.java
-//                 ^ storage.type.class.java
+//                 ^ support.class.java
 
     a instanceof b.c.d
 //    ^^^^^^^^^^^^^^^^^ meta.instanceof.java
@@ -9208,7 +9208,7 @@ class TypeComparisonExpressionsTests {
 //                ^ punctuation.accessor.dot.java
 //                 ^ variable.namespace.java
 //                  ^ punctuation.accessor.dot.java
-//                   ^ storage.type.class.java
+//                   ^ support.class.java
 
     a instanceof b.c.d e f
 //    ^^^^^^^^^^^^^^^^^^ meta.instanceof.java
@@ -9218,14 +9218,14 @@ class TypeComparisonExpressionsTests {
 //                ^ punctuation.accessor.dot.java
 //                 ^ variable.namespace.java
 //                  ^ punctuation.accessor.dot.java
-//                   ^ storage.type.class.java
+//                   ^ support.class.java
 //                     ^ variable.other.java
 //                       ^ variable.other.java
 
     a instanceof Object
 //    ^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //    ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//               ^^^^^^ storage.type.class.java
+//               ^^^^^^ support.class.java
   }
 //^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 
@@ -9240,12 +9240,12 @@ class TypeComparisonExpressionsTests {
 //  ^^^^^^^^^^^ meta.instanceof.java - meta.path
 //             ^^^^^^^^^ meta.instanceof.java meta.path.java
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//             ^ storage.type.class.java
+//             ^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
 //               ^ variable.language.wildcard.java
 //                ^ punctuation.definition.generic.end.java
 //                 ^ punctuation.accessor.dot.java
-//                  ^ storage.type.class.java
+//                  ^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ variable.language.wildcard.java
 //                     ^ punctuation.definition.generic.end.java
@@ -9261,7 +9261,7 @@ class TypeComparisonExpressionsTests {
 //    ^ keyword.operator.assignment.java
 //      ^ variable.other.java
 //        ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//                   ^ storage.type.class.java
+//                   ^ support.class.java
 //                    ^ keyword.operator.ternary.java
 //                     ^^^^ constant.numeric.value.java
 //                         ^ keyword.operator.ternary.java
@@ -9278,7 +9278,7 @@ class TypeComparisonExpressionsTests {
 //                         ^^^^^^^^^^^^^^^^^^^ - meta.instanceof
 //  ^^^ variable.other.java
 //      ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//                 ^^^^^^ storage.type.class.java
+//                 ^^^^^^ support.class.java
 //                        ^ variable.other.java
 //                          ^^ keyword.operator.logical.java
 //                             ^ variable.other.java
@@ -9295,7 +9295,7 @@ class TypeComparisonExpressionsTests {
 //  ^^^ variable.other.java
 //      ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //                 ^ punctuation.section.group.begin.java
-//                   ^^^^^^ storage.type.class.java
+//                   ^^^^^^ support.class.java
 //                         ^^ storage.modifier.array.java
 //                            ^ variable.other.java
 //                              ^ punctuation.section.group.end.java
@@ -9310,21 +9310,21 @@ class TypeComparisonExpressionsTests {
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //      ^ variable.other.java
 //        ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//                   ^^^^^^^^^ storage.type.class.java
+//                   ^^^^^^^^^ support.class.java
 //                            ^ punctuation.section.group.begin.java
-//                             ^^^^^^^^^^^^ storage.type.class.java
+//                             ^^^^^^^^^^^^ support.class.java
 //                                         ^ punctuation.section.group.begin.java
-//                                          ^^^^^ storage.type.class.java
+//                                          ^^^^^ support.class.java
 //                                                ^ variable.other.java
 //                                                 ^ punctuation.separator.comma.java
-//                                                   ^^^^^ storage.type.class.java
+//                                                   ^^^^^ support.class.java
 //                                                         ^ variable.other.java
 //                                                          ^ punctuation.section.group.end.java
 //                                                           ^ punctuation.separator.comma.java
                                coloredpoint lr)) {
 //                            ^^^^^^^^^^^^^^^^^ meta.instanceof.java
 //                                             ^ - meta.instanceof
-//                             ^^^^^^^^^^^^ storage.type.class.java
+//                             ^^^^^^^^^^^^ support.class.java
 //                                          ^^ variable.other.java
 //                                            ^^ punctuation.section.group.end.java
 //                                               ^ punctuation.section.block.begin.java
@@ -9347,7 +9347,7 @@ class TypeComparisonExpressionsTests {
 //  ^^^ variable.other.java
 //      ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //                 ^ punctuation.section.group.begin.java
-//                  ^^^^^^ storage.type.class.java
+//                  ^^^^^^ support.class.java
 //                        ^ punctuation.section.group.begin.java
 //                         ^^^^^^^ storage.type.primitive.java
 //                                 ^ variable.other.java
@@ -9357,7 +9357,7 @@ class TypeComparisonExpressionsTests {
 //                                         ^ variable.other.java
 //                                          ^ punctuation.section.group.end.java
 //                                           ^ punctuation.separator.comma.java
-//                                             ^^^ storage.type.class.java
+//                                             ^^^ support.class.java
 //                                                ^ punctuation.section.group.begin.java
 //                                                 ^^^ storage.type.primitive.java
 //                                                     ^ variable.other.java
@@ -9385,12 +9385,12 @@ class TypeComparisonExpressionsTests {
 //                                         ^ meta.group.java - meta.instanceof
 //      ^^ variable.other.java
 //         ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//                    ^^^ storage.type.class.java
+//                    ^^^ support.class.java
 //                       ^ punctuation.definition.generic.begin.java
-//                        ^^^^^^ storage.type.class.java
+//                        ^^^^^^ support.class.java
 //                              ^ punctuation.definition.generic.end.java
 //                               ^ punctuation.section.group.begin.java
-//                                ^^^^^^ storage.type.class.java
+//                                ^^^^^^ support.class.java
 //                                       ^ variable.other.java
 //                                        ^ punctuation.section.group.end.java
 
@@ -9410,9 +9410,9 @@ class TypeComparisonExpressionsTests {
 //                                      ^ meta.group.java - meta.instanceof
 //      ^^ variable.other.java
 //         ^^^^^^^^^^ keyword.other.storage.instanceof.java
-//                    ^^^ storage.type.class.java
+//                    ^^^ support.class.java
 //                       ^ punctuation.definition.generic.begin.java
-//                        ^^^^^^ storage.type.class.java
+//                        ^^^^^^ support.class.java
 //                              ^ punctuation.definition.generic.end.java
 //                               ^ punctuation.section.group.begin.java
 //                                ^^^ storage.type.variant.java
@@ -9469,9 +9469,9 @@ class LambdasExpressionsTests {
 //                            ^^^^^^ meta.function.anonymous.java - meta.group
 //    ^^^ storage.type.primitive
 //        ^ variable.parameter.java
-//           ^^^ storage.type.class.java
+//           ^^^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
-//               ^^^^^^^ storage.type.class.java
+//               ^^^^^^^ support.class.java
 //                      ^ punctuation.definition.generic.end.java
 //                          ^ variable.parameter.java
 //                             ^^ keyword.declaration.function.arrow.java
@@ -9487,9 +9487,9 @@ class LambdasExpressionsTests {
 //           ^ punctuation.separator.comma.java
         Foo<Integer>[] b
 //     ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.parameters.java meta.group.java - meta.function.anonymous meta.function.anonymous
-//      ^^^ storage.type.class.java
+//      ^^^ support.class.java
 //         ^ punctuation.definition.generic.begin.java
-//          ^^^^^^^ storage.type.class.java
+//          ^^^^^^^ support.class.java
 //                 ^ punctuation.definition.generic.end.java
 //                     ^ variable.parameter.java
     )
@@ -9584,7 +9584,7 @@ class LambdasExpressionsTests {
 //                                    ^^^^^ storage.modifier.java
 //                                          ^^^^^^^^^^^^^ meta.annotation
 //                                          ^ punctuation.definition.annotation
-//                                                        ^^^^^^ storage.type.class.java - meta.annotation
+//                                                        ^^^^^^ support.class.java - meta.annotation
 //                                                               ^^^ variable.parameter.java
 //                                                                    ^^ keyword.declaration.function.arrow.java - meta.function.anonymous.parameters.java
 
@@ -9592,7 +9592,7 @@ class LambdasExpressionsTests {
 //                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.parameters.java
 //                                    ^^^^^^^^^^^^^ meta.annotation
 //                                    ^ punctuation.definition.annotation
-//                                                  ^^^^^^ storage.type.class.java - meta.annotation
+//                                                  ^^^^^^ support.class.java - meta.annotation
 //                                                         ^^^ variable.parameter.java
 //                                                              ^^ keyword.declaration.function.arrow.java - meta.function.anonymous.parameters.java
 
@@ -9601,16 +9601,16 @@ class LambdasExpressionsTests {
 //                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
 //                                    ^ punctuation.definition.annotation
 //                                                  ^^^ variable.parameter.java
-//                                                        ^^^ storage.type.class.java
+//                                                        ^^^ support.class.java
 //                                                           ^ punctuation.accessor.dot.java
 //                                                            ^^^ constant.other.java
-//                                                                 ^^^^^^ storage.type.class.java - meta.annotation
+//                                                                 ^^^^^^ support.class.java - meta.annotation
 //                                                                        ^^^ variable.parameter.java
 //                                                                             ^^ keyword.declaration.function.arrow.java - meta.function.anonymous.parameters.java
 
   Function<String, String> lambda4 = (String foo) -> foo;
 //                                   ^^^^^^^^^^^^ meta.function.anonymous.parameters.java
-//                                    ^^^^^^ storage.type.class.java - meta.annotation
+//                                    ^^^^^^ support.class.java - meta.annotation
 //                                           ^^^ variable.parameter.java
 //                                                ^^ keyword.declaration.function.arrow.java - meta.function.anonymous.parameters.java
 
@@ -9653,7 +9653,7 @@ class LambdasExpressionsTests {
 
   Function<String[], String> lambda9 = (String... foo) -> foo[0];
 //                                     ^^^^^^^^^^^^^^^ meta.function.anonymous.parameters.java
-//                                      ^^^^^^ storage.type.class.java - meta.annotation
+//                                      ^^^^^^ support.class.java - meta.annotation
 //                                            ^^^ keyword.operator.variadic.java
 //                                                ^^^ variable.parameter.java
 //                                                     ^^ keyword.declaration.function.arrow.java - meta.function.anonymous.parameters.java
@@ -9669,7 +9669,7 @@ class LambdasExpressionsTests {
 //                        ^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.java
 //                         ^^ keyword.declaration.function.arrow.java
 //                            ^^^ keyword.other.storage.new.java
-//                                ^^^^^^^^ storage.type.class.java
+//                                ^^^^^^^^ support.class.java
 //                                        ^ punctuation.section.group.begin.java
 //                                        ^^^^^ meta.group.java
 //                                         ^^^ variable.other.java
@@ -9710,7 +9710,7 @@ class LambdasExpressionsTests {
 //        ^ punctuation.accessor.dot.java
 //         ^^^^^^^^^^^^^^ variable.annotation.java
 //                       ^ punctuation.section.group.begin.java
-//                         ^^^^^^^^^^^^^ storage.type.class.java
+//                         ^^^^^^^^^^^^^ support.class.java
 //                                      ^ punctuation.accessor.dot.java
 //                                       ^^^^^^^^^^^^^^ constant.other.java
 public class GrafoTest {
@@ -9745,14 +9745,14 @@ public class GrafoTest {
         Grafo grafo = new Grafo( true );
         final Grafo temposMaisCedo = new Grafo( true );
 //      ^ storage.modifier
-//            ^ storage.type.class
+//            ^ support.class
     }
 
 
      @Partial @Mock(type=Grafo.class) DataLoader inline;
 //   ^^^^^^^^                          meta.annotation
 //            ^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
-//                                    ^ storage.type.class
+//                                    ^ support.class
 
      @Override public int inline() {
 //   ^^^^^^^^^ meta.annotation
@@ -9765,13 +9765,13 @@ public class GrafoTest {
 //                               ^ storage.modifier - meta.annotation
          @Named(value = "") List<T> p2, @NonNull final String p3) {}
 //       ^^^^^^^^^^^^^^^^^^ meta.annotation
-//                          ^ storage.type.class
+//                          ^ support.class
 //                              ^ meta.generic punctuation.definition.generic.begin
 //                                  ^ variable.parameter
 //                                    ^ punctuation.separator
 //                                      ^^^^^^^^ meta.annotation
 //                                               ^ storage.modifier - meta.annotation
-//                                                     ^ storage.type.class
+//                                                     ^ support.class
 
 }
 
@@ -9821,12 +9821,12 @@ public class GrafoTest {
 //^^^^^^^^^^^^^^^ meta.class.java meta.annotation.identifier.java
 //               ^^ meta.class.java meta.annotation.parameters.java
   Foo.class,
-//^^^ storage.type.class.java
+//^^^ support.class.java
 //   ^ punctuation.accessor.dot.java
 //    ^^^^^ variable.language.class.java - storage.type.java
 //         ^ punctuation.separator.comma.java
   Bar.class
-//^^^ storage.type.class.java
+//^^^ support.class.java
 //   ^ punctuation.accessor.dot.java
 //    ^^^^^ variable.language.class.java - storage.type.java
 })
@@ -9914,10 +9914,10 @@ public class Foo {
 //   ^^^^^^^^^^^^ meta.annotation.identifier.java variable.annotation.java
 //               ^ - meta.annotation.identifier.java - variable
 //                ^ - meta.annotation.identifier.java
-//                ^^^^^^^ storage.type.class.java
+//                ^^^^^^^ support.class.java
 //                        ^^^^^^^^^^^^^^ variable.parameter.java
     String unannotatedParam) {
-//  ^ storage.type.class.java
+//  ^ support.class.java
 //         ^ variable.parameter.java
     return;
 //  ^^^^^^ keyword.control.flow.return.java
@@ -9925,18 +9925,18 @@ public class Foo {
 
   public static void main(String[] args, String<List> moreArgs, a.b.c.Foo bar) {}
 //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.java
-//                        ^^^^^^ storage.type.class.java
+//                        ^^^^^^ support.class.java
 //                              ^^ storage.modifier.array.java
 //                                 ^^^^ variable.parameter.java
 //                                     ^ punctuation.separator.comma.java
 //                                             ^^^^^^ meta.generic.java
-//                                       ^^^^^^ storage.type.class.java
-//                                              ^^^^ storage.type.class.java
+//                                       ^^^^^^ support.class.java
+//                                              ^^^^ support.class.java
 //                                                    ^^^^^^^^ variable.parameter.java
 //                                                                ^ variable.namespace.java
 //                                                                 ^ punctuation.accessor.dot.java
 //                                                                   ^ punctuation.accessor.dot.java
-//                                                                    ^^^ storage.type.class.java
+//                                                                    ^^^ support.class.java
 //                                                                        ^^^ variable.parameter.java
 
   MyClass myClass = new MyClass(


### PR DESCRIPTION
This PR proposes to change scope of classes to `support.class`.

Java decided to use `storage.type.class` as `support` scopes are said to be used for types provided by (standard) libraries only. Thus `storage.type` would be the scope for all user defined data types.

The truth according to TextMate's is exactly vice versa.

`storage.type` is meant for basic builtin data types of a language, such as `int`, `char`, ...

`support.class`, `support.type`, ... however are meant for all kinds of custom or user defined data types - not only those from standard libraries.

As such it makes very much sense most (all) other syntaxes use `support.class` for `ClassTypes`.

This commit intents to make Java follow those rules, too, again.