### PR TITLE
[CSS] Highlight calc() in all function arguments

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1864,7 +1864,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: color-adjuster-functions # must be included before `color-values`
     - include: color-values
     - include: angle-constants
@@ -1889,7 +1888,6 @@ contexts:
     - include: function-arguments-prototype
     - include: alpha-delimiters
     - include: comma-delimiters
-    - include: calc-functions
     - include: angle-constants
     - include: percentage-constants
     - include: scalar-constants
@@ -1912,7 +1910,6 @@ contexts:
     - include: function-arguments-prototype
     - include: alpha-delimiters
     - include: comma-delimiters
-    - include: calc-functions
     - include: percentage-constants
     - include: scalar-constants
 
@@ -1936,7 +1933,6 @@ contexts:
   blend-adjust-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: color-values
     - include: percentage-constants
     - match: \b(?i:rgb|hsl|hwb){{break}}
@@ -1953,7 +1949,6 @@ contexts:
   hue-adjust-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: color-adjuster-operators
     - include: angle-constants
 
@@ -1968,7 +1963,6 @@ contexts:
   rgba-adjust-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: color-adjuster-operators
     - include: percentage-constants
     - include: scalar-constants
@@ -1984,7 +1978,6 @@ contexts:
   saturation-adjust-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: color-adjuster-operators
     - include: percentage-constants
 
@@ -2001,7 +1994,6 @@ contexts:
   tint-adjust-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: percentage-constants
 
 ###[ BUILTIN FILTER FUNCTIONS ]################################################
@@ -2038,7 +2030,6 @@ contexts:
   blur-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: length-constants
 
   brightness-functions:
@@ -2053,7 +2044,6 @@ contexts:
   brightness-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: percentage-constants
     - include: scalar-constants
 
@@ -2069,7 +2059,6 @@ contexts:
   drop-shadow-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: color-values
     - include: length-constants
 
@@ -2085,7 +2074,6 @@ contexts:
   hue-rotate-function-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: angle-constants
 
 ###[ BUILTIN GRID FUNCTIONS ]##################################################
@@ -2103,7 +2091,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: grid-constants
     - include: length-constants
     - include: percentage-constants
@@ -2123,7 +2110,6 @@ contexts:
     - include: comma-delimiters
     - match: \b(?i:auto-fill|auto-fit){{break}}
       scope: keyword.other.grid.css
-    - include: calc-functions
     - include: minmax-functions
     - include: grid-constants
     - include: length-constants
@@ -2290,7 +2276,6 @@ contexts:
       scope: keyword.other.shape.css
     - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
       scope: support.constant.property-value.css
-    - include: calc-functions
     - include: length-constants
     - include: percentage-constants
 
@@ -2308,7 +2293,6 @@ contexts:
     - include: function-arguments-prototype
     - match: \b(?i:round){{break}}
       scope: keyword.other.shape.css
-    - include: calc-functions
     - include: length-constants
     - include: percentage-constants
 
@@ -2327,7 +2311,6 @@ contexts:
     - include: comma-delimiters
     - match: \b(?i:nonzero|evenodd){{break}}
       scope: support.constant.property-value.css
-    - include: calc-functions
     - include: length-constants
     - include: percentage-constants
 
@@ -2345,7 +2328,6 @@ contexts:
     - include: function-arguments-prototype
     - match: \b(?i:auto){{break}}
       scope: support.constant.property-value.css
-    - include: calc-functions
     - include: length-constants
 
 ###[ BUILTIN TIMING FUNCTIONS ]################################################
@@ -2363,7 +2345,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: scalar-constants
 
   step-timing-functions:
@@ -2379,7 +2360,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - match: \b(?i:end|middle|start){{break}}
       scope: keyword.other.timing.css
     - include: scalar-integer-constants
@@ -2413,7 +2393,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: angle-constants
 
   transform-functions-with-angles-scalars-args:
@@ -2429,7 +2408,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: angle-constants
     - include: scalar-constants
 
@@ -2446,7 +2424,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: length-constants
     - include: percentage-constants
 
@@ -2463,7 +2440,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: percentage-constants
     - include: scalar-constants
 
@@ -2480,7 +2456,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: scalar-constants
 
   transform-functions-with-angle-args:
@@ -2495,7 +2470,6 @@ contexts:
   transform-function-angle-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: angle-constants
 
   transform-functions-with-length-args:
@@ -2510,7 +2484,6 @@ contexts:
   transform-function-length-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: length-constants
     - include: none-constants
 
@@ -2526,7 +2499,6 @@ contexts:
   transform-function-length-percentage-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: length-constants
     - include: percentage-constants
 
@@ -2542,7 +2514,6 @@ contexts:
   transform-function-scalar-arguments-list-body:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
-    - include: calc-functions
     - include: scalar-constants
 
 ###[ BUILTIN URL FUNCTIONS ]###################################################
@@ -2659,7 +2630,6 @@ contexts:
     - include: function-arguments-prototype
     - include: comma-delimiters
     - include: attr-functions
-    - include: calc-functions
     - match: '{{float}}({{units}})?'
       scope: meta.number.float.decimal.css
       captures:
@@ -2691,7 +2661,6 @@ contexts:
     - meta_content_scope: meta.function-call.arguments.css meta.group.css
     - include: function-arguments-prototype
     - include: comma-delimiters
-    - include: calc-functions
     - include: vendor-prefixes
     - include: color-values
     - include: quoted-strings
@@ -2779,6 +2748,7 @@ contexts:
     - match: (?=[;{}])
       pop: 1
     - include: comments
+    - include: calc-functions
     - include: var-functions
     - include: illegal-groups
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -3497,8 +3497,17 @@
 /*                           ^^^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*                              ^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 
-    top: repeating-linear-gradient();
-/*       ^^^^^^^^^^^^^^^^^^^^^^^^^ support.function.gradient.css */
+    top: repeating-linear-gradient(transparent 0 var(--height), green var(--height) calc(var(--height) * 2));
+/*       ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.identifier.css support.function.gradient.css */
+/*                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*                                 ^^^^^^^^^^^ support.constant.color.w3c.special.css */
+/*                                             ^ constant.numeric.value.css */
+/*                                               ^^^^^^^^^^^^^ meta.function-call meta.function-call */
+/*                                                            ^ punctuation.separator.sequence.css */
+/*                                                              ^^^^^ support.constant.color.w3c.standard.css */
+/*                                                                    ^^^^^^^^^^^^^ meta.function-call meta.function-call */
+/*                                                                                  ^^^^ meta.function-call.identifier.css support.function.calc.css */
+/*                                                                                       ^^^^^^^^^^^^^ meta.function-call meta.function-call meta.function-call */
 
     top: radial-gradient();
 /*       ^^^^^^^^^^^^^^^ support.function.gradient.css */


### PR DESCRIPTION
Fixes #3748

This commit adds `calc()` function to `function-arguments-prototype` so it is highlighted in all function arguments. The function is valid in majority of function calls. Maybe not everywhere, but we don't want to be a linter - or at least reduce those habits.

A first step to a somewhat more lazy parsing of CSS.