### PR TITLE
[Python] Fix escaped unicode scopes

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -3299,10 +3299,10 @@ contexts:
       scope: invalid.deprecated.character.escape.python
 
   escaped-unicode-chars:
-    - match: \\U\h{8}
-      scope: constant.character.escape.unicode.16-bit-hex.python
     - match: \\u\h{4}
-      scope: constant.character.escape.unicode.32-bit-hex.python
+      scope: constant.character.escape.unicode.16bit.python
+    - match: \\U\h{8}
+      scope: constant.character.escape.unicode.32bit.python
     - match: \\N\{[-a-zA-Z ]+\}
       scope: constant.character.escape.unicode.name.python
 

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -20,10 +20,10 @@ var = "\x00 \xaa \xAF \070 \0 \r \n \t \\ \a \b \' \v \f \u0aF1 \UFe0a182f \N{SP
 #                                               ^^ constant.character.escape
 #                                                  ^^ constant.character.escape
 #                                                     ^^ constant.character.escape
-#                                                        ^^^^^^ constant.character.escape.unicode
-#                                                               ^^^^^^^^^^ constant.character.escape.unicode
-#                                                                          ^^^^^^^^^ constant.character.escape.unicode
-#                                                                                    ^^^^^^^^^^^^^^^ constant.character.escape.unicode
+#                                                        ^^^^^^ constant.character.escape.unicode.16bit
+#                                                               ^^^^^^^^^^ constant.character.escape.unicode.32bit
+#                                                                          ^^^^^^^^^ constant.character.escape.unicode.name
+#                                                                                    ^^^^^^^^^^^^^^^ constant.character.escape.unicode.name
 
 invalid_escapes = "\.  \-"
 #                  ^^ invalid.deprecated.character.escape.python


### PR DESCRIPTION
This commit...

1. assigns correct scopes to 16bit vs. 32bit unicode escapes. They were swapped.
2. shortens the scope a bit. `.16bit` and `.32bit` should be enough.