### PR TITLE
[Lua] Fix block comment end

### DIFF
--- a/Lua/Comments.tmPreferences
+++ b/Lua/Comments.tmPreferences
@@ -25,6 +25,18 @@
 				<key>value</key>
 				<string>]]</string>
 			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
+				<key>value</key>
+				<string>--[[</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_3</string>
+				<key>value</key>
+				<string>--]]</string>
+			</dict>
 		</array>
 	</dict>
 </dict>

--- a/Lua/Comments.tmPreferences
+++ b/Lua/Comments.tmPreferences
@@ -23,7 +23,7 @@
 				<key>name</key>
 				<string>TM_COMMENT_END_2</string>
 				<key>value</key>
-				<string>--]]</string>
+				<string>]]</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
This is how comments in Lua work:
```Lua
-- This is a comment

--[[This is block comment
spanning over multiple lines]]
```
I've personally never seen `--]]` used to end block comments.