### PR TITLE
[Batch File] Fix escaped percentage not being detected

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -380,11 +380,16 @@ contexts:
       scope: variable.parameter.option.recursive.dosbatch
       captures:
         1: punctuation.definition.variable.dosbatch
-      push: path-pattern
+      push: ctl-for-maybe-r-args
     - match: (?i:/\S+){{arg_break}}
       scope: invalid.illegal.parameter.dosbatch
       pop: 1
     - include: else-pop
+
+  ctl-for-maybe-r-args:
+    - match: (?={{var_parameter}})
+      pop: 1
+    - include: path-pattern
 
   ctl-for-maybe-f-args:
     - match: \"
@@ -1591,7 +1596,7 @@ contexts:
       set:
         - path-pattern-quoted-body
         - path-pattern-relative
-    - match: (?=(?!%%)\S)
+    - match: (?=\S)
       set:
         - path-pattern-unquoted-body
         - path-pattern-relative

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1816,7 +1816,7 @@ put arg1 arg2
 ::       ^^ constant.character.escape.dosbatch
 ::         ^^^^^^^^^^^^^^^^ - constant.character
 
-   ECHO cd = @( ^
+   doskey cd = @( ^
    for %%^^^^ in ("") do @for /f "delims=" %%a in (^^""$*%%~^^"^") do @( ^
 :: ^^^^ - constant
 ::     ^^^^^^ constant.character.escape.dosbatch
@@ -1824,12 +1824,20 @@ put arg1 arg2
 ::                                         ^^ constant.character.escape.dosbatch
 ::                                           ^^^^^^ - constant
 ::                                                 ^^ constant.character.escape.dosbatch
-::                                                   ^^^^ - constant
+::                                                   ^^^ - constant
+::                                                      ^ constant.other.placeholder.dosbatch
 ::                                                       ^^ constant.character.escape.dosbatch
 ::                                                         ^ - constant
 ::                                                          ^^ constant.character.escape.dosbatch
 ::                                                            ^^^^^^^^^^^^ - constant
 ::                                                                       ^ punctuation.separator.continuation.line.dosbatch
+
+   doskey for /f "delims=" %%p in ('"zoxide query --execute "%%CD%%\." -- "%%~1""')
+::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
+::                         ^^ constant.character.escape.dosbatch
+::                                                           ^^ constant.character.escape.dosbatch
+::                                                               ^^ constant.character.escape.dosbatch
+::                                                                         ^^ constant.character.escape.dosbatch
 
 :::: [ ECHO variables ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This PR fixes an issue which caused a path pattern to be popped off stack too early, because of an heuristic used in `for /r [path] %%f` statements to make sure to match `%%f` as for variable if `[path]` is absent.

The heuristic is now restricted to for statements only, instead of being applied to all path patterns globally.