### PR TITLE
[Git Formats] Fix attribute value completions

### DIFF
--- a/Git Formats/Completions/Git Attributes - Diff.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Diff.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.diff.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.diff.git.attributes",
     "completions": [
         {
             "trigger": "ada",

--- a/Git Formats/Completions/Git Attributes - EOL.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - EOL.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.eol.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.eol.git.attributes",
     "completions": [
         {
             "trigger": "crlf",

--- a/Git Formats/Completions/Git Attributes - Encoding.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Encoding.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & (meta.attribute.builtin.encoding.git.attributes | meta.attribute.builtin.working-tree-encoding.git.attributes)",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & (meta.attribute.builtin.encoding.git.attributes | meta.attribute.builtin.working-tree-encoding.git.attributes)",
     "completions": [
         {
             "trigger": "ASCII",

--- a/Git Formats/Completions/Git Attributes - Filter.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Filter.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.filter.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.filter.git.attributes",
     "completions": [
     ]
 }

--- a/Git Formats/Completions/Git Attributes - Merge.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Merge.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.merge.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.merge.git.attributes",
     "completions": [
         {
             "trigger": "binary",

--- a/Git Formats/Completions/Git Attributes - Text.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Text.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.text.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.text.git.attributes",
     "completions": [
         {
             "trigger": "auto",

--- a/Git Formats/Completions/Git Attributes - Whitespace.sublime-completions
+++ b/Git Formats/Completions/Git Attributes - Whitespace.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.mapping.expect-value & meta.attribute.builtin.whitespace.git.attributes",
+    "scope": "(meta.mapping.expect-value | meta.mapping.value) & meta.attribute.builtin.whitespace.git.attributes",
     "completions": [
         {
             "trigger": "blank-at-eof",


### PR DESCRIPTION
This PR fixes an issue, which caused attribute value completions in `.gitattributes` not being suggested, if the value was partly written already.

#### Example:

    file  encoding=|   <- hit `ctrl+space` = working

    file  encoding=u|  <- hit `ctrl+space` = not working!

#### Fix:

Completion selectors are adjusted to also apply on `meta.mapping.value`, which replaces `meta.mapping.expect-value` once a value is started being typed.