### PR TITLE
[Batch File] Fix interpretation of numeric handles

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1540,12 +1540,12 @@ contexts:
 ###[ PATH PATTERNS ]##########################################################
 
   redirection-interpolations:
-    - match: \s*(?=\d*(?:<&?|>[&>]?))
+    - match: \s*(?=(?:\d)?(?:<&?|>[&>]?))
       push: redirection-interpolations-body
 
   redirection-interpolations-body:
     - meta_include_prototype: false
-    - match: (\d*)(<&?|>[&>]?)
+    - match: (\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch
@@ -1561,12 +1561,12 @@ contexts:
     - include: immediately-pop
 
   redirections:
-    - match: (?=\d*(<&?|>[&>]?))
+    - match: (?=(?:\d)?(?:<&?|>[&>]?))
       push: redirection-body
 
   redirection-body:
     - meta_include_prototype: false
-    - match: (\d*)(<&?|>[&>]?)
+    - match: (\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1561,7 +1561,7 @@ contexts:
     - include: immediately-pop
 
   redirections:
-    - match: (?=(?:\d)?(?:<&?|>[&>]?))
+    - match: (?=\d?(?:<&?|>[&>]?))
       push: redirection-body
 
   redirection-body:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1540,7 +1540,7 @@ contexts:
 ###[ PATH PATTERNS ]##########################################################
 
   redirection-interpolations:
-    - match: \s*(?=(?:\d)?(?:<&?|>[&>]?))
+    - match: \s*(?=\d?(?:<&?|>[&>]?))
       push: redirection-interpolations-body
 
   redirection-interpolations-body:

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -2388,6 +2388,14 @@ put arg1 arg2
    set ^=
 ::     ^^ invalid.illegal.parameter.dosbatch
 
+   set 12>nul
+::     ^^ variable.other.readwrite.dosbatch
+::     ^^ - meta.redirection
+::       ^^^^ meta.redirection.dosbatch
+::           ^ - meta.redirection
+::       ^ keyword.operator.assignment.redirection.dosbatch
+::        ^^^ constant.language.null.dosbatch
+
    set foo_bar & echo %foo_bar%
 :: ^^^^^^^^^^^ meta.command.set.dosbatch
 ::            ^ - meta.command
@@ -2840,6 +2848,16 @@ put arg1 arg2
 ::     ^^^^^^^ variable.other.readwrite
 ::            ^ keyword.operator.assignment - meta.expression.dosbatch
 ::              ^^^ string.unquoted
+
+   set abc /a = 1+2>nul
+:: ^^^ support.function.builtin.dosbatch
+::     ^^^^^^^ variable.other.readwrite
+::            ^ keyword.operator.assignment - meta.expression.dosbatch
+::              ^^^ string.unquoted
+::              ^^^ - meta.redirection
+::                 ^^^^ meta.redirection.dosbatch
+::                 ^ keyword.operator.assignment.redirection.dosbatch
+::                  ^^^ constant.language.null.dosbatch
 
    set /A hello_world
 :: ^^^ support.function.builtin.dosbatch


### PR DESCRIPTION
An optional numeric handle consists of **exactly one** number between 0 and 9.

In action:

```batchfile
~\Packages$ rem `set 12 ^>nul`, not `set 1 2^>nul`
~\Packages$ set 12>nul
Environment variable 12 not defined
```

Unofficial source for reference: https://ss64.com/nt/syntax-redirection.html